### PR TITLE
Introduce a simple regression test

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -147,6 +147,10 @@ class ClusterTester(Test):
     def init_resources(self, n_db_nodes=None, n_loader_nodes=None, dbs_block_device_mappings=None, loaders_block_device_mappings=None, loaders_type=None, dbs_type=None):
         if n_db_nodes is None:
             n_db_nodes = self.params.get('n_db_nodes')
+        if n_db_nodes <= 0:
+            self.error('Invalid parameter n_db_nodes: %s,'
+                       ' it should be larger than zero.' % n_db_nodes)
+
         if n_loader_nodes is None:
             n_loader_nodes = self.params.get('n_loaders')
         if n_loader_nodes <= 0:

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -275,6 +275,10 @@ class ClusterTester(Test):
             self.fail("cassandra-stress errors on "
                       "nodes:\n%s" % "\n".join(errors))
 
+    @clean_aws_resources
+    def get_stress_results(self, queue):
+        return self.loaders.get_stress_results(queue)
+
     def get_auth_provider(self, user, password):
         return PlainTextAuthProvider(username=user, password=password)
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -149,6 +149,10 @@ class ClusterTester(Test):
             n_db_nodes = self.params.get('n_db_nodes')
         if n_loader_nodes is None:
             n_loader_nodes = self.params.get('n_loaders')
+        if n_loader_nodes <= 0:
+            self.error('Invalid parameter n_loader_nodes/n_loaders: %s,'
+                       ' it should be larger than zero.' % n_loader_nodes)
+
         if loaders_type is None:
             loaders_type = self.params.get('instance_type_loader')
         if dbs_type is None:

--- a/simple_regression_test.py
+++ b/simple_regression_test.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2016 ScyllaDB
+
+
+from avocado import main
+
+from sdcm.tester import ClusterTester
+
+
+class SimpleRegressionTest(ClusterTester):
+
+    """
+    Test Scylla performance regression with cassandra-stress.
+
+    :avocado: enable
+    """
+
+    def test_simple_regression(self):
+        """
+        Test steps:
+
+        1. Run a write workload
+        2. Run a read workload (after the write - cache will contain some data)
+        3. Restart node, run a read workload (cache will be empty)
+        4. Run a mixed read write workload
+        """
+        # run a write workload
+        stress_queue = self.run_stress_thread(
+                         duration=self.params.get('cassandra_stress_duration'),
+                         population_size=self.params.get(
+                                           'cassandra_stress_population_size'),
+                         threads=self.params.get('cassandra_stress_threads'),
+                         mode='write')
+        write_results = self.get_stress_results(queue=stress_queue)
+
+        # run a read workload
+        stress_queue = self.run_stress_thread(
+                         duration=self.params.get('cassandra_stress_duration'),
+                         population_size=self.params.get(
+                                           'cassandra_stress_population_size'),
+                         threads=self.params.get('cassandra_stress_threads'),
+                         mode='read')
+        read_results = self.get_stress_results(queue=stress_queue)
+
+        # restart all the nodes
+        for loader in self.db_cluster.nodes:
+            loader.restart()
+
+        # run a mixed read write workload
+        stress_queue = self.run_stress_thread(
+                         duration=self.params.get('cassandra_stress_duration'),
+                         population_size=self.params.get(
+                                           'cassandra_stress_population_size'),
+                         threads=self.params.get('cassandra_stress_threads'),
+                         mode='mixed')
+        mixed_results = self.get_stress_results(queue=stress_queue)
+
+
+if __name__ == '__main__':
+    main()

--- a/simple_regression_test.py
+++ b/simple_regression_test.py
@@ -27,6 +27,26 @@ class SimpleRegressionTest(ClusterTester):
     :avocado: enable
     """
 
+    str_pattern = '%8s%16s%10s%14s%16s%12s%12s%14s'
+
+    def display_single_result(self, result):
+        self.log.info(self.str_pattern % (result['op rate'],
+                                          result['partition rate'],
+                                          result['row rate'],
+                                          result['latency mean'],
+                                          result['latency median'],
+                                          result['latency 95th percentile'],
+                                          result['latency 99th percentile'],
+                                          result['latency 99.9th percentile']))
+
+    def display_results(self, results):
+        self.log.info(self.str_pattern % ('op-rate', 'partition-rate',
+                                          'row-rate', 'latency-mean',
+                                          'latency-median', 'l-94th-pct',
+                                          'l-99th-pct', 'l-99.9th-pct'))
+        for single_result in results:
+            self.display_single_result(single_result)
+
     def test_simple_regression(self):
         """
         Test steps:
@@ -67,6 +87,9 @@ class SimpleRegressionTest(ClusterTester):
                          mode='mixed')
         mixed_results = self.get_stress_results(queue=stress_queue)
 
+        self.display_results(write_results)
+        self.display_results(read_results)
+        self.display_results(mixed_results)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
A simple regression test to use cassandra-stress as workloads, it contains write/read/mixed stresses.
We can do result compare and analysis in future patches.