### PR TITLE
Refactor: moving cqlsh and nodetool calls to run from BaseNode objects

### DIFF
--- a/jenkins-pipelines/longevity-1tb-7days-1Dis-2NonDis-Nemesises.jenkinsfile
+++ b/jenkins-pipelines/longevity-1tb-7days-1Dis-2NonDis-Nemesises.jenkinsfile
@@ -1,0 +1,16 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    params: params,
+
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/longevity/longevity-1TB-7days-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml',
+
+    timeout: [time: 10960, unit: 'MINUTES'],
+    post_behaviour: 'destroy'
+)

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -311,18 +311,15 @@ class LongevityTest(ClusterTester):
         For cases we are testing many keyspaces and tables, It's a possibility that we will do it better and faster than
         cassandra-stress.
         """
-        node = self.db_cluster.nodes[0]
-        with self.cql_connection_patient(node) as session:
 
-            self.log.debug('Pre Creating Schema for c-s with {} keyspaces'.format(keyspace_num))
-
-            for i in xrange(1, keyspace_num+1):
-                keyspace_name = 'keyspace{}'.format(i)
-                self.create_keyspace(session, keyspace_name, rf=3)
-                self.log.debug('{} Created'.format(keyspace_name))
-                self.create_cf(session,  'standard1', key_type='blob', read_repair=0.0, compact_storage=True,
-                               columns={'"C0"': 'blob', '"C1"': 'blob', '"C2"': 'blob', '"C3"': 'blob', '"C4"': 'blob'},
-                               in_memory=in_memory, scylla_encryption_options=scylla_encryption_options)
+        self.log.debug('Pre Creating Schema for c-s with {} keyspaces'.format(keyspace_num))
+        for i in xrange(1, keyspace_num+1):
+            keyspace_name = 'keyspace{}'.format(i)
+            self.create_keyspace(keyspace_name=keyspace_name, replication_factor=3)
+            self.log.debug('{} Created'.format(keyspace_name))
+            self.create_table(name='standard1', key_type='blob', read_repair=0.0, compact_storage=True,
+                              columns={'"C0"': 'blob', '"C1"': 'blob', '"C2"': 'blob', '"C3"': 'blob', '"C4"': 'blob'},
+                              in_memory=in_memory, scylla_encryption_options=scylla_encryption_options)
 
     def _flush_all_nodes(self):
         """
@@ -330,4 +327,4 @@ class LongevityTest(ClusterTester):
         :return:
         """
         for node in self.db_cluster.nodes:
-            node.remoter.run('sudo nodetool flush')
+            node.run_nodetool("flush")

--- a/refresh_test.py
+++ b/refresh_test.py
@@ -68,15 +68,14 @@ class RefreshTest(ClusterTester):
         Load newly placed SSTables to the system
         """
         self.log.debug('Make sure keyspace1.standard1 exists')
-        result = node.remoter.run('nodetool --host localhost cfstats keyspace1.standard1')
+        result = node.run_nodetool(sub_cmd="cfstats", args="keyspace1.standard1")
         assert result.exit_status == 0
 
-        node.remoter.run('nodetool --host localhost refresh -- keyspace1 standard1')
-        cmd = "select * from keyspace1.standard1 where key=0x314e344b4d504d4b4b30"
-        node.remoter.run('cqlsh -e "{}" {}'.format(cmd, node.private_ip_address), verbose=True)
+        node.run_nodetool(sub_cmd="refresh", args="-- keyspace1 standard1")
+        node.run_cqlsh("select * from keyspace1.standard1 where key=0x314e344b4d504d4b4b30")
         for i in range(int(self.params.get('flush_times', default=1))):
             time.sleep(int(self.params.get('flush_period', default=60)))
-            node.remoter.run('nodetool --host localhost flush')
+            node.run_nodetool("flush")
 
     def check_timeout(self):
         assert self.monitors.nodes, 'Monitor node should be set, we will try to get metrics from Prometheus server'

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2557,6 +2557,7 @@ class BaseScyllaCluster(object):
         self.get_seed_nodes()
         self.get_scylla_version()
         self.set_traffic_control()
