### PR TITLE
fix missing import dedent

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -8,6 +8,7 @@ import yaml
 from botocore.exceptions import WaiterError, ClientError
 import boto3.session
 from avocado.utils import runtime as avocado_runtime
+from textwrap import dedent
 
 import cluster
 import ec2_client


### PR DESCRIPTION
dedent() is used by PR #760 , but it's imported. This PR fixed it.