### PR TITLE
sdcm: Libvirt Backend

### DIFF
--- a/big_cluster.py
+++ b/big_cluster.py
@@ -38,7 +38,9 @@ class HugeClusterTest(ClusterTester):
         logging.getLogger('botocore').setLevel(logging.CRITICAL)
         logging.getLogger('boto3').setLevel(logging.CRITICAL)
 
-        self.init_resources(n_db_nodes=40, n_loader_nodes=1)
+        loader_info = {'n_nodes': 1, 'device_mappings': None, 'type': None}
+        db_info = {'n_nodes': 40, 'device_mappings': None, 'type': None}
+        self.init_resources(loader_info=loader_info, db_info=db_info)
         self.loaders.wait_for_init()
         self.db_cluster.wait_for_init()
         self.stress_thread = None

--- a/data_dir/scylla.yaml
+++ b/data_dir/scylla.yaml
@@ -9,12 +9,6 @@ n_db_nodes: 6
 # increasing the size of the DB instance (instance_type_db parameter),
 # since 't2.micro' nodes tend to struggle with a lot of load.
 n_loaders: 1
-# What is the backend that the suite will use to get machines from.
-# Right now the only supported mode is 'aws'
-cluster_backend: 'aws'
-# From 0.19 on, iotune will require bigger disk, so let's use a big
-# loader instance by default.
-instance_type_loader: 'c3.large'
 # Nemesis class to use (possible types in sdcm.nemesis). Example: StopStartMonkey
 nemesis_class_name: 'ChaosMonkey'
 # Nemesis sleep interval to use if None provided specifically
@@ -39,37 +33,59 @@ space_node_threshold: 6442450944
 # update_db_binary: $path_of_the_new_scylla_binary
 update_db_binary: ''
 
-regions: !mux
-    us_west_1:
-        region_name: 'us-west-1'
-        security_group_ids: 'sg-dcd785b9'
-        subnet_id: 'subnet-10a04c75'
-        ami_id_db_scylla: 'ami-2be31b46'
-        ami_db_scylla_user: 'centos'
-        ami_id_loader: 'ami-32bcc552'
-        ami_loader_user: 'centos'
-        ami_id_db_cassandra: 'ami-3cf7c979'
-        ami_db_cassandra_user: 'ubuntu'
-    us_west_2:
-        region_name: 'us-west-2'
-        security_group_ids: 'sg-81703ae4'
-        subnet_id: 'subnet-5207ee37'
-        ami_id_db_scylla: 'ami-15b84575'
-        ami_db_scylla_user: 'centos'
-        ami_id_loader: 'ami-15b84575'
-        ami_loader_user: 'centos'
-        ami_id_db_cassandra: 'ami-1cff962c'
-        ami_db_cassandra_user: 'ubuntu'
-    us_east_1:
-        region_name: 'us-east-1'
-        security_group_ids: 'sg-c5e1f7a0'
-        subnet_id: 'subnet-ec4a72c4'
-        ami_id_db_scylla: 'ami-e16a888c'
-        ami_db_scylla_user: 'centos'
-        ami_id_loader: 'ami-e16a888c'
-        ami_loader_user: 'centos'
-        ami_id_db_cassandra: 'ami-ada2b6c4'
-        ami_db_cassandra_user: 'ubuntu'
+backends: !mux
+    libvirt: !mux
+        cluster_backend: 'libvirt'
+        libvirt_uri: 'qemu:///system'
+        libvirt_bridge: 'virbr0'
+        libvirt_loader_image: '/path/to/your/loader_base_image.qcow2'
+        libvirt_loader_image_user: 'centos'
+        libvirt_loader_image_password: '123456'
+        libvirt_loader_os_type: 'linux'
+        libvirt_loader_os_variant: 'centos7.0'
+        libvirt_loader_memory: 2048
+        libvirt_db_image: '/path/to/your/db_base_image.qcow2'
+        libvirt_db_image_user: 'centos'
+        libvirt_db_image_password: '123456'
+        libvirt_db_os_type: 'linux'
+        libvirt_db_os_variant: 'centos7.0'
+        libvirt_db_memory: 2048
+    aws: !mux
+        # What is the backend that the suite will use to get machines from.
+        cluster_backend: 'aws'
+        # From 0.19 on, iotune will require bigger disk, so let's use a big
+        # loader instance by default.
+        instance_type_loader: 'c3.large'
+        us_west_1:
+            region_name: 'us-west-1'
+            security_group_ids: 'sg-dcd785b9'
+            subnet_id: 'subnet-10a04c75'
+            ami_id_db_scylla: 'ami-2be31b46'
+            ami_db_scylla_user: 'centos'
+            ami_id_loader: 'ami-32bcc552'
+            ami_loader_user: 'centos'
+            ami_id_db_cassandra: 'ami-3cf7c979'
+            ami_db_cassandra_user: 'ubuntu'
+        us_west_2:
+            region_name: 'us-west-2'
+            security_group_ids: 'sg-81703ae4'
+            subnet_id: 'subnet-5207ee37'
+            ami_id_db_scylla: 'ami-15b84575'
+            ami_db_scylla_user: 'centos'
+            ami_id_loader: 'ami-15b84575'
+            ami_loader_user: 'centos'
+            ami_id_db_cassandra: 'ami-1cff962c'
+            ami_db_cassandra_user: 'ubuntu'
+        us_east_1:
+            region_name: 'us-east-1'
+            security_group_ids: 'sg-c5e1f7a0'
+            subnet_id: 'subnet-ec4a72c4'
+            ami_id_db_scylla: 'ami-e16a888c'
+            ami_db_scylla_user: 'centos'
+            ami_id_loader: 'ami-e16a888c'
+            ami_loader_user: 'centos'
+            ami_id_db_cassandra: 'ami-ada2b6c4'
+            ami_db_cassandra_user: 'ubuntu'
 
 databases: !mux
     cassandra:

--- a/data_dir/scylla.yaml
+++ b/data_dir/scylla.yaml
@@ -9,6 +9,9 @@ n_db_nodes: 6
 # increasing the size of the DB instance (instance_type_db parameter),
 # since 't2.micro' nodes tend to struggle with a lot of load.
 n_loaders: 1
+# What is the backend that the suite will use to get machines from.
+# Right now the only supported mode is 'aws'
+cluster_backend: 'aws'
 # From 0.19 on, iotune will require bigger disk, so let's use a big
 # loader instance by default.
 instance_type_loader: 'c3.large'

--- a/data_dir/scylla.yaml
+++ b/data_dir/scylla.yaml
@@ -38,6 +38,7 @@ backends: !mux
         cluster_backend: 'libvirt'
         libvirt_uri: 'qemu:///system'
         libvirt_bridge: 'virbr0'
+        scylla_repo: 'http://downloads.scylladb.com/rpm/centos/scylla-1.2.repo'
         libvirt_loader_image: '/path/to/your/loader_base_image.qcow2'
         libvirt_loader_image_user: 'centos'
         libvirt_loader_image_password: '123456'

--- a/grow_cluster_test.py
+++ b/grow_cluster_test.py
@@ -52,8 +52,11 @@ class GrowClusterTest(ClusterTester):
         # replication factor settings we're using with cassandra-stress
         self._cluster_starting_size = 3
         self._cluster_target_size = None
