### PR TITLE
Calls to cql_connection_patient*(), session are being closed

### DIFF
--- a/cql_test.py
+++ b/cql_test.py
@@ -33,23 +33,23 @@ class CQLExampleTest(ClusterTester):
         Create a table, run a few sql statements
         """
         node = self.db_cluster.nodes[0]
-        session = self.cql_connection_patient(node)
-        self.create_ks(session, 'ks', 1)
-        session.execute("""
-            CREATE TABLE test1 (
-                k int,
-                c1 int,
-                c2 int,
-                v1 int,
-                v2 int,
-                PRIMARY KEY (k, c1, c2)
-            );
-        """)
-        time.sleep(1)
-        session.execute("INSERT INTO test1 (k, c1, c2, v1, v2) "
-                        "VALUES (1, 2, 3, 4, 5)")
-        res = session.execute("SELECT v1, v2 from test1")
-        self.log.debug(res)
+        with self.cql_connection_patient(node) as session:
+            self.create_ks(session, 'ks', 1)
+            session.execute("""
+                CREATE TABLE test1 (
+                    k int,
+                    c1 int,
+                    c2 int,
+                    v1 int,
+                    v2 int,
+                    PRIMARY KEY (k, c1, c2)
+                );
+            """)
+            time.sleep(1)
+            session.execute("INSERT INTO test1 (k, c1, c2, v1, v2) "
+                            "VALUES (1, 2, 3, 4, 5)")
+            res = session.execute("SELECT v1, v2 from test1")
+            self.log.debug(res)
 
 
 if __name__ == '__main__':

--- a/longevity_large_partition_test.py
+++ b/longevity_large_partition_test.py
@@ -16,28 +16,28 @@ class LargePartitionLongevetyTest(LongevityTest):
 
     def _pre_create_schema(self, in_memory=False):
         node = self.db_cluster.nodes[0]
-        session = self.cql_connection_patient(node)
-        session.execute("""
-                CREATE KEYSPACE IF NOT EXISTS scylla_bench WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}
-        """)
-        session.execute("""
-                CREATE TABLE IF NOT EXISTS scylla_bench.test (
-                pk bigint,
-                ck bigint,
-                v blob,
-                PRIMARY KEY (pk, ck)
-            ) WITH CLUSTERING ORDER BY (ck ASC)
-                AND bloom_filter_fp_chance = 0.01
-                AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
-                AND comment = ''
-                AND compression = {}
-                AND crc_check_chance = 1.0
-                AND dclocal_read_repair_chance = 0.0
-                AND default_time_to_live = 0
-                AND gc_grace_seconds = 864000
-                AND max_index_interval = 2048
-                AND memtable_flush_period_in_ms = 0
-                AND min_index_interval = 128
-                AND read_repair_chance = 0.0
-                AND speculative_retry = 'NONE';
-                        """)
+        with self.cql_connection_patient(node) as session:
+            session.execute("""
+                    CREATE KEYSPACE IF NOT EXISTS scylla_bench WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}
+            """)
+            session.execute("""
+                    CREATE TABLE IF NOT EXISTS scylla_bench.test (
+                    pk bigint,
+                    ck bigint,
+                    v blob,
+                    PRIMARY KEY (pk, ck)
+                ) WITH CLUSTERING ORDER BY (ck ASC)
+                    AND bloom_filter_fp_chance = 0.01
+                    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
+                    AND comment = ''
+                    AND compression = {}
+                    AND crc_check_chance = 1.0
+                    AND dclocal_read_repair_chance = 0.0
+                    AND default_time_to_live = 0
+                    AND gc_grace_seconds = 864000
+                    AND max_index_interval = 2048
+                    AND memtable_flush_period_in_ms = 0
+                    AND min_index_interval = 128
+                    AND read_repair_chance = 0.0
+                    AND speculative_retry = 'NONE';
+                            """)

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -279,34 +279,34 @@ class LongevityTest(ClusterTester):
         remove when resolved
         """
         node = self.db_cluster.nodes[0]
