### PR TITLE
remove loaders from node_exporter & prometheus API server list

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -556,8 +556,13 @@ class BaseNode(object):
         self.remoter.receive_files(src=self.prometheus_data_dir, dst=dst)
 
     def _write_prometheus_cfg(self, targets):
-        scylla_targets_list = ['%s:9180' % str(ip) for ip in targets['db_nodes'] + targets['loaders']]
-        node_exporter_targets_list = ['%s:9100' % str(ip) for ip in targets['db_nodes'] + targets['loaders']]
+        """
+        9180 -> prometheus API server
+        9100 -> node exporter
+        9103 -> collectd exporter
+        """
+        scylla_targets_list = ['%s:9180' % str(ip) for ip in targets['db_nodes']]
+        node_exporter_targets_list = ['%s:9100' % str(ip) for ip in targets['db_nodes']]
         loader_targets_list = ['%s:9103' % str(ip) for ip in targets['loaders']]
         prometheus_cfg = """
 global:


### PR DESCRIPTION
Current configuration caused Grafana displayed some 'Dead Nodes', and loaders
are wrongly counted into the 'Total Nodes'.

Because we added loaders to scylla_targets_list and assigned to 'scylla' job.
Query of 'Total Nodes' in Grafana:

    count(up{job="scylla"})

We only used collectd exporter to export stress latency to prometheus server,
let's remove loaders from node_exporter(9100) & prometheus API server(9180) list.