### PR TITLE
Introduce rolling upgrade test

### DIFF
--- a/tests/rolling-upgrade-gce.yaml
+++ b/tests/rolling-upgrade-gce.yaml
@@ -1,0 +1,61 @@
+test_duration: 65
+
+n_db_nodes: 4
+n_loaders: 1
+n_monitor_nodes: 1
+gce_datacenter: 'us-east1-b'
+
+# workloads
+prepare_write_stress: cassandra-stress write no-warmup cl=QUORUM n=10000000 -schema 'replication(factor=2)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5
+stress_cmd_read_10m: cassandra-stress read no-warmup cl=QUORUM duration=10m -schema 'replication(factor=2)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5
+stress_cmd_read_clall: cassandra-stress read no-warmup cl=ALL n=10000000 -schema 'replication(factor=2)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5
+stress_cmd_read_20m: cassandra-stress read no-warmup cl=QUORUM duration=20m -schema 'replication(factor=2)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5
+
+user_prefix: 'rolling-upgrade-VERSION'
+failure_post_behavior: keep
+
+experimental: 'true'
+
+backends: !mux
+    gce: !mux
+        cluster_backend: 'gce'
+        user_credentials_path: '~/.ssh/scylla-test'
+        gce_user_credentials: '~/Scylla-c41b78923a54.json'
+        gce_service_account_email: 'skilled-adapter-452@appspot.gserviceaccount.com'
+        gce_project: 'skilled-adapter-452'
+        gce_image: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
+        gce_image_username: 'scylla-test'
+        gce_instance_type_db: 'n1-highmem-8'
+        gce_root_disk_type_db: 'pd-ssd'
+        gce_root_disk_size_db: 50
+        gce_n_local_ssd_disk_db: 1
+        gce_instance_type_loader: 'n1-standard-2'
+        gce_root_disk_type_loader: 'pd-standard'
+        gce_root_disk_size_loader: 50
+        gce_n_local_ssd_disk_loader: 0
+        gce_instance_type_monitor: 'n1-standard-1'
+        gce_root_disk_type_monitor: 'pd-standard'
+        gce_root_disk_size_monitor: 50
+        gce_n_local_ssd_disk_monitor: 0
+
+databases: !mux
+    scylla:
+        db_type: scylla
+
+base_version: !mux
+    2.1:
+        scylla_repo: https://s3.amazonaws.com/downloads.scylladb.com/rpm/unstable/centos/branch-2.1/96/scylla.repo
+    2.2:
+        scylla_repo: https://s3.amazonaws.com/downloads.scylladb.com/rpm/unstable/centos/branch-2.2/28/scylla.repo
+    2017.1:
+        scylla_repo: https://s3.amazonaws.com/downloads.scylladb.com/enterprise/rpm/unstable/centos/branch-2017.1/34/scylla.repo
+    2018.1.0:
+        scylla_repo: https://s3.amazonaws.com/downloads.scylladb.com/enterprise/rpm/unstable/centos/branch-2018.1/22/scylla.repo
+
+new_version: !mux
+    2.2:
+        repo_file: https://s3.amazonaws.com/downloads.scylladb.com/rpm/unstable/centos/branch-2.2/28/scylla.repo
+    2018.1:
+        repo_file: https://s3.amazonaws.com/downloads.scylladb.com/enterprise/rpm/unstable/centos/branch-2018.1/22/scylla.repo
+    2018.1.1:
+        repo_file: https://s3.amazonaws.com/downloads.scylladb.com/enterprise/rpm/unstable/centos/branch-2018.1/32/scylla.repo

--- a/tests/rolling-upgrade-gce.yaml
+++ b/tests/rolling-upgrade-gce.yaml
@@ -6,10 +6,10 @@ n_monitor_nodes: 1
 gce_datacenter: 'us-east1-b'
 
 # workloads
