### PR TITLE
sdcm/fill_db_data.py: use CL=QUORUM

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -23,6 +23,7 @@ from uuid import UUID
 from avocado import main
 from cassandra import InvalidRequest
 from cassandra.util import sortedset
+from cassandra import ConsistencyLevel
 
 from sdcm.tester import ClusterTester
 
@@ -2907,6 +2908,8 @@ class FillDatabaseData(ClusterTester):
         # Prepare connection and keyspace
         node = self.db_cluster.nodes[0]
         session = self.cql_connection_patient(node)
+        # override driver consistency level
+        session.default_consistency_level = ConsistencyLevel.QUORUM
 
         session.execute("""
             CREATE KEYSPACE IF NOT EXISTS keyspace1
@@ -2924,6 +2927,8 @@ class FillDatabaseData(ClusterTester):
         # Prepare connection
         node = self.db_cluster.nodes[0]
         session = self.cql_connection_patient(node)
+        # override driver consistency level
+        session.default_consistency_level = ConsistencyLevel.QUORUM
 
         session.execute("USE keyspace1;")
 


### PR DESCRIPTION
Counter can't be updated correctly when use ConsistencyLevel.ONE.
The correct CL is QUORUM, this patch changed all tests in fill_db_data.py
use CL=QUORUM.

Related issue: https://github.com/scylladb/scylla/issues/4362
