### PR TITLE
cluster: support multiple datacenters

### DIFF
--- a/data_dir/scylla.yaml
+++ b/data_dir/scylla.yaml
@@ -136,6 +136,20 @@ backends: !mux
             ami_db_cassandra_user: 'ubuntu'
             ami_id_monitor: 'ami-79d3f06e'
             ami_monitor_user: 'centos'
+        #multiple datacenters
+        us_east_1_and_us_west_2:
+            user_credentials_path: ''
+            region_name: 'us-east-1 us-west-2'
+            security_group_ids: 'sg-c5e1f7a0 sg-81703ae4'
+            subnet_id: 'subnet-ec4a72c4 subnet-5207ee37'
+            ami_id_db_scylla: 'ami-79d3f06e ami-ec3e9e8c'
+            ami_db_scylla_user: 'centos'
+            ami_id_loader: 'ami-79d3f06e'
+            ami_loader_user: 'centos'
+            ami_id_db_cassandra: 'ami-ada2b6c4'
+            ami_db_cassandra_user: 'ubuntu'
+            ami_id_monitor: 'ami-79d3f06e'
+            ami_monitor_user: 'centos'
 
     openstack: !mux
         cluster_backend: 'openstack'
@@ -193,6 +207,9 @@ backends: !mux
         scylla_repo: 'http://downloads.scylladb.com/rpm/centos/scylla-1.4.repo'
         us_east_1:
           gce_datacenter: 'us-east1-b'
+        # multiple datacenters
+        # us_east_1_and_asias_northeast_1:
+        #   gce_datacenter: 'us-east1-b asia-northeast1-a'
 
 databases: !mux
     cassandra:

--- a/data_dir/scylla.yaml
+++ b/data_dir/scylla.yaml
@@ -6,8 +6,8 @@ test_duration: 60
 stress_cmd: cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000
 # tcpdump to try to capture nodetool API
 tcpdump: false
-# Number of database nodes
-n_db_nodes: 6
+# Number list of database nodes in multiple date centers. Legacy type (int): Number of database nodes
+n_db_nodes: '6'
 # If you want to use more than 1 loader node, I recommend
 # increasing the size of the DB instance (instance_type_db parameter),
 # since 't2.micro' nodes tend to struggle with a lot of load.

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1144,7 +1144,7 @@ class GCENode(BaseNode):
     def __init__(self, gce_instance, gce_service, credentials,
                  node_prefix='node', node_index=1, gce_image_username='root',
                  base_logdir=None, dc_idx=0):
-        name = '%s-%s' % (node_prefix, node_index)
+        name = '%s-%s-%s' % (node_prefix, dc_idx, node_index)
         self._instance = gce_instance
         self._gce_service = gce_service
         self._wait_public_ip()

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2653,7 +2653,9 @@ class GCECluster(BaseCluster):
 
             self._node_index += 1
             self.nodes += [n]
-            if len(self.nodes) - len(nodes) > 0:
+
+            local_nodes = [n for n in self.nodes if n.dc_idx == dc_idx]
+            if len(local_nodes) - len(nodes) > 0:
                 n.is_addition = True
 
         assert len(nodes) == count, 'Fail to create {} instances'.format(count)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2970,7 +2970,7 @@ class ScyllaGCECluster(GCECluster, BaseScyllaCluster):
         return added_nodes
 
     def _node_setup(self, node, seed_address):
-        node.remoter.run('sudo systemctl stop scylla-server.service')
+        node.remoter.run('sudo systemctl stop scylla-server.service', ignore_status=True)
         yaml_dst_path = os.path.join(tempfile.mkdtemp(prefix='scylla-longevity'),
                                      'scylla.yaml')
         # Sometimes people might set up base images with

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1501,7 +1501,8 @@ class BaseCluster(object):
                 errors.append({node.name: node_errors})
         return errors
 
-    def set_tc(self, node, dst_nodes):
+    def set_tc(self, node, dst_nodes, local_nodes):
+        # FIXME: local_nodes isn't used
         node.remoter.run("sudo modprobe sch_netem")
         node.remoter.run("sudo tc qdisc del dev eth0 root", ignore_status=True)
         node.remoter.run("sudo tc qdisc add dev eth0 handle 1: root prio")
@@ -3109,7 +3110,8 @@ class ScyllaGCECluster(GCECluster, BaseScyllaCluster):
 
         for node in node_list:
             dst_nodes = [n for n in node_list if n.dc_idx != node.dc_idx]
