### PR TITLE
Added support for Ubuntu18

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -487,6 +487,9 @@ class BaseNode(object):
         if self.is_ubuntu16() and ubuntu16_pkgs:
             self.remoter.run('sudo apt-get install -y %s' % ubuntu16_pkgs)
             return
+        if self.is_ubuntu18() and ubuntu18_pkgs:
+            self.remoter.run('sudo apt-get install -y %s' % ubuntu18_pkgs)
+            return
         if self.is_ubuntu14() and ubuntu14_pkgs:
             self.remoter.run('sudo apt-get install -y %s' % ubuntu14_pkgs)
             return

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2511,7 +2511,10 @@ class BaseLoaderSet(object):
             """)
             node.remoter.run('sudo bash -cxe "%s"' % install_java_script)
 
-        node.download_scylla_repo(self.params.get('scylla_repo'))
+        scylla_repo_loader = self.params.get('scylla_repo_loader')
+        if not scylla_repo_loader:
+            scylla_repo_loader = self.params.get('scylla_repo')
+        node.download_scylla_repo(scylla_repo_loader)
         if node.is_rhel_like():
             node.remoter.run('sudo yum install -y {}-tools'.format(node.scylla_pkg()))
             node.remoter.run('sudo yum install -y screen')

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1359,6 +1359,9 @@ server_encryption_options:
                     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B2BFD3660EF3F5B
                     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 17723034C56D4B19
                     add-apt-repository -y ppa:scylladb/ppa
+                    apt-get update
+                    apt-get install -y openjdk-8-jre-headless
+                    update-java-alternatives -s java-1.8.0-openjdk-amd64
                 """)
                 self.remoter.run('sudo bash -cxe "%s"' % install_prereqs)
             elif self.is_debian8():

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1353,6 +1353,14 @@ server_encryption_options:
                 self.remoter.run('sudo apt-get update')
                 self.remoter.run('sudo apt-get install -y openjdk-8-jre-headless')
                 self.remoter.run('sudo update-java-alternatives -s java-1.8.0-openjdk-amd64')
+            elif self.is_ubuntu18() or self.is_ubuntu16():
+                install_prereqs = dedent("""
+                    apt-get install software-properties-common -y
+                    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B2BFD3660EF3F5B
+                    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 17723034C56D4B19
+                    add-apt-repository -y ppa:scylladb/ppa
+                """)
+                self.remoter.run('sudo bash -cxe "%s"' % install_prereqs)
             elif self.is_debian8():
                 self.remoter.run("sudo sed -i -e 's/jessie-updates/stable-updates/g' /etc/apt/sources.list")
                 self.remoter.run('echo "deb http://archive.debian.org/debian jessie-backports main" |sudo tee /etc/apt/sources.list.d/backports.list')

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -420,6 +420,8 @@ class BaseNode(object):
                 distro = Distro.UBUNTU14
             elif 'Ubuntu 16.04' in result.stdout:
                 distro = Distro.UBUNTU16
+            elif 'Ubuntu 18.04' in result.stdout:
+                distro = Distro.UBUNTU18
             elif 'Debian GNU/Linux 8' in result.stdout:
                 distro = Distro.DEBIAN8
             elif 'Debian GNU/Linux 9' in result.stdout:
@@ -455,8 +457,11 @@ class BaseNode(object):
     def is_ubuntu16(self):
         return self.distro == Distro.UBUNTU16
 
+    def is_ubuntu18(self):
+        return self.distro == Distro.UBUNTU18
+
     def is_ubuntu(self):
-        return self.distro == Distro.UBUNTU16 or self.distro == Distro.UBUNTU14
+        return self.distro == Distro.UBUNTU16 or self.distro == Distro.UBUNTU14 or self.distro == Distro.UBUNTU18
 
     def is_debian8(self):
         return self.distro == Distro.DEBIAN8

--- a/sdcm/collectd.py
+++ b/sdcm/collectd.py
@@ -397,12 +397,12 @@ LoadPlugin processes
         if self.node.is_rhel_like():
             # Disable SELinux to allow the unix socket plugin to work
             self.node.remoter.run('sudo setenforce 0', ignore_status=True)
-        if self.node.is_rhel_like() or self.node.is_ubuntu16():
+        if self.node.is_rhel_like() or self.node.is_ubuntu16() or self.node.is_ubuntu18():
             self.node.remoter.run('sudo systemctl enable collectd.service')
         if self.node.is_docker():
             self.node.remoter.run('sudo /usr/sbin/collectd')
         else:
-            if self.node.is_rhel_like() or self.node.is_ubuntu16():
+            if self.node.is_rhel_like() or self.node.is_ubuntu16() or self.node.is_ubuntu18():
                 self.node.remoter.run('sudo systemctl restart collectd.service')
             else:
                 self.node.remoter.run('sudo service collectd restart')
@@ -435,7 +435,7 @@ WantedBy=multi-user.target
             if self.node.is_docker():
                 self.node.remoter.run('sudo {} -collectd.listen-address=:65534 &'.format(self.collectd_exporter_path))
             else:
-                if self.node.is_rhel_like() or self.node.is_ubuntu16():
+                if self.node.is_rhel_like() or self.node.is_ubuntu16() or self.node.is_ubuntu18():
                     self.node.remoter.run('sudo systemctl start collectd-exporter.service')
                 else:
                     self.node.remoter.run('sudo service collectd-exporter start')

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -148,6 +148,9 @@ class SCTConfiguration(dict):
 
              help="Url to the repo of scylla version to install scylla from for managment tests"),
 
+        dict(name="scylla_repo_loader", env="SCT_SCYLLA_REPO_LOADER", type=str,
+             help="Url to the repo of scylla version to install c-s for loader"),
+
         dict(name="scylla_mgmt_repo", env="SCT_SCYLLA_MGMT_REPO",
              type=str,
              help="Url to the repo of scylla manager version to install for management tests"),

--- a/sdcm/utils.py
+++ b/sdcm/utils.py
@@ -144,8 +144,9 @@ class Distro(Enum):
     RHEL7 = 2
     UBUNTU14 = 3
     UBUNTU16 = 4
-    DEBIAN8 = 5
-    DEBIAN9 = 6
+    UBUNTU18 = 5
+    DEBIAN8 = 6
+    DEBIAN9 = 7
 
 
 def get_data_dir_path(*args):


### PR DESCRIPTION
We don't have AMI for Ubuntu 18, so we need to test rolling upgrade of Ubuntu18 with GCE backends.
We might also use this to test virt-manager on Ubuntu 18.04 in future.