### PR TITLE
New longevity

### DIFF
--- a/longevity_test.py
+++ b/longevity_test.py
@@ -15,6 +15,7 @@
 
 import os
 import re
+import time
 from avocado import main
 
 from sdcm.tester import ClusterTester
@@ -41,21 +42,37 @@ class LongevityTest(ClusterTester):
                                     test_type=self.test_type,
                                     test_id=self.test_id)
         stress_queue = list()
+        write_queue = list()
 
         # prepare write workload
         prepare_write_cmd = self.params.get('prepare_write_cmd')
+        keyspace_num = self.params.get('keyspace_num', default=1)
+        pre_create_schema = self.params.get('pre_create_schema', default=False)
+
         if prepare_write_cmd:
-            write_queue = self.run_stress_thread(stress_cmd=prepare_write_cmd)
+            # If the test load is too heavy for one lader (e.g. many keyspaces), the load should be splitted evenly
+            # across the loaders (round_robin).
+            if pre_create_schema:
+                self._pre_create_schema()
+            if keyspace_num > 1 and self.params.get('round_robin', default='').lower() == 'true':
+                self.log.debug("Using round_robin for multiple Keyspaces...")
+                for i in xrange(1, keyspace_num):
+                    keyspace_name = 'keyspace{}'.format(i)
+                    write_queue.append(self.run_stress_thread(stress_cmd=prepare_write_cmd, keyspace_name=keyspace_name))
+                    time.sleep(5)
+            else:
+                write_queue.append(self.run_stress_thread(stress_cmd=prepare_write_cmd, keyspace_num=keyspace_num))
             self.db_cluster.wait_total_space_used_per_node()
             self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
-            self.verify_stress_thread(queue=write_queue)
+            for stress in write_queue:
+                self.verify_stress_thread(queue=stress)
 
         stress_cmds = self.params.get('stress_cmd')
         stress_multiplier = self.params.get('stress_multiplier', default=1)
         if stress_multiplier > 1:
             stress_cmds *= stress_multiplier
         for stress_cmd in stress_cmds:
-            params = {'stress_cmd': stress_cmd}
+            params = {'stress_cmd': stress_cmd, 'keyspace_num': keyspace_num}
             if 'counter_' in stress_cmd:
                 self._create_counter_table()
             if 'profile' in stress_cmd:
