### PR TITLE
refactor longevity multi keyspaces

### DIFF
--- a/longevity_test.py
+++ b/longevity_test.py
@@ -102,19 +102,19 @@ class LongevityTest(ClusterTester):
             # In some cases (like many keyspaces), we want to create the schema (all keyspaces & tables) before the load
             # starts - due to the heavy load, the schema propogation can take long time and c-s fails.
             if pre_create_schema:
-                self._pre_create_schema()
+                self._pre_create_schema(keyspace_num)
             # When the load is too heavy for one lader when using MULTI-KEYSPACES, the load is spreaded evenly across
             # the loaders (round_robin).
             if keyspace_num > 1 and self.params.get('round_robin', default='false').lower() == 'true':
                 self.log.debug("Using round_robin for multiple Keyspaces...")
                 for i in xrange(1, keyspace_num + 1):
                     keyspace_name = self._get_keyspace_name(i)
-                    self._run_all_stress_cmds(write_queue, params={'stress_cmd':prepare_write_cmd,
+                    self._run_all_stress_cmds(write_queue, params={'stress_cmd': prepare_write_cmd,
                                                                    'keyspace_name': keyspace_name,
                                                                    'round_robin': True})
             # Not using round_robin and all keyspaces will run on all loaders
             else:
-                self._run_all_stress_cmds(write_queue, params={'stress_cmd':prepare_write_cmd,
+                self._run_all_stress_cmds(write_queue, params={'stress_cmd': prepare_write_cmd,
                                                                'keyspace_num': keyspace_num})
 
             # In some cases we don't want the nemesis to run during the "prepare" stage in order to be 100% sure that
@@ -144,7 +144,7 @@ class LongevityTest(ClusterTester):
 
         stress_cmd = self.params.get('stress_cmd', default=None)
         if stress_cmd:
-            # Stress: Same as in prepare_write - allow the load to be spread across all loaders when using MULTI-KEYSPACES
+            # Stress: Same as in prepare_write - allow the load to be spread across all loaders when using multi ks
             if keyspace_num > 1 and self.params.get('round_robin', default='false').lower() == 'true':
                 self.log.debug("Using round_robin for multiple Keyspaces...")
                 for i in xrange(1, keyspace_num + 1):
@@ -170,6 +170,50 @@ class LongevityTest(ClusterTester):
 
         for stress in stress_queue:
             self.verify_stress_thread(queue=stress)
+
+    def test_batch_custom_time(self):
+        """
+        The test runs like test_custom_time but desgined for running multiple stress commands in batches.
+        It take the keyspace_num and calculates the number of batches to run based on batch_size.
+        For every batch, it runs the stress and verify them and only then moves to the next batch.
+
+        Test assumes:
+        - pre_create_schema (The test pre-creating the schema for all batches)
+        - round_robin
+        - No nemesis during prepare
+
+        :param keyspace_num: Number of keyspaces to be batched (in future it can be enahnced with number of tables).
+        :param batch_size: Number of stress commands to run together in a batch.
+        """
+        self.db_cluster.add_nemesis(nemesis=self.get_nemesis_class(), tester_obj=self)
+
+        total_stress = self.params.get('keyspace_num')  # In future it may be 1 keyspace but multiple tables in it.
+        batch_size = self.params.get('batch_size', default=1)
+
+        prepare_write_cmd = self.params.get('prepare_write_cmd', default=None)
+        if prepare_write_cmd:
+            self._run_stress_in_batches(total_stress=total_stress, batch_size=batch_size,
+                                        stress_cmd=prepare_write_cmd)
+
+        self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
+
+        stress_cmd = self.params.get('stress_cmd', default=None)
+        self._run_stress_in_batches(total_stress=total_stress, batch_size=batch_size,
+                                    stress_cmd=stress_cmd)
+
+    def _run_stress_in_batches(self, total_stress, batch_size, stress_cmd):
+        stress_queue = list()
+        self._pre_create_schema(keyspace_num=total_stress)
+
+        num_of_batches = int(total_stress / batch_size)
+        while num_of_batches > 0:
+            num_of_batches = num_of_batches - 1
+            for i in xrange(1, total_stress + 1):
+                keyspace_name = self._get_keyspace_name(i)
+                self._run_all_stress_cmds(stress_queue, params={'stress_cmd': stress_cmd,
+                                                                'keyspace_name': keyspace_name, 'round_robin': True})
+            for stress in stress_queue:
+                self.verify_stress_thread(queue=stress)
 
     def _create_counter_table(self):
         """
@@ -206,7 +250,7 @@ class LongevityTest(ClusterTester):
                 AND speculative_retry = '99.0PERCENTILE';
         """)
 
-    def _pre_create_schema(self, in_memory=False):
+    def _pre_create_schema(self, keyspace_num=1, in_memory=False):
         """
         For cases we are testing many keyspaces and tables, It's a possibility that we will do it better and faster than
         cassandra-stress.
@@ -214,7 +258,6 @@ class LongevityTest(ClusterTester):
         node = self.db_cluster.nodes[0]
         session = self.cql_connection_patient(node)
 
-        keyspace_num = self.params.get('keyspace_num', default=1)
         self.log.debug('Pre Creating Schema for c-s with {} keyspaces'.format(keyspace_num))
 
         for i in xrange(1, keyspace_num+1):
@@ -232,6 +275,7 @@ class LongevityTest(ClusterTester):
         """
         for node in self.db_cluster.nodes:
             node.remoter.run('sudo nodetool flush')
+
 
 if __name__ == '__main__':
     main()

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -45,7 +45,7 @@ class LongevityTest(ClusterTester):
             # Run all stress commands
             self.log.debug('stress cmd: {}'.format(stress_cmd))
             stress_queue.append(self.run_stress_thread(**params))
-            time.sleep(10)
+            time.sleep(2)
 
             # Remove "user profile" param for the next command
             if 'profile' in params:

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -198,7 +198,7 @@ class LongevityTest(ClusterTester):
         self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
 
         stress_cmd = self.params.get('stress_cmd', default=None)
-        self._run_stress_in_batches(total_stress=total_stress, batch_size=batch_size,
+        self._run_stress_in_batches(total_stress=batch_size, batch_size=batch_size,
                                     stress_cmd=stress_cmd)
 
     def _run_stress_in_batches(self, total_stress, batch_size, stress_cmd):

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -206,9 +206,8 @@ class LongevityTest(ClusterTester):
         self._pre_create_schema(keyspace_num=total_stress)
 
         num_of_batches = int(total_stress / batch_size)
-        while num_of_batches > 0:
-            num_of_batches = num_of_batches - 1
-            for i in xrange(1, total_stress + 1):
+        for batch in xrange(0, num_of_batches):
+            for i in xrange(1 + batch * batch_size, (batch + 1) * batch_size + 1):
                 keyspace_name = self._get_keyspace_name(i)
                 self._run_all_stress_cmds(stress_queue, params={'stress_cmd': stress_cmd,
                                                                 'keyspace_name': keyspace_name, 'round_robin': True})

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -849,7 +849,7 @@ class ClusterTester(db_stats.TestStatsMixin, Test):
                                   bypassed_exception=NoHostAvailable)
 
     def create_ks(self, session, name, rf):
-        query = 'CREATE KEYSPACE %s WITH replication={%s}'
+        query = 'CREATE KEYSPACE IF NOT EXISTS %s WITH replication={%s}'
         if isinstance(rf, types.IntType):
             # we assume simpleStrategy
             session.execute(query % (name,
@@ -876,11 +876,11 @@ class ClusterTester(db_stats.TestStatsMixin, Test):
                 additional_columns = "%s, %s %s" % (additional_columns, k, v)
 
         if additional_columns == "":
-            query = ('CREATE COLUMNFAMILY %s (key %s, c varchar, v varchar, '
+            query = ('CREATE COLUMNFAMILY IF NOT EXISTS %s (key %s, c varchar, v varchar, '
                      'PRIMARY KEY(key, c)) WITH comment=\'test cf\'' %
                      (name, key_type))
         else:
-            query = ('CREATE COLUMNFAMILY %s (key %s PRIMARY KEY%s) '
+            query = ('CREATE COLUMNFAMILY IF NOT EXISTS %s (key %s PRIMARY KEY%s) '
                      'WITH comment=\'test cf\'' %
                      (name, key_type, additional_columns))
 

--- a/tests/longevity-multi-keyspaces.yaml
+++ b/tests/longevity-multi-keyspaces.yaml
@@ -1,54 +1,39 @@
+# Test
 test_duration: 3600
-prepare_write_cmd: "cassandra-stress write no-warmup cl=QUORUM n=1000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=2 -pop seq=1..1000000 -log interval=90"
-stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=12h -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=2 -pop seq=1..1000000 -log interval=90"]
+prepare_write_cmd: ["cassandra-stress write no-warmup cl=QUORUM n=1000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..1000000 -log interval=30"]
+stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=12h -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..1000000 -log interval=90"]
 keyspace_num: 1000
-n_db_nodes: 6
-n_loaders: 20
-n_monitor_nodes: 1
+batch_size: 50
 nemesis_class_name: 'ChaosMonkey'
 nemesis_interval: 30
+
+# Env
+n_db_nodes: 6
+n_loaders: 10
+n_monitor_nodes: 1
 user_prefix: 'longevity-1000-keyspaces-VERSION'
 failure_post_behavior: keep
-space_node_threshold: 1024
 ip_ssh_connections: 'private'
+store_results_in_elasticsearch: False
+
+# Scylla Args
 experimental: 'true'
-round_robin: 'true'
-pre_create_schema: True
-nemesis_during_prepare: 'false'
-instance_provision: 'spot_low_price'
 append_scylla_args: '--blocked-reactor-notify-ms 1000'
 
+# Manager
 use_mgmt: true
 mgmt_port: 10090
 scylla_repo_m: 'http://repositories.scylladb.com/scylla/repo/qa-test/centos/scylladb-2018.1.repo'
 scylla_mgmt_repo: 'http://repositories.scylladb.com/scylla/repo/qa-test/centos/scylladb-manager-1.3.repo'
 
 backends: !mux
-    gce: !mux
-        cluster_backend: 'gce'
-        user_credentials_path: '~/.ssh/scylla-test'
-        gce_network: 'qa-vpc'
-        gce_image: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
-        gce_image_username: 'scylla-test'
-        gce_instance_type_db: 'n1-highmem-16'
-        gce_root_disk_type_db: 'pd-ssd'
-        gce_root_disk_size_db: 50
-        gce_n_local_ssd_disk_db: 8
-        gce_instance_type_loader: 'n1-highmem-8'
-        gce_root_disk_type_loader: 'pd-standard'
-        gce_n_local_ssd_disk_loader: 0
-        gce_instance_type_monitor: 'n1-standard-4'
-        gce_root_disk_type_monitor: 'pd-ssd'
-        gce_root_disk_size_monitor: 50
-        gce_n_local_ssd_disk_monitor: 0
-        scylla_repo: 'REPO_FILE_PATH'
-        us_east_1:
-          gce_datacenter: 'us-east1-b'
     aws: !mux
         cluster_backend: 'aws'
-        instance_type_loader: 'c4.8xlarge'
+        user_credentials_path: '~/.ssh/scylla-qa-ec2'
+        instance_type_loader: 'c5.4xlarge'
         instance_type_monitor: 't2.large'
         instance_type_db: 'i3.8xlarge'
+        instance_provision: 'spot_low_price'
         us_east_1:
             region_name: 'us-east-1'
             security_group_ids: 'sg-5e79983a'
@@ -61,13 +46,6 @@ backends: !mux
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'
 
-    docker: !mux
-        cluster_backend: 'docker'
-        docker_image: 'scylladb/scylla'
-        user_credentials_path: '~/.ssh/scylla-test'
-
 databases: !mux
-    cassandra:
-        db_type: cassandra
     scylla:
         db_type: scylla

--- a/tests/longevity-multi-keyspaces.yaml
+++ b/tests/longevity-multi-keyspaces.yaml
@@ -1,7 +1,7 @@
 # Test
 test_duration: 3600
 prepare_write_cmd: ["cassandra-stress write no-warmup cl=QUORUM n=4000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=20 -pop seq=1..4000000 -log interval=30"]
-stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=12h -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..4000000 -log interval=90"]
+stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=48h -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..4000000 -log interval=90"]
 keyspace_num: 1000
 batch_size: 100
 nemesis_class_name: 'ChaosMonkey'

--- a/tests/longevity-multi-keyspaces.yaml
+++ b/tests/longevity-multi-keyspaces.yaml
@@ -1,7 +1,7 @@
 # Test
 test_duration: 3600
-prepare_write_cmd: ["cassandra-stress write no-warmup cl=QUORUM n=100000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..100000000 -log interval=30"]
-stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=12h -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..100000000 -log interval=90"]
+prepare_write_cmd: ["cassandra-stress write no-warmup cl=QUORUM n=4000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=20 -pop seq=1..4000000 -log interval=30"]
+stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=12h -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..4000000 -log interval=90"]
 keyspace_num: 1000
 batch_size: 100
 nemesis_class_name: 'ChaosMonkey'

--- a/tests/longevity-multi-keyspaces.yaml
+++ b/tests/longevity-multi-keyspaces.yaml
@@ -1,9 +1,9 @@
 # Test
 test_duration: 3600
-prepare_write_cmd: ["cassandra-stress write no-warmup cl=QUORUM n=1000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..1000000 -log interval=30"]
-stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=12h -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..1000000 -log interval=90"]
+prepare_write_cmd: ["cassandra-stress write no-warmup cl=QUORUM n=100000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..100000000 -log interval=30"]
+stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=12h -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..100000000 -log interval=90"]
 keyspace_num: 1000
-batch_size: 50
+batch_size: 100
 nemesis_class_name: 'ChaosMonkey'
 nemesis_interval: 30
 


### PR DESCRIPTION
1. Adding new test "test_batch_custom_time" that run the stress commands in batches according to batch_size parameter in yaml.

This type of test should be used for scale testing.
Currently it's for testing multiple keyspace, but later can be expand to test multi tables.

2. Refactoring the longevity-multi-keyspaces.yaml to support the new test.

3. Refactor _pre_create_schems so it won't get yaml params in inner function, but will get it as a param.

4. PEP8 fixes.