### PR TITLE
config: fix typo of parameter space_node_threshold

### DIFF
--- a/data_dir/scylla.yaml
+++ b/data_dir/scylla.yaml
@@ -24,11 +24,11 @@ user_prefix:
 # Keep AWS instances running and leave credentials alone (keep)
 # Stop AWS instances and leave credentials alone (stop)
 failure_post_behavior: destroy
-# Space node treshold before starting nemesis (bytes)
+# Space node threshold before starting nemesis (bytes)
 # The default value is 6GB (6x1024^3 bytes)
 # This value is supposed to reproduce
 # https://github.com/scylladb/scylla/issues/1140
-space_node_treshold: 6442450944
+space_node_threshold: 6442450944
 
 # The new db binary will be uploaded to db instance to replace the one
 # provided by the ami. This is useful to test out a new scylla version


### PR DESCRIPTION
space_node_treshold -> space_node_threshold

Signed-off-by: Amos Kong <amos@scylladb.com>


Additional Error Information:
======================
ERROR| Traceback (most recent call last):
ERROR|   File "/home/amos/scylla-cluster-tests/longevity_test.py", line 40, in test_custom_time
ERROR|     self.db_cluster.wait_total_space_used_per_node()
ERROR|   File "/home/amos/scylla-cluster-tests/sdcm/cluster.py", line 600, in wait_total_space_used_per_node
ERROR|     size = int(self.params.get('space_node_threshold')) 
ERROR| TypeError: int() argument must be a string or a number, not 'NoneType'