### PR TITLE
_run_nodetool: fix NameError

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -144,6 +144,7 @@ class Nemesis(object):
                            result.duration)
             return result
         except (UnexpectedExit, Failure):
+        except (UnexpectedExit, Failure) as details:
             err = ("nodetool command '%s' failed on node %s: %s" %
                    (cmd, node, details.result))
             self.error_list.append(err)


### PR DESCRIPTION
NameError: global name 'details' is not defined
This issue was introduced by commit dd716c863ad3cf4cba1899a3ec3f500ec6150198

/CC @aleksbykov 