### PR TITLE
longevity: authenticator support

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2993,6 +2993,12 @@ class ScyllaGCECluster(GCECluster, BaseScyllaCluster):
         if self._experimental():
             scylla_yaml_contents += "\nexperimental: true\n"
 
+        authenticator = self.params.get('authenticator')
+        if authenticator in ['AllowAllAuthenticator', 'PasswordAuthenticator']:
+            p = re.compile('[# ]*authenticator:.*')
+            scylla_yaml_contents = p.sub('authenticator: {0}'.format(authenticator),
+                                         scylla_yaml_contents)
+
         with open(yaml_dst_path, 'w') as f:
             f.write(scylla_yaml_contents)
 

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3157,6 +3157,12 @@ class ScyllaAWSCluster(AWSCluster, BaseScyllaCluster):
             scylla_yaml_contents = f.read()
         scylla_yaml_contents += "\nexperimental: true\n"
 
+        authenticator = self.params.get('authenticator')
+        if authenticator in ['AllowAllAuthenticator', 'PasswordAuthenticator']:
+            p = re.compile('[# ]*authenticator:.*')
+            scylla_yaml_contents = p.sub('authenticator: {0}'.format(authenticator),
+                                         scylla_yaml_contents)
+
         with open(yaml_dst_path, 'w') as f:
             f.write(scylla_yaml_contents)
 

--- a/tests/gce-longevity-1.7-1TB-7days.yaml
+++ b/tests/gce-longevity-1.7-1TB-7days.yaml
@@ -1,6 +1,4 @@
 test_duration: 10080
-stress_cmd: cassandra-stress write cl=QUORUM duration=10080m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1000 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1000000000 -log interval=5
-stress_cmd_1: cassandra-stress counter_write cl=QUORUM duration=10080m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000
 n_db_nodes: 4
 n_loaders: 1
 n_monitor_nodes: 1
@@ -11,6 +9,15 @@ failure_post_behavior: keep
 space_node_threshold: 644245094
 ip_ssh_connections: 'private'
 experimental: 'true'
+
+auth:
+    default:
+        stress_cmd: cassandra-stress write cl=QUORUM duration=10080m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1000 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1000000000 -log interval=5
+        stress_cmd_1: cassandra-stress counter_write cl=QUORUM duration=10080m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000
+    enable:
+        stress_cmd: cassandra-stress write cl=QUORUM duration=10080m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native user=cassandra password=cassandra -rate threads=1000 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1000000000 -log interval=5
+        stress_cmd_1: cassandra-stress counter_write cl=QUORUM duration=10080m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native user=cassandra password=cassandra -rate threads=1000 -pop seq=1..10000000
+        authenticator: 'PasswordAuthenticator'
 
 backends: !mux
     gce: !mux

--- a/tests/gce-longevity-1.7-small-7days.yaml
+++ b/tests/gce-longevity-1.7-small-7days.yaml
@@ -1,6 +1,4 @@
 test_duration: 10080
-stress_cmd: cassandra-stress write cl=QUORUM duration=10080m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..100000000 -log interval=5
-stress_cmd_1: cassandra-stress counter_write cl=QUORUM duration=10080m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..100000000
 n_db_nodes: 6
 n_loaders: 1
 n_monitor_nodes: 1
@@ -11,6 +9,15 @@ failure_post_behavior: keep
 space_node_threshold: 644245094
 ip_ssh_connections: 'private'
 experimental: 'true'
+
+auth:
+    default:
+        stress_cmd: cassandra-stress write cl=QUORUM duration=10080m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..100000000 -log interval=5
+        stress_cmd_1: cassandra-stress counter_write cl=QUORUM duration=10080m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..100000000
+    enable:
+        stress_cmd: cassandra-stress write cl=QUORUM duration=10080m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native user=cassandra password=cassandra -rate threads=1000 -pop seq=1..100000000 -log interval=5
+        stress_cmd_1: cassandra-stress counter_write cl=QUORUM duration=10080m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native user=cassandra password=cassandra -rate threads=1000 -pop seq=1..100000000
+        authenticator: 'PasswordAuthenticator'
 
 backends: !mux
     gce: !mux


### PR DESCRIPTION
User and password will be passed through c-s cmdline, and authenticator can be configured from yaml config.