-        session = self.cql_connection_patient(node)
-        session.execute("""
-            CREATE KEYSPACE IF NOT EXISTS keyspace1
-            WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'} AND durable_writes = true;
-        """)
-        session.execute("""
-            CREATE TABLE IF NOT EXISTS keyspace1.counter1 (
-                key blob PRIMARY KEY,
-                "C0" counter,
-                "C1" counter,
-                "C2" counter,
-                "C3" counter,
-                "C4" counter
-            ) WITH COMPACT STORAGE
-                AND bloom_filter_fp_chance = 0.01
-                AND caching = '{"keys":"ALL","rows_per_partition":"ALL"}'
-                AND comment = ''
-                AND compaction = {'class': 'SizeTieredCompactionStrategy'}
-                AND compression = {}
-                AND dclocal_read_repair_chance = 0.1
-                AND default_time_to_live = 0
-                AND gc_grace_seconds = 864000
-                AND max_index_interval = 2048
-                AND memtable_flush_period_in_ms = 0
-                AND min_index_interval = 128
-                AND read_repair_chance = 0.0
-                AND speculative_retry = '99.0PERCENTILE';
-        """)
+        with self.cql_connection_patient(node) as session:
+            session.execute("""
+                CREATE KEYSPACE IF NOT EXISTS keyspace1
+                WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'} AND durable_writes = true;
+            """)
+            session.execute("""
+                CREATE TABLE IF NOT EXISTS keyspace1.counter1 (
+                    key blob PRIMARY KEY,
+                    "C0" counter,
+                    "C1" counter,
+                    "C2" counter,
+                    "C3" counter,
+                    "C4" counter
+                ) WITH COMPACT STORAGE
+                    AND bloom_filter_fp_chance = 0.01
+                    AND caching = '{"keys":"ALL","rows_per_partition":"ALL"}'
+                    AND comment = ''
+                    AND compaction = {'class': 'SizeTieredCompactionStrategy'}
+                    AND compression = {}
+                    AND dclocal_read_repair_chance = 0.1
+                    AND default_time_to_live = 0
+                    AND gc_grace_seconds = 864000
+                    AND max_index_interval = 2048
+                    AND memtable_flush_period_in_ms = 0
+                    AND min_index_interval = 128
+                    AND read_repair_chance = 0.0
+                    AND speculative_retry = '99.0PERCENTILE';
+            """)
 
     def _pre_create_schema(self, keyspace_num=1, in_memory=False):
         """
@@ -314,17 +314,17 @@ class LongevityTest(ClusterTester):
         cassandra-stress.
         """
         node = self.db_cluster.nodes[0]
-        session = self.cql_connection_patient(node)
+        with self.cql_connection_patient(node) as session:
 
-        self.log.debug('Pre Creating Schema for c-s with {} keyspaces'.format(keyspace_num))
+            self.log.debug('Pre Creating Schema for c-s with {} keyspaces'.format(keyspace_num))
 
-        for i in xrange(1, keyspace_num+1):
-            keyspace_name = 'keyspace{}'.format(i)
-            self.create_ks(session, keyspace_name, rf=3)
-            self.log.debug('{} Created'.format(keyspace_name))
-            self.create_cf(session,  'standard1', key_type='blob', read_repair=0.0, compact_storage=True,
-                           columns={'"C0"': 'blob', '"C1"': 'blob', '"C2"': 'blob', '"C3"': 'blob', '"C4"': 'blob'},
-                           in_memory=in_memory)
+            for i in xrange(1, keyspace_num+1):
+                keyspace_name = 'keyspace{}'.format(i)
+                self.create_ks(session, keyspace_name, rf=3)
+                self.log.debug('{} Created'.format(keyspace_name))
+                self.create_cf(session,  'standard1', key_type='blob', read_repair=0.0, compact_storage=True,
+                               columns={'"C0"': 'blob', '"C1"': 'blob', '"C2"': 'blob', '"C3"': 'blob', '"C4"': 'blob'},
+                               in_memory=in_memory)
 
     def _flush_all_nodes(self):
         """

--- a/performance_regression_user_profiles_test.py
+++ b/performance_regression_user_profiles_test.py
@@ -34,8 +34,8 @@ class PerformanceRegressionUserProfilesTest(ClusterTester):
             ks = [line.split(':')[-1].strip() for line in fdr.readlines() if line.startswith('keyspace:')]
         if ks:
             self.log.debug('Drop keyspace {}'.format(ks[0]))
-            session = self.cql_connection_patient(self.db_cluster.nodes[0])
-            session.execute('DROP KEYSPACE IF EXISTS {};'.format(ks[0]))
+            with self.cql_connection_patient(self.db_cluster.nodes[0]) as session:
+                session.execute('DROP KEYSPACE IF EXISTS {};'.format(ks[0]))
 
     def test_user_profiles(self):
         """

