### PR TITLE
Revert "gce: reserve public ip addresses as static during test"

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1362,7 +1362,6 @@ class BaseCluster(object):
         self.nodes = []
         self.nemesis = []
         self.params = params
-        self.static_addresses = []
         self.add_nodes(n_nodes)
         self.coredumps = dict()
 
@@ -2544,8 +2543,6 @@ class GCECluster(BaseCluster):
                                                      image=self._gce_image,
                                                      ex_disks_gce_struct=gce_disk_struct)
             self.log.info('Created instance %s', instance)
-            if 'db-node' in name:
-                self.static_addresses.append(self._gce_service.ex_create_address(name, address=instance.public_ips[0]))
             GCE_INSTANCES.append(instance)
             try:
                 n = GCENode(gce_instance=instance,
@@ -3050,8 +3047,6 @@ class ScyllaGCECluster(GCECluster, BaseScyllaCluster):
     def destroy(self):
         self.stop_nemesis()
         super(ScyllaGCECluster, self).destroy()
-        for i in self.static_addresses:
-            self._gce_service.ex_destroy_address(i)
 
 
 class ScyllaAWSCluster(AWSCluster, BaseScyllaCluster):


### PR DESCRIPTION
This reverts commit 1545308ee1c624aa8e58289c05a3ddd12dc710fd.

There is a quota of 7 static IPs only in GCE, let's revert this patch.