### PR TITLE
Support to run multiple c-stress in each loader

### DIFF
--- a/grow_cluster_test.py
+++ b/grow_cluster_test.py
@@ -15,6 +15,7 @@
 
 import logging
 import time
+import datetime
 
 from avocado import main
 
@@ -114,12 +115,19 @@ class GrowClusterTest(ClusterTester):
         # Set space_node_threshold in config file for the size
         self.db_cluster.wait_total_space_used_per_node()
 
+        start = datetime.datetime.now()
+        self.log.info('Starting to grow cluster: %s' % str(start))
+
         self.db_cluster.add_nemesis(nemesis=GrowClusterMonkey,
                                     monitoring_set=self.monitors)
         while len(self.db_cluster.nodes) < cluster_target_size:
             # Run GrowClusterMonkey to add one node at a time
             self.db_cluster.start_nemesis(interval=10)
             self.db_cluster.stop_nemesis(timeout=None)
+
+        end = datetime.datetime.now()
+        self.log.info('Growing cluster finished: %s' % str(end))
+        self.log.info('Growing cluster costs: %s' % str(end - start))
 
         # Run 2 more minutes before stop c-s
         time.sleep(2 * 60)

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -141,9 +141,8 @@ class PerformanceRegressionTest(ClusterTester):
                     loader.restart()
             else:
                 # run a workload
-                stress_queue = self.run_stress_thread(
-                    stress_cmd=base_cmd % mode)
-                results = self.get_stress_results(queue=stress_queue)
+                stress_queue = self.run_stress_thread(stress_cmd=base_cmd % mode, stress_num=2)
+                results = self.get_stress_results(queue=stress_queue, stress_num=2)
                 self.display_results(results)
 
 if __name__ == '__main__':

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -41,9 +41,9 @@ class PerformanceRegressionTest(ClusterTester):
                                           result['Total partitions'],
                                           result['Total errors']))
 
-    def get_test_xml(self, result, idx):
+    def get_test_xml(self, result):
         test_content = """
-  <test name="simple_regression_test-stress_modes: (%s) Loader%s" executed="yes">
+  <test name="simple_regression_test-stress_modes: (%s) Loader%s CPU%s" executed="yes">
     <description>"simple regression test, ami_id: %s, scylla version:
     %s", stress_mode: %s, hardware: %s</description>
     <targets>
@@ -74,6 +74,8 @@ class PerformanceRegressionTest(ClusterTester):
   </test>
 """ % (self.params.get('stress_modes'),
             idx,
+            result['loader_idx'],
+            result['cpu_idx'],
             self.params.get('ami_id_db_scylla'),
             self.params.get('ami_id_db_scylla_desc'),
             self.params.get('stress_modes'),
@@ -104,9 +106,9 @@ class PerformanceRegressionTest(ClusterTester):
                                           'total-partitions', 'total-err'))
 
         test_xml = ""
-        for idx, single_result in enumerate(results):
+        for single_result in results:
             self.display_single_result(single_result)
