### PR TITLE
optimize enospc test

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -31,7 +31,7 @@ from cassandra.policies import WhiteListRoundRobinPolicy
 
 from .data_path import get_data_path
 from .log import SDCMAdapter
-from . import wait
+from avocado.utils import wait
 
 from sdcm.utils import remote_get_file
 
@@ -287,32 +287,48 @@ class Nemesis(object):
         else:
             nodes = [self.target_node]
         self._set_current_disruption('Enospc test on {}'.format(nodes))
+
+        def search_database_enospc(node):
+            """
+            Search database log by executing cmd inside node, use shell tool to
+            avoid return and process huge data.
+            """
+            cmd = "journalctl --no-tail --no-pager -u scylla-server.service|grep 'No space left on device'|wc -l"
+            result = node.remoter.run(cmd, verbose=True)
+            return int(result.stdout)
+
+        def approach_enospc():
+            # get the size of free space (default unit: KB)
+            result = node.remoter.run("df -l|grep '/var/lib/scylla'")
+            free_space_size = result.stdout.split()[3]
+
+            occupy_space_size = int(int(free_space_size) * 90 / 100)
+            occupy_space_cmd = 'sudo fallocate -l {}K /var/lib/scylla/occupy_90percent.{}'.format(occupy_space_size, datetime.datetime.now().strftime('%s'))
+            self.log.debug('Cost 90% free space on /var/lib/scylla/ by {}'.format(occupy_space_cmd))
+            try:
+                node.remoter.run(occupy_space_cmd, verbose=True)
+            except Exception as details:
+                self.log.error(str(details))
+            return search_database_enospc(node) > orig_errors
+
         for node in nodes:
             result = node.remoter.run('cat /proc/mounts')
             if '/var/lib/scylla' not in result.stdout:
                 self.log.error("Scylla doesn't use an individual storage, skip enospc test")
                 continue
 
-            # get the size of free space (default unit: KB)
-            result = node.remoter.run("df -l|grep '/var/lib/scylla'")
-            free_space_size = result.stdout.split()[3]
-
-            occupy_space_size = int(int(free_space_size) * 99.99 / 100)
-            occupy_space_cmd = 'sudo fallocate -l {}K /var/lib/scylla/occupy_99percent'.format(occupy_space_size)
-            self.log.debug('Cost 99% free space on /var/lib/scylla/ by {}'.format(occupy_space_cmd))
-
             # check original ENOSPC error
-            orig_errors = node.search_database_log('No space left on device')
-            result = node.remoter.run(occupy_space_cmd, ignore_status=True, verbose=True)
-            wait.wait_for(func=lambda: len(node.search_database_log('No space left on device')) > len(orig_errors),
+            orig_errors = search_database_enospc(node)
+            wait.wait_for(func=approach_enospc,
+                          timeout=300,
                           step=5,
                           text='Wait for new ENOSPC error occurs in database')
 
             self.log.debug('Sleep {} seconds before releasing space to scylla'.format(sleep_time))
             time.sleep(sleep_time)
 
-            self.log.debug('Delete occupy_99percent file to release space to scylla-server')
-            node.remoter.run('sudo rm -rf /var/lib/scylla/occupy_99percent')
+            self.log.debug('Delete occupy_90percent file to release space to scylla-server')
+            node.remoter.run('sudo rm -rf /var/lib/scylla/occupy_90percent.*')
 
             self.log.debug('Sleep a while before restart scylla-server')
             time.sleep(sleep_time / 2)


### PR DESCRIPTION
Set timeout in waiting enospc error to avoid test stuck.

Search enospc error by checking database log inside node,
there is some cache delay in local saved database log.

Try to occupy the free space in wait loop, this helps to
trigger enospce eaily in slow workload, compaction, etc
condition.