### PR TITLE
sdcm.nemesis: Fix Travis CI

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -19,8 +19,6 @@ import inspect
 import logging
 import random
 import time
-import threading
-import Queue
 
 from avocado.utils import process
 


### PR DESCRIPTION
Travis pointed out that we forgot to remove the unused imports
in 0536ff4e26686362271125e87e2992fc1ceaea39. This commit fixes
the problem.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>