### PR TITLE
run_cqlsh: disable color output

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2781,7 +2781,7 @@ class BaseLoaderSet(object):
             db_node_ip {str} -- ip of db_node
         """
         cmd = 'SELECT keyspace_name, table_name from system_schema.tables'
-        result = loader_node.remoter.run('cqlsh --execute "{}" {}'.format(cmd, db_node_ip), verbose=False)
+        result = loader_node.remoter.run('cqlsh --no-color --execute "{}" {}'.format(cmd, db_node_ip), verbose=False)
 
         avaialable_ks_cf = []
         for row in result.stdout.split('\n'):
@@ -2814,7 +2814,7 @@ class BaseLoaderSet(object):
 
         self.log.info('Fullscan for ks.cf: {}'.format(ks_cf))
         cmd = 'select count(*) from {}'.format(ks_cf)
-        result = loader_node.remoter.run('cqlsh --execute "{}" {}'.format(cmd, db_node_ip), verbose=False)
+        result = loader_node.remoter.run('cqlsh --no-color --execute "{}" {}'.format(cmd, db_node_ip), verbose=False)
 
         return result
 

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2065,7 +2065,7 @@ class BaseScyllaCluster(object):
                         self.log.error("Unknown ScyllaDB version")
 
     def run_cqlsh(self, node, cql_cmd, timeout=60, verbose=True, split=False):
-        cmd = 'cqlsh -e "{}" {} --request-timeout={}'.format(cql_cmd, node.private_ip_address, timeout)
+        cmd = 'cqlsh --no-color -e "{}" {} --request-timeout={}'.format(cql_cmd, node.private_ip_address, timeout)
         cqlsh_out = node.remoter.run(cmd, timeout=timeout, verbose=verbose)
         # stdout of cqlsh example:
         #      pk


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylla-cluster-tests/issues/808

We try to get keyspaces' name from cqlsh output, the color string will
introduce wrong keyspace name.

Running 'cqlsh -e "select keyspace_name from system_schema.keyspaces" 10.142.0.45 --request-timeout=60'
[stdout]  ESC[0;1;31mkeyspace_nameESC[0m
[stdout] --------------------
[stdout]         ESC[0;1;33msystem_authESC[0m
[stdout]       ESC[0;1;33msystem_schemaESC[0m
[stdout]           ESC[0;1;33mkeyspace1ESC[0m
[stdout]  ESC[0;1;33msystem_distributedESC[0m
[stdout]              ESC[0;1;33msystemESC[0m
[stdout]       ESC[0;1;33msystem_tracesESC[0m
[stdout]
[stdout] (6 rows)

Running 'nodetool cfstats ESC[0;1;33mkeyspace1ESC[0m'
[stdout] nodetool: Unknown keyspace: ESC[0
[stdout] See 'nodetool help' or 'nodetool help <command>'.
[stdout] bash: 1: command not found
[stdout] bash: $'33mkeyspace1\E[0m': command not found
