### PR TITLE
Manager v1.4 adjustments for sanity test support

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -31,9 +31,6 @@ class MgmtCliTest(ClusterTester):
 
     :avocado: enable
     """
-    MANAGER_IDENTITY_FILE_DIR = '/root/.ssh'
-    MANAGER_IDENTITY_FILE_NAME = 'scylla-manager.pem'
-    MANAGER_IDENTITY_FILE = os.path.join(MANAGER_IDENTITY_FILE_DIR, MANAGER_IDENTITY_FILE_NAME)
     CLUSTER_NAME = "mgr_cluster1"
 
     def test_mgmt_repair_nemesis(self):
@@ -69,7 +66,7 @@ class MgmtCliTest(ClusterTester):
         assert mgr_cluster.name == cluster_orig_name+"_renamed", "Cluster name wasn't changed after update command"
 
         origin_ssh_user = mgr_cluster.ssh_user
-        origin_rsa_id = self.MANAGER_IDENTITY_FILE
+        origin_rsa_id = mgmt.MANAGER_IDENTITY_FILE
         new_ssh_user = "centos"
         new_rsa_id = '/tmp/scylla-test'
 

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -31,7 +31,9 @@ class MgmtCliTest(ClusterTester):
 
     :avocado: enable
     """
-    MANAGER_IDENTITY_FILE = '/tmp/scylla_manager_pem'
+    MANAGER_IDENTITY_FILE_DIR = '/root/.ssh'
+    MANAGER_IDENTITY_FILE_NAME = 'scylla-manager.pem'
+    MANAGER_IDENTITY_FILE = os.path.join(MANAGER_IDENTITY_FILE_DIR, MANAGER_IDENTITY_FILE_NAME)
     CLUSTER_NAME = "mgr_cluster1"
 
     def test_mgmt_repair_nemesis(self):

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -19,7 +19,7 @@ import time
 from avocado import main
 
 from sdcm import mgmt
-from sdcm.mgmt import HostStatus, HostSsl
+from sdcm.mgmt import HostStatus, HostSsl, HostRestStatus
 from sdcm.nemesis import MgmtRepair
 from sdcm.tester import ClusterTester
 from sdcm.cluster import Setup
@@ -142,6 +142,8 @@ class MgmtCliTest(ClusterTester):
         dict_host_health = mgr_cluster.get_hosts_health()
         for host_health in dict_host_health.values():
             assert host_health.status == HostStatus.UP, "Not all hosts status is 'UP'"
+            assert host_health.rest_status == HostRestStatus.UP, "Not all hosts REST status is 'UP'"
+
 
         # Check for sctool status change after scylla-server down
         other_host.stop_scylla_server()
@@ -151,6 +153,8 @@ class MgmtCliTest(ClusterTester):
 
         dict_host_health = mgr_cluster.get_hosts_health()
         assert dict_host_health[other_host_ip].status == HostStatus.DOWN, "Host: {} status is not 'DOWN'".format(other_host_ip)
+        assert dict_host_health[other_host_ip].rest_status == HostRestStatus.DOWN, "Host: {} REST status is not 'DOWN'".format(other_host_ip)
+
         other_host.start_scylla_server()
 
     def test_manager_upgrade(self):

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -108,6 +108,9 @@ class MgmtCliTest(ClusterTester):
         mgr_cluster = manager_tool.add_cluster(name=self.CLUSTER_NAME+"_encryption", db_cluster=self.db_cluster)
         self._generate_load()
         repair_task = mgr_cluster.create_repair_task()
+        dict_host_health = mgr_cluster.get_hosts_health()
+        for host_health in dict_host_health.values():
+            assert host_health.ssl == HostSsl.OFF, "Not all hosts ssl is 'OFF'"
         self.db_cluster.enable_client_encrypt()
         mgr_cluster.update(client_encrypt=True)
         repair_task.start(use_continue=True)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1335,6 +1335,7 @@ server_encryption_options:
 
         if self.is_rhel_like():
             self.remoter.run('sudo yum install -y epel-release', retry=3)
+            self.remoter.run('sudo yum install python36-PyYAML -y', retry=3)
         else:
             self.remoter.run('sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B2BFD3660EF3F5B', retry=3)
             self.remoter.run('sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 17723034C56D4B19', retry=3)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1296,6 +1296,7 @@ server_encryption_options:
             self.remoter.run('sudo supervisorctl start scylla-manager')
         else:
             self.remoter.run('sudo systemctl restart scylla-manager.service')
