### PR TITLE
Fixing default device name when not using aws_root_disk_name_monitor …

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -413,7 +413,7 @@ class ClusterTester(db_stats.TestStatsMixin, Test):
         if monitor_info['device_mappings'] is None:
             if monitor_info['disk_size']:
                 monitor_info['device_mappings'] = [{
-                    "DeviceName": self.params.get("aws_root_disk_name_monitor", "/dev/sda1"),
+                    "DeviceName": self.params.get("aws_root_disk_name_monitor", default="/dev/sda1"),
                     "Ebs": {
                         "VolumeSize": monitor_info['disk_size'],
                         "VolumeType": "gp2"


### PR DESCRIPTION
…param in YAML