### PR TITLE
Fix `params.get()` calls in upgrade_test calling with old avocado arg…

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -40,9 +40,9 @@ class UpgradeTest(FillDatabaseData):
     upgrade_rollback_mode = None
 
     def upgrade_node(self, node):
-        new_scylla_repo = self.params.get('new_scylla_repo', None,  None)
-        new_version = self.params.get('new_version', None,  '')
-        upgrade_node_packages = self.params.get('upgrade_node_packages')
+        new_scylla_repo = self.params.get('new_scylla_repo', default=None)
+        new_version = self.params.get('new_version', default='')
+        upgrade_node_packages = self.params.get('upgrade_node_packages', default=None)
         self.log.info('Upgrading a Node')
 
         # We assume that if update_db_packages is not empty we install packages from there.


### PR DESCRIPTION
…uments

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (`hydra unit-tests`)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
