### PR TITLE
RestartThenRepairNode: increase database up timeout to 4 hours

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -146,7 +146,7 @@ class Nemesis(object):
 
         # Let's wait for the target Node to have their services re-started
         self.log.info('Waiting scylla services to be restarted after we killed them...')
-        self.target_node.wait_db_up()
+        self.target_node.wait_db_up(timeout=14400)
         self.log.info('Waiting JMX services to be restarted after we killed them...')
         self.target_node.wait_jmx_up()
 


### PR DESCRIPTION
In one 1TB longevity, the database serivce on target node took about 3+ hours
to be up, original data was removed during the restart, the default 1 hour
isn't enough for streaming.
