### PR TITLE
cleanup: always get monitor snapshot

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2008,6 +2008,9 @@ class BaseMonitorSet(object):
         Take snapshot for grafana monitor in the end of test
         """
         phantomjs_url = "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2"
+        if not self.grafana_start_time:
+            self.log.error("grafana isn't setup, skip to get snapshot")
+            return
         start_time = str(self.grafana_start_time).split('.')[0] + '000'
 
         try:

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2381,7 +2381,6 @@ class MonitorSetLibvirt(LibvirtCluster, BaseMonitorSet):
 
     def destroy(self):
         self.log.info('Destroy nodes')
-        self.get_monitor_snapshot()
         for node in self.nodes:
             node.destroy()
 
@@ -3461,7 +3460,6 @@ class MonitorSetOpenStack(OpenStackCluster, BaseMonitorSet):
 
     def destroy(self):
         self.log.info('Destroy nodes')
-        self.get_monitor_snapshot()
         for node in self.nodes:
             node.destroy()
 
@@ -3491,7 +3489,6 @@ class MonitorSetGCE(GCECluster, BaseMonitorSet):
 
     def destroy(self):
         self.log.info('Destroy nodes')
-        self.get_monitor_snapshot()
         for node in self.nodes:
             node.destroy()
 
@@ -3524,6 +3521,5 @@ class MonitorSetAWS(AWSCluster, BaseMonitorSet):
 
     def destroy(self):
         self.log.info('Destroy nodes')
-        self.get_monitor_snapshot()
         for node in self.nodes:
             node.destroy()

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -761,6 +761,7 @@ class ClusterTester(Test):
                 self.db_cluster = None
         if self.monitors is not None:
             self.monitors.get_backtraces()
+            self.monitors.get_monitor_snapshot()
             self.monitors.download_monitor_data()
             if self._failure_post_behavior == 'destroy':
                 self.monitors.destroy()


### PR DESCRIPTION
Get monitor snapshot before destorying monitor, then we can always
get snapshot even monitor isn't destroyed.

additional fix for https://github.com/scylladb/scylla-cluster-tests/pull/295