### PR TITLE
Add new config settings to configure number of oracle test nodes

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -95,6 +95,9 @@ class SCTConfiguration(dict):
         dict(name="n_db_nodes", env="SCT_N_DB_NODES",  type=int_or_list,
              help="Number list of database nodes in multiple data centers."),
 
+        dict(name="n_test_oracle_db_nodes", env="SCT_N_TEST_ORACLE_DB_NODES",  type=int_or_list,
+             help="Number list of oracle test nodes in multiple data centers."),
+
         dict(name="n_loaders", env="SCT_N_LOADERS",  type=int_or_list,
              help="Number list of loader nodes in multiple data centers"),
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -538,8 +538,10 @@ class ClusterTester(db_stats.TestStatsMixin, Test):
                     **cl_params)
             elif db_type == 'mixed_scylla':
                 cluster.Setup.mixed_cluster(True)
+                n_test_oracle_db_nodes = self.params.get('n_test_oracle_db_nodes', 1)
                 cl_params.update(dict(ec2_instance_type=self.params.get('instance_type_db_oracle'),
-                                      user_prefix=user_prefix + '-oracle'))
+                                      user_prefix=user_prefix + '-oracle',
+                                      n_nodes=[n_test_oracle_db_nodes]))
                 return ScyllaAWSCluster(
                     ec2_ami_id=self.params.get('ami_id_db_oracle').split(),
                     ec2_ami_username=self.params.get('ami_db_scylla_user'),

--- a/test-cases/gemini/gemini-basic-3h.yaml
+++ b/test-cases/gemini/gemini-basic-3h.yaml
@@ -1,5 +1,6 @@
 test_duration: 500
 n_db_nodes: 3
+n_test_oracle_db_nodes: 1
 n_loaders: 1
 n_monitor_nodes: 1
 instance_type_db: 'i3.large'
@@ -11,7 +12,7 @@ store_results_in_elasticsearch: False
 # cmd: gemini -d -n [NUM_OF_TEST_ITERATIONS] -c [NUM_OF_THREADS] -p [NUM_OF_PARTITION_KEYS_PER_THREAD] -m mixed -f
 # the below cmd runs about 3 hours
 gemini_cmd: "gemini -d --duration 10800s -c 20 -p 100 -m mixed -f"
-gemini_version: '0.9.2'
+gemini_version: 'latest'
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 
 db_type: mixed_scylla

--- a/tests/gemini_test.yaml
+++ b/tests/gemini_test.yaml
@@ -1,5 +1,6 @@
 test_duration: 500
 n_db_nodes: 1
+n_test_oracle_db_nodes: 1
 n_loaders: 1
 n_monitor_nodes: 1
 user_prefix: 'gemini-test-3h-200gb-VERSION'
@@ -14,7 +15,7 @@ store_results_in_elasticsearch: False
 # cmd: gemini -d -n [NUM_OF_TEST_ITERATIONS] -c [NUM_OF_THREADS] -p [NUM_OF_PARTITION_KEYS_PER_THREAD] -m mixed -f
 # the below cmd runs about 3 hours
 gemini_cmd: "gemini -d --duration 10800s -c 20 -p 100 -m mixed -f"
-gemini_version: '0.9.2'
+gemini_version: 'latest'
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json'
 
 reuse_cluster: False


### PR DESCRIPTION
new parameter n_ot_nodes (number oracle test nodes in cluster).
if not set in configuration file, default is 1.