### PR TITLE
loaer_ami v5: add shard aware driver

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -8,12 +8,12 @@ regions_data:
   us-east-1:
     security_group_ids: 'sg-c5e1f7a0'
     subnet_id: 'subnet-ec4a72c4'
-    ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+    ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
     ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
   eu-west-1:
     security_group_ids: 'sg-059a7f66a947d4b5c'
     subnet_id: 'subnet-088fddaf520e4c7a8'
-    ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+    ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
     ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
 
 aws_root_disk_size_monitor: 20  # GB, remove this field if default disk size should be used

--- a/tests/aws-grow-cluster-200nodes.yaml
+++ b/tests/aws-grow-cluster-200nodes.yaml
@@ -30,7 +30,7 @@ backends: !mux
             security_group_ids: 'sg-5e79983a'
             subnet_id: 'subnet-ad3ce9f4'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
@@ -40,7 +40,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/corrupt-then-rebuild.yaml
+++ b/tests/corrupt-then-rebuild.yaml
@@ -42,7 +42,7 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
@@ -52,7 +52,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/destroy-data-then-repair.yaml
+++ b/tests/destroy-data-then-repair.yaml
@@ -43,7 +43,7 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
@@ -53,7 +53,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/dns-cluster-5min.yaml
+++ b/tests/dns-cluster-5min.yaml
@@ -43,7 +43,7 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
@@ -53,7 +53,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/enospc-30mins.yaml
+++ b/tests/enospc-30mins.yaml
@@ -37,7 +37,7 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
@@ -47,7 +47,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/gemini_test.yaml
+++ b/tests/gemini_test.yaml
@@ -39,7 +39,7 @@ backends: !mux
             subnet_id: 'subnet-c327759a'
             ami_db_scylla_user: 'centos'
             ami_id_db_scylla: 'AMI-ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_loader_user: 'centos'
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_monitor_user: 'centos'

--- a/tests/hinted-handoff.yaml
+++ b/tests/hinted-handoff.yaml
@@ -33,7 +33,7 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-ec4a72c4'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
@@ -43,7 +43,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/janus-graph.yaml
+++ b/tests/janus-graph.yaml
@@ -34,7 +34,7 @@ backends: !mux
             security_group_ids: 'sg-81703ae4'
             subnet_id: 'subnet-5207ee37'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-0011d4855d80b3127' # Loader dedicated AMI
+            ami_id_loader: 'ami-0e4373a35e7d9ccdb' # Loader dedicated AMI
             ami_id_monitor: 'ami-01ed306a12b7d1c96' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
@@ -44,7 +44,7 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
@@ -54,7 +54,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/longevity-1TB-7days-authorization-and-tls-ssl.yaml
+++ b/tests/longevity-1TB-7days-authorization-and-tls-ssl.yaml
@@ -76,7 +76,7 @@ backends: !mux
             security_group_ids: 'sg-5e79983a'
             subnet_id: 'subnet-c327759a'
             ami_id_db_scylla: 'AMI-ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             aws_root_disk_size_monitor: 20  # GB
             ami_db_scylla_user: 'centos'
@@ -87,7 +87,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             aws_root_disk_size_monitor: 20  # GB
             ami_db_scylla_user: 'centos'

--- a/tests/longevity-1TB-7days.yaml
+++ b/tests/longevity-1TB-7days.yaml
@@ -69,7 +69,7 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI-ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             aws_root_disk_size_monitor: 20  # GB
             ami_db_scylla_user: 'centos'
@@ -80,7 +80,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             aws_root_disk_size_monitor: 20  # GB
             ami_db_scylla_user: 'centos'

--- a/tests/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
+++ b/tests/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
@@ -64,7 +64,7 @@ backends: !mux
             security_group_ids: 'sg-5e79983a'
             subnet_id: 'subnet-c327759a'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
@@ -74,7 +74,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/longevity-2mv-backpressure-4d.yaml
+++ b/tests/longevity-2mv-backpressure-4d.yaml
@@ -62,7 +62,7 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-ec4a72c4'
             ami_id_db_scylla: 'AMI-ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/longevity-48h-verify-multiDC.yaml
+++ b/tests/longevity-48h-verify-multiDC.yaml
@@ -36,7 +36,7 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0 sg-81703ae4'
             subnet_id: 'subnet-ec4a72c4 subnet-5207ee37'
             ami_id_db_scylla: 'AMI_ID_EAST AMI_ID_WEST'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
@@ -48,7 +48,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c sg-81703ae4'
             subnet_id: 'subnet-088fddaf520e4c7a8 subnet-5207ee37'
             ami_id_db_scylla: 'AMI_ID_EU_WEST AMI_ID_US_WEST'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/longevity-50GB-4days-authorization-and-tls-ssl.yaml
+++ b/tests/longevity-50GB-4days-authorization-and-tls-ssl.yaml
@@ -72,7 +72,7 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI-ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
@@ -85,7 +85,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI-ID'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             aws_root_disk_size_monitor: 20  # GB
             ami_db_scylla_user: 'centos'

