### PR TITLE
gce: use public ip for ssh connections

### DIFF
--- a/tests/longevity-50GB-4days-authorization-and-tls-ssl.yaml
+++ b/tests/longevity-50GB-4days-authorization-and-tls-ssl.yaml
@@ -13,7 +13,7 @@ nemesis_interval: 5
 user_prefix: 'longevity-tls-50gb-4d-not-jenkins'
 failure_post_behavior: keep
 space_node_threshold: 644245094
-ip_ssh_connections: 'private'
+ip_ssh_connections: 'public'
 experimental: 'true'
 server_encrypt: 'true'
 # Setting client encryption to false for now, till we will find the way to make c-s work with that

--- a/tests/longevity-50GB-4days.yaml
+++ b/tests/longevity-50GB-4days.yaml
@@ -13,7 +13,7 @@ nemesis_interval: 5
 user_prefix: 'longevity-50gb-4d-not-jenkins'
 failure_post_behavior: keep
 space_node_threshold: 644245094
-ip_ssh_connections: 'private'
+ip_ssh_connections: 'public'
 experimental: 'true'
 
 


### PR DESCRIPTION
When qa-vpc is used, sct can't access db/loader/monitor instances by private ip.