### PR TITLE
Encode result.stdout and stderr to use them in tests

### DIFF
--- a/sdcm/remote.py
+++ b/sdcm/remote.py
@@ -229,7 +229,8 @@ class RemoteCmdRunner(CommandRunner):
                     raise
 
         self._print_command_results(result, verbose)
-
+        result.stdout = result.stdout.encode(encoding='utf-8')
+        result.stderr = result.stderr.encode(encoding='utf-8')
         return result
 
     def is_up(self, timeout=30):


### PR DESCRIPTION
By default Fabric return Result object where the Result.stdout and
Result.stderr are stored depend on python version (in python2 is
unicode string, in python3 it is bytearray). To Correctly print stdout
or stderr the we encode string to string with encoding utf-8.