### PR TITLE
Do not start multiple c-s at the same time

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1113,6 +1113,7 @@ class BaseLoaderSet(object):
                                             args=(loader,))
             setup_thread.daemon = True
             setup_thread.start()
+            time.sleep(30)
 
         return queue
 


### PR DESCRIPTION
To avoid schema management issues - we avoid starting multiple loaders
c-s at the same time and force 30 seconds between them

Signed-off-by: Shlomi Livne <shlomi@scylladb.com>