### PR TITLE
additional fix for loader/monitor ami-id

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2411,6 +2411,9 @@ class BaseLoaderSet(object):
             self.kill_stress_thread()
             return
 
+        cs_exporter_setup = CassandraStressExporterSetup()
+        cs_exporter_setup.install(node)
+
         result = node.remoter.run('test -e ~/PREPARED-LOADER', ignore_status=True)
         if result.exit_status == 0:
             self.log.debug('Skip loader setup for using a prepared AMI')
@@ -2456,8 +2459,6 @@ class BaseLoaderSet(object):
             node.remoter.run("echo 'export DB_ADDRESS=%s' >> $HOME/.bashrc" % db_node_address)
 
         node.wait_cs_installed(verbose=verbose)
-        cs_exporter_setup = CassandraStressExporterSetup()
-        cs_exporter_setup.install(node)
 
         # scylla-bench
         node.remoter.run('sudo yum install git -y')

--- a/tests/gemini_test.yaml
+++ b/tests/gemini_test.yaml
@@ -39,9 +39,9 @@ backends: !mux
             subnet_id: 'subnet-c327759a'
             ami_db_scylla_user: 'centos'
             ami_id_db_scylla: 'AMI-ID'
-            ami_id_loader: 'AMI-ID'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
             ami_loader_user: 'centos'
-            ami_id_monitor: 'AMI-ID'
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_monitor_user: 'centos'
 
 databases: !mux

--- a/tests/janus-graph.yaml
+++ b/tests/janus-graph.yaml
@@ -34,8 +34,8 @@ backends: !mux
             security_group_ids: 'sg-81703ae4'
             subnet_id: 'subnet-5207ee37'
             ami_id_db_scylla: 'AMI_ID'
+            ami_id_loader: 'ami-0011d4855d80b3127' # Loader dedicated AMI
             ami_id_monitor: 'ami-01ed306a12b7d1c96' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
-            ami_id_loader: 'ami-0011d4855d80b3127'
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/longevity-2mv-backpressure-4d.yaml
+++ b/tests/longevity-2mv-backpressure-4d.yaml
@@ -62,7 +62,7 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-ec4a72c4'
             ami_id_db_scylla: 'AMI-ID'
-            ami_id_loader: 'AMI-ID'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/master_doc.yaml
+++ b/tests/master_doc.yaml
@@ -171,7 +171,7 @@ backends: !mux
             subnet_id: 'subnet-5207ee37'
             ami_id_db_scylla: 'ami-ec3e9e8c'
             ami_db_scylla_user: 'centos'
-            ami_id_loader: 'ami-ec3e9e8c'
+            ami_id_loader: 'ami-0011d4855d80b3127' # Loader dedicated AMI
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-1cff962c'
             ami_db_cassandra_user: 'ubuntu'
@@ -198,11 +198,11 @@ backends: !mux
             subnet_id: 'subnet-ec4a72c4 subnet-5207ee37'
             ami_id_db_scylla: 'ami-79d3f06e ami-ec3e9e8c'
             ami_db_scylla_user: 'centos'
-            ami_id_loader: 'ami-79d3f06e'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-ada2b6c4'
             ami_db_cassandra_user: 'ubuntu'
-            ami_id_monitor: 'ami-79d3f06e'
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_monitor_user: 'centos'
 
     openstack: !mux

--- a/tests/perf-regression-latency-in-memory.yaml
+++ b/tests/perf-regression-latency-in-memory.yaml
@@ -70,7 +70,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-0006222380fb72d8d' # Loader dedicated AMI
+            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'


### PR DESCRIPTION
Some un-serious change was missing in https://github.com/scylladb/scylla-cluster-tests/pull/920