### PR TITLE
fix pattern to make cluster_name update work again

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1018,8 +1018,9 @@ WantedBy=multi-user.target
                                          scylla_yaml_contents)
 
         if cluster_name:
-            scylla_yaml_contents = scylla_yaml_contents.replace("cluster_name: 'Test Cluster'",
-                                                                "cluster_name: '{0}'".format(cluster_name))
+            p = re.compile('[# ]*cluster_name:.*')
+            scylla_yaml_contents = p.sub('cluster_name: {0}'.format(cluster_name),
+                                         scylla_yaml_contents)
 
         if enable_exp:
             scylla_yaml_contents += "\nexperimental: true\n"


### PR DESCRIPTION
The default cluster name is changed in default scylla.yaml, our pattern doesn't work.

changes in master & 2.1:
```
+++ b/conf/scylla.yaml
@@ -14,7 +14,7 @@
 # one logical cluster from joining another.
 # It is recommended to change the default value when creating a new cluster.
 # You can NOT modify this value for an existing cluster
-cluster_name: 'Test Cluster'
+#cluster_name: 'ScyllaDB Cluster'
 
 # This defines the number of tokens randomly assigned to this node on the ring
 # The more tokens, relative to other nodes, the larger the proportion of data
```