### PR TITLE
AWS: enable auto_bootstrap for additional nodes

### DIFF
--- a/grow_cluster_test.py
+++ b/grow_cluster_test.py
@@ -76,7 +76,7 @@ class GrowClusterTest(ClusterTester):
 
     def add_nodes(self, add_node_cnt):
         self.metrics_srv.event_start('add_node')
-        new_nodes = self.db_cluster.add_nodes(count=add_node_cnt)
+        new_nodes = self.db_cluster.add_nodes(count=add_node_cnt, enable_auto_bootstrap=True)
         self.db_cluster.wait_for_init(node_list=new_nodes)
         self.metrics_srv.event_stop('add_node')
         self.reconfigure_monitor()

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -810,17 +810,23 @@ class BaseNode(object):
 
         if self.enable_auto_bootstrap:
             if 'auto_bootstrap' in scylla_yaml_contents:
+                if re.findall("auto_bootstrap: False", scylla_yaml_contents):
+                    self.log.debug('auto_bootstrap is not set as expected, update it to `True`.')
                 p = re.compile('auto_bootstrap:.*')
                 scylla_yaml_contents = p.sub('auto_bootstrap: True',
                                              scylla_yaml_contents)
             else:
+                self.log.debug('auto_bootstrap is missing, set it `True`.')
                 scylla_yaml_contents += "\nauto_bootstrap: True\n"
         else:
             if 'auto_bootstrap' in scylla_yaml_contents:
+                if re.findall("auto_bootstrap: True", scylla_yaml_contents):
+                    self.log.debug('auto_bootstrap is not set as expected, update it to `False`.')
                 p = re.compile('auto_bootstrap:.*')
                 scylla_yaml_contents = p.sub('auto_bootstrap: False',
                                              scylla_yaml_contents)
             else:
+                self.log.debug('auto_bootstrap is missing, set it `False`.')
                 scylla_yaml_contents += "\nauto_bootstrap: False\n"
 
         if authenticator in ['AllowAllAuthenticator', 'PasswordAuthenticator']:

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1095,7 +1095,7 @@ class BaseCluster(object):
     def wait_for_init(self):
         raise NotImplementedError("Derived class must implement 'wait_for_init' method!")
 
