### PR TITLE
hydra.sh: fix nested escape character problem

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -83,4 +83,4 @@ docker run --rm ${TTY_STDIN} --privileged \
     ${AWS_OPTIONS} \
     --net=host \
     scylladb/hydra:v${VERSION} \
-    /bin/bash -c "${TERM_SET_SIZE} eval ${CMD}"
+    /bin/bash -c "${TERM_SET_SIZE} eval '${CMD}'"


### PR DESCRIPTION
Fail example:
- ./docker/env/hydra.sh list-resources --user "Amos Kong"
- ./docker/env/hydra.sh list-resources --user \"Amos Kong\"

Good example:
- ./docker/env/hydra.sh list-resources --user \\\"Amos Kong\\\"

After this fix, we only need once of escape.
`./docker/env/hydra.sh list-resources --user \"Amos Kong\"` works.

Fixes #1043

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (`hydra unit-tests`)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
