### PR TITLE
use private ip for ssh connections

### DIFF
--- a/tests/longevity-1TB-7days-authorization-and-tls-ssl.yaml
+++ b/tests/longevity-1TB-7days-authorization-and-tls-ssl.yaml
@@ -13,7 +13,7 @@ nemesis_interval: 30
 user_prefix: 'longevity-tls-1tb-7d-not-jenkins'
 failure_post_behavior: keep
 space_node_threshold: 644245094
-ip_ssh_connections: 'public'
+ip_ssh_connections: 'private'
 experimental: 'true'
 server_encrypt: 'true'
 # Setting client encryption to false for now, till we will find the way to make c-s work with that

--- a/tests/longevity-1TB-7days.yaml
+++ b/tests/longevity-1TB-7days.yaml
@@ -13,7 +13,7 @@ nemesis_interval: 30
 user_prefix: 'longevity-1tb-7d-not-jenkins'
 failure_post_behavior: keep
 space_node_threshold: 644245094
-ip_ssh_connections: 'public'
+ip_ssh_connections: 'private'
 experimental: 'true'
 
 

--- a/tests/longevity-50GB-4days-authorization-and-tls-ssl.yaml
+++ b/tests/longevity-50GB-4days-authorization-and-tls-ssl.yaml
@@ -13,7 +13,7 @@ nemesis_interval: 5
 user_prefix: 'longevity-tls-50gb-4d-not-jenkins'
 failure_post_behavior: keep
 space_node_threshold: 644245094
-ip_ssh_connections: 'public'
+ip_ssh_connections: 'private'
 experimental: 'true'
 server_encrypt: 'true'
 # Setting client encryption to false for now, till we will find the way to make c-s work with that

--- a/tests/longevity-50GB-4days.yaml
+++ b/tests/longevity-50GB-4days.yaml
@@ -13,7 +13,7 @@ nemesis_interval: 5
 user_prefix: 'longevity-50gb-4d-not-jenkins'
 failure_post_behavior: keep
 space_node_threshold: 644245094
-ip_ssh_connections: 'public'
+ip_ssh_connections: 'private'
 experimental: 'true'
 
 


### PR DESCRIPTION
When we migrate all SCT builders into qa-vpc, we can continue to using
private ip for ssh connections between builders and instances.

# IMPORTANT
### We should apply this PR when all GCE SCT builders are migrated into qa-vpc.