-            self.set_tc(node, dst_nodes)
+            local_nodes = [n for n in node_list if n.dc_idx == node.dc_idx and n != node]
+            self.set_tc(node, dst_nodes, local_nodes)
 
     def destroy(self):
         self.stop_nemesis()

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3113,7 +3113,8 @@ class ScyllaGCECluster(GCECluster, BaseScyllaCluster):
         for node in node_list:
             dst_nodes = [n for n in node_list if n.dc_idx != node.dc_idx]
             local_nodes = [n for n in node_list if n.dc_idx == node.dc_idx and n != node]
-            self.set_tc(node, dst_nodes, local_nodes)
+            if self.params.get('enable_tc').lower() == 'true':
+                self.set_tc(node, dst_nodes, local_nodes)
 
     def destroy(self):
         self.stop_nemesis()

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3104,7 +3104,9 @@ class ScyllaGCECluster(GCECluster, BaseScyllaCluster):
         time_elapsed = time.time() - start_time
         self.log.debug('Setup duration -> %s s', int(time_elapsed))
         if not node_list[0].scylla_version:
-            result = node_list[0].remoter.run("scylla --version")
+            result = node_list[0].remoter.run("rpm -q scylla")
+            match = re.findall("scylla-(.*).el7.centos", result.stdout)
+            node_list[0].scylla_version = match[0] if match else ''
             for node in node_list:
                 node.scylla_version = result.stdout
 
@@ -3237,7 +3239,9 @@ class ScyllaAWSCluster(AWSCluster, BaseScyllaCluster):
         time_elapsed = time.time() - start_time
         self.log.debug('Setup duration -> %s s', int(time_elapsed))
         if not node_list[0].scylla_version:
-            result = node_list[0].remoter.run("scylla --version")
+            result = node_list[0].remoter.run("rpm -q scylla")
+            match = re.findall("scylla-(.*).el7.centos", result.stdout)
+            node_list[0].scylla_version = match[0] if match else ''
             for node in node_list:
                 node.scylla_version = result.stdout
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -242,7 +242,7 @@ class Nemesis(object):
                 self.reconfigure_monitoring()
                 # Replace the node that was terminated.
                 if add_node:
-                    new_nodes = self.cluster.add_nodes(count=1)
+                    new_nodes = self.cluster.add_nodes(count=1, dc_idx=self.target_node.dc_idx)
                     self.cluster.wait_for_init(node_list=new_nodes)
                     self.reconfigure_monitoring()
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -209,8 +209,12 @@ class Nemesis(object):
     def reconfigure_monitoring(self):
         for monitoring_node in self.monitoring_set.nodes:
             self.log.info('Monitoring node: %s', str(monitoring_node))
-            targets = [n.private_ip_address for n in self.cluster.nodes]
-            targets += [n.private_ip_address for n in self.loaders.nodes]
+            if len(self.cluster.datacenter) > 1:
+                targets = [n.public_ip_address for n in self.cluster.nodes]
+                targets += [n.public_ip_address for n in self.loaders.nodes]
+            else:
+                targets = [n.private_ip_address for n in self.cluster.nodes]
+                targets += [n.private_ip_address for n in self.loaders.nodes]
             monitoring_node.reconfigure_prometheus(targets=targets)
 
     def disrupt_nodetool_decommission(self, add_node=True):

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -345,10 +345,15 @@ class Nemesis(object):
         self.log.info('StopStart %s', self.target_node)
         self.target_node.restart()
 
-    def call_random_disrupt_method(self):
-        disrupt_methods = [attr[1] for attr in inspect.getmembers(self) if
-                           attr[0].startswith('disrupt_') and
-                           callable(attr[1])]
+    def call_random_disrupt_method(self, disrupt_methods=None):
+        if not disrupt_methods:
+            disrupt_methods = [attr[1] for attr in inspect.getmembers(self) if
+                               attr[0].startswith('disrupt_') and
+                               callable(attr[1])]
+        else:
+            disrupt_methods = [attr[1] for attr in inspect.getmembers(self) if
+                               attr[0] in disrupt_methods and
+                               callable(attr[1])]
         disrupt_method = random.choice(disrupt_methods)
         disrupt_method()
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -512,6 +512,13 @@ class ChaosMonkey(Nemesis):
         self.call_random_disrupt_method()
 
 
