### PR TITLE
New instance types for loader and db servers

### DIFF
--- a/tests/dns-cluster-5min.yaml
+++ b/tests/dns-cluster-5min.yaml
@@ -1,5 +1,5 @@
 test_duration: 20
-stress_cmd: "cassandra-stress write no-warmup cl=QUORUM duration=15m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=500 -errors ignore -pop seq=1..1000000"
+stress_cmd: "cassandra-stress write no-warmup cl=QUORUM duration=15m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=500 -pop seq=1..1000000"
 n_db_nodes: 3
 n_loaders: 1
 n_monitor_nodes: 1

--- a/tests/enospc-30mins.yaml
+++ b/tests/enospc-30mins.yaml
@@ -4,7 +4,7 @@ n_loaders: 4
 n_monitor_nodes: 1
 user_prefix: 'cases-enospc-VERSION'
 failure_post_behavior: destroy
-stress_cmd: cassandra-stress write no-warmup cl=QUORUM duration=20m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -errors ignore -pop seq=1..10000000
+stress_cmd: cassandra-stress write no-warmup cl=QUORUM duration=20m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=1..10000000
 instance_provision: 'spot_low_price'
 
 backends: !mux

--- a/tests/gce-multidc-1.7.yaml
+++ b/tests/gce-multidc-1.7.yaml
@@ -75,4 +75,4 @@ databases: !mux
         instance_type_db: 'm3.large'
     scylla:
         db_type: scylla
-        instance_type_db: 'i2.2xlarge'
+        instance_type_db: 'i3.2xlarge'

--- a/tests/gce-multiple-dc-shutdown-30mins.yaml
+++ b/tests/gce-multiple-dc-shutdown-30mins.yaml
@@ -4,7 +4,7 @@ n_loaders: 1
 n_monitor_nodes: 1
 user_prefix: 'gce-multi-dc-shutdown-1-7'
 failure_post_behavior: destroy
-stress_cmd: cassandra-stress write no-warmup cl=QUORUM duration=30m -schema 'replication(factor=1)' -port jmx=6868 -mode cql3 native -rate threads=100 -errors ignore -pop seq=1..10000000 -log interval=5
+stress_cmd: cassandra-stress write no-warmup cl=QUORUM duration=30m -schema 'replication(factor=1)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=1..10000000 -log interval=5
 
 backends: !mux
     gce: !mux

--- a/tests/google-cloud-snitch.yaml
+++ b/tests/google-cloud-snitch.yaml
@@ -56,4 +56,4 @@ backends: !mux
 databases: !mux
     scylla:
         db_type: scylla
-        instance_type_db: 'i2.4xlarge'
+        instance_type_db: 'i3.4xlarge'

--- a/tests/janus-graph.yaml
+++ b/tests/janus-graph.yaml
@@ -28,7 +28,7 @@ backends: !mux
           gce_datacenter: 'us-east1-b'
     aws: !mux
         cluster_backend: 'aws'
-        instance_type_loader: 'c4.large'
+        instance_type_loader: 'c4.2xlarge'
         instance_type_monitor: 't2.small'
         us_west_2:
             region_name: 'us-west-2'

--- a/tests/longevity-50GB-4days-authorization-and-tls-ssl.yaml
+++ b/tests/longevity-50GB-4days-authorization-and-tls-ssl.yaml
@@ -79,4 +79,4 @@ databases: !mux
         instance_type_db: 'm3.large'
     scylla:
         db_type: scylla
-        instance_type_db: 'i2.4xlarge'
+        instance_type_db: 'i3.4xlarge'

--- a/tests/longevity-50GB-4days.yaml
+++ b/tests/longevity-50GB-4days.yaml
@@ -81,4 +81,4 @@ databases: !mux
         instance_type_db: 'm3.large'
     scylla:
         db_type: scylla
-        instance_type_db: 'i2.4xlarge'
+        instance_type_db: 'i3.4xlarge'

