### PR TITLE
Backport PR #920 to SCT branch-3.0

### DIFF
--- a/data_dir/scylla.yaml
+++ b/data_dir/scylla.yaml
@@ -103,12 +103,12 @@ backends: !mux
             security_group_ids: 'sg-dcd785b9'
             subnet_id: 'subnet-10a04c75'
             ami_id_db_scylla: 'ami-19eca679'
+            ami_id_loader: 'ami-0dad569a4bdbc86a1' # Loader dedicated AMI
+            ami_id_monitor: 'ami-074e2d6769f445be5' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
-            ami_id_loader: 'ami-19eca679'
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-3cf7c979'
             ami_db_cassandra_user: 'ubuntu'
-            ami_id_monitor: 'ami-19eca679'
             ami_monitor_user: 'centos'
         us_west_2:
             user_credentials_path: ''
@@ -116,12 +116,12 @@ backends: !mux
             security_group_ids: 'sg-81703ae4'
             subnet_id: 'subnet-5207ee37'
             ami_id_db_scylla: 'ami-ec3e9e8c'
+            ami_id_monitor: 'ami-01ed306a12b7d1c96' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
+            ami_id_loader: 'ami-0011d4855d80b3127' # Loader dedicated AMI
             ami_db_scylla_user: 'centos'
-            ami_id_loader: 'ami-ec3e9e8c'
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-1cff962c'
             ami_db_cassandra_user: 'ubuntu'
-            ami_id_monitor: 'ami-ec3e9e8c'
             ami_monitor_user: 'centos'
         us_east_1:
             user_credentials_path: ''
@@ -129,12 +129,12 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-ec4a72c4'
             ami_id_db_scylla: 'ami-79d3f06e'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
-            ami_id_loader: 'ami-79d3f06e'
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-ada2b6c4'
             ami_db_cassandra_user: 'ubuntu'
-            ami_id_monitor: 'ami-79d3f06e'
             ami_monitor_user: 'centos'
         #multiple datacenters
         us_east_1_and_us_west_2:
@@ -143,12 +143,12 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0 sg-81703ae4'
             subnet_id: 'subnet-ec4a72c4 subnet-5207ee37'
             ami_id_db_scylla: 'ami-79d3f06e ami-ec3e9e8c'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
-            ami_id_loader: 'ami-79d3f06e'
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-ada2b6c4'
             ami_db_cassandra_user: 'ubuntu'
-            ami_id_monitor: 'ami-79d3f06e'
             ami_monitor_user: 'centos'
 
     openstack: !mux

--- a/tests/aws-grow-cluster-200nodes.yaml
+++ b/tests/aws-grow-cluster-200nodes.yaml
@@ -27,12 +27,12 @@ backends: !mux
             security_group_ids: 'sg-5e79983a'
             subnet_id: 'subnet-ad3ce9f4'
             ami_id_db_scylla: 'ami-56373b2d'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
-            ami_id_loader: 'ami-56373b2d'
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-3eff0028'
             ami_db_cassandra_user: 'ubuntu'
-            ami_id_monitor: 'ami-56373b2d'
             ami_monitor_user: 'centos'
     gce: !mux
         cluster_backend: 'gce'

--- a/tests/corrupt-then-rebuild.yaml
+++ b/tests/corrupt-then-rebuild.yaml
@@ -45,8 +45,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_monitor: 'AMI_ID'
-            ami_id_loader: 'AMI_ID'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/destroy-data-then-repair.yaml
+++ b/tests/destroy-data-then-repair.yaml
@@ -46,8 +46,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_monitor: 'AMI_ID'
-            ami_id_loader: 'AMI_ID'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/dns-cluster-5min.yaml
+++ b/tests/dns-cluster-5min.yaml
@@ -46,8 +46,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_monitor: 'AMI_ID'
-            ami_id_loader: 'AMI_ID'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/enospc-30mins.yaml
+++ b/tests/enospc-30mins.yaml
@@ -40,8 +40,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_monitor: 'AMI_ID'
-            ami_id_loader: 'AMI_ID'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/gce-multidc-1.7.yaml
+++ b/tests/gce-multidc-1.7.yaml
@@ -36,12 +36,12 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0 sg-81703ae4'
             subnet_id: 'subnet-ec4a72c4 subnet-5207ee37'
             ami_id_db_scylla: 'ami-40a0e756 ami-77e78617'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