+        time.sleep(5)
 
     def install_mgmt(self, scylla_repo, scylla_mgmt_repo):
         self.log.debug('Install scylla-manager')

--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -36,6 +36,13 @@ class HostSsl(Enum):
     ON = "ON"
     OFF = "OFF"
 
+    @classmethod
+    def from_str(cls, output_str):
+        try:
+            output_str = output_str.upper()
+            return getattr(cls, output_str)
+        except AttributeError:
+            raise ScyllaManagerError("Could not recognize returned task status: {}".format(output_str))
 
 class HostStatus(Enum):
     UP = "UP"
@@ -407,7 +414,7 @@ class ManagerCluster(ScyllaManagerBase):
                     status = list_cql[0]
                     rtt = list_cql[1].strip("()") if len(list_cql) == 2 else "N/A"
                     ssl = line[ssl_col_idx]
-                    dict_hosts_health[host] = self._HostHealth(status=HostStatus.from_str(status), rtt=rtt, ssl=ssl)
+                    dict_hosts_health[host] = self._HostHealth(status=HostStatus.from_str(status), rtt=rtt, ssl=HostSsl.from_str(ssl))
             logger.debug("Cluster {} Hosts Health is:".format(self.id))
             for ip, health in dict_hosts_health.items():
                 logger.debug("{}: {},{},{}".format(ip, health.status, health.rtt, health.ssl))

--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -458,25 +458,25 @@ class ScyllaManagerTool(ScyllaManagerBase):
         return ManagerCluster(manager_node=self.manager_node, cluster_id=cluster_id)
 
     def scylla_mgr_ssh_setup(self, node_ip, user='centos', identity_file='/tmp/scylla-test',
-                             manager_user='scylla-manager', manager_identity_file=MANAGER_IDENTITY_FILE):
+                             create_user=None):
         """
-        scyllamgr_ssh_setup -u <username> -i <path to private key> --m <manager username> -o <path to manager private key> [HOST...]
-          -u --user				SSH user name used to connect to hosts
-          -i --identity-file			path to identity file containing SSH private key
-          -m --manager-user			user name that will be created and configured on hosts, default scylla-manager
-          -o --manager-identity-file		path to identity file containing SSH private key for MANAGER_USERNAME, if there is no such file it will be created
-          -d --discover				use first host to discover and setup all hosts in a cluster
+        scyllamgr_ssh_setup [--ssh-user <username>] [--ssh-identity-file <path to private key>] [--ssh-config-file <path to SSH config file>] [--create-user <username>] [--single-node] [--debug] SCYLLA_NODE_IP
+           -u --ssh-user <username>        username used to connect to Scylla nodes, must be a sudo enabled user
+           -i --ssh-identity-file <file>        path to SSH identity file (private key) for user
+           -c --ssh-config-file <file>        path to alternate SSH configuration file, see man ssh_config
+              --create-user <username>        username that will be created on Scylla nodes, default scylla-manager
+              --single-node            setup the given node only, skip discovery of all the cluster nodes
+              --debug                display debug info
 
-
-        :param node_ip:
-        :param identity_file:
-        :param manager_user:
-        :return:
-
-        sudo scyllamgr_ssh_setup --user centos --identity-file /tmp/scylla-qa-ec2 --manager-user scylla-manager --manager-identity-file /tmp/scylla_manager_pem --discover 54.158.51.22"
+        sudo scyllamgr_ssh_setup -u centos -i /tmp/scylla-qa-ec2 192.168.100.11
         """
-        cmd = 'sudo scyllamgr_ssh_setup --user {} --identity-file {} --manager-user {} --manager-identity-file {} --discover {}'.format(
-            user, identity_file, manager_user, manager_identity_file, node_ip)
+        cmd = 'sudo scyllamgr_ssh_setup'
+        if create_user:
+            cmd += " --create-user {}".format(create_user)
+        # create-user
+        cmd += ' -u {} -i {} {}'.format(
+            user, identity_file, node_ip)
+
         logger.debug("SSH setup command is: {}".format(cmd))
         res = self.manager_node.remoter.run(cmd)
         MgrUtils.verify_errorless_result(cmd=cmd, res=res)

