### PR TITLE
trivial: cleanup trailing whitespace

### DIFF
--- a/data_dir/scylla.yaml
+++ b/data_dir/scylla.yaml
@@ -222,5 +222,5 @@ databases: !mux
         # Let's use c3.large since we're using iotune
         # and we'll stress the DB nodes more thoroughly
         instance_type_db: 'c3.large'
-        # Spawn a monitor node 
+        # Spawn a monitor node
         n_monitor_nodes: 1

--- a/tests/dns-cluster-15min.yaml
+++ b/tests/dns-cluster-15min.yaml
@@ -1,7 +1,7 @@
 test_duration: 15
 stress_cmd: "cassandra-stress write no-warmup cl=QUORUM duration=15m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=10 -errors ignore -pop seq=1..1000000"
 n_db_nodes: 3
-n_loaders: 1 
+n_loaders: 1
 n_monitor_nodes: 1
 user_prefix: 'cases-dns-VERSION'
 failure_post_behavior: destory
@@ -15,7 +15,7 @@ backends: !mux
         cluster_backend: 'aws'
         instance_type_loader: 'c4.4xlarge'
         instance_type_monitor: 't2.small'
-        instance_type_db: 'i3.2xlarge'        
+        instance_type_db: 'i3.2xlarge'
         us_east_1:
             region_name: 'us-east-1'
             security_group_ids: 'sg-c5e1f7a0'
@@ -23,8 +23,8 @@ backends: !mux
             ami_id_db_scylla: 'AMI_ID'
             ami_id_monitor: 'AMI_ID'
             ami_id_loader: 'AMI_ID'
-            ami_db_scylla_user: 'centos'            
-            ami_loader_user: 'centos'            
+            ami_db_scylla_user: 'centos'
+            ami_loader_user: 'centos'
             ami_monitor_user: 'centos'
 
 databases: !mux

--- a/tests/gce-multidc-1.7.yaml
+++ b/tests/gce-multidc-1.7.yaml
@@ -18,8 +18,8 @@ ip_ssh_connections: 'public'
 ami_id_db_scylla_desc: '1.7.rc2'
 
 #es_url:
-#es_user: 
-#es_password: 
+#es_user:
+#es_password:
 
 backends: !mux
     aws: !mux


### PR DESCRIPTION
Check by `git grep '\s$'`