### PR TITLE
Rename simple_regression_test.py -> performance_regression_test.py

### DIFF
--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -19,7 +19,7 @@ from avocado import main
 from sdcm.tester import ClusterTester
 
 
-class SimpleRegressionTest(ClusterTester):
+class PerformanceRegressionTest(ClusterTester):
 
     """
     Test Scylla performance regression with cassandra-stress.


### PR DESCRIPTION
The original name, simple_regression_test.py is not very
informative, as it can mean just about everything. Let's
use performance_regression_test.py, to at least hint at
the fact that we are testing for regressions in performance
(even if one can argue that 'performance' is a pretty broad
term in itself).

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>