--- a/tests/longevity-50GB-4days.yaml
+++ b/tests/longevity-50GB-4days.yaml
@@ -67,7 +67,7 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI-ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
@@ -80,7 +80,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI-ID'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/longevity-counters-4d-multidc.yaml
+++ b/tests/longevity-counters-4d-multidc.yaml
@@ -39,7 +39,7 @@ backends: !mux
             subnet_id: 'subnet-ec4a72c4 subnet-5207ee37 subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID_EAST AMI_ID_WEST AMI_ID_EU_WEST'
             ami_db_scylla_user: 'centos'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_loader_user: 'centos'
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_monitor_user: 'centos'

--- a/tests/longevity-in-memory-36GB-4days.yaml
+++ b/tests/longevity-in-memory-36GB-4days.yaml
@@ -65,7 +65,7 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-ec4a72c4'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
@@ -76,7 +76,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/longevity-large-partition-4days.yaml
+++ b/tests/longevity-large-partition-4days.yaml
@@ -64,7 +64,7 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-ec4a72c4'
             ami_id_db_scylla: 'AMI-ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             aws_root_disk_size_monitor: 20  # GB
             ami_db_scylla_user: 'centos'
@@ -75,7 +75,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/longevity-multi-keyspaces.yaml
+++ b/tests/longevity-multi-keyspaces.yaml
@@ -40,7 +40,7 @@ backends: !mux
             security_group_ids: 'sg-5e79983a'
             subnet_id: 'subnet-c327759a'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             aws_root_disk_size_monitor: 20  # GB
             ami_db_scylla_user: 'centos'
@@ -51,7 +51,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/longevity-mv-si-4days.yaml
+++ b/tests/longevity-mv-si-4days.yaml
@@ -65,7 +65,7 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-ec4a72c4'
             ami_id_db_scylla: 'AMI-ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             aws_root_disk_size_monitor: 20  # GB
             ami_db_scylla_user: 'centos'
@@ -76,7 +76,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/longevity-staging.yaml
+++ b/tests/longevity-staging.yaml
@@ -63,7 +63,7 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
@@ -76,7 +76,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/manager-regression-multiDC-set-distro.yaml
+++ b/tests/manager-regression-multiDC-set-distro.yaml
@@ -31,7 +31,7 @@ backends: !mux
             subnet_id: 'subnet-ec4a72c4 subnet-5207ee37'
             ami_id_db_scylla: 'AMI_ID_EAST AMI_ID_WEST'
             ami_db_scylla_user: 'centos'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-ada2b6c4'
             ami_db_cassandra_user: 'ubuntu'
@@ -42,7 +42,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c sg-81703ae4'
             subnet_id: 'subnet-088fddaf520e4c7a8 subnet-5207ee37'
             ami_id_db_scylla: 'AMI_ID_EU_WEST AMI_ID_US_WEST'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/master_doc.yaml
+++ b/tests/master_doc.yaml
@@ -158,7 +158,7 @@ backends: !mux
             subnet_id: 'subnet-10a04c75'
             ami_id_db_scylla: 'ami-19eca679'
             ami_db_scylla_user: 'centos'
-            ami_id_loader: 'ami-0dad569a4bdbc86a1' # Loader dedicated AMI
+            ami_id_loader: 'ami-0a2ac860155a18864' # Loader dedicated AMI
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-3cf7c979'
             ami_db_cassandra_user: 'ubuntu'
@@ -171,7 +171,7 @@ backends: !mux
             subnet_id: 'subnet-5207ee37'
             ami_id_db_scylla: 'ami-ec3e9e8c'
             ami_db_scylla_user: 'centos'
-            ami_id_loader: 'ami-0011d4855d80b3127' # Loader dedicated AMI
+            ami_id_loader: 'ami-0e4373a35e7d9ccdb' # Loader dedicated AMI
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-1cff962c'
             ami_db_cassandra_user: 'ubuntu'
@@ -184,7 +184,7 @@ backends: !mux
             subnet_id: 'subnet-ec4a72c4'
             ami_id_db_scylla: 'ami-79d3f06e'
             ami_db_scylla_user: 'centos'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-ada2b6c4'
             ami_db_cassandra_user: 'ubuntu'
@@ -198,7 +198,7 @@ backends: !mux
             subnet_id: 'subnet-ec4a72c4 subnet-5207ee37'
             ami_id_db_scylla: 'ami-79d3f06e ami-ec3e9e8c'
             ami_db_scylla_user: 'centos'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_loader_user: 'centos'
             ami_id_db_cassandra: 'ami-ada2b6c4'
             ami_db_cassandra_user: 'ubuntu'

--- a/tests/perf-regression-2mv.yaml
+++ b/tests/perf-regression-2mv.yaml
@@ -52,7 +52,7 @@ backends: !mux
             security_group_ids: 'sg-5e79983a'
             subnet_id: 'subnet-c327759a'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