@@ -113,6 +130,24 @@ class LongevityTest(ClusterTester):
                 AND read_repair_chance = 0.0
                 AND speculative_retry = '99.0PERCENTILE';
         """)
+
+    def _pre_create_schema(self):
+        """
+        For cases we are testing many keyspaces and tables, It's a possibility that we will do it better and faster than
+        cassandra-stress.
+        """
+        node = self.db_cluster.nodes[0]
+        session = self.cql_connection_patient(node)
+
+        keyspace_num = self.params.get('keyspace_num', default=1)
+        self.log.debug('Pre Creating Schema for c-s with {} keyspaces'.format(keyspace_num))
+
+        for i in xrange(1, keyspace_num):
+            keyspace_name = 'keyspace{}'.format(i)
+            self.create_ks(session, keyspace_name, rf=3)
+            self.log.debug('{} Created'.format(keyspace_name))
+            self.create_cf(session,  'standard1', key_type='blob', read_repair=0.0, compact_storage=True,
+                           columns={'"C0"': 'blob', '"C1"': 'blob', '"C2"': 'blob', '"C3"': 'blob', '"C4"': 'blob'})
 
 
 if __name__ == '__main__':

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1706,6 +1706,7 @@ class BaseLoaderSet(object):
                 node.remoter.run("source $HOME/.bashrc")
                 node.remoter.run("go get github.com/pdziepak/scylla-bench")
 
+
             queue.put(node)
             queue.task_done()
 
@@ -1732,9 +1733,12 @@ class BaseLoaderSet(object):
             self._loader_queue = [node for node in self.nodes]
         return self._loader_queue.pop(0)
 
-    def run_stress_thread(self, stress_cmd, timeout, output_dir, stress_num=1, keyspace_num=1, profile=None,
-                          node_list=[]):
-        stress_cmd = stress_cmd.replace(" -schema ", " -schema keyspace=keyspace$2 ")
+    def run_stress_thread(self, stress_cmd, timeout, output_dir, stress_num=1, keyspace_num=1, keyspace_name='',
+                          profile=None, node_list=[]):
+        if keyspace_name:
+            stress_cmd = stress_cmd.replace(" -schema ", " -schema keyspace={} ".format(keyspace_name))
+        else:
+            stress_cmd = stress_cmd.replace(" -schema ", " -schema keyspace=keyspace$2 ")
         if profile:
             with open(profile) as fp:
                 profile_content = fp.read()
@@ -1802,6 +1806,7 @@ class BaseLoaderSet(object):
             # cancel stress_num
             stress_num = 1
             loaders = [self.get_loader()]
+            self.log.debug("Round-Robin through loaders, Selected loader is {} ".format(loaders))
         else:
             loaders = self.nodes
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -676,8 +676,9 @@ class ClusterTester(Test):
         self.verify_stress_thread(stress_queue)
 
     @clean_aws_resources
-    def run_stress_thread(self, stress_cmd, duration=None, stress_num=1, keyspace_num=1, profile=None, prefix=''):
-        #stress_cmd = self._cs_add_node_flag(stress_cmd)
+    def run_stress_thread(self, stress_cmd, duration=None, stress_num=1, keyspace_num=1, profile=None, prefix='',
+                          keyspace_name=''):
+        # stress_cmd = self._cs_add_node_flag(stress_cmd)
         if duration is None:
             duration = self.params.get('test_duration')
         timeout = duration * 60 + 600
@@ -686,6 +687,7 @@ class ClusterTester(Test):
                                               self.outputdir,
                                               stress_num=stress_num,
                                               keyspace_num=keyspace_num,
+                                              keyspace_name=keyspace_name,
                                               profile=profile,
                                               node_list=self.db_cluster.nodes)
 

--- a/tests/longevity-1TB-7days-authorization-and-tls-ssl.yaml
+++ b/tests/longevity-1TB-7days-authorization-and-tls-ssl.yaml
@@ -18,7 +18,6 @@ experimental: 'true'
 server_encrypt: 'true'
 # Setting client encryption to false for now, till we will find the way to make c-s work with that
 client_encrypt: 'false'
-append_conf: 'enable_sstable_data_integrity_check: true'
 
 
 backends: !mux

--- a/tests/longevity-1TB-7days.yaml
+++ b/tests/longevity-1TB-7days.yaml
@@ -15,7 +15,6 @@ failure_post_behavior: keep
 space_node_threshold: 644245094
 ip_ssh_connections: 'public'
 experimental: 'true'
-append_conf: 'enable_sstable_data_integrity_check: true'
 
 
 backends: !mux

--- a/tests/longevity-50GB-4days-authorization-and-tls-ssl.yaml
+++ b/tests/longevity-50GB-4days-authorization-and-tls-ssl.yaml
@@ -18,8 +18,6 @@ experimental: 'true'
 server_encrypt: 'true'
 # Setting client encryption to false for now, till we will find the way to make c-s work with that
 client_encrypt: 'false'
-append_conf: 'enable_sstable_data_integrity_check: true'
-
 
 
 backends: !mux

--- a/tests/longevity-50GB-4days.yaml
+++ b/tests/longevity-50GB-4days.yaml
@@ -15,7 +15,6 @@ failure_post_behavior: keep
 space_node_threshold: 644245094
 ip_ssh_connections: 'public'
 experimental: 'true'
-append_conf: 'enable_sstable_data_integrity_check: true'
 
 
 backends: !mux

--- a/tests/longevity-multi-keyspaces.yaml
+++ b/tests/longevity-multi-keyspaces.yaml
@@ -9,7 +9,7 @@ nemesis_class_name: 'ChaosMonkey'
 nemesis_interval: 30
 user_prefix: 'longevity-1000-keyspaces-VERSION'
 failure_post_behavior: keep
-space_node_threshold: 64424500
+space_node_threshold: 6442450
 ip_ssh_connections: 'private'
 experimental: 'true'
 round_robin: 'true'

--- a/tests/longevity-multi-keyspaces.yaml
+++ b/tests/longevity-multi-keyspaces.yaml
@@ -1,0 +1,63 @@
+test_duration: 3600
+prepare_write_cmd: "cassandra-stress write no-warmup cl=QUORUM duration=48h -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=2 -pop seq=1..10000000 -log interval=30"
+stress_cmd: ["cassandra-stress read cl=QUORUM n=10000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=20 -pop seq=1..10000000 -log interval=10"]
+keyspace_num: 1000
+n_db_nodes: 4
+n_loaders: 5
+n_monitor_nodes: 1
+nemesis_class_name: 'ChaosMonkey'
+nemesis_interval: 30
+user_prefix: 'longevity-1000-keyspaces-VERSION'
+failure_post_behavior: keep
+space_node_threshold: 64424500
+ip_ssh_connections: 'private'
+experimental: 'true'
+round_robin: 'true'
+pre_create_schema: True
+
+
+backends: !mux
+    gce: !mux
+        cluster_backend: 'gce'
+        user_credentials_path: '~/.ssh/scylla-test'
+        gce_user_credentials: '~/Scylla-c41b78923a54.json'
+        gce_service_account_email: 'skilled-adapter-452@appspot.gserviceaccount.com'
+        gce_project: 'skilled-adapter-452'
+        gce_network: 'qa-vpc'
+        gce_image: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
+        gce_image_username: 'scylla-test'
+        gce_instance_type_db: 'n1-highmem-16'
+        gce_root_disk_type_db: 'pd-ssd'
+        gce_root_disk_size_db: 50
+        gce_n_local_ssd_disk_db: 8
+        gce_instance_type_loader: 'n1-highmem-8'
+        gce_root_disk_type_loader: 'pd-standard'
+        gce_n_local_ssd_disk_loader: 0
+        gce_instance_type_monitor: 'n1-standard-4'
+        gce_root_disk_type_monitor: 'pd-ssd'
+        gce_root_disk_size_monitor: 50
+        gce_n_local_ssd_disk_monitor: 0
+        scylla_repo: 'REPO_FILE_PATH'
+        us_east_1:
+          gce_datacenter: 'us-east1-b'
+    aws: !mux
+        cluster_backend: 'aws'
+        instance_type_loader: 'c4.8xlarge'
+        instance_type_monitor: 'c4.2xlarge'
+        instance_type_db: 'i3.8xlarge'
+        us_east_1:
+            region_name: 'us-east-1'
+            security_group_ids: 'sg-c5e1f7a0'
+            subnet_id: 'subnet-d934e980'
+            ami_id_db_scylla: 'AMI_ID'
+            ami_id_loader: 'AMI_ID'
+            ami_id_monitor: 'AMI_ID'
+            ami_db_scylla_user: 'centos'
+            ami_loader_user: 'centos'
+            ami_monitor_user: 'centos'
+
+databases: !mux
+    cassandra:
+        db_type: cassandra
+    scylla:
+        db_type: scylla

--- a/tests/longevity-staging.yaml
+++ b/tests/longevity-staging.yaml
@@ -1,0 +1,71 @@
+test_duration: 10080
+prepare_write_cmd: "cassandra-stress write no-warmup cl=QUORUM duration=48h -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=2 -pop seq=1..10000000 -log interval=30"
+# stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=10080m -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=20 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..10000000 -log interval=5",
+#             "cassandra-stress counter_write cl=QUORUM duration=10080m -schema 'replication(factor=3) compaction(strategy=DateTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=1 -pop seq=1..10000000",
+#             "cassandra-stress user profile=/tmp/cs_mv_profile.yaml ops'(insert=3,read1=1,read2=1,read3=1)' cl=QUORUM duration=10080m -port jmx=6868 -mode cql3 native -rate threads=10"]
+# stress_read_cmd: ["cassandra-stress read duration=5760m -mode cql3 native -rate threads=10 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..10000000 -port jmx=6868 -log interval=5",
+#                  "cassandra-stress counter_read duration=5760m -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..10000000"]
+keyspace_num: 100
+n_db_nodes: 4
+n_loaders: 5
+n_monitor_nodes: 1
+nemesis_class_name: 'ChaosMonkey'
+nemesis_interval: 30
+user_prefix: 'longevity-1000-keyspaces-not-jenkins'
+failure_post_behavior: keep
+space_node_threshold: 64424500
+ip_ssh_connections: 'private'
+experimental: 'true'
+append_conf: 'enable_sstable_data_integrity_check: true'
+round_robin: 'true'
+pre_create_schema: True
+
+
+backends: !mux
+    gce: !mux
+        cluster_backend: 'gce'
+        user_credentials_path: '~/.ssh/scylla-test'
+        gce_user_credentials: '~/Scylla-c41b78923a54.json'
+        gce_service_account_email: 'skilled-adapter-452@appspot.gserviceaccount.com'
+        gce_project: 'skilled-adapter-452'
+        gce_network: 'qa-vpc'
+        gce_image: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
+        gce_image_username: 'scylla-test'
+        gce_instance_type_db: 'n1-highmem-16'
+        gce_root_disk_type_db: 'pd-ssd'
+        gce_root_disk_size_db: 50
+        gce_n_local_ssd_disk_db: 8
+        gce_instance_type_loader: 'n1-standard-8'
+        gce_root_disk_type_loader: 'pd-standard'
+        gce_n_local_ssd_disk_loader: 0
+        gce_instance_type_monitor: 'n1-standard-4'
+        gce_root_disk_type_monitor: 'pd-standard'
+        gce_root_disk_size_monitor: 50
+        gce_n_local_ssd_disk_monitor: 0
+        scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/unstable/centos/branch-1.7/17/scylla.repo'
+        us_east_1:
+          gce_datacenter: 'us-east1-b'
+    aws: !mux
+        cluster_backend: 'aws'
+        instance_type_loader: 'c4.4xlarge'
+        instance_type_monitor: 'c4.2xlarge'
+        us_east_1:
+            region_name: 'us-east-1'
+            security_group_ids: 'sg-c5e1f7a0'
+            subnet_id: 'subnet-d934e980'
+            ami_id_db_scylla: 'ami-29035f52'
+            ami_db_scylla_user: 'centos'
+            ami_id_loader: 'ami-29035f52'
+            ami_loader_user: 'centos'
+            ami_id_db_cassandra: 'ami-3eff0028'
+            ami_db_cassandra_user: 'ubuntu'
+            ami_id_monitor: 'ami-29035f52'
+            ami_monitor_user: 'centos'
+
+databases: !mux
+    cassandra:
+        db_type: cassandra
+        instance_type_db: 'm3.large'
+    scylla:
+        db_type: scylla
+        instance_type_db: 'i2.4xlarge'


### PR DESCRIPTION
Not ready to merge yet, but most of the code is there.
Leftovers after test completed:
- Rename longevity-staging to something better.
- Add more stress CMDs to Yaml.
- Add the load distribution support to stress_cmd same as did for prepare_write_cmd.
- More tuning of threads and population after the test run long enough.
- Change to 1000 keyspaces.
- Test with more than one table (10?) per keyspace.