### PR TITLE
ssl_conf: fix error in overwrite subdirectory

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -847,7 +847,7 @@ class BaseNode(object):
         if server_encrypt or client_encrypt:
             self.remoter.send_files(src='./data_dir/ssl_conf',
                                     dst='/tmp/')
-            self.remoter.run('sudo mv /tmp/ssl_conf/* /etc/scylla/')
+            self.remoter.run('sudo mv /tmp/ssl_conf/*.* /etc/scylla/')
 
         if server_encrypt:
             scylla_yaml_contents += """


### PR DESCRIPTION
In the past, self.node_config_setup() will be called only once. I saw
clean_replacement_node_ip() would repeatedly call self.node_config_setup().
After merged PR #625, clean_replacement_node_ip() won't be used. So issue
 #624 won't occur.

This patch only ignored subdirectory in moving the files.