### PR TITLE
Monitoring: don't start scylla monitoring when reusing cluster

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2094,7 +2094,6 @@ class BaseMonitorSet(object):
         node.wait_ssh_up()
 
         if Setup.REUSE_CLUSTER:
-            self.start_scylla_monitoring(node)  # during download_monitor_data scylla monitoring is stopped
             return
         self.install_scylla_monitoring(node)
         self.configure_scylla_monitoring(node)


### PR DESCRIPTION
Scylla grafana monitoring is kept running at the end of the test since a5ebc8c0b48ae111a5db17842c537ba7bb46aec3