### PR TITLE
sdcm: Simplify cassandra-stress interface

### DIFF
--- a/big_cluster_test.py
+++ b/big_cluster_test.py
@@ -54,7 +54,7 @@ class HugeClusterTest(ClusterTester):
         """
         Test a huge Scylla cluster
         """
-        self.run_stress(duration=20)
+        self.run_stress(stress_cmd=self.params.get('stress_cmd'), duration=20)
 
 if __name__ == '__main__':
     main()

--- a/data_dir/sct_log_formatter
+++ b/data_dir/sct_log_formatter
@@ -1,0 +1,50 @@
+#!/bin/env python
+
+import os
+import sys
+import json
+import datetime
+
+systemd_logging_level_mapping = {
+    u'0': 'emerg  ',
+    u'1': 'alert  ',
+    u'2': 'crit   ',
+    u'3': 'err    ',
+    u'4': 'warning',
+    u'5': 'notice ',
+    u'6': 'info   ',
+    u'7': 'debug  ',
+}
+
+
+def process_entry(entry):
+    if entry:
+        try:
+            realtime_timestamp = datetime.datetime.fromtimestamp(float(entry['__REALTIME_TIMESTAMP']) / 1E6)
+            message = entry['MESSAGE']
+            formatted_timestamp = realtime_timestamp.strftime('%b %d %H:%M:%S')
+            priority = systemd_logging_level_mapping[entry['PRIORITY']]
+            msg = '%s %s| %s\n' % (formatted_timestamp, priority, message)
+            sys.stdout.write(msg)
+            sys.stdout.flush()
+        except Exception:
+            pass
+
+
+def main():
+    sys.stdout.flush()
+    try:
+        with os.fdopen(sys.stdin.fileno(), 'r', 1) as input:
+            while True:
+                line = sys.stdin.readline()
+                try:
+                    entry = json.loads(line)
+                except Exception:
+                    entry = {}
+                process_entry(entry)
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == '__main__':
+    main()

--- a/data_dir/scylla.yaml
+++ b/data_dir/scylla.yaml
@@ -1,19 +1,9 @@
 # Test duration (min). Parameter used to keep instances produced by tests that
 # are supposed to run longer than 24 hours from being killed
 test_duration: 60
-# default cassandra stress duration (min) if none specified
-cassandra_stress_duration: 60
-# default cassandra stress thread number if none specified
-cassandra_stress_threads: 1000
-# default cassandra stress population size if none specified
-cassandra_stress_population_size: 10000000
-# default cassandra stress columns per row
-#cassandra_column_per_row: 5
-# default cassandra stress row limit. If specified, this will override
-# 'cassandra_stress_duration'
-#cassandra_row_limit: 1000000
-# default rate limit if none specified
-#cassandra_stress_limits: 5000/s
+# cassandra-stress command. You can specify everything but the -node parameter,
+# which is going to be provided by the test suite infrastructure
+stress_cmd: cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000
 # Number of database nodes
 n_db_nodes: 6
 # If you want to use more than 1 loader node, I recommend

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -29,58 +29,12 @@ class LongevityTest(ClusterTester):
 
     default_params = {'timeout': 650000}
 
-    def test_row_limit(self):
-        """
-        Run cassandra-stress with params defined in data_dir/scylla.yaml
-        """
-        self.db_cluster.add_nemesis(self.get_nemesis_class())
-        stress_queue = self.run_stress_thread(row_limit=self.params.get('cassandra_row_limit'),
-                                              population_size=self.params.get('cassandra_stress_population_size'),
-                                              column_per_row=self.params.get('cassandra_column_per_row'))
-        self.db_cluster.wait_total_space_used_per_node()
-        self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
-        self.verify_stress_thread(queue=stress_queue)
-
     def test_custom_time(self):
         """
         Run cassandra-stress with params defined in data_dir/scylla.yaml
         """
         self.db_cluster.add_nemesis(self.get_nemesis_class())
-        stress_queue = self.run_stress_thread(duration=self.params.get('cassandra_stress_duration'),
-                                              population_size=self.params.get('cassandra_stress_population_size'))
-        self.db_cluster.wait_total_space_used_per_node()
-        self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
-        self.verify_stress_thread(queue=stress_queue)
-
-    def test_12_hours(self):
-        """
-        Run cassandra-stress on a cluster for 12 hours.
-        """
-        self.db_cluster.add_nemesis(self.get_nemesis_class())
-        stress_queue = self.run_stress(duration=60 * 12,
-                                       population_size=self.params.get('cassandra_stress_population_size'))
-        self.db_cluster.wait_total_space_used_per_node()
-        self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
-        self.verify_stress_thread(queue=stress_queue)
-
-    def test_1_day(self):
-        """
-        Run cassandra-stress on a cluster for 24 hours.
-        """
-        self.db_cluster.add_nemesis(self.get_nemesis_class())
-        stress_queue = self.run_stress(duration=60 * 24,
-                                       population_size=self.params.get('cassandra_stress_population_size'))
-        self.db_cluster.wait_total_space_used_per_node()
-        self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
-        self.verify_stress_thread(queue=stress_queue)
-
-    def test_1_week(self):
-        """
-        Run cassandra-stress on a cluster for 1 week.
-        """
-        self.db_cluster.add_nemesis(self.get_nemesis_class())
-        stress_queue = self.run_stress(duration=60 * 24 * 7,
-                                       population_size=self.params.get('cassandra_stress_population_size'))
+        stress_queue = self.run_stress_thread(stress_cmd=self.params.get('stress_cmd'))
         self.db_cluster.wait_total_space_used_per_node()
         self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
         self.verify_stress_thread(queue=stress_queue)

