### PR TITLE
gce: update cpuPlatform info if cluster is created

### DIFF
--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -274,7 +274,7 @@ class TestStatsMixin(Stats):
         new_scylla_packages = self.params.get('update_db_packages')
         setup_details['packages_updated'] = True if new_scylla_packages and os.listdir(new_scylla_packages) else False
         setup_details['cpu_platform'] = 'UNKNOWN'
-        if is_gce:
+        if is_gce and self.db_cluster:
             setup_details['cpu_platform'] = self.db_cluster.nodes[0]._instance.extra.get('cpuPlatform', 'UNKNOWN')
 
         return setup_details


### PR DESCRIPTION
GCE longevity failed in setup stage, this patch fixed the issue.

```
19:59:36 avocado.test: START 1-longevity_test.py:LongevityTest.test_custom_time
19:59:36 avocado.test: Exception in setUp. Will clean resources
19:59:36 Traceback (most recent call last):
19:59:36   File "/jenkins/slave/workspace/scylla-3.0/3.0-test/scylla-longevity-gce-test-amos-clone/label/gce-qavpc/sdcm/tester.py", line 128, in wrapper
19:59:36     return method(*args, **kwargs)
19:59:36   File "/jenkins/slave/workspace/scylla-3.0/3.0-test/scylla-longevity-gce-test-amos-clone/label/gce-qavpc/sdcm/tester.py", line 172, in setUp
19:59:36     self.create_test_stats()
19:59:36   File "/jenkins/slave/workspace/scylla-3.0/3.0-test/scylla-longevity-gce-test-amos-clone/label/gce-qavpc/sdcm/db_stats.py", line 298, in create_test_stats
19:59:36     self._stats['setup_details'] = self.get_setup_details()
19:59:36   File "/jenkins/slave/workspace/scylla-3.0/3.0-test/scylla-longevity-gce-test-amos-clone/label/gce-qavpc/sdcm/db_stats.py", line 278, in get_setup_details
19:59:36     setup_details['cpu_platform'] = self.db_cluster.nodes[0]._instance.extra.get('cpuPlatform', 'UNKNOWN')
19:59:36 AttributeError: 'NoneType' object has no attribute 'nodes'
```