### PR TITLE
abort_repair nemesis: skip abort_repair nemesis if repair streaming does't start

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -830,11 +830,14 @@ class Nemesis(object):
             result = self.target_node.remoter.run('curl -X GET --header "Content-Type: application/json" --header "Accept: application/json" "http://127.0.0.1:10000/stream_manager/"')
             return 'repair-' in result.stdout
 
-        wait_wrap.wait_for(func=repair_streaming_exists,
-                           timeout=300,
-                           step=1,
-                           throw_exc=True,
-                           text='Wait for repair starts')
+        ret = wait_wrap.wait_for(func=repair_streaming_exists,
+                                 timeout=300,
+                                 step=1,
+                                 throw_exc=False,
+                                 text='Wait for repair starts')
+        if not ret:
+            self.log.debug('No repair streaming starts, skip to abort repair streaming.')
+            return
 
         self.log.debug("Abort repair streaming by storage_service/force_terminate_repair API")
         with DbEventsFilter(type='DATABASE_ERROR', line="repair's stream failed: streaming::stream_exception"), \


### PR DESCRIPTION
If there is no inconsistent data, streaming won't be started. So we can try to
stop the target node a while (30 seconds) to make the data to be inconsistent,
then repair.

Fixes #885


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (`hydra unit-tests`)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
