### PR TITLE
change Repair abort to call api service from db node

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -994,10 +994,6 @@ WantedBy=multi-user.target
             p = re.compile('\n[# ]*rpc_address:.*')
             scylla_yaml_contents = p.sub('\nrpc_address: {0}'.format(self.private_ip_address),
                                          scylla_yaml_contents)
-            # Set api_address
-            p = re.compile('\n[# ]*api_address:.*')
-            scylla_yaml_contents = p.sub('\napi_address: {0}'.format(self.private_ip_address),
-                                         scylla_yaml_contents)
         if broadcast:
             # Set broadcast_address
             p = re.compile('[# ]*broadcast_address:.*')


### PR DESCRIPTION
housekeeping, scylla-manager and node_health_check all use 127.0.0.1 as api address. This PR change repair abort to call api service by 127.0.0.1 on db node.

(need more testing before merge)