### PR TITLE
strict pattern for rpc_address

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1003,8 +1003,8 @@ WantedBy=multi-user.target
             scylla_yaml_contents = p.sub('listen_address: {0}'.format(self.private_ip_address),
                                          scylla_yaml_contents)
             # Set rpc_address
-            p = re.compile('rpc_address:.*')
-            scylla_yaml_contents = p.sub('rpc_address: {0}'.format(self.private_ip_address),
+            p = re.compile('\n[# ]*rpc_address:.*')
+            scylla_yaml_contents = p.sub('\nrpc_address: {0}'.format(self.private_ip_address),
                                          scylla_yaml_contents)
         if broadcast:
             # Set broadcast_address


### PR DESCRIPTION
Current pattern might wrongly match 'broadcast_rpc_address'.

Other parameter doesn't have strict pattern, but they doesn't have problem right now. Let's just fix rpc_address.

Test Result:  only rpc_address was updated,  broadcast_rpc_address wasn't changed.
```
[scylla-test@longevity-50gb-4d-master-db-node-568b6ef3-0-1 ~]$ cat /etc/scylla/scylla.yaml |grep rpc_address
# Set rpc_address OR rpc_interface, not both. Interfaces must correspond
# Leaving rpc_address blank has the same effect as on listen_address
# set broadcast_rpc_address to a value other than 0.0.0.0.
rpc_address: 10.142.0.9
# rpc_address. If rpc_address is set to 0.0.0.0, broadcast_rpc_address must
# broadcast_rpc_address: 1.2.3.4
# same as the rpc_address. The port however is different and specified below.
```