### PR TITLE
Manager 1 3 1

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -106,7 +106,7 @@ class MgmtCliTest(ClusterTester):
         manager_tool = mgmt.get_scylla_manager_tool(manager_node=self.monitors.nodes[0])
         selected_host_ip = self._get_cluster_hosts_ip()[0]
         cluster_name = 'mgr_cluster1'
-        mgr_cluster = manager_tool.get_cluster(cluster_name=cluster_name) or manager_tool.add_cluster(name=cluster_name, host=selected_host_ip)
+        mgr_cluster = manager_tool.get_cluster(cluster_name=cluster_name) or manager_tool.add_cluster(name=cluster_name, db_cluster=self.db_cluster)
         other_host, other_host_ip = [host_data for host_data in self._get_cluster_hosts_with_ips() if host_data[1] != selected_host_ip][0]
 
         sleep = 40

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -116,6 +116,8 @@ class MgmtCliTest(ClusterTester):
         dict_host_health = mgr_cluster.get_hosts_health()
         for host_health in dict_host_health.values():
             assert host_health.ssl == HostSsl.ON, "Not all hosts ssl is 'ON'"
+            assert host_health.status == HostStatus.UP, "Not all hosts status is 'UP'"
+
 
     def test_mgmt_cluster_healthcheck(self):
 

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1145,9 +1145,8 @@ client_encryption_options:          # <client_encrypt>
         else:
             self.remoter.run('sudo systemctl restart scylla-manager.service')
 
-    def install_mgmt(self, scylla_repo, scylla_mgmt_repo, client_encrypt = False):
+    def install_mgmt(self, scylla_repo, scylla_mgmt_repo, manager_backend_client_encrypt=None):
         self.log.debug('Install scylla-manager')
-        logger.debug('Using parameters of - client_encrypt:[{}] '.format(client_encrypt))
         rsa_id_dst = '/tmp/scylla-test'
         rsa_id_dst_pub = '/tmp/scylla-test-pub'
         mgmt_user = 'scylla-manager'
@@ -1188,9 +1187,8 @@ client_encryption_options:          # <client_encrypt>
             self.remoter.run('sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B2BFD3660EF3F5B', retry=3)
             self.remoter.run('sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 17723034C56D4B19', retry=3)
 
-        if client_encrypt:
-            self.log.debug("Copying TLS files from data_dir to node")
-            self.remoter.send_files(src='./data_dir/ssl_conf', dst='/tmp/')
+        self.log.debug("Copying TLS files from data_dir to node")
+        self.remoter.send_files(src='./data_dir/ssl_conf', dst='/tmp/')
 
         self.download_scylla_repo(scylla_repo)
         self.download_scylla_manager_repo(scylla_mgmt_repo)
@@ -2523,8 +2521,8 @@ class BaseMonitorSet(object):
         if self.params.get('use_mgmt', default=None):
             scylla_repo_m = self.params.get('scylla_repo_m')
             scylla_mgmt_repo = self.params.get('scylla_mgmt_repo')
-            client_encrypt = self.params.get('client_encrypt')
-            node.install_mgmt(scylla_repo=scylla_repo_m, scylla_mgmt_repo=scylla_mgmt_repo, client_encrypt=client_encrypt)
+            manager_backend_client_encrypt = self.params.get('manager_backend_client_encrypt')
+            node.install_mgmt(scylla_repo=scylla_repo_m, scylla_mgmt_repo=scylla_mgmt_repo, manager_backend_client_encrypt=manager_backend_client_encrypt)
 
     def set_local_sct_ip(self):
         sct_public_ip = self.params.get('sct_public_ip')

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1144,6 +1144,7 @@ client_encryption_options:
 
     def install_mgmt(self, scylla_repo, scylla_mgmt_repo, client_encrypt = False):
         self.log.debug('Install scylla-manager')
+        logger.debug('Using parameters of - client_encrypt:[{}] '.format(client_encrypt))
         rsa_id_dst = '/tmp/scylla-test'
         rsa_id_dst_pub = '/tmp/scylla-test-pub'
         mgmt_user = 'scylla-manager'
@@ -1185,8 +1186,8 @@ client_encryption_options:
             self.remoter.run('sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 17723034C56D4B19', retry=3)
 
         if client_encrypt:
-            self.remoter.send_files(src='./data_dir/ssl_conf',
-                                    dst='/tmp/')
+            self.log.debug("Copying TLS files from data_dir to node")
+            self.remoter.send_files(src='./data_dir/ssl_conf', dst='/tmp/')
 
         self.download_scylla_repo(scylla_repo)
         self.download_scylla_manager_repo(scylla_mgmt_repo)

--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -507,7 +507,7 @@ class ScyllaManagerTool(ScyllaManagerBase):
         if client_encrypt != False:
             if not db_cluster:
                 logger.warning("db_cluster is not given. Scylla-Manager connection to cluster may fail since not using client-encryption parameters.")
-            else:
+            else: # check if scylla-node has client-encrypt
                 db_node, _ip = self._get_cluster_hosts_with_ips(db_cluster=db_cluster)[0]
                 if client_encrypt or db_node.is_client_encrypt:
                     cmd += " --ssl-user-cert-file {} --ssl-user-key-file {}".format(SSL_USER_CERT_FILE,

--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -481,11 +481,11 @@ class ScyllaManagerTool(ScyllaManagerBase):
 
     def add_cluster(self, name, host = None, db_cluster = None, client_encrypt = None):
         """
-        :param name:
-        :param host:
-        :param db_cluster:
-        :param client_encrypt:
-        :return:
+        :param name: cluster name
+        :param host: cluster node IP
+        :param db_cluster: scylla cluster
+        :param client_encrypt: is TSL client encryption enable/disable
+        :return: ManagerCluster
 
         --host string              hostname or IP of one of the cluster nodes
         -n, --name alias               alias you can give to your cluster


### PR DESCRIPTION
(1) Added client-encryption support for scylla-manager 1.3.1. in both commands of:
sctool cluster add, sctool cluster update.

(2) Added support for scylla node to dynamically enable/disable client-encryption at run time.

(3) Added client-encryption test, to test all the above. (no changes required in yaml).