### PR TITLE
RFC: still use private ip for prometheus in multiple DCs case

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -221,7 +221,10 @@ class Nemesis(object):
             self.target_node.wait_db_up()
 
     def reconfigure_monitoring(self):
-        ip_addr_attr = 'public_ip_address' if len(self.cluster.datacenter) > 1 else 'private_ip_address'
+        if self.cluster.params.get('cluster_backend') != 'gce' and len(self.cluster.datacenter) > 1:
+            ip_addr_attr = 'public_ip_address'
+        else:
+            ip_addr_attr = 'private_ip_address'
         targets = [getattr(n, ip_addr_attr) for n in self.cluster.nodes]
         loader_targets = [getattr(n, ip_addr_attr) for n in self.loaders.nodes]
         for monitoring_node in self.monitoring_set.nodes:

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -245,7 +245,10 @@ class ClusterTester(Test):
         self.db_cluster.wait_for_init()
         db_node_address = self.db_cluster.nodes[0].private_ip_address
         self.loaders.wait_for_init(db_node_address=db_node_address)
-        ip_addr_attr = 'public_ip_address' if len(self.db_cluster.datacenter) > 1 else 'private_ip_address'
+        if self.params.get('cluster_backend') != 'gce' and len(self.cluster.datacenter) > 1:
+            ip_addr_attr = 'public_ip_address'
+        else:
+            ip_addr_attr = 'private_ip_address'
         self.monitors.wait_for_init(targets={'db_nodes': [getattr(n, ip_addr_attr) for n in self.db_cluster.nodes],
                                              'loaders': [getattr(n, ip_addr_attr) for n in self.loaders.nodes]},
                                     scylla_version=self.db_cluster.nodes[0].scylla_version)


### PR DESCRIPTION
Base on current firewall rule, it's fine to access instances by private ips
across regions in GCE. But we have to add new rule to allow accessing by
public ip.