### PR TITLE
refresh test: time optimize

### DIFF
--- a/tests/gce-refresh-1.7-30mins.small.yaml
+++ b/tests/gce-refresh-1.7-30mins.small.yaml
@@ -1,10 +1,15 @@
 test_duration: 45
-n_db_nodes: 3
-n_loaders: 4
+n_db_nodes: 2
+n_loaders: 1
 n_monitor_nodes: 1
 user_prefix: 'gce-refresh-1-7'
 failure_post_behavior: destroy
-stress_cmd: cassandra-stress write no-warmup cl=QUORUM duration=30m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -errors ignore -pop seq=1..10000000 -log interval=5
+prepare_stress_cmd: cassandra-stress write no-warmup cl=QUORUM duration=30s -schema 'replication(factor=1)' -port jmx=6868 -mode cql3 native -rate threads=10 -errors ignore -pop seq=1..10000000 -log interval=5
+stress_cmd: cassandra-stress write no-warmup cl=QUORUM duration=3m -schema 'replication(factor=1)' -port jmx=6868 -mode cql3 native -rate threads=100 -errors ignore -pop seq=1..10000000 -log interval=5
+# 3.5K (10 rows)
+sstable_url: 'https://s3.amazonaws.com/scylla-qa-team/keyspace1.standard1.small.tar.gz'
+sstable_file: '/tmp/keyspace1.standard1.small.tar.gz'
+sstable_md5: '76cca3135e175d859c0efb67c6a7b233'
 
 backends: !mux
     gce: !mux

--- a/tests/gce-refresh-1.7-30mins.yaml
+++ b/tests/gce-refresh-1.7-30mins.yaml
@@ -4,7 +4,13 @@ n_loaders: 1
 n_monitor_nodes: 1
 user_prefix: 'gce-refresh-1-7'
 failure_post_behavior: destroy
-stress_cmd: cassandra-stress write no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=10 -errors ignore -pop seq=1..10000000 -log interval=5
+prepare_stress_cmd: cassandra-stress write no-warmup cl=QUORUM duration=30s -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=10 -errors ignore -pop seq=1..10000000 -log interval=5
+stress_cmd: cassandra-stress write no-warmup cl=QUORUM duration=3m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=10 -errors ignore -pop seq=1..10000000 -log interval=5
+# 100G, the big file will be saved to GCE image
+sstable_url: 'https://s3.amazonaws.com/scylla-qa-team/keyspace1.standard1.tar.gz'
+sstable_file: '/tmp/keyspace1.standard1.tar.gz'
+sstable_md5: 'f64ab85111e817f22f93653a4a791b1f'
+skip_download: 'true'
 
 backends: !mux
     gce: !mux


### PR DESCRIPTION
In longevity test, persistent heavy stress is in background, we can't stop it. But the uncompress is effected when node is serving workload, but we need stress during the refresh.

So we can reserve current refresh monkey for longevity test, and optimize refresh test. Start stress when sstable is uncompressed.