### PR TITLE
dding master dashboards to start-all

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3293,7 +3293,7 @@ class BaseMonitorSet(object):
             ./start-all.sh \
             -s {0.monitoring_conf_dir}/scylla_servers.yml \
             -n {0.monitoring_conf_dir}/node_exporter_servers.yml \
-            -d {0.monitoring_data_dir} -l -v {0.monitoring_version} -b "-web.enable-admin-api"
+            -d {0.monitoring_data_dir} -l -v master,{0.monitoring_version} -b "-web.enable-admin-api"
         """.format(self))
         node.remoter.run("bash -ce '%s'" % run_script, verbose=True)
         self.add_sct_dashboards_to_grafana(node)


### PR DESCRIPTION
adding master dashboards to start-all scripts so we always load them. this is helpful when there aren't dashboards for new releases and when detecting issues in dashboards that one want to compare to master