### PR TITLE
install epel for mmonitor instance

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2388,6 +2388,7 @@ class BaseMonitorSet(object):
     def install_scylla_monitoring_prereqs(self, node):
         if node.is_rhel_like():
             prereqs_script = dedent("""
+                yum install -y epel-release
                 yum install -y python-pip unzip wget docker
                 pip install --upgrade pip
                 pip install pyyaml


### PR DESCRIPTION
This change was introduced by commit ba31703c73c2dfb68e1185508cc1229497141d4c
in master. Backport one line to branch-3.0.

Epel isn't installed on some clean CentOS7 AMI.
