### PR TITLE
Change large-partitions to use i3en instead of i3

### DIFF
--- a/test-cases/longevity/longevity-large-partition-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-4days.yaml
@@ -8,7 +8,7 @@ n_db_nodes: 4
 n_loaders: 3
 n_monitor_nodes: 1
 
-instance_type_db: 'i3.2xlarge'
+instance_type_db: 'i3en.3xlarge'
 
 nemesis_class_name: 'ChaosMonkey'
 nemesis_interval: 30


### PR DESCRIPTION
I3en support was added in Scylla (high NVME capacity instances).
I3en.3xlarge has 96GB RAM and 12vCPU (instead of i3.2xlarge that has 61GB and 8vCPU).