### PR TITLE
fix file transmission and ssh connection

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -589,7 +589,8 @@ scrape_configs:
         try:
             self.remoter.send_files(src=tmp_path_prom,
                                     dst=self.prometheus_custom_cfg_path,
-                                    verbose=True)
+                                    verbose=True,
+                                    ssh_timeout=60)
         finally:
             shutil.rmtree(tmp_dir_prom)
 

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -45,6 +45,7 @@ from libcloud.compute.providers import get_driver
 
 from .log import SDCMAdapter
 from .remote import Remote
+from .remote import disable_master_ssh
 from . import data_path
 from . import wait
 
@@ -82,6 +83,8 @@ COREDUMP_MAX_SIZE = 1024 * 1024 * 1024 * 5
 def set_duration(duration):
     global TEST_DURATION
     TEST_DURATION = duration
+    if TEST_DURATION >= 3 * 60:
+        disable_master_ssh()
 
 
 def set_libvirt_uri(libvirt_uri):

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -352,6 +352,7 @@ class BaseNode(object):
         self.database_log = os.path.join(self.logdir, 'database.log')
         self._database_log_errors_index = []
         self._database_error_patterns = ['std::bad_alloc']
+        self.wait_ssh_up(verbose=False)
         self.start_journal_thread()
         self.start_backtrace_thread()
         # We should disable bootstrap when we create nodes to establish the cluster,

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -587,7 +587,8 @@ scrape_configs:
             tmp_cfg_prom.write(prometheus_cfg)
         try:
             self.remoter.send_files(src=tmp_path_prom,
-                                    dst=self.prometheus_custom_cfg_path)
+                                    dst=self.prometheus_custom_cfg_path,
+                                    verbose=True)
         finally:
             shutil.rmtree(tmp_dir_prom)
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -19,6 +19,7 @@ import inspect
 import logging
 import random
 import time
+import datetime
 
 from avocado.utils import process
 
@@ -157,6 +158,7 @@ class Nemesis(object):
         raise NotImplementedError('Derived classes must implement disrupt()')
 
     def _set_current_disruption(self, label):
+        self.log.debug('Set current_disruption -> %s', label)
         self.current_disruption = label
         self.log.info(label)
 
@@ -256,8 +258,8 @@ def log_time_elapsed(method):
     :return: Wrapped method.
     """
     def wrapper(*args, **kwargs):
-        args[0].log.debug('Start -> %s', args[0].current_disruption)
         start_time = time.time()
+        args[0].log.debug('Start disruption at `%s`', datetime.datetime.fromtimestamp(start_time))
         result = None
         try:
             result = method(*args, **kwargs)

--- a/sdcm/remote.py
+++ b/sdcm/remote.py
@@ -756,7 +756,7 @@ class BaseRemote(object):
                 self._cleanup_master_ssh()
 
         # Start a new master SSH connection.
-        if self.master_ssh_job is None:
+        if self.master_ssh_job is None and self.master_ssh_tempdir is None:
             # Create a shared socket in a temp location.
             self.master_ssh_tempdir = tempfile.mkdtemp(prefix='ssh-master')
             self.master_ssh_option = ("-o ControlPath=%s/socket" %

--- a/sdcm/remote.py
+++ b/sdcm/remote.py
@@ -393,7 +393,7 @@ class BaseRemote(object):
         return '%s %s "%s"' % (base_cmd, self.hostname,
                                astring.shell_escape(cmd))
 
-    def _make_scp_cmd(self, src, dst):
+    def _make_scp_cmd(self, src, dst, connect_timeout=300, alive_interval=300):
         """
         Given a list of source paths and a destination path, produces the
         appropriate scp command for encoding it. Remote paths must be
@@ -402,9 +402,11 @@ class BaseRemote(object):
         key_option = ''
         if self.key_file:
             key_option = '-i %s' % os.path.expanduser(self.key_file)
