### PR TITLE
cluster: retry to add keep-alive tag in error case

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1041,7 +1041,8 @@ class GCENode(BaseNode):
             self.log.info('Test duration set to %s. '
                           'Tagging node with "keep-alive"',
                           TEST_DURATION)
-            self._gce_service.ex_set_node_tags(self._instance, ['keep-alive'])
+            self._instance_wait_safe(self._gce_service.ex_set_node_tags,
+                                     self._instance, ['keep-alive'])
 
     def _instance_wait_safe(self, instance_method, *args, **kwargs):
         """


### PR DESCRIPTION
I saw some error in adding tag for gce instance, it seems
the problem from GCE service. However it's necessary to
use safely retry for calling gce method.

https://github.com/scylladb/scylla-cluster-tests/issues/254

Signed-off-by: Amos Kong <amos@scylladb.com>