### PR TITLE
Fix `hydra run-test` to have test failures in output.log

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -287,7 +287,7 @@ class OutputLogger(object):
 
 @cli.command('run-test', help="Run SCT test using unittest")
 @click.argument('argv')
-@click.option('-b', '--backend', type=click.Choice(SCTConfiguration.available_backends), default='aws')
+@click.option('-b', '--backend', type=click.Choice(SCTConfiguration.available_backends), help="Backend to use")
 @click.option('-c', '--config', multiple=True, type=click.Path(exists=True), help="Test config .yaml to use, can have multiple of those")
 @click.option('-l', '--logdir', help="Directory to use for logs")
 def run_test(argv, backend, config, logdir):
@@ -304,7 +304,7 @@ def run_test(argv, backend, config, logdir):
     sys.stderr = OutputLogger(logfile, sys.stderr)
 
     unittest.main(module=None, argv=['python -m unittest', argv],
-                  testRunner=xmlrunner.XMLTestRunner(output='test-reports'),
+                  testRunner=xmlrunner.XMLTestRunner(stream=sys.stderr, output=os.path.join(Setup.logdir(), 'test-reports')),
                   failfast=False, buffer=False, catchbreak=True)
 
 

--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -278,8 +278,8 @@ class FillDatabaseData(ClusterTester):
                             ) WITH COMPACT STORAGE;"""],
             'truncates': ['TRUNCATE limit_ranges_test'],
             'inserts': [
-                "INSERT INTO limit_ranges_test (userid, url, time) VALUES ({}, 'http://foo.{}', 42)".format(id, tld)
-                for id in xrange(0, 100) for tld in ['com', 'org', 'net']],
+                "INSERT INTO limit_ranges_test (userid, url, time) VALUES ({}, 'http://foo.{}', 42)".format(_id, tld)
+                for _id in xrange(0, 100) for tld in ['com', 'org', 'net']],
             'queries': [
                 "SELECT * FROM limit_ranges_test WHERE token(userid) >= token(2) LIMIT 1",
                 "SELECT * FROM limit_ranges_test WHERE token(userid) > token(2) LIMIT 1"],
@@ -299,9 +299,9 @@ class FillDatabaseData(ClusterTester):
                             ) WITH COMPACT STORAGE;"""],
             'truncates': ['TRUNCATE limit_multiget_test'],
             'inserts': [
-                "INSERT INTO limit_multiget_test (userid, url, time) VALUES ({}, 'http://foo.{}', 42)".format(id,
+                "INSERT INTO limit_multiget_test (userid, url, time) VALUES ({}, 'http://foo.{}', 42)".format(_id,
                                                                                                               tld)
-                for id in xrange(0, 100) for tld in ['com', 'org', 'net']],
+                for _id in xrange(0, 100) for tld in ['com', 'org', 'net']],
             'queries': [
                 "SELECT * FROM limit_multiget_test WHERE userid IN (48, 2) LIMIT 1"],
             'results': [
@@ -346,7 +346,7 @@ class FillDatabaseData(ClusterTester):
             'truncates': ['TRUNCATE limit_sparse_test'],
             'inserts': [
                 "INSERT INTO limit_sparse_test (userid, url, day, month, year) VALUES ({}, 'http://foo.{}', 1, 'jan', 2012)".format(
-                    id, tld) for id in xrange(0, 100) for tld in ['com', 'org', 'net']],
+                    _id, tld) for _id in xrange(0, 100) for tld in ['com', 'org', 'net']],
             'queries': [
                 "SELECT * FROM limit_sparse_test LIMIT 4"],
             'results': [


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- ~~[ ] New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- ~~[ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (`hydra unit-tests`)
- ~~[ ] I have updated the Readme/doc folder accordingly (if needed)~~
