### PR TITLE
use clean CentOS7 for monitor & use fixed AMI name in config files for loader/monitor

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -8,13 +8,13 @@ regions_data:
   us-east-1:
     security_group_ids: 'sg-c5e1f7a0'
     subnet_id: 'subnet-ec4a72c4'
-    ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-    ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+    ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+    ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
   eu-west-1:
     security_group_ids: 'sg-059a7f66a947d4b5c'
     subnet_id: 'subnet-088fddaf520e4c7a8'
-    ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-    ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+    ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+    ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
 
 aws_root_disk_size_monitor: 20  # GB, remove this field if default disk size should be used
 aws_root_disk_name_monitor: "/dev/sda1"  # use "/dev/xvda" for Debian 8 image

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2411,6 +2411,9 @@ class BaseLoaderSet(object):
             self.kill_stress_thread()
             return
 
+        cs_exporter_setup = CassandraStressExporterSetup()
+        cs_exporter_setup.install(node)
+
         result = node.remoter.run('test -e ~/PREPARED-LOADER', ignore_status=True)
         if result.exit_status == 0:
             self.log.debug('Skip loader setup for using a prepared AMI')
@@ -2456,8 +2459,6 @@ class BaseLoaderSet(object):
             node.remoter.run("echo 'export DB_ADDRESS=%s' >> $HOME/.bashrc" % db_node_address)
 
         node.wait_cs_installed(verbose=verbose)
-        cs_exporter_setup = CassandraStressExporterSetup()
-        cs_exporter_setup.install(node)
 
         # scylla-bench
         node.remoter.run('sudo yum install git -y')

--- a/tests/aws-grow-cluster-200nodes.yaml
+++ b/tests/aws-grow-cluster-200nodes.yaml
@@ -30,8 +30,8 @@ backends: !mux
             security_group_ids: 'sg-5e79983a'
             subnet_id: 'subnet-ad3ce9f4'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'
@@ -40,8 +40,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/corrupt-then-rebuild.yaml
+++ b/tests/corrupt-then-rebuild.yaml
@@ -42,8 +42,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'
@@ -52,8 +52,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/destroy-data-then-repair.yaml
+++ b/tests/destroy-data-then-repair.yaml
@@ -43,8 +43,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'
@@ -53,8 +53,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/dns-cluster-5min.yaml
+++ b/tests/dns-cluster-5min.yaml
@@ -43,8 +43,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'
@@ -53,8 +53,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/enospc-30mins.yaml
+++ b/tests/enospc-30mins.yaml
@@ -37,8 +37,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'
@@ -47,8 +47,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/gemini_test.yaml
+++ b/tests/gemini_test.yaml
@@ -39,9 +39,9 @@ backends: !mux
             subnet_id: 'subnet-c327759a'
             ami_db_scylla_user: 'centos'
             ami_id_db_scylla: 'AMI-ID'
-            ami_id_loader: 'AMI-ID'
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_loader_user: 'centos'
-            ami_id_monitor: 'AMI-ID'
             ami_monitor_user: 'centos'
 
 databases: !mux

--- a/tests/hinted-handoff.yaml
+++ b/tests/hinted-handoff.yaml
@@ -33,8 +33,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-ec4a72c4'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'
@@ -43,8 +43,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/janus-graph.yaml
+++ b/tests/janus-graph.yaml
@@ -34,8 +34,8 @@ backends: !mux
             security_group_ids: 'sg-81703ae4'
             subnet_id: 'subnet-5207ee37'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_monitor: 'AMI_ID'
-            ami_id_loader: 'AMI_ID'
+            ami_id_loader: 'ami-0011d4855d80b3127'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-01ed306a12b7d1c96'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'
@@ -44,8 +44,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'
@@ -54,8 +54,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/longevity-1TB-7days-authorization-and-tls-ssl.yaml
+++ b/tests/longevity-1TB-7days-authorization-and-tls-ssl.yaml
@@ -76,8 +76,8 @@ backends: !mux
             security_group_ids: 'sg-5e79983a'
             subnet_id: 'subnet-c327759a'
             ami_id_db_scylla: 'AMI-ID'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             aws_root_disk_size_monitor: 20  # GB
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
@@ -87,8 +87,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             aws_root_disk_size_monitor: 20  # GB
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/longevity-1TB-7days.yaml
+++ b/tests/longevity-1TB-7days.yaml
@@ -69,8 +69,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI-ID'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             aws_root_disk_size_monitor: 20  # GB
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
@@ -80,8 +80,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             aws_root_disk_size_monitor: 20  # GB
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
+++ b/tests/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
@@ -64,8 +64,8 @@ backends: !mux
             security_group_ids: 'sg-5e79983a'
             subnet_id: 'subnet-c327759a'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'
