### PR TITLE
upload json file with stats in ES after perf tests

### DIFF
--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -14,9 +14,14 @@
 # Copyright (c) 2016 ScyllaDB
 
 
+import datetime
+import json
 import os
-from avocado import main
+import re
 
+import requests
+
+from avocado import main
 from sdcm.tester import ClusterTester
 
 
@@ -42,9 +47,9 @@ class PerformanceRegressionTest(ClusterTester):
                                           result['Total partitions'],
                                           result['Total errors']))
 
-    def get_test_xml(self, result):
+    def get_test_xml(self, result, test_name='simple_regression_test'):
         test_content = """
-  <test name="simple_regression_test-stress_modes: (%s) Loader%s CPU%s Keyspace%s" executed="yes">
+  <test name="%s-stress_modes: (%s) Loader%s CPU%s Keyspace%s" executed="yes">
     <description>"simple regression test, ami_id: %s, scylla version:
     %s", stress_mode: %s, hardware: %s</description>
     <targets>
@@ -73,7 +78,8 @@ class PerformanceRegressionTest(ClusterTester):
       </metrics>
     </result>
   </test>
-""" % (self.params.get('stress_modes'),
+""" % (test_name,
+            self.params.get('stress_modes'),
             result['loader_idx'],
             result['cpu_idx'],
             result['keyspace_idx'],
@@ -99,7 +105,35 @@ class PerformanceRegressionTest(ClusterTester):
 
         return test_content
 
-    def display_results(self, results):
+    def generate_stats_json(self, results, cmds=[]):
+        metrics = {}
+
+        for p in self.params.iteritems():
+            metrics[p[1]] = p[2]
+
+        # we use cmds
+        del metrics['stress_cmd']
+        for cmd in cmds:
+            metrics = self.add_stress_cmd_params(metrics, cmd)
+            metrics = self.add_stress_cmd_params(metrics, cmd)
+
+        metrics['test_name'] = self.params.id.name
+        metrics['stats'] = results
+
+        if 'es_password' in metrics:
+            # hide ES password
+            metrics['es_password'] = '******'
+
+        metrics['time_completed'] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
+
+        test_name_file = metrics['test_name'].replace(':', '__').replace('.', '_')
+
+        with open('jenkins_%s.json' % test_name_file, 'w') as fp:
+            json.dump(metrics, fp, indent=4)
+
+        self.upload_stats_es(metrics, test_name=test_name_file)
+
+    def display_results(self, results, test_name='simple_regression_test'):
         self.log.info(self.str_pattern % ('op-rate', 'partition-rate',
                                           'row-rate', 'latency-mean',
                                           'latency-median', 'l-94th-pct',
@@ -109,16 +143,108 @@ class PerformanceRegressionTest(ClusterTester):
         test_xml = ""
         for single_result in results:
             self.display_single_result(single_result)
-            test_xml += self.get_test_xml(single_result)
+            test_xml += self.get_test_xml(single_result, test_name=test_name)
 
         f = open(os.path.join(self.logdir,
                               'jenkins_perf_PerfPublisher.xml'), 'w')
-        content = """<report name="simple_regression_test report" categ="none">
+        content = """<report name="%s report" categ="none">
 %s
-</report>""" % test_xml
+</report>""" % (test_name, test_xml)
 
         f.write(content)
         f.close()
+
+    def add_stress_cmd_params(self, result, cmd):
+        cmd = cmd.strip()
+        cmd = cmd.strip().split('cassandra-stress')[1].strip()
+        if cmd.split(' ')[0] in ['read', 'write', 'mixed']:
+            section = 'cassandra-stress ' + cmd.split(' ')[0]
+            result[section] = {}
+            # cmd = ' '.join(cmd.split(' ')[1:]).strip()
+            # result[section]['no-warmup'] = False
+            if cmd.startswith('no-warmup'):
+                result[section]['no-warmup'] = True
+                # cmd = cmd.strip('no-warmup')[1:].strip()
+
+            match = re.search('(cl\s?=\s?\w+)', cmd)
+            if match:
+                result[section]['cl'] = match.group(0).split('=')[1].strip()
+
+            match = re.search('(duration\s?=\s?\W+)', cmd)
+            if match:
+                result[section]['duration'] = match.group(0).split('=')[1].strip()
+
+            match = re.search('( n\s?=\s?\W+)', cmd)
+            if match:
+                result[section]['n'] = match.group(0).split('=')[1].strip()
+
+            for temp in cmd.split(' -')[1:]:
+                k = temp.split()[0]
+                match = re.search('(-' + k + '\s+([^-| ]+))', cmd)
+                if match:
+                    result[section][k] = match.group(2).strip()
+        return result
+
+    def upload_stats_es(self, metrics, test_name):
+        """
+        custom date format is used in ES
+        curl -XPUT 'https://USER:PASSWORD@HOST_NAME:9243/performanceregressiontest' -H 'Content-Type:application/json' -d'{
+           "mappings":{
+              "performanceregressiontest":{
+                 "properties":{
+                    "time_completed":{
+                       "type":"date",
+                       "format":"yyyy-MM-dd HH:mm"
+                    }
+                 }
+              }
+           }
+        }
+        """
+        stats_to_add = {}
+
+        for key in metrics['stats'][0].keys():
+            summary = 0
+            for stat in metrics['stats']:
+                try:
+                    summary += float(stat[key])
+                except:
+                    stats_to_add[key] = stat[key]
+            if summary != summary:
+                stats_to_add[key] = None
+            elif key not in stats_to_add:
+                stats_to_add[key] = round(summary / len(metrics['stats']), 1)
+
+        result = {}
+        for k, v in metrics.iteritems():
+            if k == 'stats':
+                continue
+            value = v
+            try:
+                value = int(v)
+            except:
+                try:
+                    value = float(v)
+                except:
+                    pass
+
+            result[k] = value
+
+        result.update(stats_to_add)
+
+        with open('jenkins_%s_summary.json' % test_name, 'w') as fp:
+            json.dump(result, fp, indent=4)
+
+        self.log.info(json.dumps(result, indent=4))
+        if self.params.get('es_url'):
+            url = '%s/performanceregressiontest/%s/%s_%s?pretty' % \
+                  (self.params.get('es_url'), result['test_name'],
+                   result['ami_id_db_scylla_desc'], result['time_completed'])
+
+            headers = {'Accept': 'application/json', 'Content-Type': 'application/json'}
+            r = requests.post(url, data=open('jenkins_%s_summary.json' % test_name, 'rb'), headers=headers,
+                              auth=(self.params.get('es_user'), self.params.get('es_password')))
+            self.log.info(r.content)
 
     def test_simple_regression(self):
         """
@@ -150,6 +276,7 @@ class PerformanceRegressionTest(ClusterTester):
             self.display_results(results)
         except:
             pass
+        self.generate_stats_json(results, [base_cmd])
 
     def test_read(self):
         """
@@ -178,6 +305,7 @@ class PerformanceRegressionTest(ClusterTester):
             self.display_results(results)
         except:
             pass
+        self.generate_stats_json(results, [base_cmd_w, base_cmd_r])
 
     def test_mixed(self):
         """
@@ -207,6 +335,7 @@ class PerformanceRegressionTest(ClusterTester):
             self.display_results(results)
         except:
             pass
+        self.generate_stats_json(results, [base_cmd_w, base_cmd_m])
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
 at the end of any test from performance_regression_test.py we generate json file with stats
 that then will be used to upload on ES

 file name: jenkins_%s.json' % test_name

 to upload test stats in ES we need specify the following parmas in yaml file:
 es_url: https://HOST_NAME:9243
 es_user: elastic
 es_password: password