### PR TITLE
Fix possible test termination upon monitor node deploy

### DIFF
--- a/sdcm/remote.py
+++ b/sdcm/remote.py
@@ -1050,7 +1050,10 @@ class RemoteFabric(object):
             except Exception as details:
                 if i == retry:
                     self.log.error('Error executing command: {cmd}\ndetails: {details}'.format(**locals()))
-                    raise
+                    if isinstance(details, UnexpectedExit):
+                        raise process.CmdError(command=details.result.command, additional_text=details)
+                    else:
+                        raise
         if verbose:
             self.log.debug('Command {} finished with status {}'.format(result.command, result.exited))
         #     self.log.debug('STDOUT: {}'.format(result.stdout.encode('utf-8')))


### PR DESCRIPTION
For transition period, upon monitor node deploy, if docker containers
are not started from first time by any reason, test running could be
terminated due to another exception raised.