### PR TITLE
hydra: display machine status in list-resources

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -96,7 +96,7 @@ def list_resources(ctx, user, test_id):
         instances = list_instances_aws(params)
         instances = [i for i in instances if not i['State']['Name'] == 'terminated']
         if instances:
-            x = PrettyTable(["InstanceId", "Name", "PublicIpAddress", "TestId", "LaunchTime"])
+            x = PrettyTable(["InstanceId", "Name", "PublicIpAddress", "TestId", "LaunchTime", "State"])
             x.align = "l"
             x.sortby = 'TestId'
 
@@ -107,7 +107,7 @@ def list_resources(ctx, user, test_id):
                            name[0] if name else 'N/A',
                            instance['PublicDnsName'],
                            test_id[0] if test_id else 'N/A',
-                           instance['LaunchTime'].ctime()])
+                           instance['LaunchTime'].ctime(), instance['State']['Name']])
             click.echo(x.get_string(title="Resources used by '{}' in AWS".format(user)))
         else:
             click.secho("No resources found on AWS", fg='green')
@@ -116,7 +116,7 @@ def list_resources(ctx, user, test_id):
 
         if instances:
 
-            x = PrettyTable(["Name", "TestId", "LaunchTime", "PublicIps"])
+            x = PrettyTable(["Name", "TestId", "LaunchTime", "PublicIps", "Status"])
             x.align = "l"
             x.sortby = 'TestId'
             for instance in instances:
@@ -126,7 +126,8 @@ def list_resources(ctx, user, test_id):
                 x.add_row([instance.name,
                            test_id,
                            instance.extra['creationTimestamp'],
-                           ", ".join(instance.public_ips)])
+                           ", ".join(instance.public_ips),
+                           instance.extra['status']])
             click.echo(x.get_string(title="Resources used by '{}' in GCE".format(user)))
         else:
             click.secho("No resources found on GCE", fg='green')

--- a/sct.py
+++ b/sct.py
@@ -123,10 +123,19 @@ def list_resources(ctx, user, test_id):
                 tags = instance.extra['metadata'].get('items', [])
                 test_id = [t['value'] for t in tags if t['key'] == 'TestId']
                 test_id = test_id[0] if test_id else 'N/A'
+                if not instance.public_ips:
+                    ips = ""
+                else:
+                    # instance.public_ips of stopped instance might be [None]
+                    ips = []
+                    for i in instance.public_ips:
+                        ips.append(i if i else '')
+                    ips = ", ".join(ips)
+
                 x.add_row([instance.name,
                            test_id,
                            instance.extra['creationTimestamp'],
-                           ", ".join(instance.public_ips),
+                           ips,
                            instance.extra['status']])
             click.echo(x.get_string(title="Resources used by '{}' in GCE".format(user)))
         else:

--- a/sdcm/utils.py
+++ b/sdcm/utils.py
@@ -390,7 +390,7 @@ def restore_monitoring_stack(test_id):
 
 
 aws_regions = ['us-east-1', 'eu-west-1', 'us-west-2']
-gce_regions = ['us-east1-b', 'us-west1-b', 'us-east4-b']
+gce_regions = ['us-east1-b', 'us-west1-b', 'us-east4-b', 'asia-northeast1-b']
 
 
 def clean_cloud_instances(tags_dict):

--- a/sdcm/utils.py
+++ b/sdcm/utils.py
@@ -511,8 +511,7 @@ def list_instances_gce(tags_dict, region_name=None):
             # we go over all the expected tags, and check if they exist in on the node/instance
             # if all of them exists we delete that node
             if all([any([t['key'] == key and t['value'] == value for t in tags]) for key, value in tags_dict.items()]):
-                if not node.state == 'STOPPED':
-                    instances += [node]
+                instances += [node]
     return instances
 
 


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (`hydra unit-tests`)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~

```
+--------------------------------------------------------------------------------------------------------------------+
|                                          Resources used by 'Amos' in AWS                                           |
+---------------------+------------------------------+-----------------+--------+--------------------------+---------+
| InstanceId          | Name                         | PublicIpAddress | TestId | LaunchTime               | State   |
+---------------------+------------------------------+-----------------+--------+--------------------------+---------+
| i-xxxxxxxxxxxxx | Fedora29-builder-scylla-amos |                 | N/A    | Thu May 16 03:08:07 2019 | stopped |
+---------------------+------------------------------+-----------------+--------+--------------------------+---------+
+-------------------------------------------------------------------------------------------------+
|                                 Resources used by 'Amos' in GCE                                 |
+--------------------------+--------+-------------------------------+----------------+------------+
| Name                     | TestId | LaunchTime                    | PublicIps      | Status     |
+--------------------------+--------+-------------------------------+----------------+------------+
| amos-centos7-xxxx     | N/A    | 2017-09-27T01:20:48.392-07:00 | xxxx | RUNNING    |
| amos-centos7-xxxx       | N/A    | 2018-05-17T01:12:23.976-07:00 | xxxx   | TERMINATED |
+--------------------------+--------+-------------------------------+----------------+------------+
```