### PR TITLE
Stop background threads started by BaseNode

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1032,6 +1032,7 @@ class OpenStackNode(BaseNode):
 
     def destroy(self):
         self._instance.destroy()
+        self.stop_task_threads()
         self.log.info('Destroyed')
 
 
@@ -1129,6 +1130,7 @@ class GCENode(BaseNode):
 
     def destroy(self):
         self._instance_wait_safe(self._instance.destroy)
+        self.stop_task_threads()
         self.log.info('Destroyed')
 
 
@@ -1217,6 +1219,7 @@ class AWSNode(BaseNode):
         self._instance.terminate()
         global EC2_INSTANCES
         EC2_INSTANCES.remove(self._instance)
+        self.stop_task_threads()
         self.log.info('Destroyed')
 
 
@@ -1301,6 +1304,7 @@ class LibvirtNode(BaseNode):
         self._domain.destroy()
         self._domain.undefine()
         remove_if_exists(self._backing_image)
+        self.stop_task_threads()
         self.log.info('Destroyed')
 
 


### PR DESCRIPTION
One longevity job reached max limit of open files after run for
3 days. It's caused by that some background threads still run
after node is destroyed, there are many open log file and ssh
connections.

This patchset stops the threads before destroying the node.

https://github.com/scylladb/scylla-cluster-tests/issues/262