### PR TITLE
correct the node that nodetool executes on

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -129,7 +129,7 @@ class Nemesis(object):
             return result
         except process.CmdError, details:
             err = ("nodetool command '%s' failed on node %s: %s" %
-                   (cmd, self.target_node, details.result))
+                   (cmd, node, details.result))
             self.error_list.append(err)
             self.log.error(err)
             return None


### PR DESCRIPTION
The node that nodetool executes on is configurable, not always be the target
node. In one terminate_and_replace_node nemesis, the target node has been terminated,
it caused _run_nodetool() failed.

Traceback (most recent call last):
  File "/sct/sdcm/nemesis.py", line 753, in wrapper
    result = method(*args, **kwargs)
  File "/sct/sdcm/nemesis.py", line 906, in disrupt
    self.call_random_disrupt_method()
  File "/sct/sdcm/nemesis.py", line 444, in call_random_disrupt_method
    disrupt_method()
  File "/sct/sdcm/nemesis.py", line 304, in disrupt_terminate_and_replace_node
    self.repair_nodetool_repair(new_node)
  File "/sct/sdcm/nemesis.py", line 458, in repair_nodetool_repair
    self._run_nodetool(repair_cmd, node)
  File "/sct/sdcm/nemesis.py", line 132, in _run_nodetool
    (cmd, self.target_node, details.result))
  File "/sct/sdcm/cluster.py", line 670, in __str__
    self.public_ip_address,
  File "/sct/sdcm/cluster_aws.py", line 288, in public_ip_address
    return self._instance.public_ip_address
  File "/usr/lib/python2.7/site-packages/boto3/resources/factory.py", line 345, in property_loader
    return self.meta.data.get(name)
AttributeError: 'NoneType' object has no attribute 'get'

Signed-off-by: Amos Kong <amos@scylladb.com>