### PR TITLE
Changes to longevity yamls

### DIFF
--- a/tests/gemini_test.yaml
+++ b/tests/gemini_test.yaml
@@ -31,7 +31,7 @@ backends: !mux
     aws: !mux
         cluster_backend: 'aws'
         instance_type_loader: 'c4.2xlarge'
-        instance_type_monitor: 't2.small'
+        instance_type_monitor: 't3.small'
         user_credentials_path: '~/.ssh/scylla-test'
         us_east_1:
             region_name: 'us-east-1'

--- a/tests/google-cloud-snitch.yaml
+++ b/tests/google-cloud-snitch.yaml
@@ -10,9 +10,6 @@ endpoint_snitch: 'GoogleCloudSnitch'
 
 stress_cmd: cassandra-stress write cl=QUORUM duration=20m -schema 'replication(strategy=NetworkTopologyStrategy,us-east1scylla_node_east=3,us-west1scylla_node_west=3)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..100000000000
 
-# aws instance_provision: on_demand|spot_fleet|spot_low_price|spot_duration
-instance_provision: 'on_demand'
-
 backends: !mux
     gce: !mux
         cluster_backend: 'gce'
@@ -33,34 +30,7 @@ backends: !mux
         gce_n_local_ssd_disk_monitor: 0
         scylla_repo: 'SCYLLA_REPO_FILE_URL'
         gce_datacenter: 'us-east1-b us-west1-b'
-    aws: !mux
-        cluster_backend: 'aws'
-        instance_type_loader: 'c4.4xlarge'
-        instance_type_monitor: 'c4.2xlarge'
-        us_east_1_and_us_west_2:
-            region_name: 'us-east-1 us-west-2'
-            security_group_ids: 'sg-c5e1f7a0 sg-81703ae4'
-            subnet_id: 'subnet-d934e980 subnet-5207ee37'
-            ami_id_db_scylla: 'AMI_ID_EAST AMI_ID_WEST'
-            ami_id_loader: 'AMI_ID_EAST'
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
-            ami_db_scylla_user: 'centos'
-            ami_loader_user: 'centos'
-            ami_monitor_user: 'centos'
-            ami_id_db_cassandra: 'ami-3eff0028'
-            ami_db_cassandra_user: 'ubuntu'
-        eu_west_1_and_us_west_2:
-            region_name: 'eu-west-1 us-west-2'
-            security_group_ids: 'sg-059a7f66a947d4b5c sg-81703ae4'
-            subnet_id: 'subnet-088fddaf520e4c7a8 subnet-5207ee37'
-            ami_id_db_scylla: 'AMI_ID_EU_WEST AMI_ID_US_WEST'
-            ami_id_loader: 'AMI_ID_EU_WEST'
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
-            ami_db_scylla_user: 'centos'
-            ami_loader_user: 'centos'
-            ami_monitor_user: 'centos'
 
 databases: !mux
     scylla:
         db_type: scylla
-        instance_type_db: 'i3.4xlarge'

--- a/tests/janus-graph.yaml
+++ b/tests/janus-graph.yaml
@@ -27,8 +27,8 @@ backends: !mux
           gce_datacenter: 'us-east1-b'
     aws: !mux
         cluster_backend: 'aws'
-        instance_type_loader: 'c4.large'
-        instance_type_monitor: 't2.small'
+        instance_type_loader: 'c5.large'
+        instance_type_monitor: 't3.small'
         us_west_2:
             region_name: 'us-west-2'
             security_group_ids: 'sg-81703ae4'

--- a/tests/longevity-1TB-7days-authorization-and-tls-ssl.yaml
+++ b/tests/longevity-1TB-7days-authorization-and-tls-ssl.yaml
@@ -65,8 +65,8 @@ backends: !mux
     aws: !mux
         cluster_backend: 'aws'
         user_credentials_path: '~/.ssh/scylla-qa-ec2'
