### PR TITLE
cluster_aws: stop scylla-server by default after scylla-ami-setup

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -372,9 +372,12 @@ class ScyllaAWSCluster(cluster.BaseScyllaCluster, AWSCluster):
 
     def add_nodes(self, count, ec2_user_data='', dc_idx=0):
         if not ec2_user_data:
-            ec2_user_data = ('--clustername %s --bootstrap true '
-                             '--totalnodes %s ' % (self.name,
-                                                   count))
+            if self._ec2_user_data:
+                ec2_user_data = self._ec2_user_data
+            else:
+                ec2_user_data = ('--clustername %s --bootstrap true '
+                                 '--totalnodes %s ' % (self.name,
+                                                       count))
         if self.nodes:
             if dc_idx > 0:
                 node_public_ips = [node.public_ip_address for node

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -351,7 +351,7 @@ class ScyllaAWSCluster(cluster.BaseScyllaCluster, AWSCluster):
         name = '%s-%s' % (cluster_prefix, shortid)
         user_data = ('--clustername %s '
                      '--totalnodes %s' % (name, sum(n_nodes)))
-        if params.get('stop_service') == 'true':
+        if params.get('stop_service', default='true') == 'true':
             user_data += ' --stop-services'
         super(ScyllaAWSCluster, self).__init__(ec2_ami_id=ec2_ami_id,
                                                ec2_subnet_id=ec2_subnet_id,


### PR DESCRIPTION
`stop_service` parameter doesn't work right now, the first patch made it work again. The second patch changed the stop_service as default.