+        self.log.info("All DB nodes configured and stated. ScyllaDB status:\n%s" % self.nodes[0].run_nodetool("status"))
 
     def restart_scylla(self, nodes=None):
         if nodes:

--- a/sdcm/cluster_baremetal.py
+++ b/sdcm/cluster_baremetal.py
@@ -16,13 +16,14 @@ class NodeIpsNotConfiguredError(Exception):
 
 class PhysicalMachineNode(cluster.BaseNode):
 
-    def __init__(self, name, public_ip, private_ip, credentials, base_logdir=None, node_prefix=None):
+    def __init__(self, name, parent_cluster, public_ip, private_ip, credentials, base_logdir=None, node_prefix=None):
         ssh_login_info = {'hostname': None,
                           'user': credentials.name,
                           'key_file': credentials.key_file}
         self._public_ip = public_ip
         self._private_ip = private_ip
         super(PhysicalMachineNode, self).__init__(name=name,
+                                                  parent_cluster=parent_cluster,
                                                   base_logdir=base_logdir,
                                                   ssh_login_info=ssh_login_info,
                                                   node_prefix=node_prefix)
@@ -78,8 +79,9 @@ class PhysicalMachineCluster(cluster.BaseCluster):
 
     def _create_node(self, name, public_ip, private_ip):
         return PhysicalMachineNode(name,
-                                   public_ip,
-                                   private_ip,
+                                   parent_cluster=self,
+                                   public_ip=public_ip,
+                                   private_ip=private_ip,
                                    credentials=self.credentials[0],
                                    base_logdir=self.logdir,
                                    node_prefix=self.node_prefix)

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -16,7 +16,7 @@ class GCENode(cluster.BaseNode):
     Wraps GCE instances, so that we can also control the instance through SSH.
     """
 
-    def __init__(self, gce_instance, gce_service, credentials,
+    def __init__(self, gce_instance, gce_service, credentials, parent_cluster,
                  node_prefix='node', node_index=1, gce_image_username='root',
                  base_logdir=None, dc_idx=0):
         name = '%s-%s-%s' % (node_prefix, dc_idx, node_index)
@@ -28,6 +28,7 @@ class GCENode(cluster.BaseNode):
                           'key_file': credentials.key_file,
                           'extra_ssh_options': '-tt'}
         super(GCENode, self).__init__(name=name,
+                                      parent_cluster=parent_cluster,
                                       ssh_login_info=ssh_login_info,
                                       base_logdir=base_logdir,
                                       node_prefix=node_prefix,
@@ -285,6 +286,7 @@ class GCECluster(cluster.BaseCluster):
             return GCENode(gce_instance=instance,
                            gce_service=self._gce_services[dc_idx],
                            credentials=self._credentials[0],
+                           parent_cluster=self,
                            gce_image_username=self._gce_image_username,
                            node_prefix=self.node_prefix,
                            node_index=node_index,

--- a/sdcm/cluster_openstack.py
+++ b/sdcm/cluster_openstack.py
@@ -53,7 +53,7 @@ class OpenStackNode(cluster.BaseNode):
     Wraps EC2.Instance, so that we can also control the instance through SSH.
     """
 
-    def __init__(self, openstack_instance, openstack_service, credentials,
+    def __init__(self, openstack_instance, openstack_service, parent_cluster, credentials,
                  node_prefix='node', node_index=1, openstack_image_username='root',
                  base_logdir=None):
         name = '%s-%s' % (node_prefix, node_index)
@@ -66,6 +66,7 @@ class OpenStackNode(cluster.BaseNode):
                           'wait_key_installed': 30,
                           'extra_ssh_options': '-tt'}
         super(OpenStackNode, self).__init__(name=name,
+                                            parent_cluster=parent_cluster,
                                             ssh_login_info=ssh_login_info,
                                             base_logdir=base_logdir,
                                             node_prefix=node_prefix)
@@ -178,7 +179,7 @@ class OpenStackCluster(cluster.BaseCluster):
                                                            ex_keyname=self._credentials.name)
             cluster.OPENSTACK_INSTANCES.append(instance)
             nodes.append(OpenStackNode(openstack_instance=instance, openstack_service=self._openstack_service,
-                                       credentials=self._credentials,
+                                       credentials=self._credentials, parent_cluster=self,
                                        openstack_image_username=self._openstack_image_username,
                                        node_prefix=self.node_prefix, node_index=node_index,
                                        base_logdir=self.logdir))

