### PR TITLE
requirements.txt: update apache-libcloud to 2.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ boto3==1.3.1
 awscli==1.10.47
 aexpect==1.2.0
 cassandra-driver==3.10
-apache-libcloud==1.4.0
+apache-libcloud==2.2.1
 requests
 elasticsearch
 sortedcontainers


### PR DESCRIPTION
Some GCE errors caused Avocado abort, the problem doesn't
exist after upgrading apache-libcloud to latest 2.2.1