### PR TITLE
add a shared config for enospc and refresh tests

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1822,7 +1822,8 @@ class BaseLoaderSet(object):
         queue = Queue.Queue()
 
         def node_run_stress(node, loader_idx, cpu_idx, keyspace_idx, profile, stress_cmd):
-            first_node = [n for n in node_list if n.dc_idx == loader_idx % 3][0]
+            first_node = [n for n in node_list if n.dc_idx == loader_idx % 3]
+            first_node = first_node[0] if first_node else node_list[0]
             stress_cmd += " -node {}".format(first_node.private_ip_address)
             stress_cmd = "mkfifo /tmp/cs_pipe_$1_$2; cat /tmp/cs_pipe_$1_$2|python /usr/bin/cassandra_stress_exporter & " +\
                          stress_cmd +\

--- a/tests/gce-enospc-refresh-1.7-30mins.yaml
+++ b/tests/gce-enospc-refresh-1.7-30mins.yaml
@@ -1,0 +1,68 @@
+test_duration: 45
+n_monitor_nodes: 1
+failure_post_behavior: destroy
+
+tests: !mux
+    enospc:
+        n_db_nodes: 3
+        n_loaders: 4
+        user_prefix: 'gce-enospc-1-7'
+        stress_cmd: cassandra-stress write no-warmup cl=QUORUM duration=30m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -errors ignore -pop seq=1..10000000
+        gce_root_disk_size_db: 50
+    refresh:
+        n_db_nodes: 3
+        n_loaders: 1
+        user_prefix: 'gce-refresh-1-7'
+        prepare_stress_cmd: cassandra-stress write no-warmup cl=QUORUM duration=30s -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=10 -errors ignore -pop seq=1..10000000 -log interval=5
+        stress_cmd: cassandra-stress write no-warmup cl=QUORUM duration=3m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=10 -errors ignore -pop seq=1..10000000 -log interval=5
+        # 100G, the big file will be saved to GCE image
+        sstable_url: 'https://s3.amazonaws.com/scylla-qa-team/keyspace1.standard1.tar.gz'
+        sstable_file: '/tmp/keyspace1.standard1.tar.gz'
+        sstable_md5: 'f64ab85111e817f22f93653a4a791b1f'
+        skip_download: 'true'
+        # the image contains a big sstable: /tmp/keyspace1.standard1.tar.gz
+        gce_image_db: 'https://www.googleapis.com/compute/v1/projects/skilled-adapter-452/global/images/gce-img-100g-sstable-20170622'
+        gce_root_disk_size_db: 120
+    small_refresh:
+        n_db_nodes: 2
+        n_loaders: 1
+        prepare_stress_cmd: cassandra-stress write no-warmup cl=QUORUM duration=30s -schema 'replication(factor=1)' -port jmx=6868 -mode cql3 native -rate threads=10 -errors ignore -pop seq=1..10000000 -log interval=5
+        stress_cmd: cassandra-stress write no-warmup cl=QUORUM duration=3m -schema 'replication(factor=1)' -port jmx=6868 -mode cql3 native -rate threads=100 -errors ignore -pop seq=1..10000000 -log interval=5
+        # 3.5K (10 rows)
+        sstable_url: 'https://s3.amazonaws.com/scylla-qa-team/keyspace1.standard1.small.tar.gz'
+        sstable_file: '/tmp/keyspace1.standard1.small.tar.gz'
+        sstable_md5: '76cca3135e175d859c0efb67c6a7b233'
+        gce_root_disk_size_db: 50
+
+backends: !mux
+    gce: !mux
+        cluster_backend: 'gce'
+        user_credentials_path: '~/.ssh/scylla-test'
+        gce_user_credentials: '~/Scylla-c41b78923a54.json'
+        gce_service_account_email: 'skilled-adapter-452@appspot.gserviceaccount.com'
+        gce_project: 'skilled-adapter-452'
+        gce_image: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
+        gce_image_username: 'scylla-test'
+        gce_instance_type_db: 'n1-highmem-16'
+        gce_root_disk_type_db: 'pd-ssd'
+        gce_n_local_ssd_disk_db: 1
+        gce_instance_type_loader: 'n1-standard-2'
+        gce_root_disk_type_loader: 'pd-standard'
+        gce_n_local_ssd_disk_loader: 0
+        gce_instance_type_monitor: 'n1-standard-1'
+        gce_root_disk_type_monitor: 'pd-standard'
+        gce_root_disk_size_monitor: 50
+        gce_n_local_ssd_disk_monitor: 0
+        scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/unstable/centos/branch-1.7/30/scylla.repo'
+        us_east_1:
+          gce_datacenter: 'us-east1-b'
+
+
+
+databases: !mux
+    cassandra:
+        db_type: cassandra
+        instance_type_db: 'm3.large'
+    scylla:
+        db_type: scylla
+        instance_type_db: 'c3.large'


### PR DESCRIPTION
We want to run both enospc and refresh tests in a jenkins job,
two avocado cmmands will be used, the added config is shared
by two avocado commands.

Example Job:   [job/scylla-1.7-enospc-refresh/label=gce2/16/console](http://jenkins.cloudius-systems.com/job/scylla-1.7-enospc-refresh/label=gce2/16/console)

```
Jenkins execute shell:
...
avocado run refresh_test.py:RefreshTest.test_refresh_node --multiplex ./tests/gce-enospc-refresh-1.7-30mins.yaml --filter-only /run/backends/gce /run/databases/scylla /run/tests/refresh --xunit "$WORKSPACE/results.xml" --job-results-dir "$WORKSPACE" --show-job-log
avocado run enospc_test.py:EnospcTest.test_enospc_nodes --multiplex ./tests/gce-enospc-refresh-1.7-30mins.yaml --filter-only /run/backends/gce /run/databases/scylla /run/tests/enospc --xunit "$WORKSPACE/results.xml" --job-results-dir "$WORKSPACE" --show-job-log
```