### PR TITLE
append -L option for curl cmdline

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1063,6 +1063,9 @@ client_encryption_options:
                                 dst='/tmp/scylla.yaml')
         self.remoter.run('sudo mv /tmp/scylla.yaml {}'.format(yaml_file))
 
+    def download_scylla_repo(self, scylla_repo, repo_path='/etc/yum.repos.d/scylla.repo'):
+        self.remoter.run('sudo curl -o %s -L %s' % (repo_path, scylla_repo))
+
     def install_mgmt(self, scylla_repo, scylla_mgmt_repo, mgmt_port, db_hosts):
         self.log.debug('Install scylla-manager')
         rsa_id_dst = '/tmp/scylla-test'
@@ -1071,8 +1074,8 @@ client_encryption_options:
         mgmt_conf_dst = '/etc/scylla-manager/scylla-manager.yaml'
 
         self.remoter.run('sudo yum install -y epel-release', retry=3)
-        self.remoter.run('sudo curl -o /etc/yum.repos.d/scylla.repo -L {}'.format(scylla_repo))
-        self.remoter.run('sudo curl -o /etc/yum.repos.d/scylla-manager.repo -L {}'.format(scylla_mgmt_repo))
+        self.download_scylla_repo(scylla_repo)
+        self.download_scylla_repo(scylla_mgmt_repo, repo_path='/etc/yum.repos.d/scylla-manager.repo')
         if self.is_docker():
             self.remoter.run('sudo yum remove -y scylla scylla-jmx scylla-tools scylla-tools-core'
                              ' scylla-server scylla-conf')

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -311,7 +311,7 @@ class ScyllaGCECluster(GCECluster, cluster.BaseScyllaCluster):
             node.remoter.run('sudo yum update -y --skip-broken', retry=3)
         node.remoter.run('sudo yum install -y rsync tcpdump screen wget net-tools')
         yum_config_path = '/etc/yum.repos.d/scylla.repo'