-            ami_id_loader: 'ami-40a0e756'
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-ada2b6c4'
             ami_db_cassandra_user: 'ubuntu'
-            ami_id_monitor: 'ami-40a0e756'
             ami_monitor_user: 'centos'
     gce: !mux
         cluster_backend: 'gce'

--- a/tests/google-cloud-snitch.yaml
+++ b/tests/google-cloud-snitch.yaml
@@ -45,12 +45,12 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'ami-29035f52'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
-            ami_id_loader: 'ami-29035f52'
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-3eff0028'
             ami_db_cassandra_user: 'ubuntu'
-            ami_id_monitor: 'ami-29035f52'
             ami_monitor_user: 'centos'
 
 databases: !mux

--- a/tests/hinted-handoff.yaml
+++ b/tests/hinted-handoff.yaml
@@ -33,8 +33,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-ec4a72c4'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_monitor: 'AMI_ID'
-            ami_id_loader: 'AMI_ID'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/janus-graph.yaml
+++ b/tests/janus-graph.yaml
@@ -37,8 +37,8 @@ backends: !mux
             security_group_ids: 'sg-81703ae4'
             subnet_id: 'subnet-5207ee37'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_monitor: 'AMI_ID'
-            ami_id_loader: 'AMI_ID'
+            ami_id_monitor: 'ami-01ed306a12b7d1c96' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
+            ami_id_loader: 'ami-0011d4855d80b3127' # Loader dedicated AMI
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'
@@ -47,8 +47,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_monitor: 'AMI_ID'
-            ami_id_loader: 'AMI_ID'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/longevity-1TB-7days-authorization-and-tls-ssl.yaml
+++ b/tests/longevity-1TB-7days-authorization-and-tls-ssl.yaml
@@ -76,8 +76,8 @@ backends: !mux
             security_group_ids: 'sg-5e79983a'
             subnet_id: 'subnet-c327759a'
             ami_id_db_scylla: 'AMI-ID'
-            ami_id_loader: 'AMI-ID'
-            ami_id_monitor: 'AMI-ID'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             aws_root_disk_size_monitor: 20  # GB
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/longevity-1TB-7days.yaml
+++ b/tests/longevity-1TB-7days.yaml
@@ -72,8 +72,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI-ID'
-            ami_id_loader: 'AMI-ID'
-            ami_id_monitor: 'AMI-ID'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             aws_root_disk_size_monitor: 20  # GB
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
+++ b/tests/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
@@ -61,8 +61,8 @@ backends: !mux
             security_group_ids: 'sg-5e79983a'
             subnet_id: 'subnet-c327759a'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_monitor: 'AMI_ID'
-            ami_id_loader: 'AMI_ID'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/longevity-50GB-4days-authorization-and-tls-ssl.yaml
+++ b/tests/longevity-50GB-4days-authorization-and-tls-ssl.yaml
@@ -65,12 +65,12 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'ami-29035f52'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
-            ami_id_loader: 'ami-29035f52'
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-3eff0028'
             ami_db_cassandra_user: 'ubuntu'
-            ami_id_monitor: 'ami-29035f52'
             aws_root_disk_size_monitor: 20  # GB
             ami_monitor_user: 'centos'
 

--- a/tests/longevity-50GB-4days.yaml
+++ b/tests/longevity-50GB-4days.yaml
@@ -67,12 +67,12 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'ami-29035f52'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
-            ami_id_loader: 'ami-29035f52'
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-3eff0028'
             ami_db_cassandra_user: 'ubuntu'
