### PR TITLE
GCE: support pd-ssd disk

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -265,6 +265,8 @@ class ClusterTester(Test):
             loader_info['disk_size'] = self.params.get('gce_root_disk_size_loader')
         if loader_info['n_local_ssd'] is None:
             loader_info['n_local_ssd'] = self.params.get('gce_n_local_ssd_disk_loader')
+        if loader_info['pd_ssd_size'] is None:
+            loader_info['pd_ssd_size'] = self.params.get('gce_pd_ssd_disk_size_loader')
         if db_info['n_nodes'] is None:
             n_db_nodes = self.params.get('n_db_nodes')
             if isinstance(n_db_nodes, int):  # legacy type
@@ -281,6 +283,8 @@ class ClusterTester(Test):
             db_info['disk_size'] = self.params.get('gce_root_disk_size_db')
         if db_info['n_local_ssd'] is None:
             db_info['n_local_ssd'] = self.params.get('gce_n_local_ssd_disk_db')
+        if db_info['pd_ssd_size'] is None:
+            db_info['pd_ssd_size'] = self.params.get('gce_pd_ssd_disk_size_db')
         if monitor_info['n_nodes'] is None:
             monitor_info['n_nodes'] = self.params.get('n_monitor_nodes')
         if monitor_info['type'] is None:
@@ -291,6 +295,8 @@ class ClusterTester(Test):
             monitor_info['disk_size'] = self.params.get('gce_root_disk_size_monitor')
         if monitor_info['n_local_ssd'] is None:
             monitor_info['n_local_ssd'] = self.params.get('gce_n_local_ssd_disk_monitor')
+        if monitor_info['pd_ssd_size'] is None:
+            monitor_info['pd_ssd_size'] = self.params.get('gce_pd_ssd_disk_size_monitor')
         user_prefix = self.params.get('user_prefix', None)
         service_account_email = self.params.get('gce_service_account_email', None)
         user_credentials = self.params.get('gce_user_credentials', None)
@@ -320,7 +326,8 @@ class ClusterTester(Test):
                                            user_prefix=user_prefix,
                                            n_nodes=db_info['n_nodes'],
                                            params=self.params,
-                                           gce_datacenter=gce_datacenter)
+                                           gce_datacenter=gce_datacenter,
+                                           gce_pd_ssd_size=db_info['pd_ssd_size'])
 
         scylla_repo = get_data_path('scylla.repo')
         self.loaders = LoaderSetGCE(gce_image=self.params.get('gce_image'),
@@ -335,7 +342,8 @@ class ClusterTester(Test):
                                     scylla_repo=scylla_repo,
                                     user_prefix=user_prefix,
                                     n_nodes=loader_info['n_nodes'],
-                                    params=self.params)
+                                    params=self.params,
+                                    gce_pd_ssd_size=loader_info['pd_ssd_size'])
 
         if monitor_info['n_nodes'] > 0:
             self.monitors = MonitorSetGCE(gce_image=self.params.get('gce_image'),
@@ -350,7 +358,8 @@ class ClusterTester(Test):
                                           scylla_repo=scylla_repo,
                                           user_prefix=user_prefix,
                                           n_nodes=monitor_info['n_nodes'],
-                                          params=self.params)
+                                          params=self.params,
+                                          gce_pd_ssd_size=monitor_info['pd_ssd_size'])
         else:
             self.monitors = NoMonitorSet()
 
@@ -530,14 +539,14 @@ class ClusterTester(Test):
                        monitor_info=None):
         if loader_info is None:
             loader_info = {'n_nodes': None, 'type': None, 'disk_size': None, 'disk_type': None, 'n_local_ssd': None,
-                           'device_mappings': None}
+                           'device_mappings': None, 'pd_ssd_size': None}
         if db_info is None:
             db_info = {'n_nodes': None, 'type': None, 'disk_size': None, 'disk_type': None, 'n_local_ssd': None,
-                       'device_mappings': None}
+                       'device_mappings': None, 'pd_ssd_size': None}
 
         if monitor_info is None:
             monitor_info = {'n_nodes': None, 'type': None, 'disk_size': None, 'disk_type': None, 'n_local_ssd': None,
-                            'device_mappings': None}
+                            'device_mappings': None, 'pd_ssd_size': None}
 
         cluster_backend = self.params.get('cluster_backend')
         if cluster_backend is None:


### PR DESCRIPTION
The local-ssd resources might be taken by multiple large clusters. We have many sd-ssd resources, which isn't used effectively. So let's support and use pd-ssd.