-        instance_type_loader: 'c4.4xlarge'
-        instance_type_monitor: 'c4.2xlarge'
+        instance_type_loader: 'c5.2xlarge'
+        instance_type_monitor: 't3.small'
         instance_type_db: 'i3.4xlarge'
         us_east_1:
             region_name: 'us-east-1'

--- a/tests/longevity-1TB-7days.yaml
+++ b/tests/longevity-1TB-7days.yaml
@@ -14,22 +14,22 @@ stress_read_cmd: ["cassandra-stress read         cl=QUORUM duration=10080m      
                   "cassandra-stress read         cl=QUORUM duration=10020m -schema 'replication(factor=3) compression=SnappyCompressor compaction(strategy=SizeTieredCompactionStrategy)'  -port jmx=6868 -mode cql3 native compression=snappy -rate threads=20 -pop seq=1..50000000 -log interval=5",
                   "cassandra-stress read         cl=QUORUM duration=10030m -schema 'replication(factor=3) compression=DeflateCompressor compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=none   -rate threads=20 -pop seq=1..50000000 -log interval=5",
                   "cassandra-stress counter_read cl=QUORUM duration=10080m                                                                                                                 -port jmx=6868 -mode cql3 native                    -rate threads=10 -pop seq=1..10000000"]
+run_fullscan: 'random, 30'
 n_db_nodes: 4
 n_loaders: 2
 n_monitor_nodes: 1
 nemesis_class_name: 'ChaosMonkey'
 nemesis_interval: 30
-nemesis_during_prepare: 'false'
+nemesis_during_prepare: 'true'
 user_prefix: 'longevity-1tb-7d-VERSION'
 failure_post_behavior: keep
 space_node_threshold: 644245094
 ip_ssh_connections: 'private'
 experimental: 'true'
-# append_conf: 'enable_sstable_data_integrity_check: true'
 append_scylla_args: '--blocked-reactor-notify-ms 500'
 
 # aws instance_provision: on_demand|spot_fleet|spot_low_price|spot_duration
-instance_provision: 'on_demand'
+instance_provision: 'mixed'
 
 # scylla-manager configuration
 # if running on aws and use_mgmt is true, the monitor image should not contain scylla
@@ -61,8 +61,8 @@ backends: !mux
           gce_datacenter: 'us-east1-b'
     aws: !mux
         cluster_backend: 'aws'
-        instance_type_loader: 'c4.4xlarge'
-        instance_type_monitor: 'c4.2xlarge'
+        instance_type_loader: 'c5.large'
+        instance_type_monitor: 't3.small'
         instance_type_db: 'i3.4xlarge'
         us_east_1:
             region_name: 'us-east-1'

--- a/tests/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
+++ b/tests/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
@@ -3,6 +3,7 @@ prepare_write_cmd: "cassandra-stress write cl=ALL n=200200300  -schema 'replicat
 prepare_verify_cmd: "cassandra-stress read cl=ALL n=200200300  -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native user=cassandra password=cassandra -rate threads=2000 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..200200300 -log interval=15"
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=2860m  -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native user=cassandra password=cassandra -rate threads=250  -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=400200300..600200300 -log interval=15"]
 stress_read_cmd: ["cassandra-stress read cl=ONE duration=2860m -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native user=cassandra password=cassandra -rate threads=250  -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..200200300 -log interval=5"]
+run_fullscan: 'keyspace1.standard1, 5' # 'ks.cf|random, interval(min)''
 n_db_nodes: 4
 n_loaders: 1
 n_monitor_nodes: 1
@@ -19,7 +20,7 @@ append_scylla_args: '--blocked-reactor-notify-ms 500'
 
 
 # aws instance_provision: on_demand|spot_fleet|spot_low_price|spot_duration
-instance_provision: 'on_demand'
+instance_provision: 'mixed'
 
 # scylla-manager configuration
 # if running on aws and use_mgmt is true, the monitor image should not contain scylla
@@ -53,8 +54,8 @@ backends: !mux
         cluster_backend: 'aws'
         user_credentials_path: '~/.ssh/scylla-qa-ec2'
         instance_type_db: 'i3.4xlarge'