@@ -62,7 +62,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/perf-regression-latency-1TB.yaml
+++ b/tests/perf-regression-latency-1TB.yaml
@@ -56,7 +56,7 @@ backends: !mux
             security_group_ids: 'sg-5e79983a'
             subnet_id: 'subnet-c327759a'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
@@ -66,7 +66,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/perf-regression-latency-500gb-30min.yaml
+++ b/tests/perf-regression-latency-500gb-30min.yaml
@@ -56,7 +56,7 @@ backends: !mux
             security_group_ids: 'sg-5e79983a'
             subnet_id: 'subnet-c327759a'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
@@ -66,7 +66,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/perf-regression-latency-in-memory.yaml
+++ b/tests/perf-regression-latency-in-memory.yaml
@@ -60,7 +60,7 @@ backends: !mux
             security_group_ids: 'sg-5e79983a'
             subnet_id: 'subnet-c327759a'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
@@ -70,7 +70,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/perf-regression-mv.100threads.30M-keys-i3.yaml
+++ b/tests/perf-regression-mv.100threads.30M-keys-i3.yaml
@@ -52,7 +52,7 @@ backends: !mux
             security_group_ids: 'sg-5e79983a'
             subnet_id: 'subnet-c327759a'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
@@ -62,7 +62,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/perf-regression-user-profiles.yaml
+++ b/tests/perf-regression-user-profiles.yaml
@@ -56,7 +56,7 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
@@ -68,7 +68,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/perf-regression.100threads.30M-keys-i3.yaml
+++ b/tests/perf-regression.100threads.30M-keys-i3.yaml
@@ -51,7 +51,7 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-ec4a72c4'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
@@ -61,7 +61,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/perf-regression.100threads.30M-keys.yaml
+++ b/tests/perf-regression.100threads.30M-keys.yaml
@@ -49,7 +49,7 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-ec4a72c4'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
@@ -59,7 +59,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/refresh-30mins-100mb.yaml
+++ b/tests/refresh-30mins-100mb.yaml
@@ -42,7 +42,7 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
@@ -52,7 +52,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/refresh-30mins-120gb.yaml
+++ b/tests/refresh-30mins-120gb.yaml
@@ -44,7 +44,7 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
@@ -54,7 +54,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/repair-240mins-100G.yaml
+++ b/tests/repair-240mins-100G.yaml
@@ -63,7 +63,7 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-d934e980'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'
@@ -73,7 +73,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'

--- a/tests/sample.yaml
+++ b/tests/sample.yaml
@@ -71,7 +71,7 @@ backends: !mux
             security_group_ids: 'sg-c5e1f7a0'
             subnet_id: 'subnet-ec4a72c4'
             ami_id_db_scylla: 'ami-b4f8b4cb'  # Scylla 2.2 AMI
-            ami_id_loader: 'ami-059dd02510b5f5841' # Loader dedicated AMI
+            ami_id_loader: 'ami-0803fc42f8277925f' # Loader dedicated AMI
             ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             aws_root_disk_size_monitor: 10  # GB, remove this field if default disk size should be used
             aws_root_disk_name_monitor: "/dev/sda1"  # use "/dev/xvda" for Debian 8 image
@@ -83,7 +83,7 @@ backends: !mux
             security_group_ids: 'sg-059a7f66a947d4b5c'
             subnet_id: 'subnet-088fddaf520e4c7a8'
             ami_id_db_scylla: 'AMI_ID'
-            ami_id_loader: 'ami-07d0df7186ef5adc5' # Loader dedicated AMI
+            ami_id_loader: 'ami-0668349068972415c' # Loader dedicated AMI
             ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
             ami_db_scylla_user: 'centos'
             ami_loader_user: 'centos'


### PR DESCRIPTION
Added a binary /usr/bin/cassandra-stress-share-aware in loader,
which will use share-aware driver.

Details
```
1. build shard aware java driver

 $ git clone https://github.com/scylladb/java-driver.git
 $ cd java-driver/
 $ git checkout -b 3.5.1-scylla origin/3.5.1-scylla
 $ mvn install OR  mvn clean package
 $ find .|grep cassandra-driver-core.*jar
./driver-core/target/cassandra-driver-core-3.5.1.jar
./driver-core/target/cassandra-driver-core-3.5.1-tests.jar
./driver-core/target/cassandra-driver-core-3.5.1-sources.jar
./driver-core/target/cassandra-driver-core-3.5.1-test-sources.jar
./driver-core/target/cassandra-driver-core-3.5.1-shaded.jar

2. build scylla-tools-java (c-s)
  $ git clone https://github.com/scylladb/scylla-tools-java/
  $ cd scylla-tools-java/
  # add cassandra-stress-share-aware script
    https://github.com/amoskong/scylla-tools-java/commits/shard-aware-cs
  $ ant
  $ yum install build/redhat/RPMS/noarch/scylla-tools.*rpm

```