### PR TITLE
scale test: run on spot_fleet by default and

### DIFF
--- a/grow_cluster_test.py
+++ b/grow_cluster_test.py
@@ -93,10 +93,8 @@ class GrowClusterTest(ClusterTester):
         duration = 60 * nodes_to_add
         stress_queue = self.run_stress_thread(stress_cmd=stress_cmd,
                                               duration=duration)
-        # Wait for cluster is filled with data
-        # Set space_node_threshold in config file for the size
-        self.db_cluster.wait_total_space_used_per_node()
 
+        time.sleep(2 * 60)
         start = datetime.datetime.now()
         self.log.info('Starting to grow cluster: %s' % str(start))
 

--- a/tests/aws-grow-cluster-200nodes.yaml
+++ b/tests/aws-grow-cluster-200nodes.yaml
@@ -1,7 +1,6 @@
 test_duration: 1440
 cassandra_stress_threads: 500
 cassandra_stress_population_size: 10000000
-nemesis_interval: 1
 user_prefix: 'cluster-scale-test'
 failure_post_behavior: destroy
 space_node_threshold: 100
@@ -11,8 +10,8 @@ n_monitor_nodes: 1
 cluster_target_size: 200
 add_node_cnt: 1
 experimental: 'true'
-instance_provision: 'on_demand'
-# instance_provision can be one of the following: on_demand|spot_fleet|spot_low_price|spot_duration
+# aws instance provision: on_demand|spot_fleet|spot_low_price|spot_duration
+instance_provision: 'spot_fleet'
 
 backends: !mux
     aws: !mux


### PR DESCRIPTION
not wait for total space before adding nodes