### PR TITLE
fix the first keyspace name of multiple keyspaces

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1538,7 +1538,7 @@ class BaseLoaderSet(object):
 
         for loader_idx, loader in enumerate(self.nodes):
             for cpu_idx in range(stress_num):
-                for ks_idx in range(keyspace_num):
+                for ks_idx in range(1, keyspace_num + 1):
                     setup_thread = threading.Thread(target=node_run_stress,
                                                     args=(loader, loader_idx,
                                                           cpu_idx, ks_idx))

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -730,9 +730,10 @@ class ClusterTester(Test):
 
     def clean_resources(self):
         self.log.debug('Cleaning up resources used in the test')
-        db_cluster_errors = self.db_cluster.get_node_database_errors()
+        db_cluster_errors = None
         db_cluster_coredumps = None
         if self.db_cluster is not None:
+            db_cluster_errors = self.db_cluster.get_node_database_errors()
             self.db_cluster.get_backtraces()
             db_cluster_coredumps = self.db_cluster.coredumps
             for current_nemesis in self.db_cluster.nemesis:


### PR DESCRIPTION
The default keyspace name is `keyspace1`, but current first keyspace is keyspace0.
This patchset skipped keyspace0.