### PR TITLE
gce: try to record cpu platform information

### DIFF
--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -264,6 +264,7 @@ class GCECluster(cluster.BaseCluster):
             instances = self._create_instances(count, dc_idx)
 
         self.log.debug('instances: %s', instances)
+        self.log.debug('GCE instance extra info: %s', instances[0].extra)
         for ind, instance in enumerate(instances):
             node_index = ind + self._node_index + 1
             node = self._create_node(instance, node_index, dc_idx)

--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -184,6 +184,9 @@ class TestStatsMixin(Stats):
 
         new_scylla_packages = self.params.get('update_db_packages')
         setup_details['packages_updated'] = True if new_scylla_packages and os.listdir(new_scylla_packages) else False
+        setup_details['cpu_platform'] = 'UNKNOWN'
+        if is_gce:
+            setup_details['cpu_platform'] = self.db_cluster.nodes[0]._instance.extra.get('cpuPlatform', 'UNKNOWN')
 
         return setup_details
 


### PR DESCRIPTION
We can change libcloud GCENodeDriver._to_node() to dump the cpu platform,
file path is /usr/lib/python2.7/site-packages/libcloud/compute/drivers/gce.py

This patch tried to collect this info to test results.