### PR TITLE
repair_then_repair_node: prevent scylla-server to run before RAID resetup finishes

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -403,6 +403,7 @@ class AWSNode(cluster.BaseNode):
             if 'replace_address_first_boot:' not in output.stdout:
                 self.remoter.run('sudo echo replace_address_first_boot: %s >> /etc/scylla/scylla.yaml' %
                                  self._instance.private_ip_address)
+            self.remoter.run('sudo systemctl disable scylla-server')
         self._instance.stop()
         self._instance_wait_safe(self._instance.wait_until_stopped)
         self._instance.start()
@@ -414,8 +415,9 @@ class AWSNode(cluster.BaseNode):
         self.wait_ssh_up()
 
         if any(ss in self._instance.instance_type for ss in ['i3', 'i2']):
-            self.remoter.run('sudo /usr/lib/scylla/scylla-ami/scylla_create_devices')
             self.stop_scylla_server(verify_down=False)
+            self.remoter.run('sudo /usr/lib/scylla/scylla-ami/scylla_create_devices')
+            self.remoter.run('sudo systemctl enable scylla-server')
             self.start_scylla_server(verify_up=False)
 
     def reboot(self, hard=True, verify_ssh=True):


### PR DESCRIPTION
Sometimes, scylla-server starts before RAID resetup. Then RAID setup will break
db data.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (`hydra unit-tests`)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
