### PR TITLE
changing longevity 1tb back to CL=QUORUM

### DIFF
--- a/test-cases/longevity/longevity-1TB-7days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-1TB-7days-authorization-and-tls-ssl.yaml
@@ -1,6 +1,5 @@
 test_duration: 10900
-prepare_write_cmd:  "cassandra-stress write cl=ALL n=1100200300 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native  -rate threads=1000 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1100200300"
-prepare_verify_cmd: "cassandra-stress read cl=ALL  n=1100200300 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native  -rate threads=1000 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1100200300"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=1100200300 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native  -rate threads=1000 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1100200300"
 
 stress_cmd: ["cassandra-stress mixed         cl=QUORUM duration=10080m -schema 'replication(factor=3)                               compaction(strategy=LeveledCompactionStrategy)'    -port jmx=6868 -mode cql3 native  -rate threads=20 -pop seq=1..1100200300  -log interval=5 -col 'size=FIXED(1024) n=FIXED(1)'",
              "cassandra-stress write         cl=QUORUM duration=10010m -schema 'replication(factor=3) compression=LZ4Compressor     compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=lz4                   -rate threads=50 -pop seq=1..50000000    -log interval=5",


### PR DESCRIPTION
Currently, with the recent changes this test is broken.
nemesis_during_prepare is true by default and prepare with CL=ALL will fail.
I'm reverting the prepare stage to be QUORUM as it was in the past and changed to catch a suspect data loss issue.
The reads are in cl=QUORUM, so it shouldn't have any issue.