### PR TITLE
Fix error of type if SCT_N_LOADERS env exported

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -46,6 +46,12 @@ def str_or_list(value):
 
 
 def int_or_list(value):
+    try:
+        value = int(value)
+        return value
+    except Exception:
+        pass
+
     if isinstance(value, basestring):
         try:
             values = value.split()
@@ -53,8 +59,6 @@ def int_or_list(value):
             return value
         except Exception:  # pylint: disable=broad-except
             pass
-    elif isinstance(value, int):
-        return value
 
     raise ValueError("{} isn't int or list".format(value))
 


### PR DESCRIPTION
if number of loader is set as env via command
export SCT_N_LOADERS=1

the SCTConfig parsed it as string and exception with wrong type
is raised:

10:22:34 failure_post_behavior: ''
10:22:34 instance_provision: spot_low_price
10:22:34 instance_type_db: i3.4xlarge
10:22:34 instance_type_loader: c5.xlarge
10:22:34 instance_type_monitor: t3.small
10:22:34 ip_ssh_connections: public
10:22:34 mgmt_port: 10090
10:22:34 monitor_branch: branch-2.3
10:22:34 n_db_nodes: 6
10:22:34 n_loaders: '1'
10:22:34 n_monitor_nodes: 1

10:02:30 Cluster longevity-10gb-3h-master-loader-set-874b41d8 (AMI: ['ami-0668349068972415c'] Type: c5.xlarge): Init nodes
10:02:30 Exception in setUp. Will call tearDown
10:02:30 Traceback (most recent call last):
10:02:30   File "/sct/sdcm/tester.py", line 135, in wrapper
10:02:30     return method(*args, **kwargs)
10:02:30   File "/sct/sdcm/tester.py", line 222, in setUp
10:02:30     self.init_resources()
10:02:30   File "/sct/sdcm/tester.py", line 735, in init_resources
10:02:30     monitor_info=monitor_info)
10:02:30   File "/sct/sdcm/tester.py", line 581, in get_cluster_aws
10:02:30     **common_params)
10:02:30   File "/sct/sdcm/cluster_aws.py", line 757, in __init__
10:02:30     node_type=node_type)
10:02:30   File "/sct/sdcm/cluster_aws.py", line 104, in __init__
10:02:30     region_names=self.region_names)
10:02:30   File "/sct/sdcm/cluster.py", line 1755, in __init__
10:02:30     raise ValueError('Unsupported type: {}'.format(type(n_nodes)))
10:02:30 ValueError: Unsupported type: <type 'str'>