### PR TITLE
Branch 2.3 es backport

### DIFF
--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -270,30 +270,31 @@ class TestStatsMixin(Stats):
             self._stats['results']['stats_total'] = total_stats
 
     def update_test_details(self, errors=None, coredumps=None, snapshot_uploaded=False, scylla_conf=False):
-        self._stats['test_details']['time_completed'] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
-        if self.monitors:
-            url_s3 = self.get_s3_url(os.path.normpath(self.job.logdir))
-            self._stats['test_details']['prometheus_report'] = url_s3 + ".zip"
-            # setup grafana_snapshot value only when snapshot is successfully uploaded
-            if snapshot_uploaded:
-                self._stats['test_details']['grafana_snapshot'] = url_s3 + ".png"
+        if self.create_stats:
+            self._stats['test_details']['time_completed'] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
+            if self.monitors:
+                url_s3 = self.get_s3_url(os.path.normpath(self.job.logdir))
+                self._stats['test_details']['prometheus_report'] = url_s3 + ".zip"
+                # setup grafana_snapshot value only when snapshot is successfully uploaded
+                if snapshot_uploaded:
+                    self._stats['test_details']['grafana_snapshot'] = url_s3 + ".png"
 
-        if scylla_conf and 'scylla_args' not in self._stats['test_details'].keys():
-            node = self.db_cluster.nodes[0]
-            res = node.remoter.run('grep ^SCYLLA_ARGS /etc/sysconfig/scylla-server', verbose=True)
-            self._stats['test_details']['scylla_args'] = res.stdout.strip()
-            res = node.remoter.run('cat /etc/scylla.d/io.conf', verbose=True)
-            self._stats['test_details']['io_conf'] = res.stdout.strip()
-            res = node.remoter.run('cat /etc/scylla.d/cpuset.conf', verbose=True)
-            self._stats['test_details']['cpuset_conf'] = res.stdout.strip()
+            if self.db_cluster and scylla_conf and 'scylla_args' not in self._stats['test_details'].keys():
+                node = self.db_cluster.nodes[0]
+                res = node.remoter.run('grep ^SCYLLA_ARGS /etc/sysconfig/scylla-server', verbose=True)
+                self._stats['test_details']['scylla_args'] = res.stdout.strip()
+                res = node.remoter.run('cat /etc/scylla.d/io.conf', verbose=True)
+                self._stats['test_details']['io_conf'] = res.stdout.strip()
+                res = node.remoter.run('cat /etc/scylla.d/cpuset.conf', verbose=True)
+                self._stats['test_details']['cpuset_conf'] = res.stdout.strip()
 
-        self._stats['status'] = self.status
-        update_data = {'status': self._stats['status'], 'test_details': self._stats['test_details']}
-        if errors:
-            update_data.update({'errors': errors})
-        if coredumps:
-            update_data.update({'coredumps': coredumps})
-        self.update(update_data)
+            self._stats['status'] = self.status
+            update_data = {'status': self._stats['status'], 'test_details': self._stats['test_details']}
+            if errors:
+                update_data.update({'errors': errors})
+            if coredumps:
+                update_data.update({'coredumps': coredumps})
+            self.update(update_data)
 
     def check_regression(self):
         ra = ResultsAnalyzer(index=self._test_index,

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -156,7 +156,7 @@ class ClusterTester(db_stats.TestStatsMixin, Test):
         cluster.Setup.reuse_cluster(self.params.get('reuse_cluster', default=False))
 
         # for saving test details in DB
-        self.create_stats = True
+        self.create_stats = self.params.get(key='store_results_in_elasticsearch', default=True)
 
     @clean_resources_on_exception
     def setUp(self):
@@ -195,11 +195,12 @@ class ClusterTester(db_stats.TestStatsMixin, Test):
     def get_stats_obj(self):
         """
         Allow access db stats object to external objects like Nemesis - for updates
-        :return: db_stats.Stats object
+        :return: db_stats.Stats object or None if param store_results_in_elasticsearch set to False in yaml.
         """
-        return db_stats.Stats(test_index=self._test_index,
-                              test_type=self._test_type,
-                              test_id=self._test_id)
+        if self.params.get(key='store_results_in_elasticsearch', default=True):
+            return db_stats.Stats(test_index=self._test_index,
+                                  test_type=self._test_type,
+                                  test_id=self._test_id)
 
     def get_cluster_openstack(self, loader_info, db_info, monitor_info):
         if loader_info['n_nodes'] is None:

--- a/tests/sample.yaml
+++ b/tests/sample.yaml
@@ -1,0 +1,53 @@
+test_duration: 10 # [minutes] + 10 minutes (more than 1800 keep-alive)
+prepare_write_cmd: "cassandra-stress write no-warmup cl=QUORUM n=3000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1 -pop seq=1..3000"
+stress_read_cmd: ["cassandra-stress read no-warmup cl=QUORUM duration=10m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=1 -pop 'dist=gauss(1..3000,1500,150)'"]
+
+stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=10m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=2 -pop seq=1..3000 -log interval=5"
+             ]
+n_db_nodes: 3
+n_loaders: 1
+#round_robin: 'true' # when num loader more than 1
+n_monitor_nodes: 1
+keyspace_num: 1
+user_prefix: 'sample-configuration-tst'
+nemesis_class_name: 'NoOpMonkey' # no nemesis will be applied
+nemesis_interval: 5
+nemesis_during_prepare: 'true'
+failure_post_behavior: destroy
+space_node_threshold: 167000
+store_results_in_elasticsearch: False
+
+# scylla-manager configuration
+# if running on aws and use_mgmt is true, the monitor image should not contain scylla
+use_mgmt: true
+mgmt_port: 10090
+scylla_repo_m: 'http://repositories.scylladb.com/scylla/repo/f4a2920f80c4bf178217c2553ad65ad7/centos/scylladb-2017.1.repo'
+scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/branch-1.0/latest/scylla-manager.repo'
+
+
+# email definitions to send regression report
+send_email: true
+email_recipients: ['bentsi@scylladb.com']
+
+backends: !mux
+    aws: !mux
+        instance_provision: 'spot_low_price' # Allowed values: on_demand|spot_fleet|spot_low_price|spot_duration
+        cluster_backend: 'aws'
+        user_credentials_path: '~/.ssh/scylla-qa-ec2'
+        instance_type_loader: 'c4.xlarge'
+        instance_type_monitor: 't2.small'
+        instance_type_db: 'i3.large'
+        us_east_1:
+            region_name: 'us-east-1'
+            security_group_ids: 'sg-c5e1f7a0'
+            subnet_id: 'subnet-ec4a72c4'
+            ami_id_db_scylla: 'ami-b4f8b4cb'  # Scylla 2.2 AMI
+            ami_id_monitor: 'ami-b4f8b4cb'  # Scylla 2.2 AMI
+            ami_id_loader: 'ami-b4f8b4cb'  # Scylla 2.2 AMI
+            ami_db_scylla_user: 'centos'
+            ami_loader_user: 'centos'
+            ami_monitor_user: 'centos'
+
+databases: !mux
+    scylla:
+        db_type: scylla


### PR DESCRIPTION
rolling upgrade of 2.3 jobs failed for es connection problem. This PR backported two patches to disable store result to es.