### PR TITLE
better balance in randomly calling nemesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -60,6 +60,7 @@ class Nemesis(object):
         self.test_type = kwargs.get('test_type', None)
         self.test_id = kwargs.get('test_id', None)
         self.metrics_srv = prometheus.nemesis_metrics_obj()
+        self._random_sequence = None
 
     def update_stats(self, disrupt, status=True, data={}):
         key = {True: 'runs', False: 'failures'}
@@ -386,6 +387,44 @@ class Nemesis(object):
         self.metrics_srv.event_stop(disrupt_method_name)
         self.log.info("<<<<<<<<<<<<<Finished random_disrupt_method %s" % disrupt_method_name)
 
+    def random_order_call_disrupt_methods(self, disrupt_methods=None):
+        if not disrupt_methods:
+            disrupt_methods = [attr[1] for attr in inspect.getmembers(self) if
+                               attr[0].startswith('disrupt_') and
+                               callable(attr[1])]
+        else:
+            disrupt_methods = [attr[1] for attr in inspect.getmembers(self) if
+                               attr[0] in disrupt_methods and
+                               callable(attr[1])]
+
+        if not self._random_sequence:
+            # Generate random sequence, every method has same chance to be called.
+            # Here we use multiple original methods list, it will increase the chance
+            # to call same method continuously.
+            #
+            # Adjust the rate according to the test duration. Try to call more unique
+            # methods and don't wait to long time to meet the balance if the test
+            # duration is short.
+            test_duration = self.cluster.params.get('test_duration', default=180)
+            if test_duration < 600:     # less than 10 hours
+                rate = 1
+            elif test_duration < 4320:  # less than 3 days
+                rate = 2
+            else:
+                rate = 3
+            multiple_disrupt_methods = disrupt_methods * rate
+            random.shuffle(multiple_disrupt_methods)
+            self._random_sequence = multiple_disrupt_methods
+        # consume the random sequence
+        disrupt_method = self._random_sequence.pop()
+
+        disrupt_method_name = disrupt_method.__name__.replace('disrupt_', '')
+        self.log.info(">>>>>>>>>>>>>Started disrupt_method %s" % disrupt_method_name)
+        self.metrics_srv.event_start(disrupt_method_name)
+        disrupt_method()
+        self.metrics_srv.event_stop(disrupt_method_name)
+        self.log.info("<<<<<<<<<<<<<Finished disrupt_method %s" % disrupt_method_name)
+
     def repair_nodetool_repair(self):
         repair_cmd = 'nodetool -h localhost repair'
         self._run_nodetool(repair_cmd, self.target_node)
@@ -584,6 +623,11 @@ class ChaosMonkey(Nemesis):
     def disrupt(self):
         self.call_random_disrupt_method()
 
+class AllMonkey(Nemesis):
+
+    @log_time_elapsed_and_status
+    def disrupt(self):
+        self.random_order_call_disrupt_methods()
 
 class MdcChaosMonkey(Nemesis):
 


### PR DESCRIPTION
As we saw in summit demo, the nemesis calling isn't balanced.
Our random policy is correct, if we call call_random_disrupt_method()
more times, the balance will be better. But some nemesis take long
time referencing to the test duration and methods number.

This patch introduced a random sequence, which will make all methods
have same chance to be called. And it adjust the sequence length according
to the test duration.