### PR TITLE
refresh: increase the c-s load

### DIFF
--- a/tests/gce-refresh-1.7-30mins.yaml
+++ b/tests/gce-refresh-1.7-30mins.yaml
@@ -1,11 +1,11 @@
 test_duration: 45
 n_db_nodes: 3
-n_loaders: 1
+n_loaders: 4
 n_monitor_nodes: 1
 user_prefix: 'gce-refresh-1-7'
 failure_post_behavior: destroy
 prepare_stress_cmd: cassandra-stress write no-warmup cl=QUORUM duration=30s -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=10 -errors ignore -pop seq=1..10000000 -log interval=5
-stress_cmd: cassandra-stress write no-warmup cl=QUORUM duration=3m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=10 -errors ignore -pop seq=1..10000000 -log interval=5
+stress_cmd: cassandra-stress write no-warmup cl=QUORUM duration=30m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -errors ignore -pop seq=1..10000000 -log interval=5
 # 100G, the big file will be saved to GCE image
 sstable_url: 'https://s3.amazonaws.com/scylla-qa-team/keyspace1.standard1.tar.gz'
 sstable_file: '/tmp/keyspace1.standard1.tar.gz'


### PR DESCRIPTION
Increase the workload to cover scylla-enterprise/issues/32,
we need to check grafana if timeout wave exists.