### PR TITLE
in-memory: wrap ratio parameter by single quotes

### DIFF
--- a/test-cases/longevity/longevity-in-memory-36GB-4days.yaml
+++ b/test-cases/longevity/longevity-in-memory-36GB-4days.yaml
@@ -1,7 +1,7 @@
 test_duration: 6550
 prepare_write_cmd: ["cassandra-stress write                       cl=QUORUM n=21000000     -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=500 -pop seq=1..21000000 -col 'size=FIXED(200) n=FIXED(5)' -log interval=10",
                     "cassandra-stress counter_write               cl=QUORUM n=12345678     -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=1..12345678"]
-stress_cmd:        ["cassandra-stress mixed ratio(write=1,read=8) cl=QUORUM duration=5760m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -pop seq=1..21000000 -col 'size=FIXED(200) n=FIXED(5)' -log interval=10"]
+stress_cmd:        ["cassandra-stress mixed 'ratio(write=1,read=8)' cl=QUORUM duration=5760m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -pop seq=1..21000000 -col 'size=FIXED(200) n=FIXED(5)' -log interval=10"]
 stress_read_cmd:   ["cassandra-stress read                        cl=QUORUM duration=5760m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=1..21000000 -col 'size=FIXED(200) n=FIXED(5)' -log interval=10",
                     "cassandra-stress counter_read                cl=QUORUM duration=5760m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=10  -pop seq=1..12345678"]
 run_fullscan: 'random, 5' # 'ks.cf|random, interval(min)''

--- a/tests/longevity-in-memory-36GB-4days.yaml
+++ b/tests/longevity-in-memory-36GB-4days.yaml
@@ -1,7 +1,7 @@
 test_duration: 6550
 prepare_write_cmd: ["cassandra-stress write                       cl=QUORUM n=21000000     -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=500 -pop seq=1..21000000 -col 'size=FIXED(200) n=FIXED(5)' -log interval=10",
                     "cassandra-stress counter_write               cl=QUORUM n=12345678     -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=1..12345678"]
-stress_cmd:        ["cassandra-stress mixed ratio(write=1,read=8) cl=QUORUM duration=5760m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -pop seq=1..21000000 -col 'size=FIXED(200) n=FIXED(5)' -log interval=10"]
+stress_cmd:        ["cassandra-stress mixed 'ratio(write=1,read=8)' cl=QUORUM duration=5760m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -pop seq=1..21000000 -col 'size=FIXED(200) n=FIXED(5)' -log interval=10"]
 stress_read_cmd:   ["cassandra-stress read                        cl=QUORUM duration=5760m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=1..21000000 -col 'size=FIXED(200) n=FIXED(5)' -log interval=10",
                     "cassandra-stress counter_read                cl=QUORUM duration=5760m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=10  -pop seq=1..12345678"]
 run_fullscan: 'random, 5' # 'ks.cf|random, interval(min)''


### PR DESCRIPTION
bash: syntax error near unexpected token `('

Related with https://github.com/scylladb/scylla-cluster-tests/pull/1020

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (`hydra unit-tests`)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
