### PR TITLE
change replace_address to replace_address_first_boot, otherwise a node that was restarted won't start later in case of reboot or stop-start server

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -336,8 +336,8 @@ class AWSNode(cluster.BaseNode):
             """)
             self.remoter.run("sudo bash -cxe '%s'" % clean_script)
             output = self.remoter.run('sudo grep replace_address: /etc/scylla/scylla.yaml', ignore_status=True)
-            if 'replace_address:' not in output.stdout:
-                self.remoter.run('sudo echo replace_address: %s >> /etc/scylla/scylla.yaml' %
+            if 'replace_address_first_boot:' not in output.stdout:
+                self.remoter.run('sudo echo replace_address_first_boot: %s >> /etc/scylla/scylla.yaml' %
                                  self._instance.private_ip_address)
         self._instance.stop()
         self._instance_wait_safe(self._instance.wait_until_stopped)


### PR DESCRIPTION
Backport needed for branch-3.0