### PR TITLE
Longevity GCE: bug fixing to make it stable

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2300,6 +2300,7 @@ class OpenStackCluster(BaseCluster):
                                                     self._openstack_instance_type)
 
     def add_nodes(self, count, ec2_user_data=''):
+        nodes = []
         size = [d for d in self._openstack_service.list_sizes() if d.name == self._openstack_instance_type][0]
         image = self._openstack_service.get_image(self._openstack_image)
         networks = [n for n in self._openstack_service.ex_list_networks() if n.name == self._openstack_network]
@@ -2308,12 +2309,17 @@ class OpenStackCluster(BaseCluster):
             instance = self._openstack_service.create_node(name=name, image=image, size=size, networks=networks,
                                                            ex_keyname=self._credentials.name)
             OPENSTACK_INSTANCES.append(instance)
-            self.nodes.append(OpenStackNode(openstack_instance=instance, openstack_service=self._openstack_service,
-                                            credentials=self._credentials,
-                                            openstack_image_username=self._openstack_image_username,
-                                            node_prefix=self.node_prefix, node_index=node_index,
-                                            base_logdir=self.logdir))
-            self._node_index += 1
+            nodes.append(OpenStackNode(openstack_instance=instance, openstack_service=self._openstack_service,
+                                       credentials=self._credentials,
+                                       openstack_image_username=self._openstack_image_username,
+                                       node_prefix=self.node_prefix, node_index=node_index,
+                                       base_logdir=self.logdir))
+
+        self.log.info('added nodes: %s', nodes)
+        self._node_index += len(nodes)
+        self.nodes += nodes
+
+        return nodes
 
 
 class GCECluster(BaseCluster):
@@ -2382,6 +2388,7 @@ class GCECluster(BaseCluster):
                 "autoDelete": True}
 
     def add_nodes(self, count, ec2_user_data=''):
+        nodes = []
         name = "%s-idx" % self.node_prefix
         gce_disk_struct = list()
         gce_disk_struct.append(self._get_root_disk_struct(name=name,
@@ -2398,14 +2405,18 @@ class GCECluster(BaseCluster):
         self.log.info('Created instances: %s', instances)
         for node_index, instance in enumerate(instances):
             GCE_INSTANCES.append(instance)
-            self.nodes.append(GCENode(gce_instance=instance,
-                                      gce_service=self._gce_service,
-                                      credentials=self._credentials,
-                                      gce_image_username=self._gce_image_username,
-                                      node_prefix=self.node_prefix,
-                                      node_index=node_index + 1,
-                                      base_logdir=self.logdir))
-            self._node_index += 1
+            nodes.append(GCENode(gce_instance=instance,
+                                 gce_service=self._gce_service,
+                                 credentials=self._credentials,
+                                 gce_image_username=self._gce_image_username,
+                                 node_prefix=self.node_prefix,
+                                 node_index=node_index + 1,
+                                 base_logdir=self.logdir))
+        self.log.info('added nodes: %s', nodes)
+        self._node_index += len(nodes)
+        self.nodes += nodes
+
+        return nodes
 
 
 class AWSCluster(BaseCluster):

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2685,7 +2685,7 @@ class ScyllaOpenStackCluster(OpenStackCluster, BaseScyllaCluster):
         for node in node_list:
             self.collectd_setup.install(node)
 
-        seed = node_list[0].public_ip_address
+        seed = self.nodes[0].private_ip_address
         # If we setup all nodes in paralel, we might have troubles
         # with nodes not able to contact the seed node.
         # Let's setup the seed node first, then set up the others
@@ -2879,7 +2879,7 @@ class ScyllaGCECluster(GCECluster, BaseScyllaCluster):
             node.wait_ssh_up(verbose=verbose)
             self.collectd_setup.install(node)
 
-        seed = node_list[0].private_ip_address
+        seed = self.nodes[0].private_ip_address
         for node in node_list:
             setup_thread = threading.Thread(target=node_setup,
                                             args=(node, seed))

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2847,6 +2847,7 @@ class ScyllaGCECluster(GCECluster, BaseScyllaCluster):
 
         # avoid using node.remoter in thread
         for node in node_list:
+            node.wait_ssh_up(verbose=verbose)
             self.collectd_setup.install(node)
 
         seed = node_list[0].private_ip_address

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -163,6 +163,7 @@ class ClusterTester(Test):
         db_node_address = self.db_cluster.nodes[0].private_ip_address
         self.loaders.wait_for_init(db_node_address=db_node_address)
         nodes_monitored = [node.private_ip_address for node in self.db_cluster.nodes]
+        nodes_monitored += [node.private_ip_address for node in self.loaders.nodes]
         self.monitors.wait_for_init(targets=nodes_monitored)
 
     def get_nemesis_class(self):


### PR DESCRIPTION
We are creating db instances in parallel both AWS and GCE,
it has chance to bootstrap nodes in same time, sometimes it
triggers this error:

seastar - Exiting on unhandled exception: std::runtime_error
(Other bootstrapping/leaving/moving nodes detected, cannot
 bootstrap while consistent_rangemovement is true)

Set auto_bootstrap to false for the nodes we want to boot at
the same time. This patch disabled auto_bootstrap for GCE and
AWS.


This PR also fixed some bugs in DecommissionMonkey.
    https://github.com/scylladb/scylla-cluster-tests/issues/240
    https://github.com/scylladb/scylla-cluster-tests/issues/239
    https://github.com/scylladb/scylla-cluster-tests/issues/241
    set wrong seed ip for additional nodes

