### PR TITLE
Repair abort nemesis v2

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -985,6 +985,10 @@ WantedBy=multi-user.target
             p = re.compile('\n[# ]*rpc_address:.*')
             scylla_yaml_contents = p.sub('\nrpc_address: {0}'.format(self.private_ip_address),
                                          scylla_yaml_contents)
+            # Set api_address
+            p = re.compile('\n[# ]*api_address:.*')
+            scylla_yaml_contents = p.sub('\napi_address: {0}'.format(self.private_ip_address),
+                                         scylla_yaml_contents)
         if broadcast:
             # Set broadcast_address
             p = re.compile('[# ]*broadcast_address:.*')


### PR DESCRIPTION
The new nemesis is used to test abort repair. It starts repair target_node
in background, wait until the repair starts, then try to abort the repair
streaming.

v2: address Larisa's comments. appended a patch to change api_address