### PR TITLE
add_nodes: fix assign of bootstrap argument

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -202,6 +202,22 @@ class AWSCluster(cluster.BaseCluster):
             self._reuse_credentials = cluster.UserRemoteCredentials(key_file=instance_key_file)
         return self._reuse_credentials
 
+    def update_bootstrap(self, ec2_user_data, enable_auto_bootstrap):
+        """
+        Update --bootstrap argument inside ec2_user_data string.
+        """
+        if enable_auto_bootstrap:
+            if '--bootstrap ' in ec2_user_data:
+                ec2_user_data.replace('--bootstrap false', '--bootstrap true')
+            else:
+                ec2_user_data += ' --bootstrap true '
+        else:
+            if '--bootstrap ' in ec2_user_data:
+                ec2_user_data.replace('--bootstrap true', '--bootstrap false')
+            else:
+                ec2_user_data += ' --bootstrap false '
+        return ec2_user_data
+
     def add_nodes(self, count, ec2_user_data='', dc_idx=0, enable_auto_bootstrap=False):
         if cluster.Setup.REUSE_CLUSTER:
             instances = self._get_instances()

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -393,9 +393,7 @@ class ScyllaAWSCluster(cluster.BaseScyllaCluster, AWSCluster):
             if self._ec2_user_data:
                 ec2_user_data = self._ec2_user_data
             else:
-                ec2_user_data = ('--clustername %s --bootstrap true '
-                                 '--totalnodes %s ' % (self.name,
-                                                       count))
+                ec2_user_data = ('--clustername %s --totalnodes %s ' % (self.name, count))
         if self.nodes:
             if dc_idx > 0:
                 node_public_ips = [node.public_ip_address for node
@@ -409,8 +407,9 @@ class ScyllaAWSCluster(cluster.BaseScyllaCluster, AWSCluster):
                 seeds = ",".join(node_private_ips)
                 if not seeds:
                     seeds = self.nodes[0].private_ip_address
-            ec2_user_data += ' --seeds %s --bootstrap true' % seeds
+            ec2_user_data += ' --seeds %s ' % seeds
 
+        ec2_user_data = self.update_bootstrap(ec2_user_data, enable_auto_bootstrap)
         added_nodes = super(ScyllaAWSCluster, self).add_nodes(count=count,
                                                               ec2_user_data=ec2_user_data,
                                                               dc_idx=dc_idx,

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -507,12 +507,13 @@ class CassandraAWSCluster(ScyllaAWSCluster):
         if not ec2_user_data:
             if self.nodes:
                 seeds = ",".join(self.get_seed_nodes())
-                ec2_user_data = ('--clustername %s --bootstrap true '
+                ec2_user_data = ('--clustername %s '
                                  '--totalnodes %s --seeds %s '
                                  '--version community '
                                  '--release 2.1.15' % (self.name,
                                                        count,
                                                        seeds))
+        ec2_user_data = self.update_bootstrap(ec2_user_data, enable_auto_bootstrap)
         added_nodes = super(ScyllaAWSCluster, self).add_nodes(count=count,
                                                               ec2_user_data=ec2_user_data,
                                                               dc_idx=dc_idx)


### PR DESCRIPTION
We had added a parameter (enable_auto_bootstrap) for add_nodes() function,
but we still have some logic to decide the bootstrap value inside add_nodes().
We should directly assign bootstrap argument in ec2_user_data referencing the
`enable_auto_bootstrap` parameter.

This problem was reported by Yakovlev Julia.