-        command = ("scp -rq %s -o StrictHostKeyChecking=no "
+        command = ("scp -r %s -o StrictHostKeyChecking=no -o BatchMode=yes "
+                   "-o ConnectTimeout=%d -o ServerAliveInterval=%d "
                    "-o UserKnownHostsFile=%s -P %d %s %s '%s'")
-        return command % (self.master_ssh_option, self.known_hosts_file,
+        return command % (self.master_ssh_option, connect_timeout,
+                          alive_interval, self.known_hosts_file,
                           self.port, key_option, " ".join(src), dst)
 
     def _make_rsync_compatible_globs(self, pth, is_local):

--- a/sdcm/remote.py
+++ b/sdcm/remote.py
@@ -257,6 +257,11 @@ def _make_ssh_command(user="root", port=22, opts='', hosts_file='/dev/null',
                            alive_interval, user, port)
 
 
+def disable_master_ssh():
+    global ENABLE_MASTER_SSH
+    ENABLE_MASTER_SSH = False
+
+
 class BaseRemote(object):
 
     def __init__(self, hostname, user="root", port=22, password="",

--- a/sdcm/remote.py
+++ b/sdcm/remote.py
@@ -399,10 +399,13 @@ class BaseRemote(object):
         appropriate scp command for encoding it. Remote paths must be
         pre-encoded.
         """
+        key_option = ''
+        if self.key_file:
+            key_option = '-i %s' % self.key_file
         command = ("scp -rq %s -o StrictHostKeyChecking=no "
-                   "-o UserKnownHostsFile=%s -P %d %s '%s'")
+                   "-o UserKnownHostsFile=%s -P %d %s %s '%s'")
         return command % (self.master_ssh_option, self.known_hosts_file,
-                          self.port, " ".join(src), dst)
+                          self.port, key_option, " ".join(src), dst)
 
     def _make_rsync_compatible_globs(self, pth, is_local):
         """

--- a/sdcm/remote.py
+++ b/sdcm/remote.py
@@ -521,7 +521,7 @@ class BaseRemote(object):
 
     def receive_files(self, src, dst, delete_dst=False,
                       preserve_perm=True, preserve_symlinks=False,
-                      verbose=False):
+                      verbose=False, ssh_timeout=None):
         """
         Copy files from the remote host to a local path.
 
@@ -546,6 +546,7 @@ class BaseRemote(object):
         :param preserve_symlinks: Try to preserve symlinks instead of
             transforming them into files/dirs on copy.
         :param verbose: Log commands being used and their outputs.
+        :param ssh_timeout: Timeout is used for ssh_run()
 
         :raises: process.CmdError if the remote copy command failed.
         """
@@ -566,7 +567,7 @@ class BaseRemote(object):
                 rsync = self._make_rsync_cmd([remote_source], local_dest,
                                              delete_dst, preserve_symlinks)
                 ssh_run(rsync, shell=True, extra_text=self.hostname,
-                        verbose=verbose)
+                        verbose=verbose, timeout=ssh_timeout)
                 try_scp = False
             except process.CmdError, e:
                 self.log.warning("Trying scp, rsync failed: %s", e)
@@ -587,7 +588,7 @@ class BaseRemote(object):
                 local_dest = astring.shell_escape(dst)
                 scp = self._make_scp_cmd([remote_source], local_dest)
                 ssh_run(scp, shell=True, extra_text=self.hostname,
-                        verbose=verbose)
+                        verbose=verbose, timeout=ssh_timeout)
 
         if not preserve_perm:
             # we have no way to tell scp to not try to preserve the
@@ -597,7 +598,7 @@ class BaseRemote(object):
             self._set_umask_perms(dst)
 
     def send_files(self, src, dst, delete_dst=False,
-                   preserve_symlinks=False, verbose=False):
+                   preserve_symlinks=False, verbose=False, ssh_timeout=None):
         """
         Copy files from a local path to the remote host.
 
@@ -620,6 +621,7 @@ class BaseRemote(object):
         :param preserve_symlinks: Try to preserve symlinks instead of
             transforming them into files/dirs on copy.
         :param verbose: Log commands being used and their outputs.
+        :param ssh_timeout: Timeout is used for ssh_run()
 
         :raises: process.CmdError if the remote copy command failed
         """
