### PR TITLE
Increase timeout of adding new node procedure during decommission test

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1182,7 +1182,7 @@ def wait_for_init_wrap(method):
         logger.debug('Method kwargs: %s', kwargs)
         node_list = kwargs.get('node_list', None) or cl_inst.nodes
         timeout = kwargs.get('timeout', None)
-        setup_kwargs = {k: kwargs[k] for k in kwargs if k not in ('node_list', 'timeout')}
+        setup_kwargs = {k: kwargs[k] for k in kwargs if k != 'node_list'}
 
         queue = Queue.Queue()
 
@@ -1578,7 +1578,7 @@ class BaseScyllaCluster(object):
             nemesis_thread.join(timeout)
         self.nemesis_threads = []
 
-    def node_setup(self, node, verbose=False):
+    def node_setup(self, node, verbose=False, timeout=30):
         """
         Install, configure and run scylla on node
         :param node: scylla node object
@@ -1631,7 +1631,7 @@ class BaseScyllaCluster(object):
             self.log.info('io.conf right after reboot')
             node.remoter.run('sudo cat /etc/scylla.d/io.conf')
 
-        node.wait_db_up()
+        node.wait_db_up(timeout=timeout)
         node.wait_jmx_up()
         if node.replacement_node_ip:
             # If this is a replacement node, we need to set back configuration in case
@@ -1662,7 +1662,7 @@ class BaseLoaderSet(object):
         self._loader_queue = []
         self.params = params
 
-    def node_setup(self, node, verbose=False, db_node_address=None):
+    def node_setup(self, node, verbose=False, db_node_address=None, **kwargs):
         self.log.info('Setup in BaseLoaderSet')
         node.wait_ssh_up(verbose=verbose)
 

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -401,7 +401,7 @@ class ScyllaAWSCluster(cluster.BaseScyllaCluster, AWSCluster):
                                                               enable_auto_bootstrap=enable_auto_bootstrap)
         return added_nodes
 
-    def node_setup(self, node, verbose=False):
+    def node_setup(self, node, verbose=False, timeout=3600):
         if not cluster.Setup.REUSE_CLUSTER:
             node.wait_ssh_up(verbose=verbose)
             authenticator = self.params.get('authenticator')
@@ -430,7 +430,7 @@ class ScyllaAWSCluster(cluster.BaseScyllaCluster, AWSCluster):
                              verbose=verbose, ignore_status=True)
             node.remoter.run('sudo systemctl restart scylla-server.service')
 
-        node.wait_db_up(verbose=verbose)
+        node.wait_db_up(verbose=verbose, timeout=timeout)
         node.remoter.run('nodetool status', verbose=True, retry=5)
 
     def destroy(self):


### PR DESCRIPTION
Increase timeout of adding new node procedure during decommission test and take it into account in wait_for_init 