### PR TITLE
GCE & AWS: add workspace and system name to metadata/tags

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -81,6 +81,7 @@ COREDUMP_MAX_SIZE = 1024 * 1024 * 1024 * 5
 IP_SSH_CONNECTIONS = 'public'
 TASK_QUEUE = 'task_queue'
 RES_QUEUE = 'res_queue'
+WORKSPACE = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 
 
 def set_ip_ssh_connections(ip_type):

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -248,6 +248,9 @@ class AWSNode(cluster.BaseNode):
                           cluster.TEST_DURATION)
             self._ec2_service.create_tags(Resources=[self._instance.id],
                                           Tags=[{'Key': 'keep', 'Value': 'alive'}])
+        self._ec2_service.create_tags(Resources=[self._instance.id],
+                                      Tags=[{'Key': 'workspace', 'Value': cluster.WORKSPACE},
+                                            {'Key': 'uname', 'Value': ' | '.join(os.uname())}])
 
     @property
     def public_ip_address(self):

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -45,6 +45,8 @@ class GCENode(cluster.BaseNode):
                           cluster.TEST_DURATION)
             self._instance_wait_safe(self._gce_service.ex_set_node_tags,
                                      self._instance, ['keep-alive'])
+        self._instance_wait_safe(self._gce_service.ex_set_node_metadata,
+                                 self._instance, {'workspace': cluster.WORKSPACE, 'uname': ' | '.join(os.uname())})
 
     def _instance_wait_safe(self, instance_method, *args, **kwargs):
         """


### PR DESCRIPTION
The workspace might contain the username and Jenkins job name,
we can know the owner and the SCT/Jenkins execution condition
by workspace & system name.

It's helpful to process the orphan instances to save resources.

GCE:
![image](https://user-images.githubusercontent.com/309708/34032581-caee21c6-e1b1-11e7-86b5-82bbf07be26f.png)

AWS:
![34032654-248ad7a6-e1b2-11e7-9564-c03e32a9f3ec](https://user-images.githubusercontent.com/309708/34032794-90bc69f8-e1b2-11e7-841b-6b2c2e496dc5.png)

