### PR TITLE
Log run info decorator

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -786,7 +786,7 @@ WantedBy=multi-user.target
     def destroy(self):
         raise NotImplementedError('Derived classes must implement destroy')
 
-    def wait_ssh_up(self, verbose=True, timeout=None):
+    def wait_ssh_up(self, verbose=True, timeout=300):
         text = None
         if verbose:
             text = '%s: Waiting for SSH to be up' % self

--- a/sdcm/remote.py
+++ b/sdcm/remote.py
@@ -725,7 +725,8 @@ class BaseRemote(object):
         """
         try:
             self._ssh_ping()
-        except process.CmdError:
+        except process.CmdError as e:
+            self.log.error("Error while executing SSH command: %s" % e.result)
             return False
         except Exception, details:
             self.log.error('Error checking if SSH is up: %s', details)

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -996,6 +996,7 @@ class ClusterTester(Test):
 
     def clean_resources(self):
         self.log.debug('Cleaning up resources used in the test')
+        self.kill_stress_thread()
         db_cluster_errors = None
         db_cluster_coredumps = None
         if self.db_cluster is not None:

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1014,6 +1014,12 @@ class ClusterTester(Test):
                 for node in self.db_cluster.nodes:
                     node.instance.stop()
                 self.db_cluster = None
+            elif self._failure_post_behavior == 'keep':
+                # Stopping nemesis, using timeout of 30 minutes, since replace/decomission node can take time
+                self.db_cluster.stop_nemesis(timeout=1800)
+                for node in self.db_cluster.nodes:
+                    node.stop_task_threads(timeout=600)
+
         if self.loaders is not None:
             self.loaders.get_backtraces()
             if self._failure_post_behavior == 'destroy':


### PR DESCRIPTION
**Added log_run_info decorator and minor bug fixes**
 About decorator (from doc string):

>         Decorator that prints BEGIN before the function runs and END when function finished running.
>         Uses function name as a name of action or string that can be given to the decorator.
>         If the function is a method of a class object, the class name will be printed out.
> 
>         Usage examples:
>             @log_run_info
>             def foo(x, y=1):
>                 pass
>             In: foo(1)
>             Out:
>                 BEGIN: foo
>                 END: foo (ran 0.000164)s
> 
>             @log_run_info("Execute nemesis")
>             def disrupt():
>                 pass
>             In: disrupt()
>             Out:
>                 BEGIN: Execute nemesis
>                 END: Execute nemesis (ran 0.000271)s