### PR TITLE
Add timeout for verify_results() and get_results()

### DIFF
--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -171,7 +171,7 @@ class CassandraStressThread(object):
         results = []
 
         LOGGER.debug('Wait for %s stress threads results', self.max_workers)
-        for future in concurrent.futures.as_completed(self.results_futures):
+        for future in concurrent.futures.as_completed(self.results_futures, timeout=self.timeout):
             results.append(future.result())
 
         for node, result in results:
@@ -189,7 +189,7 @@ class CassandraStressThread(object):
         errors = []
 
         LOGGER.debug('Wait for %s stress threads to verify', self.max_workers)
-        for future in concurrent.futures.as_completed(self.results_futures):
+        for future in concurrent.futures.as_completed(self.results_futures, timeout=self.timeout):
             results.append(future.result())
 
         for node, result in results:


### PR DESCRIPTION
Since remoter.run() timeout is now no-op, we need to timeout on waiting for the futures