### PR TITLE
Avocado install fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,11 +36,15 @@ What's inside?
 Regular Setup
 -------------
 
+Install freetype and C++ environment.
+
+    sudo yum install freetype-devel gcc-c++
+
 Install ``boto3`` and ``awscli`` (the last one is to help you configure aws), ``matplotlib`` and ``aexpect``::
 
     sudo -H pip install boto3
     sudo -H pip install awscli
-    sudo -H pip install matplotlib
+    sudo -H pip install matplotlib==1.5.0
     sudo -H pip install aexpect
 
 Install avocado. Make sure you install the LTS version (36.X), as newer versions have API incompatibilities with scylla-cluster-tests.

--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,9 @@ Example: Following the instructions in the link, after you download the repo fil
 Change enabled=1 in [avocado] to enabled=0, and enabled=0 in [avocado-lts] to enabled=1.
 Now you can install avocado LTS with the dnf command mentioned in the docs.
 
+If you are using a too recent fedora version for which there is no avocado lts release
+(>24) then replace $releasever by 24.
+
 Configure aws::
 
     aws configure


### PR DESCRIPTION

Allows people to install Avocado in fedora 25.