### PR TITLE
AWS root device size + store_results_in_elasticsearch fixes

### DIFF
--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -37,7 +37,6 @@ class PerformanceRegressionTest(ClusterTester):
 
     def __init__(self, *args, **kwargs):
         super(PerformanceRegressionTest, self).__init__(*args, **kwargs)
-        self.create_stats = False
 
     def display_single_result(self, result):
         self.log.info(self.str_pattern % (result['op rate'],
@@ -151,7 +150,7 @@ class PerformanceRegressionTest(ClusterTester):
         if save_stats:
             self.create_test_stats(sub_type=sub_type)
         stress_queue = self.run_stress_thread(stress_cmd=stress_cmd, stress_num=stress_num, keyspace_num=keyspace_num,
-                                              prefix=prefix)
+                                              prefix=prefix, stats_aggregate_cmds=False)
         results = self.get_stress_results(queue=stress_queue, store_results=True)
         if save_stats:
             self.update_test_details(scylla_conf=True)
@@ -212,7 +211,8 @@ class PerformanceRegressionTest(ClusterTester):
         base_cmd_w = self.params.get('stress_cmd_w')
         self.create_test_stats()
         # run a workload
-        stress_queue = self.run_stress_thread(stress_cmd=base_cmd_w, stress_num=2, keyspace_num=1)
+        stress_queue = self.run_stress_thread(stress_cmd=base_cmd_w, stress_num=2, keyspace_num=1,
+                                              stats_aggregate_cmds=False)
         results = self.get_stress_results(queue=stress_queue)
 
         self.update_test_details(scylla_conf=True)
@@ -278,13 +278,14 @@ class PerformanceRegressionTest(ClusterTester):
 
         self.create_test_stats(sub_type='write-prepare')
         # run a write workload
-        stress_queue = self.run_stress_thread(stress_cmd=base_cmd_w, stress_num=2, prefix='preload-')
+        stress_queue = self.run_stress_thread(stress_cmd=base_cmd_w, stress_num=2, prefix='preload-',
+                                              stats_aggregate_cmds=False)
         self.get_stress_results(queue=stress_queue, store_results=False)
         self.update_test_details()
 
         # run a read workload
         self.create_test_stats()
-        stress_queue = self.run_stress_thread(stress_cmd=base_cmd_r, stress_num=2)
+        stress_queue = self.run_stress_thread(stress_cmd=base_cmd_r, stress_num=2, stats_aggregate_cmds=False)
         results = self.get_stress_results(queue=stress_queue)
 
         self.update_test_details(scylla_conf=True)
@@ -344,13 +345,14 @@ class PerformanceRegressionTest(ClusterTester):
 
         self.create_test_stats(sub_type='write-prepare')
         # run a write workload as a preparation
-        stress_queue = self.run_stress_thread(stress_cmd=base_cmd_w, stress_num=2, prefix='preload-')
+        stress_queue = self.run_stress_thread(stress_cmd=base_cmd_w, stress_num=2, prefix='preload-',
+                                              stats_aggregate_cmds=False)
         self.get_stress_results(queue=stress_queue, store_results=False)
         self.update_test_details()
 
         # run a mixed workload
         self.create_test_stats()
-        stress_queue = self.run_stress_thread(stress_cmd=base_cmd_m, stress_num=2)
+        stress_queue = self.run_stress_thread(stress_cmd=base_cmd_m, stress_num=2, stats_aggregate_cmds=False)
         results = self.get_stress_results(queue=stress_queue)
 
         self.update_test_details(scylla_conf=True)
@@ -388,13 +390,14 @@ class PerformanceRegressionTest(ClusterTester):
                     params.update({'stress_cmd': stress_cmd})
 
                     # Run all stress commands
+                    params.update(dict(stats_aggregate_cmds=False))
                     self.log.debug('RUNNING stress cmd: {}'.format(stress_cmd))
                     stress_queue.append(self.run_stress_thread(**params))
 
             # One stress cmd command
             else:
                     stress_queue.append(self.run_stress_thread(stress_cmd=prepare_write_cmd, stress_num=1,
-                                                               prefix='preload-'))
+                                                               prefix='preload-', stats_aggregate_cmds=False))
 
             for stress in stress_queue:
                 self.get_stress_results(queue=stress, store_results=False)
