### PR TITLE
perf regression: support multiple keyspace

### DIFF
--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -14,6 +14,7 @@
 # Copyright (c) 2016 ScyllaDB
 
 
+import os
 from avocado import main
 
 from sdcm.tester import ClusterTester
@@ -109,7 +110,8 @@ class PerformanceRegressionTest(ClusterTester):
             self.display_single_result(single_result)
             test_xml += self.get_test_xml(single_result)
 
-        f = open('jenkins_perf_PerfPublisher.xml', 'w')
+        f = open(os.path.join(self.logdir,
+                              'jenkins_perf_PerfPublisher.xml'), 'w')
         content = """<report name="simple_regression_test report" categ="none">
 %s
 </report>""" % test_xml

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -44,7 +44,7 @@ class PerformanceRegressionTest(ClusterTester):
 
     def get_test_xml(self, result):
         test_content = """
-  <test name="simple_regression_test-stress_modes: (%s) Loader%s CPU%s" executed="yes">
+  <test name="simple_regression_test-stress_modes: (%s) Loader%s CPU%s Keyspace%s" executed="yes">
     <description>"simple regression test, ami_id: %s, scylla version:
     %s", stress_mode: %s, hardware: %s</description>
     <targets>
@@ -76,6 +76,7 @@ class PerformanceRegressionTest(ClusterTester):
 """ % (self.params.get('stress_modes'),
             result['loader_idx'],
             result['cpu_idx'],
+            result['keyspace_idx'],
             self.params.get('ami_id_db_scylla'),
             self.params.get('ami_id_db_scylla_desc'),
             self.params.get('stress_modes'),

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -143,8 +143,8 @@ class PerformanceRegressionTest(ClusterTester):
                     loader.restart()
             else:
                 # run a workload
-                stress_queue = self.run_stress_thread(stress_cmd=base_cmd % mode, stress_num=2)
-                results = self.get_stress_results(queue=stress_queue, stress_num=2)
+                stress_queue = self.run_stress_thread(stress_cmd=base_cmd % mode, stress_num=2, keyspace_num=100)
+                results = self.get_stress_results(queue=stress_queue, stress_num=2, keyspace_num=100)
 
         try:
             self.display_results(results)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ boto3==1.3.1
 awscli==1.10.47
 aexpect==1.2.0
 cassandra-driver==2.7.2
+apache-libcloud==1.4.0

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1432,8 +1432,9 @@ class BaseLoaderSet(object):
         time_elapsed = time.time() - start_time
         self.log.debug('Setup duration -> %s s', int(time_elapsed))
 
-    def run_stress_thread(self, stress_cmd, timeout, output_dir, stress_num=1):
-        stress_cmd = "mkfifo /tmp/cs_pipe_$1; cat /tmp/cs_pipe_$1|python /usr/bin/cassandra_stress_exporter & " + stress_cmd + "|tee /tmp/cs_pipe_$1; pkill -P $$ -f cassandra_stress_exporter; rm -f /tmp/cs_pipe_$1"
+    def run_stress_thread(self, stress_cmd, timeout, output_dir, stress_num=1, keyspace_num=1):
+        stress_cmd = stress_cmd.replace(" -schema ", " -schema keyspace=keyspace$1 ")
+        stress_cmd = "mkfifo /tmp/cs_pipe_$1_$2; cat /tmp/cs_pipe_$1_$2|python /usr/bin/cassandra_stress_exporter & " + stress_cmd + "|tee /tmp/cs_pipe_$1_$2; pkill -P $$ -f cassandra_stress_exporter; rm -f /tmp/cs_pipe_$1_$2"
         # We'll save a script with the last c-s command executed on loaders
         stress_script = script.TemporaryScript(name='run_cassandra_stress.sh',
                                                content='%s\n' % stress_cmd)
@@ -1441,7 +1442,7 @@ class BaseLoaderSet(object):
         stress_script.save()
         queue = Queue.Queue()
 
-        def node_run_stress(node, loader_idx, cpu_idx):
+        def node_run_stress(node, loader_idx, cpu_idx, keyspace_idx):
             try:
                 logdir = path.init_dir(output_dir, self.name)
             except OSError:
@@ -1451,7 +1452,7 @@ class BaseLoaderSet(object):
                                          (loader_idx, cpu_idx, uuid.uuid4()))
             # This tag will be output in the header of c-stress result,
             # we parse it to know the loader & cpu info in _parse_cs_summary().
