### PR TITLE
Fix ngrok to work when using `cluster_reuse: true`

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -233,7 +233,7 @@ class ClusterTester(db_stats.TestStatsMixin, Test):
 
         # change RF of system_auth
         system_auth_rf = self.params.get('system_auth_rf', default=3)
-        if system_auth_rf:
+        if system_auth_rf and not cluster.Setup.REUSE_CLUSTER:
             self.log.info('change RF of system_auth to %s' % system_auth_rf)
             node = self.db_cluster.nodes[0]
             with self.cql_connection_patient(node) as session:


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (`hydra unit-tests`)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