-        self.init_resources(n_db_nodes=self._cluster_starting_size,
-                            n_loader_nodes=1)
+        loader_info = {'n_nodes': 1, 'device_mappings': None,
+                       'type': None}
+        db_info = {'n_nodes': self._cluster_starting_size,
+                   'device_mappings': None, 'type': None}
+        self.init_resources(loader_info=loader_info, db_info=db_info)
         self.loaders.wait_for_init()
         self.db_cluster.wait_for_init()
         self.stress_thread = None

--- a/query_limits_test.py
+++ b/query_limits_test.py
@@ -44,12 +44,12 @@ class QueryLimitsTest(ClusterTester):
                 "Ebs": {"Iops": 100,
                         "VolumeType": "io1",
                         "DeleteOnTermination": True}}]
-
+        loader_info = {'n_nodes': 1, 'device_mappings': None,
+                       'type': 'm4.4xlarge'}
+        db_info = {'n_nodes': 1, 'device_mappings': bdm,
+                   'type': 'm4.4xlarge'}
         # Use big instance to be not throttled by the network
-        self.init_resources(n_db_nodes=1, n_loader_nodes=1,
-                            dbs_block_device_mappings=bdm,
-                            dbs_type='m4.4xlarge',
-                            loaders_type='m4.4xlarge')
+        self.init_resources(loader_info=loader_info, db_info=db_info)
         self.loaders.wait_for_init()
         self.db_cluster.wait_for_init()
         self.stress_thread = None

--- a/reduce_cluster_test.py
+++ b/reduce_cluster_test.py
@@ -52,7 +52,11 @@ class ReduceClusterTest(ClusterTester):
         # replication factor settings we're using with cassandra-stress
         self._cluster_starting_size = cluster_starting_size
         self._cluster_target_size = cluster_target_size
-        self.init_resources(n_db_nodes=self._cluster_starting_size, n_loader_nodes=1)
+        loader_info = {'n_nodes': 1, 'device_mappings': None,
+                       'type': None}
+        db_info = {'n_nodes': self._cluster_starting_size,
+                   'device_mappings': None, 'type': None}
+        self.init_resources(loader_info=loader_info, db_info=db_info)
         self.loaders.wait_for_init()
         self.db_cluster.wait_for_init()
 

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -141,80 +141,47 @@ class RemoteCredentials(object):
         self.log.info('Destroyed')
 
 
-class Node(object):
+class BaseNode(object):
 
-    """
-    Wraps EC2.Instance, so that we can also control the instance through SSH.
-    """
-
-    def __init__(self, ec2_instance, ec2_service, credentials,
-                 node_prefix='node', node_index=1, ami_username='root',
-                 base_logdir=None):
-        self.instance = ec2_instance
-        self.name = '%s-%s' % (node_prefix, node_index)
+    def __init__(self, name, ssh_login_info=None, base_logdir=None):
+        self.name = name
+        self.is_seed = None
         try:
             self.logdir = path.init_dir(base_logdir, self.name)
         except OSError:
             self.logdir = os.path.join(base_logdir, self.name)
-        self.ec2 = ec2_service
-        self._instance_wait_safe(self.instance.wait_until_running)
-        self.wait_public_ip()
-        self.is_seed = None
-        self.ec2.create_tags(Resources=[self.instance.id],
-                             Tags=[{'Key': 'Name', 'Value': self.name}])
-        # Make the instance created to be immune to Tzach's killer script
-        self.ec2.create_tags(Resources=[self.instance.id],
-                             Tags=[{'Key': 'keep', 'Value': 'alive'}])
-        self.remoter = Remote(hostname=self.instance.public_ip_address,
-                              user=ami_username,
-                              key_file=credentials.key_file)
+
+        self.remoter = Remote(**ssh_login_info)
         logger = logging.getLogger('avocado.test')
         self.log = SDCMAdapter(logger, extra={'prefix': str(self)})
-        self.log.debug("SSH access -> 'ssh -i %s %s@%s'",
-                       credentials.key_file, ami_username,
-                       self.instance.public_ip_address)
+        self.log.debug(self.remoter.ssh_debug_cmd())
+
         self._journal_thread = None
-        self.start_journal_thread()
-        # We'll assume 0 coredump for starters, if by a chance there
-        # are already coredumps in there the coredump backtrace
-        # code will report all of them.
         self._n_coredumps = 0
         self._backtrace_thread = None
-        self.start_backtrace_thread()
+        self._public_ip_address = None
+        self._private_ip_address = None
+
         self.cs_start_time = None
-
-    def _instance_wait_safe(self, instance_method):
-        """
-        Wrapper around AWS instance waiters that is safer to use.
-
-        Since AWS adopts an eventual consistency model, sometimes the method
-        wait_until_running will raise a botocore.exceptions.WaiterError saying
-        the instance does not exist. AWS API guide [1] recommends that the
-        procedure is retried using an exponencial backoff algorithm [2].
-
-        :see: [1] http://docs.aws.amazon.com/AWSEC2/latest/APIReference/query-api-troubleshooting.html#eventual-consistency
-        :see: [2] http://docs.aws.amazon.com/general/latest/gr/api-retries.html
-        """
-        threshold = 300
-        ok = False
-        retries = 0
-        max_retries = 9
-        while not ok and retries <= max_retries:
-            try:
-                instance_method()
-                ok = True
-            except WaiterError:
-                time.sleep(max((2 ** retries) * 2, threshold))
-                retries += 1
-
-        if not ok:
-            raise NodeError('AWS instance %s waiter error after '
-                            'exponencial backoff wait' % self.instance.id)
+        self.start_journal_thread()
+        self.start_backtrace_thread()
 
     def file_exists(self, file_path):
-        result = self.remoter.run('sudo test -e %s' % file_path,
-                                  ignore_status=True)
-        return result.exit_status == 0
+        try:
+            result = self.remoter.run('sudo test -e %s' % file_path,
+                                      ignore_status=True)
+            return result.exit_status == 0
+        except Exception as details:
+            self.log.error('Error checking if file %s exists: %s',
+                           file_path, details)
+
+    @property
+    def public_ip_address(self):
+        return self._public_ip_address
+
+    @property
+    def private_ip_address(self):
+        return self._private_ip_address
 
     def retrieve_journal(self):
         try:
@@ -222,13 +189,13 @@ class Node(object):
             result = self.remoter.run('journalctl --version',
                                       ignore_status=True)
             if result.exit_status == 0:
-                # Here we're assuming that journalctl systems are Scylla AMIs
+                # Here we're assuming that journalctl systems are Scylla images
                 db_services_log_cmd = ('sudo journalctl -f '
                                        '-u scylla-io-setup.service '
                                        '-u scylla-server.service '
                                        '-u scylla-jmx.service')
             else:
