### PR TITLE
import full global gitignore of JetBrains IDEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,57 @@ ide.general.xml
 inspection/Default.xml
 codestyles/Default.xml
 _linux/*
+
+####################################
+# Date: Tue Jun 27 07:47:59 CST 2017
+# From: https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore
+#
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/dictionaries
+
+# Sensitive or high-churn files:
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.xml
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+
+# Gradle:
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# CMake
+cmake-build-debug/
+
+# Mongo Explorer plugin:
+.idea/**/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties


### PR DESCRIPTION
Source:
https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore

Let's try to avoid the disturb of auto commits of PyCharm config.