### PR TITLE
Limit user_prefix to 32 characters

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -959,7 +959,7 @@ class SCTConfiguration(dict):
             if not version_tag:
                 version_tag = getpass.getuser()
 
-            self['user_prefix'] = "{}-{}".format(user_prefix, version_tag)
+            self['user_prefix'] = "{}-{}".format(user_prefix, version_tag)[:35]
 
         LOGGER.info(self.dump_config())
 

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -110,7 +110,7 @@ class ConfigurationTests(unittest.TestCase):
         os.environ['SCT_AMI_ID_DB_SCYLLA_DESC'] = 'master'
         conf = SCTConfiguration()
         conf.verify_configuration()
-        self.assertEqual(conf.get('user_prefix'), 'longevity-50gb-4d-not-jenkins-master')
+        self.assertEqual(conf.get('user_prefix'), 'longevity-50gb-4d-not-jenkins-maste')
 
     def test_10_mananger_regression(self):
 


### PR DESCRIPTION
Since GCE node names are limited to 63 characters 

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (`hydra unit-tests`)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