--- a/tests/longevity-staging.yaml
+++ b/tests/longevity-staging.yaml
@@ -90,7 +90,7 @@ databases: !mux
         instance_type_db: 'm3.large'
     scylla:
         db_type: scylla
-        instance_type_db: 'i2.4xlarge'
+        instance_type_db: 'i3.4xlarge'
     mixed:
         db_type: mixed
-        instance_type_db: 'i2.4xlarge'
+        instance_type_db: 'i3.4xlarge'

--- a/tests/old/aws-longevity-1.6-1TB-7days.yaml
+++ b/tests/old/aws-longevity-1.6-1TB-7days.yaml
@@ -63,4 +63,4 @@ databases: !mux
         instance_type_db: 'm3.large'
     scylla:
         db_type: scylla
-        instance_type_db: 'i2.4xlarge'
+        instance_type_db: 'i3.4xlarge'

--- a/tests/old/aws-longevity-1.6.2-1TB-7days-leveled.yaml
+++ b/tests/old/aws-longevity-1.6.2-1TB-7days-leveled.yaml
@@ -63,4 +63,4 @@ databases: !mux
         instance_type_db: 'm3.large'
     scylla:
         db_type: scylla
-        instance_type_db: 'i2.4xlarge'
+        instance_type_db: 'i3.4xlarge'

--- a/tests/old/aws-sstable-1.7.yaml
+++ b/tests/old/aws-sstable-1.7.yaml
@@ -33,4 +33,4 @@ databases: !mux
         instance_type_db: 'm3.large'
     scylla:
         db_type: scylla
-        instance_type_db: 'i2.4xlarge'
+        instance_type_db: 'i3.4xlarge'

--- a/tests/perf-regression-latency-1TB.yaml
+++ b/tests/perf-regression-latency-1TB.yaml
@@ -4,9 +4,9 @@ prepare_write_cmd: ["cassandra-stress write no-warmup cl=QUORUM n=250000000 -sch
                     "cassandra-stress write no-warmup cl=QUORUM n=250000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=500000000..750000000",
                     "cassandra-stress write no-warmup cl=QUORUM n=250000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=750000000..1000000000"]
 
-stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=100 limit=15000/s' -errors ignore -col 'size=FIXED(1024) n=FIXED(1)' -pop 'dist=gauss(1..1000000000,500000000,50000000)' "
-stress_cmd_r: "cassandra-stress read no-warmup  cl=QUORUM duration=50m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=100 limit=10000/s' -errors ignore -col 'size=FIXED(1024) n=FIXED(1)' -pop 'dist=gauss(1..1000000000,500000000,50000000)' "
-stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=100 limit=9000/s' -errors ignore -col 'size=FIXED(1024) n=FIXED(1)' -pop 'dist=gauss(1..1000000000,500000000,50000000)' "
+stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=100 limit=15000/s' -col 'size=FIXED(1024) n=FIXED(1)' -pop 'dist=gauss(1..1000000000,500000000,50000000)' "
+stress_cmd_r: "cassandra-stress read no-warmup  cl=QUORUM duration=50m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=100 limit=10000/s' -col 'size=FIXED(1024) n=FIXED(1)' -pop 'dist=gauss(1..1000000000,500000000,50000000)' "
+stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=100 limit=9000/s' -col 'size=FIXED(1024) n=FIXED(1)' -pop 'dist=gauss(1..1000000000,500000000,50000000)' "
 n_db_nodes: 3
 n_loaders: 4
 n_monitor_nodes: 1

--- a/tests/perf-regression-latency-1TB.yaml
+++ b/tests/perf-regression-latency-1TB.yaml
@@ -49,7 +49,7 @@ backends: !mux
 
     aws: !mux
         cluster_backend: 'aws'
-        instance_type_loader: 'c4.large'
+        instance_type_loader: 'c4.2xlarge'
         instance_type_monitor: t2.small
         instance_type_db: 'i3.4xlarge'
         us_east_1:

