### PR TITLE
Fix CmdExecTimeout object

### DIFF
--- a/sdcm/remote.py
+++ b/sdcm/remote.py
@@ -59,7 +59,6 @@ class ConnectionCmdTimeout(Connection):
         super(ConnectionCmdTimeout, self).__init__(host, user, port, config, gateway, forward_agent, connect_timeout, connect_kwargs)
         self.cmd_timeout = None
 
-    @opens
     def run(self, command, **kwargs):
         self.cmd_timeout = kwargs.pop('cmd_timeout', None)
         return super(ConnectionCmdTimeout, self).run(command, **kwargs)

--- a/sdcm/remote.py
+++ b/sdcm/remote.py
@@ -59,10 +59,10 @@ class ConnectionCmdTimeout(Connection):
         super(ConnectionCmdTimeout, self).__init__(host, user, port, config, gateway, forward_agent, connect_timeout, connect_kwargs)
         self.cmd_timeout = None
 
+    @opens
     def run(self, command, **kwargs):
         self.cmd_timeout = kwargs.pop('cmd_timeout', None)
-        runner = self.config.runners.remote(self)
-        return self._run(runner, command, **kwargs)
+        return super(ConnectionCmdTimeout, self).run(command, **kwargs)
 
     @opens
     def create_session(self):


### PR DESCRIPTION
- add decorator
- add super() call

## PR pre-checks (self review)
<!--- Put an `x` in all the boxes that apply: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (`hydra unit-tests`)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
