### PR TITLE
cassandra: Install and configure collectd

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -45,6 +45,9 @@ from .remote import Remote
 from . import data_path
 from . import wait
 
+from .collectd import CassandraCollectdSetup
+from .collectd import ScyllaCollectdSetup
+
 SCYLLA_CLUSTER_DEVICE_MAPPINGS = [{"DeviceName": "/dev/xvdb",
                                    "Ebs": {"VolumeSize": 40,
                                            "DeleteOnTermination": True,
@@ -510,99 +513,6 @@ WantedBy=multi-user.target
             self.remoter.run('sudo systemctl start prometheus.service')
         finally:
             shutil.rmtree(tmp_dir_prom)
-
-    def _set_collectd_exporter_paths(self):
-        self.collectd_exporter_system_base_dir = '/var/tmp'
-        self.collectd_exporter_base_dir = 'collectd_exporter-0.3.1.linux-amd64'
-        self.collectd_exporter_tarball = '%s.tar.gz' % self.collectd_exporter_base_dir
-        self.collectd_exporter_base_url = 'https://github.com/prometheus/collectd_exporter/releases/download/0.3.1'
-        self.collectd_exporter_system_dir = os.path.join(self.collectd_exporter_system_base_dir,
-                                                         self.collectd_exporter_base_dir)
-        self.collectd_exporter_path = os.path.join(self.collectd_exporter_system_dir, 'collectd_exporter')
-
-    def _setup_collectd(self):
-        collectd_cfg = """
-LoadPlugin network
-LoadPlugin disk
-LoadPlugin interface
-LoadPlugin unixsock
-LoadPlugin df
-LoadPlugin processes
-<Plugin network>
-        Listen "127.0.0.1" "25826"
-        Server "127.0.0.1" "65534"
-        Forward true
-</Plugin>
-<Plugin disk>
-</Plugin>
-<Plugin interface>
-</Plugin>
-<Plugin "df">
-  FSType "xfs"
-  IgnoreSelected false
-</Plugin>
-<Plugin unixsock>
-    SocketFile "/var/run/collectd-unixsock"
-    SocketPerms "0666"
-</Plugin>
-<Plugin processes>
-    Process "scylla"
-</Plugin>
-"""
-        tmp_dir_exporter = tempfile.mkdtemp(prefix='scm-collectd-exporter')
-        tmp_path_exporter = os.path.join(tmp_dir_exporter, 'scylla.conf')
-        tmp_path_remote = '/tmp/scylla-collectd.conf'
-        system_path_remote = '/etc/collectd.d/scylla.conf'
-        with open(tmp_path_exporter, 'w') as tmp_cfg_prom:
-            tmp_cfg_prom.write(collectd_cfg)
-        try:
-            self.remoter.send_files(src=tmp_path_exporter, dst=tmp_path_remote)
-            self.remoter.run('sudo mv %s %s' %
-                             (tmp_path_remote, system_path_remote))
-            self.remoter.run('sudo service collectd restart')
-        finally:
-            shutil.rmtree(tmp_dir_exporter)
-
-    def _setup_collectd_exporter(self):
-        systemd_unit = """[Unit]
-Description=Collectd Exporter
-
-[Service]
-Type=simple
-User=root
-Group=root
-ExecStart=%s -collectd.listen-address=:65534
-
-[Install]
-WantedBy=multi-user.target
-""" % self.collectd_exporter_path
-
-        tmp_dir_exporter = tempfile.mkdtemp(prefix='collectd-systemd-service')
-        tmp_path_exporter = os.path.join(tmp_dir_exporter, 'collectd-exporter.service')
-        tmp_path_remote = '/tmp/collectd-exporter.service'
-        system_path_remote = '/etc/systemd/system/collectd-exporter.service'
-        with open(tmp_path_exporter, 'w') as tmp_cfg_prom:
-            tmp_cfg_prom.write(systemd_unit)
-        try:
-            self.remoter.send_files(src=tmp_path_exporter, dst=tmp_path_remote)
-            self.remoter.run('sudo mv %s %s' %
-                             (tmp_path_remote, system_path_remote))
-            self.remoter.run('sudo systemctl start collectd-exporter.service')
-        finally:
-            shutil.rmtree(tmp_dir_exporter)
-
-    def install_collectd_exporter(self):
-        if self.init_system == 'systemd':
-            self._setup_collectd()
-            self._set_collectd_exporter_paths()
-            self.remoter.run('curl %s/%s -o %s/%s -L' %
-                             (self.collectd_exporter_base_url, self.collectd_exporter_tarball,
-                              self.collectd_exporter_system_base_dir, self.collectd_exporter_tarball))
-            self.remoter.run('tar -xzvf %s/%s -C %s' %
-                             (self.collectd_exporter_system_base_dir,
-                              self.collectd_exporter_tarball,
-                              self.collectd_exporter_system_base_dir))
-            self._setup_collectd_exporter()
 
     def journal_thread(self):
         while True:
@@ -1712,6 +1622,7 @@ class ScyllaLibvirtCluster(LibvirtCluster, BaseScyllaCluster):
                                                    node_prefix=node_prefix,
                                                    n_nodes=n_nodes,
                                                    params=params)
+        self.collectd_setup = ScyllaCollectdSetup()
         self.seed_nodes_private_ips = None
         self.termination_event = threading.Event()
         self.nemesis_threads = []
@@ -1764,10 +1675,8 @@ class ScyllaLibvirtCluster(LibvirtCluster, BaseScyllaCluster):
             'sudo /usr/lib/scylla/scylla_setup --nic eth0 --no-raid-setup')
         node.remoter.run('sudo systemctl enable scylla-server.service')
         node.remoter.run('sudo systemctl enable scylla-jmx.service')
-        node.remoter.run('sudo systemctl enable collectd.service')
         node.remoter.run('sudo systemctl start scylla-server.service')
         node.remoter.run('sudo systemctl start scylla-jmx.service')
-        node.remoter.run('sudo systemctl start collectd.service')
         node.remoter.run('sudo iptables -F')
 
     def wait_for_init(self, node_list=None, verbose=False):
@@ -1792,11 +1701,14 @@ class ScyllaLibvirtCluster(LibvirtCluster, BaseScyllaCluster):
             node.wait_db_up(verbose=verbose)
             node.remoter.run('sudo yum install -y scylla-gdb',
                              verbose=verbose, ignore_status=True)
-            node.install_collectd_exporter()
             queue.put(node)
             queue.task_done()
 
         start_time = time.time()
+
+        # avoid using node.remoter in thread
+        for node in node_list:
+            self.collectd_setup.install(node)
 
         seed = node_list[0].public_ip_address
         # If we setup all nodes in paralel, we might have troubles
@@ -2067,6 +1979,7 @@ class ScyllaAWSCluster(AWSCluster, BaseScyllaCluster):
                                                node_prefix=node_prefix,
                                                n_nodes=n_nodes,
                                                params=params)