-prepare_write_stress: cassandra-stress write no-warmup cl=QUORUM n=10000000 -schema 'replication(factor=2)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5
-stress_cmd_read_10m: cassandra-stress read no-warmup cl=QUORUM duration=10m -schema 'replication(factor=2)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5
-stress_cmd_read_clall: cassandra-stress read no-warmup cl=ALL n=10000000 -schema 'replication(factor=2)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5
-stress_cmd_read_20m: cassandra-stress read no-warmup cl=QUORUM duration=20m -schema 'replication(factor=2)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5
+prepare_write_stress: cassandra-stress write no-warmup cl=QUORUM n=10000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5
+stress_cmd_read_10m: cassandra-stress read no-warmup cl=QUORUM duration=10m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5
+stress_cmd_read_clall: cassandra-stress read no-warmup cl=ALL n=10000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5
+stress_cmd_read_20m: cassandra-stress read no-warmup cl=QUORUM duration=20m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5
 
 user_prefix: 'rolling-upgrade-VERSION'
 failure_post_behavior: keep

--- a/tests/rolling-upgrade-gce.yaml
+++ b/tests/rolling-upgrade-gce.yaml
@@ -43,19 +43,14 @@ databases: !mux
         db_type: scylla
 
 base_version: !mux
+    2.0:
+        scylla_repo: https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-2.0.repo
     2.1:
-        scylla_repo: https://s3.amazonaws.com/downloads.scylladb.com/rpm/unstable/centos/branch-2.1/96/scylla.repo
+        scylla_repo: https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-2.1.repo
     2.2:
-        scylla_repo: https://s3.amazonaws.com/downloads.scylladb.com/rpm/unstable/centos/branch-2.2/28/scylla.repo
+        scylla_repo: https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-2.2.repo
     2017.1:
-        scylla_repo: https://s3.amazonaws.com/downloads.scylladb.com/enterprise/rpm/unstable/centos/branch-2017.1/34/scylla.repo
+        scylla_repo: https://s3.amazonaws.com/downloads.scylladb.com/enterprise/rpm/centos/scylla-enterprise-2017.1.repo
     2018.1.0:
-        scylla_repo: https://s3.amazonaws.com/downloads.scylladb.com/enterprise/rpm/unstable/centos/branch-2018.1/22/scylla.repo
-
-new_version: !mux
-    2.2:
-        repo_file: https://s3.amazonaws.com/downloads.scylladb.com/rpm/unstable/centos/branch-2.2/28/scylla.repo
-    2018.1:
-        repo_file: https://s3.amazonaws.com/downloads.scylladb.com/enterprise/rpm/unstable/centos/branch-2018.1/22/scylla.repo
-    2018.1.1:
-        repo_file: https://s3.amazonaws.com/downloads.scylladb.com/enterprise/rpm/unstable/centos/branch-2018.1/32/scylla.repo
+        # official release 2018.1.0
+        scylla_repo: https://s3.amazonaws.com/downloads.scylladb.com/enterprise/rpm/unstable/centos/branch-2018.1/29/scylla.repo

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -40,7 +40,7 @@ class UpgradeTest(FillDatabaseData):
 
         # We assume that if update_db_packages is not empty we install packages from there.
         # In this case we don't use upgrade based on repo_file(ignored sudo yum update scylla...)
-        result = node.remoter.run('rpm -qa scylla-server')
+        result = node.remoter.run('rpm -qa scylla\*server')
         orig_ver = result.stdout
         if upgrade_node_packages:
             # update_scylla_packages
@@ -79,7 +79,7 @@ class UpgradeTest(FillDatabaseData):
             node.remoter.run('sudo yum update scylla{0}\* -y'.format(ver_suffix))
         node.remoter.run('sudo systemctl start scylla-server.service')
         node.wait_db_up(verbose=True)
-        result = node.remoter.run('rpm -qa scylla-server')
+        result = node.remoter.run('rpm -qa scylla\*server')
         new_ver = result.stdout
         assert orig_ver != new_ver, "scylla-server version isn't changed"
 

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -51,6 +51,7 @@ class UpgradeTest(FillDatabaseData):
             # flush all memtables to SSTables
             node.remoter.run('sudo nodetool drain')
             node.remoter.run('sudo nodetool snapshot')
+            node.remoter.run('sudo systemctl stop scylla-server.service')
             # update *development* packages
             node.remoter.run('sudo rpm -UvhR --oldpackage /tmp/scylla/*development*', ignore_status=True)
             # and all the rest
@@ -69,12 +70,13 @@ class UpgradeTest(FillDatabaseData):
             # flush all memtables to SSTables
             node.remoter.run('sudo nodetool drain')
             node.remoter.run('sudo nodetool snapshot')
