### PR TITLE
[BACKPORT] Manager v1.3.1 additions

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -175,6 +175,10 @@ class MgmtCliTest(ClusterTester):
         for repair_task in repair_task_list:
             self.log.debug("{} status: {}".format(repair_task.id, repair_task.status))
 
+        self.log.info('Running a new repair task after upgrade')
+        repair_task = mgr_cluster.create_repair_task()
+        self.log.debug("{} status: {}".format(repair_task.id, repair_task.status))
+        
     def test_manager_rollback_upgrade(self):
         """
         Test steps:

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1032,7 +1032,8 @@ server_encryption_options:
         else:
             repo_path = '/etc/apt/sources.list.d/scylla.list'
             self.remoter.run('sudo curl -o %s -L %s' % (repo_path, scylla_repo))
-            self.remoter.run('sudo apt-get update')
+            self.remoter.run(cmd="sudo apt-get update", ignore_status=True)
+
 
     def download_scylla_manager_repo(self, scylla_repo):
         if self.is_rhel_like():
@@ -1041,7 +1042,8 @@ server_encryption_options:
             repo_path = '/etc/apt/sources.list.d/scylla-manager.list'
         self.remoter.run('sudo curl -o %s -L %s' % (repo_path, scylla_repo))
         if not self.is_rhel_like():
-            self.remoter.run('sudo apt-get update')
+            self.remoter.run(cmd="sudo apt-get update", ignore_status=True)
+
 
     def clean_scylla(self):
         """
@@ -1135,7 +1137,7 @@ server_encryption_options:
         if self.is_rhel_like():
             self.remoter.run('sudo yum update scylla-manager -y')
         else:
-            self.remoter.run('sudo apt-get update')
+            self.remoter.run(cmd="sudo apt-get update", ignore_status=True)
             # Upgrade should update packages of:
             # 1) scylla-manager
             # 2) scylla-manager-client
@@ -1156,15 +1158,29 @@ server_encryption_options:
         if not (self.is_rhel_like() or self.is_debian() or self.is_ubuntu()):
             raise ValueError('Unsupported Distribution type: {}'.format(str(self.distro)))
         if self.is_debian8():
+            self.remoter.run(cmd="sudo sed -i -e 's/jessie-updates/stable-updates/g' /etc/apt/sources.list")
+            self.remoter.run(cmd="sudo touch /etc/apt/sources.list.d/jessie-backports.list")
+            self.remoter.run(
+                cmd="sudo echo 'deb http://archive.debian.org/debian jessie-backports main' | sudo tee /etc/apt/sources.list.d/jessie-backports.list")
+            self.remoter.run(cmd="sudo touch /etc/apt/apt.conf.d/99jessie-backports")
+            self.remoter.run(
+                cmd="sudo echo 'Acquire::Check-Valid-Until \"false\";' | sudo tee /etc/apt/apt.conf.d/99jessie-backports")
+            self.remoter.run('sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F76221572C52609D', retry=3)
             install_transport_https = dedent("""
-                if [ ! -f /etc/apt/sources.list.d/backports.list ]; then sudo echo 'deb http://http.debian.net/debian jessie-backports main' | sudo tee /etc/apt/sources.list.d/backports.list > /dev/null; fi
-                apt-get install apt-transport-https
-                apt-get install gnupg-curl
-                apt-get update
-                apt-key adv --fetch-keys https://download.opensuse.org/repositories/home:/scylladb:/scylla-3rdparty-jessie/Debian_8.0/Release.key
-                apt-get install -t jessie-backports ca-certificates-java -y
-                        """)
+                            if [ ! -f /etc/apt/sources.list.d/backports.list ]; then sudo echo 'deb http://http.debian.net/debian jessie-backports main' | sudo tee /etc/apt/sources.list.d/backports.list > /dev/null; fi
+                            apt-get install apt-transport-https
+                            apt-get install gnupg-curl
+            """)
             self.remoter.run('sudo bash -cxe "%s"' % install_transport_https)
+            self.remoter.run(cmd="sudo apt-get update", ignore_status=True)
+
+
+            install_transport_backports = dedent("""
+                apt-key adv --fetch-keys https://download.opensuse.org/repositories/home:/scylladb:/scylla-3rdparty-jessie/Debian_8.0/Release.key
+                # apt-get install -t jessie-backports ca-certificates-java -y
+                apt-get install ca-certificates-java -y
+            """)
+            self.remoter.run('sudo bash -cxe "%s"' % install_transport_backports)
 
 
         if self.is_debian9():
@@ -1179,7 +1195,7 @@ server_encryption_options:
 
         if self.is_debian():
             install_open_jdk = dedent("""
