### PR TITLE
[WIP] sdcm: Make IP to access machine instances configurable

### DIFF
--- a/data_dir/scylla.yaml
+++ b/data_dir/scylla.yaml
@@ -29,7 +29,12 @@ failure_post_behavior: destroy
 # This value is supposed to reproduce
 # https://github.com/scylladb/scylla/issues/1140
 space_node_threshold: 6442450944
-
+# Type of IP used to connect to machine instances.
+# This depends on whether you are running your tests from a machine inside
+# your cloud provider, where it makes sense to use 'private', or outside (use 'public')
+# Default: Use public IPs to connect to instances (public)
+# Use private IPs to connect to instances (private)
+ip_ssh_connections: 'public'
 # The new db binary will be uploaded to db instance to replace the one
 # provided by the ami. This is useful to test out a new scylla version
 # without making a new ami.

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -78,6 +78,12 @@ DEFAULT_USER_PREFIX = getpass.getuser()
 TEST_DURATION = 60
 # max limit of coredump file can be uploaded(5 GB)
 COREDUMP_MAX_SIZE = 1024 * 1024 * 1024 * 5
+IP_SSH_CONNECTIONS = 'public'
+
+
+def set_ip_ssh_connections(ip_type):
+    global IP_SSH_CONNECTIONS
+    IP_SSH_CONNECTIONS = ip_type
 
 
 def set_duration(duration):
@@ -362,6 +368,8 @@ class BaseNode(object):
         # if we want to add more nodes when the cluster already exists, then we should
         # enable bootstrap. So addition means not the first set of node.
         self.is_addition = False
+        self._ssh_ip_mapping = {'public': self.public_ip_address,
+                                'private': self.private_ip_address}
 
     def file_exists(self, file_path):
         try:
@@ -971,7 +979,7 @@ class OpenStackNode(BaseNode):
         self._instance = openstack_instance
         self._openstack_service = openstack_service
         self._wait_private_ip()
-        ssh_login_info = {'hostname': self.public_ip_address,
+        ssh_login_info = {'hostname': self._ssh_ip_mapping[IP_SSH_CONNECTIONS],
                           'user': openstack_image_username,
                           'key_file': credentials.key_file,
                           'wait_key_installed': 30,
@@ -1036,7 +1044,7 @@ class GCENode(BaseNode):
         self._instance = gce_instance
         self._gce_service = gce_service
         self._wait_public_ip()
-        ssh_login_info = {'hostname': self.public_ip_address,
+        ssh_login_info = {'hostname': self._ssh_ip_mapping[IP_SSH_CONNECTIONS],
                           'user': gce_image_username,
                           'key_file': credentials.key_file,
                           'extra_ssh_options': '-tt'}
@@ -1136,7 +1144,7 @@ class AWSNode(BaseNode):
         self._wait_public_ip()
         self._ec2.create_tags(Resources=[self._instance.id],
                               Tags=[{'Key': 'Name', 'Value': name}])
-        ssh_login_info = {'hostname': self._instance.public_ip_address,
+        ssh_login_info = {'hostname': self._ssh_ip_mapping[IP_SSH_CONNECTIONS],
                           'user': ami_username,
                           'key_file': credentials.key_file}
         super(AWSNode, self).__init__(name=name,
@@ -1222,7 +1230,7 @@ class LibvirtNode(BaseNode):
         self._hypervisor = hypervisor
         wait.wait_for(self._domain.isActive)
         self._wait_public_ip()
-        ssh_login_info = {'hostname': self.public_ip_address,
+        ssh_login_info = {'hostname': self._ssh_ip_mapping[IP_SSH_CONNECTIONS],
                           'user': domain_username,
                           'password': domain_password}
         super(LibvirtNode, self).__init__(name=name,

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -143,6 +143,10 @@ class ClusterTester(Test):
                                             job=job, runner_queue=runner_queue)
         self._failure_post_behavior = self.params.get(key='failure_post_behavior',
                                                       default='destroy')
+        ip_ssh_connections = self.params.get(key='ip_ssh_connections', default='public')
+        self.log.debug("IP used for SSH connections is '%s'",
+                       ip_ssh_connections)
+        cluster.set_ip_ssh_connections(ip_ssh_connections)
         self.log.debug("Behavior on failure/post test is '%s'",
                        self._failure_post_behavior)
         cluster.register_cleanup(cleanup=self._failure_post_behavior)


### PR DESCRIPTION
ATTENTION: Untested. Please pick the implementation, test it and see if there's merit to it.

When one runs SCT from a cloud provider instance, in
the same internal network as the machine instances that
will be accessible, it's always advantageous to use
internal IPs, but when a work laptop is used, you have
to use the public IPs to access them. Make that aspect
configurable, and make the default value 'public'.

Signed-off-by: Lucas Meneghel Rodrigues <lookkas@gmail.com>