### PR TITLE
Longevity counters

### DIFF
--- a/tests/longevity-counters-4d-multidc.yaml
+++ b/tests/longevity-counters-4d-multidc.yaml
@@ -1,0 +1,51 @@
+test_duration: 5760
+#stress_cmd: "cassandra-stress user profile=/tmp/cs_mv_profile.yaml ops'(insert=1,read=1)' cl=QUORUM duration=5500m -port jmx=6868 -mode cql3 native -rate threads=100"
+cs_user_profiles:
+    scylla-qa-internal/cust_g/data_by_tracking_id.yaml
+cs_duration: '5500m'
+n_db_nodes: '6 6 6'
+n_loaders: 3
+n_monitor_nodes: 1
+monitor_branch: 'branch-2.2'
+user_prefix: longevity-counters-4d-VERSION
+failure_post_behavior: keep
+space_node_threshold: 6442
+ip_ssh_connections: 'public'
+
+ami_id_db_scylla_desc: counters-VERSION
+
+nemesis_class_name: 'ChaosMonkey'
+nemesis_interval: 15
+nemesis_during_prepare: 'false'
+
+append_scylla_args: '--blocked-reactor-notify-ms 500'
+
+use_mgmt: true
+mgmt_port: 10090
+scylla_repo_m: 'http://repositories.scylladb.com/scylla/repo/qa-test/centos/scylladb-2018.1.repo'
+scylla_mgmt_repo: 'http://repositories.scylladb.com/scylla/repo/qa-test/centos/scylladb-manager-1.3.repo'
+
+backends: !mux
+    aws: !mux
+        cluster_backend: 'aws'
+        instance_type_db: 'i3.2xlarge'
+        instance_type_loader: 'c5.large'
+        instance_type_monitor: 't3.small'
+        instance_provision: 'mixed'
+        user_credentials_path: '~/.ssh/scylla-qa-ec2'
+        us_east_1_and_us_west_2_and_eu_west_1:
+            region_name: 'us-east-1 us-west-2 eu-west-1'
+            security_group_ids: 'sg-c5e1f7a0 sg-81703ae4 sg-059a7f66a947d4b5c'
+            subnet_id: 'subnet-ec4a72c4 subnet-5207ee37 subnet-088fddaf520e4c7a8'
+            ami_id_db_scylla: 'AMI_ID_EAST AMI_ID_WEST AMI_ID_EU_WEST'
+            ami_db_scylla_user: 'centos'
+            ami_id_loader: 'ami-07797ae1c88489b80' # Loader dedicated AMI
+            ami_loader_user: 'centos'
+            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_monitor_user: 'centos'
+            aws_root_disk_size_monitor: 20  # GB
+
+
+databases: !mux
+    scylla:
+        db_type: scylla

--- a/tests/longevity-counters-4d-multidc.yaml
+++ b/tests/longevity-counters-4d-multidc.yaml
@@ -1,5 +1,5 @@
 test_duration: 5760
-#stress_cmd: "cassandra-stress user profile=/tmp/cs_mv_profile.yaml ops'(insert=1,read=1)' cl=QUORUM duration=5500m -port jmx=6868 -mode cql3 native -rate threads=100"
+#stress_cmd: Inside the user-profile file.
 cs_user_profiles:
     scylla-qa-internal/cust_g/data_by_tracking_id.yaml
 cs_duration: '5500m'
@@ -39,7 +39,7 @@ backends: !mux
             subnet_id: 'subnet-ec4a72c4 subnet-5207ee37 subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID_EAST AMI_ID_WEST AMI_ID_EU_WEST'
             ami_db_scylla_user: 'centos'
-            ami_id_loader: 'ami-07797ae1c88489b80' # Loader dedicated AMI
+            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
             ami_loader_user: 'centos'
             ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
             ami_monitor_user: 'centos'


### PR DESCRIPTION
This PR introducing new longevity test for counters workload in a multi-DC scenario.
The Schema is taken from a remote (private) repository that is cloned in the jenkins job (aka "user profile").

The PR was tested using job: 
http://jenkins.cloudius-systems.com:8080/job/scylla-3.0/job/3.0-test/job/scylla-longevity-counters-multi-DC-aws-test/

During my testing I had to use few commits from @fruch that hasn't merged yet + temporary fixes for multi-DC and public IP usages.