### PR TITLE
sdcm.nemesis: Do not restart scylla-server after killing scylla

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -117,15 +117,6 @@ class Nemesis(object):
         kill_cmd = "sudo pkill -9 scylla"
         self.target_node.remoter.run(kill_cmd, ignore_status=True)
 
-        # TODO: Due to scylla-server.service changing behavior
-        # now we don't wait the DB to be down
-        # self.target_node.wait_db_down()
-
-        # TODO: Remove scylla-server restart upon systemd service is fixed
-        # https://github.com/scylladb/scylla/issues/904
-        restart_cmd = 'sudo systemctl restart scylla-server.service'
-        self.target_node.remoter.run(restart_cmd)
-
         # Let's wait for the target Node to have their services re-started
         self.target_node.wait_db_up()
 


### PR DESCRIPTION
The scylla systemd process used to not restart on abnormal
termination, see issue:

https://github.com/scylladb/scylla/issues/904

That got fixed with:

https://github.com/scylladb/scylla/commit/1b49c0ce19d22b891f3cd4161cfe2a809ab64c06

Therefore, the workarounds involving manually restarting
scylla are not necessary anymore and should be removed.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>