### PR TITLE
Longevity test for large partitions using scylla-bench

### DIFF
--- a/longevity_large_partition_test.py
+++ b/longevity_large_partition_test.py
@@ -1,0 +1,44 @@
+from longevity_test import LongevityTest
+
+
+class LargePartitionLongevetyTest(LongevityTest):
+
+    """
+    :avocado: enable
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(LargePartitionLongevetyTest, self).__init__(*args, **kwargs)
+
+    def test_large_partition_longevity(self):
+        self._pre_create_schema()
+        self.test_custom_time()
+
+    def _pre_create_schema(self, in_memory=False):
+        node = self.db_cluster.nodes[0]
+        session = self.cql_connection_patient(node)
+        session.execute("""
+                CREATE KEYSPACE IF NOT EXISTS scylla_bench WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}
+        """)
+        session.execute("""
+                CREATE TABLE IF NOT EXISTS scylla_bench.test (
+                pk bigint,
+                ck bigint,
+                v blob,
+                PRIMARY KEY (pk, ck)
+            ) WITH CLUSTERING ORDER BY (ck ASC)
+                AND bloom_filter_fp_chance = 0.01
+                AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
+                AND comment = ''
+                AND compression = {}
+                AND crc_check_chance = 1.0
+                AND dclocal_read_repair_chance = 0.0
+                AND default_time_to_live = 0
+                AND gc_grace_seconds = 864000 
+                AND max_index_interval = 2048
+                AND memtable_flush_period_in_ms = 0
+                AND min_index_interval = 128
+                AND read_repair_chance = 0.0
+                AND speculative_retry = 'NONE';
+                        """)
+

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -832,15 +832,23 @@ class BaseNode(object):
     def _parse_cfstats(cfstats_output):
         stat_dict = {}
         for line in cfstats_output.splitlines()[1:]:
+            # Example of line of cfstats output:
+            #       Space used (total): 123456
             stat_line = [element for element in line.strip().split(':') if
                          element]
             if stat_line:
                 try:
                     try:
+                        # Fix for space_node_threshold: if there are a few tables in the keyspace and space is used by the
+                        # table, that arrives last in the cfstats output, will be less then space_node_threshold,
+                        # the nemesis never will be run. Because of this, we sum space of all tables in the keyspace
+                        # This function is used just for wait_total_space_used_per_node, so I fix "Space used.." statistics only
+                        current_value = stat_dict[stat_line[0]] if 'Space used' in stat_line[0] \
+                                                                   and stat_line[0] in stat_dict else 0
                         if '.' in stat_line[1].split()[0]:
-                            stat_dict[stat_line[0]] = float(stat_line[1].split()[0])
+                            stat_dict[stat_line[0]] = float(stat_line[1].split()[0]) + current_value
                         else:
-                            stat_dict[stat_line[0]] = int(stat_line[1].split()[0])
+                            stat_dict[stat_line[0]] = int(stat_line[1].split()[0]) + current_value
                     except IndexError:
                         continue
                 except ValueError:
@@ -1996,9 +2004,17 @@ class BaseScyllaCluster(object):
                     else:
                         self.log.error("Unknown ScyllaDB version")
 
-    def run_cqlsh(self, node, cql_cmd, timeout=60, verbose=True):
-        cqlsh_out = node.remoter.run('cqlsh -e "{}" {}'.format(cql_cmd, node.private_ip_address), timeout=timeout, verbose=verbose)
-        return cqlsh_out.stdout
+    def run_cqlsh(self, node, cql_cmd, timeout=60, verbose=True, split=False):
+        cmd = 'cqlsh -e "{}" {} --request-timeout={}'.format(cql_cmd, node.private_ip_address, timeout)
+        cqlsh_out = node.remoter.run(cmd, timeout=timeout, verbose=verbose)
+        # stdout of cqlsh example:
+        #      pk
+        #      ----
+        #       2
+        #       3
+        #
+        #      (10 rows)
+        return cqlsh_out.stdout if not split else [line.strip() for line in cqlsh_out.stdout.split('\n')]
 
     def get_test_keyspaces(self):
         out = self.run_cqlsh(node=self.nodes[0], cql_cmd='select keyspace_name from system_schema.keyspaces')

--- a/tests/longevity-large-partition-4days.yaml
+++ b/tests/longevity-large-partition-4days.yaml
@@ -1,0 +1,79 @@
+test_duration: 6480
+prepare_write_cmd:  ["scylla-bench -workload=sequential -mode=write -max-rate=300 -replication-factor=3 -partition-count=10 -clustering-row-count=10000000 -clustering-row-size=5120 -concurrency=7 -rows-per-request=10",
+                     "scylla-bench -workload=uniform -mode=read -replication-factor=3 -partition-count=10 -clustering-row-count=10000000 -clustering-row-size=5120 -rows-per-request=10 -concurrency=7 -max-rate=32000 -duration=5760m"
+                    ]
+n_db_nodes: 4
+n_loaders: 3
+n_monitor_nodes: 1
+nemesis_class_name: 'ChaosMonkey'
+nemesis_interval: 30
+nemesis_during_prepare: 'true'
+user_prefix: 'longevity-large-partitions-4d-VERSION'
+failure_post_behavior: keep
+space_node_threshold: 644245094
+ip_ssh_connections: 'private'
+experimental: 'true'
+bench_run: 'true'
+# To validate rows in partitions: collect data about partitions and their rows amount
+# before and after running nemesis and compare it
+validate_partitions: true
+table_name: "scylla_bench.test"
+primary_key_column: "pk"
+
+append_scylla_args: '--blocked-reactor-notify-ms 500'
+
+# aws instance_provision: on_demand|spot_fleet|spot_low_price|spot_duration
+instance_provision: 'spot_low_price'
+
+# scylla-manager configuration
+# if running on aws and use_mgmt is true, the monitor image should not contain scylla
+use_mgmt: true
+mgmt_port: 10090
+scylla_repo_m: 'http://repositories.scylladb.com/scylla/repo/qa-test/centos/scylladb-2018.1.repo'
+scylla_mgmt_repo: 'http://repositories.scylladb.com/scylla/repo/qa-test/centos/scylladb-manager-1.3.repo'
+
+backends: !mux
+    gce: !mux
+        cluster_backend: 'gce'
+        user_credentials_path: '~/.ssh/scylla-test'
+        gce_network: 'qa-vpc'
+        gce_image: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
+        gce_image_username: 'scylla-test'
+        gce_instance_type_db: 'n1-highmem-16'
+        gce_root_disk_type_db: 'pd-ssd'
+        gce_root_disk_size_db: 50
+        gce_n_local_ssd_disk_db: 8
+        gce_instance_type_loader: 'n1-standard-4'
+        gce_root_disk_type_loader: 'pd-standard'
+        gce_n_local_ssd_disk_loader: 0
+        gce_instance_type_monitor: 'n1-standard-2'
+        gce_root_disk_type_monitor: 'pd-standard'
+        gce_root_disk_size_monitor: 50
+        gce_n_local_ssd_disk_monitor: 0
+        scylla_repo: 'SCYLLA_REPO_FILE_URL'
+        us_east_1:
+          gce_datacenter: 'us-east1-b'
+    aws: !mux
+        cluster_backend: 'aws'
+        user_credentials_path: '~/.ssh/scylla-qa-ec2'
+        instance_type_loader: 'c5.xlarge'
+        instance_type_monitor: 't3.small'
+        instance_type_db: 'i3.2xlarge'
+        us_east_1:
+            region_name: 'us-east-1'
+            security_group_ids: 'sg-c5e1f7a0'
+            subnet_id: 'subnet-ec4a72c4'
+            ami_id_db_scylla: 'AMI-ID'
+            ami_id_loader: 'AMI-ID'
+            ami_id_monitor: 'ami-9887c6e7' # Clean CentOs 7 ami
+            aws_root_disk_size_monitor: 20  # GB
+            ami_db_scylla_user: 'centos'
+            ami_loader_user: 'centos'
+            ami_monitor_user: 'centos'
+
+databases: !mux
+    cassandra:
+        db_type: cassandra
+    scylla:
+        db_type: scylla
+


### PR DESCRIPTION
As part of this PR added fix for:
Longevity test starts nemesis according to space_node_threshold parameter. It checks if the size on the disk is reach this value. If the keyspace has a few tables, size of just last table in cfstats output is taken into account. So in this case may be that the nemesis never will be started.
This fix summarize the size of all tables in the keyspace