-            ami_id_monitor: 'ami-29035f52'
             aws_root_disk_size_monitor: 20  # GB
             ami_monitor_user: 'centos'
 

--- a/tests/longevity-multi-keyspaces.yaml
+++ b/tests/longevity-multi-keyspaces.yaml
@@ -40,8 +40,8 @@ backends: !mux
             security_group_ids: 'sg-5e79983a'
             subnet_id: 'subnet-c327759a'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'AMI_ID'
-            ami_id_monitor: 'AMI_ID'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             aws_root_disk_size_monitor: 20  # GB
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/longevity-mv-si-4days.yaml
+++ b/tests/longevity-mv-si-4days.yaml
@@ -68,8 +68,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-ec4a72c4'
             ami_id_db_scylla: 'AMI-ID'
-            ami_id_loader: 'AMI-ID'
-            ami_id_monitor: 'AMI-ID'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             aws_root_disk_size_monitor: 20  # GB
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/longevity-staging.yaml
+++ b/tests/longevity-staging.yaml
@@ -61,12 +61,12 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'ami-29035f52'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
-            ami_id_loader: 'ami-29035f52'
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-3eff0028'
             ami_db_cassandra_user: 'ubuntu'
-            ami_id_monitor: 'ami-29035f52'
             ami_monitor_user: 'centos'
             aws_root_disk_size_monitor: 20  # GB
 

--- a/tests/old/aws-longevity-1.6-1TB-7days.yaml
+++ b/tests/old/aws-longevity-1.6-1TB-7days.yaml
@@ -49,12 +49,12 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-ec4a72c4'
             ami_id_db_scylla: 'ami-3eff0028'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
-            ami_id_loader: 'ami-3eff0028'
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-3eff0028'
             ami_db_cassandra_user: 'ubuntu'
-            ami_id_monitor: 'ami-3eff0028'
             ami_monitor_user: 'centos'
 
 databases: !mux

--- a/tests/old/aws-longevity-1.6.2-1TB-7days-leveled.yaml
+++ b/tests/old/aws-longevity-1.6.2-1TB-7days-leveled.yaml
@@ -49,12 +49,12 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-ec4a72c4'
             ami_id_db_scylla: 'ami-5ba00c4d'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
-            ami_id_loader: 'ami-5ba00c4d'
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-5ba00c4d'
             ami_db_cassandra_user: 'ubuntu'
-            ami_id_monitor: 'ami-5ba00c4d'
             ami_monitor_user: 'centos'
 
 databases: !mux

--- a/tests/old/aws-sstable-1.7.yaml
+++ b/tests/old/aws-sstable-1.7.yaml
@@ -19,12 +19,12 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'ami-7e137d68'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
-            ami_id_loader: 'ami-7e137d68'
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-3eff0028'
             ami_db_cassandra_user: 'ubuntu'
-            ami_id_monitor: 'ami-3d101f2a'
             ami_monitor_user: 'centos'
 
 databases: !mux

--- a/tests/perf-regression-2mv.yaml
+++ b/tests/perf-regression-2mv.yaml
@@ -55,8 +55,8 @@ backends: !mux
             security_group_ids: 'sg-5e79983a'
             subnet_id: 'subnet-c327759a'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'AMI_ID'
-            ami_id_monitor: 'AMI_ID'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/perf-regression-latency-1TB.yaml
+++ b/tests/perf-regression-latency-1TB.yaml
@@ -61,8 +61,8 @@ backends: !mux
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'AMI_ID'
-            ami_id_monitor: 'AMI_ID'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
 
 databases: !mux
     cassandra:

--- a/tests/perf-regression-mv.100threads.30M-keys-i3.yaml
+++ b/tests/perf-regression-mv.100threads.30M-keys-i3.yaml
@@ -57,8 +57,8 @@ backends: !mux
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'AMI_ID'
-            ami_id_monitor: 'AMI_ID'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
 
     docker: !mux
         cluster_backend: 'docker'