@@ -405,7 +408,7 @@ class PerformanceRegressionTest(ClusterTester):
 
         # Run WRITE workload
         self.create_test_stats(sub_type='write')
-        stress_queue = self.run_stress_thread(stress_cmd=base_cmd_w, stress_num=1)
+        stress_queue = self.run_stress_thread(stress_cmd=base_cmd_w, stress_num=1, stats_aggregate_cmds=False)
         results = self.get_stress_results(queue=stress_queue)
         self.update_test_details()
         # TEMP check if possible
@@ -416,7 +419,7 @@ class PerformanceRegressionTest(ClusterTester):
 
         # Run READ workload
         self.create_test_stats(sub_type='read')
-        stress_queue = self.run_stress_thread(stress_cmd=base_cmd_r, stress_num=1)
+        stress_queue = self.run_stress_thread(stress_cmd=base_cmd_r, stress_num=1, stats_aggregate_cmds=False)
         results = self.get_stress_results(queue=stress_queue)
         self.update_test_details()
         self.display_results(results, test_name='test_latency')
@@ -426,7 +429,7 @@ class PerformanceRegressionTest(ClusterTester):
 
         # run MIXED workload
         self.create_test_stats(sub_type='mixed')
-        stress_queue = self.run_stress_thread(stress_cmd=base_cmd_m, stress_num=1)
+        stress_queue = self.run_stress_thread(stress_cmd=base_cmd_m, stress_num=1, stats_aggregate_cmds=False)
         results = self.get_stress_results(queue=stress_queue)
         self.update_test_details(scylla_conf=True)
         self.display_results(results, test_name='test_latency')
@@ -443,7 +446,7 @@ class PerformanceRegressionTest(ClusterTester):
                       "32 -concurrency 512 -replication-factor 3")
 
         self.create_test_stats()
-        stress_queue = self.run_stress_thread_bench(stress_cmd=base_cmd_r)
+        stress_queue = self.run_stress_thread_bench(stress_cmd=base_cmd_r, stats_aggregate_cmds=False)
         results = self.get_stress_results_bench(queue=stress_queue)
 
         self.update_test_details(scylla_conf=True)
@@ -489,7 +492,7 @@ class PerformanceRegressionTest(ClusterTester):
 
         self.create_test_stats(sub_type='write')
         self._scylla_bench_prepare_table()
-        self.run_stress_thread_bench(stress_cmd=cmd_w)
+        self.run_stress_thread_bench(stress_cmd=cmd_w, stats_aggregate_cmds=False)
         start_timestamp = int(time.time())
         self.db_cluster.wait_total_space_used_per_node(700 * KB * KB * KB, 'scylla_bench.test')  # 700GB
 
@@ -498,7 +501,7 @@ class PerformanceRegressionTest(ClusterTester):
                  "-rows-per-request=1000000 -no-lower-bound -start-timestamp=%s -duration=60m" % start_timestamp)
 
         self.create_test_stats(sub_type='read')
-        stress_queue = self.run_stress_thread_bench(stress_cmd=cmd_r)
+        stress_queue = self.run_stress_thread_bench(stress_cmd=cmd_r, stats_aggregate_cmds=False)
         results = self.get_stress_results_bench(queue=stress_queue)
         self.update_test_details()
         self.display_results(results, test_name='test_timeseries_read_bench')
@@ -519,7 +522,8 @@ class PerformanceRegressionTest(ClusterTester):
             self.log.debug('Run stress test with user profile {}'.format(user_profile))
             assert os.path.exists(user_profile), 'File not found: {}'.format(user_profile)
             self.log.debug('Stress cmd: {}'.format(stress_cmd))
-            stress_queue = self.run_stress_thread(stress_cmd=stress_cmd, stress_num=1, profile=user_profile)
+            stress_queue = self.run_stress_thread(stress_cmd=stress_cmd, stress_num=1, profile=user_profile,
+                                                  stats_aggregate_cmds=False)
             results = self.get_stress_results(queue=stress_queue)
             self.update_test_details(scylla_conf=True)
             self.display_results(results, test_name=test_name)

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -135,8 +135,8 @@ class AWSCluster(cluster.BaseCluster):
                            network_if=interfaces,
                            key_pair=self._credentials[dc_idx].key_pair_name,
                            user_data=ec2_user_data,
