### PR TITLE
kill_stress_thread: kill cassandra-stress processes one by one

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2598,7 +2598,7 @@ class BaseLoaderSet(object):
         return queue
 
     def kill_stress_thread(self):
-        kill_script_contents = 'PIDS=$(pgrep -f cassandra-stress) && pkill -TERM -P $PIDS'
+        kill_script_contents = 'for PID in `pgrep -f cassandra-stress`; do pkill -TERM -P $PID; done'
         kill_script = script.TemporaryScript(name='kill_cassandra_stress.sh',
                                              content=kill_script_contents)
         kill_script.save()


### PR DESCRIPTION
Currently we append all PIDs in pkill commandline, but I saw the following
error:
  08:29:30 pkill: only one pattern can be provided
  08:29:30 Try `pkill --help' for more information.