### PR TITLE
new nemesis: Invoke a second rebuild (related to #2780)

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -180,6 +180,24 @@ class Nemesis(object):
         self.log.info('Waiting JMX services to start after node reboot')
         self.target_node.wait_jmx_up()
 
+    def disrupt_multiple_hard_reboot_node(self):
+
+        num_of_reboots = random.randint(2, 10)
+        for i in range(num_of_reboots):
+            self._set_current_disruption('MultipleHardRebootNode %s' % self.target_node)
+            self.log.debug("Rebooting {} out of {} times".format(i+1,num_of_reboots))
+            self.target_node.reboot(hard=True)
+            if random.choice([True,False]):
+                self.log.info('Waiting scylla services to start after node reboot')
+                self.target_node.wait_db_up()
+            else:
+                self.log.info('Waiting JMX services to start after node reboot')
+                self.target_node.wait_jmx_up()
+            sleep_time = random.randint(0,100)
+            self.log.info('Sleep {} seconds after hard reboot and service-up for node {}'.format(sleep_time, self.target_node))
+            time.sleep(sleep_time)
+
+
     def disrupt_soft_reboot_node(self):
         self._set_current_disruption('SoftRebootNode %s' % self.target_node)
         self.target_node.reboot(hard=False)
@@ -810,6 +828,12 @@ class RestartThenRepairNodeMonkey(Nemesis):
     @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_restart_then_repair_node()
+
+class MultipleHardRebootNodeMonkey(Nemesis):
+
+    @log_time_elapsed_and_status
+    def disrupt(self):
+        self.disrupt_multiple_hard_reboot_node()
 
 class HardRebootNodeMonkey(Nemesis):
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -197,6 +197,19 @@ class Nemesis(object):
             self.log.info('Sleep {} seconds after hard reboot and service-up for node {}'.format(sleep_time, self.target_node))
             time.sleep(sleep_time)
 
+    def disrupt_invoke_second_rebuild(self):
+
+        self._set_current_disruption('InvokeSecondRebuild %s' % self.target_node)
+        self.log.info("First, corrupt DB data of node: {}".format(self.target_node))
+        self._destroy_data()
+
+        def _invoke_rebuild(self):
+            rebuild_cmd = 'nodetool -h localhost rebuild &>/dev/null &'
+            result = self._run_nodetool(rebuild_cmd, self.target_node)
+
+        for i in range(1,6):
+            self.log.info("Starting rebuild {}/5 on node: {}".format(i, self.target_node))
+            _invoke_rebuild(self)
 
     def disrupt_soft_reboot_node(self):
         self._set_current_disruption('SoftRebootNode %s' % self.target_node)
@@ -835,6 +848,13 @@ class MultipleHardRebootNodeMonkey(Nemesis):
     def disrupt(self):
         self.disrupt_multiple_hard_reboot_node()
 
+class InvokeSecondRebuildMonkey(Nemesis):
+
+    @log_time_elapsed_and_status
+    def disrupt(self):
+        self.disrupt_invoke_second_rebuild()
+
+# disrupt_invoke_second_rebuild
 class HardRebootNodeMonkey(Nemesis):
 
     @log_time_elapsed_and_status


### PR DESCRIPTION
InvokeSecondRebuildMonkey sample nemesis output:
```
2018-12-24 21:54:56,621 nemesis          L0212 INFO | sdcm.nemesis.InvokeSecondRebuildMonkey: Starting rebuild 1/5 on node: Node yaron_manager_multidc-db-node-a61f117e-3 [3.84.101.57 | 172.30.0.242] (seed: False)
2018-12-24 21:54:59,038 nemesis          L0212 INFO | sdcm.nemesis.InvokeSecondRebuildMonkey: Starting rebuild 2/5 on node: Node yaron_manager_multidc-db-node-a61f117e-3 [3.84.101.57 | 172.30.0.242] (seed: False)
2018-12-24 21:55:01,428 remote           L0194 DEBUG| [3.84.101.57] [stdout] Dec 24 21:55:01 info   |  [shard 0] storage_service - Streaming for rebuild successful
2018-12-24 21:55:01,435 nemesis          L0212 INFO | sdcm.nemesis.InvokeSecondRebuildMonkey: Starting rebuild 3/5 on node: Node yaron_manager_multidc-db-node-a61f117e-3 [3.84.101.57 | 172.30.0.242] (seed: False)
2018-12-24 21:55:03,689 nemesis          L0212 INFO | sdcm.nemesis.InvokeSecondRebuildMonkey: Starting rebuild 4/5 on node: Node yaron_manager_multidc-db-node-a61f117e-3 [3.84.101.57 | 172.30.0.242] (seed: False)
2018-12-24 21:55:03,963 remote           L0194 DEBUG| [3.84.101.57] [stdout] Dec 24 21:55:03 info   |  [shard 0] storage_service - Streaming for rebuild successful
2018-12-24 21:55:06,041 nemesis          L0212 INFO | sdcm.nemesis.InvokeSecondRebuildMonkey: Starting rebuild 5/5 on node: Node yaron_manager_multidc-db-node-a61f117e-3 [3.84.101.57 | 172.30.0.242] (seed: False)
2018-12-24 21:55:06,396 remote           L0194 DEBUG| [3.84.101.57] [stdout] Dec 24 21:55:06 info   |  [shard 0] storage_service - Streaming for rebuild successful
2018-12-24 21:55:09,145 remote           L0194 DEBUG| [3.84.101.57] [stdout] Dec 24 21:55:09 info   |  [shard 0] storage_service - Streaming for rebuild successful
2018-12-24 21:55:11,294 remote           L0194 DEBUG| [3.84.101.57] [stdout] Dec 24 21:55:11 info   |  [shard 0] storage_service - Streaming for rebuild successful
```