-                # Here we are assuming we're using a cassandra AMI, based
+                # Here we are assuming we're using a cassandra image, based
                 # on older Ubuntu
                 cassandra_log = '/var/log/cassandra/system.log'
                 wait.wait_for(self.file_exists, step=10,
@@ -237,7 +204,7 @@ class Node(object):
             self.remoter.run(db_services_log_cmd,
                              verbose=True, ignore_status=True,
                              log_file=log_file)
-        except Exception, details:
+        except Exception as details:
             self.log.error('Error retrieving remote node DB service log: %s',
                            details)
 
@@ -263,7 +230,7 @@ class Node(object):
                 backtrace_cmd += ' -1'
             return self.remoter.run(backtrace_cmd,
                                     verbose=False, ignore_status=True)
-        except Exception, details:
+        except Exception as details:
             self.log.error('Error retrieving core dump backtraces : %s',
                            details)
 
@@ -282,12 +249,15 @@ class Node(object):
             if line.startswith('Coredump:'):
                 coredump = line.split()[-1]
                 coredump_id = os.path.basename(coredump)[:-3]
-                upload_url = base_upload_url % (coredump_id, os.path.basename(coredump))
-                self.log.info('Uploading coredump %s to %s' % (coredump, upload_url))
-                self.remoter.run("sudo curl --request PUT --upload-file '%s' '%s'" %
-                                 (coredump, upload_url))
-                self.log.info("To download it, you may use 'curl --user-agent [user-agent] %s > %s'", upload_url,
-                              os.path.basename(coredump))
+                upload_url = base_upload_url % (coredump_id,
+                                                os.path.basename(coredump))
+                self.log.info('Uploading coredump %s to %s' %
+                              (coredump, upload_url))
+                self.remoter.run("sudo curl --request PUT --upload-file "
+                                 "'%s' '%s'" % (coredump, upload_url))
+                self.log.info("To download it, you may use "
+                              "'curl --user-agent [user-agent] %s > %s'",
+                              upload_url, os.path.basename(coredump))
         with open(log_file, 'a') as log_file_obj:
             log_file_obj.write(output)
         for line in output.splitlines():
@@ -305,7 +275,7 @@ class Node(object):
             result = self.remoter.run(n_backtraces_cmd,
                                       verbose=False, ignore_status=True)
             return len(result.stdout.splitlines())
-        except Exception, details:
+        except Exception as details:
             self.log.error('Error retrieving number of core dumps : %s',
                            details)
             return None
@@ -337,31 +307,15 @@ class Node(object):
 
     def __str__(self):
         return 'Node %s [%s | %s] (seed: %s)' % (self.name,
-                                                 self.instance.public_ip_address,
-                                                 self.instance.private_ip_address,
+                                                 self.public_ip_address,
+                                                 self.private_ip_address,
                                                  self.is_seed)
 
-    def wait_public_ip(self):
-        while self.instance.public_ip_address is None:
-            time.sleep(1)
-            self.instance.reload()
-
     def restart(self):
-        self.instance.stop()
-        self._instance_wait_safe(self.instance.wait_until_stopped)
-        self.instance.start()
-        self._instance_wait_safe(self.instance.wait_until_running)
-        self.wait_public_ip()
-        self.log.debug('Got new public IP %s',
-                       self.instance.public_ip_address)
-        self.remoter.hostname = self.instance.public_ip_address
-        self.wait_db_up()
+        raise NotImplementedError('Derived classes must implement restart')
 
     def destroy(self):
-        self.instance.terminate()
-        global EC2_INSTANCES
-        EC2_INSTANCES.remove(self.instance)
-        self.log.info('Destroyed')
+        raise NotImplementedError('Derived classes must implement destroy')
 
     def wait_ssh_up(self, verbose=True):
         text = None
@@ -375,26 +329,21 @@ class Node(object):
             result = self.remoter.run('netstat -a | grep :9042',
                                       verbose=False, ignore_status=True)
             return result.exit_status == 0
-        except Exception, details:
+        except Exception as details:
             self.log.error('Error checking for DB status: %s', details)
             return False
 
     def cs_installed(self, cassandra_stress_bin=None):
         if cassandra_stress_bin is None:
             cassandra_stress_bin = '/usr/bin/cassandra-stress'
-        try:
-            result = self.remoter.run('test -x %s' % cassandra_stress_bin,
-                                      verbose=False, ignore_status=True)
-            return result.exit_status == 0
-        except Exception, details:
-            self.log.error('Error checking for cassandra-stress: %s', details)
-            return False
+        return self.file_exists(cassandra_stress_bin)
 
     @staticmethod
     def _parse_cfstats(cfstats_output):
         stat_dict = {}
         for line in cfstats_output.splitlines()[1:]:
-            stat_line = [element for element in line.strip().split(':') if element]
+            stat_line = [element for element in line.strip().split(':') if
+                         element]
             if stat_line:
                 try:
                     try:
@@ -410,26 +359,31 @@ class Node(object):
 
     def _get_tcpdump_logs(self, tcpdump_id):
         try:
-            log_file = os.path.join(self.logdir, 'tcpdump-%s.log' % tcpdump_id)
-            pcap_tmp_file = os.path.join('/tmp', 'tcpdump-%s.pcap' % tcpdump_id)
-            pcap_file = os.path.join(self.logdir, 'tcpdump-%s.pcap' % tcpdump_id)
-            self.remoter.run('sudo tcpdump -vv -i lo port 10000 -w %s' % pcap_tmp_file,
-                             ignore_status=True, log_file=log_file)
+            log_name = 'tcpdump-%s.log' % tcpdump_id
+            pcap_name = 'tcpdump-%s.pcap' % tcpdump_id
+            log_file = os.path.join(self.logdir, log_name)
+            pcap_tmp_file = os.path.join('/tmp', pcap_name)
+            pcap_file = os.path.join(self.logdir, pcap_name)
+            self.remoter.run('sudo tcpdump -vv -i lo port 10000 -w %s' %
+                             pcap_tmp_file, ignore_status=True,
+                             log_file=log_file)
             self.remoter.receive_files(src=pcap_tmp_file, dst=pcap_file)
-        except Exception, details:
+        except Exception as details:
             self.log.error('Error running tcpdump on lo, tcp port 10000: %s',
                            str(details))
 
     def get_cfstats(self):
         def keyspace1_available():
-            res = self.remoter.run('nodetool cfstats keyspace1', ignore_status=True)
+            res = self.remoter.run('nodetool cfstats keyspace1',
+                                   ignore_status=True)
             return res.exit_status == 0
         tcpdump_id = uuid.uuid4()
         self.log.info('START tcpdump thread uuid: %s', tcpdump_id)
         tcpdump_thread = threading.Thread(target=self._get_tcpdump_logs,
                                           kwargs={'tcpdump_id': tcpdump_id})
         tcpdump_thread.start()
-        wait.wait_for(keyspace1_available, step=60, text='Waiting until keyspace1 is available')
+        wait.wait_for(keyspace1_available, step=60,
+                      text='Waiting until keyspace1 is available')
         try:
             result = self.remoter.run('nodetool cfstats keyspace1')
         except process.CmdError:
@@ -463,40 +417,106 @@ class Node(object):
                       text=text)
 
 
-class Cluster(object):
+class AWSNode(BaseNode):
 
     """
-    Cluster of Node objects, started on Amazon EC2.
+    Wraps EC2.Instance, so that we can also control the instance through SSH.
     """
 
