### PR TITLE
longevity/refresh: use prepared image contains 200G sstables

### DIFF
--- a/tests/longevity-1TB-7days-authorization-and-tls-ssl.yaml
+++ b/tests/longevity-1TB-7days-authorization-and-tls-ssl.yaml
@@ -28,7 +28,9 @@ backends: !mux
         gce_image_username: 'scylla-test'
         gce_instance_type_db: 'n1-highmem-16'
         gce_root_disk_type_db: 'pd-ssd'
-        gce_root_disk_size_db: 50
+        # the image contains a big sstable: /tmp/keyspace1.standard1.tar.gz
+        gce_image_db: 'https://www.googleapis.com/compute/v1/projects/skilled-adapter-452/global/images/gce-img-100g-sstable-20170622'
+        gce_root_disk_size_db: 120
         gce_n_local_ssd_disk_db: 8
         gce_instance_type_loader: 'n1-standard-4'
         gce_root_disk_type_loader: 'pd-standard'

--- a/tests/longevity-1TB-7days.yaml
+++ b/tests/longevity-1TB-7days.yaml
@@ -25,7 +25,9 @@ backends: !mux
         gce_image_username: 'scylla-test'
         gce_instance_type_db: 'n1-highmem-16'
         gce_root_disk_type_db: 'pd-ssd'
-        gce_root_disk_size_db: 50
+        # the image contains a big sstable: /tmp/keyspace1.standard1.tar.gz
+        gce_image_db: 'https://www.googleapis.com/compute/v1/projects/skilled-adapter-452/global/images/gce-img-100g-sstable-20170622'
+        gce_root_disk_size_db: 120
         gce_n_local_ssd_disk_db: 8
         gce_instance_type_loader: 'n1-standard-4'
         gce_root_disk_type_loader: 'pd-standard'

--- a/tests/longevity-50GB-4days.yaml
+++ b/tests/longevity-50GB-4days.yaml
@@ -25,7 +25,9 @@ backends: !mux
         gce_image_username: 'scylla-test'
         gce_instance_type_db: 'n1-highmem-16'
         gce_root_disk_type_db: 'pd-ssd'
-        gce_root_disk_size_db: 50
+        # the image contains a big sstable: /tmp/keyspace1.standard1.tar.gz
+        gce_image_db: 'https://www.googleapis.com/compute/v1/projects/skilled-adapter-452/global/images/gce-img-100g-sstable-20170622'
+        gce_root_disk_size_db: 120
         gce_n_local_ssd_disk_db: 2
         gce_instance_type_loader: 'n1-standard-4'
         gce_root_disk_type_loader: 'pd-standard'


### PR DESCRIPTION
Current longevity runs Refresh(3.5K, 10rows) and BigRefresh (200G before
compress). But default image doesn't have compressed sstables for BigRefresh,
which is necessary.

This patch updates longevity config to use customized image only for root disk
of all db nodes. Then the BigRefresh will really work.