### PR TITLE
Fix issue with show empty avg aio metrics in regression report

### DIFF
--- a/sdcm/microbenchmarking.py
+++ b/sdcm/microbenchmarking.py
@@ -50,6 +50,7 @@ class MicroBenchmarkingResultsAnalyzer(BaseResultsAnalyzer):
             "hits.hits._source.test_run_date",
             "hits.hits._source.test_group_properties.name",  # large-partition-skips
             "hits.hits._source.results.stats.aio",
+            "hits.hits._source.results.stats.avg aio",
             "hits.hits._source.results.stats.cpu",
             "hits.hits._source.results.stats.time (s)",
             "hits.hits._source.results.stats.frag/s",
@@ -153,7 +154,10 @@ class MicroBenchmarkingResultsAnalyzer(BaseResultsAnalyzer):
                 last_idx = -2
             else:  # when current results are on disk but db is not updated
                 last_idx = -1
-            cur_val = float(current_result["results"]["stats"][metrica])
+
+            cur_val = current_result["results"]["stats"].get(metrica, None)
+            if cur_val:
+                cur_val = float(cur_val)
 
             last_val = get_metrica_val(list_of_results_from_db[last_idx])
             last_commit = get_commit_id(list_of_results_from_db[last_idx])
@@ -177,7 +181,7 @@ class MicroBenchmarkingResultsAnalyzer(BaseResultsAnalyzer):
 
             }
 
-            if (diff_last < -5 or diff_best < -5):
+            if ((diff_last and diff_last < -5) or (diff_best and diff_best < -5)):
                 report_results[test_type]["has_diff"] = True
                 stats["has_regression"] = True
 


### PR DESCRIPTION
avg aio metrics will not be shown in regression metrics if its
best or diff value is None

if avg aio missing in results, the comparing will be passed through

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (`hydra unit-tests`)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
