### PR TITLE
[v2] scylla_setup: use full path of ip command

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1108,7 +1108,7 @@ client_encryption_options:
         Setup scylla
         :param disks: list of disk names
         """
-        result = self.remoter.run('`which ip` -o link show |grep ether |awk -F": " \'{print $2}\'', verbose=True)
+        result = self.remoter.run('/sbin/ip -o link show |grep ether |awk -F": " \'{print $2}\'', verbose=True)
         devname = result.stdout.strip()
         self.remoter.run('sudo /usr/lib/scylla/scylla_setup --nic {} --disks {}'.format(devname, ','.join(disks)))
         result = self.remoter.run('cat /proc/mounts')


### PR DESCRIPTION
This PR reverted https://github.com/scylladb/scylla-cluster-tests/pull/727.
and has a new patch to refix the problem.

`which ip` doesn't work with CentOS when we execute remote command, the PATH doesn't contain `/sbin/` or `/usr/sbin`.

Let's continue use `/sbin/ip`


```
Ubuntu 16.04
$ ssh -o "StrictHostKeyChecking no" -o UserKnownHostsFile=/var/tmp/knowhost -i ~/.ssh/scylla-test -lscylla-test  -tt -a -x  35.190.151.2  'echo $PATH'
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games

CentOS7
$ ssh -o "StrictHostKeyChecking no" -o UserKnownHostsFile=/var/tmp/knowhost -i ~/.ssh/scylla-test -lscylla-test  -tt -a -x  35.237.20.47 'echo $PATH'
/usr/local/bin:/usr/bin:/opt/scylladb/bin:/opt/scylladb/sbin
```