### PR TITLE
Fixing hydra run docker group

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -78,7 +78,7 @@ docker run --rm ${TTY_STDIN} --privileged \
     -w ${WORK_DIR} \
     -e JOB_NAME=${JOB_NAME} \
     -e BUILD_URL=${BUILD_URL} \
-    -u $(id -u ${USER}):$(grep "docker" /etc/group|cut -d: -f3) \
+    -u $(id -u ${USER}):$(grep "docker:" /etc/group|cut -d: -f3) \
     ${SCT_OPTIONS} \
     ${BUILD_OPTIONS} \
     ${AWS_OPTIONS} \


### PR DESCRIPTION
on builders we have:
```
[jenkins@aws-us-builder4 ~]$ grep "docker" /etc/group
dockerroot:x:994:
docker:x:1002:jenkins
```
so the command should be more restrictive since currently, it selects first groups that match `docker` prefix
@aleksbykov  FYI