--- a/tests/perf-regression-user-profiles.yaml
+++ b/tests/perf-regression-user-profiles.yaml
@@ -59,12 +59,12 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'ami-7e137d68'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
-            ami_id_loader: 'ami-7e137d68'
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-3eff0028'
             ami_db_cassandra_user: 'ubuntu'
-            ami_id_monitor: 'ami-3d101f2a'
             ami_monitor_user: 'centos'
 
 databases: !mux

--- a/tests/perf-regression.100threads.30M-keys-i3.yaml
+++ b/tests/perf-regression.100threads.30M-keys-i3.yaml
@@ -56,8 +56,8 @@ backends: !mux
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'AMI_ID'
-            ami_id_monitor: 'AMI_ID'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
 
     docker: !mux
         cluster_backend: 'docker'

--- a/tests/perf-regression.100threads.30M-keys.yaml
+++ b/tests/perf-regression.100threads.30M-keys.yaml
@@ -55,8 +55,8 @@ backends: !mux
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'AMI_ID'
-            ami_id_monitor: 'AMI_ID'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
 
     docker: !mux
         cluster_backend: 'docker'

--- a/tests/refresh-30mins-100mb.yaml
+++ b/tests/refresh-30mins-100mb.yaml
@@ -45,8 +45,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_monitor: 'AMI_ID'
-            ami_id_loader: 'AMI_ID'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/refresh-30mins-120gb.yaml
+++ b/tests/refresh-30mins-120gb.yaml
@@ -47,8 +47,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_monitor: 'AMI_ID'
-            ami_id_loader: 'AMI_ID'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/repair-240mins-100G.yaml
+++ b/tests/repair-240mins-100G.yaml
@@ -66,8 +66,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'AMI_ID'
-            ami_id_monitor: 'AMI_ID'
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
             ami_monitor_user: 'centos'

--- a/tests/sample.yaml
+++ b/tests/sample.yaml
@@ -54,8 +54,8 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-ec4a72c4'
             ami_id_db_scylla: 'ami-b4f8b4cb'  # Scylla 2.2 AMI
-            ami_id_monitor: 'ami-b4f8b4cb'  # Scylla 2.2 AMI
-            ami_id_loader: 'ami-b4f8b4cb'  # Scylla 2.2 AMI
+            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             aws_root_disk_size_monitor: 10  # GB
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'


### PR DESCRIPTION
I tried to backport AMI/loader patches from (v1.v2.v3.v4) one by one, but there are many repeated conflicts. We can just update it to latest one (monitor: v3, loader: v4)

```
    Updating AMIs to latest loader and clean CentOS 7 1901_01
    
    Manually backport PR #920 (commit cd988159f5d9644ed212db9f2d03226b0e554921) to
    branch-3.0 to avoid conflicts. In future, we can just use sed to replace to new
    version.
    
    Checked by:
    
    $ git grep '^\ *region_name:'|sed -e 's/.*region_name:/region_name:/g'|sort -n|uniq  -c
       1 region_name: 'us-east-1 us-west-1'
       2 region_name: 'us-east-1 us-west-2'
      29 region_name: 'us-east-1'
       1 region_name: 'us-west-1'
       2 region_name: 'us-west-2'
    
    $ git grep ami_id|egrep "(loader:|monitor:)"|sed -e 's/.*ami_id/ami_id/g'|sort -n|uniq -c
       2 ami_id_loader: 'ami-0011d4855d80b3127' # Loader dedicated AMI
      32 ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
       1 ami_id_loader: 'ami-0dad569a4bdbc86a1' # Loader dedicated AMI
       2 ami_id_monitor: 'ami-01ed306a12b7d1c96' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
      32 ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
       1 ami_id_monitor: 'ami-074e2d6769f445be5' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
```