### PR TITLE
update perf regression test to save results to xml for jenkins

### DIFF
--- a/data_dir/scylla.yaml
+++ b/data_dir/scylla.yaml
@@ -68,6 +68,7 @@ backends: !mux
         instance_type_loader: 'c3.large'
         # Size of AWS monitor instance
         instance_type_monitor: t2.small
+        ami_id_db_scylla_desc: '1.3-dev'
         us_west_1:
             user_credentials_path: ''
             region_name: 'us-west-1'

--- a/data_dir/scylla.yaml
+++ b/data_dir/scylla.yaml
@@ -4,6 +4,8 @@ test_duration: 60
 # cassandra-stress command. You can specify everything but the -node parameter,
 # which is going to be provided by the test suite infrastructure
 stress_cmd: cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000
+# cassandra-stress mode series
+stress_modes: 'write read restart mixed'
 # Number of database nodes
 n_db_nodes: 6
 # If you want to use more than 1 loader node, I recommend

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -44,12 +44,12 @@ class PerformanceRegressionTest(ClusterTester):
   <test name="simple_regression_test" executed="yes">
     <description>"simple regression test"</description>
     <targets>
-      <target threaded="yes">target-%s</target>
-      <ami_id>%s</ami_id>
-      <stress_modes>%s</stress_modes>
+      <target threaded="yes">target-ami_id-%s</target>
+      <target threaded="yes">target-version-%s</target>
+      <target threaded="yes">stress_modes-%s</target>
     </targets>
-    <platform name="scylla_platform">
-      <instance_type_db>%s</instance_type_db>
+    <platform name="AWS platform">
+      <hardware>%s</hardware>
     </platform>
 
     <result>
@@ -69,7 +69,7 @@ class PerformanceRegressionTest(ClusterTester):
   </test>
 </report>
 """ % (self.params.get('ami_id_db_scylla'),
-            self.params.get('ami_id_db_scylla'),
+            self.params.get('ami_id_db_scylla_desc'),
             self.params.get('stress_modes'),
             self.params.get('instance_type_db'),
             result['op rate'],

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -59,7 +59,7 @@ class PerformanceRegressionTest(ClusterTester):
         # run a write workload
         base_cmd = ("cassandra-stress %s cl=QUORUM duration=60m "
                     "-schema 'replication(factor=3)' -port jmx=6868 "
-                    "-mode cql3 native -rate threads=1000 "
+                    "-mode cql3 native -rate threads=1000 -errors ignore "
                     "-pop seq=1..10000000")
         stress_queue = self.run_stress_thread(stress_cmd=base_cmd % 'write')
         write_results = self.get_stress_results(queue=stress_queue)

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -57,7 +57,7 @@ class PerformanceRegressionTest(ClusterTester):
         4. Run a mixed read write workload
         """
         # run a write workload
-        base_cmd = ("cassandra-stress %s cl=QUORUM duration=60m "
+        base_cmd = ("cassandra-stress %s no-warmup cl=QUORUM duration=60m "
                     "-schema 'replication(factor=3)' -port jmx=6868 "
                     "-mode cql3 native -rate threads=1000 -errors ignore "
                     "-pop seq=1..10000000")

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -38,11 +38,12 @@ class PerformanceRegressionTest(ClusterTester):
                                           result['latency 95th percentile'],
                                           result['latency 99th percentile'],
                                           result['latency 99.9th percentile']))
-        f = open('jenkins_perf_PerfPublisher.xml', 'w')
-        content = """<report name="simple_regression_test report" categ="none">
 
-  <test name="simple_regression_test" executed="yes">
-    <description>"simple regression test"</description>
+    def get_test_xml(self, result, idx):
+        test_content = """
+  <test name="simple_regression_test-stress_modes: (%s) Loader%s" executed="yes">
+    <description>"simple regression test, ami_id: %s, scylla version:
+    %s", stress_mode: %s, hardware: %s</description>
     <targets>
       <target threaded="yes">target-ami_id-%s</target>
       <target threaded="yes">target-version-%s</target>
@@ -67,8 +68,13 @@ class PerformanceRegressionTest(ClusterTester):
       </metrics>
     </result>
   </test>
-</report>
-""" % (self.params.get('ami_id_db_scylla'),
+""" % (self.params.get('stress_modes'),
+            idx,
+            self.params.get('ami_id_db_scylla'),
+            self.params.get('ami_id_db_scylla_desc'),
+            self.params.get('stress_modes'),
+            self.params.get('instance_type_db'),
+            self.params.get('ami_id_db_scylla'),
             self.params.get('ami_id_db_scylla_desc'),
             self.params.get('stress_modes'),
             self.params.get('instance_type_db'),
@@ -82,16 +88,26 @@ class PerformanceRegressionTest(ClusterTester):
             result['latency 99th percentile'],
             result['latency 99.9th percentile'])
 
-        f.write(content)
-        f.close()
+        return test_content
 
     def display_results(self, results):
         self.log.info(self.str_pattern % ('op-rate', 'partition-rate',
                                           'row-rate', 'latency-mean',
                                           'latency-median', 'l-94th-pct',
                                           'l-99th-pct', 'l-99.9th-pct'))
-        for single_result in results:
+
+        test_xml = ""
+        for idx, single_result in enumerate(results):
             self.display_single_result(single_result)
