### PR TITLE
Fixing #530: incorrect sequence of actions when destroying node.

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -775,12 +775,12 @@ WantedBy=multi-user.target
         raise NotImplementedError('Derived classes must implement restart')
 
     def stop_task_threads(self, timeout=10):
-        del(self.remoter)
         self.termination_event.set()
         if self._backtrace_thread:
             self._backtrace_thread.join(timeout)
         if self._journal_thread:
             self._journal_thread.join(timeout)
+        self.remoter.close()
 
     def destroy(self):
         raise NotImplementedError('Derived classes must implement destroy')

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -300,9 +300,9 @@ class AWSNode(cluster.BaseNode):
         self.wait_db_up()
 
     def destroy(self):
+        self.stop_task_threads()
         self._instance.terminate()
         cluster.EC2_INSTANCES.remove(self._instance)
-        self.stop_task_threads()
         self.log.info('Destroyed')
 
 

--- a/sdcm/cluster_baremetal.py
+++ b/sdcm/cluster_baremetal.py
@@ -54,8 +54,7 @@ class PhysicalMachineNode(cluster.BaseNode):
         self.remoter.run('sudo reboot -h now', ignore_status=True)
 
     def destroy(self):
-        # do nothing
-        pass
+        self.stop_task_threads()  # For future implementation of destroy
 
 
 class PhysicalMachineCluster(cluster.BaseCluster):

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -110,8 +110,8 @@ class GCENode(cluster.BaseNode):
         self._instance_wait_safe(self._instance.reboot)
 
     def destroy(self):
-        self._instance_wait_safe(self._instance.destroy)
         self.stop_task_threads()
+        self._instance_wait_safe(self._instance.destroy)
         self.log.info('Destroyed')
 
 

--- a/sdcm/cluster_libvirt.py
+++ b/sdcm/cluster_libvirt.py
@@ -94,10 +94,10 @@ class LibvirtNode(cluster.BaseNode):
         self.wait_db_up()
 
     def destroy(self):
+        self.stop_task_threads()
         self._domain.destroy()
         self._domain.undefine()
         cluster.remove_if_exists(self._backing_image)
-        self.stop_task_threads()
         self.log.info('Destroyed')
 
 

--- a/sdcm/cluster_openstack.py
+++ b/sdcm/cluster_openstack.py
@@ -109,8 +109,8 @@ class OpenStackNode(cluster.BaseNode):
         self._instance.reboot()
 
     def destroy(self):
-        self._instance.destroy()
         self.stop_task_threads()
+        self._instance.destroy()
         self.log.info('Destroyed')
 
 

--- a/sdcm/remote.py
+++ b/sdcm/remote.py
@@ -736,7 +736,10 @@ class BaseRemote(object):
     def close(self):
         global splist
         for sp in splist:
-            sp.kill()
+            try:
+                sp.kill()
+            except OSError as e:
+                self.log.warning("Unable to kill [%s]: %r" % (sp, e))
         self._cleanup_master_ssh()
         os.remove(self.known_hosts_file)
 


### PR DESCRIPTION
First of all, consumers of Remote object should finish their work and only then Remote object should be closed
Details in #530 