### PR TITLE
release subprocess and fd when node is destroyed

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -784,6 +784,7 @@ WantedBy=multi-user.target
         raise NotImplementedError('Derived classes must implement restart')
 
     def stop_task_threads(self, timeout=10):
+        del(self.remoter)
         self.termination_event.set()
         if self._backtrace_thread:
             self._backtrace_thread.join(timeout)

--- a/sdcm/remote.py
+++ b/sdcm/remote.py
@@ -204,6 +204,10 @@ class SSHSubProcess(process.SubProcess):
                 if lock is not None:
                     lock.release()
 
+    def close_file_handler(self):
+        if self._file_handler:
+            self._file_handler.close()
+
 
 def ssh_run(cmd, timeout=None, verbose=True, ignore_status=False,
             allow_output_check='all', shell=False, env=None,
@@ -216,6 +220,7 @@ def ssh_run(cmd, timeout=None, verbose=True, ignore_status=False,
 
     splist.append(sp)
     cmd_result = sp.run(timeout=timeout)
+    sp.close_file_handler()
     splist.remove(sp)
 
     fail_condition = cmd_result.exit_status != 0 or cmd_result.interrupted


### PR DESCRIPTION
When longevity job run about 3 days, avocado reached open-file limit (4096). Some ssh processes still exist when the nodes are removed in Decommission nemesis testing, and file descriptors of database.log aren't closed.

This patchset try to cleanup resources of ssh (delete remoter object, kill subprocess, close log fd).

Issue: https://github.com/scylladb/scylla-cluster-tests/issues/262