-        instance_type_loader: 'c4.4xlarge'
-        instance_type_monitor: 'c4.2xlarge'
+        instance_type_loader: 'c5.large'
+        instance_type_monitor: 't3.small'
         us_east_1:
             region_name: 'us-east-1'
             security_group_ids: 'sg-5e79983a'

--- a/tests/longevity-48h-verify-multiDC.yaml
+++ b/tests/longevity-48h-verify-multiDC.yaml
@@ -1,13 +1,14 @@
-test_duration: 2860
+test_duration: 3000
 prepare_write_cmd:  "cassandra-stress write cl=ALL n=200200300 -schema 'replication(strategy=NetworkTopologyStrategy,us-eastscylla_node_east=3,us-west-2scylla_node_west=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -pop seq=1..200200300"
-prepare_verify_cmd: "cassandra-stress read  cl=ALL n=200200300 -schema 'replication(strategy=NetworkTopologyStrategy,us-eastscylla_node_east=3,us-west-2scylla_node_west=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -pop seq=1..200200300"
 stress_cmd: "cassandra-stress write cl=QUORUM duration=2860m -schema 'replication(strategy=NetworkTopologyStrategy,us-eastscylla_node_east=3,us-west-2scylla_node_west=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -pop seq=400200300..600200300"
 stress_read_cmd: "cassandra-stress read cl=ONE duration=2860m -schema 'replication(strategy=NetworkTopologyStrategy,us-eastscylla_node_east=3,us-west-2scylla_node_west=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -pop seq=1..200200300"
-n_db_nodes: '3 3'
+run_fullscan: 'random, 30'
+n_db_nodes: '4 3'
 n_loaders: 1
 n_monitor_nodes: 1
 nemesis_class_name: 'LimitedChaosMonkey'
 nemesis_interval: 5
+nemesis_during_prepare: 'false'
 user_prefix: longevity-multidc-200gb-vfy-VERSION
 failure_post_behavior: keep
 space_node_threshold: 6442
@@ -25,13 +26,10 @@ scylla_mgmt_repo: 'http://repositories.scylladb.com/scylla/repo/qa-test/centos/s
 
 backends: !mux
     aws: !mux
-        # What is the backend that the suite will use to get machines from.
         cluster_backend: 'aws'
-        # From 0.19 on, iotune will require bigger disk, so let's use a big
-        # loader instance by default.
-        instance_type_loader: 'c4.large'
-        # Size of AWS monitor instance
-        instance_type_monitor: 't2.small'
+        instance_provision: 'mixed'
+        instance_type_loader: 'c5.large'
+        instance_type_monitor: 't3.small'
         us_east_1_and_us_west_2:
             user_credentials_path: '~/.ssh/scylla-qa-ec2'
             region_name: 'us-east-1 us-west-2'

--- a/tests/longevity-50GB-4days-authorization-and-tls-ssl.yaml
+++ b/tests/longevity-50GB-4days-authorization-and-tls-ssl.yaml
@@ -11,6 +11,7 @@ stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=5760m -port jmx=6868
                   "cassandra-stress read cl=QUORUM duration=5760m -schema 'replication(factor=3) compression=LZ4Compressor compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=lz4 -rate threads=20 -pop seq=1..100000000 -log interval=5",
                   "cassandra-stress read cl=QUORUM duration=5760m -schema 'replication(factor=3) compression=SnappyCompressor compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=snappy -rate threads=20 -pop seq=1..100000000 -log interval=5",
                   "cassandra-stress read cl=QUORUM duration=5760m -schema 'replication(factor=3) compression=DeflateCompressor compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=none -rate threads=20 -pop seq=1..100000000 -log interval=5"]
+run_fullscan: 'keyspace1.standard1, 5' # 'ks.cf|random, interval(min)''
 n_db_nodes: 6
 n_loaders: 3
 n_monitor_nodes: 1
@@ -27,8 +28,8 @@ client_encrypt: 'false'
 # append_conf: 'enable_sstable_data_integrity_check: true'
 append_scylla_args: '--blocked-reactor-notify-ms 500'
 
