### PR TITLE
Stopping scylla before trying to delete sstables during nemesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -157,11 +157,17 @@ class Nemesis(object):
         self.target_node.remoter.send_files(break_scylla,
                                             "/tmp/break_scylla.sh")
 
+	# Stop scylla service before deleting sstables to avoid partial deletion of files that are under compaction
+	self.target_node.remoter.run('sudo systemctl stop scylla-server.service')
+        self.target_node.wait_db_down()
+	
         # corrupt the DB
         self.target_node.remoter.run('chmod +x /tmp/break_scylla.sh')
         self.target_node.remoter.run('sudo /tmp/break_scylla.sh')
 
-        self._kill_scylla_daemon()
+	# Start scylla
+	self.target_node.remoter.run('sudo systemctl start scylla-server.service')
+        self.target_node.wait_db_up()
 
     def disrupt(self):
         raise NotImplementedError('Derived classes must implement disrupt()')


### PR DESCRIPTION
Due to an issue sometimes happens in longevity when we try to delete
some sstables and delete fails to delete all relevant files, we decided
to stop scylla before corrupting it.