### PR TITLE
sdcm.tester: Remove extra is None condition

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -157,7 +157,7 @@ class ClusterTester(Test):
             loader_info['type'] = self.params.get('instance_type_loader')
         if db_info['n_nodes'] is None:
             db_info['n_nodes'] = self.params.get('n_db_nodes')
-        if db_info['type'] is None is None:
+        if db_info['type'] is None:
             db_info['type'] = self.params.get('instance_type_db')
         user_prefix = self.params.get('user_prefix', None)
         session = boto3.session.Session(region_name=self.params.get('region_name'))


### PR DESCRIPTION
Although the second is None condition is valid python,
the entire expression will always evaluate to False and
was a mistake made during a rebase of one particular
Pull Request. Let's remove the extra condition.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>