-                           count=count)
-
+                           count=count,
+                           block_device_mappings=self._ec2_block_device_mappings)
         if self.instance_provision == INSTANCE_PROVISION_SPOT_DURATION:
             # duration value must be a multiple of 60
             spot_params.update({'duration': cluster.TEST_DURATION / 60 * 60 + 60})

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -403,6 +403,16 @@ class ClusterTester(db_stats.TestStatsMixin, Test):
             monitor_info['n_nodes'] = self.params.get('n_monitor_nodes')
         if monitor_info['type'] is None:
             monitor_info['type'] = self.params.get('instance_type_monitor')
+        if monitor_info['disk_size'] is None:
+            monitor_info['disk_size'] = self.params.get('aws_root_disk_size_monitor', default=10)
+        if monitor_info['device_mappings'] is None:
+            monitor_info['device_mappings'] = [{
+                "DeviceName": "/dev/sda1",  # Root device
+                "Ebs": {
+                    "VolumeSize": monitor_info['disk_size'],
+                    "VolumeType": "gp2"
+                }
+            }]
         user_prefix = self.params.get('user_prefix', None)
 
         user_credentials = self.params.get('user_credentials_path', None)

--- a/tests/longevity-1TB-7days-authorization-and-tls-ssl.yaml
+++ b/tests/longevity-1TB-7days-authorization-and-tls-ssl.yaml
@@ -76,6 +76,7 @@ backends: !mux
             ami_id_db_scylla: 'AMI-ID'
             ami_id_loader: 'AMI-ID'
             ami_id_monitor: 'AMI-ID'
+            aws_root_disk_size_monitor: 20  # GB
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/longevity-1TB-7days.yaml
+++ b/tests/longevity-1TB-7days.yaml
@@ -72,6 +72,7 @@ backends: !mux
             ami_id_db_scylla: 'AMI-ID'
             ami_id_loader: 'AMI-ID'
             ami_id_monitor: 'AMI-ID'
+            aws_root_disk_size_monitor: 20  # GB
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/longevity-50GB-4days-authorization-and-tls-ssl.yaml
+++ b/tests/longevity-50GB-4days-authorization-and-tls-ssl.yaml
@@ -71,6 +71,7 @@ backends: !mux
             ami_id_db_cassandra: 'ami-3eff0028'
             ami_db_cassandra_user: 'ubuntu'
             ami_id_monitor: 'ami-29035f52'
+            aws_root_disk_size_monitor: 20  # GB
             ami_monitor_user: 'centos'
 
 databases: !mux

--- a/tests/longevity-50GB-4days.yaml
+++ b/tests/longevity-50GB-4days.yaml
@@ -73,6 +73,7 @@ backends: !mux
             ami_id_db_cassandra: 'ami-3eff0028'
             ami_db_cassandra_user: 'ubuntu'
             ami_id_monitor: 'ami-29035f52'
+            aws_root_disk_size_monitor: 20  # GB
             ami_monitor_user: 'centos'
 
 databases: !mux

--- a/tests/sample.yaml
+++ b/tests/sample.yaml
@@ -19,7 +19,7 @@ store_results_in_elasticsearch: False
 
 # scylla-manager configuration
 # if running on aws and use_mgmt is true, the monitor image should not contain scylla
-use_mgmt: true
+use_mgmt: false
 mgmt_port: 10090
 scylla_repo_m: 'http://repositories.scylladb.com/scylla/repo/f4a2920f80c4bf178217c2553ad65ad7/centos/scylladb-2017.1.repo'
 scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/branch-1.0/latest/scylla-manager.repo'
@@ -44,6 +44,7 @@ backends: !mux
             ami_id_db_scylla: 'ami-b4f8b4cb'  # Scylla 2.2 AMI
             ami_id_monitor: 'ami-b4f8b4cb'  # Scylla 2.2 AMI
             ami_id_loader: 'ami-b4f8b4cb'  # Scylla 2.2 AMI
+            aws_root_disk_size_monitor: 10  # GB
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'


### PR DESCRIPTION
Added ability to set root device size for AWS instances and fixes for `store_results_in_elasticsearch` YAML parameter