### PR TITLE
Reverting back to running del on remoter object 

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -787,7 +787,7 @@ WantedBy=multi-user.target
             self._backtrace_thread.join(timeout)
         if self._journal_thread:
             self._journal_thread.join(timeout)
-        self.remoter.close()
+        del(self.remoter)
 
     def destroy(self):
         raise NotImplementedError('Derived classes must implement destroy')


### PR DESCRIPTION
when running stop_task_threads

The reason is the remoter.close method is not implemented correctly since it
closes all SSH subprocesses regardless to the specific host.
@roydahan 