-        node.remoter.run('sudo curl %s -o %s' %
+        node.remoter.run('sudo curl %s -o %s -L' %
                          (self.params.get('scylla_repo'), yum_config_path))
         node.remoter.run('sudo yum install -y {}'.format(node.scylla_pkg()))
 
@@ -410,7 +410,7 @@ class LoaderSetGCE(GCECluster, cluster.BaseLoaderSet):
         self.log.info('Setup in LoaderSetGCE')
         node.wait_ssh_up(verbose=verbose)
         yum_config_path = '/etc/yum.repos.d/scylla.repo'
-        node.remoter.run('sudo curl %s -o %s' %
+        node.remoter.run('sudo curl %s -o %s -L' %
                          (self.params.get('scylla_repo'), yum_config_path))
         node.remoter.run('sudo yum install -y {}-tools'.format(node.scylla_pkg()))
         node.wait_cs_installed(verbose=verbose)

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -310,9 +310,7 @@ class ScyllaGCECluster(GCECluster, cluster.BaseScyllaCluster):
         else:
             node.remoter.run('sudo yum update -y --skip-broken', retry=3)
         node.remoter.run('sudo yum install -y rsync tcpdump screen wget net-tools')
-        yum_config_path = '/etc/yum.repos.d/scylla.repo'
-        node.remoter.run('sudo curl %s -o %s -L' %
-                         (self.params.get('scylla_repo'), yum_config_path))
+        node.download_scylla_repo(self.params.get('scylla_repo'))
         node.remoter.run('sudo yum install -y {}'.format(node.scylla_pkg()))
 
         endpoint_snitch = ''
@@ -409,9 +407,7 @@ class LoaderSetGCE(GCECluster, cluster.BaseLoaderSet):
     def node_setup(self, node, verbose=False, db_node_address=None):
         self.log.info('Setup in LoaderSetGCE')
         node.wait_ssh_up(verbose=verbose)
-        yum_config_path = '/etc/yum.repos.d/scylla.repo'
-        node.remoter.run('sudo curl %s -o %s -L' %
-                         (self.params.get('scylla_repo'), yum_config_path))
+        node.download_scylla_repo(self.params.get('scylla_repo'))
         node.remoter.run('sudo yum install -y {}-tools'.format(node.scylla_pkg()))
         node.wait_cs_installed(verbose=verbose)
         node.remoter.run('sudo yum install -y screen')

--- a/sdcm/cluster_libvirt.py
+++ b/sdcm/cluster_libvirt.py
@@ -220,7 +220,7 @@ class ScyllaLibvirtCluster(LibvirtCluster, cluster.BaseScyllaCluster):
         node.remoter.run('sudo yum update -y --skip-broken')
         node.remoter.run('sudo yum install -y rsync tcpdump screen')
         yum_config_path = '/etc/yum.repos.d/scylla.repo'
-        node.remoter.run('sudo curl %s -o %s' %
+        node.remoter.run('sudo curl %s -o %s -L' %
                          (self.params.get('scylla_repo'), yum_config_path))
         node.remoter.run('sudo yum install -y {}'.format(node.scylla_pkg()))
         node.config_setup(seed_address=self.get_seed_nodes_by_flag(),
@@ -331,7 +331,7 @@ class LoaderSetLibvirt(LibvirtCluster, cluster.BaseLoaderSet):
             self.log.info('Setup in LoaderSetLibvirt')
             node.wait_ssh_up(verbose=verbose)
             yum_config_path = '/etc/yum.repos.d/scylla.repo'
-            node.remoter.run('sudo curl %s -o %s' %
+            node.remoter.run('sudo curl %s -o %s -L' %
                              (self.params.get('scylla_repo'), yum_config_path))
             node.remoter.run('sudo yum install -y {}-tools'.format(node.scylla_pkg()))
             node.wait_cs_installed(verbose=verbose)

--- a/sdcm/cluster_libvirt.py
+++ b/sdcm/cluster_libvirt.py
@@ -219,9 +219,7 @@ class ScyllaLibvirtCluster(LibvirtCluster, cluster.BaseScyllaCluster):
         node.remoter.run('sudo yum clean all')
         node.remoter.run('sudo yum update -y --skip-broken')
         node.remoter.run('sudo yum install -y rsync tcpdump screen')
-        yum_config_path = '/etc/yum.repos.d/scylla.repo'
-        node.remoter.run('sudo curl %s -o %s -L' %
-                         (self.params.get('scylla_repo'), yum_config_path))
+        node.download_scylla_repo(self.params.get('scylla_repo'))
         node.remoter.run('sudo yum install -y {}'.format(node.scylla_pkg()))
         node.config_setup(seed_address=self.get_seed_nodes_by_flag(),
                           cluster_name=self.name,
@@ -330,9 +328,7 @@ class LoaderSetLibvirt(LibvirtCluster, cluster.BaseLoaderSet):
         def node_setup(node):
             self.log.info('Setup in LoaderSetLibvirt')
             node.wait_ssh_up(verbose=verbose)
-            yum_config_path = '/etc/yum.repos.d/scylla.repo'
-            node.remoter.run('sudo curl %s -o %s -L' %
-                             (self.params.get('scylla_repo'), yum_config_path))
+            node.download_scylla_repo(self.params.get('scylla_repo'))
             node.remoter.run('sudo yum install -y {}-tools'.format(node.scylla_pkg()))
             node.wait_cs_installed(verbose=verbose)
             node.remoter.run('sudo yum install -y screen')

--- a/sdcm/cluster_openstack.py
+++ b/sdcm/cluster_openstack.py
@@ -229,7 +229,7 @@ class ScyllaOpenStackCluster(OpenStackCluster, cluster.BaseScyllaCluster):
         node.remoter.run('sudo yum update -y --skip-broken')
         node.remoter.run('sudo yum install -y rsync tcpdump screen wget')
         yum_config_path = '/etc/yum.repos.d/scylla.repo'
-        node.remoter.run('sudo curl %s -o %s' %
+        node.remoter.run('sudo curl %s -o %s -L' %
                          (self.params.get('scylla_repo'), yum_config_path))
         node.remoter.run('sudo yum install -y {}'.format(node.scylla_pkg()))
         node.config_setup(seed_address=self.get_seed_nodes_by_flag(),
@@ -343,7 +343,7 @@ class LoaderSetOpenStack(OpenStackCluster, cluster.BaseLoaderSet):
             self.log.info('Setup in LoaderSetOpenStack')
             node.wait_ssh_up(verbose=verbose)
             yum_config_path = '/etc/yum.repos.d/scylla.repo'
-            node.remoter.run('sudo curl %s -o %s' %
+            node.remoter.run('sudo curl %s -o %s -L' %
                              (self.params.get('scylla_repo'), yum_config_path))
             node.remoter.run('sudo yum install -y {}-tools'.format(node.scylla_pkg()))
             node.wait_cs_installed(verbose=verbose)

--- a/sdcm/cluster_openstack.py
+++ b/sdcm/cluster_openstack.py
@@ -228,9 +228,7 @@ class ScyllaOpenStackCluster(OpenStackCluster, cluster.BaseScyllaCluster):
         node.remoter.run('sudo yum clean all')
         node.remoter.run('sudo yum update -y --skip-broken')
         node.remoter.run('sudo yum install -y rsync tcpdump screen wget')
-        yum_config_path = '/etc/yum.repos.d/scylla.repo'
-        node.remoter.run('sudo curl %s -o %s -L' %
-                         (self.params.get('scylla_repo'), yum_config_path))
+        node.download_scylla_repo(self.params.get('scylla_repo'))
         node.remoter.run('sudo yum install -y {}'.format(node.scylla_pkg()))
         node.config_setup(seed_address=self.get_seed_nodes_by_flag(),
                           cluster_name=self.name,
@@ -342,9 +340,7 @@ class LoaderSetOpenStack(OpenStackCluster, cluster.BaseLoaderSet):
         def node_setup(node):
             self.log.info('Setup in LoaderSetOpenStack')
             node.wait_ssh_up(verbose=verbose)
-            yum_config_path = '/etc/yum.repos.d/scylla.repo'
-            node.remoter.run('sudo curl %s -o %s -L' %
-                             (self.params.get('scylla_repo'), yum_config_path))
+            node.download_scylla_repo(self.params.get('scylla_repo'))
             node.remoter.run('sudo yum install -y {}-tools'.format(node.scylla_pkg()))
             node.wait_cs_installed(verbose=verbose)
             node.remoter.run('sudo yum install -y screen')


### PR DESCRIPTION
One GCE job failed to download private repo by curl, it returned a html of
301 error, not a valid repo file. We can solve the problem by append `-L`
option for curl cmdline.