-    def __init__(self, ec2_ami_id, ec2_subnet_id, ec2_security_group_ids,
-                 service, credentials, cluster_uuid=None,
-                 ec2_instance_type='c4.xlarge', ec2_ami_username='root',
-                 ec2_user_data='', ec2_block_device_mappings=None,
-                 cluster_prefix='cluster',
+    def __init__(self, ec2_instance, ec2_service, credentials,
+                 node_prefix='node', node_index=1, ami_username='root',
+                 base_logdir=None):
+        name = '%s-%s' % (node_prefix, node_index)
+        self._instance = ec2_instance
+        self._ec2 = ec2_service
+        self._instance_wait_safe(self._instance.wait_until_running)
+        self._wait_public_ip()
+        self._ec2.create_tags(Resources=[self._instance.id],
+                              Tags=[{'Key': 'Name', 'Value': name}])
+        # Make the instance created to be immune to Tzach's killer script
+        self._ec2.create_tags(Resources=[self._instance.id],
+                              Tags=[{'Key': 'keep', 'Value': 'alive'}])
+        ssh_login_info = {'hostname': self._instance.public_ip_address,
+                          'user': ami_username,
+                          'key_file': credentials.key_file}
+        super(AWSNode, self).__init__(name=name,
+                                      ssh_login_info=ssh_login_info,
+                                      base_logdir=base_logdir)
+
+    @property
+    def public_ip_address(self):
+        return self._instance.public_ip_address
+
+    @property
+    def private_ip_address(self):
+        return self._instance.private_ip_address
+
+    def _instance_wait_safe(self, instance_method):
+        """
+        Wrapper around AWS instance waiters that is safer to use.
+
+        Since AWS adopts an eventual consistency model, sometimes the method
+        wait_until_running will raise a botocore.exceptions.WaiterError saying
+        the instance does not exist. AWS API guide [1] recommends that the
+        procedure is retried using an exponencial backoff algorithm [2].
+
+        :see: [1] http://docs.aws.amazon.com/AWSEC2/latest/APIReference/query-api-troubleshooting.html#eventual-consistency
+        :see: [2] http://docs.aws.amazon.com/general/latest/gr/api-retries.html
+        """
+        threshold = 300
+        ok = False
+        retries = 0
+        max_retries = 9
+        while not ok and retries <= max_retries:
+            try:
+                instance_method()
+                ok = True
+            except WaiterError:
+                time.sleep(max((2 ** retries) * 2, threshold))
+                retries += 1
+
+        if not ok:
+            raise NodeError('AWS instance %s waiter error after '
+                            'exponencial backoff wait' % self._instance.id)
+
+    def _wait_public_ip(self):
+        while self._instance.public_ip_address is None:
+            time.sleep(1)
+            self._instance.reload()
+
+    def restart(self):
+        self._instance.stop()
+        self._instance_wait_safe(self._instance.wait_until_stopped)
+        self._instance.start()
+        self._instance_wait_safe(self._instance.wait_until_running)
+        self._wait_public_ip()
+        self.log.debug('Got new public IP %s',
+                       self._instance.public_ip_address)
+        self.remoter.hostname = self._instance.public_ip_address
+        self.wait_db_up()
+
+    def destroy(self):
+        self._instance.terminate()
+        global EC2_INSTANCES
+        EC2_INSTANCES.remove(self._instance)
+        self.log.info('Destroyed')
+
+
+class BaseCluster(object):
+
+    """
+    Cluster of Node objects.
+    """
+
+    def __init__(self, cluster_uuid=None, cluster_prefix='cluster',
                  node_prefix='node', n_nodes=10, params=None):
-        global CREDENTIALS
-        CREDENTIALS.append(credentials)
-
-        self.ec2_ami_id = ec2_ami_id
-        self.ec2_subnet_id = ec2_subnet_id
-        self.ec2_security_group_ids = ec2_security_group_ids
-        self.ec2 = service
-        self.credentials = credentials
-        self.ec2_instance_type = ec2_instance_type
-        self.ec2_ami_username = ec2_ami_username
-        if ec2_block_device_mappings is None:
-            ec2_block_device_mappings = []
-        self.ec2_block_device_mappings = ec2_block_device_mappings
-        self.ec2_user_data = ec2_user_data
-        self.node_prefix = node_prefix
-        self.ec2_ami_id = ec2_ami_id
         if cluster_uuid is None:
             self.uuid = uuid.uuid4()
         else:
             self.uuid = cluster_uuid
         self.shortid = str(self.uuid)[:8]
         self.name = '%s-%s' % (cluster_prefix, self.shortid)
+        self.node_prefix = '%s-%s' % (node_prefix, self.shortid)
         # I wanted to avoid some parameter passing
         # from the tester class to the cluster test.
         assert 'AVOCADO_TEST_LOGDIR' in os.environ
@@ -526,22 +546,75 @@ class Cluster(object):
             node.get_backtraces()
 
     def add_nodes(self, count, ec2_user_data=''):
+        pass
+
+    def get_node_private_ips(self):
+        return [node.private_ip_address for node in self.nodes]
+
+    def get_node_public_ips(self):
+        return [node.public_ip_address for node in self.nodes]
+
+    def destroy(self):
+        self.log.info('Destroy nodes')
+        for node in self.nodes:
+            node.destroy()
+
+
+class AWSCluster(BaseCluster):
+
+    """
+    Cluster of Node objects, started on Amazon EC2.
+    """
+
+    def __init__(self, ec2_ami_id, ec2_subnet_id, ec2_security_group_ids,
+                 service, credentials, cluster_uuid=None,
+                 ec2_instance_type='c4.xlarge', ec2_ami_username='root',
+                 ec2_user_data='', ec2_block_device_mappings=None,
+                 cluster_prefix='cluster',
+                 node_prefix='node', n_nodes=10, params=None):
+        global CREDENTIALS
+        CREDENTIALS.append(credentials)
+
+        self._ec2_ami_id = ec2_ami_id
+        self._ec2_subnet_id = ec2_subnet_id
+        self._ec2_security_group_ids = ec2_security_group_ids
+        self._ec2 = service
+        self._credentials = credentials
+        self._ec2_instance_type = ec2_instance_type
+        self._ec2_ami_username = ec2_ami_username
+        if ec2_block_device_mappings is None:
+            ec2_block_device_mappings = []
+        self._ec2_block_device_mappings = ec2_block_device_mappings
+        self._ec2_user_data = ec2_user_data
+        self._ec2_ami_id = ec2_ami_id
+        super(AWSCluster, self).__init__(cluster_uuid=cluster_uuid,
+                                         cluster_prefix=cluster_prefix,
+                                         node_prefix=node_prefix,
+                                         n_nodes=n_nodes,
+                                         params=params)
+
+    def __str__(self):
+        return 'Cluster %s (AMI: %s Type: %s)' % (self.name,
+                                                  self._ec2_ami_id,
+                                                  self._ec2_instance_type)
+
+    def add_nodes(self, count, ec2_user_data=''):
         if not ec2_user_data:
-            ec2_user_data = self.ec2_user_data
+            ec2_user_data = self._ec2_user_data
         global EC2_INSTANCES
         self.log.debug("Passing user_data '%s' to create_instances",
                        ec2_user_data)
-        instances = self.ec2.create_instances(ImageId=self.ec2_ami_id,
-                                              UserData=ec2_user_data,
-                                              MinCount=count,
-                                              MaxCount=count,
-                                              KeyName=self.credentials.key_pair.name,
-                                              SecurityGroupIds=self.ec2_security_group_ids,
-                                              BlockDeviceMappings=self.ec2_block_device_mappings,
-                                              SubnetId=self.ec2_subnet_id,
-                                              InstanceType=self.ec2_instance_type)
+        instances = self._ec2.create_instances(ImageId=self._ec2_ami_id,
+                                               UserData=ec2_user_data,
+                                               MinCount=count,
+                                               MaxCount=count,
+                                               KeyName=self._credentials.key_pair.name,
+                                               SecurityGroupIds=self._ec2_security_group_ids,
+                                               BlockDeviceMappings=self._ec2_block_device_mappings,
+                                               SubnetId=self._ec2_subnet_id,
+                                               InstanceType=self._ec2_instance_type)
         EC2_INSTANCES += instances
-        added_nodes = [self._create_node(instance, self.ec2_ami_username,
+        added_nodes = [self._create_node(instance, self._ec2_ami_username,
                                          self.node_prefix, node_index,
                                          self.logdir)
                        for node_index, instance in
@@ -549,33 +622,16 @@ class Cluster(object):
         self.nodes += added_nodes
         return added_nodes
 
-    def __str__(self):
-        return 'Cluster %s (AMI: %s Type: %s)' % (self.name,
-                                                  self.ec2_ami_id,
-                                                  self.ec2_instance_type)
-
     def _create_node(self, instance, ami_username, node_prefix, node_index,
                      base_logdir):
-        node_prefix = '%s-%s' % (node_prefix, self.shortid)
-        return Node(ec2_instance=instance, ec2_service=self.ec2,
-                    credentials=self.credentials, ami_username=ami_username,
-                    node_prefix=node_prefix, node_index=node_index,
-                    base_logdir=base_logdir)
-
-    def get_node_private_ips(self):
-        return [node.instance.private_ip_address for node in self.nodes]
-
-    def get_node_public_ips(self):
-        return [node.instance.public_ip_address for node in self.nodes]
-
-    def destroy(self):
-        self.log.info('Destroy nodes')
-        for node in self.nodes:
-            node.destroy()
+        return AWSNode(ec2_instance=instance, ec2_service=self._ec2,
+                       credentials=self._credentials, ami_username=ami_username,
+                       node_prefix=node_prefix, node_index=node_index,
+                       base_logdir=base_logdir)
 
     def cfstat_reached_threshold(self, key, threshold):
         """
-        Find whether a certain cfstat key in all nodes reached a certain threshold value.
+        Find whether a certain cfstat key in all nodes reached a certain value.
 
         :param key: cfstat key, example, 'Space used (total)'.
         :param threshold: threshold value for cfstats key. Example, 2432043080.
@@ -601,7 +657,7 @@ class Cluster(object):
         self.wait_cfstat_reached_threshold('Space used (total)', size)
 
 
-class ScyllaCluster(Cluster):
+class ScyllaAWSCluster(AWSCluster):
 
     def __init__(self, ec2_ami_id, ec2_subnet_id, ec2_security_group_ids,
                  service, credentials, ec2_instance_type='c4.xlarge',
@@ -618,20 +674,20 @@ class ScyllaCluster(Cluster):
         name = '%s-%s' % (cluster_prefix, shortid)
         user_data = ('--clustername %s '
                      '--totalnodes %s' % (name, n_nodes))
-        super(ScyllaCluster, self).__init__(ec2_ami_id=ec2_ami_id,
-                                            ec2_subnet_id=ec2_subnet_id,
-                                            ec2_security_group_ids=ec2_security_group_ids,
-                                            ec2_instance_type=ec2_instance_type,
-                                            ec2_ami_username=ec2_ami_username,
-                                            ec2_user_data=user_data,
-                                            ec2_block_device_mappings=ec2_block_device_mappings,
-                                            cluster_uuid=cluster_uuid,
-                                            service=service,
-                                            credentials=credentials,
-                                            cluster_prefix=cluster_prefix,
-                                            node_prefix=node_prefix,
-                                            n_nodes=n_nodes,
-                                            params=params)
+        super(ScyllaAWSCluster, self).__init__(ec2_ami_id=ec2_ami_id,
+                                               ec2_subnet_id=ec2_subnet_id,
+                                               ec2_security_group_ids=ec2_security_group_ids,
+                                               ec2_instance_type=ec2_instance_type,
+                                               ec2_ami_username=ec2_ami_username,
+                                               ec2_user_data=user_data,
+                                               ec2_block_device_mappings=ec2_block_device_mappings,
+                                               cluster_uuid=cluster_uuid,
+                                               service=service,
+                                               credentials=credentials,
+                                               cluster_prefix=cluster_prefix,
+                                               node_prefix=node_prefix,
+                                               n_nodes=n_nodes,
+                                               params=params)
         self.nemesis = []
         self.nemesis_threads = []
         self.termination_event = threading.Event()
@@ -657,7 +713,7 @@ class ScyllaCluster(Cluster):
         seed_nodes_private_ips = self.get_seed_nodes_private_ips()
         seed_nodes = []
         for node in self.nodes:
-            if node.instance.private_ip_address in seed_nodes_private_ips:
+            if node.private_ip_address in seed_nodes_private_ips:
                 node.is_seed = True
                 seed_nodes.append(node)
             else:
@@ -667,15 +723,15 @@ class ScyllaCluster(Cluster):
     def add_nodes(self, count, ec2_user_data=''):
         if not ec2_user_data:
             if self.nodes:
-                node_private_ips = [node.instance.private_ip_address for node
+                node_private_ips = [node.private_ip_address for node
                                     in self.nodes if node.is_seed]
                 seeds = ",".join(node_private_ips)
                 ec2_user_data = ('--clustername %s --bootstrap true '
                                  '--totalnodes %s --seeds %s' % (self.name,
                                                                  count,
                                                                  seeds))
-        added_nodes = super(ScyllaCluster, self).add_nodes(count=count,
-                                                           ec2_user_data=ec2_user_data)
+        added_nodes = super(ScyllaAWSCluster, self).add_nodes(count=count,
+                                                              ec2_user_data=ec2_user_data)
         return added_nodes
 
     def get_node_info_list(self, verification_node):
@@ -768,7 +824,7 @@ class ScyllaCluster(Cluster):
 
     def destroy(self):
         self.stop_nemesis()
-        super(ScyllaCluster, self).destroy()
+        super(ScyllaAWSCluster, self).destroy()
 
     def update_db_binary(self, node_list=None):
         if node_list is None:
@@ -797,7 +853,7 @@ class ScyllaCluster(Cluster):
                 node.wait_db_up()
 
 
-class CassandraCluster(ScyllaCluster):
+class CassandraAWSCluster(ScyllaAWSCluster):
 
     def __init__(self, ec2_ami_id, ec2_subnet_id, ec2_security_group_ids,
                  service, credentials, ec2_instance_type='c4.xlarge',
@@ -819,20 +875,20 @@ class CassandraCluster(ScyllaCluster):
                      '--totalnodes %s --version community '
                      '--release 2.1.8' % (name, n_nodes))
 
-        super(ScyllaCluster, self).__init__(ec2_ami_id=ec2_ami_id,
-                                            ec2_subnet_id=ec2_subnet_id,
-                                            ec2_security_group_ids=ec2_security_group_ids,
-                                            ec2_instance_type=ec2_instance_type,
-                                            ec2_ami_username=ec2_ami_username,
-                                            ec2_user_data=user_data,
-                                            ec2_block_device_mappings=ec2_block_device_mappings,
-                                            cluster_uuid=cluster_uuid,
-                                            service=service,
-                                            credentials=credentials,
-                                            cluster_prefix=cluster_prefix,
-                                            node_prefix=node_prefix,
-                                            n_nodes=n_nodes,
-                                            params=params)
+        super(ScyllaAWSCluster, self).__init__(ec2_ami_id=ec2_ami_id,
+                                               ec2_subnet_id=ec2_subnet_id,
+                                               ec2_security_group_ids=ec2_security_group_ids,
+                                               ec2_instance_type=ec2_instance_type,
+                                               ec2_ami_username=ec2_ami_username,
+                                               ec2_user_data=user_data,
+                                               ec2_block_device_mappings=ec2_block_device_mappings,
+                                               cluster_uuid=cluster_uuid,
+                                               service=service,
+                                               credentials=credentials,
+                                               cluster_prefix=cluster_prefix,
+                                               node_prefix=node_prefix,
+                                               n_nodes=n_nodes,
+                                               params=params)
         self.nemesis = []
         self.nemesis_threads = []
         self.termination_event = threading.Event()
@@ -860,8 +916,8 @@ class CassandraCluster(ScyllaCluster):
                                  '--release 2.1.8' % (self.name,
                                                       count,
                                                       seeds))
-        added_nodes = super(ScyllaCluster, self).add_nodes(count=count,
-                                                           ec2_user_data=ec2_user_data)
+        added_nodes = super(ScyllaAWSCluster, self).add_nodes(count=count,
+                                                              ec2_user_data=ec2_user_data)
         return added_nodes
 
     def wait_for_init(self, node_list=None, verbose=False):
@@ -900,7 +956,7 @@ class CassandraCluster(ScyllaCluster):
         self.log.debug('Setup duration -> %s s', int(time_elapsed))
 
 
-class LoaderSet(Cluster):
+class LoaderSetAWS(AWSCluster):
 
     def __init__(self, ec2_ami_id, ec2_subnet_id, ec2_security_group_ids,
                  service, credentials, ec2_instance_type='c4.xlarge',
@@ -909,19 +965,19 @@ class LoaderSet(Cluster):
                  user_prefix=None, n_nodes=10, params=None):
         node_prefix = _prepend_user_prefix(user_prefix, 'scylla-loader-node')
         cluster_prefix = _prepend_user_prefix(user_prefix, 'scylla-loader-set')
-        super(LoaderSet, self).__init__(ec2_ami_id=ec2_ami_id,
-                                        ec2_subnet_id=ec2_subnet_id,
-                                        ec2_security_group_ids=ec2_security_group_ids,
-                                        ec2_instance_type=ec2_instance_type,
-                                        ec2_ami_username=ec2_ami_username,
-                                        ec2_user_data='--stop-services',
-                                        service=service,
-                                        ec2_block_device_mappings=ec2_block_device_mappings,
-                                        credentials=credentials,
-                                        cluster_prefix=cluster_prefix,
-                                        node_prefix=node_prefix,
-                                        n_nodes=n_nodes,
-                                        params=params)
+        super(LoaderSetAWS, self).__init__(ec2_ami_id=ec2_ami_id,
+                                           ec2_subnet_id=ec2_subnet_id,
+                                           ec2_security_group_ids=ec2_security_group_ids,
+                                           ec2_instance_type=ec2_instance_type,
+                                           ec2_ami_username=ec2_ami_username,
+                                           ec2_user_data='--stop-services',
+                                           service=service,
+                                           ec2_block_device_mappings=ec2_block_device_mappings,
+                                           credentials=credentials,
+                                           cluster_prefix=cluster_prefix,
+                                           node_prefix=node_prefix,
+                                           n_nodes=n_nodes,
+                                           params=params)
         self.scylla_repo = scylla_repo
 
     def wait_for_init(self, verbose=False):

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1039,8 +1039,14 @@ class ScyllaLibvirtCluster(LibvirtCluster, BaseScyllaCluster):
     def _node_setup(self, node, seed_address):
         yaml_dst_path = os.path.join(tempfile.mkdtemp(prefix='scylla-longevity'),
                                      'scylla.yaml')
+        node.remoter.run('sudo yum remove -y abrt')
+        node.remoter.run('sudo yum update -y')
         node.remoter.run('sudo yum install -y rsync')
         node.remoter.run('sudo yum install -y tcpdump')
+        yum_config_path = '/etc/yum.repos.d/scylla.repo'
+        node.remoter.run('sudo curl %s -o %s' %
+                         (self.params.get('scylla_repo'), yum_config_path))
+        node.remoter.run('sudo yum install -y scylla')
         node.remoter.receive_files(src='/etc/scylla/scylla.yaml',
                                    dst=yaml_dst_path)
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -175,7 +175,7 @@ class Nemesis(object):
 
     def disrupt_nodetool_decommission(self, add_node=True):
         self._set_current_disruption('Decommission %s' % self.target_node)
-        target_node_ip = self.target_node.instance.private_ip_address
+        target_node_ip = self.target_node.private_ip_address
         decommission_cmd = 'nodetool --host localhost decommission'
         result = self._run_nodetool(decommission_cmd, self.target_node)
         if result is not None:

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -268,6 +268,13 @@ def log_time_elapsed(method):
     return wrapper
 
 
+class NoOpMonkey(Nemesis):
+
+    @log_time_elapsed
+    def disrupt(self):
+        time.sleep(300)
+
+
 class StopStartMonkey(Nemesis):
 
     @log_time_elapsed

--- a/sdcm/remote.py
+++ b/sdcm/remote.py
@@ -273,6 +273,15 @@ class BaseRemote(object):
         logger = logging.getLogger('avocado.test')
         self.log = SDCMAdapter(logger, extra={'prefix': str(self)})
 
+    def ssh_debug_cmd(self):
+        if self.key_file:
+            return "SSH access -> 'ssh -i %s %s@%s'" % (self.key_file,
+                                                        self.user,
+                                                        self.ip)
+        else:
+            return "SSH access -> 'ssh %s@%s'" % (self.user,
+                                                  self.ip)
+
     def __str__(self):
         return 'Remote [%s@%s]' % (self.user, self.hostname)
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -28,10 +28,10 @@ from cassandra.policies import WhiteListRoundRobinPolicy
 
 from . import cluster
 from . import nemesis
-from .cluster import CassandraCluster
-from .cluster import LoaderSet
+from .cluster import CassandraAWSCluster
+from .cluster import LoaderSetAWS
 from .cluster import RemoteCredentials
-from .cluster import ScyllaCluster
+from .cluster import ScyllaAWSCluster
 from .data_path import get_data_path
 
 try:
@@ -169,46 +169,46 @@ class ClusterTester(Test):
                                              user_prefix=user_prefix)
 
         if self.params.get('db_type') == 'scylla':
-            self.db_cluster = ScyllaCluster(ec2_ami_id=self.params.get('ami_id_db_scylla'),
-                                            ec2_ami_username=self.params.get('ami_db_scylla_user'),
-                                            ec2_security_group_ids=[self.params.get('security_group_ids')],
-                                            ec2_subnet_id=self.params.get('subnet_id'),
-                                            ec2_instance_type=dbs_type,
-                                            service=service,
-                                            credentials=self.credentials,
-                                            ec2_block_device_mappings=dbs_block_device_mappings,
-                                            user_prefix=user_prefix,
-                                            n_nodes=n_db_nodes,
-                                            params=self.params)
-        elif self.params.get('db_type') == 'cassandra':
-            self.db_cluster = CassandraCluster(ec2_ami_id=self.params.get('ami_id_db_cassandra'),
-                                               ec2_ami_username=self.params.get('ami_db_cassandra_user'),
+            self.db_cluster = ScyllaAWSCluster(ec2_ami_id=self.params.get('ami_id_db_scylla'),
+                                               ec2_ami_username=self.params.get('ami_db_scylla_user'),
                                                ec2_security_group_ids=[self.params.get('security_group_ids')],
                                                ec2_subnet_id=self.params.get('subnet_id'),
                                                ec2_instance_type=dbs_type,
                                                service=service,
-                                               ec2_block_device_mappings=dbs_block_device_mappings,
                                                credentials=self.credentials,
+                                               ec2_block_device_mappings=dbs_block_device_mappings,
                                                user_prefix=user_prefix,
                                                n_nodes=n_db_nodes,
                                                params=self.params)
+        elif self.params.get('db_type') == 'cassandra':
+            self.db_cluster = CassandraAWSCluster(ec2_ami_id=self.params.get('ami_id_db_cassandra'),
+                                                  ec2_ami_username=self.params.get('ami_db_cassandra_user'),
+                                                  ec2_security_group_ids=[self.params.get('security_group_ids')],
+                                                  ec2_subnet_id=self.params.get('subnet_id'),
+                                                  ec2_instance_type=dbs_type,
+                                                  service=service,
+                                                  ec2_block_device_mappings=dbs_block_device_mappings,
+                                                  credentials=self.credentials,
+                                                  user_prefix=user_prefix,
+                                                  n_nodes=n_db_nodes,
+                                                  params=self.params)
         else:
             self.error('Incorrect parameter db_type: %s' %
                        self.params.get('db_type'))
 
         scylla_repo = get_data_path('scylla.repo')
-        self.loaders = LoaderSet(ec2_ami_id=self.params.get('ami_id_loader'),
-                                 ec2_ami_username=self.params.get('ami_loader_user'),
-                                 ec2_security_group_ids=[self.params.get('security_group_ids')],
-                                 ec2_subnet_id=self.params.get('subnet_id'),
-                                 ec2_instance_type=loaders_type,
-                                 service=service,
-                                 ec2_block_device_mappings=loaders_block_device_mappings,
-                                 credentials=self.credentials,
-                                 scylla_repo=scylla_repo,
-                                 user_prefix=user_prefix,
-                                 n_nodes=n_loader_nodes,
-                                 params=self.params)
+        self.loaders = LoaderSetAWS(ec2_ami_id=self.params.get('ami_id_loader'),
+                                    ec2_ami_username=self.params.get('ami_loader_user'),
+                                    ec2_security_group_ids=[self.params.get('security_group_ids')],
+                                    ec2_subnet_id=self.params.get('subnet_id'),
+                                    ec2_instance_type=loaders_type,
+                                    service=service,
+                                    ec2_block_device_mappings=loaders_block_device_mappings,
+                                    credentials=self.credentials,
+                                    scylla_repo=scylla_repo,
+                                    user_prefix=user_prefix,
+                                    n_nodes=n_loader_nodes,
+                                    params=self.params)
 
     def get_stress_cmd(self, duration=None, threads=None, population_size=None,
                        mode='write'):

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -114,11 +114,14 @@ class ClusterTester(Test):
 
     def __init__(self, methodName='test', name=None, params=None,
                  base_logdir=None, tag=None, job=None, runner_queue=None):
-        super(ClusterTester, self).__init__(methodName=methodName, name=name, params=params,
-                                            base_logdir=base_logdir, tag=tag, job=job,
-                                            runner_queue=runner_queue)
-        self._failure_post_behavior = self.params.get(key='failure_post_behavior', default='destroy')
-        self.log.debug("Behavior on failure/post test is '%s'", self._failure_post_behavior)
+        super(ClusterTester, self).__init__(methodName=methodName, name=name,
+                                            params=params,
+                                            base_logdir=base_logdir, tag=tag,
+                                            job=job, runner_queue=runner_queue)
+        self._failure_post_behavior = self.params.get(key='failure_post_behavior',
+                                                      default='destroy')
+        self.log.debug("Behavior on failure/post test is '%s'",
+                       self._failure_post_behavior)
         cluster.register_cleanup(cleanup=self._failure_post_behavior)
 
     @clean_aws_resources
@@ -144,7 +147,10 @@ class ClusterTester(Test):
         return getattr(nemesis, class_name)
 
     @clean_aws_resources
-    def init_resources(self, n_db_nodes=None, n_loader_nodes=None, dbs_block_device_mappings=None, loaders_block_device_mappings=None, loaders_type=None, dbs_type=None):
+    def init_resources(self, n_db_nodes=None, n_loader_nodes=None,
+                       dbs_block_device_mappings=None,
+                       loaders_block_device_mappings=None,
+                       loaders_type=None, dbs_type=None):
         if n_db_nodes is None:
             n_db_nodes = self.params.get('n_db_nodes')
         if n_db_nodes <= 0:

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -210,30 +210,33 @@ class ClusterTester(Test):
 
     def get_cluster_libvirt(self, loader_info, db_info):
 
-        def _set_from_params(dict_key, params_key):
-            conf_dict = dict()
-            conf_dict[dict_key] = self.params.get(params_key)
-            return conf_dict
+        def _set_from_params(base_dict, dict_key, params_key):
+            if base_dict.get(dict_key) is None:
+                conf_dict = dict()
+                conf_dict[dict_key] = self.params.get(params_key)
+                return conf_dict
+            else:
+                return {}
 
-        loader_info.update(_set_from_params('n_nodes', 'n_loaders'))
-        loader_info.update(_set_from_params('image', 'libvirt_loader_image'))
-        loader_info.update(_set_from_params('user', 'libvirt_loader_image_user'))
-        loader_info.update(_set_from_params('password', 'libvirt_loader_image_password'))
-        loader_info.update(_set_from_params('os_type', 'libvirt_loader_os_type'))
-        loader_info.update(_set_from_params('os_variant', 'libvirt_loader_os_variant'))
-        loader_info.update(_set_from_params('memory', 'libvirt_loader_memory'))
-        loader_info.update(_set_from_params('bridge', 'libvirt_bridge'))
-        loader_info.update(_set_from_params('uri', 'libvirt_uri'))
+        loader_info.update(_set_from_params(loader_info, 'n_nodes', 'n_loaders'))
+        loader_info.update(_set_from_params(loader_info, 'image', 'libvirt_loader_image'))
+        loader_info.update(_set_from_params(loader_info, 'user', 'libvirt_loader_image_user'))
+        loader_info.update(_set_from_params(loader_info, 'password', 'libvirt_loader_image_password'))
+        loader_info.update(_set_from_params(loader_info, 'os_type', 'libvirt_loader_os_type'))
+        loader_info.update(_set_from_params(loader_info, 'os_variant', 'libvirt_loader_os_variant'))
+        loader_info.update(_set_from_params(loader_info, 'memory', 'libvirt_loader_memory'))
+        loader_info.update(_set_from_params(loader_info, 'bridge', 'libvirt_bridge'))
+        loader_info.update(_set_from_params(loader_info, 'uri', 'libvirt_uri'))
 
-        db_info.update(_set_from_params('n_nodes', 'n_db_nodes'))
-        db_info.update(_set_from_params('image', 'libvirt_db_image'))
-        db_info.update(_set_from_params('user', 'libvirt_db_image_user'))
-        db_info.update(_set_from_params('password', 'libvirt_db_image_password'))
-        db_info.update(_set_from_params('os_type', 'libvirt_db_os_type'))
-        db_info.update(_set_from_params('os_variant', 'libvirt_db_os_variant'))
-        db_info.update(_set_from_params('memory', 'libvirt_db_memory'))
-        db_info.update(_set_from_params('bridge', 'libvirt_bridge'))
-        db_info.update(_set_from_params('uri', 'libvirt_uri'))
+        db_info.update(_set_from_params(db_info, 'n_nodes', 'n_db_nodes'))
+        db_info.update(_set_from_params(db_info, 'image', 'libvirt_db_image'))
+        db_info.update(_set_from_params(db_info, 'user', 'libvirt_db_image_user'))
+        db_info.update(_set_from_params(db_info, 'password', 'libvirt_db_image_password'))
+        db_info.update(_set_from_params(db_info, 'os_type', 'libvirt_db_os_type'))
+        db_info.update(_set_from_params(db_info, 'os_variant', 'libvirt_db_os_variant'))
+        db_info.update(_set_from_params(db_info, 'memory', 'libvirt_db_memory'))
+        db_info.update(_set_from_params(db_info, 'bridge', 'libvirt_bridge'))
+        db_info.update(_set_from_params(db_info, 'uri', 'libvirt_uri'))
 
         user_prefix = self.params.get('user_prefix', None)
 
@@ -344,7 +347,7 @@ class ClusterTester(Test):
     def _create_session(self, node, keyspace, user, password, compression,
                         protocol_version, load_balancing_policy=None,
                         port=None, ssl_opts=None):
-        node_ips = [node.instance.public_ip_address]
+        node_ips = [node.public_ip_address]
         if not port:
             port = 9042
 
@@ -393,7 +396,7 @@ class ClusterTester(Test):
                                  protocol_version=None, port=None,
                                  ssl_opts=None):
 
-        wlrr = WhiteListRoundRobinPolicy([node.instance.public_ip_address])
+        wlrr = WhiteListRoundRobinPolicy([node.public_ip_address])
         return self._create_session(node, keyspace, user, password,
                                     compression, protocol_version, wlrr,
                                     port=port, ssl_opts=ssl_opts)

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -146,27 +146,15 @@ class ClusterTester(Test):
         class_name = self.params.get('nemesis_class_name')
         return getattr(nemesis, class_name)
 
-    @clean_aws_resources
-    def init_resources(self, n_db_nodes=None, n_loader_nodes=None,
-                       dbs_block_device_mappings=None,
-                       loaders_block_device_mappings=None,
-                       loaders_type=None, dbs_type=None):
-        if n_db_nodes is None:
-            n_db_nodes = self.params.get('n_db_nodes')
-        if n_db_nodes <= 0:
-            self.error('Invalid parameter n_db_nodes: %s,'
-                       ' it should be larger than zero.' % n_db_nodes)
-
-        if n_loader_nodes is None:
-            n_loader_nodes = self.params.get('n_loaders')
-        if n_loader_nodes <= 0:
-            self.error('Invalid parameter n_loader_nodes/n_loaders: %s,'
-                       ' it should be larger than zero.' % n_loader_nodes)
-
-        if loaders_type is None:
-            loaders_type = self.params.get('instance_type_loader')
-        if dbs_type is None:
-            dbs_type = self.params.get('instance_type_db')
+    def get_cluster_aws(self, loader_info, db_info):
+        if loader_info['n_nodes'] is None:
+            loader_info['n_nodes'] = self.params.get('n_loaders')
+        if loader_info['type'] is None:
+            loader_info['type'] = self.params.get('instance_type_loader')
+        if db_info['n_nodes'] is None:
+            db_info['n_nodes'] = self.params.get('n_db_nodes')
+        if db_info['type'] is None is None:
+            db_info['type'] = self.params.get('instance_type_db')
         user_prefix = self.params.get('user_prefix', None)
         session = boto3.session.Session(region_name=self.params.get('region_name'))
         service = session.resource('ec2')
@@ -179,24 +167,24 @@ class ClusterTester(Test):
                                                ec2_ami_username=self.params.get('ami_db_scylla_user'),
                                                ec2_security_group_ids=[self.params.get('security_group_ids')],
                                                ec2_subnet_id=self.params.get('subnet_id'),
-                                               ec2_instance_type=dbs_type,
+                                               ec2_instance_type=db_info['type'],
                                                service=service,
                                                credentials=self.credentials,
-                                               ec2_block_device_mappings=dbs_block_device_mappings,
+                                               ec2_block_device_mappings=db_info['device_mappings'],
                                                user_prefix=user_prefix,
-                                               n_nodes=n_db_nodes,
+                                               n_nodes=db_info['n_nodes'],
                                                params=self.params)
         elif self.params.get('db_type') == 'cassandra':
             self.db_cluster = CassandraAWSCluster(ec2_ami_id=self.params.get('ami_id_db_cassandra'),
                                                   ec2_ami_username=self.params.get('ami_db_cassandra_user'),
                                                   ec2_security_group_ids=[self.params.get('security_group_ids')],
                                                   ec2_subnet_id=self.params.get('subnet_id'),
-                                                  ec2_instance_type=dbs_type,
+                                                  ec2_instance_type=db_info['type'],
                                                   service=service,
-                                                  ec2_block_device_mappings=dbs_block_device_mappings,
+                                                  ec2_block_device_mappings=db_info['device_mappings'],
                                                   credentials=self.credentials,
                                                   user_prefix=user_prefix,
-                                                  n_nodes=n_db_nodes,
+                                                  n_nodes=db_info['n_nodes'],
                                                   params=self.params)
         else:
             self.error('Incorrect parameter db_type: %s' %
@@ -207,14 +195,30 @@ class ClusterTester(Test):
                                     ec2_ami_username=self.params.get('ami_loader_user'),
                                     ec2_security_group_ids=[self.params.get('security_group_ids')],
                                     ec2_subnet_id=self.params.get('subnet_id'),
-                                    ec2_instance_type=loaders_type,
+                                    ec2_instance_type=loader_info['type'],
                                     service=service,
-                                    ec2_block_device_mappings=loaders_block_device_mappings,
+                                    ec2_block_device_mappings=loader_info['device_mappings'],
                                     credentials=self.credentials,
                                     scylla_repo=scylla_repo,
                                     user_prefix=user_prefix,
-                                    n_nodes=n_loader_nodes,
+                                    n_nodes=loader_info['n_nodes'],
                                     params=self.params)
+
+    def get_cluster_libvirt(self, loader_info, db_info):
+        raise NotImplementedError('Yet to be implemented')
+
+    @clean_aws_resources
+    def init_resources(self, loader_info=None, db_info=None):
+        if loader_info is None:
+            loader_info = {'n_nodes': None, 'type': None,
+                           'device_mappings': None}
+        if db_info is None:
+            db_info = {'n_nodes': None, 'type': None,
+                       'device_mappings': None}
+        if self.params.get('cluster_backend') == 'aws':
+            self.get_cluster_aws(loader_info=loader_info, db_info=db_info)
+        elif self.params.get('cluster_backend') == 'libvirt':
+            self.get_cluster_libvirt(loader_info=loader_info, db_info=db_info)
 
     def get_stress_cmd(self, duration=None, threads=None, population_size=None,
                        mode='write'):


### PR DESCRIPTION
Make it possible for the cluster suite to run using libvirt VMs. This introduces the new classes and a new feature for sdcm.remote to simply install the user's ssh key into the generated vms.