-            test_xml += self.get_test_xml(single_result, idx)
+            test_xml += self.get_test_xml(single_result)
 
         f = open('jenkins_perf_PerfPublisher.xml', 'w')
         content = """<report name="simple_regression_test report" categ="none">

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -149,5 +149,33 @@ class PerformanceRegressionTest(ClusterTester):
         except:
             pass
 
+    def test_read(self):
+        """
+        Test steps:
+
+        1. Run a write workload as a preparation
+        2. Run a read workload
+        """
+        base_cmd_w = ("cassandra-stress write no-warmup cl=QUORUM n=30000000 "
+                      "-schema 'replication(factor=3)' -port jmx=6868 "
+                      "-mode cql3 native -rate threads=500 -errors ignore "
+                      "-pop seq=1..30000000")
+        base_cmd_r = ("cassandra-stress read no-warmup cl=QUORUM duration=50m "
+                      "-schema 'replication(factor=3)' -port jmx=6868 "
+                      "-mode cql3 native -rate threads=500 -errors ignore "
+                      "-pop 'dist=gauss(1..30000000,15000000,1500000)' ")
+
+        # run a write workload
+        stress_queue = self.run_stress_thread(stress_cmd=base_cmd_w, stress_num=2)
+        results = self.get_stress_results(queue=stress_queue, stress_num=2)
+
+        stress_queue = self.run_stress_thread(stress_cmd=base_cmd_r, stress_num=2)
+        results = self.get_stress_results(queue=stress_queue, stress_num=2)
+
+        try:
+            self.display_results(results)
+        except:
+            pass
+
 if __name__ == '__main__':
     main()

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -143,7 +143,11 @@ class PerformanceRegressionTest(ClusterTester):
                 # run a workload
                 stress_queue = self.run_stress_thread(stress_cmd=base_cmd % mode, stress_num=2)
                 results = self.get_stress_results(queue=stress_queue, stress_num=2)
-                self.display_results(results)
+
+        try:
+            self.display_results(results)
+        except:
+            pass
 
 if __name__ == '__main__':
     main()

--- a/reduce_cluster_test.py
+++ b/reduce_cluster_test.py
@@ -14,6 +14,7 @@
 # Copyright (c) 2016 ScyllaDB
 
 import logging
+import datetime
 
 from avocado import main
 
@@ -100,6 +101,9 @@ class ReduceClusterTest(ClusterTester):
         # Set space_node_threshold in config file for the size
         self.db_cluster.wait_total_space_used_per_node()
 
+        start = datetime.datetime.now()
+        self.log.info('Starting to reduce cluster: %s' % str(start))
+
         self.db_cluster.add_nemesis(nemesis=DecommissionNoAddMonkey,
                                     monitoring_set=self.monitors)
         # Have c-s run for 2 + 3 minutes before we start to do decommission
@@ -110,6 +114,10 @@ class ReduceClusterTest(ClusterTester):
             # Run DecommissionNoAddMonkey once to decommission one node a time
             self.db_cluster.start_nemesis(interval=10)
             self.db_cluster.stop_nemesis(timeout=None)
+
+        end = datetime.datetime.now()
+        self.log.info('Reducing cluster finished: %s' % str(end))
+        self.log.info('Reducing cluster costs: %s' % str(end - start))
 
         # Run 2 more minutes before stop c-s
         time.sleep(2 * 60)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1303,7 +1303,12 @@ class BaseLoaderSet(object):
             node.remoter.send_files(stress_script.path, dst_stress_script_dir)
             node.remoter.run(cmd='chmod +x %s' % dst_stress_script)
 
-            node_cmd = 'echo %s; %s' % (tag, dst_stress_script)
+            if stress_num > 1:
+                node_cmd = 'taskset -c %s %s' % (cpu_idx, dst_stress_script)
+            else:
+                node_cmd = dst_stress_script
+            node_cmd = 'echo %s; %s' % (tag, node_cmd)
+
             result = node.remoter.run(cmd=node_cmd,
                                       timeout=timeout,
                                       ignore_status=True,

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1297,7 +1297,7 @@ class BaseLoaderSet(object):
                                              os.path.basename(stress_script.path))
             node.remoter.send_files(stress_script.path, dst_stress_script_dir)
             node.remoter.run(cmd='chmod +x %s' % dst_stress_script)
-            result = node.remoter.run(cmd=stress_cmd,
+            result = node.remoter.run(cmd=dst_stress_script,
                                       timeout=timeout,
                                       ignore_status=True,
                                       watch_stdout_pattern='total,',

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1279,6 +1279,7 @@ class BaseLoaderSet(object):
         # We'll save a script with the last c-s command executed on loaders
         stress_script = script.TemporaryScript(name='run_cassandra_stress.sh',
                                                content='%s\n' % stress_cmd)
+        self.log.info('Stress script content:\n%s' % stress_cmd)
         stress_script.save()
         queue = Queue.Queue()
 

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1275,20 +1275,25 @@ class BaseLoaderSet(object):
         time_elapsed = time.time() - start_time
         self.log.debug('Setup duration -> %s s', int(time_elapsed))
 
-    def run_stress_thread(self, stress_cmd, timeout, output_dir):
+    def run_stress_thread(self, stress_cmd, timeout, output_dir, stress_num=1):
         # We'll save a script with the last c-s command executed on loaders
         stress_script = script.TemporaryScript(name='run_cassandra_stress.sh',
                                                content='%s\n' % stress_cmd)
         stress_script.save()
         queue = Queue.Queue()
 
-        def node_run_stress(node):
+        def node_run_stress(node, loader_idx, cpu_idx):
             try:
                 logdir = path.init_dir(output_dir, self.name)
             except OSError:
                 logdir = os.path.join(output_dir, self.name)
-            log_file_name = os.path.join(logdir, 'cassandra-stress-%s.log' %
-                                         uuid.uuid4())
+            log_file_name = os.path.join(logdir,
+                                         'cassandra-stress-l%s-c%s-%s.log' %
+                                         (loader_idx, cpu_idx, uuid.uuid4()))
+            # This tag will be output in the header of c-stress result,
+            # we parse it to know the loader & cpu info in _parse_cs_summary().
+            tag = 'TAG: loader_idx:%s-cpu_idx:%s' % (loader_idx, cpu_idx)
+
             self.log.debug('cassandra-stress log: %s', log_file_name)
             loader_user = (self.params.get('libvirt_loader_image_user') or
                            self.params.get('ami_loader_user'))
@@ -1297,7 +1302,9 @@ class BaseLoaderSet(object):
                                              os.path.basename(stress_script.path))
             node.remoter.send_files(stress_script.path, dst_stress_script_dir)
             node.remoter.run(cmd='chmod +x %s' % dst_stress_script)
-            result = node.remoter.run(cmd=dst_stress_script,
+
+            node_cmd = 'echo %s; %s' % (tag, dst_stress_script)
+            result = node.remoter.run(cmd=node_cmd,
                                       timeout=timeout,
                                       ignore_status=True,
                                       watch_stdout_pattern='total,',
@@ -1306,12 +1313,14 @@ class BaseLoaderSet(object):
             queue.put((node, result))
             queue.task_done()
 
-        for loader in self.nodes:
-            setup_thread = threading.Thread(target=node_run_stress,
-                                            args=(loader,))
-            setup_thread.daemon = True
-            setup_thread.start()
-            time.sleep(30)
+        for loader_idx, loader in enumerate(self.nodes):
+            for cpu_idx in range(stress_num):
+                setup_thread = threading.Thread(target=node_run_stress,
+                                                args=(loader, loader_idx,
+                                                      cpu_idx))
+                setup_thread.daemon = True
+                setup_thread.start()
+                time.sleep(30)
 
         return queue
 
@@ -1348,6 +1357,12 @@ class BaseLoaderSet(object):
 
         for line in lines:
             line.strip()
+            # Parse loader & cpu info
+            if line.startswith('TAG:'):
+                ret = re.findall("TAG: loader_idx:(\d+)-cpu_idx:(\d+)", line)
+                results['loader_idx'] = ret[0][0]
+                results['cpu_idx'] = ret[0][1]
+
             if line.startswith('Results:'):
                 enable_parse = True
                 continue
@@ -1477,10 +1492,10 @@ class BaseLoaderSet(object):
 
         return errors
 
-    def get_stress_results(self, queue):
+    def get_stress_results(self, queue, stress_num=1):
         results = []
         ret = []
-        while len(results) != len(self.nodes):
+        while len(results) != len(self.nodes) * stress_num:
             try:
                 results.append(queue.get(block=True, timeout=5))
             except Queue.Empty:

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -355,13 +355,14 @@ class ClusterTester(Test):
         self.verify_stress_thread(stress_queue)
 
     @clean_aws_resources
-    def run_stress_thread(self, stress_cmd, duration=None):
+    def run_stress_thread(self, stress_cmd, duration=None, stress_num=1):
         stress_cmd = self._cs_add_node_flag(stress_cmd)
         if duration is None:
             duration = self.params.get('test_duration')
         timeout = duration * 60 + 600
         return self.loaders.run_stress_thread(stress_cmd, timeout,
-                                              self.outputdir)
+                                              self.outputdir,
+                                              stress_num=stress_num)
 
     @clean_aws_resources
     def kill_stress_thread(self):
@@ -381,8 +382,8 @@ class ClusterTester(Test):
                       "nodes:\n%s" % "\n".join(errors))
 
     @clean_aws_resources
-    def get_stress_results(self, queue):
-        return self.loaders.get_stress_results(queue)
+    def get_stress_results(self, queue, stress_num=1):
+        return self.loaders.get_stress_results(queue, stress_num=stress_num)
 
     def get_auth_provider(self, user, password):
         return PlainTextAuthProvider(username=user, password=password)


### PR DESCRIPTION
C-stress supports multiple threads itself, we want to reduce the switch cost of cpu.
This patchset supported to run multiple c-stress in each loader, and pin the c-stress process to single cpu. It used to reduce the cpu cost and have heavy stress for ScyllaDB.
Results of all c-stress will be collected and saved to xml file.