### PR TITLE
alwasy enable Public IP in creating aws instances

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1973,14 +1973,17 @@ class AWSCluster(BaseCluster):
         global EC2_INSTANCES
         self.log.debug("Passing user_data '%s' to create_instances",
                        ec2_user_data)
+        interfaces = [{'DeviceIndex': 0,
+                       'SubnetId': self._ec2_subnet_id,
+                       'AssociatePublicIpAddress': True,
+                       'Groups': self._ec2_security_group_ids}]
         instances = self._ec2.create_instances(ImageId=self._ec2_ami_id,
                                                UserData=ec2_user_data,
                                                MinCount=count,
                                                MaxCount=count,
                                                KeyName=self._credentials.key_pair_name,
-                                               SecurityGroupIds=self._ec2_security_group_ids,
                                                BlockDeviceMappings=self._ec2_block_device_mappings,
-                                               SubnetId=self._ec2_subnet_id,
+                                               NetworkInterfaces=interfaces,
                                                InstanceType=self._ec2_instance_type)
         instance_ids = [i.id for i in instances]
         region_name = self.params.get('region_name')


### PR DESCRIPTION
Problem: Public IP isn't assigned when I used subnet-c327759a, the first patch changes SCT to always enable public IP.
