### PR TITLE
longevity: don't use upper letter in keyspace name

### DIFF
--- a/longevity_test.py
+++ b/longevity_test.py
@@ -76,7 +76,8 @@ class LongevityTest(ClusterTester):
 
         if 'compression' in stress_cmd:
             if 'keyspace_name' not in params:
-                keyspace_name = "keyspace_{}".format(re.search('compression=(.*)Compressor', stress_cmd).group(1))
+                compression_prefix = re.search('compression=(.*)Compressor', stress_cmd).group(1)
+                keyspace_name = "keyspace_{}".format(compression_prefix.lower())
                 params.update({'keyspace_name': keyspace_name})
 
         return params


### PR DESCRIPTION
Upper letter is supported to be used in keyspace name, but it requires
additional quotation marks when it's used in cqlsh statement.

> ALTER TABLE keyspace_Deflate.standard1 WITH ...;
InvalidRequest: Error from server: code=2200 [Invalid query] message="Keyspace keyspace_deflate does not exist"

> ALTER TABLE "keyspace_Deflate".standard1 WITH ...;
Works well.

Longterm solution is adding quotation marks to keyspace name that contains
upper letter automatically, and make sure all cqlsh statements used upper
keyspace name work well.


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (`hydra unit-tests`)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
