### PR TITLE
use --skip-broken when 'yum update -y'

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1103,7 +1103,7 @@ class GCENode(BaseNode):
 
         if not ok:
             raise NodeError('GCE instance %s method call error after '
-                            'exponencial backoff wait' % self._instance.id)
+                            'exponential backoff wait' % self._instance.id)
 
     @property
     def public_ip_address(self):
@@ -1504,7 +1504,7 @@ class BaseScyllaCluster(object):
         def update_scylla_packages(node, queue):
             node.log.info('Updating DB binary')
             node.remoter.send_files(new_scylla_bin, '/tmp/scylla', verbose=True)
-            node.remoter.run('sudo yum update -y')
+            node.remoter.run('sudo yum update -y --skip-broken')
             node.remoter.run('sudo yum install python34-PyYAML -y')
             # replace the packages
             node.remoter.run('yum list installed | grep scylla')


### PR DESCRIPTION
to avoid env issue like:

--> Processing Dependency: /sbin/new-kernel-pkg for package: kernel-4.9.17-8.31.amzn1.x86_64
--> Finished Dependency Resolution
Error: Package: kernel-4.9.17-8.31.amzn1.x86_64 (@amzn-main)
           Requires: /sbin/new-kernel-pkg
           Removing: grubby-8.28-17.el7.x86_64 (@base)
               Not found
           Updated By: grubby-8.28-21.el7_3.x86_64 (updates)
               Not found
 You could try using --skip-broken to work around the problem
 You could try running: rpm -Va --nofiles --nodigest