### PR TITLE
Fix start avocado if SCT_NEW_CONFIG env var was set

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -933,7 +933,7 @@ class SCTConfiguration(dict):
 
         # check if there are SCT_* environment variable which aren't documented
         config_keys = set([opt['env'] for opt in self.config_options])
-        env_keys = set([o for o in os.environ.keys() if o.startswith('SCT_')])
+        env_keys = set([o for o in os.environ.keys() if o.startswith('SCT_') and o != 'SCT_NEW_CONFIG'])
         unknown_env_keys = (env_keys.difference(config_keys))
         if unknown_env_keys:
             output = ["{}={}".format(key, os.environ.get(key)) for key in unknown_env_keys]


### PR DESCRIPTION
If start hydra with SCT_NEW_CONFIG env var, avocado not started due to issue
ocado.test:
avocado.test: Temporary dir: /var/tmp/avocado_mTXVFE
avocado.test:
avocado.test: Variant 1:    /
avocado.test:
avocado.test: Job ID: 3600d8e536669994d15c9c1a0fdf6178d4d88023
avocado.test:
avocado.test: /usr/lib/python2.7/site-packages/elasticsearch/connection/http_urllib3.py:111: UserWarning: Connecting to 746f0ad652a3447d83b1572f657c67cb.us-east-1.aws.found.io using SSL with verify_certs=False is insecure.
avocado.test:   'Connecting to %s using SSL with verify_certs=False is insecure.' % host)
avocado.test: PARAMS (key=timeout, path=*, default=None) => 650000
avocado.test: START 1-longevity_test.py:LongevityTest.test_custom_time
avocado.test: Process Process-1:
avocado.test: Traceback (most recent call last):
avocado.test:   File "/usr/lib64/python2.7/multiprocessing/process.py", line 258, in _bootstrap
avocado.test:     self.run()
avocado.test:   File "/usr/lib64/python2.7/multiprocessing/process.py", line 114, in run
avocado.test:     self._target(*self._args, **self._kwargs)
avocado.test:   File "/usr/lib/python2.7/site-packages/avocado/core/runner.py", line 237, in _run_test
avocado.test:     instance = loader.load_test(test_factory)
avocado.test:   File "/usr/lib/python2.7/site-packages/avocado/core/loader.py", line 263, in load_test
avocado.test:     test_instance = test_class(**test_parameters)
avocado.test:   File "/sct/sdcm/tester.py", line 155, in __init__
avocado.test:     self.params.verify_configuration()
avocado.test:   File "/sct/sdcm/sct_config.py", line 940, in verify_configuration
avocado.test:     raise ValueError("Unsupported environment variables were used:\n\t - {}".format("\n\t - ".join(output)))
avocado.test: ValueError: Unsupported environment variables were used:
avocado.test: 	 - SCT_NEW_CONFIG=yes