@@ -74,8 +74,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/longevity-2mv-backpressure-4d.yaml
+++ b/tests/longevity-2mv-backpressure-4d.yaml
@@ -62,8 +62,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-ec4a72c4'
             ami_id_db_scylla: 'AMI-ID'
-            ami_id_loader: 'AMI-ID'
-            ami_id_monitor: 'ami-9887c6e7' # Clean CentOs 7 ami
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/longevity-48h-verify-multiDC.yaml
+++ b/tests/longevity-48h-verify-multiDC.yaml
@@ -36,8 +36,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0 sg-81703ae4'
             subnet_id: 'subnet-ec4a72c4 subnet-5207ee37'
             ami_id_db_scylla: 'AMI_ID_EAST AMI_ID_WEST'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'
@@ -48,8 +48,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c sg-81703ae4'
             subnet_id: 'subnet-088fddaf520e4c7a8 subnet-5207ee37'
             ami_id_db_scylla: 'AMI_ID_EU_WEST AMI_ID_US_WEST'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/longevity-50GB-4days-authorization-and-tls-ssl.yaml
+++ b/tests/longevity-50GB-4days-authorization-and-tls-ssl.yaml
@@ -72,8 +72,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI-ID'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-3eff0028'
@@ -85,8 +85,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI-ID'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             aws_root_disk_size_monitor: 20  # GB
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/longevity-50GB-4days.yaml
+++ b/tests/longevity-50GB-4days.yaml
@@ -67,8 +67,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI-ID'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-3eff0028'
@@ -80,8 +80,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI-ID'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/longevity-counters-4d-multidc.yaml
+++ b/tests/longevity-counters-4d-multidc.yaml
@@ -39,9 +39,9 @@ backends: !mux
             subnet_id: 'subnet-ec4a72c4 subnet-5207ee37 subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID_EAST AMI_ID_WEST AMI_ID_EU_WEST'
             ami_db_scylla_user: 'centos'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
             ami_loader_user: 'centos'
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_monitor_user: 'centos'
             aws_root_disk_size_monitor: 20  # GB
 

--- a/tests/longevity-in-memory-36GB-4days.yaml
+++ b/tests/longevity-in-memory-36GB-4days.yaml
@@ -65,8 +65,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-ec4a72c4'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'
@@ -76,8 +76,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/longevity-large-partition-4days.yaml
+++ b/tests/longevity-large-partition-4days.yaml
@@ -64,22 +64,22 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-ec4a72c4'
             ami_id_db_scylla: 'AMI-ID'
-            ami_id_loader: 'AMI-ID'
-            ami_id_monitor: 'ami-9887c6e7' # Clean CentOs 7 ami
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             aws_root_disk_size_monitor: 20  # GB
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'
         eu_west_1:
-                    region_name: 'eu-west-1'
-                    security_group_ids: 'sg-059a7f66a947d4b5c'
-                    subnet_id: 'subnet-088fddaf520e4c7a8'
-                    ami_id_db_scylla: 'AMI_ID'
-                    ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-                    ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
-                    ami_db_scylla_user: 'centos'
-                    ami_loader_user: 'centos'
-                    ami_monitor_user: 'centos'
+            region_name: 'eu-west-1'
+            security_group_ids: 'sg-059a7f66a947d4b5c'
+            subnet_id: 'subnet-088fddaf520e4c7a8'
+            ami_id_db_scylla: 'AMI_ID'
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
+            ami_db_scylla_user: 'centos'
+            ami_loader_user: 'centos'
+            ami_monitor_user: 'centos'
 
 databases: !mux
     cassandra:

--- a/tests/longevity-multi-keyspaces.yaml
+++ b/tests/longevity-multi-keyspaces.yaml
@@ -40,8 +40,8 @@ backends: !mux
             security_group_ids: 'sg-5e79983a'
             subnet_id: 'subnet-c327759a'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             aws_root_disk_size_monitor: 20  # GB
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
@@ -51,8 +51,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/longevity-mv-si-4days.yaml
+++ b/tests/longevity-mv-si-4days.yaml
@@ -65,8 +65,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-ec4a72c4'
             ami_id_db_scylla: 'AMI-ID'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             aws_root_disk_size_monitor: 20  # GB
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
@@ -76,8 +76,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/longevity-staging.yaml
+++ b/tests/longevity-staging.yaml
@@ -63,8 +63,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-3eff0028'
@@ -76,8 +76,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/manager-regression-multiDC-set-distro.yaml
+++ b/tests/manager-regression-multiDC-set-distro.yaml
@@ -31,7 +31,7 @@ backends: !mux
             subnet_id: 'subnet-ec4a72c4 subnet-5207ee37'
             ami_id_db_scylla: 'AMI_ID_EAST AMI_ID_WEST'
             ami_db_scylla_user: 'centos'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-ada2b6c4'
             ami_db_cassandra_user: 'ubuntu'
@@ -42,8 +42,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c sg-81703ae4'
             subnet_id: 'subnet-088fddaf520e4c7a8 subnet-5207ee37'
             ami_id_db_scylla: 'AMI_ID_EU_WEST AMI_ID_US_WEST'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/master_doc.yaml
+++ b/tests/master_doc.yaml
@@ -157,12 +157,12 @@ backends: !mux
             security_group_ids: 'sg-dcd785b9'
             subnet_id: 'subnet-10a04c75'
             ami_id_db_scylla: 'ami-19eca679'
+            ami_id_loader: 'ami-0dad569a4bdbc86a1'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-074e2d6769f445be5'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
-            ami_id_loader: 'ami-19eca679'
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-3cf7c979'
             ami_db_cassandra_user: 'ubuntu'
-            ami_id_monitor: 'ami-19eca679'
             ami_monitor_user: 'centos'
         us_west_2:
             user_credentials_path: ''
@@ -170,12 +170,12 @@ backends: !mux
             security_group_ids: 'sg-81703ae4'
             subnet_id: 'subnet-5207ee37'
             ami_id_db_scylla: 'ami-ec3e9e8c'
+            ami_id_loader: 'ami-0011d4855d80b3127'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-01ed306a12b7d1c96'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
-            ami_id_loader: 'ami-ec3e9e8c'
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-1cff962c'
             ami_db_cassandra_user: 'ubuntu'
-            ami_id_monitor: 'ami-ec3e9e8c'
             ami_monitor_user: 'centos'
         us_east_1:
             user_credentials_path: ''
@@ -183,12 +183,12 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-ec4a72c4'
             ami_id_db_scylla: 'ami-79d3f06e'
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
-            ami_id_loader: 'ami-79d3f06e'
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-ada2b6c4'
             ami_db_cassandra_user: 'ubuntu'
-            ami_id_monitor: 'ami-79d3f06e'
             ami_monitor_user: 'centos'
         #multiple datacenters
         us_east_1_and_us_west_2:
@@ -197,12 +197,12 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0 sg-81703ae4'
             subnet_id: 'subnet-ec4a72c4 subnet-5207ee37'
             ami_id_db_scylla: 'ami-79d3f06e ami-ec3e9e8c'
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
-            ami_id_loader: 'ami-79d3f06e'
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-ada2b6c4'
             ami_db_cassandra_user: 'ubuntu'
-            ami_id_monitor: 'ami-79d3f06e'
             ami_monitor_user: 'centos'
 
     openstack: !mux

--- a/tests/perf-regression-2mv.yaml
+++ b/tests/perf-regression-2mv.yaml
@@ -52,8 +52,8 @@ backends: !mux
             security_group_ids: 'sg-5e79983a'
             subnet_id: 'subnet-c327759a'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'
