### PR TITLE
run_thress_thread: try to start stresses at same time

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1791,7 +1791,6 @@ class BaseLoaderSet(object):
                                                           cpu_idx, ks_idx, profile, stress_cmd))
                     setup_thread.daemon = True
                     setup_thread.start()
-                    time.sleep(30)
 
         return queue
 


### PR DESCRIPTION
C-s stresses should be started at the same time, currently it
can take them ~10mins when we have many loaders.
This patch changed the run_stress_thread to wait until other
threads finish the prepare, then really start the stress together.

Doesn't sleep between start multiple load
