### PR TITLE
Fix _pre_create_schema function in longevity test

### DIFF
--- a/longevity_test.py
+++ b/longevity_test.py
@@ -217,7 +217,7 @@ class LongevityTest(ClusterTester):
         keyspace_num = self.params.get('keyspace_num', default=1)
         self.log.debug('Pre Creating Schema for c-s with {} keyspaces'.format(keyspace_num))
 
-        for i in xrange(1, keyspace_num):
+        for i in xrange(1, keyspace_num+1):
             keyspace_name = 'keyspace{}'.format(i)
             self.create_ks(session, keyspace_name, rf=3)
             self.log.debug('{} Created'.format(keyspace_name))


### PR DESCRIPTION
The _pre_create_schema has problem in "for i in xrange(1, keyspace_num)" - because of xrange starts from 1, it not create keyspace and table in case it's asked to create 1 keyspace, or on less, then asked.