### PR TITLE
Test in mgmt_cli_test that tests the repair ability.

### DIFF
--- a/cql_test.py
+++ b/cql_test.py
@@ -34,7 +34,7 @@ class CQLExampleTest(ClusterTester):
         """
         node = self.db_cluster.nodes[0]
         with self.cql_connection_patient(node) as session:
-            self.create_ks(session, 'ks', 1)
+            self.create_keyspace(session, 'ks', 1)
             session.execute("""
                 CREATE TABLE test1 (
                     k int,

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -320,7 +320,7 @@ class LongevityTest(ClusterTester):
 
             for i in xrange(1, keyspace_num+1):
                 keyspace_name = 'keyspace{}'.format(i)
-                self.create_ks(session, keyspace_name, rf=3)
+                self.create_keyspace(session, keyspace_name, rf=3)
                 self.log.debug('{} Created'.format(keyspace_name))
                 self.create_cf(session,  'standard1', key_type='blob', read_repair=0.0, compact_storage=True,
                                columns={'"C0"': 'blob', '"C1"': 'blob', '"C2"': 'blob', '"C3"': 'blob', '"C4"': 'blob'},

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1006,23 +1006,6 @@ class ClusterTester(db_stats.TestStatsMixin, Test):
                                   ssl_opts=ssl_opts,
                                   bypassed_exception=NoHostAvailable)
 
-    def create_ks(self, session, name, rf):
-        query = 'CREATE KEYSPACE IF NOT EXISTS %s WITH replication={%s}'
-        if isinstance(rf, types.IntType):
-            # we assume simpleStrategy
-            session.execute(query % (name,
-                                     "'class':'SimpleStrategy', "
-                                     "'replication_factor':%d" % rf))
-        else:
-            assert len(rf) != 0, "At least one datacenter/rf pair is needed"
-            # we assume networkTopologyStrategy
-            options = ', '.join(['\'%s\':%d' % (d, r) for
-                                 d, r in rf.iteritems()])
-            session.execute(query % (name,
-                                     "'class':'NetworkTopologyStrategy', %s" %
-                                     options))
-        session.execute('USE %s' % name)
-
     def is_keyspace_in_cluster(self, session, keyspace_name):
         query_result = session.execute("SELECT * FROM system_schema.keyspaces;")
         keyspace_list = [row.keyspace_name.lower() for row in query_result.current_rows]


### PR DESCRIPTION
The test adds two keyspaces to the cluster: one with SimpleStrategy and one with LocalStrategy. The test makes sure that all of the relevant system tables and the one with simplestrategy appear in the repair, and that the one iwith the localstrategy does not.
I also added a function in ClusterTester that grants the ability to create a generic keyspace and validates that it exists across the cluster