### PR TITLE
db_up: netstat to only look for listening cnx

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -622,7 +622,7 @@ WantedBy=multi-user.target
 
     def db_up(self):
         try:
-            result = self.remoter.run('netstat -a | grep :9042',
+            result = self.remoter.run('netstat -l | grep :9042',
                                       verbose=False, ignore_status=True)
             return result.exit_status == 0
         except Exception as details:
@@ -631,7 +631,7 @@ WantedBy=multi-user.target
 
     def jmx_up(self):
         try:
-            result = self.remoter.run('netstat -a | grep :7199',
+            result = self.remoter.run('netstat -l | grep :7199',
                                       verbose=False, ignore_status=True)
             return result.exit_status == 0
         except Exception as details:
@@ -878,7 +878,7 @@ class LibvirtNode(BaseNode):
     # Remove after node setup is finished
     def db_up(self):
         try:
-            result = self.remoter.run('netstat -a | grep :9042',
+            result = self.remoter.run('netstat -l | grep :9042',
                                       verbose=False, ignore_status=True)
             return result.exit_status == 0
         except Exception as details:


### PR DESCRIPTION
netstat -a will see SO_LINGER ESTABLISHED connexions
that will be present on cassandra after the server is
stopped. This make sct see cassandra as running after
it has been stopped. Since db_up equal True while the
database is down db_down is False hence making the test
suite stall.

netstat -l only look for the listening connexions.

Signed-off-by: Benoît Canet <benoit@scylladb.com>