+class MdcChaosMonkey(Nemesis):
+
+    @log_time_elapsed_and_status
+    def disrupt(self):
+        self.call_random_disrupt_method(disrupt_methods=['disrupt_destroy_data_then_repair', 'disrupt_no_corrupt_repair', 'disrupt_nodetool_decommission'])
+
+
 class UpgradeNemesis(Nemesis):
 
     # upgrade a single node

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -162,11 +162,13 @@ class ClusterTester(Test):
         self.db_cluster.wait_for_init()
         db_node_address = self.db_cluster.nodes[0].private_ip_address
         self.loaders.wait_for_init(db_node_address=db_node_address)
-        nodes_monitored = [node.private_ip_address for node in self.db_cluster.nodes]
-        nodes_monitored += [node.private_ip_address for node in self.loaders.nodes]
-        self.monitors.wait_for_init(targets=nodes_monitored,
-                                    scylla_version=self.db_cluster.nodes[0].scylla_version,
-                                    is_enterprise=self.db_cluster.nodes[0].is_enterprise)
+        if len(self.db_cluster.datacenter) > 1:
+            targets = [n.public_ip_address for n in self.db_cluster.nodes]
+            targets += [n.public_ip_address for n in self.loaders.nodes]
+        else:
+            targets = [n.private_ip_address for n in self.db_cluster.nodes]
+            targets += [n.private_ip_address for n in self.loaders.nodes]
+        self.monitors.wait_for_init(targets=targets, scylla_version=self.db_cluster.nodes[0].scylla_version)
 
     def get_nemesis_class(self):
         """

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -559,7 +559,8 @@ class ClusterTester(Test):
     def _cs_add_node_flag(self, stress_cmd):
         if '-node' not in stress_cmd:
             if len(self.db_cluster.datacenter) > 1:
-                ip = self.db_cluster.get_node_public_ips()[0]
+                ips = [ip for ip in self.db_cluster.get_node_public_ips()]
+                ip = ','.join(ips)
             else:
                 ip = self.db_cluster.get_node_private_ips()[0]
             stress_cmd = '%s -node %s' % (stress_cmd, ip)

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -558,7 +558,10 @@ class ClusterTester(Test):
 
     def _cs_add_node_flag(self, stress_cmd):
         if '-node' not in stress_cmd:
-            ip = self.db_cluster.get_node_private_ips()[0]
+            if len(self.db_cluster.datacenter) > 1:
+                ip = self.db_cluster.get_node_public_ips()[0]
+            else:
+                ip = self.db_cluster.get_node_private_ips()[0]
             stress_cmd = '%s -node %s' % (stress_cmd, ip)
         return stress_cmd
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -353,7 +353,13 @@ class ClusterTester(Test):
         if loader_info['type'] is None:
             loader_info['type'] = self.params.get('instance_type_loader')
         if db_info['n_nodes'] is None:
-            db_info['n_nodes'] = self.params.get('n_db_nodes')
+            n_db_nodes = self.params.get('n_db_nodes')
+            if type(n_db_nodes) == int:  # legacy type
+                db_info['n_nodes'] = [n_db_nodes]
+            elif type(n_db_nodes) == str:  # latest type to support multiple datacenters
+                db_info['n_nodes'] = [int(n) for n in n_db_nodes.split()]
+            else:
+                self.fail('Unsupported parameter type: {}'.format(type(n_db_nodes)))
         if db_info['type'] is None:
             db_info['type'] = self.params.get('instance_type_db')
         if monitor_info['n_nodes'] is None:

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -264,7 +264,13 @@ class ClusterTester(Test):
         if loader_info['n_local_ssd'] is None:
             loader_info['n_local_ssd'] = self.params.get('gce_n_local_ssd_disk_loader')
         if db_info['n_nodes'] is None:
-            db_info['n_nodes'] = self.params.get('n_db_nodes')
+            n_db_nodes = self.params.get('n_db_nodes')
+            if isinstance(n_db_nodes, int):  # legacy type
+                db_info['n_nodes'] = [n_db_nodes]
+            elif isinstance(n_db_nodes, str):  # latest type to support multiple datacenters
+                db_info['n_nodes'] = [int(n) for n in n_db_nodes.split()]
+            else:
+                self.fail('Unsupported parameter type: {}'.format(type(n_db_nodes)))
         if db_info['type'] is None:
             db_info['type'] = self.params.get('gce_instance_type_db')
         if db_info['disk_type'] is None:

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -577,7 +577,7 @@ class ClusterTester(Test):
 
     @clean_aws_resources
     def run_stress_thread(self, stress_cmd, duration=None, stress_num=1, keyspace_num=1, profile=None):
-        stress_cmd = self._cs_add_node_flag(stress_cmd)
+        #stress_cmd = self._cs_add_node_flag(stress_cmd)
         if duration is None:
             duration = self.params.get('test_duration')
         timeout = duration * 60 + 600
@@ -585,7 +585,8 @@ class ClusterTester(Test):
                                               self.outputdir,
                                               stress_num=stress_num,
                                               keyspace_num=keyspace_num,
-                                              profile=profile)
+                                              profile=profile,
+                                              node_list=self.db_cluster.nodes)
 
     @clean_aws_resources
     def kill_stress_thread(self):

--- a/tests/gce-multidc-1.7.yaml
+++ b/tests/gce-multidc-1.7.yaml
@@ -1,0 +1,78 @@
+test_duration: 10080
+stress_cmd: cassandra-stress write cl=QUORUM duration=10080m -schema 'replication(strategy=NetworkTopologyStrategy,us-east1-b=3,us-west1-b=3,us-east4-b=2)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..100000000000
+cassandra_stress_duration: 10080
+cassandra_stress_threads: 1000
+cassandra_stress_population_size: 100000000000
+#n_db_nodes: 3
+n_db_nodes: '5 5 3'
+n_loaders: 3
+n_monitor_nodes: 1
+nemesis_class_name: 'MdcChaosMonkey'
+#nemesis_class_name: 'DrainerMonkey'
+nemesis_interval: 5
+user_prefix: 'sct-multidc'
+failure_post_behavior: keep
+space_node_threshold: 6442
+ip_ssh_connections: 'public'
+
+ami_id_db_scylla_desc: '1.7.rc2'
+
+#es_url:
+#es_user: 
+#es_password: 
+
+backends: !mux
+    aws: !mux
+        # What is the backend that the suite will use to get machines from.
+        cluster_backend: 'aws'
+        # From 0.19 on, iotune will require bigger disk, so let's use a big
+        # loader instance by default.
+        instance_type_loader: 'c3.large'
+        # Size of AWS monitor instance
+        instance_type_monitor: t2.small
+        us_east_1_and_us_west_2:
+            user_credentials_path: ''
+            region_name: 'us-east-1 us-west-2'
+            security_group_ids: 'sg-c5e1f7a0 sg-81703ae4'
+            subnet_id: 'subnet-ec4a72c4 subnet-5207ee37'
+            ami_id_db_scylla: 'ami-40a0e756 ami-77e78617'
+            ami_db_scylla_user: 'centos'
+            ami_id_loader: 'ami-40a0e756'
+            ami_loader_user: 'centos'
+            ami_id_db_cassandra: 'ami-ada2b6c4'
+            ami_db_cassandra_user: 'ubuntu'
+            ami_id_monitor: 'ami-40a0e756'
+            ami_monitor_user: 'centos'
+    gce: !mux
+        cluster_backend: 'gce'
+        user_credentials_path: '~/.ssh/scylla-test'
+        gce_user_credentials: '~/Scylla-c41b78923a54.json'
+        gce_service_account_email: 'skilled-adapter-452@appspot.gserviceaccount.com'
+        gce_project: 'skilled-adapter-452'
+        gce_image: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
+        gce_image_username: 'scylla-test'
+        gce_instance_type_db: 'n1-highmem-8'
+        gce_root_disk_type_db: 'pd-ssd'
+        gce_root_disk_size_db: 50
+        gce_n_local_ssd_disk_db: 1
+        gce_instance_type_loader: 'n1-highcpu-4'
+        gce_root_disk_type_loader: 'pd-standard'
+        gce_root_disk_size_loader: 50
+        gce_n_local_ssd_disk_loader: 0
+        gce_instance_type_monitor: 'n1-standard-2'
+        gce_root_disk_type_monitor: 'pd-standard'
+        gce_root_disk_size_monitor: 50
+        gce_n_local_ssd_disk_monitor: 0
+        scylla_repo: https://s3.amazonaws.com/downloads.scylladb.com/rpm/unstable/centos/branch-1.7/37/scylla.repo
+        #us_east_1:
+        #  gce_datacenter: 'us-east1-b'
+        multi_dcs:
+          gce_datacenter: 'us-east1-b us-west1-b us-east4-b'
+
+databases: !mux
+    cassandra:
+        db_type: cassandra
+        instance_type_db: 'm3.large'
+    scylla:
+        db_type: scylla
+        instance_type_db: 'i2.2xlarge'


### PR DESCRIPTION
Introduced a new parameter 'n_db_nodes_dcs', it's number list of database
nodes in multiple datecenter.

The multi-dc implement is using one gce region right now, we can extend it to multiple regions in future.

Reference: http://docs.scylladb.com/procedures/create_cluster_multidc/