### PR TITLE
Renamed clean_aws_resources 

### DIFF
--- a/big_cluster_test.py
+++ b/big_cluster_test.py
@@ -18,7 +18,7 @@ import logging
 from avocado import main
 
 from sdcm.tester import ClusterTester
-from sdcm.tester import clean_aws_resources
+from sdcm.tester import clean_resources_on_exception
 
 
 class HugeClusterTest(ClusterTester):
@@ -29,7 +29,7 @@ class HugeClusterTest(ClusterTester):
     :avocado: enable
     """
 
-    @clean_aws_resources
+    @clean_resources_on_exception
     def setUp(self):
         self.credentials = None
         self.db_cluster = None

--- a/query_limits_test.py
+++ b/query_limits_test.py
@@ -18,7 +18,7 @@ import logging
 from avocado import main
 
 from sdcm.tester import ClusterTester
-from sdcm.tester import clean_aws_resources
+from sdcm.tester import clean_resources_on_exception
 
 
 class QueryLimitsTest(ClusterTester):
@@ -29,7 +29,7 @@ class QueryLimitsTest(ClusterTester):
     :avocado: enable
     """
 
-    @clean_aws_resources
+    @clean_resources_on_exception
     def setUp(self):
         self.credentials = None
         self.db_cluster = None

--- a/reduce_cluster_test.py
+++ b/reduce_cluster_test.py
@@ -19,7 +19,7 @@ import datetime
 from avocado import main
 
 from sdcm.tester import ClusterTester
-from sdcm.tester import clean_aws_resources
+from sdcm.tester import clean_resources_on_exception
 from sdcm.nemesis import Nemesis
 from sdcm.nemesis import log_time_elapsed
 import time
@@ -40,7 +40,7 @@ class ReduceClusterTest(ClusterTester):
     :avocado: enable
     """
 
-    @clean_aws_resources
+    @clean_resources_on_exception
     def setUp(self):
         self.credentials = None
         self.db_cluster = None


### PR DESCRIPTION
Renamed clean_aws_resources to the name that reflects what what it really does: cleans resources if exception happens

Also added "@wraps" decorator to save docstrings and wrapped func name.
@roydahan 
@larisau @amoskong 