+            node.remoter.run('sudo systemctl stop scylla-server.service')
             node.remoter.run('sudo chown root.root /etc/yum.repos.d/scylla.repo')
             node.remoter.run('sudo chmod 644 /etc/yum.repos.d/scylla.repo')
             node.remoter.run('sudo yum clean all')
             ver_suffix = '-{}'.format(new_version) if new_version else ''
             node.remoter.run('sudo yum update scylla{0}\* -y'.format(ver_suffix))
-        node.remoter.run('sudo systemctl restart scylla-server.service')
+        node.remoter.run('sudo systemctl start scylla-server.service')
         node.wait_db_up(verbose=True)
         new_ver = node.remoter.run('rpm -qa scylla-server')
         if orig_ver == new_ver:

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -40,7 +40,8 @@ class UpgradeTest(FillDatabaseData):
 
         # We assume that if update_db_packages is not empty we install packages from there.
         # In this case we don't use upgrade based on repo_file(ignored sudo yum update scylla...)
-        orig_ver = node.remoter.run('rpm -qa scylla-server')
+        result = node.remoter.run('rpm -qa scylla-server')
+        orig_ver = result.stdout
         if upgrade_node_packages:
             # update_scylla_packages
             node.remoter.send_files(upgrade_node_packages, '/tmp/scylla', verbose=True)
@@ -78,9 +79,9 @@ class UpgradeTest(FillDatabaseData):
             node.remoter.run('sudo yum update scylla{0}\* -y'.format(ver_suffix))
         node.remoter.run('sudo systemctl start scylla-server.service')
         node.wait_db_up(verbose=True)
-        new_ver = node.remoter.run('rpm -qa scylla-server')
-        if orig_ver == new_ver:
-            self.log.error('scylla-server version isn\'t changed')
+        result = node.remoter.run('rpm -qa scylla-server')
+        new_ver = result.stdout
+        assert orig_ver != new_ver, "scylla-server version isn't changed"
 
     def rollback_node(self, node):
         self.log.info('Rollbacking a Node')

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -156,10 +156,10 @@ class UpgradeTest(FillDatabaseData):
         # upgrade all the nodes in random order
         for i in indexes:
             self.db_cluster.node_to_upgrade = self.db_cluster.nodes[i]
-            self.log.info('Upgrade Node begin')
+            self.log.info('Upgrade Node %s begin', self.db_cluster.node_to_upgrade.name)
             self.upgrade_node(self.db_cluster.node_to_upgrade)
             time.sleep(300)
-            self.log.info('Upgrade Node ended')
+            self.log.info('Upgrade Node %s ended', self.db_cluster.node_to_upgrade.name)
 
         self.log.info('Run some Queries to verify data AFTER UPGRADE')
         self.verify_db_data()

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -124,39 +124,6 @@ class UpgradeTest(FillDatabaseData):
         self.verify_db_data()
         self.verify_stress_thread(stress_queue)
 
-    def test_20_minutes(self):
-        """
-        Run cassandra-stress on a cluster for 20 minutes, together with node upgrades.
-        If upgrade_node_packages defined we specify duration 10 * len(nodes) minutes.
-        """
-        self.db_cluster.add_nemesis(nemesis=UpgradeNemesis,
-                                    loaders=self.loaders,
-                                    monitoring_set=self.monitors)
-        self.db_cluster.start_nemesis(interval=10)
-        duration = 20
-        if self.params.get('upgrade_node_packages'):
-            duration = 30 * len(self.db_cluster.nodes)
-        self.run_stress(stress_cmd=self.params.get('stress_cmd'), duration=duration)
-
-    def test_20_minutes_rollback(self):
-        """
-        Run cassandra-stress on a cluster for 20 minutes, together with node upgrades.
-        """
-        self.db_cluster.add_nemesis(nemesis=UpgradeNemesis,
-                                    loaders=self.loaders,
-                                    monitoring_set=self.monitors)
-        self.db_cluster.start_nemesis(interval=10)
-        self.db_cluster.stop_nemesis(timeout=None)
-
-        self.db_cluster.clean_nemesis()
-
-        self.db_cluster.add_nemesis(nemesis=RollbackNemesis,
-                                    loaders=self.loaders,
-                                    monitoring_set=self.monitors)
-        self.db_cluster.start_nemesis(interval=10)
-        self.run_stress(stress_cmd=self.params.get('stress_cmd'),
-                        duration=self.params.get('cassandra_stress_duration', 20))
-
 
 if __name__ == '__main__':
     main()

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -48,6 +48,8 @@ class UpgradeTest(FillDatabaseData):
             node.remoter.run('sudo yum install python34-PyYAML -y')
             # replace the packages
             node.remoter.run('rpm -qa scylla\*')