+            test_xml += self.get_test_xml(single_result, idx)
+
+        f = open('jenkins_perf_PerfPublisher.xml', 'w')
+        content = """<report name="simple_regression_test report" categ="none">
+%s
+</report>""" % test_xml
+
+        f.write(content)
+        f.close()
 
     def test_simple_regression(self):
         """

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -38,6 +38,52 @@ class PerformanceRegressionTest(ClusterTester):
                                           result['latency 95th percentile'],
                                           result['latency 99th percentile'],
                                           result['latency 99.9th percentile']))
+        f = open('jenkins_perf_PerfPublisher.xml', 'w')
+        content = """<report name="simple_regression_test report" categ="none">
+
+  <test name="simple_regression_test" executed="yes">
+    <description>"simple regression test"</description>
+    <targets>
+      <target threaded="yes">target-%s</target>
+      <ami_id>%s</ami_id>
+      <stress_modes>%s</stress_modes>
+    </targets>
+    <platform name="scylla_platform">
+      <instance_type_db>%s</instance_type_db>
+    </platform>
+
+    <result>
+      <success passed="yes" state="1"/>
+      <performance unit="kbs" mesure="%s" isRelevant="true" />
+      <metrics>
+        <op-rate unit="op/s" mesure="%s" isRelevant="true" />
+        <partition-rate unit="pk/s" mesure="%s" isRelevant="true" />
+        <row-rate unit="row/s" mesure="%s" isRelevant="true" />
+        <latency-mean unit="mean" mesure="%s" isRelevant="true" />
+        <latency-median unit="med" mesure="%s" isRelevant="true" />
+        <l-95th-pct unit=".95" mesure="%s" isRelevant="true" />
+        <l-99th-pct unit=".99" mesure="%s" isRelevant="true" />
+        <l-99.9th-pct unit=".999" mesure="%s" isRelevant="true" />
+      </metrics>
+    </result>
+  </test>
+</report>
+""" % (self.params.get('ami_id_db_scylla'),
+            self.params.get('ami_id_db_scylla'),
+            self.params.get('stress_modes'),
+            self.params.get('instance_type_db'),
+            result['op rate'],
+            result['op rate'],
+            result['partition rate'],
+            result['row rate'],
+            result['latency mean'],
+            result['latency median'],
+            result['latency 95th percentile'],
+            result['latency 99th percentile'],
+            result['latency 99.9th percentile'])
+
+        f.write(content)
+        f.close()
 
     def display_results(self, results):
         self.log.info(self.str_pattern % ('op-rate', 'partition-rate',

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -27,7 +27,7 @@ class PerformanceRegressionTest(ClusterTester):
     :avocado: enable
     """
 
-    str_pattern = '%8s%16s%10s%14s%16s%12s%12s%14s'
+    str_pattern = '%8s%16s%10s%14s%16s%12s%12s%14s%16s%16s'
 
     def display_single_result(self, result):
         self.log.info(self.str_pattern % (result['op rate'],
@@ -37,7 +37,9 @@ class PerformanceRegressionTest(ClusterTester):
                                           result['latency median'],
                                           result['latency 95th percentile'],
                                           result['latency 99th percentile'],
-                                          result['latency 99.9th percentile']))
+                                          result['latency 99.9th percentile'],
+                                          result['Total partitions'],
+                                          result['Total errors']))
 
     def get_test_xml(self, result, idx):
         test_content = """
@@ -65,6 +67,8 @@ class PerformanceRegressionTest(ClusterTester):
         <l-95th-pct unit=".95" mesure="%s" isRelevant="true" />
         <l-99th-pct unit=".99" mesure="%s" isRelevant="true" />
         <l-99.9th-pct unit=".999" mesure="%s" isRelevant="true" />
+        <total_partitions unit="total_partitions" mesure="%s" isRelevant="true" />
+        <total_errors unit="total_errors" mesure="%s" isRelevant="true" />
       </metrics>
     </result>
   </test>
@@ -86,7 +90,9 @@ class PerformanceRegressionTest(ClusterTester):
             result['latency median'],
             result['latency 95th percentile'],
             result['latency 99th percentile'],
-            result['latency 99.9th percentile'])
+            result['latency 99.9th percentile'],
+            result['Total partitions'],
+            result['Total errors'])
 
         return test_content
 
@@ -94,7 +100,8 @@ class PerformanceRegressionTest(ClusterTester):
         self.log.info(self.str_pattern % ('op-rate', 'partition-rate',
                                           'row-rate', 'latency-mean',
                                           'latency-median', 'l-94th-pct',
-                                          'l-99th-pct', 'l-99.9th-pct'))
+                                          'l-99th-pct', 'l-99.9th-pct',
+                                          'total-partitions', 'total-err'))
 
         test_xml = ""
         for idx, single_result in enumerate(results):


### PR DESCRIPTION
Description for this series:
We want to test performance with multiple loader, multiple c-stress in single loader. This patchset implemented this and save results to a xml file, which will be parsed by jenkins plugin (PerfPublisher) and import the results to jenkins server. Then we can check and compare history result in jenkins, it's helpful for us to find out regression between different releases.

I also updated the commitlog of each patch, fixed some coding style.

Reference:
https://wiki.jenkins-ci.org/display/JENKINS/PerfPublisher+Plugin