@@ -62,8 +62,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/perf-regression-latency-1TB.yaml
+++ b/tests/perf-regression-latency-1TB.yaml
@@ -56,8 +56,8 @@ backends: !mux
             security_group_ids: 'sg-5e79983a'
             subnet_id: 'subnet-c327759a'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'
@@ -66,8 +66,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/perf-regression-latency-500gb-30min.yaml
+++ b/tests/perf-regression-latency-500gb-30min.yaml
@@ -56,8 +56,8 @@ backends: !mux
             security_group_ids: 'sg-5e79983a'
             subnet_id: 'subnet-c327759a'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'
@@ -66,8 +66,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/perf-regression-latency-in-memory.yaml
+++ b/tests/perf-regression-latency-in-memory.yaml
@@ -60,8 +60,8 @@ backends: !mux
             security_group_ids: 'sg-5e79983a'
             subnet_id: 'subnet-c327759a'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'
@@ -70,8 +70,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/perf-regression-mv.100threads.30M-keys-i3.yaml
+++ b/tests/perf-regression-mv.100threads.30M-keys-i3.yaml
@@ -52,8 +52,8 @@ backends: !mux
             security_group_ids: 'sg-5e79983a'
             subnet_id: 'subnet-c327759a'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'
@@ -62,8 +62,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/perf-regression-user-profiles.yaml
+++ b/tests/perf-regression-user-profiles.yaml
@@ -56,8 +56,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-3eff0028'
@@ -68,8 +68,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/perf-regression.100threads.30M-keys-i3.yaml
+++ b/tests/perf-regression.100threads.30M-keys-i3.yaml
@@ -51,8 +51,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-ec4a72c4'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'
@@ -61,8 +61,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/perf-regression.100threads.30M-keys.yaml
+++ b/tests/perf-regression.100threads.30M-keys.yaml
@@ -49,8 +49,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-ec4a72c4'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'
@@ -59,8 +59,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/refresh-30mins-100mb.yaml
+++ b/tests/refresh-30mins-100mb.yaml
@@ -42,8 +42,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'
@@ -52,8 +52,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/refresh-30mins-120gb.yaml
+++ b/tests/refresh-30mins-120gb.yaml
@@ -44,8 +44,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'
@@ -54,8 +54,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/repair-240mins-100G.yaml
+++ b/tests/repair-240mins-100G.yaml
@@ -63,8 +63,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'
@@ -73,8 +73,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/sample.yaml
+++ b/tests/sample.yaml
@@ -71,8 +71,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-ec4a72c4'
             ami_id_db_scylla: 'ami-b4f8b4cb'  # Scylla 2.2 AMI
-            ami_id_loader: 'ami-050c06c3e20036edc' # Loader dedicated AMI
-            ami_id_monitor: 'ami-01d6b0d7e0d98969b' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0878efb77c212f4d3'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             aws_root_disk_size_monitor: 10  # GB, remove this field if default disk size should be used
             aws_root_disk_name_monitor: "/dev/sda1"  # use "/dev/xvda" for Debian 8 image
             ami_db_scylla_user: 'centos'
@@ -83,8 +83,8 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
-            ami_id_monitor: 'ami-0f478f18d613e3662' # Monitor dedicated AMI
+            ami_id_loader: 'ami-0e47e49f5ac9b11ad'  # Loader dedicated AMI
+            ami_id_monitor: 'ami-0ff760d16d9497662'  # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'


### PR DESCRIPTION
Let's use this public clean centos7, which is also used as base to build scylla ami. (https://github.com/scylladb/scylla/blob/master/dist/ami/build_ami.sh#L61)
I just created an instance, it's clean, no scylla stuffs.

us-east-1: ami-ae7bfdb8
us-west-1: ami-7c280d1c
us-west-2: ami-0c2aba6c
eu-west-1: ami-0d063c6b
eu-west-2: ami-c22236a6

Loader:
us-east-1: ami-050c06c3e20036edc
us-west-1: ami-0ce02e670b7ab726a
us-west-2: ami-05e91e409f39e7046
eu-west-1: ami-0006222380fb72d8d
eu-west-2: ami-0a0ab32338be1d1d0