--- a/tests/perf-regression-mv.100threads.30M-keys-i3.yaml
+++ b/tests/perf-regression-mv.100threads.30M-keys-i3.yaml
@@ -45,7 +45,7 @@ backends: !mux
 
     aws: !mux
         cluster_backend: 'aws'
-        instance_type_loader: 'c4.large'
+        instance_type_loader: 'c4.2xlarge'
         instance_type_monitor: t2.small
         instance_type_db: 'i3.4xlarge'
         us_east_1:

--- a/tests/perf-regression-mv.100threads.30M-keys-i3.yaml
+++ b/tests/perf-regression-mv.100threads.30M-keys-i3.yaml
@@ -1,8 +1,8 @@
 test_duration: 70
-stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=60m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -errors ignore -pop seq=1..30000000"
-prepare_write_cmd: "cassandra-stress write no-warmup cl=QUORUM n=30000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -errors ignore -pop seq=1..30000000"
-stress_cmd_r: "cassandra-stress read no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -errors ignore -pop 'dist=gauss(1..30000000,15000000,1500000)' "
-stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -errors ignore -pop 'dist=gauss(1..30000000,15000000,1500000)' "
+stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=60m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=1..30000000"
+prepare_write_cmd: "cassandra-stress write no-warmup cl=QUORUM n=30000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=1..30000000"
+stress_cmd_r: "cassandra-stress read no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop 'dist=gauss(1..30000000,15000000,1500000)' "
+stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop 'dist=gauss(1..30000000,15000000,1500000)' "
 n_db_nodes: 3
 n_loaders: 4
 n_monitor_nodes: 1

--- a/tests/perf-regression.100threads.30M-keys-i3.yaml
+++ b/tests/perf-regression.100threads.30M-keys-i3.yaml
@@ -1,8 +1,8 @@
 test_duration: 70
-stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=60m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -errors ignore -pop seq=1..30000000"
-prepare_write_cmd: "cassandra-stress write no-warmup cl=QUORUM n=30000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -errors ignore -pop seq=1..30000000"
-stress_cmd_r: "cassandra-stress read no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -errors ignore -pop 'dist=gauss(1..30000000,15000000,1500000)' "
-stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -errors ignore -pop 'dist=gauss(1..30000000,15000000,1500000)' "
+stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=60m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=1..30000000"
+prepare_write_cmd: "cassandra-stress write no-warmup cl=QUORUM n=30000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=1..30000000"
+stress_cmd_r: "cassandra-stress read no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop 'dist=gauss(1..30000000,15000000,1500000)' "
+stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop 'dist=gauss(1..30000000,15000000,1500000)' "
 n_db_nodes: 3
 n_loaders: 4
 n_monitor_nodes: 1

--- a/tests/perf-regression.100threads.30M-keys-i3.yaml
+++ b/tests/perf-regression.100threads.30M-keys-i3.yaml
@@ -44,7 +44,7 @@ backends: !mux
 
     aws: !mux
         cluster_backend: 'aws'
-        instance_type_loader: 'c4.large'
+        instance_type_loader: 'c4.2xlarge'
         instance_type_monitor: t2.small
         instance_type_db: 'i3.2xlarge'
         us_east_1:

--- a/tests/perf-regression.100threads.30M-keys.yaml
+++ b/tests/perf-regression.100threads.30M-keys.yaml
@@ -1,8 +1,8 @@
 test_duration: 70
-stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=60m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -errors ignore -pop seq=1..30000000"
-prepare_write_cmd: "cassandra-stress write no-warmup cl=QUORUM n=30000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -errors ignore -pop seq=1..30000000"
-stress_cmd_r: "cassandra-stress read no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -errors ignore -pop 'dist=gauss(1..30000000,15000000,1500000)' "
-stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -errors ignore -pop 'dist=gauss(1..30000000,15000000,1500000)' "
+stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=60m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=1..30000000"
+prepare_write_cmd: "cassandra-stress write no-warmup cl=QUORUM n=30000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=1..30000000"
+stress_cmd_r: "cassandra-stress read no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop 'dist=gauss(1..30000000,15000000,1500000)' "
+stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop 'dist=gauss(1..30000000,15000000,1500000)' "
 n_db_nodes: 3
 n_loaders: 4
 n_monitor_nodes: 1

