### PR TITLE
sdcm.tester: Use cassandra-stress default population size from config

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -296,7 +296,7 @@ class ClusterTester(Test):
         """
         ip = self.db_cluster.get_node_private_ips()[0]
         if population_size is None:
-            population_size = 10000000
+            population_size = self.params.get('cassandra_stress_population_size')
         if duration is None:
             duration = self.params.get('cassandra_stress_duration')
         if threads is None:


### PR DESCRIPTION
Instead of hardcoding that value.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>