### PR TITLE
collectd/centos: Do not restart collectd using service

### DIFF
--- a/sdcm/collectd.py
+++ b/sdcm/collectd.py
@@ -390,7 +390,6 @@ LoadPlugin processes
     def start_collectd_service(self):
         self.node.remoter.run('sudo systemctl enable collectd.service')
         self.node.remoter.run('sudo systemctl start collectd.service')
-        self.node.remoter.run('sudo service collectd restart')
 
     def collectd_exporter_setup(self):
         systemd_unit = """[Unit]


### PR DESCRIPTION
The Scylla AMI is using systemd. This spurious service
line went in, remove it.

Signed-off-by: Benoît Canet <benoit@scylladb.com>