-                apt-get install -y openjdk-8-jre-headless
+                apt-get install -y openjdk-8-jre-headless -t jessie-backports
                 update-java-alternatives --jre-headless -s java-1.8.0-openjdk-amd64
             """)
             self.remoter.run('sudo bash -cxe "%s"' % install_open_jdk)
@@ -1202,7 +1218,7 @@ server_encryption_options:
         if self.is_rhel_like():
             self.remoter.run('sudo yum install -y scylla-manager')
         else:
-            self.remoter.run('sudo apt-get update')
+            self.remoter.run(cmd="sudo apt-get update", ignore_status=True)
             self.remoter.run('sudo apt-get install -y scylla-manager --force-yes')
 
         if self.is_docker():
@@ -2557,23 +2573,26 @@ class BaseMonitorSet(object):
                 pip install pyyaml
             """)
         elif node.is_debian():
+            node.remoter.run('sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F76221572C52609D', retry=3)
+            node.remoter.run(cmd="sudo apt-get update", ignore_status=True)
+            node.remoter.run(cmd="sudo apt-get dist-upgrade -y")
+            node.remoter.run(
+                cmd="sudo echo 'deb https://apt.dockerproject.org/repo debian-jessie main' | sudo tee /etc/apt/sources.list.d/docker.list")
+            node.remoter.run(cmd="sudo apt-get update", ignore_status=True)
+            node.remoter.run(cmd="sudo apt-get install docker-engine -y --force-yes")
+            node.remoter.run(cmd="sudo apt-get install -y curl")
+            node.remoter.run(cmd="sudo apt-get install software-properties-common -y")
+            node.remoter.run(cmd="sudo apt-get update", ignore_status=True)
+            node.remoter.run(cmd="sudo apt-get install -y python-setuptools wget")
+            node.remoter.run(cmd="sudo apt-get install -y unzip")
             prereqs_script = dedent("""
-                apt-get update
-                apt-get install -y curl
-                curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -
-                apt-get install software-properties-common -y
-                add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
-                apt-get update
-                apt-get install -y docker
-                curl -sSL https://get.docker.com/ | sh
-                apt-get install -y python-setuptools unzip wget
                 easy_install pip
                 pip install --upgrade pip
                 pip install pyyaml
             """)
         else:
             raise ValueError('Unsupported Distribution type: {}'.format(str(node.distro)))
-        node.remoter.run("sudo bash -ce '%s'" % prereqs_script)
+        node.remoter.run(cmd="sudo bash -ce '%s'" % prereqs_script)
 
     def download_scylla_monitoring(self, node):
         install_script = dedent("""

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1202,6 +1202,7 @@ server_encryption_options:
 
         if self.is_rhel_like():
             self.remoter.run('sudo yum install -y epel-release', retry=3)
+            self.remoter.run('sudo yum install python36-PyYAML -y', retry=3)
         else:
             self.remoter.run('sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B2BFD3660EF3F5B', retry=3)
             self.remoter.run('sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 17723034C56D4B19', retry=3)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1146,6 +1146,7 @@ server_encryption_options:
             self.remoter.run('sudo supervisorctl start scylla-manager')
         else:
             self.remoter.run('sudo systemctl restart scylla-manager.service')
+        time.sleep(5)
 
     def install_mgmt(self, scylla_repo, scylla_mgmt_repo, manager_backend_client_encrypt=None):
         self.log.debug('Install scylla-manager')

--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -585,13 +585,13 @@ class ScyllaManagerToolNonRedhat(ScyllaManagerTool):
                         sudo apt-get remove scylla-manager-client -y
                         sudo rm -rf {}
                         sudo apt-get clean
-                        sudo apt-get update
                     """.format(self.manager_repo_path)) # +" /var/lib/scylla-manager/*"))
         self.manager_node.remoter.run('sudo bash -cxe "%s"' % remove_post_upgrade_repo)
+        self.manager_node.remoter.run('sudo apt-get update', ignore_status=True)
 
         # Downgrade to pre-upgrade scylla-manager repository
         self.manager_node.download_scylla_manager_repo(scylla_mgmt_repo)
-        res = self.manager_node.remoter.run('sudo apt-get update')
+        res = self.manager_node.remoter.run('sudo apt-get update', ignore_status=True)
         res = self.manager_node.remoter.run('apt-cache  show scylla-manager-client | grep Version:')
         rollback_to_version = res.stdout.split()[1]
         logger.debug("Rolling back manager version from: {} to: {}".format(manager_from_version, rollback_to_version))

--- a/tests/manager-regression-multiDC-set-distro.yaml
+++ b/tests/manager-regression-multiDC-set-distro.yaml
@@ -15,6 +15,7 @@ mgmt_port: 10090
 scylla_repo_m: SCYLLA_ENTERPRISE_REPO
 scylla_mgmt_repo: SCYLLA_MGR_REPO
 scylla_mgmt_upgrade_to_repo: SCYLLA_MGR_UPGRADE_TO_REPO
+instance_provision: 'spot_low_price'
 
 backends: !mux
     aws: !mux


### PR DESCRIPTION
only the last commit of " Added instance_provision: 'spot_low_price' " is new in this PR.

all the other commits were merged before to master but not backported to branch manager-v1.3.1 for some reason. ( in PR: https://github.com/scylladb/scylla-cluster-tests/pull/876 )