### PR TITLE
perf-regression: cleanup test_simple_regression()

### DIFF
--- a/data_dir/scylla.yaml
+++ b/data_dir/scylla.yaml
@@ -4,8 +4,6 @@ test_duration: 60
 # cassandra-stress command. You can specify everything but the -node parameter,
 # which is going to be provided by the test suite infrastructure
 stress_cmd: cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000
-# cassandra-stress mode series
-stress_modes: 'write read restart mixed'
 # tcpdump to try to capture nodetool API
 tcpdump: false
 # Number of database nodes

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -44,13 +44,12 @@ class PerformanceRegressionTest(ClusterTester):
 
     def get_test_xml(self, result):
         test_content = """
-  <test name="simple_regression_test-stress_modes: (%s) Loader%s CPU%s Keyspace%s" executed="yes">
+  <test name="simple_regression_test: Loader%s CPU%s Keyspace%s" executed="yes">
     <description>"simple regression test, ami_id: %s, scylla version:
-    %s", stress_mode: %s, hardware: %s</description>
+    %s", hardware: %s</description>
     <targets>
       <target threaded="yes">target-ami_id-%s</target>
       <target threaded="yes">target-version-%s</target>
-      <target threaded="yes">stress_modes-%s</target>
     </targets>
     <platform name="AWS platform">
       <hardware>%s</hardware>
@@ -73,17 +72,14 @@ class PerformanceRegressionTest(ClusterTester):
       </metrics>
     </result>
   </test>
-""" % (self.params.get('stress_modes'),
-            result['loader_idx'],
+""" % (result['loader_idx'],
             result['cpu_idx'],
             result['keyspace_idx'],
             self.params.get('ami_id_db_scylla'),
             self.params.get('ami_id_db_scylla_desc'),
-            self.params.get('stress_modes'),
             self.params.get('instance_type_db'),
             self.params.get('ami_id_db_scylla'),
             self.params.get('ami_id_db_scylla_desc'),
-            self.params.get('stress_modes'),
             self.params.get('instance_type_db'),
             result['op rate'],
             result['op rate'],
@@ -120,31 +116,21 @@ class PerformanceRegressionTest(ClusterTester):
         f.write(content)
         f.close()
 
-    def test_simple_regression(self):
+    def test_write(self):
         """
         Test steps:
 
         1. Run a write workload
-        2. Run a read workload (after the write - cache will contain some data)
-        3. Restart node, run a read workload (cache will be empty)
-        4. Run a mixed read write workload
         """
         # run a write workload
-        base_cmd = ("cassandra-stress %s no-warmup cl=QUORUM duration=60m "
-                    "-schema 'replication(factor=3)' -port jmx=6868 "
-                    "-mode cql3 native -rate threads=100 -errors ignore "
-                    "-pop seq=1..10000000")
+        base_cmd_w = ("cassandra-stress write no-warmup cl=QUORUM duration=60m "
+                      "-schema 'replication(factor=3)' -port jmx=6868 "
+                      "-mode cql3 native -rate threads=100 -errors ignore "
+                      "-pop seq=1..10000000")
 
-        stress_modes = self.params.get(key='stress_modes', default='write')
-        for mode in stress_modes.split():
-            if mode == 'restart':
-                # restart all the nodes
-                for loader in self.db_cluster.nodes:
-                    loader.restart()
-            else:
-                # run a workload
-                stress_queue = self.run_stress_thread(stress_cmd=base_cmd % mode, stress_num=2, keyspace_num=100)
-                results = self.get_stress_results(queue=stress_queue, stress_num=2, keyspace_num=100)
+        # run a workload
+        stress_queue = self.run_stress_thread(stress_cmd=base_cmd_w, stress_num=2, keyspace_num=100)
+        results = self.get_stress_results(queue=stress_queue, stress_num=2, keyspace_num=100)
 
         try:
             self.display_results(results)


### PR DESCRIPTION
At the beginning, we tried to implement 3 subtests (write, read, mixed)
in one function-test_simple_regression(). But read & mixed tests are more
complex, so we added test_read() and test_mixed().

Let's clean test_simple_regression to only test write.