### PR TITLE
sct_config: correct new_version parameter

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -694,8 +694,8 @@ class SCTConfiguration(dict):
         # UpgradeTest
         dict(name="new_scylla_repo", env="SCT_NEW_SCYLLA_REPO",  type=str,
              help=""),
-        dict(name="new_version", env="new_version",  type=str,
-             help=""),
+        dict(name="new_version", env="SCT_NEW_VERSION",  type=str,
+             help="Assign new upgrade version, use it to upgrade to specific minor release. eg: 3.0.1"),
         dict(name="upgrade_node_packages", env="SCT_UPGRADE_NODE_PACKAGES",  type=int,
              help=""),
         dict(name="test_sst3", env="SCT_TEST_SST3",  type=boolean,

--- a/tests/master_doc.yaml
+++ b/tests/master_doc.yaml
@@ -102,11 +102,11 @@ es_user:
 es_password:
 
 # UPGRADE TESTS
-# Repo file that is used in upgrade tests( from data_dir). For example:
-# scylla.repo.upgrade_1.6, scylla.repo.upgrade_1.7, etc
-repo_file: 'scylla.repo.upgrade'
-# Major scylla version to update based on 'repo_file'
-# For example: 1.7.rc2, 1.7.0, etc...
+# Repo file that is used in upgrade tests
+new_scylla_repo: 'http://downloads.scylladb.com/rpm/centos/scylla-3.0.repo'
+
+# New scylla version to update that should exist in `new_scylla_repo`
+# For example: 3.0.rc2, 3.0.0, 3.0.1, etc...
 # By default upgrade till latest major version
 new_version: ''
 # The new scylla packages will be uploaded to db instance to update the one


### PR DESCRIPTION
The env variable isn't start with SCT_, and not capital letter.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (`hydra unit-tests`)~
- [x] I have updated the Readme/doc folder accordingly (if needed)


/cc @juliayakovlev 