### PR TITLE
_param_enabled: support bool parameter

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1680,7 +1680,12 @@ class BaseScyllaCluster(object):
 
     def _param_enabled(self, param):
         param = self.params.get(param)
-        return True if param and param.lower() == 'true' else False
+        if isinstance(param, str):
+            return True if param and param.lower() == 'true' else False
+        elif isinstance(param, bool):
+            return param
+        else:
+            raise ValueError('Unsupported type: {}'.format(type(param)))
 
 
 class BaseLoaderSet(object):


### PR DESCRIPTION
Currently string parameters work well, but bool isn't supported.

For example:
- enable_keyspace_column_family_metrics: true
- enable_keyspace_column_family_metrics: 'true'