### PR TITLE
sdcm: Fail tests if certain errors appear in Node logs

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -251,6 +251,8 @@ class BaseNode(object):
 
         self.cs_start_time = None
         self.database_log = os.path.join(self.logdir, 'database.log')
+        self._database_log_errors_index = []
+        self._database_error_patterns = ['std::bad_alloc']
         self.start_journal_thread()
         self.start_backtrace_thread()
 
@@ -704,6 +706,24 @@ LoadPlugin processes
         wait.wait_for(func=self.cs_installed, step=60,
                       text=text)
 
+    def search_database_log(self, expression):
+        matches = []
+        pattern = re.compile(expression, re.IGNORECASE)
+        with open(self.database_log, 'r') as f:
+            for index, line in enumerate(f):
+                if index not in self._database_log_errors_index:
+                    m = pattern.search(line)
+                    if m:
+                        self._database_log_errors_index.append(index)
+                        matches.append((index, line))
+        return matches
+
+    def search_database_log_errors(self):
+        errors = []
+        for expression in self._database_error_patterns:
+            errors += self.search_database_log(expression)
+        return errors
+
 
 class AWSNode(BaseNode):
 
@@ -932,6 +952,14 @@ class BaseCluster(object):
 
     def get_node_public_ips(self):
         return [node.public_ip_address for node in self.nodes]
+
+    def get_node_database_errors(self):
+        errors = []
+        for node in self.nodes:
+            node_errors = node.search_database_log_errors()
+            if node_errors:
+                errors.append({node.name: node_errors})
+        return errors
 
     def destroy(self):
         self.log.info('Destroy nodes')

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -605,6 +605,7 @@ class ClusterTester(Test):
 
     def clean_resources(self):
         self.log.debug('Cleaning up resources used in the test')
+        db_cluster_errors = self.db_cluster.get_node_database_errors()
         db_cluster_coredumps = None
         if self.db_cluster is not None:
             self.db_cluster.get_backtraces()
@@ -645,6 +646,15 @@ class ClusterTester(Test):
         if db_cluster_coredumps:
             self.fail('Found coredumps on DB cluster nodes: %s' %
                       db_cluster_coredumps)
+
+        if db_cluster_errors:
+            self.log.error('Errors found on DB node logs:')
+            for node_errors in db_cluster_errors:
+                for node_name in node_errors:
+                    for (index, line) in node_errors[node_name]:
+                        self.log.error('%s: L%s -> %s',
+                                       node_name, index + 1, line.strip())
+            self.fail('Errors found on DB node logs (see test logs)')
 
     def tearDown(self):
         self.clean_resources()


### PR DESCRIPTION
Search database logs for potential problems, and mark
the test with FAIL status if any problem patterns are
found in any of the database nodes. We are starting with
std::bad_alloc, and plan on adding more patterns as
we learn about any problematic conditions.

Signed-off-by: Lucas Meneghel Rodrigues lmr@scylladb.com
