### PR TITLE
Added version decorator

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -261,10 +261,12 @@ cli.add_command(investigate)
 
 
 @cli.command('unit-tests', help="Run all the SCT internal unit-tests")
-def unit_tests():
+@click.option("-t", "--test", required=False, default="test*.py",
+              help="Run specific test file from unit-tests directory")
+def unit_tests(test):
     import unittest
 
-    test_suite = unittest.TestLoader().discover('unit_tests', top_level_dir='.')
+    test_suite = unittest.TestLoader().discover('unit_tests', pattern=test, top_level_dir='.')
     result = unittest.TextTestRunner(verbosity=2).run(test_suite)
     sys.exit(not result.wasSuccessful())
 

--- a/sdcm/utils.py
+++ b/sdcm/utils.py
@@ -723,3 +723,57 @@ class ScyllaCQLSession(object):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.cluster.shutdown()
+
+
+class MethodVersionNotFound(Exception):
+    pass
+
+
+class version(object):
+    VERSIONS = {}
+    """
+        Runs a method according to the version attribute of the class method
+        Limitations: currently, can't work if the same method name in the same file used in different
+                     classes
+        Example:
+                In [3]: class VersionedClass(object):
+                   ...:     def __init__(self, current_version):
+                   ...:         self.version = current_version
+                   ...:
+                   ...:     @version("1.2")
+                   ...:     def setup(self):
+                   ...:         return "1.2"
+                   ...:
+                   ...:     @version("2")
+                   ...:     def setup(self):
+                   ...:         return "2"
+
+                In [4]: vc = VersionedClass("2")
+
+                In [5]: vc.setup()
+                Out[5]: '2'
+
+                In [6]: vc = VersionedClass("1.2")
+
+                In [7]: vc.setup()
+                Out[7]: '1.2'
+    """
+
+    def __init__(self, ver):
+        self.version = ver
+
+    def __call__(self, func):
+        self.VERSIONS[(self.version, func.func_name, func.func_code.co_filename)] = func
+
+        @wraps(func)
+        def inner(*args, **kwargs):
+            cls_self = args[0]
+            func_to_run = self.VERSIONS.get((cls_self.version, func.func_name, func.func_code.co_filename))
+            if func_to_run:
+                return func_to_run(*args, **kwargs)
+            else:
+                raise MethodVersionNotFound("Method '{}' with version '{}' not defined in '{}'!".format(
+                    func.func_name,
+                    cls_self.version,
+                    cls_self.__class__.__name__))
+        return inner

--- a/unit_tests/test_utils_version.py
+++ b/unit_tests/test_utils_version.py
@@ -1,0 +1,76 @@
+import random
+from unittest import TestCase
+from sdcm.utils import version
+
+
+class VersionedClass(object):
+    def __init__(self, current_version):
+        self.version = current_version
+
+    @version("1.2")
+    def setup(self, data=None):
+        return "1.2", data
+
+    @version("2")
+    def setup(self, data=None):
+        return "2", data
+
+    @version("3")
+    def setup(self, data=None):
+        return "3", data
+
+
+class MutliVersionMethods(VersionedClass):
+
+    @version("1.2")
+    def mvc(self):
+        return "1.2"
+
+    @version("2")
+    def mvc(self):
+        return "2"
+
+    @version("3")
+    def mvc(self):
+        return "3"
+
+
+class TestUtilsVersionDecorator(TestCase):
+    def test_runs_correct_version(self):
+        versions = ["1.2", "2", "3"]
+        random.shuffle(versions)
+        for ver in versions:
+            print ver
+            vc = VersionedClass(ver)
+            got_ver, _ = vc.setup()
+            assert ver == got_ver
+
+    def test_assert_no_version_attribute(self):
+        vc = VersionedClass("1")
+        del vc.version
+        self.assertRaises(AttributeError, vc.setup)
+
+    def test_version_not_found(self):
+        from sdcm.utils import MethodVersionNotFound
+        vc = VersionedClass("1")
+        self.assertRaises(MethodVersionNotFound, vc.setup)
+
+    def test_different_versioned_methods(self):
+        versions = ["1.2", "2", "3"]
+        random.shuffle(versions)
+        for ver in versions:
+            print ver
+            vc = MutliVersionMethods(ver)
+            got_ver = vc.mvc()
+            assert ver == got_ver
+            assert vc.mvc.__func__.__name__ == "mvc"
+            got_ver, data = vc.setup("data")
+            assert ver == got_ver
+            assert data == "data"
+            assert vc.setup.__func__.__name__ == "setup"
+
+    def test_data_returned_correctly(self):
+        ver = "3"
+        vc = VersionedClass(ver)
+        _, data = vc.setup(ver)
+        assert data == ver


### PR DESCRIPTION
        Runs a method according to the version attribute of the class method
        Limitations: currently, can't work if the same method name in the same file used in different
                     classes
        Example:
                In [3]: class VersionedClass(object):
                   ...:     def __init__(self, current_version):
                   ...:         self.version = current_version
                   ...:
                   ...:     @version("1.2")
                   ...:     def setup(self):
                   ...:         return "1.2"
                   ...:
                   ...:     @version("2")
                   ...:     def setup(self):
                   ...:         return "2"
                 In [4]: vc = VersionedClass("2")
                 In [5]: vc.setup()
                Out[5]: '2'
                 In [6]: vc = VersionedClass("1.2")
                 In [7]: vc.setup()
                Out[7]: '1.2'

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (`hydra unit-tests`)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