--- a/sdcm/docker.py
+++ b/sdcm/docker.py
@@ -42,11 +42,12 @@ def _cmd(cmd, timeout=10, sudo=False):
 
 class DockerNode(cluster.BaseNode):
 
-    def __init__(self, name, credentials, base_logdir=None, node_prefix=None):
+    def __init__(self, name, credentials, parent_cluster, base_logdir=None, node_prefix=None):
         ssh_login_info = {'hostname': None,
                           'user': 'scylla-test',
                           'key_file': credentials.key_file}
         super(DockerNode, self).__init__(name=name,
+                                         parent_cluster=parent_cluster,
                                          base_logdir=base_logdir,
                                          ssh_login_info=ssh_login_info,
                                          node_prefix=node_prefix)
@@ -76,9 +77,10 @@ class DockerNode(cluster.BaseNode):
     def private_ip_address(self):
         return self._get_public_ip_address()
 
-    def run_nodetool(self, cmd):
+    def run_nodetool(self, sub_cmd, args="", options="", ignore_status=False):
+        cmd = self._gen_nodetool_cmd(sub_cmd, args, options)
         logger.debug('run nodetool %s' % cmd)
-        return _cmd('exec {} nodetool {}'.format(self.name, cmd))
+        return _cmd('exec {} {}'.format(self.name, cmd))
 
     def wait_public_ip(self):
         while not self._public_ip_address:
@@ -148,6 +150,7 @@ class DockerCluster(cluster.BaseCluster):
     def _create_node(self, node_name):
         return DockerNode(node_name,
                           credentials=self.credentials[0],
+                          parent_cluster=self,
                           base_logdir=self.logdir,
                           node_prefix=self.node_prefix)
 

--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -678,8 +678,8 @@ class ScyllaManagerToolNonRedhat(ScyllaManagerTool):
 
     def rollback_upgrade(self, scylla_mgmt_repo):
         manager_from_version = self.version[0]
