### PR TITLE
wait_ssh_up: assert network status after waiting it to be up

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -707,6 +707,7 @@ class BaseNode(object):
         if verbose:
             text = '%s: Waiting for SSH to be up' % self
         wait.wait_for(func=self.remoter.is_up, step=10, text=text, timeout=timeout, throw_exc=True)
+        assert self.remoter.is_up(), "Network still isn't up after waiting"
         if not self._sct_log_formatter_installed:
             self.install_sct_log_formatter()
         if not self.distro:


### PR DESCRIPTION
We allow to throw exception in waiting network up, but ssh_ping exception is
suppressed in is_up().

This patch added an assert, then we cleanly know network problem.