### PR TITLE
verify_stress_thread: only warn when results is empty

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -719,7 +719,7 @@ class ClusterTester(db_stats.TestStatsMixin, Test):
         # use the last 5 lines for the final error message.
         if results and self.create_stats:
             self.update_stress_results(results)
-        else:
+        if not results:
             self.log.warning('There is no stress results, probably stress thread has failed.')
         errors = errors[-5:]
         if errors:


### PR DESCRIPTION
If we disable store_results_in_elasticsearch, we can always see warning:

 WARNI| There is no stress results, probably stress thread has failed.

The problem was introduced by 48e77d5d0133ae085507c353fe4250692587360e