### PR TITLE
Fix failure_post_behavior flag behavior

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -159,11 +159,21 @@ def register_cleanup(cleanup='destroy'):
 
 
 class Setup(object):
+
+    KEEP_ALIVE = False
+
     REUSE_CLUSTER = False
 
     @classmethod
     def reuse_cluster(cls, val=False):
         cls.REUSE_CLUSTER = val
+
+    @classmethod
+    def keep_cluster(cls, val='destroy'):
+        if val in 'keep':
+            cls.KEEP_ALIVE = True
+        else:
+            cls.KEEP_ALIVE = False
 
 
 class NodeError(Exception):

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -275,13 +275,16 @@ class AWSNode(cluster.BaseNode):
             tags_list = [{'Key': 'Name', 'Value': name},
                          {'Key': 'workspace', 'Value': cluster.WORKSPACE},
                          {'Key': 'uname', 'Value': ' | '.join(os.uname())}]
-            if cluster.TEST_DURATION >= 24 * 60:
+            if cluster.TEST_DURATION >= 24 * 60 or cluster.Setup.KEEP_ALIVE:
                 self.log.info('Test duration set to %s. '
+                              'Keep cluster on failure %s. '
                               'Tagging node with {"keep": "alive"}',
-                              cluster.TEST_DURATION)
+                              cluster.TEST_DURATION, cluster.Setup.KEEP_ALIVE)
                 tags_list.append({'Key': 'keep', 'Value': 'alive'})
+
             self._ec2_service.create_tags(Resources=[self._instance.id],
                                           Tags=tags_list)
+
 
     @property
     def public_ip_address(self):

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -37,10 +37,12 @@ class GCENode(cluster.BaseNode):
                                       base_logdir=base_logdir,
                                       node_prefix=node_prefix,
                                       dc_idx=dc_idx)
-        if cluster.TEST_DURATION >= 24 * 60:
+
+        if cluster.TEST_DURATION >= 24 * 60 or cluster.Setup.KEEP_ALIVE:
             self.log.info('Test duration set to %s. '
+                          'Keep cluster on failure %s. '
                           'Tagging node with "keep-alive"',
-                          cluster.TEST_DURATION)
+                          cluster.TEST_DURATION, cluster.Setup.KEEP_ALIVE)
             self._instance_wait_safe(self._gce_service.ex_set_node_tags,
                                      self._instance, ['keep-alive'])
         self._instance_wait_safe(self._gce_service.ex_set_node_metadata,

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -156,12 +156,12 @@ class ClusterTester(db_stats.TestStatsMixin, Test):
         cluster.set_duration(self._duration)
 
         cluster.Setup.reuse_cluster(self.params.get('reuse_cluster', default=False))
+        cluster.Setup.keep_cluster(self._failure_post_behavior)
 
         # for saving test details in DB
-        self.create_stats = self.params.get(key='store_results_in_elasticsearch',default=True)
+        self.create_stats = self.params.get(key='store_results_in_elasticsearch', default=True)
         self.scylla_dir = SCYLLA_DIR
         self.scylla_hints_dir = os.path.join(self.scylla_dir, "hints")
-
 
     @clean_resources_on_exception
     def setUp(self):


### PR DESCRIPTION
when failure_post_behavior is "keep" adding keep-alive tag to all instances in the clusters