-# aws instance_provision: on_demand|spot_fleet|spot_low_price|spot_duration
-instance_provision: 'spot_low_price'
+# aws instance_provision: on_demand|spot_fleet|spot_low_price|spot_duration|mixed
+instance_provision: 'mixed'
 
 # scylla-manager configuration
 # if running on aws and use_mgmt is true, the monitor image should not contain scylla

--- a/tests/longevity-in-memory-36GB-4days.yaml
+++ b/tests/longevity-in-memory-36GB-4days.yaml
@@ -4,6 +4,7 @@ prepare_write_cmd: ["cassandra-stress write         cl=QUORUM n=21000000     -sc
 stress_cmd:        ["cassandra-stress mixed         cl=QUORUM duration=5760m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -pop seq=1..21000000 -col 'size=FIXED(200) n=FIXED(5)' -log interval=10"]
 stress_read_cmd:   ["cassandra-stress read          cl=QUORUM duration=5760m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=1..21000000 -col 'size=FIXED(200) n=FIXED(5)' -log interval=10",
                     "cassandra-stress counter_read  cl=QUORUM duration=5760m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=10  -pop seq=1..12345678"]
+run_fullscan: 'random, 5' # 'ks.cf|random, interval(min)''
 n_db_nodes: 5
 n_loaders: 2
 n_monitor_nodes: 1
@@ -22,7 +23,7 @@ client_encrypt: 'false'
 append_scylla_args: '--blocked-reactor-notify-ms 500 --in-memory-storage-size-mb 80000'
 
 # aws instance_provision: on_demand|spot_fleet|spot_low_price|spot_duration
-instance_provision: 'on_demand'
+instance_provision: 'mixed'
 
 # scylla-manager configuration
 # if running on aws and use_mgmt is true, the monitor image should not contain scylla
@@ -57,7 +58,7 @@ backends: !mux
         cluster_backend: 'aws'
         user_credentials_path: '~/.ssh/scylla-qa-ec2'
         instance_type_loader: 'c4.2xlarge'
-        instance_type_monitor: 't2.small'
+        instance_type_monitor: 't3.small'
         instance_type_db: 'i3.4xlarge'
         us_east_1:
             region_name: 'us-east-1'

--- a/tests/longevity-large-partition-4days.yaml
+++ b/tests/longevity-large-partition-4days.yaml
@@ -23,7 +23,7 @@ primary_key_column: "pk"
 append_scylla_args: '--blocked-reactor-notify-ms 500'
 
 # aws instance_provision: on_demand|spot_fleet|spot_low_price|spot_duration
-instance_provision: 'spot_low_price'
+instance_provision: 'mixed'
 
 # scylla-manager configuration
 # if running on aws and use_mgmt is true, the monitor image should not contain scylla

--- a/tests/longevity-multi-keyspaces.yaml
+++ b/tests/longevity-multi-keyspaces.yaml
@@ -2,6 +2,7 @@
 test_duration: 3600
 prepare_write_cmd: ["cassandra-stress write no-warmup cl=QUORUM n=4000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=20 -pop seq=1..4000000 -log interval=30"]
 stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=48h -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..4000000 -log interval=90"]
+run_fullscan: 'random, 30'
 keyspace_num: 1000
 batch_size: 100
 nemesis_class_name: 'ChaosMonkey'
@@ -18,7 +19,7 @@ store_results_in_elasticsearch: False
 
 # Scylla Args
 experimental: 'true'
-append_scylla_args: '--blocked-reactor-notify-ms 1000'
+append_scylla_args: '--blocked-reactor-notify-ms 500'
 
 # Manager
 use_mgmt: true
@@ -31,9 +32,9 @@ backends: !mux
         cluster_backend: 'aws'
         user_credentials_path: '~/.ssh/scylla-qa-ec2'
         instance_type_loader: 'c5.4xlarge'
-        instance_type_monitor: 't2.large'
+        instance_type_monitor: 't3.large'
         instance_type_db: 'i3.8xlarge'
-        instance_provision: 'spot_low_price'
+        instance_provision: 'mixed'
         us_east_1:
             region_name: 'us-east-1'
             security_group_ids: 'sg-5e79983a'

--- a/tests/longevity-mv-si-4days.yaml
+++ b/tests/longevity-mv-si-4days.yaml
@@ -8,6 +8,7 @@ stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_profile_4mv_5queries.y
                   "cassandra-stress user profile=/tmp/c-s_profile_2si_2queries.yaml ops'(insert=10,si_p_read1=1,si_p_read2=1)' cl=QUORUM duration=5760m -port jmx=6868 -mode cql3 native -rate threads=10"
 
                  ]
