### PR TITLE
Add explicit gemini version to email report

### DIFF
--- a/gemini_test.py
+++ b/gemini_test.py
@@ -52,7 +52,7 @@ class GeminiTest(ClusterTester):
             "start_time": "",
             "end_time": "",
             "gemini_cmd": "",
-            "gemini_version": self.params.get('gemini_version', default='latest'),
+            "gemini_version": self.loaders.gemini_version,
             "scylla_version": self.db_cluster.nodes[0].scylla_version,
             "scylla_ami_id": self.params.get('ami_id_db_scylla'),
             "scylla_instance_type": self.params.get('instance_type_db'),

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -869,7 +869,7 @@ class ClusterTester(db_stats.TestStatsMixin, Test):
             for res in results:
                 stats['results'].append(res)
                 for err_type in ['write_errors', 'read_errors', 'errors']:
-                    if res[err_type]:
+                    if err_type in res.keys() and res[err_type]:
                         self.log.error("Gemini {} errors: {}".format(err_type, res[err_type]))
                         stats['status'] = 'FAILED'
         if not stats['status']:


### PR DESCRIPTION
Adding new property which contain gemini version
returned by ./gemini --version

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (`hydra unit-tests`)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
