### PR TITLE
test_latency - change order of workloads + wait for compactions

### DIFF
--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -430,11 +430,11 @@ class PerformanceRegressionTest(ClusterTester):
         """
         # TO DO: add limit ops based on results.
         self.preload_data()
-        time.sleep(60)
-        self.run_write_workload()
-        time.sleep(60)
+        self.wait_no_compactions_running()
         self.run_read_workload()
-        time.sleep(60)
+        self.wait_no_compactions_running()
+        self.run_write_workload()
+        self.wait_no_compactions_running()
         self.run_mixed_workload()
 
     def test_uniform_counter_update_bench(self):

--- a/tests/perf-regression-latency-1TB.yaml
+++ b/tests/perf-regression-latency-1TB.yaml
@@ -6,7 +6,7 @@ prepare_write_cmd: ["cassandra-stress write no-warmup cl=ALL n=250000000 -schema
 
 stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=60m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=100 throttle=15000/s' -col 'size=FIXED(1024) n=FIXED(1)' -pop 'dist=gauss(1..1000000000,500000000,50000000)' "
 stress_cmd_r: "cassandra-stress read no-warmup  cl=QUORUM duration=90m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=100 throttle=10000/s' -col 'size=FIXED(1024) n=FIXED(1)' -pop 'dist=gauss(1..1000000000,500000000,50000000)' "
-stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=60m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=100 throttle=9000/s' -col 'size=FIXED(1024) n=FIXED(1)' -pop 'dist=gauss(1..1000000000,500000000,50000000)' "
+stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=60m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=100 throttle=9000/s'  -col 'size=FIXED(1024) n=FIXED(1)' -pop 'dist=gauss(1..1000000000,500000000,50000000)' "
 n_db_nodes: 3
 n_loaders: 4
 n_monitor_nodes: 1


### PR DESCRIPTION
changing the order of workloads in test_latency and replacing the sleep time with a wait for compactions to settle down method