### PR TITLE
monitor: use private ip in configuring monitor

### DIFF
--- a/big_cluster_test.py
+++ b/big_cluster_test.py
@@ -46,8 +46,8 @@ class HugeClusterTest(ClusterTester):
                             monitor_info=monitor_info)
         self.loaders.wait_for_init()
         self.db_cluster.wait_for_init()
-        nodes_monitored = [node.public_ip_address for node in self.db_cluster.nodes]
-        nodes_monitored += [node.public_ip_address for node in self.loaders.nodes]
+        nodes_monitored = [node.private_ip_address for node in self.db_cluster.nodes]
+        nodes_monitored += [node.private_ip_address for node in self.loaders.nodes]
         self.monitors.wait_for_init(targets=nodes_monitored)
         self.stress_thread = None
 

--- a/grow_cluster_test.py
+++ b/grow_cluster_test.py
@@ -67,8 +67,8 @@ class GrowClusterTest(ClusterTester):
                             monitor_info=monitor_info)
         self.loaders.wait_for_init()
         self.db_cluster.wait_for_init()
-        nodes_monitored = [node.public_ip_address for node in self.db_cluster.nodes]
-        nodes_monitored += [node.public_ip_address for node in self.loaders.nodes]
+        nodes_monitored = [node.private_ip_address for node in self.db_cluster.nodes]
+        nodes_monitored += [node.private_ip_address for node in self.loaders.nodes]
         self.monitors.wait_for_init(targets=nodes_monitored)
         self.stress_thread = None
 

--- a/query_limits_test.py
+++ b/query_limits_test.py
@@ -55,8 +55,8 @@ class QueryLimitsTest(ClusterTester):
                             monitor_info=monitor_info)
         self.loaders.wait_for_init()
         self.db_cluster.wait_for_init()
-        nodes_monitored = [node.public_ip_address for node in self.db_cluster.nodes]
-        nodes_monitored += [node.public_ip_address for node in self.loaders.nodes]
+        nodes_monitored = [node.private_ip_address for node in self.db_cluster.nodes]
+        nodes_monitored += [node.private_ip_address for node in self.loaders.nodes]
         self.monitors.wait_for_init(targets=nodes_monitored)
         self.stress_thread = None
 

--- a/reduce_cluster_test.py
+++ b/reduce_cluster_test.py
@@ -65,8 +65,8 @@ class ReduceClusterTest(ClusterTester):
                             monitor_info=monitor_info)
         self.loaders.wait_for_init()
         self.db_cluster.wait_for_init()
-        nodes_monitored = [node.public_ip_address for node in self.db_cluster.nodes]
-        nodes_monitored += [node.public_ip_address for node in self.loaders.nodes]
+        nodes_monitored = [node.private_ip_address for node in self.db_cluster.nodes]
+        nodes_monitored += [node.private_ip_address for node in self.loaders.nodes]
         self.monitors.wait_for_init(targets=nodes_monitored)
 
     def get_stress_cmd(self):

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -195,8 +195,8 @@ class Nemesis(object):
     def reconfigure_monitoring(self):
         for monitoring_node in self.monitoring_set.nodes:
             self.log.info('Monitoring node: %s', str(monitoring_node))
-            targets = [n.public_ip_address for n in self.cluster.nodes]
-            targets += [n.public_ip_address for n in self.loaders.nodes]
+            targets = [n.private_ip_address for n in self.cluster.nodes]
+            targets += [n.private_ip_address for n in self.loaders.nodes]
             monitoring_node.reconfigure_prometheus(targets=targets)
 
     def disrupt_nodetool_decommission(self, add_node=True):


### PR DESCRIPTION
I wish to reduce network load in monitor in some special
case. For example, one or more nodes are removed, there
are many network timeout/waiting/err for prometheus
service in monitor.

The ip addresses are only used for prometheus service
in monitor node. It doesn't care where sct is running.