### PR TITLE
Fix the best result for new metrica

### DIFF
--- a/sdcm/microbenchmarking.py
+++ b/sdcm/microbenchmarking.py
@@ -120,16 +120,18 @@ class MicroBenchmarkingResultsAnalyzer(BaseResultsAnalyzer):
                                                   "%Y%m%d").date()
 
             def get_best_result_for_metrica():
+                # build new list with results where analyzing metrica is not None
+                list_for_searching = [el for el in list_of_results_from_db if get_metrica_val(el)]
 
                 if metrica in higher_better:
-                    best_result = max(list_of_results_from_db, key=get_metrica_val)
+                    best_result = max(list_for_searching, key=get_metrica_val)
                 elif metrica in lower_better:
-                    best_result = min(list_of_results_from_db, key=get_metrica_val)
+                    best_result = min(list_for_searching, key=get_metrica_val)
 
                 return best_result
 
             def count_diff(cur_val, dif_val):
-                if dif_val is None:
+                if cur_val is None or dif_val is None:
                     return None
 
                 ret_dif = ((cur_val - dif_val) / dif_val) * 100 if dif_val > 0 else cur_val * 100


### PR DESCRIPTION
best result for lower_best metrica is found as
result of min function. if metrica is not in result,
then min function return the first element in list with None.
generate new list with result from db where metrica is not None.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
- [x] I gave variables/functions meaningful self-explanatory names
- [x]  I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (`hydra unit-tests`)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
