### PR TITLE
Support assign multiple seeds

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1464,6 +1464,20 @@ class BaseScyllaCluster(object):
                 node.is_seed = False
         return seed_nodes
 
+    def get_seed_nodes_by_flag(self):
+        """
+        We set is_seed at two point, before and after node_setup.
+        However, we can only call this function when the flag is set.
+        """
+        node_private_ips = [node.private_ip_address for node
+                            in self.nodes if node.is_seed]
+        seeds = ",".join(node_private_ips)
+        if not seeds:
+            # use first node as seed by default
+            seeds = self.nodes[0].private_ip_address
+            seeds = self.nodes[0].is_seed = True
+        return seeds
+
     def _update_db_binary(self, new_scylla_bin, node_list):
         self.log.debug('User requested to update DB binary...')
 

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -384,8 +384,7 @@ class ScyllaAWSCluster(AWSCluster, cluster.BaseScyllaCluster):
         if len(self.datacenter) > 1:
             endpoint_snitch = "Ec2MultiRegionSnitch"
             node.datacenter_setup(self.datacenter)
-            seed_address = self.nodes[0].public_ip_address
-            node.config_setup(seed_address=seed_address,
+            node.config_setup(seed_address=self.get_seed_nodes_by_flag(),
                               enable_exp=self._param_enabled('experimental'),
                               endpoint_snitch=endpoint_snitch,
                               broadcast=node.public_ip_address,

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -654,6 +654,9 @@ class ClusterTester(Test):
         elif cluster_backend == 'gce':
             self.get_cluster_gce(loader_info=loader_info, db_info=db_info,
                                  monitor_info=monitor_info)
+        seeds_num = self.params.get('seeds_num', default=1)
+        for i in range(seeds_num):
+            self.db_cluster.nodes[i].is_seed = True
 
     def _cs_add_node_flag(self, stress_cmd):
         if '-node' not in stress_cmd:


### PR DESCRIPTION
Introduced a new parameter 'seeds_num' in configure file to assign the seeds number.

In this patchset, we extended the usage of node.is_seed flag. We mark it at init stage, and try to get a seed address list in node_setup() referencing to the flag.