### PR TITLE
Added new nemesis: MultipleHardRebootNodeMonkey - disrupt_multiple_hard_reboot_node

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -180,6 +180,24 @@ class Nemesis(object):
         self.log.info('Waiting JMX services to start after node reboot')
         self.target_node.wait_jmx_up()
 
+    def disrupt_multiple_hard_reboot_node(self):
+
+        num_of_reboots = random.randint(2, 10)
+        for i in range(num_of_reboots):
+            self._set_current_disruption('MultipleHardRebootNode %s' % self.target_node)
+            self.log.debug("Rebooting {} out of {} times".format(i+1,num_of_reboots))
+            self.target_node.reboot(hard=True)
+            if random.choice([True,False]):
+                self.log.info('Waiting scylla services to start after node reboot')
+                self.target_node.wait_db_up()
+            else:
+                self.log.info('Waiting JMX services to start after node reboot')
+                self.target_node.wait_jmx_up()
+            sleep_time = random.randint(0,100)
+            self.log.info('Sleep {} seconds after hard reboot and service-up for node {}'.format(sleep_time, self.target_node))
+            time.sleep(sleep_time)
+
+
     def disrupt_soft_reboot_node(self):
         self._set_current_disruption('SoftRebootNode %s' % self.target_node)
         self.target_node.reboot(hard=False)
@@ -810,6 +828,12 @@ class RestartThenRepairNodeMonkey(Nemesis):
     @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_restart_then_repair_node()
+
+class MultipleHardRebootNodeMonkey(Nemesis):
+
+    @log_time_elapsed_and_status
+    def disrupt(self):
+        self.disrupt_multiple_hard_reboot_node()
 
 class HardRebootNodeMonkey(Nemesis):
 


### PR DESCRIPTION
example log output:
```
2018-12-19 10:17:02,545 nemesis          L0229 DEBUG| sdcm.nemesis.MultipleHardRebootNodeMonkey: Set current_disruption -> MultipleHardRebootNode Node yaron_manager_multidc-db-node-67cec470-2 [34.230.47.80 | 172.30.0.202] (seed: False)
2018-12-19 10:18:07,934 nemesis          L0193 INFO | sdcm.nemesis.MultipleHardRebootNodeMonkey: Waiting JMX services to start after node reboot
2018-12-19 10:19:10,182 nemesis          L0196 INFO | sdcm.nemesis.MultipleHardRebootNodeMonkey: Sleep 29 seconds after hard reboot and service-up for node Node yaron_manager_multidc-db-node-67cec470-2 [34.230.47.80 | 172.30.0.202] (seed: False)
2018-12-19 10:19:39,197 nemesis          L0229 DEBUG| sdcm.nemesis.MultipleHardRebootNodeMonkey: Set current_disruption -> MultipleHardRebootNode Node yaron_manager_multidc-db-node-67cec470-2 [34.230.47.80 | 172.30.0.202] (seed: False)
2018-12-19 10:20:43,991 nemesis          L0190 INFO | sdcm.nemesis.MultipleHardRebootNodeMonkey: Waiting scylla services to start after node reboot
2018-12-19 10:21:52,089 nemesis          L0196 INFO | sdcm.nemesis.MultipleHardRebootNodeMonkey: Sleep 94 seconds after hard reboot and service-up for node Node yaron_manager_multidc-db-node-67cec470-2 [34.230.47.80 | 172.30.0.202] (seed: False)
2018-12-19 10:23:26,165 nemesis          L0229 DEBUG| sdcm.nemesis.MultipleHardRebootNodeMonkey: Set current_disruption -> MultipleHardRebootNode Node yaron_manager_multidc-db-node-67cec470-2 [34.230.47.80 | 172.30.0.202] (seed: False)
2018-12-19 10:24:33,475 nemesis          L0193 INFO | sdcm.nemesis.MultipleHardRebootNodeMonkey: Waiting JMX services to start after node reboot
2018-12-19 10:25:35,761 nemesis          L0196 INFO | sdcm.nemesis.MultipleHardRebootNodeMonkey: Sleep 13 seconds after hard reboot and service-up for node Node yaron_manager_multidc-db-node-67cec470-2 [34.230.47.80 | 172.30.0.202] (seed: False)
2018-12-19 10:25:48,774 nemesis          L0229 DEBUG| sdcm.nemesis.MultipleHardRebootNodeMonkey: Set current_disruption -> MultipleHardRebootNode Node yaron_manager_multidc-db-node-67cec470-2 [34.230.47.80 | 172.30.0.202] (seed: False)
```