### PR TITLE
Fix debian/ubuntu upgrade command to be noninteractive

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1439,7 +1439,7 @@ server_encryption_options:
                 """)
                 self.remoter.run('sudo bash -cxe "%s"' % install_debian_9_prereqs)
 
-            self.remoter.run('sudo apt-get upgrade -y')
+            self.remoter.run('sudo DEBIAN_FRONTEND=noninteractive apt-get --force-yes -o Dpkg::Options::="--force-confold" -o Dpkg::Options::="--force-confdef" upgrade -y')
             self.remoter.run('sudo apt-get install -y rsync tcpdump screen wget net-tools')
             self.download_scylla_repo(scylla_repo)
             self.remoter.run('sudo apt-get update')


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (`hydra unit-tests`)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
