### PR TITLE
introduce enospc test

### DIFF
--- a/enospc_test.py
+++ b/enospc_test.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2017 ScyllaDB
+
+from avocado import main
+from sdcm.tester import ClusterTester
+from sdcm.nemesis import EnospcAllNodesMonkey
+
+
+class EnospcTest(ClusterTester):
+    """
+    Cost rest space to trigger ENOSPC error for scylla,
+    and then release space to recover scylla service.
+    :avocado: enable
+    """
+    def test_enospc_nodes(self):
+        self.db_cluster.add_nemesis(nemesis=EnospcAllNodesMonkey,
+                                    loaders=self.loaders,
+                                    monitoring_set=self.monitors)
+
+        # run a write workload
+        stress_queue = self.run_stress_thread(stress_cmd=self.params.get('stress_cmd'),
+                                              stress_num=2, keyspace_num=1)
+
+        self.db_cluster.start_nemesis(interval=15)
+        self.db_cluster.stop_nemesis(timeout=1000)
+
+        self.get_stress_results(queue=stress_queue, stress_num=2, keyspace_num=1)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/gce-enospc-1.7-30mins.yaml
+++ b/tests/gce-enospc-1.7-30mins.yaml
@@ -1,0 +1,41 @@
+test_duration: 40
+n_db_nodes: 3
+n_loaders: 4
+n_monitor_nodes: 1
+user_prefix: 'gce-enospc-1-7'
+failure_post_behavior: destroy
+stress_cmd: cassandra-stress write no-warmup cl=QUORUM duration=20m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -errors ignore -pop seq=1..10000000
+
+backends: !mux
+    gce: !mux
+        cluster_backend: 'gce'
+        user_credentials_path: '~/.ssh/scylla-test'
+        gce_user_credentials: '~/Scylla-c41b78923a54.json'
+        gce_service_account_email: 'skilled-adapter-452@appspot.gserviceaccount.com'
+        gce_project: 'skilled-adapter-452'
+        gce_image: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
+        gce_image_username: 'scylla-test'
+        gce_instance_type_db: 'n1-highmem-16'
+        gce_root_disk_type_db: 'pd-ssd'
+        gce_root_disk_size_db: 50
+        gce_n_local_ssd_disk_db: 1
+        gce_instance_type_loader: 'n1-standard-2'
+        gce_root_disk_type_loader: 'pd-standard'
+        gce_n_local_ssd_disk_loader: 0
+        gce_instance_type_monitor: 'n1-standard-1'
+        gce_root_disk_type_monitor: 'pd-standard'
+        gce_root_disk_size_monitor: 50
+        gce_n_local_ssd_disk_monitor: 0
+        scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/unstable/centos/branch-1.7/30/scylla.repo'
+        us_east_1:
+          gce_datacenter: 'us-east1-b'
+
+
+
+databases: !mux
+    cassandra:
+        db_type: cassandra
+        instance_type_db: 'm3.large'
+    scylla:
+        db_type: scylla
+        instance_type_db: 'c3.large'


### PR DESCRIPTION
Repeatedly cost rest space to trigger ENOSPC error for scylla, and release space for recover scylla.