### PR TITLE
update_db_binary: adapt relocated scylla binary

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1423,7 +1423,8 @@ server_encryption_options:
     @log_run_info
     def start_scylla(self, verify_up=True, verify_down=False, timeout=300):
         self.start_scylla_server(verify_up=verify_up, verify_down=verify_down, timeout=timeout)
-        self.start_scylla_jmx(verify_up=verify_up, verify_down=False, timeout=timeout)
+        if verify_up:
+            self.wait_jmx_up(timeout=timeout)
 
     def stop_scylla_server(self, verify_up=False, verify_down=True, timeout=300, ignore_status=False):
         if verify_up:
@@ -1448,7 +1449,8 @@ server_encryption_options:
     @log_run_info
     def stop_scylla(self, verify_up=False, verify_down=True, timeout=300):
         self.stop_scylla_server(verify_up=verify_up, verify_down=verify_down, timeout=timeout)
-        self.stop_scylla_jmx(verify_up=False, verify_down=verify_down, timeout=timeout)
+        if verify_down:
+            self.wait_jmx_down(timeout=timeout)
 
     def enable_client_encrypt(self):
         SCYLLA_YAML_PATH_TMP = "/tmp/scylla.yaml"

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1858,10 +1858,10 @@ class BaseScyllaCluster(object):
                 binary_path = '/usr/bin/scylla'
             # replace the binary
             prereqs_script = dedent("""
-            cp -f {binary_path} {binary_path}.origin
-            cp -f /tmp/scylla {binary_path}
-            chown root.root {binary_path}
-            chmod +x {binary_path}
+                cp -f {binary_path} {binary_path}.origin
+                cp -f /tmp/scylla {binary_path}
+                chown root.root {binary_path}
+                chmod +x {binary_path}
             """.format(**locals()))
             node.remoter.run("sudo bash -ce '%s'" % prereqs_script)
             queue.put(node)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1423,7 +1423,7 @@ server_encryption_options:
     @log_run_info
     def start_scylla(self, verify_up=True, verify_down=False, timeout=300):
         self.start_scylla_server(verify_up=verify_up, verify_down=verify_down, timeout=timeout)
-        self.start_scylla_jmx(verify_up=verify_up, verify_down=verify_down, timeout=timeout)
+        self.start_scylla_jmx(verify_up=verify_up, verify_down=False, timeout=timeout)
 
     def stop_scylla_server(self, verify_up=False, verify_down=True, timeout=300, ignore_status=False):
         if verify_up:
@@ -1448,7 +1448,7 @@ server_encryption_options:
     @log_run_info
     def stop_scylla(self, verify_up=False, verify_down=True, timeout=300):
         self.stop_scylla_server(verify_up=verify_up, verify_down=verify_down, timeout=timeout)
-        self.stop_scylla_jmx(verify_up=verify_up, verify_down=verify_down, timeout=timeout)
+        self.stop_scylla_jmx(verify_up=False, verify_down=verify_down, timeout=timeout)
 
     def enable_client_encrypt(self):
         SCYLLA_YAML_PATH_TMP = "/tmp/scylla.yaml"


### PR DESCRIPTION
Scylla binary is moved to different directory after relocation,
then we can't always copy binary to original /usr/bin/scylla.
