### PR TITLE
Fix enterprise longevity

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3138,7 +3138,7 @@ class ScyllaGCECluster(GCECluster, BaseScyllaCluster):
         time_elapsed = time.time() - start_time
         self.log.debug('Setup duration -> %s s', int(time_elapsed))
         if not node_list[0].scylla_version:
-            result = node_list[0].remoter.run("rpm -q scylla")
+            result = node_list[0].remoter.run("rpm -q {}".format(node_list[0].scylla_pkg()))
             match = re.findall("scylla-(.*).el7.centos", result.stdout)
             node_list[0].scylla_version = match[0] if match else ''
             for node in node_list:
@@ -3285,7 +3285,7 @@ class ScyllaAWSCluster(AWSCluster, BaseScyllaCluster):
         time_elapsed = time.time() - start_time
         self.log.debug('Setup duration -> %s s', int(time_elapsed))
         if not node_list[0].scylla_version:
-            result = node_list[0].remoter.run("rpm -q scylla-enterprise || rpm -q scylla")
+            result = node_list[0].remoter.run("rpm -q {}".format(node_list[0].scylla_pkg()))
             match = re.findall("scylla-(.*).el7.centos", result.stdout)
             node_list[0].scylla_version = match[0] if match else ''
             for node in node_list:

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -813,16 +813,18 @@ class ClusterTester(Test):
             self.monitors.download_monitor_data()
 
             # upload prometheus data
-            prometheus_folder = glob.glob(os.path.join(self.logdir, '*monitor*/*monitor*/prometheus/'))[0]
-            file_path = os.path.normpath(self.job.logdir)
-            shutil.make_archive(file_path, 'zip', prometheus_folder)
-            result_path = '%s.zip' % file_path
-            with open(result_path) as fh:
-                mydata = fh.read()
-                url_s3 = ClusterTester.get_s3_url(result_path)
-                self.log.info("uploading prometheus data on %s" % url_s3)
-                response = requests.put(url_s3, data=mydata)
-                self.log.info(response.text)
+            prometheus_folder = glob.glob(os.path.join(self.logdir, '*monitor*/*monitor*/prometheus/'))
+            if prometheus_folder:
+                prometheus_folder = prometheus_folder[0]
+                file_path = os.path.normpath(self.job.logdir)
+                shutil.make_archive(file_path, 'zip', prometheus_folder)
+                result_path = '%s.zip' % file_path
+                with open(result_path) as fh:
+                    mydata = fh.read()
+                    url_s3 = ClusterTester.get_s3_url(result_path)
+                    self.log.info("uploading prometheus data on %s" % url_s3)
+                    response = requests.put(url_s3, data=mydata)
+                    self.log.info(response.text)
 
             grafana_snapshots = glob.glob(os.path.join(self.logdir, '*monitor*/*grafana-snapshot*'))
             if grafana_snapshots:

--- a/sdcm/utils.py
+++ b/sdcm/utils.py
@@ -59,7 +59,7 @@ def get_monitor_version(full_version, clone=False):
     if not full_version or '666.development' in full_version:
         ret = 'master'
     else:
-        ret = re.findall("^\w+.\w+", full_version)[0]
+        ret = re.findall("-(\d+\.\d+)", full_version)[0]
 
     # We only add dashboard for release version, let's use master for pre-release version
     jsons = glob.glob('data_dir/grafana/*.%s.json' % ret)


### PR DESCRIPTION
issue 1: failed to get version by `rpm -q scylla`, package name is wrong
issue 2: index error in matching monitor data directory
issue 3: match a wrong main version from rpm output

The PR was tested by [jenkins job 31](http://jenkins.cloudius-systems.com:8080/job/scylla-enterprise-2017.1-longevity-gce/31/)