### PR TITLE
Support to init multi seeds firstly

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -429,7 +429,8 @@ class ScyllaAWSCluster(cluster.BaseScyllaCluster, AWSCluster):
                               client_encrypt=self._param_enabled('client_encrypt'),
                               append_scylla_args=self.params.get('append_scylla_args'))
         else:
-            node.config_setup(enable_exp=self._param_enabled('experimental'),
+            node.config_setup(seed_address=seed_address,
+                              enable_exp=self._param_enabled('experimental'),
                               endpoint_snitch=endpoint_snitch,
                               authenticator=self.params.get('authenticator'),
                               server_encrypt=self._param_enabled('server_encrypt'),
@@ -438,7 +439,10 @@ class ScyllaAWSCluster(cluster.BaseScyllaCluster, AWSCluster):
 
     def node_setup(self, node, verbose=False, timeout=3600):
         endpoint_snitch = self.params.get('endpoint_snitch')
-        seed_address = self.get_seed_nodes_by_flag(private_ip=False)
+        if len(self.datacenter) > 1:
+            seed_address = self.get_seed_nodes_by_flag(private_ip=False)
+        else:
+            seed_address = self.get_seed_nodes_by_flag(private_ip=True)
 
         def scylla_ami_setup_done():
             """

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -171,7 +171,12 @@ class ClusterTester(db_stats.TestStatsMixin, Test):
         if self.create_stats:
             self.create_test_stats()
         self.init_resources()
-        self.db_cluster.wait_for_init()
+        if self.params.get('seeds_first', default='false') == 'true':
+            seeds_num = self.params.get('seeds_num', default=1)
+            self.db_cluster.wait_for_init(node_list=self.db_cluster.nodes[:seeds_num])
+            self.db_cluster.wait_for_init(node_list=self.db_cluster.nodes[seeds_num:])
+        else:
+            self.db_cluster.wait_for_init()
         if self.cs_db_cluster:
             self.cs_db_cluster.wait_for_init()
         db_node_address = self.db_cluster.nodes[0].private_ip_address


### PR DESCRIPTION
In scale test, we recommend to use multiple seeds and init seeds first.
This PR supported to use multiple seeds in aws (gce should work), and init multiple seeds firstly.