### PR TITLE
Adding 'mixed' type for AWS cluster deployment

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -654,8 +654,16 @@ class ClusterTester(db_stats.TestStatsMixin, Test):
             self.get_cluster_baremetal()
 
         seeds_num = self.params.get('seeds_num', default=1)
-        for i in range(seeds_num):
-            self.db_cluster.nodes[i].is_seed = True
+        if self.params.get('instance_provision') == 'mixed':
+            for node in self.db_cluster.nodes:
+                if seeds_num == 0:
+                    break
+                if node.is_spot:
+                    node.is_seed = True
+                    seeds_num -= 1
+        else:
+            for i in range(seeds_num):
+                self.db_cluster.nodes[i].is_seed = True
 
     def _cs_add_node_flag(self, stress_cmd):
         if '-node' not in stress_cmd:

--- a/tests/sample.yaml
+++ b/tests/sample.yaml
@@ -42,7 +42,10 @@ ip_ssh_connections: 'private'
 
 backends: !mux
     aws: !mux
-        instance_provision: 'spot_low_price' # Allowed values: on_demand|spot_fleet|spot_low_price|spot_duration
+        # instace_provision: mixed - create maximum 2 on_demand instances and other as spot_low_price instaces for db_nodes
+        #                            loader nodes as spot_low_price instaces
+        #                            monitor nodes as on_demand instance
+        instance_provision: 'spot_low_price' # Allowed values: on_demand|spot_fleet|spot_low_price|spot_duration|mixed
         cluster_backend: 'aws'
         user_credentials_path: '~/.ssh/scylla-qa-ec2'
         instance_type_loader: 'c4.xlarge'


### PR DESCRIPTION
Mixed type of aws cluster deployment allow to create:
- monitoring nodes with instance type - ON_DEMAND always
- db seeds nodes are created as SPOT instances, not seeds nodes as On demand.
Nemesises which are restart, stop nodes will be run only on On demand instances.
only in mixed type.