### PR TITLE
use single c-s process per loader to prepare write data

### DIFF
--- a/longevity_test.py
+++ b/longevity_test.py
@@ -45,8 +45,8 @@ class LongevityTest(ClusterTester):
         # prepare write workload
         prepare_write_cmd = self.params.get('prepare_write_cmd')
         if prepare_write_cmd:
-            write_queue = self.run_stress_thread(stress_cmd=prepare_write_cmd, stress_num=2)
-            self.verify_stress_thread(queue=write_queue, stress_num=2)
+            write_queue = self.run_stress_thread(stress_cmd=prepare_write_cmd)
+            self.verify_stress_thread(queue=write_queue)
 
         for stress_cmd in self.params.get('stress_cmd'):
             params = {'stress_cmd': stress_cmd}


### PR DESCRIPTION
In my 1tb-7days-ssl test, nemesis started after job run 12 hours.

Multiple processes will repeatly write all the data, reduce the
process number to save the prepare time.

![image](https://user-images.githubusercontent.com/309708/33100504-95a6c2ee-cf4f-11e7-9661-01e5737ea206.png)
