### PR TITLE
Disable backtrace decoding by default

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -30,3 +30,5 @@ spot_max_price: 0.60
 failure_post_behavior: destroy
 
 cloud_credentials_path: '~/.ssh/support'
+
+backtrace_decoding: false

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -164,6 +164,7 @@ class Setup(object):
     REUSE_CLUSTER = False
     MIXED_CLUSTER = False
     MULTI_REGION = False
+    BACKTRACE_DECODING = False
 
     _test_id = None
     _test_name = None
@@ -1143,13 +1144,14 @@ class BaseNode(object):
             backtraces = filter(filter_backtraces, backtraces)
 
             for backtrace in backtraces:
-                if backtrace['event'].raw_backtrace:
-                    try:
-                        scylla_debug_info = self.get_scylla_debuginfo_file()
-                        output = self.remoter.run('addr2line -Cpife {0} {1}'.format(scylla_debug_info, " ".join(backtrace['event'].raw_backtrace.split('\n'))), verbose=False)
-                        backtrace['event'].add_backtrace_info(backtrace=output.stdout)
-                    except Exception:
-                        self.log.exception("failed to decode backtrace")
+                if Setup.BACKTRACE_DECODING:
+                    if backtrace['event'].raw_backtrace:
+                        try:
+                            scylla_debug_info = self.get_scylla_debuginfo_file()
+                            output = self.remoter.run('addr2line -Cpife {0} {1}'.format(scylla_debug_info, " ".join(backtrace['event'].raw_backtrace.split('\n'))), verbose=False)
+                            backtrace['event'].add_backtrace_info(backtrace=output.stdout)
+                        except Exception:
+                            self.log.exception("failed to decode backtrace")
                 backtrace['event'].publish()
 
         return matches

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -204,6 +204,10 @@ class SCTConfiguration(dict):
             using ngrok server, see readme for more instructions
          """),
 
+        dict(name="backtrace_decoding", env="SCT_BACKTRACE_DECODING", type=boolean,
+             help="""If True, all backtraces found in db nodes would be decoded automatically"""),
+
+
         dict(name="reuse_cluster", env="SCT_REUSE_CLUSTER", type=str,
              help="""
             If true `test_id` would be used to run a test with existing cluster.

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -180,6 +180,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
         elif cluster_backend == 'gce':
             cluster.Setup.set_multi_region(len(self.params.get('gce_datacenter').split()) > 1)
 
+        cluster.Setup.BACKTRACE_DECODING = self.params.get('backtrace_decoding')
+
         version_tag = self.params.get('ami_id_db_scylla_desc')
         if version_tag:
             cluster.Setup.tags('version', version_tag)


### PR DESCRIPTION
At least until we figure out a better way to not effect
the cluster under test too much

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (`hydra unit-tests`)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
