### PR TITLE
add read workload at the end of longevity

### DIFF
--- a/longevity_test.py
+++ b/longevity_test.py
@@ -61,6 +61,12 @@ class LongevityTest(ClusterTester):
         for stress in stress_queue:
             self.verify_stress_thread(queue=stress)
 
+        # read workload
+        read_stress_cmd = self.params.get('read_stress_cmd')
+        if read_stress_cmd:
+            stress_queue = self.run_stress_thread(stress_cmd=read_stress_cmd, stress_num=2)
+            results = self.get_stress_results(queue=stress_queue, stress_num=2)
+
     def _create_counter_table(self):
         """
         workaround for the issue https://github.com/scylladb/scylla-tools-java/issues/32

--- a/tests/longevity-50GB-4days.yaml
+++ b/tests/longevity-50GB-4days.yaml
@@ -1,4 +1,5 @@
-test_duration: 5760
+test_duration: 11580
+read_stress_cmd: "cassandra-stress read cl=QUORUM duration=5760m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=500 -pop seq=1..100000000 -log interval=5"
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=5760m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..100000000 -log interval=5",
              "cassandra-stress counter_write cl=QUORUM duration=5760m -schema 'replication(factor=3) compaction(strategy=DateTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..1000000",
              "cassandra-stress user profile=/tmp/cs_mv_profile.yaml ops'(insert=3,read1=1,read2=1,read3=1)' cl=QUORUM duration=5760m -port jmx=6868 -mode cql3 native -rate threads=100"]


### PR DESCRIPTION
We have write, counter write, MV workload in current longevity test, this PR added an important read workload for longevity test.