### PR TITLE
grow/reduce_cluster_test.py: Update get_stress_cmd parameters

### DIFF
--- a/grow_cluster_test.py
+++ b/grow_cluster_test.py
@@ -46,6 +46,7 @@ class GrowClusterTest(ClusterTester):
         self.credentials = None
         self.db_cluster = None
         self.loaders = None
+        self.monitors = None
         logging.getLogger('botocore').setLevel(logging.CRITICAL)
         logging.getLogger('boto3').setLevel(logging.CRITICAL)
         # We're starting the cluster with 3 nodes due to
@@ -66,7 +67,8 @@ class GrowClusterTest(ClusterTester):
         self.monitors.wait_for_init(targets=nodes_monitored)
         self.stress_thread = None
 
-    def get_stress_cmd(self, duration=None, threads=None, population_size=None):
+    def get_stress_cmd(self, duration=None, threads=None, population_size=None,
+                       mode='write', limit=None, row_size=None):
         """
         Get a cassandra stress cmd string suitable for grow cluster purposes.
 

--- a/reduce_cluster_test.py
+++ b/reduce_cluster_test.py
@@ -43,6 +43,7 @@ class ReduceClusterTest(ClusterTester):
         self.credentials = None
         self.db_cluster = None
         self.loaders = None
+        self.monitors = None
         logging.getLogger('botocore').setLevel(logging.CRITICAL)
         logging.getLogger('boto3').setLevel(logging.CRITICAL)
         self.stress_thread = None
@@ -65,7 +66,8 @@ class ReduceClusterTest(ClusterTester):
         nodes_monitored = [node.public_ip_address for node in self.db_cluster.nodes]
         self.monitors.wait_for_init(targets=nodes_monitored)
 
-    def get_stress_cmd(self, duration=None, threads=None, population_size=None):
+    def get_stress_cmd(self, duration=None, threads=None, population_size=None,
+                       mode='write', limit=None, row_size=None):
         """
         Get a cassandra stress cmd string suitable for reduce cluster purposes.
 


### PR DESCRIPTION
Since the introduction of new parameters to that method,
the grow/reduce_cluster_test.py implementation lagged behind.
Let's fix this.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>