### PR TITLE
workaround: Install the python36 version of PyYAML

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1042,6 +1042,7 @@ client_encryption_options:
                 self.remoter.run('sudo yum update -y --skip-broken', retry=3)
             self.remoter.run('sudo yum install -y rsync tcpdump screen wget net-tools')
             self.download_scylla_repo(scylla_repo)
+            self.remoter.run('sudo yum install -y python36-PyYAML')
             self.remoter.run('sudo yum install -y {}'.format(self.scylla_pkg()))
             self.remoter.run('sudo yum install -y scylla-gdb', ignore_status=True)
         else:


### PR DESCRIPTION
Reference:
https://docs.scylladb.com/troubleshooting/python-error-no-module-named-yaml/
