### PR TITLE
Add compression workloads to longevity

### DIFF
--- a/tests/longevity-1TB-7days-authorization-and-tls-ssl.yaml
+++ b/tests/longevity-1TB-7days-authorization-and-tls-ssl.yaml
@@ -1,10 +1,16 @@
 test_duration: 10080
 prepare_write_cmd: "cassandra-stress write cl=QUORUM n=1100200300 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=1000 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1100200300"
 stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=10080m -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=20 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1100200300 -log interval=5",
+             "cassandra-stress write cl=QUORUM duration=10010m -schema 'replication(factor=3) compression=LZ4Compressor compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=lz4 -rate threads=50 -pop seq=1..1100000000 -log interval=5",
+             "cassandra-stress write cl=QUORUM duration=10020m -schema 'replication(factor=3) compression=SnappyCompressor compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=snappy -rate threads=50 -pop seq=1..1100000000 -log interval=5",
+             "cassandra-stress write cl=QUORUM duration=10030m -schema 'replication(factor=3) compression=DeflateCompressor compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=none -rate threads=50 -pop seq=1..1100000000 -log interval=5",
              "cassandra-stress counter_write cl=QUORUM duration=10080m -schema 'replication(factor=3) compaction(strategy=DateTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=1 -pop seq=1..10000000",
              "cassandra-stress user profile=/tmp/cs_mv_profile.yaml ops'(insert=3,read1=1,read2=1,read3=1)' cl=QUORUM duration=10080m -port jmx=6868 -mode cql3 native -rate threads=10"]
-stress_read_cmd: ["cassandra-stress read duration=10080m -mode cql3 native -rate threads=10 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1100200300 -port jmx=6868 -log interval=5",
-                  "cassandra-stress counter_read duration=10080m -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..10000000"]
+stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=10080m -mode cql3 native -rate threads=10 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1100200300 -port jmx=6868 -log interval=5",
+                  "cassandra-stress read cl=QUORUM duration=10010m -schema 'replication(factor=3) compression=LZ4Compressor compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=lz4 -rate threads=20 -pop seq=1..1100000000 -log interval=5",
+                  "cassandra-stress read cl=QUORUM duration=10020m -schema 'replication(factor=3) compression=SnappyCompressor compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=snappy -rate threads=20 -pop seq=1..1100000000 -log interval=5",
+                  "cassandra-stress read cl=QUORUM duration=10030m -schema 'replication(factor=3) compression=DeflateCompressor compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=none -rate threads=20 -pop seq=1..1100000000 -log interval=5",
+                  "cassandra-stress counter_read cl=QUORUM duration=10080m -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..10000000"]
 n_db_nodes: 4
 n_loaders: 2
 n_monitor_nodes: 1

--- a/tests/longevity-1TB-7days.yaml
+++ b/tests/longevity-1TB-7days.yaml
@@ -2,9 +2,15 @@ test_duration: 10080
 prepare_write_cmd: "cassandra-stress write cl=QUORUM n=1100200300 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=1000 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1100200300"
 stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=10080m -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=20 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1100200300 -log interval=5",
              "cassandra-stress counter_write cl=QUORUM duration=10080m -schema 'replication(factor=3) compaction(strategy=DateTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=1 -pop seq=1..10000000",
-             "cassandra-stress user profile=/tmp/cs_mv_profile.yaml ops'(insert=3,read1=1,read2=1,read3=1)' cl=QUORUM duration=10080m -port jmx=6868 -mode cql3 native -rate threads=10"]
-stress_read_cmd: ["cassandra-stress read duration=10080m -mode cql3 native -rate threads=10 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1100200300 -port jmx=6868 -log interval=5",
-                  "cassandra-stress counter_read duration=10080m -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..10000000"]
+             "cassandra-stress user profile=/tmp/cs_mv_profile.yaml ops'(insert=3,read1=1,read2=1,read3=1)' cl=QUORUM duration=10080m -port jmx=6868 -mode cql3 native -rate threads=10",
+             "cassandra-stress write cl=QUORUM duration=10010m -schema 'replication(factor=3) compression=LZ4Compressor compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=lz4 -rate threads=50 -pop seq=1..1100000000 -log interval=5",
+             "cassandra-stress write cl=QUORUM duration=10020m -schema 'replication(factor=3) compression=SnappyCompressor compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=snappy -rate threads=50 -pop seq=1..1100000000 -log interval=5",
+             "cassandra-stress write cl=QUORUM duration=10030m -schema 'replication(factor=3) compression=DeflateCompressor compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=none -rate threads=50 -pop seq=1..1100000000 -log interval=5"]
+stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=10080m -mode cql3 native -rate threads=10 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1100200300 -port jmx=6868 -log interval=5",
+                  "cassandra-stress counter_read cl=QUORUM duration=10080m -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..10000000",
+                  "cassandra-stress read cl=QUORUM duration=10010m -schema 'replication(factor=3) compression=LZ4Compressor compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=lz4 -rate threads=20 -pop seq=1..1100000000 -log interval=5",
+                  "cassandra-stress read cl=QUORUM duration=10020m -schema 'replication(factor=3) compression=SnappyCompressor compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=snappy -rate threads=20 -pop seq=1..1100000000 -log interval=5",
+                  "cassandra-stress read cl=QUORUM duration=10030m -schema 'replication(factor=3) compression=DeflateCompressor compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=none -rate threads=20 -pop seq=1..1100000000 -log interval=5"]
 n_db_nodes: 4
 n_loaders: 2
 n_monitor_nodes: 1

--- a/tests/longevity-50GB-4days-authorization-and-tls-ssl.yaml
+++ b/tests/longevity-50GB-4days-authorization-and-tls-ssl.yaml
@@ -3,8 +3,8 @@ prepare_write_cmd: "cassandra-stress write cl=QUORUM n=100000000 -schema 'replic
 stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=5760m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=20 -pop seq=1..100000000 -log interval=5",
              "cassandra-stress counter_write cl=QUORUM duration=5760m -schema 'replication(factor=3) compaction(strategy=DateTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=1 -pop seq=1..1000000",
              "cassandra-stress user profile=/tmp/cs_mv_profile.yaml ops'(insert=3,read1=1,read2=1,read3=1)' cl=QUORUM duration=5760m -port jmx=6868 -mode cql3 native -rate threads=10"]
-stress_read_cmd: ["cassandra-stress read duration=5760m -port jmx=6868 -mode cql3 native -rate threads=20 -pop seq=1..100000000 -log interval=5",
-                  "cassandra-stress counter_read duration=5760m -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..1000000"]
+stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=5760m -port jmx=6868 -mode cql3 native -rate threads=20 -pop seq=1..100000000 -log interval=5",
+                  "cassandra-stress counter_read cl=QUORUM duration=5760m -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..1000000"]
 n_db_nodes: 6
 n_loaders: 3
 n_monitor_nodes: 1


### PR DESCRIPTION
1. Add compression workloads to longevity 1TB (both types).

2. Add cl=quorum to read workloads.