### PR TITLE
Reuse cluster

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1807,6 +1807,7 @@ class BaseLoaderSet(object):
         node.wait_ssh_up(verbose=verbose)
 
         if Setup.REUSE_CLUSTER:
+            self.kill_stress_thread()
             return
 
         # The init scripts should install/update cs, so

--- a/tests/longevity-staging.yaml
+++ b/tests/longevity-staging.yaml
@@ -20,6 +20,13 @@ append_conf: 'enable_sstable_data_integrity_check: true'
 round_robin: 'true'
 pre_create_schema: True
 
+reuse_cluster: False
+db_nodes_public_ip: []
+db_nodes_private_ip: []
+loaders_public_ip: []
+loaders_private_ip: []
+monitor_nodes_public_ip: []
+monitor_nodes_private_ip: []
 
 backends: !mux
     gce: !mux


### PR DESCRIPTION
Run SCT on existing cluster

[addition by Roy]:
This PR should add SCT the ability to re-run a test on an existing cluster and do not provision a new cluster during the setup phase.

It should help us in many cases where we run longevity for few days and something happened to the test (Jenkins crushed, unhandled exception in one of the nemesis, etc..).

The way we want to use it, is providing the list of cluster IPs in the test yaml and let the SCT load the cluster objects and run the test again (e.g. run the load and start nemesis for longevity).