+        self.manager_node.run_cqlsh("DROP KEYSPACE scylla_manager")
         remove_post_upgrade_repo = dedent("""
-                        cqlsh -e 'DROP KEYSPACE scylla_manager'
                         sudo systemctl stop scylla-manager
                         sudo systemctl stop scylla-server.service
                         sudo apt-get remove scylla-manager -y

--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -678,8 +678,8 @@ class ScyllaManagerToolNonRedhat(ScyllaManagerTool):
 
     def rollback_upgrade(self, scylla_mgmt_repo):
         manager_from_version = self.version[0]
-        self.manager_node.run_cqlsh("DROP KEYSPACE scylla_manager")
         remove_post_upgrade_repo = dedent("""
+                        cqlsh -e 'DROP KEYSPACE scylla_manager'
                         sudo systemctl stop scylla-manager
                         sudo systemctl stop scylla-server.service
                         sudo apt-get remove scylla-manager -y

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -811,8 +811,14 @@ class Nemesis(object):
         thread1.start()
 
         def repair_streaming_exists():
-            result = self.target_node.remoter.run('curl -X GET --header "Content-Type: application/json" --header "Accept: application/json" "http://127.0.0.1:10000/stream_manager/"')
-            return 'repair-' in result.stdout
+            active_repair_cmd = 'curl -s -X GET --header "Content-Type: application/json" --header ' \
+                                '"Accept: application/json" "http://127.0.0.1:10000/storage_service/active_repair/"'
+            result = self.target_node.remoter.run(active_repair_cmd)
+            active_repairs = re.match(".*\[(\d)\].*", result.stdout)
+            if active_repairs:
+                self.log.debug("Found '%s' active repairs", active_repairs.group(1))
+                return True
+            return False
 
         wait.wait_for(func=repair_streaming_exists,
                       timeout=300,

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -83,10 +83,10 @@ class CassandraStressThread(object):
         elif 'keyspace=' not in stress_cmd:  # if keyspace is defined in the command respect that
             stress_cmd = stress_cmd.replace(" -schema ", " -schema keyspace=keyspace{} ".format(keyspace_idx))
 
-        cql_auth = self.loader_set.get_cql_auth()
-        if cql_auth and 'user=' not in stress_cmd:
+        credentials = self.loader_set.get_db_auth()
+        if credentials and 'user=' not in stress_cmd:
             # put the credentials into the right place into -mode section
-            stress_cmd = re.sub(r'(-mode.*?)-', r'\1 user={} password={} -'.format(*cql_auth), stress_cmd)
+            stress_cmd = re.sub(r'(-mode.*?)-', r'\1 user={} password={} -'.format(*credentials), stress_cmd)
 
         if self.node_list and '-node' not in stress_cmd:
             first_node = [n for n in self.node_list if n.dc_idx == loader_idx % 3]  # make sure each loader is targeting on datacenter/region
@@ -227,7 +227,7 @@ if __name__ == '__main__':
         dc_idx = 1
 
     class LoaderSetDummy(object):
-        def get_cql_auth(self):
+        def get_db_auth(self):
             return None
 
         name = 'LoaderSetDummy'

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -223,8 +223,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
         self.monitors = None
         self.connections = []
 
-        if self.create_stats:
-            self.create_test_stats()
         self.init_resources()
         if self.params.get('seeds_first', default='false') == 'true':
             seeds_num = self.params.get('seeds_num', default=1)
@@ -234,6 +232,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
             self.db_cluster.wait_for_init()
         if self.cs_db_cluster:
             self.cs_db_cluster.wait_for_init()
+
+        if self.create_stats:
+            self.create_test_stats()
 
         # change RF of system_auth
         system_auth_rf = self.params.get('system_auth_rf', default=3)

--- a/snitch_test.py
+++ b/snitch_test.py
@@ -25,7 +25,7 @@ class SnitchTest(ClusterTester):
         """
         Verify the snitch setup, and check if system.peers is empty.
         """
-        result = self.db_cluster.nodes[0].remoter.run('nodetool describecluster')
+        result = self.db_cluster.nodes[0].run_nodetool("describecluster")
         assert 'GoogleCloudSnitch' in result.stdout, "Cluster doesn't use GoogleCloudSnitch"
 
         with self.cql_connection_patient_exclusive(self.db_cluster.nodes[0], timeout=60) as session:
@@ -35,7 +35,7 @@ class SnitchTest(ClusterTester):
 
         self.log.info("PASS: system.peers isn't empty as expected")
 
-        result = self.db_cluster.nodes[0].remoter.run('nodetool status', verbose=True)
+        result = self.db_cluster.nodes[0].run_nodetool("status")
         assert 'Datacenter: us-east1scylla_node_east' in result.stdout
         assert 'Datacenter: us-west1scylla_node_west' in result.stdout
 

--- a/sstable_corrupt.py
+++ b/sstable_corrupt.py
@@ -57,7 +57,7 @@ class SstableCorruptTest(ClusterTester):
         self._run_stress('write', population_size)
 
         logger.debug('Flush sstables')
-        self.db_cluster.nodes[0].run('nodetool flush')
+        self.db_cluster.nodes[0].run_nodetool('flush')
 
         self.corrupt_sstables()
         self._run_stress('read', population_size)

--- a/test-cases/longevity/longevity-1TB-7days-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
+++ b/test-cases/longevity/longevity-1TB-7days-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
@@ -1,0 +1,42 @@
+test_duration: 10900
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=1100200300 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native  -rate threads=1000 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1100200300"
+
+stress_cmd: ["cassandra-stress mixed         cl=QUORUM duration=10080m -schema 'replication(factor=3)                               compaction(strategy=LeveledCompactionStrategy)'    -port jmx=6868 -mode cql3 native  -rate threads=20 -pop seq=1..1100200300  -log interval=5 -col 'size=FIXED(1024) n=FIXED(1)'",
+             "cassandra-stress write         cl=QUORUM duration=10010m -schema 'replication(factor=3) compression=LZ4Compressor     compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=lz4                   -rate threads=50 -pop seq=1..50000000    -log interval=5",
+             "cassandra-stress write         cl=QUORUM duration=10020m -schema 'replication(factor=3) compression=SnappyCompressor  compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=snappy                -rate threads=50 -pop seq=1..50000000    -log interval=5",
+             "cassandra-stress write         cl=QUORUM duration=10030m -schema 'replication(factor=3) compression=DeflateCompressor compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=none                  -rate threads=50 -pop seq=1..50000000    -log interval=5",
+             "cassandra-stress counter_write cl=QUORUM duration=10080m -schema 'replication(factor=3) compaction(strategy=DateTieredCompactionStrategy)'                               -port jmx=6868 -mode cql3 native                                   -rate threads=10 -pop seq=1..10000000",
+             "cassandra-stress user profile=/tmp/cs_mv_profile.yaml ops'(insert=3,read1=1,read2=1,read3=1)' cl=QUORUM duration=10080m                                                  -port jmx=6868 -mode cql3 native                                   -rate threads=10"]
+
+stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=10080m                                                                                                                 -port jmx=6868 -mode cql3 native  -rate threads=10 -pop seq=1..1100200300  -log interval=5 -col 'size=FIXED(1024) n=FIXED(1)'",
+                  "cassandra-stress read cl=QUORUM duration=10010m -schema 'replication(factor=3) compression=LZ4Compressor compaction(strategy=SizeTieredCompactionStrategy)'     -port jmx=6868 -mode cql3 native compression=lz4                   -rate threads=20 -pop seq=1..50000000    -log interval=5",
+                  "cassandra-stress read cl=QUORUM duration=10020m -schema 'replication(factor=3) compression=SnappyCompressor compaction(strategy=SizeTieredCompactionStrategy)'  -port jmx=6868 -mode cql3 native compression=snappy                -rate threads=20 -pop seq=1..50000000    -log interval=5",
+                  "cassandra-stress read cl=QUORUM duration=10030m -schema 'replication(factor=3) compression=DeflateCompressor compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=none                  -rate threads=20 -pop seq=1..50000000    -log interval=5",
+                  "cassandra-stress counter_read cl=QUORUM duration=10080m -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..10000000"]
+run_fullscan: 'random, 17'  # 'ks.cf|random, interval(min)''
+
+n_db_nodes: 5
+n_loaders: 2
+n_monitor_nodes: 1
+
+instance_type_db: 'i3.4xlarge'
+instance_type_loader: 'c5.2xlarge'
+instance_type_monitor: 't3.large'
+
+nemesis_class_name: 'DisruptiveMonkey:1 NonDisruptiveMonkey:2'
+nemesis_interval: 30
+nemesis_during_prepare: 'true'
+
+user_prefix: 'longevity-tls-1tb-7d-1dis-2nondis'
+failure_post_behavior: destroy
+space_node_threshold: 644245094
+server_encrypt: 'true'
+# Setting client encryption to false for now, till we will find the way to make c-s work with that
+client_encrypt: 'false'
+
+authenticator: 'PasswordAuthenticator'
+authenticator_user: cassandra
+authenticator_password: cassandra
+authorizer: 'CassandraAuthorizer'
+
+use_mgmt: false

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -43,7 +43,8 @@ class TestBaseNode(unittest.TestCase):
         cls.temp_dir = tempfile.mkdtemp()
         start_events_device(cls.temp_dir, timeout=5)
 
-        cls.node = DummyNode(name='test_node', base_logdir=cls.temp_dir, ssh_login_info=dict(key_file='~/.ssh/scylla-test'))
+        cls.node = DummyNode(name='test_node', parent_cluster=None,
+                             base_logdir=cls.temp_dir, ssh_login_info=dict(key_file='~/.ssh/scylla-test'))
         cls.node.remoter = DummyRemote()
 
         cls.node.database_log = os.path.join(os.path.dirname(__file__), 'test_data', 'database.log')


### PR DESCRIPTION
Currently all over the coded cqlsh and nodetool are run by raw command using remoter object.
To prevent errors and handle Authentication cqlsh and nodetool command are now run from one place.
- Added 1 disruptive 2 nondisruptive Nemesis pipeline and YAML
- fixes
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (`hydra unit-tests`)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
