### PR TITLE
sdcm.nemesis: Wait until JMX service is back after nemesis killed scylla

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -119,7 +119,10 @@ class Nemesis(object):
         self.target_node.remoter.run(kill_cmd, ignore_status=True)
 
         # Let's wait for the target Node to have their services re-started
+        self.log.info('Waiting scylla services to be restarted after we killed them...')
         self.target_node.wait_db_up()
+        self.log.info('Waiting JMX services to be restarted after we killed them...')
+        self.target_node.wait_jmx_up()
 
     def disrupt_stop_wait_start_scylla_server(self, sleep_time=300):
         self._set_current_disruption('StopWaitStartService %s' % self.target_node)


### PR DESCRIPTION
We thought it was sufficient to wait until scylla was up
after its process was killed. However, under higher loads,
the JMX service may take longer to be back up. Let's make
sure JMX is back before executing admin commands on nodes.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@scylladb.com>