@@ -640,7 +642,7 @@ class BaseRemote(object):
                 rsync = self._make_rsync_cmd(local_sources, remote_dest,
                                              delete_dst, preserve_symlinks)
                 ssh_run(rsync, shell=True, extra_text=self.hostname,
-                        verbose=verbose)
+                        verbose=verbose, timeout=ssh_timeout)
                 try_scp = False
             except process.CmdError, details:
                 self.log.warning("Trying scp, rsync failed: %s", details)
@@ -685,7 +687,7 @@ class BaseRemote(object):
             if local_sources:
                 scp = self._make_scp_cmd(local_sources, remote_dest)
                 ssh_run(scp, shell=True, extra_text=self.hostname,
-                        verbose=verbose)
+                        verbose=verbose, timeout=ssh_timeout)
 
     def _ssh_ping(self, timeout=30):
         try:

--- a/sdcm/remote.py
+++ b/sdcm/remote.py
@@ -521,7 +521,7 @@ class BaseRemote(object):
 
     def receive_files(self, src, dst, delete_dst=False,
                       preserve_perm=True, preserve_symlinks=False,
-                      verbose=False, ssh_timeout=None):
+                      verbose=False, ssh_timeout=300):
         """
         Copy files from the remote host to a local path.
 

--- a/sdcm/remote.py
+++ b/sdcm/remote.py
@@ -570,6 +570,8 @@ class BaseRemote(object):
                 try_scp = False
             except process.CmdError, e:
                 self.log.warning("Trying scp, rsync failed: %s", e)
+                # Make sure master ssh available
+                self.start_master_ssh()
 
         if try_scp:
             # scp has no equivalent to --delete, just drop the entire dest dir
@@ -642,6 +644,8 @@ class BaseRemote(object):
                 try_scp = False
             except process.CmdError, details:
                 self.log.warning("Trying scp, rsync failed: %s", details)
+                # Make sure master ssh available
+                self.start_master_ssh()
 
         if try_scp:
             # scp has no equivalent to --delete, just drop the entire dest dir

--- a/sdcm/remote.py
+++ b/sdcm/remote.py
@@ -371,7 +371,7 @@ class BaseRemote(object):
                                     opts=self.master_ssh_option,
                                     hosts_file=self.known_hosts_file,
                                     key_file=self.key_file,
-                                    extra_ssh_options=self.extra_ssh_options)
+                                    extra_ssh_options=self.extra_ssh_options.replace('-tt', '-t'))
         if delete_dst:
             delete_flag = "--delete"
         else:

--- a/sdcm/remote.py
+++ b/sdcm/remote.py
@@ -251,7 +251,7 @@ def _make_ssh_command(user="root", port=22, opts='', hosts_file='/dev/null',
                      "-o ConnectTimeout=%d -o ServerAliveInterval=%d "
                      "-l %s -p %d")
     if key_file is not None:
-        base_command += ' -i %s' % key_file
+        base_command += ' -i %s' % os.path.expanduser(key_file)
     assert connect_timeout > 0  # can't disable the timeout
     return base_command % (opts, hosts_file, connect_timeout,
                            alive_interval, user, port)
@@ -401,7 +401,7 @@ class BaseRemote(object):
         """
         key_option = ''
         if self.key_file:
-            key_option = '-i %s' % self.key_file
+            key_option = '-i %s' % os.path.expanduser(self.key_file)
         command = ("scp -rq %s -o StrictHostKeyChecking=no "
                    "-o UserKnownHostsFile=%s -P %d %s %s '%s'")
         return command % (self.master_ssh_option, self.known_hosts_file,

--- a/sdcm/remote.py
+++ b/sdcm/remote.py
@@ -375,7 +375,7 @@ class BaseRemote(object):
             symlink_flag = ""
         else:
             symlink_flag = "-L"
-        command = "rsync %s %s --timeout=100000 --rsh='%s' -az %s %s"
+        command = "rsync %s %s --timeout=300 --rsh='%s' -az %s %s"
         return command % (symlink_flag, delete_flag, ssh_cmd,
                           " ".join(src), dst)
 


### PR DESCRIPTION
rsync used a huge timeout in sending files, it might block the testing, the patchset reduced it to 300s.

if rsync failed to sending files, we will retry scp, but current scp cmdline didn't has SSH Key option. It's fixed by last patch.
