### PR TITLE
use default timeout in stop_task_threads

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1003,7 +1003,7 @@ class ClusterTester(db_stats.TestStatsMixin, Test):
                 # Stopping nemesis, using timeout of 30 minutes, since replace/decommission node can take time
                 self.db_cluster.stop_nemesis(timeout=1800)
                 for node in self.db_cluster.nodes:
-                    node.stop_task_threads(timeout=600)
+                    node.stop_task_threads()
 
         if self.loaders is not None:
             self.loaders.get_backtraces()


### PR DESCRIPTION
Journal thread blocks and never checks the termination event, Bentsi is working
to fix it. Current stop_task_threads takes 10+ mins for each node, let's use
default timeout 10s.
