### PR TITLE
reducing the size of longevity to 50GB

### DIFF
--- a/tests/gce-longevity-1.7-small-7days.yaml
+++ b/tests/gce-longevity-1.7-small-7days.yaml
@@ -1,6 +1,6 @@
 test_duration: 10080
-stress_cmd: cassandra-stress write cl=QUORUM duration=10080m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..100000000000 -log interval=5
-stress_cmd_1: cassandra-stress counter_write cl=QUORUM duration=10080m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..100000000000
+stress_cmd: cassandra-stress write cl=QUORUM duration=10080m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..100000000 -log interval=5
+stress_cmd_1: cassandra-stress counter_write cl=QUORUM duration=10080m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..100000000
 n_db_nodes: 6
 n_loaders: 1
 n_monitor_nodes: 1


### PR DESCRIPTION
The current number was 100B which is way more than 100GB, anyway the
disk size is 375GB and 100GB will be to big anyway.
reducing to 100M partitions which should be 50GB.