--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -392,22 +392,19 @@ class ManagerCluster(ScyllaManagerBase):
         Gets the Manager's Cluster Nodes status
         """
         # $ sctool status -c bla
-        # Datacenter: dc1
-        # ╭───────────┬──────────┬─────┬────────────────╮
-        # │ CQL       │ API      │ SSL │ Host           │
-        # ├───────────┼──────────┼─────┼────────────────┤
-        # │ UP (12ms) │ UP (3ms) │ OFF │ 192.168.100.11 │
-        # │ UP (5ms)  │ UP (3ms) │ OFF │ 192.168.100.12 │
-        # │ UP (4ms)  │ UP (2ms) │ OFF │ 192.168.100.13 │
-        # ╰───────────┴──────────┴─────┴────────────────╯
-        # Datacenter: dc2
-        # ╭───────────┬───────────┬─────┬────────────────╮
-        # │ CQL       │ API       │ SSL │ Host           │
-        # ├───────────┼───────────┼─────┼────────────────┤
-        # │ UP (10ms) │ UP (6ms)  │ OFF │ 192.168.100.21 │
-        # │ UP (4ms)  │ UP (5ms)  │ OFF │ 192.168.100.22 │
-        # │ UP (13ms) │ UP (10ms) │ OFF │ 192.168.100.23 │
-        # ╰───────────┴───────────┴─────┴────────────────╯
+        # 19:43:56 [107.23.100.82] [stdout] Datacenter: us-eastscylla_node_east
+        # 19:43:56 [107.23.100.82] [stdout] ╭──────────┬─────┬──────────┬────────────────╮
+        # 19:43:56 [107.23.100.82] [stdout] │ CQL      │ SSL │ REST     │ Host           │
+        # 19:43:56 [107.23.100.82] [stdout] ├──────────┼─────┼──────────┼────────────────┤
+        # 19:43:56 [107.23.100.82] [stdout] │ UP (0ms) │ OFF │ UP (0ms) │ 34.205.64.58   │
+        # 19:43:56 [107.23.100.82] [stdout] │ UP (0ms) │ OFF │ UP (0ms) │ 54.159.184.253 │
+        # 19:43:56 [107.23.100.82] [stdout] ╰──────────┴─────┴──────────┴────────────────╯
+        # 19:43:56 [107.23.100.82] [stdout] Datacenter: us-west-2scylla_node_west
+        # 19:43:56 [107.23.100.82] [stdout] ╭────────────┬─────┬───────────┬──────────────╮
+        # 19:43:56 [107.23.100.82] [stdout] │ CQL        │ SSL │ REST      │ Host         │
+        # 19:43:56 [107.23.100.82] [stdout] ├────────────┼─────┼───────────┼──────────────┤
+        # 19:43:56 [107.23.100.82] [stdout] │ UP (151ms) │ OFF │ UP (80ms) │ 34.219.6.187 │
+        # 19:43:56 [107.23.100.82] [stdout] ╰────────────┴─────┴───────────┴──────────────╯
         cmd = "status -c {}".format(self.id)
         dict_status_tables = self.sctool.run(cmd=cmd, is_verify_errorless_result=True, is_multiple_tables=True)
 
@@ -420,7 +417,7 @@ class ManagerCluster(ScyllaManagerBase):
                 host_col_idx = list_titles_row.index("Host")
                 cql_status_col_idx = list_titles_row.index("CQL")
                 ssl_col_idx = list_titles_row.index("SSL")
-                rest_col_idx = list_titles_row.index("API")
+                rest_col_idx = list_titles_row.index("REST")
 
                 for line in hosts_table[1:]:
                     host = line[host_col_idx]
@@ -477,7 +474,10 @@ class ScyllaManagerTool(ScyllaManagerBase):
         time.sleep(sleep)
         logger.debug("Initiating Scylla-Manager, version: {}".format(self.version))
         dict_distro_user = {Distro.CENTOS7: 'centos', Distro.DEBIAN8: 'admin', Distro.UBUNTU16: 'ubuntu'}
-        self.user = dict_distro_user[manager_node.distro] if manager_node.distro in dict_distro_user else 'N/A'
+        try:
+            self.user = dict_distro_user[manager_node.distro]
+        except KeyError as e:
+            raise ScyllaManagerError("Non-supported Distro found on Monitoring Node: {} - {}".format(manager_node.distro, e))
 
     @property
     def version(self):


### PR DESCRIPTION
Adding the mandatory adjustments in order for scylla-manager sanity test be updated with Manager 1.4 changes (that break backward compatibility)