### PR TITLE
verify_scylla_repo_file: allow comment line in repo

### DIFF
--- a/sdcm/utils.py
+++ b/sdcm/utils.py
@@ -150,10 +150,10 @@ def get_job_name():
 def verify_scylla_repo_file(content, is_rhel_like=True):
     logger.info('Verifying Scylla repo file')
     if is_rhel_like:
-        body_prefix = ['[scylla', 'name=', 'baseurl=', 'enabled=', 'gpgcheck=', 'type=',
+        body_prefix = ['#', '[scylla', 'name=', 'baseurl=', 'enabled=', 'gpgcheck=', 'type=',
                        'skip_if_unavailable=', 'gpgkey=', 'repo_gpgcheck=', 'enabled_metadata=']
     else:
-        body_prefix = ['deb']
+        body_prefix = ['#', 'deb']
     for line in content.split('\n'):
         valid_prefix = False
         for prefix in body_prefix:


### PR DESCRIPTION
I found some comment line exist in unstable 3.0 repo of ubuntu 16.04,
we should treat it as valid.

$ curl http://downloads.scylladb.com.s3.amazonaws.com/deb/unstable/xenial/branch-3.0/121/scylladb-3.0/scylla.list
  deb [arch=amd64] http://downloads.scylladb.com/deb/unstable/xenial/branch-3.0/121/scylladb-3.0 xenial multiverse
  #deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu xenial main
  deb http://ppa.launchpad.net/scylladb/ppa/ubuntu xenial main
