### PR TITLE
Use qa-vpc and private ip for rolling upgrade

### DIFF
--- a/tests/rolling-upgrade-gce.yaml
+++ b/tests/rolling-upgrade-gce.yaml
@@ -19,11 +19,13 @@ user_prefix: 'rolling-upgrade-VERSION'
 failure_post_behavior: destroy
 
 experimental: 'true'
+ip_ssh_connections: 'private'
 
 backends: !mux
     gce: !mux
         cluster_backend: 'gce'
         user_credentials_path: '~/.ssh/scylla-test'
+        gce_network: 'qa-vpc'
         gce_image: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
         gce_image_username: 'scylla-test'
         gce_instance_type_db: 'n1-highmem-8'

--- a/tests/sample.yaml
+++ b/tests/sample.yaml
@@ -37,6 +37,9 @@ email_recipients: ['bentsi@scylladb.com']
 # Reuse cluster
 # cluster_id: "" ID of the cluster (currently db nodes only)
 
+# IP type for ssh connections, public or private
+ip_ssh_connections: 'private'
+
 backends: !mux
     aws: !mux
         instance_provision: 'spot_low_price' # Allowed values: on_demand|spot_fleet|spot_low_price|spot_duration


### PR DESCRIPTION
Rolling upgrade jobs are not stable, this PR helps to fix it.