### PR TITLE
sdcm.tester: Parametrize cassandra-stress rate limit

### DIFF
--- a/data_dir/scylla.yaml
+++ b/data_dir/scylla.yaml
@@ -4,6 +4,9 @@ cassandra_stress_duration: 60
 cassandra_stress_threads: 1000
 # default cassandra stress population size if none specified
 cassandra_stress_population_size: 10000000
+# default rate limit if none specified
+#cassandra_stress_limits: 5000/s
+# Number of database nodes
 n_db_nodes: 6
 # If you want to use more than 1 loader node, I recommend
 # increasing the size of the DB instance (instance_type_db parameter),

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -278,7 +278,7 @@ class ClusterTester(Test):
             self.get_cluster_libvirt(loader_info=loader_info, db_info=db_info)
 
     def get_stress_cmd(self, duration=None, threads=None, population_size=None,
-                       mode='write'):
+                       mode='write', limit=None):
         """
         Get a cassandra stress cmd string.
 
@@ -290,6 +290,7 @@ class ClusterTester(Test):
         :param threads: Number of threads used by cassandra stress.
         :param population_size: Size of the -pop seq1..%s argument.
         :param mode: stress mode, write/read/mixed/ect
+        :param limit: rate limit used by cassandra stress.
         :return: Cassandra stress string
         :rtype: basestring
         """
@@ -300,11 +301,17 @@ class ClusterTester(Test):
             duration = self.params.get('cassandra_stress_duration')
         if threads is None:
             threads = self.params.get('cassandra_stress_threads')
+        if limit is not None:
+            limit = "limit=%s" % limit
+        elif self.params.get('cassandra_stress_limits'):
+            limit = "limit=%s" % self.params.get('cassandra_stress_limits')
+        else:
+            limit = ""
         return ("cassandra-stress %s cl=QUORUM duration=%sm "
                 "-schema 'replication(factor=3)' -port jmx=6868 "
-                "-mode cql3 native -rate threads=%s "
+                "-mode cql3 native -rate threads=%s %s "
                 "-pop seq=1..%s -node %s" %
-                (mode, duration, threads, population_size, ip))
+                (mode, duration, threads, limit, population_size, ip))
 
     @clean_aws_resources
     def run_stress(self, stress_cmd=None, duration=None, mode='write'):


### PR DESCRIPTION
Allow users to specify rate limits in the suite configuration file.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>