### PR TITLE
Add fallback to storing monitoring data dir instead of prometheus snapshot

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -252,6 +252,10 @@ class NodeError(Exception):
             return self.msg
 
 
+class PrometheusSnapshotErrorException(Exception):
+    pass
+
+
 def prepend_user_prefix(user_prefix, base_name):
     if not user_prefix:
         user_prefix = DEFAULT_USER_PREFIX
@@ -3610,18 +3614,24 @@ class BaseMonitorSet(object):
 
         return storing_dir
 
-    def get_prometheus_snapshot(self, node):
-        # avoid cyclic-decencies between cluster and db_stats
-
+    @retrying(n=3, sleep_time=10, allowed_exceptions=(PrometheusSnapshotErrorException, ), message='Create prometheus snapshot')
+    def create_prometheus_snapshot(self, node):
         ps = PrometheusDBStats(host=node.public_ip_address)
         result = ps.create_snapshot()
-        self.log.debug(result)
         if "success" in result['status']:
             snapshot_dir = os.path.join(self.monitoring_data_dir,
                                         "snapshots",
                                         result['data']['name'])
+            return snapshot_dir
         else:
-            return ""
+            raise PrometheusSnapshotErrorException(result)
+
+    def get_prometheus_snapshot(self, node):
+        try:
+            snapshot_dir = self.create_prometheus_snapshot(node)
+        except PrometheusSnapshotErrorException as details:
+            self.log.warning('Create prometheus snapshot failed {}.\nUse prometheus data directory'.format(details))
+            snapshot_dir = self.monitoring_data_dir
 
         archive_snapshot_name = '/tmp/prometheus_snapshot-{}.tar.gz'.format(self.shortid)
         result = node.remoter.run('cd {}; tar -czvf {} .'.format(snapshot_dir,


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (`hydra unit-tests`)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
