### PR TITLE
Grafana monitor: fix nemesis dashboard config

### DIFF
--- a/data_dir/scylla-dash-per-server-nemesis.2.1.json
+++ b/data_dir/scylla-dash-per-server-nemesis.2.1.json
@@ -454,7 +454,7 @@
                         "renderer": "flot",
                         "seriesOverrides": [
                              {
-                                 "alias": "/method=\"[a-z]/",
+                                 "alias": "/method=\"[a-zA-Z]/",
                                  "fill": 2,
                                  "lines": true,
                                  "yaxis": 2

--- a/data_dir/scylla-dash-per-server-nemesis.2.2.json
+++ b/data_dir/scylla-dash-per-server-nemesis.2.2.json
@@ -454,7 +454,7 @@
                         "renderer": "flot",
                         "seriesOverrides": [
                              {
-                                 "alias": "/method=\"[a-z]/",
+                                 "alias": "/method=\"[a-zA-Z]/",
                                  "fill": 2,
                                  "lines": true,
                                  "yaxis": 2

--- a/data_dir/scylla-dash-per-server-nemesis.2.3.json
+++ b/data_dir/scylla-dash-per-server-nemesis.2.3.json
@@ -448,7 +448,12 @@
                         "points": false,
                         "renderer": "flot",
                         "seriesOverrides": [
-                            {}
+                            {
+                                "alias": "/method=\"[a-zA-Z]/",
+                                 "fill": 2,
+                                 "lines": true,
+                                 "yaxis": 2
+                            }
                         ],
                         "spaceLength": 10,
                         "span": 5,

--- a/data_dir/scylla-dash-per-server-nemesis.2017.1.json
+++ b/data_dir/scylla-dash-per-server-nemesis.2017.1.json
@@ -451,7 +451,7 @@
                         "renderer": "flot",
                         "seriesOverrides": [
                              {
-                                 "alias": "/method=\"[a-z]/",
+                                 "alias": "/method=\"[a-zA-Z]/",
                                  "fill": 2,
                                  "lines": true,
                                  "yaxis": 2

--- a/data_dir/scylla-dash-per-server-nemesis.2018.1.json
+++ b/data_dir/scylla-dash-per-server-nemesis.2018.1.json
@@ -436,7 +436,7 @@
                         "renderer": "flot",
                         "seriesOverrides": [
                              {
-                                 "alias": "/method=\"[a-z]/",
+                                 "alias": "/method=\"[a-zA-Z]/",
                                  "fill": 2,
                                  "lines": true,
                                  "yaxis": 2

--- a/data_dir/scylla-dash-per-server-nemesis.2019.1.json
+++ b/data_dir/scylla-dash-per-server-nemesis.2019.1.json
@@ -441,7 +441,7 @@
                         "renderer": "flot",
                         "seriesOverrides": [
                             {
-                                "alias": "/method=\"[a-z]/",
+                                "alias": "/method=\"[a-zA-Z]/",
                                  "fill": 2,
                                  "lines": true,
                                  "yaxis": 2

--- a/data_dir/scylla-dash-per-server-nemesis.3.0.json
+++ b/data_dir/scylla-dash-per-server-nemesis.3.0.json
@@ -441,7 +441,7 @@
                         "renderer": "flot",
                         "seriesOverrides": [
                             {
-                                "alias": "/method=\"[a-z]/",
+                                "alias": "/method=\"[a-zA-Z]/",
                                  "fill": 2,
                                  "lines": true,
                                  "yaxis": 2

--- a/data_dir/scylla-dash-per-server-nemesis.master.json
+++ b/data_dir/scylla-dash-per-server-nemesis.master.json
@@ -448,7 +448,12 @@
                         "points": false,
                         "renderer": "flot",
                         "seriesOverrides": [
-                            {}
+                            {
+                                "alias": "/method=\"[a-zA-Z]/",
+                                 "fill": 2,
+                                 "lines": true,
+                                 "yaxis": 2
+                            }
                         ],
                         "spaceLength": 10,
                         "span": 5,


### PR DESCRIPTION
* Current nemesis dashboard of 2019.1:
![image](https://user-images.githubusercontent.com/309708/56420829-241c4f00-62d2-11e9-8f9f-1bf9919dc92d.png)

* Fixed nemesis dashboard
![image](https://user-images.githubusercontent.com/309708/56420803-0a7b0780-62d2-11e9-89d7-afd363bc151d.png)
