### PR TITLE
support to verify network after reboot

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -349,13 +349,15 @@ class AWSNode(cluster.BaseNode):
             self.stop_scylla_server(verify_down=False)
             self.start_scylla_server(verify_up=False)
 
-    def reboot(self, hard=True):
+    def reboot(self, hard=True, verify_ssh=True):
         if hard:
             self.log.debug('Hardly rebooting node')
             self._instance_wait_safe(self._instance.reboot)
         else:
             self.log.debug('Softly rebooting node')
             self.remoter.run('sudo reboot', ignore_status=True)
+        if verify_ssh:
+            self.wait_ssh_up()
 
     def destroy(self):
         self.stop_task_threads()

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -113,13 +113,15 @@ class GCENode(cluster.BaseNode):
         # So, for now we will keep restart the same as hard reboot.
         self._instance_wait_safe(self._instance.reboot)
 
-    def reboot(self, hard=True):
+    def reboot(self, hard=True, verify_ssh=True):
         if hard:
             self.log.debug('Hardly rebooting node')
             self._instance_wait_safe(self._instance.reboot)
         else:
             self.log.debug('Softly rebooting node')
             self.remoter.run('sudo reboot', ignore_status=True)
+        if verify_ssh:
+            self.wait_ssh_up()
 
     def _safe_destroy(self):
         try:


### PR DESCRIPTION
Reboot is an async operation, it doesn't block until the instance is rebooted.
Sometimes, we want to do something immediately after reboot (before the instance
is available). So we can make the verify as optional.

related issue #653