-            tag = 'TAG: loader_idx:%s-cpu_idx:%s' % (loader_idx, cpu_idx)
+            tag = 'TAG: loader_idx:%s-cpu_idx:%s-keyspace_idx:%s' % (loader_idx, cpu_idx, keyspace_idx)
 
             self.log.debug('cassandra-stress log: %s', log_file_name)
             dst_stress_script_dir = os.path.join('/home', node.remoter.user)
@@ -1464,7 +1465,7 @@ class BaseLoaderSet(object):
                 node_cmd = 'taskset -c %s %s' % (cpu_idx, dst_stress_script)
             else:
                 node_cmd = dst_stress_script
-            node_cmd = 'echo %s; %s %s' % (tag, node_cmd, cpu_idx)
+            node_cmd = 'echo %s; %s %s %s' % (tag, node_cmd, cpu_idx, keyspace_idx)
 
             result = node.remoter.run(cmd=node_cmd,
                                       timeout=timeout,
@@ -1477,12 +1478,13 @@ class BaseLoaderSet(object):
 
         for loader_idx, loader in enumerate(self.nodes):
             for cpu_idx in range(stress_num):
-                setup_thread = threading.Thread(target=node_run_stress,
-                                                args=(loader, loader_idx,
-                                                      cpu_idx))
-                setup_thread.daemon = True
-                setup_thread.start()
-                time.sleep(30)
+                for ks_idx in range(keyspace_num):
+                    setup_thread = threading.Thread(target=node_run_stress,
+                                                    args=(loader, loader_idx,
+                                                          cpu_idx, ks_idx))
+                    setup_thread.daemon = True
+                    setup_thread.start()
+                    time.sleep(30)
 
         return queue
 
@@ -1521,9 +1523,10 @@ class BaseLoaderSet(object):
             line.strip()
             # Parse loader & cpu info
             if line.startswith('TAG:'):
-                ret = re.findall("TAG: loader_idx:(\d+)-cpu_idx:(\d+)", line)
+                ret = re.findall("TAG: loader_idx:(\d+)-cpu_idx:(\d+)-keyspace_idx:(\d+)", line)
                 results['loader_idx'] = ret[0][0]
                 results['cpu_idx'] = ret[0][1]
+                results['keyspace_idx'] = ret[0][2]
 
             if line.startswith('Results:'):
                 enable_parse = True
@@ -1654,10 +1657,10 @@ class BaseLoaderSet(object):
 
         return errors
 
-    def get_stress_results(self, queue, stress_num=1):
+    def get_stress_results(self, queue, stress_num=1, keyspace_num=1):
         results = []
         ret = []
-        while len(results) != len(self.nodes) * stress_num:
+        while len(results) != len(self.nodes) * stress_num * keyspace_num:
             try:
                 results.append(queue.get(block=True, timeout=5))
             except Queue.Empty:

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1433,7 +1433,7 @@ class BaseLoaderSet(object):
         self.log.debug('Setup duration -> %s s', int(time_elapsed))
 
     def run_stress_thread(self, stress_cmd, timeout, output_dir, stress_num=1):
-        stress_cmd = "mkfifo /tmp/cs_pipe; cat /tmp/cs_pipe|python /usr/bin/cassandra_stress_exporter & " + stress_cmd + "|tee /tmp/cs_pipe"
+        stress_cmd = "mkfifo /tmp/cs_pipe_$1; cat /tmp/cs_pipe_$1|python /usr/bin/cassandra_stress_exporter & " + stress_cmd + "|tee /tmp/cs_pipe_$1"
         # We'll save a script with the last c-s command executed on loaders
         stress_script = script.TemporaryScript(name='run_cassandra_stress.sh',
                                                content='%s\n' % stress_cmd)
@@ -1464,7 +1464,7 @@ class BaseLoaderSet(object):
                 node_cmd = 'taskset -c %s %s' % (cpu_idx, dst_stress_script)
             else:
                 node_cmd = dst_stress_script
-            node_cmd = 'echo %s; %s' % (tag, node_cmd)
+            node_cmd = 'echo %s; %s %s' % (tag, node_cmd, cpu_idx)
 
             result = node.remoter.run(cmd=node_cmd,
                                       timeout=timeout,

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -455,7 +455,7 @@ class BaseNode(object):
     def setup_grafana(self):
         self.remoter.run('sudo cp /etc/grafana/grafana.ini /tmp/grafana-noedit.ini')
         self.remoter.run('sudo chown %s /tmp/grafana-noedit.ini' % self.remoter.user)
-        grafana_ini_dst_path = os.path.join(tempfile.mkdtemp(prefix='scylla-longevity'),
+        grafana_ini_dst_path = os.path.join(tempfile.mkdtemp(prefix='sct'),
                                             'grafana.ini')
         self.remoter.receive_files(src='/tmp/grafana-noedit.ini',
                                    dst=grafana_ini_dst_path)
@@ -1221,8 +1221,8 @@ class BaseScyllaCluster(object):
     def get_seed_nodes_private_ips(self):
         if self.seed_nodes_private_ips is None:
             node = self.nodes[0]
-            yaml_dst_path = os.path.join(tempfile.mkdtemp(
-                prefix='scylla-longevity'), 'scylla.yaml')
+            yaml_dst_path = os.path.join(tempfile.mkdtemp(prefix='sct'),
+                                         'scylla.yaml')
             node.remoter.receive_files(src='/etc/scylla/scylla.yaml',
                                        dst=yaml_dst_path)
             with open(yaml_dst_path, 'r') as yaml_stream:
@@ -1852,7 +1852,7 @@ class ScyllaLibvirtCluster(LibvirtCluster, BaseScyllaCluster):
         self.nemesis_threads = []
 
     def _node_setup(self, node, seed_address):
-        yaml_dst_path = os.path.join(tempfile.mkdtemp(prefix='scylla-longevity'),
+        yaml_dst_path = os.path.join(tempfile.mkdtemp(prefix='sct'),
                                      'scylla.yaml')
         # Sometimes people might set up base images with
         # previous versions of scylla installed (they shouldn't).
@@ -2750,7 +2750,7 @@ class CassandraAWSCluster(ScyllaAWSCluster):
 
     def get_seed_nodes(self):
         node = self.nodes[0]
-        yaml_dst_path = os.path.join(tempfile.mkdtemp(prefix='cassandra-longevity'), 'cassandra.yaml')
+        yaml_dst_path = os.path.join(tempfile.mkdtemp(prefix='sct-cassandra'), 'cassandra.yaml')
         node.remoter.receive_files(src='/etc/cassandra/cassandra.yaml',
                                    dst=yaml_dst_path)
         with open(yaml_dst_path, 'r') as yaml_stream:

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1433,7 +1433,7 @@ class BaseLoaderSet(object):
         self.log.debug('Setup duration -> %s s', int(time_elapsed))
 
     def run_stress_thread(self, stress_cmd, timeout, output_dir, stress_num=1):
-        stress_cmd = "mkfifo /tmp/cs_pipe_$1; cat /tmp/cs_pipe_$1|python /usr/bin/cassandra_stress_exporter & " + stress_cmd + "|tee /tmp/cs_pipe_$1"
+        stress_cmd = "mkfifo /tmp/cs_pipe_$1; cat /tmp/cs_pipe_$1|python /usr/bin/cassandra_stress_exporter & " + stress_cmd + "|tee /tmp/cs_pipe_$1; pkill -P $$ -f cassandra_stress_exporter; rm -f /tmp/cs_pipe_$1"
         # We'll save a script with the last c-s command executed on loaders
         stress_script = script.TemporaryScript(name='run_cassandra_stress.sh',
                                                content='%s\n' % stress_cmd)

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -527,14 +527,15 @@ class ClusterTester(Test):
         self.verify_stress_thread(stress_queue)
 
     @clean_aws_resources
-    def run_stress_thread(self, stress_cmd, duration=None, stress_num=1):
+    def run_stress_thread(self, stress_cmd, duration=None, stress_num=1, keyspace_num=1):
         stress_cmd = self._cs_add_node_flag(stress_cmd)
         if duration is None:
             duration = self.params.get('test_duration')
         timeout = duration * 60 + 600
         return self.loaders.run_stress_thread(stress_cmd, timeout,
                                               self.outputdir,
-                                              stress_num=stress_num)
+                                              stress_num=stress_num,
+                                              keyspace_num=keyspace_num)
 
     @clean_aws_resources
     def kill_stress_thread(self):
@@ -554,8 +555,8 @@ class ClusterTester(Test):
                       "nodes:\n%s" % "\n".join(errors))
 
     @clean_aws_resources
-    def get_stress_results(self, queue, stress_num=1):
-        return self.loaders.get_stress_results(queue, stress_num=stress_num)
+    def get_stress_results(self, queue, stress_num=1, keyspace_num=1):
+        return self.loaders.get_stress_results(queue, stress_num=stress_num, keyspace_num=keyspace_num)
 
     def get_auth_provider(self, user, password):
         return PlainTextAuthProvider(username=user, password=password)


### PR DESCRIPTION
We want to test writing to multiple keyspaces in parallel, this patch supported it. Each loader will lunch multiple c-stress clients with different keyspace parameter. We set keyspace to 100 as suggested by @slivne 

This patchset also fixed some issues of regression test.