-    def add_nodes(self, count, ec2_user_data='', dc_idx=0):
+    def add_nodes(self, count, ec2_user_data='', dc_idx=0, enable_auto_bootstrap=False):
         """
         :param count: number of nodes to add
         :param ec2_user_data:

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -284,8 +284,8 @@ class BaseNode(object):
         self.start_task_threads()
         # We should disable bootstrap when we create nodes to establish the cluster,
         # if we want to add more nodes when the cluster already exists, then we should
-        # enable bootstrap. So addition means not the first set of node.
-        self.is_addition = False
+        # enable bootstrap.
+        self.enable_auto_bootstrap = False
         self.scylla_version = ''
         self.is_enterprise = None
         self.replacement_node_ip = None  # if node is a replacement for a dead node, store dead node private ip here
@@ -808,7 +808,7 @@ class BaseNode(object):
             scylla_yaml_contents = p.sub('endpoint_snitch: "{0}"'.format(endpoint_snitch),
                                          scylla_yaml_contents)
 
-        if self.is_addition:
+        if self.enable_auto_bootstrap:
             if 'auto_bootstrap' in scylla_yaml_contents:
                 p = re.compile('auto_bootstrap:.*')
                 scylla_yaml_contents = p.sub('auto_bootstrap: True',

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -393,7 +393,7 @@ class ScyllaAWSCluster(cluster.BaseScyllaCluster, AWSCluster):
                 seeds = ",".join(node_private_ips)
                 if not seeds:
                     seeds = self.nodes[0].private_ip_address
-            ec2_user_data += ' --seeds %s' % seeds
+            ec2_user_data += ' --seeds %s --bootstrap true' % seeds
 
         added_nodes = super(ScyllaAWSCluster, self).add_nodes(count=count,
                                                               ec2_user_data=ec2_user_data,

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -374,9 +374,12 @@ class ScyllaAWSCluster(cluster.BaseScyllaCluster, AWSCluster):
 
     def add_nodes(self, count, ec2_user_data='', dc_idx=0, enable_auto_bootstrap=False):
         if not ec2_user_data:
-            ec2_user_data = ('--clustername %s --bootstrap true '
-                             '--totalnodes %s ' % (self.name,
-                                                   count))
+            if self._ec2_user_data:
+                ec2_user_data = self._ec2_user_data
+            else:
+                ec2_user_data = ('--clustername %s --bootstrap true '
+                                 '--totalnodes %s ' % (self.name,
+                                                       count))
         if self.nodes:
             if dc_idx > 0:
                 node_public_ips = [node.public_ip_address for node

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -273,7 +273,7 @@ class GCECluster(cluster.BaseCluster):
             self.log.info("Added node: %s", node.name)
             local_nodes = [n for n in self.nodes if n.dc_idx == dc_idx]
             if len(local_nodes) > len(nodes):
-                node.is_addition = True
+                node.enable_auto_bootstrap = True
 
         self._node_index += count
         self.log.info('added nodes: %s', nodes)

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -255,7 +255,7 @@ class GCECluster(cluster.BaseCluster):
         except Exception as ex:
             raise CreateGCENodeError('Failed to create node: %s', ex)
 
-    def add_nodes(self, count, ec2_user_data='', dc_idx=0):
+    def add_nodes(self, count, ec2_user_data='', dc_idx=0, enable_auto_bootstrap=False):
         self.log.info("Adding nodes to cluster")
         nodes = []
         if cluster.Setup.REUSE_CLUSTER:
@@ -271,9 +271,7 @@ class GCECluster(cluster.BaseCluster):
             nodes.append(node)
             self.nodes.append(node)
             self.log.info("Added node: %s", node.name)
-            local_nodes = [n for n in self.nodes if n.dc_idx == dc_idx]
-            if len(local_nodes) > len(nodes):
-                node.enable_auto_bootstrap = True
+            node.enable_auto_bootstrap = enable_auto_bootstrap
 
         self._node_index += count
         self.log.info('added nodes: %s', nodes)

--- a/sdcm/docker.py
+++ b/sdcm/docker.py
@@ -160,7 +160,7 @@ class DockerCluster(cluster.BaseCluster):
                 return node_name, node_index
             node_index += 1
 
-    def _create_nodes(self, count, dc_idx=0):
+    def _create_nodes(self, count, dc_idx=0, enable_auto_bootstrap=False):
         """
         Create nodes from docker containers
         :param count: count of nodes to create
@@ -174,6 +174,7 @@ class DockerCluster(cluster.BaseCluster):
             seed_ip = self.nodes[0].public_ip_address if not is_seed else None
             self._create_container(node_name, is_seed, seed_ip)
             new_node = self._create_node(node_name)
+            new_node.enable_auto_bootstrap = enable_auto_bootstrap
             self.nodes.append(new_node)
             new_nodes.append(new_node)
         return new_nodes
@@ -195,11 +196,11 @@ class DockerCluster(cluster.BaseCluster):
             self.nodes.append(new_node)
         return self.nodes
 
-    def add_nodes(self, count, dc_idx=0):
+    def add_nodes(self, count, dc_idx=0, enable_auto_bootstrap=False):
         if cluster.Setup.REUSE_CLUSTER:
             return self._get_nodes()
         else:
-            return self._create_nodes(count, dc_idx)
+            return self._create_nodes(count, dc_idx, enable_auto_bootstrap)
 
     def destroy(self):
         logger.info('Destroy nodes')

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -217,7 +217,7 @@ class Nemesis(object):
     def _add_and_init_new_cluster_node(self, old_node_private_ip=None):
         """When old_node_private_ip is not None replacement node procedure is initiated"""
         self.log.info("Adding new node to cluster...")
-        new_node = self.cluster.add_nodes(count=1, dc_idx=self.target_node.dc_idx)[0]
+        new_node = self.cluster.add_nodes(count=1, dc_idx=self.target_node.dc_idx, enable_auto_bootstrap=True)[0]
         new_node.replacement_node_ip = old_node_private_ip
         self.cluster.wait_for_init(node_list=[new_node], timeout=30)
         self.monitoring_set.reconfigure_scylla_monitoring()


### PR DESCRIPTION
In Decommission nemesis, we started to replace decommission node by new node
from commit ac9c2b685cf1af13a77f7dde71ab368062ab44e6, the auto_bootstrap should
be enabled for new node.
    
Generally we should enable auto_bootstrap for additional nodes.
