### PR TITLE
Add support for selecting distro for loader

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -12,6 +12,7 @@ append_scylla_args: '--blocked-reactor-notify-ms 500 --abort-on-lsa-bad-alloc 1 
 
 # for for version selection
 scylla_linux_distro: 'centos'
+scylla_linux_distro_loader: 'centos'
 
 monitor_branch: 'branch-2.3'
 store_results_in_elasticsearch: true

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -177,15 +177,28 @@ class ConfigurationTests(unittest.TestCase):
     def test_12_scylla_version_repo_ubuntu(self):
         os.environ['SCT_CLUSTER_BACKEND'] = 'docker'
         os.environ['SCT_SCYLLA_LINUX_DISTRO'] = 'ubuntu-xenial'
+        os.environ['SCT_SCYLLA_LINUX_DISTRO_LOADER'] = 'ubuntu-xenial'
         os.environ['SCT_SCYLLA_VERSION'] = '3.0.3'
         conf = SCTConfiguration()
         conf.verify_configuration()
 
         self.assertIn('scylla_repo', conf.dump_config())
         self.assertEqual(conf.get('scylla_repo'), "https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-3.0-xenial.list")
+        self.assertEqual(conf.get('scylla_repo_loader'), "https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-3.0-xenial.list")
+
+    def test_12_scylla_version_repo_ubuntu_loader_centos(self):
+        os.environ['SCT_CLUSTER_BACKEND'] = 'docker'
+        os.environ['SCT_SCYLLA_LINUX_DISTRO'] = 'ubuntu-xenial'
+        os.environ['SCT_SCYLLA_LINUX_DISTRO_LOADER'] = 'centos'
+        os.environ['SCT_SCYLLA_VERSION'] = '3.0.3'
+        conf = SCTConfiguration()
+        conf.verify_configuration()
+
+        self.assertIn('scylla_repo', conf.dump_config())
+        self.assertEqual(conf.get('scylla_repo'), "https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-3.0-xenial.list")
+        self.assertEqual(conf.get('scylla_repo_loader'), "https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-3.0.repo")
 
     def test_config_dupes(self):
-
         def get_dupes(c):
             '''sort/tee/izip'''
             a, b = itertools.tee(sorted(c))


### PR DESCRIPTION
`scylla_linux_distro_loader` can be defined for selecting repo
for loader based on `scylla_version`. defaults to `centos`

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (`hydra unit-tests`)
- [x] I have updated the Readme/doc folder accordingly (if needed)
