### PR TITLE
fix messy code in snapshot by installing bitmap-fonts

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2351,7 +2351,7 @@ class BaseMonitorSet(object):
                               node.public_ip_address, scylla_pkg, version, start_time)
                 snapshot_path = os.path.join(self.logdir,
                                              "grafana-snapshot-%s.png" % n)
-                process.run("sudo yum install fontconfig -y")
+                process.run("sudo yum install fontconfig bitmap-fonts -y")
                 process.run("cd phantomjs-2.1.1-linux-x86_64 && "
                             "bin/phantomjs r.js \"%s\" \"%s\" 1920px" % (
                              grafana_url, snapshot_path), shell=True)


### PR DESCRIPTION
Snapshot has messy code if system doesn't have font, this patch added a working
fonts to system.