+run_fullscan: 'random, 15'
 n_db_nodes: 5
 n_loaders: 2
 n_monitor_nodes: 1
@@ -18,14 +19,12 @@ user_prefix: 'longevity-mv-si-4d-VERSION'
 failure_post_behavior: keep
 space_node_threshold: 644245
 ip_ssh_connections: 'private'
-#When the load is too heavy for one lader when using MULTI-KEYSPACES, the load is spreaded evenly across the loaders (round_robin)
 round_robin: 'false'
 experimental: 'true'
-# append_conf: 'enable_sstable_data_integrity_check: true'
-append_scylla_args: '--blocked-reactor-notify-ms 1000 --enable-sstables-mc-format true'
+append_scylla_args: '--blocked-reactor-notify-ms 500'
 
 # aws instance_provision: on_demand|spot_fleet|spot_low_price|spot_duration
-instance_provision: 'on_demand'
+instance_provision: 'mixed'
 
 # scylla-manager configuration
 # if running on aws and use_mgmt is true, the monitor image should not contain scylla
@@ -59,7 +58,7 @@ backends: !mux
         cluster_backend: 'aws'
         user_credentials_path: '~/.ssh/scylla-qa-ec2'
         instance_type_loader: 'c4.large'
-        instance_type_monitor: 't2.small'
+        instance_type_monitor: 't3.small'
         instance_type_db: 'i3.4xlarge'
         us_east_1:
             region_name: 'us-east-1'

--- a/tests/longevity-staging.yaml
+++ b/tests/longevity-staging.yaml
@@ -56,8 +56,8 @@ backends: !mux
           gce_datacenter: 'us-east1-b'
     aws: !mux
         cluster_backend: 'aws'
-        instance_type_loader: 'c4.4xlarge'
-        instance_type_monitor: 'c4.2xlarge'
+        instance_type_loader: 'c5.large'
+        instance_type_monitor: 't3.small'
         us_east_1:
             region_name: 'us-east-1'
             security_group_ids: 'sg-c5e1f7a0'

--- a/tests/manager-regression-multiDC-set-distro.yaml
+++ b/tests/manager-regression-multiDC-set-distro.yaml
@@ -23,7 +23,7 @@ backends: !mux
         # loader instance by default.
         instance_type_loader: 'c4.large'
         # Size of AWS monitor instance
-        instance_type_monitor: 't2.small'
+        instance_type_monitor: 't3.small'
         user_credentials_path: '~/.ssh/scylla-qa-ec2'
         us_east_1_and_us_west_2:
             region_name: 'us-east-1 us-west-2'

--- a/tests/perf-regression-2mv.yaml
+++ b/tests/perf-regression-2mv.yaml
@@ -44,8 +44,8 @@ backends: !mux
     aws: !mux
         cluster_backend: 'aws'
         user_credentials_path: '~/.ssh/scylla-qa-ec2'
-        instance_type_loader: 'c4.2xlarge'
-        instance_type_monitor: 'c4.2xlarge'
+        instance_type_loader: 'c5.2xlarge'
+        instance_type_monitor: 't3.small'
         instance_type_db: 'i3.4xlarge'
         us_east_1:
             region_name: 'us-east-1'

--- a/tests/perf-regression-latency-1TB.yaml
+++ b/tests/perf-regression-latency-1TB.yaml
@@ -49,7 +49,7 @@ backends: !mux
         cluster_backend: 'aws'
         user_credentials_path: '~/.ssh/scylla-qa-ec2'
         instance_type_loader: 'c4.2xlarge'
