### PR TITLE
Fix relative import

### DIFF
--- a/sdcm/remote.py
+++ b/sdcm/remote.py
@@ -28,7 +28,7 @@ from invoke.watchers import StreamWatcher, Responder
 from avocado.utils import astring
 from avocado.utils import path
 
-from .log import SDCMAdapter
+from log import SDCMAdapter
 
 
 LOGGER_NAME = 'avocado.test'

--- a/sdcm/utils.py
+++ b/sdcm/utils.py
@@ -25,7 +25,7 @@ import select
 import sys
 import math
 
-from .remote import LocalCmdRunner
+from remote import LocalCmdRunner
 from textwrap import dedent
 from functools import wraps
 from collections import defaultdict


### PR DESCRIPTION
Before fix
`scylla-cluster-tests$ hydra python ./sdcm/microbenchmarking.py --help
Docker version 18.09.4, build d14af54266
scylladb/hydra      v0.34               c53c15a68584        8 days ago          1.23GB
Image up-to-date
Obtaining QA SSH keys...
QA private key '/home/abykov/.ssh/scylla-qa-ec2' exists. Nothing to update.
QA private key '/home/abykov/.ssh/scylla-test' exists. Nothing to update.
QA private key '/home/abykov/.ssh/support' exists. Nothing to update.
QA SSH keys obtained.
Making sure the ownerships of avocado directories are of the user
running  python
Traceback (most recent call last):
  File "./sdcm/microbenchmarking.py", line 11, in <module>
    from results_analyze import BaseResultsAnalyzer
  File "/sct/sdcm/results_analyze.py", line 9, in <module>
    from db_stats import TestStatsMixin
  File "/sct/sdcm/db_stats.py", line 17, in <module>
    from utils import get_job_name, retrying, remove_comments
  File "/sct/sdcm/utils.py", line 28, in <module>
    from .remote import LocalCmdRunner
ValueError: Attempted relative import in non-package
`
After Fix
`scylla-cluster-tests$ hydra python ./sdcm/microbenchmarking.py --help
Docker version 18.09.4, build d14af54266
scylladb/hydra      v0.34               c53c15a68584        8 days ago          1.23GB
Image up-to-date
Obtaining QA SSH keys...
QA private key '/home/abykov/.ssh/scylla-qa-ec2' exists. Nothing to update.
QA private key '/home/abykov/.ssh/scylla-test' exists. Nothing to update.
QA private key '/home/abykov/.ssh/support' exists. Nothing to update.
QA SSH keys obtained.
Making sure the ownerships of avocado directories are of the user
running  python
usage: microbenchmarking.py [-h] Modes ...

Microbencmarking stats utility for upload and analyze or exclude test result from future analyze

optional arguments:
  -h, --help  show this help message and exit

Microbencmarking utility modes:
  Microbencmarking could be run in two modes definded by subcommand

  Modes       To see subcommand help use microbenchmarking.py subcommand -h
    exclude   Exclude results by testrun, testid or date
    check     Upload and analyze test result
`