+            # flush all memtables to SSTables
+            node.remoter.run('sudo nodetool drain')
             node.remoter.run('sudo nodetool snapshot')
             # update *development* packages
             node.remoter.run('sudo rpm -UvhR --oldpackage /tmp/scylla/*development*', ignore_status=True)
@@ -64,14 +66,14 @@ class UpgradeTest(FillDatabaseData):
                 node.remoter.run('sudo cp /tmp/scylla.repo /etc/yum.repos.d/scylla.repo')
             # backup the data
             node.remoter.run('sudo cp /etc/scylla/scylla.yaml /etc/scylla/scylla.yaml-backup')
+            # flush all memtables to SSTables
+            node.remoter.run('sudo nodetool drain')
             node.remoter.run('sudo nodetool snapshot')
             node.remoter.run('sudo chown root.root /etc/yum.repos.d/scylla.repo')
             node.remoter.run('sudo chmod 644 /etc/yum.repos.d/scylla.repo')
             node.remoter.run('sudo yum clean all')
             ver_suffix = '-{}'.format(new_version) if new_version else ''
             node.remoter.run('sudo yum update scylla{0}\* -y'.format(ver_suffix))
-        # flush all memtables to SSTables
-        node.remoter.run('sudo nodetool drain')
         node.remoter.run('sudo systemctl restart scylla-server.service')
         node.wait_db_up(verbose=True)
         new_ver = node.remoter.run('rpm -qa scylla-server')

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -69,8 +69,7 @@ class UpgradeTest(FillDatabaseData):
             node.remoter.run('sudo chmod 644 /etc/yum.repos.d/scylla.repo')
             node.remoter.run('sudo yum clean all')
             ver_suffix = '-{}'.format(new_version) if new_version else ''
-            node.remoter.run('sudo yum install scylla{0} scylla-server{0} scylla-jmx{0} scylla-tools{0}'
-                             ' scylla-conf{0} scylla-kernel-conf{0} scylla-debuginfo{0} -y'.format(ver_suffix))
+            node.remoter.run('sudo yum update scylla{0}\* -y'.format(ver_suffix))
         # flush all memtables to SSTables
         node.remoter.run('sudo nodetool drain')
         node.remoter.run('sudo systemctl restart scylla-server.service')

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -55,10 +55,13 @@ class UpgradeTest(FillDatabaseData):
             node.remoter.run('sudo rpm -URvh --replacefiles /tmp/scylla/* | true')
             node.remoter.run('rpm -qa scylla\*')
         elif repo_file:
-            scylla_repo = get_data_path(repo_file)
-            node.remoter.send_files(scylla_repo, '/tmp/scylla.repo', verbose=True)
-            node.remoter.run('sudo cp /etc/yum.repos.d/scylla.repo ~/scylla.repo-backup')
-            node.remoter.run('sudo cp /tmp/scylla.repo /etc/yum.repos.d/scylla.repo')
+            if repo_file.startswith('http'):
+                node.remoter.run('sudo curl -L {} -o /etc/yum.repos.d/scylla.repo')
+            else:
+                scylla_repo = get_data_path(repo_file)
+                node.remoter.send_files(scylla_repo, '/tmp/scylla.repo', verbose=True)
+                node.remoter.run('sudo cp /etc/yum.repos.d/scylla.repo ~/scylla.repo-backup')
+                node.remoter.run('sudo cp /tmp/scylla.repo /etc/yum.repos.d/scylla.repo')
             # backup the data
             node.remoter.run('sudo cp /etc/scylla/scylla.yaml /etc/scylla/scylla.yaml-backup')
             node.remoter.run('sudo nodetool snapshot')


### PR DESCRIPTION
This PR introduced a new rolling upgrade, which uses new scenario with multiple kinds of c-s workload. The patchset also introduced a helper to rollback node, and support different procedure according to the version.