--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -2907,40 +2907,40 @@ class FillDatabaseData(ClusterTester):
         """
         # Prepare connection and keyspace
         node = self.db_cluster.nodes[0]
-        session = self.cql_connection_patient(node)
-        # override driver consistency level
-        session.default_consistency_level = ConsistencyLevel.QUORUM
+        with self.cql_connection_patient(node) as session:
+            # override driver consistency level
+            session.default_consistency_level = ConsistencyLevel.QUORUM
 
-        session.execute("""
-            CREATE KEYSPACE IF NOT EXISTS keyspace1
-            WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'} AND durable_writes = true;
-            """)
-        session.execute("USE keyspace1;")
+            session.execute("""
+                CREATE KEYSPACE IF NOT EXISTS keyspace1
+                WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'} AND durable_writes = true;
+                """)
+            session.execute("USE keyspace1;")
 
-        # Create all tables according the above list
-        self.cql_create_tables(session)
+            # Create all tables according the above list
+            self.cql_create_tables(session)
 
-        # Insert data to the tables according to the "inserts" and flush to disk in several cases (nodetool flush)
-        self.cql_insert_data_to_tables(session, session.default_fetch_size)
+            # Insert data to the tables according to the "inserts" and flush to disk in several cases (nodetool flush)
+            self.cql_insert_data_to_tables(session, session.default_fetch_size)
 
     def verify_db_data(self):
         # Prepare connection
         node = self.db_cluster.nodes[0]
-        session = self.cql_connection_patient(node)
-        # override driver consistency level
-        session.default_consistency_level = ConsistencyLevel.QUORUM
+        with self.cql_connection_patient(node) as session:
+            # override driver consistency level
+            session.default_consistency_level = ConsistencyLevel.QUORUM
 
-        session.execute("USE keyspace1;")
+            session.execute("USE keyspace1;")
 
-        self.run_db_queries(session, session.default_fetch_size)
+            self.run_db_queries(session, session.default_fetch_size)
 
     def clean_db_data(self):
         # Prepare connection
         node = self.db_cluster.nodes[0]
-        session = self.cql_connection_patient(node)
+        with self.cql_connection_patient(node) as session:
 
-        session.execute("DROP KEYSPACE keyspace1;")
-        session.execute("DROP KEYSPACE ks_no_range_ghost_test;")
+            session.execute("DROP KEYSPACE keyspace1;")
+            session.execute("DROP KEYSPACE ks_no_range_ghost_test;")
 
 
 if __name__ == '__main__':

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -581,12 +581,12 @@ class Nemesis(object):
         # get the count of the truncate table
         test_keyspaces = self.cluster.get_test_keyspaces()
         cql = "SELECT COUNT(*) FROM {}.{}".format(keyspace_truncate, table)
-        session = self.tester.cql_connection_patient(self.target_node)
-        try:
-            data = session.execute(cql)
-            table_truncate_count = data[0].count
-        except InvalidRequest:
-            self.log.warning("Keyspace ks_truncate does not exist")
+        with self.tester.cql_connection_patient(self.target_node) as session:
+            try:
+                data = session.execute(cql)
+                table_truncate_count = data[0].count
+            except InvalidRequest:
+                self.log.warning("Keyspace ks_truncate does not exist")
         self.log.debug("table_truncate_count=%d", table_truncate_count)
 
         # if key space doesn't exist or the table is empty, create it using c-s
@@ -838,7 +838,7 @@ class Nemesis(object):
 
         self.log.debug("Abort repair streaming by storage_service/force_terminate_repair API")
         with DbEventsFilter(type='DATABASE_ERROR', line="repair's stream failed: streaming::stream_exception"), \
-             DbEventsFilter(type='RUNTIME_ERROR', line='Can not find stream_manager'):
+                DbEventsFilter(type='RUNTIME_ERROR', line='Can not find stream_manager'):
             self.target_node.remoter.run('curl -X POST --header "Content-Type: application/json" --header "Accept: application/json" "http://127.0.0.1:10000/storage_service/force_terminate_repair"')
             thread1.join(timeout=120)
 

--- a/sdcm/utils.py
+++ b/sdcm/utils.py
@@ -311,8 +311,8 @@ def restore_monitoring_stack(test_id):
                 """.format(workdir=monitor_stack_workdir, archive=monitoring_stack_archive_file))
             result = lr.run(cmd, ignore_status=True)
         if not result.ok:
-                logger.warning("During restoring file {} next errors occured:\n {}".format(arch['link'], result))
-                return False
+            logger.warning("During restoring file {} next errors occured:\n {}".format(arch['link'], result))
+            return False
         logger.info("Extracting data finished")
 
     logger.info('Monitoring stack files available {}'.format(monitor_stack_workdir))
@@ -699,3 +699,15 @@ def _fromtimestamp(t, tz=None):
     else:
         result = tz.fromutc(result)
     return result
+
+
+class ScyllaCQLSession(object):
+    def __init__(self, session, cluster):
+        self.session = session
+        self.cluster = cluster
+
+    def __enter__(self):
+        return self.session
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.cluster.shutdown()

--- a/snitch_test.py
+++ b/snitch_test.py
@@ -32,10 +32,11 @@ class SnitchTest(ClusterTester):
         result = self.db_cluster.nodes[0].remoter.run('nodetool describecluster')
         assert 'GoogleCloudSnitch' in result.stdout, "Cluster doesn't use GoogleCloudSnitch"
 
-        session = self.cql_connection_patient_exclusive(self.db_cluster.nodes[0], timeout=60)
-        result = list(session.execute('select * from system.peers'))
-        self.log.debug(result)
-        assert result, 'ERROR: system.peers should be not empty.'
+        with self.cql_connection_patient_exclusive(self.db_cluster.nodes[0], timeout=60) as session:
+            result = list(session.execute('select * from system.peers'))
+            self.log.debug(result)
+            assert result, 'ERROR: system.peers should be not empty.'
+
         self.log.info("PASS: system.peers isn't empty as expected")
 
         result = self.db_cluster.nodes[0].remoter.run('nodetool status', verbose=True)


### PR DESCRIPTION
example:

```python
with self.cql_connection_patient(node) as session:
    session.execute("DROP KEYSPACE keyspace1;")
    session.execute("DROP KEYSPACE ks_no_range_ghost_test;")
```
Fixes #959 

thanks to @ShlomiBalalis for helping to pinpoint the reason of this one