### PR TITLE
sdcm.cluster: Handle failures downloading prometheus dir gracefully

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1774,8 +1774,12 @@ class BaseMonitorSet(object):
 
     def download_monitor_data(self):
         for node in self.nodes:
-            node.remoter.run('sudo systemctl stop prometheus.service', ignore_status=True)
-            node.download_prometheus_data_dir()
+            try:
+                node.remoter.run('sudo systemctl stop prometheus.service', ignore_status=True)
+                node.download_prometheus_data_dir()
+            except Exception, details:
+                self.log.error('Error downloading prometheus data dir: %s',
+                               str(details))
 
 
 class NoMonitorSet(object):


### PR DESCRIPTION
Sometimes, there are failures before the prometheus data dir
was properly setup.

Therefore, downloading the prometheus data dir shouldn't
fail the entire test. So let's handle the failure more gracefully.

Signed-off-by: Lucas Meneghel Rodrigues <lookkas@gmail.com>