+        self.collectd_setup = ScyllaCollectdSetup()
         self.nemesis = []
         self.nemesis_threads = []
         self.termination_event = threading.Event()
@@ -2098,11 +2011,13 @@ class ScyllaAWSCluster(AWSCluster, BaseScyllaCluster):
             node.wait_db_up(verbose=verbose)
             node.remoter.run('sudo yum install -y scylla-gdb',
                              verbose=verbose, ignore_status=True)
-            node.install_collectd_exporter()
             queue.put(node)
             queue.task_done()
 
         start_time = time.time()
+
+        for node in node_list:
+            self.collectd_setup.install(node)
 
         for loader in node_list:
             setup_thread = threading.Thread(target=node_setup,
@@ -2167,6 +2082,7 @@ class CassandraAWSCluster(ScyllaAWSCluster):
                                                node_prefix=node_prefix,
                                                n_nodes=n_nodes,
                                                params=params)
+        self.collectd_setup = CassandraCollectdSetup()
         self.nemesis = []
         self.nemesis_threads = []
         self.termination_event = threading.Event()
@@ -2211,6 +2127,14 @@ class CassandraAWSCluster(ScyllaAWSCluster):
             queue.task_done()
 
         start_time = time.time()
+
+        # We cannot run this in a thread since our SSH connection
+        # is not thread safe
+        for node in node_list:
+            node.remoter.run('sudo apt-get update')
+            node.remoter.run('sudo apt-get install -y collectd collectd-utils')
+            node.remoter.run('sudo apt-get install -y openjdk-6-jdk')
+            self.collectd_setup.install(node)
 
         for loader in node_list:
             setup_thread = threading.Thread(target=node_setup,

--- a/sdcm/collectd.py
+++ b/sdcm/collectd.py
@@ -1,0 +1,421 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2016 ScyllaDB
+
+import os
+import tempfile
+import shutil
+
+
+class CollectdSetup(object):
+
+    def start_collectd_service(self):
+        raise NotImplementedError
+
+    def collectd_exporter_setup(self):
+        raise NotImplementedError
+
+    def collectd_config(self):
+        raise NotImplementedError
+
+    def _setup_collectd(self):
+        system_path_remote = self.collectd_config()
+        tmp_dir_exporter = tempfile.mkdtemp(prefix='collectd')
+        tmp_path_exporter = os.path.join(tmp_dir_exporter, 'scylla.conf')
+        tmp_path_remote = "/tmp/scylla-collectd.conf"
+
+        with open(tmp_path_exporter, 'w') as tmp_cfg_prom:
+            tmp_cfg_prom.write(self._collectd_cfg)
+        try:
+            self.node.remoter.send_files(src=tmp_path_exporter, dst=tmp_path_remote)
+            command = "sudo mv %s %s" % (tmp_path_remote, system_path_remote)
+            self.node.remoter.run(command)
+            self.start_collectd_service()
+        finally:
+            pass
+            shutil.rmtree(tmp_dir_exporter)
+
+    def _set_exporter_path(self):
+        self.collectd_exporter_system_base_dir = '/var/tmp'
+        self.collectd_exporter_base_dir = 'collectd_exporter-0.3.1.linux-amd64'
+        self.collectd_exporter_tarball = '%s.tar.gz' % self.collectd_exporter_base_dir
+        self.collectd_exporter_base_url = 'https://github.com/prometheus/collectd_exporter/releases/download/0.3.1'
+        self.collectd_exporter_system_dir = os.path.join(self.collectd_exporter_system_base_dir,
+                                                         self.collectd_exporter_base_dir)
+        self.collectd_exporter_path = os.path.join(self.collectd_exporter_system_dir, 'collectd_exporter')
+
+    def install(self, node):
+        self.node = node
+
+        self._setup_collectd()
+        self._set_exporter_path()
+        self.node.remoter.run('curl --insecure %s/%s -o %s/%s -L' %
+                              (self.collectd_exporter_base_url, self.collectd_exporter_tarball,
+                               self.collectd_exporter_system_base_dir, self.collectd_exporter_tarball))
+        self.node.remoter.run('tar -xzvf %s/%s -C %s' %
+                              (self.collectd_exporter_system_base_dir,
+                               self.collectd_exporter_tarball,
+                               self.collectd_exporter_system_base_dir))
+        self.collectd_exporter_setup()
+
+
+class CassandraCollectdSetup(CollectdSetup):
+
+    def collectd_config(self):
+        # The following configuration file is liberaly copy pasted from
+        # https://raw.githubusercontent.com/scylladb/cassandra-test-and-deploy/master/roles/collectd-client/templates/collectd-client.conf
+        self._collectd_cfg = """
+LoadPlugin syslog
+
+LoadPlugin aggregation
+LoadPlugin cpu
+LoadPlugin disk
+LoadPlugin interface
+LoadPlugin java
+LoadPlugin load
+LoadPlugin memory
+LoadPlugin network
+
+<Plugin "aggregation">
+ <Aggregation>
+   Plugin "cpu"
+   Type "cpu"
+
+   GroupBy "Host"
+   GroupBy "TypeInstance"
+
+   CalculateNum false
+   CalculateSum false
+   CalculateAverage true
+   CalculateMinimum false
+   CalculateMaximum false
+   CalculateStddev false
+ </Aggregation>
+</Plugin>
+
+<Plugin disk>
+    Disk "/^[hs]d[a-f][0-9]?$/"
+    IgnoreSelected false
+</Plugin>
+
+<Plugin interface>
+    Interface "eth0"
+    IgnoreSelected false
+</Plugin>
+
+<Plugin "java">
+  JVMArg "-verbose:jni"
+  JVMArg "-Djava.class.path=/usr/share/collectd/java/collectd-api.jar:/usr/share/collectd/java/generic-jmx.jar"
+  LoadPlugin "org.collectd.java.GenericJMX"
+
+  <Plugin "GenericJMX">
+    <MBean "cassandra/classes">
+      ObjectName "java.lang:type=ClassLoading"
+      InstancePrefix "cassandra_java"
+
+      <Value>
+        Type "gauge"
+        InstancePrefix "loaded_classes"
+        Table false
+        Attribute "LoadedClassCount"
+      </Value>
+    </MBean>
+
+    <MBean "cassandra/compilation">
+      ObjectName "java.lang:type=Compilation"
+      InstancePrefix "cassandra_java"
+
+      <Value>
+        Type "total_time_in_ms"
+        InstancePrefix "compilation_time"
+        Table false
+        Attribute "TotalCompilationTime"
+      </Value>
+    </MBean>
+
+    <MBean "cassandra/storage_proxy">
+      ObjectName "org.apache.cassandra.db:type=StorageProxy"
+      InstancePrefix "cassandra_activity_storage_proxy"
+
+      <Value>
+        Type "counter"
+        InstancePrefix "read"
+        Table false
+        Attribute "ReadOperations"
+      </Value>
+      <Value>
+        Type "counter"
+        InstancePrefix "write"
+        Table false
+        Attribute "WriteOperations"
+      </Value>
+
+    </MBean>
+
+    <MBean "cassandra/memory">
+      ObjectName "java.lang:type=Memory,*"
+      InstancePrefix "cassandra_java_memory"
+      <Value>
+        Type "memory"
+        InstancePrefix "heap-"
+        Table true
+        Attribute "HeapMemoryUsage"
+      </Value>
+
+      <Value>
+        Type "memory"
+        InstancePrefix "nonheap-"
+        Table true
+        Attribute "NonHeapMemoryUsage"
+      </Value>
+    </MBean>
+
+    <MBean "cassandra/memory_pool">
+      ObjectName "java.lang:type=MemoryPool,*"
+      InstancePrefix "cassandra_java_memory_pool-"
+      InstanceFrom "name"
+      <Value>
+        Type "memory"
+        Table true
+        Attribute "Usage"
+      </Value>
+    </MBean>
+
+    <MBean "cassandra/garbage_collector">
+      ObjectName "java.lang:type=GarbageCollector,*"
+      InstancePrefix "cassandra_java_gc-"
+      InstanceFrom "name"
+
+      <Value>
+        Type "invocations"
+        Table false
+        Attribute "CollectionCount"
+      </Value>
+
+      <Value>
+        Type "total_time_in_ms"
+        InstancePrefix "collection_time"
+        Table false
+        Attribute "CollectionTime"
+      </Value>
+    </MBean>
+
+    <MBean "cassandra/concurrent">
+      ObjectName "org.apache.cassandra.internal:type=*"
+      InstancePrefix "cassandra_activity_internal"
+      <Value>
+        Attribute "CompletedTasks"
+        InstanceFrom "type"
+        Type "counter"
+        InstancePrefix "tasks-"
+      </Value>
+    </MBean>
+
+    <MBean "cassandra/request">
+      ObjectName "org.apache.cassandra.request:type=*"
+      InstancePrefix "cassandra_activity_request-"
+      <Value>
+        Attribute "CompletedTasks"
+        InstanceFrom "type"
+        Type "counter"
+        InstancePrefix "tasks-"
+      </Value>
+    </MBean>
+
+    <MBean "cassandra/cfstats">
+      ObjectName "org.apache.cassandra.db:type=ColumnFamilies,*"
+      InstanceFrom "keyspace"
+      InstancePrefix "cassandra_columnfamilies_stats-"
+      <Value>
+        Attribute "ReadCount"
+        InstancePrefix "livereadcount-"
+        Type "counter"
+        InstanceFrom "columnfamily"
+      </Value>
+      <Value>
+        Attribute "TotalReadLatencyMicros"
+        InstancePrefix "livereadlatency-"
+        Type "counter"
+        InstanceFrom "columnfamily"
+      </Value>
+      <Value>
+        Attribute "WriteCount"
+        InstancePrefix "livewritecount-"
+        Type "counter"
+        InstanceFrom "columnfamily"
+      </Value>
+      <Value>
+        Attribute "TotalWriteLatencyMicros"
+        InstancePrefix "livewritelatency-"
+        Type "counter"
+        InstanceFrom "columnfamily"
+      </Value>
+      <Value>
+        Attribute "LiveSSTableCount"
+        InstancePrefix "live_sstable_count-"
+        Type "gauge"
+        InstanceFrom "columnfamily"
+      </Value>
+      <Value>
+        Attribute "TotalDiskSpaceUsed"
+        InstancePrefix "total_disk_space_used-"
+        Type "gauge"
+        InstanceFrom "columnfamily"
+      </Value>
+
+    </MBean>
+
+    <MBean "cassandra/compaction">
+      ObjectName "org.apache.cassandra.db:type=CompactionManager"
+      InstancePrefix "cassandra_compaction"
+      <Value>
+        Attribute "PendingTasks"
+        InstancePrefix "pending"
+        Type "gauge"
+      </Value>
+    </MBean>
+
+    <MBean "cassandra/storage_service">
+      ObjectName "org.apache.cassandra.db:type=StorageService"
+      InstancePrefix "cassandra_storage_service"
+      <Value>
+        Attribute "StreamThroughputMbPerSec"
+        InstancePrefix "stream"
+        Type "gauge"
+      </Value>
+    </MBean>
+
+    <Connection>
+      Host "{{collectd_node_name}}"
+      ServiceURL "service:jmx:rmi:///jndi/rmi://localhost:7199/jmxrmi"
+      Collect "cassandra/storage_proxy"
+      Collect "cassandra/classes"
+      Collect "cassandra/compilation"
+      Collect "cassandra/memory"
+      Collect "cassandra/memory_pool"
+      Collect "cassandra/garbage_collector"
+      Collect "cassandra/concurrent"
+      Collect "cassandra/cfstats"
+      Collect "cassandra/request"
+      Collect "cassandra/compaction"
+      Collect "cassandra/storage_service"
+    </Connection>
+  </Plugin>
+</Plugin>
+
+<Plugin "network">
+        Listen "127.0.0.1" "25826"
+        Server "127.0.0.1" "65534"
+        Forward true
+</Plugin>
+
+<Plugin unixsock>
+    SocketFile "/var/run/collectd-unixsock"
+    SocketPerms "0666"
+</Plugin>
+"""
+        return "/etc/collectd/collectd.conf"
+
+    def start_collectd_service(self):
+        # no need to enable anything since it's upstart, just start it.
+        self.node.remoter.run('sudo service collectd restart')
+
+    def collectd_exporter_setup(self):
+        service_file = """# Run node_exporter
+
+start on startup
+
+script
+   %s -collectd.listen-address=:65534
+end script
+""" % self.collectd_exporter_path
+
+        tmp_dir_exporter = tempfile.mkdtemp(prefix='collectd-upstart-service')
+        tmp_path_exporter = os.path.join(tmp_dir_exporter, 'collectd_exporter.conf')
+        tmp_path_remote = '/tmp/collectd_exporter.conf'
+        system_path_remote = '/etc/init/collectd_exporter.conf'
+        with open(tmp_path_exporter, 'w') as tmp_cfg_prom:
+            tmp_cfg_prom.write(service_file)
+        try:
+            self.node.remoter.send_files(src=tmp_path_exporter, dst=tmp_path_remote)
+            self.node.remoter.run('sudo mv %s %s' %
+                                  (tmp_path_remote, system_path_remote))
+            self.node.remoter.run('sudo service collectd_exporter restart')
+        finally:
+            shutil.rmtree(tmp_dir_exporter)
+
+
+class ScyllaCollectdSetup(CollectdSetup):
+
+    def collectd_config(self):
+        self._collectd_cfg = """
+LoadPlugin network
+LoadPlugin disk
+LoadPlugin interface
+LoadPlugin unixsock
+LoadPlugin df
+LoadPlugin processes
+<Plugin network>
+        Listen "127.0.0.1" "25826"
+        Server "127.0.0.1" "65534"
+        Forward true
+</Plugin>
+<Plugin disk>
+</Plugin>
+<Plugin interface>
+</Plugin>
+<Plugin "df">
+  FSType "xfs"
+  IgnoreSelected false
+</Plugin>
+<Plugin unixsock>
+    SocketFile "/var/run/collectd-unixsock"
+    SocketPerms "0666"
+</Plugin>
+<Plugin processes>
+    Process "scylla"
+</Plugin>
+"""
+        return "/etc/collectd.d/scylla.conf"
+
+    def start_collectd_service(self):
+        self.node.remoter.run('sudo systemctl enable collectd.service')
+        self.node.remoter.run('sudo systemctl start collectd.service')
+        self.node.remoter.run('sudo service collectd restart')
+
+    def collectd_exporter_setup(self):
+        systemd_unit = """[Unit]
+Description=Collectd Exporter
+
+[Service]
+Type=simple
+User=root
+Group=root
+ExecStart=%s -collectd.listen-address=:65534
+
+[Install]
+WantedBy=multi-user.target
+""" % self.collectd_exporter_path
+
+        tmp_dir_exporter = tempfile.mkdtemp(prefix='collectd-systemd-service')
+        tmp_path_exporter = os.path.join(tmp_dir_exporter, 'collectd-exporter.service')
+        tmp_path_remote = '/tmp/collectd-exporter.service'
+        system_path_remote = '/etc/systemd/system/collectd-exporter.service'
+        with open(tmp_path_exporter, 'w') as tmp_cfg_prom:
+            tmp_cfg_prom.write(systemd_unit)
+        try:
+            self.node.remoter.send_files(src=tmp_path_exporter, dst=tmp_path_remote)
+            self.node.remoter.run('sudo mv %s %s' %
+                                  (tmp_path_remote, system_path_remote))
+            self.node.remoter.run('sudo systemctl start collectd-exporter.service')
+        finally:
+            shutil.rmtree(tmp_dir_exporter)


### PR DESCRIPTION
Also take care of installing and configuring
collectd_exporter.

Note: the collectd and collectd exporter was moved
out thread simply because our SSH library is not
thread safe and this was causing weird bugs in my
setup. (Fast machine with fast internet connexion)

Signed-off-by: Benoît Canet <benoit@scylladb.co>