### PR TITLE
Remove the use of name binding from ngrok

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3121,13 +3121,12 @@ class BaseMonitorSet(object):
             "addr": port,
             "proto": "http",
             "name": "sct",
-            "subdomain": ngrok_name,
             "bind_tls": False
         }
         res = requests.post('http://localhost:4040/api/tunnels', json=tunnel)
         assert res.ok, "failed to add a ngrok tunnel [%s, %s]".format(res, res.text)
-
-        return "{}.ngrok.io:80".format(ngrok_name)
+        ngrok_address = res.json()['public_url'].replace('http://', '')
+        return "{}:80".format(ngrok_address)
 
     def set_local_sct_ip(self):
 


### PR DESCRIPTION
seems like for some user the name biding isn't working,
remove it from port setup, and a random address
generated by ngrok service would be used

## PR pre-checks (self review)
<!--- Put an `x` in all the boxes that apply: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [X] All new and existing unit tests passed (`hydra unit-tests`)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