--- a/tests/perf-regression.100threads.30M-keys.yaml
+++ b/tests/perf-regression.100threads.30M-keys.yaml
@@ -45,7 +45,7 @@ backends: !mux
         cluster_backend: 'aws'
         instance_type_loader: 'c4.2xlarge'
         instance_type_monitor: t2.small
-        instance_type_db: 'i2.2xlarge'
+        instance_type_db: 'i3.2xlarge'
         us_east_1:
             user_credentials_path: ''
             region_name: 'us-east-1'

--- a/tests/perf-regression.100threads.30M-keys.yaml
+++ b/tests/perf-regression.100threads.30M-keys.yaml
@@ -43,7 +43,7 @@ backends: !mux
 
     aws: !mux
         cluster_backend: 'aws'
-        instance_type_loader: 'c4.large'
+        instance_type_loader: 'c4.2xlarge'
         instance_type_monitor: t2.small
         instance_type_db: 'i2.2xlarge'
         us_east_1:

--- a/tests/refresh-30mins-100mb.yaml
+++ b/tests/refresh-30mins-100mb.yaml
@@ -4,8 +4,8 @@ n_loaders: 1
 n_monitor_nodes: 1
 user_prefix: 'cases-refresh-100mb-not-jenkins'
 failure_post_behavior: destroy
-prepare_stress_cmd: cassandra-stress write no-warmup cl=QUORUM n=10000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1000 -errors ignore -pop seq=1..10000000 -log interval=5
-stress_cmd: cassandra-stress write no-warmup cl=QUORUM duration=20m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1000 -errors ignore -pop seq=1..10000000 -log interval=5
+prepare_stress_cmd: cassandra-stress write no-warmup cl=QUORUM n=10000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5
+stress_cmd: cassandra-stress write no-warmup cl=QUORUM duration=20m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5
 # 100M (300000 rows)
 sstable_url: 'https://s3.amazonaws.com/scylla-qa-team/keyspace1.standard1.100M.tar.gz'
 sstable_file: '/var/tmp/keyspace1.standard1.100M.tar.gz'

--- a/tests/refresh-30mins-120gb.yaml
+++ b/tests/refresh-30mins-120gb.yaml
@@ -4,8 +4,8 @@ n_loaders: 4
 n_monitor_nodes: 1
 user_prefix: 'cases-refresh-120gb-not-jenkins'
 failure_post_behavior: destroy
-prepare_stress_cmd: cassandra-stress write no-warmup cl=QUORUM n=10000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1000 -errors ignore -pop seq=1..10000000 -log interval=5
-stress_cmd: cassandra-stress mixed no-warmup cl=QUORUM duration=80m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1000 -errors ignore -pop seq=1..10000000 -log interval=5
+prepare_stress_cmd: cassandra-stress write no-warmup cl=QUORUM n=10000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5
+stress_cmd: cassandra-stress mixed no-warmup cl=QUORUM duration=80m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5
 # 100G, the big file will be saved to GCE image
 sstable_url: 'https://s3.amazonaws.com/scylla-qa-team/keyspace1.standard1.tar.gz'
 sstable_file: '/var/tmp/keyspace1.standard1.tar.gz'

--- a/tests/repair-240mins-100G.yaml
+++ b/tests/repair-240mins-100G.yaml
@@ -60,7 +60,7 @@ backends: !mux
         cluster_backend: 'aws'
         instance_type_loader: 'c4.4xlarge'
         instance_type_monitor: 'c4.2xlarge'
-        instance_type_db: 'i2.8xlarge'
+        instance_type_db: 'i3.8xlarge'
         us_east_1:
             region_name: 'us-east-1'
             security_group_ids: 'sg-c5e1f7a0'


### PR DESCRIPTION
- changed loader instances from c4.large to c4.2xlarge 
- changed DB instances from i2 to i3
@roydahan 