--- a/maintenance_test.py
+++ b/maintenance_test.py
@@ -32,7 +32,8 @@ class MaintainanceTest(ClusterTester):
     """
 
     def _base_procedure(self, nemesis_class):
-        stress_queue = self.run_stress_thread(duration=240)
+        stress_queue = self.run_stress_thread(stress_cmd=self.params.get('stress_cmd'),
+                                              duration=240)
         self.db_cluster.wait_total_space_used_per_node()
         self.db_cluster.add_nemesis(nemesis_class)
         # Wait another 10 minutes

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -659,14 +659,11 @@ LoadPlugin processes
 
     def _get_tcpdump_logs(self, tcpdump_id):
         try:
-            log_name = 'tcpdump-%s.log' % tcpdump_id
             pcap_name = 'tcpdump-%s.pcap' % tcpdump_id
-            log_file = os.path.join(self.logdir, log_name)
             pcap_tmp_file = os.path.join('/tmp', pcap_name)
             pcap_file = os.path.join(self.logdir, pcap_name)
-            self.remoter.run('sudo tcpdump -vv -i lo port 10000 -w %s' %
-                             pcap_tmp_file, ignore_status=True,
-                             log_file=log_file)
+            self.remoter.run('sudo tcpdump -vv -i lo port 10000 -w %s > /dev/null 2>&1' %
+                             pcap_tmp_file, ignore_status=True)
             self.remoter.receive_files(src=pcap_tmp_file, dst=pcap_file)
         except Exception as details:
             self.log.error('Error running tcpdump on lo, tcp port 10000: %s',

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -181,7 +181,7 @@ class Nemesis(object):
         drain_cmd = 'nodetool -h localhost drain'
         result = self._run_nodetool(drain_cmd, self.target_node)
         if result is not None:
-            self.target_node.restart()
+            self.target_node.remoter.run('sudo systemctl restart scylla-server.service')
 
     def disrupt_nodetool_decommission(self, add_node=True):
         self._set_current_disruption('Decommission %s' % self.target_node)

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -83,7 +83,7 @@ class Nemesis(object):
         self.log.info('Average duration: %s s', avg_duration)
         self.log.info('Total execution time: %s s', int(time.time() - self.start_time))
         self.log.info('Times executed: %s', len(self.duration_list))
-        self.log.info('Unhandled exceptions: %s', len(self.error_list))
+        self.log.info('Unexpected errors: %s', len(self.error_list))
         self.log.info('Operation log:')
         for operation in self.operation_log:
             self.log.info(operation)
@@ -101,12 +101,15 @@ class Nemesis(object):
                            result.duration)
             return result
         except process.CmdError, details:
-            self.log.error("nodetool command '%s' failed on node %s: %s",
-                           cmd, self.target_node, details.result)
+            err = ("nodetool command '%s' failed on node %s: %s" %
+                   (cmd, self.target_node, details.result))
+            self.error_list.append(err)
+            self.log.error(err)
             return None
         except Exception:
-            self.log.error('Unexpected exception running nodetool',
-                           exc_info=True)
+            err = 'Unexpected exception running nodetool'
+            self.error_list.append(err)
+            self.log.error(err, exc_info=True)
             return None
 
     def _kill_scylla_daemon(self):

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -38,7 +38,7 @@ class UpgradeTest(ClusterTester):
         """
         self.db_cluster.add_nemesis(UpgradeNemesis)
         self.db_cluster.start_nemesis(interval=10)
-        self.run_stress(duration=20)
+        self.run_stress(stress_cmd=self.params.get('stress_cmd'), duration=20)
 
     def test_20_minutes_rollback(self):
         """
@@ -52,7 +52,8 @@ class UpgradeTest(ClusterTester):
 
         self.db_cluster.add_nemesis(RollbackNemesis)
         self.db_cluster.start_nemesis(interval=10)
-        self.run_stress(duration=self.params.get('cassandra_stress_duration', 20))
+        self.run_stress(stress_cmd=self.params.get('stress_cmd'),
+                        duration=self.params.get('cassandra_stress_duration', 20))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Instead of adding another layer of parameters that will
be later translated into a c-s command, that needs to be
constantly updated, let people simply state their c-s
command and let the framework do the rest.

Of course, the -node flag can be safely omitted, since
the address information is dynamic and we can fill that
out without a lot of trouble. In more specialized tests,
the test writer is free to fill -node, and if he/she does
that, we won't fill out -node.

This patch simplifies c-s handling in s-c-t quite a bit,
and makes it working with the suite a lot easier.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>