### PR TITLE
sdcm: Parametrize cassandra-stress population size

### DIFF
--- a/data_dir/scylla.yaml
+++ b/data_dir/scylla.yaml
@@ -2,6 +2,8 @@
 cassandra_stress_duration: 60
 # default cassandra stress thread number if none specified
 cassandra_stress_threads: 1000
+# default cassandra stress population size if none specified
+cassandra_stress_population_size: 10000000
 n_db_nodes: 6
 # If you want to use more than 1 loader node, I recommend
 # increasing the size of the DB instance (instance_type_db parameter),

--- a/grow_cluster_test.py
+++ b/grow_cluster_test.py
@@ -58,16 +58,19 @@ class GrowClusterTest(ClusterTester):
         self.db_cluster.wait_for_init()
         self.stress_thread = None
 
-    def get_stress_cmd(self, duration=None, threads=None):
+    def get_stress_cmd(self, duration=None, threads=None, population_size=None):
         """
         Get a cassandra stress cmd string suitable for grow cluster purposes.
 
         :param duration: Duration of stress (minutes).
         :param threads: Number of threads used by cassandra stress.
+        :param population_size: Size of the -pop seq1..%s argument.
         :return: Cassandra stress string
         :rtype: basestring
         """
         ip = self.db_cluster.get_node_private_ips()[0]
+        if population_size is None:
+            population_size = 1000000
         if duration is None:
             duration = self.params.get('cassandra_stress_duration')
         if threads is None:
@@ -75,7 +78,8 @@ class GrowClusterTest(ClusterTester):
         return ("cassandra-stress write cl=QUORUM duration=%sm "
                 "-schema 'replication(factor=3)' -port jmx=6868 "
                 "-mode cql3 native -rate threads=%s "
-                "-pop seq=1..100000 -node %s" % (duration, threads, ip))
+                "-pop seq=1..%s -node %s" %
+                (duration, threads, population_size, ip))
 
     def grow_cluster(self, cluster_target_size):
         # 60 minutes should be long enough for adding each node

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -34,7 +34,8 @@ class LongevityTest(ClusterTester):
         Run cassandra-stress with params defined in data_dir/scylla.yaml
         """
         self.db_cluster.add_nemesis(self.get_nemesis_class())
-        stress_queue = self.run_stress_thread(duration=self.params.get('cassandra_stress_duration'))
+        stress_queue = self.run_stress_thread(duration=self.params.get('cassandra_stress_duration'),
+                                              population_size=self.params.get('cassandra_stress_population_size'))
         self.db_cluster.wait_total_space_used_per_node()
         self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
         self.verify_stress_thread(queue=stress_queue)
@@ -44,7 +45,8 @@ class LongevityTest(ClusterTester):
         Run cassandra-stress on a cluster for 12 hours.
         """
         self.db_cluster.add_nemesis(self.get_nemesis_class())
-        stress_queue = self.run_stress(duration=60 * 12)
+        stress_queue = self.run_stress(duration=60 * 12,
+                                       population_size=self.params.get('cassandra_stress_population_size'))
         self.db_cluster.wait_total_space_used_per_node()
         self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
         self.verify_stress_thread(queue=stress_queue)
@@ -54,7 +56,8 @@ class LongevityTest(ClusterTester):
         Run cassandra-stress on a cluster for 24 hours.
         """
         self.db_cluster.add_nemesis(self.get_nemesis_class())
-        stress_queue = self.run_stress(duration=60 * 24)
+        stress_queue = self.run_stress(duration=60 * 24,
+                                       population_size=self.params.get('cassandra_stress_population_size'))
         self.db_cluster.wait_total_space_used_per_node()
         self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
         self.verify_stress_thread(queue=stress_queue)
@@ -64,7 +67,8 @@ class LongevityTest(ClusterTester):
         Run cassandra-stress on a cluster for 1 week.
         """
         self.db_cluster.add_nemesis(self.get_nemesis_class())
-        stress_queue = self.run_stress(duration=60 * 24 * 7)
+        stress_queue = self.run_stress(duration=60 * 24 * 7,
+                                       population_size=self.params.get('cassandra_stress_population_size'))
         self.db_cluster.wait_total_space_used_per_node()
         self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
         self.verify_stress_thread(queue=stress_queue)

--- a/reduce_cluster_test.py
+++ b/reduce_cluster_test.py
@@ -56,16 +56,19 @@ class ReduceClusterTest(ClusterTester):
         self.loaders.wait_for_init()
         self.db_cluster.wait_for_init()
 
-    def get_stress_cmd(self, duration=None, threads=None):
+    def get_stress_cmd(self, duration=None, threads=None, population_size=None):
         """
         Get a cassandra stress cmd string suitable for reduce cluster purposes.
 
         :param duration: Duration of stress (minutes).
         :param threads: Number of threads used by cassandra stress.
+        :param population_size: Size of the -pop seq1..%s argument.
         :return: Cassandra stress string
         :rtype: basestring
         """
         ip = self.db_cluster.get_node_private_ips()[0]
+        if population_size is None:
+            population_size = 1000000
         if duration is None:
             duration = self.params.get('cassandra_stress_duration')
         if threads is None:
@@ -73,7 +76,8 @@ class ReduceClusterTest(ClusterTester):
         return ("cassandra-stress write cl=QUORUM duration=%sm "
                 "-schema 'replication(factor=3)' -port jmx=6868 "
                 "-mode cql3 native -rate threads=%s "
-                "-pop seq=1..100000 -node %s" % (duration, threads, ip))
+                "-pop seq=1..%s -node %s" %
+                (duration, threads, population_size, ip))
 
     def reduce_cluster(self, cluster_starting_size, cluster_target_size=3):
         self.wait_for_init(cluster_starting_size, cluster_target_size)


### PR DESCRIPTION
For different combinations of scylla versions and instance
sizes, the population size used in cassandra-stress might
vary. Let's make that size configurable in the test yaml
file.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>