### PR TITLE
RFC: don't setup collectd for db node

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -49,8 +49,6 @@ from . import data_path
 from . import wait
 from .utils import get_monitor_version
 
-from .collectd import ScyllaCollectdSetup
-
 from .loader import CassandraStressExporterSetup
 from .prometheus import start_metrics_server
 
@@ -1637,11 +1635,6 @@ class BaseScyllaCluster(object):
 
         start_time = time.time()
 
-        # avoid using node.remoter in thread
-        for node in node_list:
-            node.wait_ssh_up(verbose=verbose)
-            self.collectd_setup.install(node)
-
         for node in node_list:
             setup_thread = threading.Thread(target=node_setup,
                                             args=(node, ))
@@ -2361,7 +2354,6 @@ class ScyllaLibvirtCluster(LibvirtCluster, BaseScyllaCluster):
                                                    node_prefix=node_prefix,
                                                    n_nodes=n_nodes,
                                                    params=params)
-        self.collectd_setup = ScyllaCollectdSetup()
         self.seed_nodes_private_ips = None
         self.termination_event = threading.Event()
         self.nemesis_threads = []
@@ -2423,7 +2415,6 @@ class ScyllaLibvirtCluster(LibvirtCluster, BaseScyllaCluster):
         # avoid using node.remoter in thread
         for node in node_list:
             node.wait_ssh_up(verbose=verbose)
-            self.collectd_setup.install(node)
 
         # If we setup all nodes in paralel, we might have troubles
         # with nodes not able to contact the seed node.
@@ -2643,7 +2634,6 @@ class ScyllaOpenStackCluster(OpenStackCluster, BaseScyllaCluster):
                                                      node_prefix=node_prefix,
                                                      n_nodes=n_nodes,
                                                      params=params)
-        self.collectd_setup = ScyllaCollectdSetup()
         self.nemesis = []
         self.nemesis_threads = []
         self.termination_event = threading.Event()
@@ -2712,10 +2702,6 @@ class ScyllaOpenStackCluster(OpenStackCluster, BaseScyllaCluster):
             queue.task_done()
 
         start_time = time.time()
-
-        # avoid using node.remoter in thread
-        for node in node_list:
-            self.collectd_setup.install(node)
 
         # If we setup all nodes in paralel, we might have troubles
         # with nodes not able to contact the seed node.

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -13,7 +13,6 @@ import boto3.session
 from avocado.utils import runtime as avocado_runtime
 
 import cluster
-from .collectd import ScyllaCollectdSetup
 from .collectd import CassandraCollectdSetup
 import ec2_client
 
@@ -343,7 +342,6 @@ class ScyllaAWSCluster(AWSCluster, cluster.BaseScyllaCluster):
                                                node_prefix=node_prefix,
                                                n_nodes=n_nodes,
                                                params=params)
-        self.collectd_setup = ScyllaCollectdSetup()
         self.nemesis = []
         self.nemesis_threads = []
         self.termination_event = threading.Event()

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -6,7 +6,6 @@ import tempfile
 import Queue
 
 import cluster
-from .collectd import ScyllaCollectdSetup
 from . import wait
 from .loader import CassandraStressExporterSetup
 
@@ -272,7 +271,6 @@ class ScyllaGCECluster(GCECluster, cluster.BaseScyllaCluster):
                                                params=params,
                                                gce_region_names=gce_datacenter,
                                                gce_pd_ssd_size=gce_pd_ssd_size)
-        self.collectd_setup = ScyllaCollectdSetup()
         self.nemesis = []
         self.nemesis_threads = []
         self.termination_event = threading.Event()


### PR DESCRIPTION
We no longer use collectd/collectd_exporter for Scylla metrics,
the install & setup of collectd in db nodes aren't necessary.

Tested with GCE, the Grafana looks good.