### PR TITLE
Validate truncation entries during rolling upgrade test

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -707,6 +707,9 @@ class SCTConfiguration(dict):
              help=""),
         dict(name="new_version", env="SCT_NEW_VERSION",  type=str,
              help="Assign new upgrade version, use it to upgrade to specific minor release. eg: 3.0.1"),
+        dict(name="target_upgrade_version", env="SCT_TAGRET_UPGRADE_VERSION",  type=str,
+             help="Assign target upgrade version, use for decide if the truncate entries test should be run. "
+                  "This test should be performed in case the target upgrade version >= 3.1"),
         dict(name="upgrade_node_packages", env="SCT_UPGRADE_NODE_PACKAGES",  type=int,
              help=""),
         dict(name="test_sst3", env="SCT_TEST_SST3",  type=boolean,

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1203,6 +1203,26 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
 
         return partitions
 
+    def get_tables_id_of_keyspace(self, session, keyspace_name):
+        query = "SELECT id FROM system_schema.tables WHERE keyspace_name='{}' ".format(keyspace_name)
+        table_id = self.rows_to_list(session.execute(query))
+        return table_id[0]
+
+    def get_tables_name_of_keyspace(self, session, keyspace_name):
+        query = "SELECT table_name FROM system_schema.tables WHERE keyspace_name='{}' ".format(keyspace_name)
+        table_id = self.rows_to_list(session.execute(query))
+        return table_id[0]
+
+    def get_truncated_time_from_system_local(self, session):
+        query = "SELECT truncated_at FROM system.local"
+        truncated_time = self.rows_to_list(session.execute(query))
+        return truncated_time
+
+    def get_truncated_time_from_system_truncated(self, session, table_id):
+        query = "SELECT truncated_at FROM system.truncated WHERE table_uuid={}".format(table_id)
+        truncated_time = self.rows_to_list(session.execute(query))
+        return truncated_time[0]
+
     def finalize_test(self):
         self.stop_resources()
         self.collect_logs()

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -59,6 +59,8 @@ def call(Map pipelineParams) {
                                             export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$GIT_BRANCH | sed -E 's+(origin/|origin/branch-)++')
                                             export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$SCT_AMI_ID_DB_SCYLLA_DESC | tr ._ - | cut -c1-8 )
 
+                                            export SCT_TAGRET_UPGRADE_VERSION=\$(echo "${GIT_BRANCH/origin\/branch-/''}")
+
                                             export SCT_GCE_IMAGE_DB=${pipelineParams.gce_image_db}
                                             export SCT_SCYLLA_LINUX_DISTRO=${pipelineParams.linux_distro}
                                             export SCT_AMI_ID_DB_SCYLLA_DESC="\$SCT_AMI_ID_DB_SCYLLA_DESC-\$SCT_SCYLLA_LINUX_DISTRO"


### PR DESCRIPTION
Feature: Move truncation records to separate table (issue #4083)
Add validation to rolling-upgrade test

The feature description:
```
Instead of sharded collection in system.local, use a
dedicated system table (system.truncated) to store
truncation positions. Makes query/update easier
and easier on the query memory.
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (`hydra unit-tests`)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
