### PR TITLE
Improve upgrade test and add rollback support

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1033,6 +1033,9 @@ class BaseScyllaCluster(object):
         self.nemesis.append(nemesis(cluster=self,
                                     termination_event=self.termination_event))
 
+    def clean_nemesis(self):
+        self.nemesis = []
+
     def start_nemesis(self, interval=30):
         self.log.debug('Start nemesis begin')
         self.termination_event = threading.Event()

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -321,10 +321,14 @@ class UpgradeNemesis(Nemesis):
         scylla_repo = get_data_path('scylla.repo.upgrade')
         node.remoter.send_files(scylla_repo, '/tmp/scylla.repo', verbose=True)
         node.remoter.run('sudo cp /tmp/scylla.repo /etc/yum.repos.d/scylla.repo')
+        # backup the data
+        node.remoter.run('sudo nodetool snapshot')
         node.remoter.run('sudo chown root.root /etc/yum.repos.d/scylla.repo')
         node.remoter.run('sudo chmod 644 /etc/yum.repos.d/scylla.repo')
         node.remoter.run('sudo yum clean all')
         node.remoter.run('sudo yum update scylla scylla-server scylla-jmx scylla-tools scylla-conf scylla-kernel-conf -y')
+        # flush all memtables to SSTables
+        node.remoter.run('sudo nodetool drain')
         node.remoter.run('sudo systemctl restart scylla-server.service')
         node.wait_db_up(verbose=True)
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -318,6 +318,7 @@ class UpgradeNemesis(Nemesis):
     # upgrade a single node
     def upgrade_node(self, node):
         self.log.info('Upgrading a Node')
+        orig_ver = node.remoter.run('rpm -qa scylla-server')
         scylla_repo = get_data_path('scylla.repo.upgrade')
         node.remoter.send_files(scylla_repo, '/tmp/scylla.repo', verbose=True)
         node.remoter.run('sudo cp /tmp/scylla.repo /etc/yum.repos.d/scylla.repo')
@@ -331,6 +332,9 @@ class UpgradeNemesis(Nemesis):
         node.remoter.run('sudo nodetool drain')
         node.remoter.run('sudo systemctl restart scylla-server.service')
         node.wait_db_up(verbose=True)
+        new_ver = node.remoter.run('rpm -qa scylla-server')
+        if orig_ver == new_ver:
+            self.log.error('scylla-server version isn\'t changed')
 
     @log_time_elapsed
     def disrupt(self):

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -324,7 +324,7 @@ class UpgradeNemesis(Nemesis):
         node.remoter.run('sudo chown root.root /etc/yum.repos.d/scylla.repo')
         node.remoter.run('sudo chmod 644 /etc/yum.repos.d/scylla.repo')
         node.remoter.run('sudo yum clean all')
-        node.remoter.run('sudo yum update scylla scylla-conf scylla-server scylla-jmx scylla-tools -y')
+        node.remoter.run('sudo yum update scylla scylla-server scylla-jmx scylla-tools scylla-conf scylla-kernel-conf -y')
         node.remoter.run('sudo systemctl restart scylla-server.service')
         node.wait_db_up(verbose=True)
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -321,8 +321,10 @@ class UpgradeNemesis(Nemesis):
         orig_ver = node.remoter.run('rpm -qa scylla-server')
         scylla_repo = get_data_path('scylla.repo.upgrade')
         node.remoter.send_files(scylla_repo, '/tmp/scylla.repo', verbose=True)
+        node.remoter.run('sudo cp /etc/yum.repos.d/scylla.repo ~/scylla.repo-backup')
         node.remoter.run('sudo cp /tmp/scylla.repo /etc/yum.repos.d/scylla.repo')
         # backup the data
+        node.remoter.run('sudo cp /etc/scylla/scylla.yaml /etc/scylla/scylla.yaml-backup')
         node.remoter.run('sudo nodetool snapshot')
         node.remoter.run('sudo chown root.root /etc/yum.repos.d/scylla.repo')
         node.remoter.run('sudo chmod 644 /etc/yum.repos.d/scylla.repo')

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -19,6 +19,7 @@ from avocado import main
 from sdcm.tester import ClusterTester
 
 from sdcm.nemesis import UpgradeNemesis
+from sdcm.nemesis import RollbackNemesis
 
 
 class UpgradeTest(ClusterTester):
@@ -36,6 +37,19 @@ class UpgradeTest(ClusterTester):
         Run cassandra-stress on a cluster for 20 minutes, together with node upgrades.
         """
         self.db_cluster.add_nemesis(UpgradeNemesis)
+        self.db_cluster.start_nemesis(interval=10)
+        self.run_stress(duration=20)
+
+    def test_20_minutes_rollback(self):
+        """
+        Run cassandra-stress on a cluster for 20 minutes, together with node upgrades.
+        """
+        self.db_cluster.add_nemesis(UpgradeNemesis)
+        self.db_cluster.start_nemesis(interval=10)
+
+        self.db_cluster.clean_nemesis()
+
+        self.db_cluster.add_nemesis(RollbackNemesis)
         self.db_cluster.start_nemesis(interval=10)
         self.run_stress(duration=20)
 


### PR DESCRIPTION
This pull requests improved existed upgrade test, not just basically upgrade the scylla, but also do some necessary backup and gracefully restart the server. And added a subtest to rollback scylla to original version using backup files.