### PR TITLE
Add second screenshot to performance email

### DIFF
--- a/sdcm/results_analyze.py
+++ b/sdcm/results_analyze.py
@@ -222,7 +222,8 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
         return None
 
     def _get_grafana_snapshot(self, test_doc):
-        return test_doc['_source']['test_details'].get('grafana_snapshot')
+        grafana_snapshot = test_doc['_source']['test_details'].get('grafana_snapshot')
+        return grafana_snapshot if isinstance(grafana_snapshot, list) else [grafana_snapshot]
 
     def _get_setup_details(self, test_doc, is_gce):
         setup_details = {'cluster_backend': test_doc['_source']['setup_details'].get('cluster_backend')}

--- a/sdcm/results_performance.html
+++ b/sdcm/results_performance.html
@@ -98,11 +98,18 @@
         <li><a href={{ dashboard_master }}>Kibana</a></li>
         <li><a href="{{ job_url }}">Jenkins job</a></li>
         {% if grafana_snapshot %}
-        <li><a href={{ grafana_snapshot }}>Download Grafana Screenshot</a></li>
+        {% if grafana_snapshot[0] %}
+        <li><a href={{ grafana_snapshot[0] }}>Download "Per server metrics nemesis" Grafana Screenshot</a></li>
+        {% endif %}
+        {% if grafana_snapshot[1] %}
+        <li><a href={{ grafana_snapshot[1] }}>Download "Overview metrics" Grafana Screenshot</a></li>
+        {% endif %}
         {% endif %}
     </ul>
     {% if grafana_snapshot %}
     <h3>Grafana Screenshot:</h3>
-    <img src="{{ grafana_snapshot }}"  height="50%" width="50%">
+    {% for snapshot in grafana_snapshot %}
+    <img src="{{ snapshot }}"  height="50%" width="50%">
+    {% endfor %}
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
- cluster.py BaseMonitorSet.get_grafana_screenshot:
  - Adding list of urls.
  - Add loop over the list of urls to create screen
shots.
  - Return value now is list of links to screenshots
- results_analyze.py PerformanceResultAnalyzer._get_grafana_snapshots
  - Return value is now list.
  - For backcompatibility, added checks if value is string, return list
- results_performance.html
  - Added the For loop to process the list of grafana links