-        instance_type_monitor: t2.small
+        instance_type_monitor: t3.small
         instance_type_db: 'i3.4xlarge'
         us_east_1:
             region_name: 'us-east-1'

--- a/tests/perf-regression-latency-500gb-30min.yaml
+++ b/tests/perf-regression-latency-500gb-30min.yaml
@@ -49,7 +49,7 @@ backends: !mux
         cluster_backend: 'aws'
         user_credentials_path: '~/.ssh/scylla-qa-ec2'
         instance_type_loader: 'c4.2xlarge'
-        instance_type_monitor: t2.small
+        instance_type_monitor: t3.small
         instance_type_db: 'i3.4xlarge'
         us_east_1:
             region_name: 'us-east-1'

--- a/tests/perf-regression-mv.100threads.30M-keys-i3.yaml
+++ b/tests/perf-regression-mv.100threads.30M-keys-i3.yaml
@@ -45,7 +45,7 @@ backends: !mux
         cluster_backend: 'aws'
         user_credentials_path: '~/.ssh/scylla-qa-ec2'
         instance_type_loader: 'c4.2xlarge'
-        instance_type_monitor: t2.small
+        instance_type_monitor: t3.small
         instance_type_db: 'i3.4xlarge'
         us_east_1:
             region_name: 'us-east-1'

--- a/tests/perf-regression-user-profiles.yaml
+++ b/tests/perf-regression-user-profiles.yaml
@@ -49,8 +49,8 @@ backends: !mux
     aws: !mux
         cluster_backend: 'aws'
         user_credentials_path: '~/.ssh/scylla-qa-ec2'
-        instance_type_loader: 'c4.4xlarge'
-        instance_type_monitor: 'c4.2xlarge'
+        instance_type_loader: 'c5.2xlarge'
+        instance_type_monitor: 't3.small'
         us_east_1:
             region_name: 'us-east-1'
             security_group_ids: 'sg-c5e1f7a0'

--- a/tests/perf-regression.100threads.30M-keys-i3.yaml
+++ b/tests/perf-regression.100threads.30M-keys-i3.yaml
@@ -44,7 +44,7 @@ backends: !mux
         cluster_backend: 'aws'
         user_credentials_path: '~/.ssh/scylla-qa-ec2'
         instance_type_loader: 'c4.2xlarge'
-        instance_type_monitor: t2.small
+        instance_type_monitor: t3.small
         instance_type_db: 'i3.2xlarge'
         us_east_1:
             region_name: 'us-east-1'

--- a/tests/perf-regression.100threads.30M-keys.yaml
+++ b/tests/perf-regression.100threads.30M-keys.yaml
@@ -42,7 +42,7 @@ backends: !mux
         cluster_backend: 'aws'
         user_credentials_path: '~/.ssh/scylla-qa-ec2'
         instance_type_loader: 'c4.2xlarge'
-        instance_type_monitor: t2.small
+        instance_type_monitor: t3.small
         instance_type_db: 'i3.2xlarge'
         us_east_1:
             region_name: 'us-east-1'

--- a/tests/repair-240mins-100G.yaml
+++ b/tests/repair-240mins-100G.yaml
@@ -55,8 +55,8 @@ backends: !mux
 
     aws: !mux
         cluster_backend: 'aws'
-        instance_type_loader: 'c4.4xlarge'
-        instance_type_monitor: 'c4.2xlarge'
+        instance_type_loader: 'c5.large'
+        instance_type_monitor: 't3.small'
         instance_type_db: 'i3.2xlarge'
         us_east_1:
             region_name: 'us-east-1'


### PR DESCRIPTION
1. Add "full_scan" load to all longevities.
2. Change provision type to "mixed" so the monitor and at least 1 node will be on_demand.

Changes to Yamls:
1. Use t3.small for monitor instances.
2. Use c5 instances in longevity loaders.

few other nipticks.