### PR TITLE
c-s script: fix a typo

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1493,7 +1493,7 @@ class BaseLoaderSet(object):
         self.log.debug('Setup duration -> %s s', int(time_elapsed))
 
     def run_stress_thread(self, stress_cmd, timeout, output_dir, stress_num=1, keyspace_num=1):
-        stress_cmd = stress_cmd.replace(" -schema ", " -schema keyspace=keyspace$1 ")
+        stress_cmd = stress_cmd.replace(" -schema ", " -schema keyspace=keyspace$2 ")
         stress_cmd = "mkfifo /tmp/cs_pipe_$1_$2; cat /tmp/cs_pipe_$1_$2|python /usr/bin/cassandra_stress_exporter & " + stress_cmd + "|tee /tmp/cs_pipe_$1_$2; pkill -P $$ -f cassandra_stress_exporter; rm -f /tmp/cs_pipe_$1_$2"
         # We'll save a script with the last c-s command executed on loaders
         stress_script = script.TemporaryScript(name='run_cassandra_stress.sh',


### PR DESCRIPTION
index of keyspace is assigned by second parameter,
but script uses the first one.

https://github.com/scylladb/scylla-cluster-tests/issues/219