### PR TITLE
make sure reboot is really executed

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -420,12 +420,23 @@ class AWSNode(cluster.BaseNode):
             self.start_scylla_server(verify_up=False)
 
     def reboot(self, hard=True, verify_ssh=True):
+        result = self.remoter.run('uptime -s')
+        pre_uptime = result.stdout
+
+        def uptime_changed():
+            result = self.remoter.run('uptime -s', ignore_status=True)
+            return pre_uptime != result.stdout
+
         if hard:
             self.log.debug('Hardly rebooting node')
             self._instance_wait_safe(self._instance.reboot)
         else:
             self.log.debug('Softly rebooting node')
             self.remoter.run('sudo reboot', ignore_status=True)
+
+        # wait until the reboot is executed
+        wait.wait_for(func=uptime_changed, step=1, timeout=60, throw_exc=True)
+
         if verify_ssh:
             self.wait_ssh_up()
 

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -110,12 +110,23 @@ class GCENode(cluster.BaseNode):
         self._instance_wait_safe(self._instance.reboot)
 
     def reboot(self, hard=True, verify_ssh=True):
+        result = self.remoter.run('uptime -s')
+        pre_uptime = result.stdout
+
+        def uptime_changed():
+            result = self.remoter.run('uptime -s', ignore_status=True)
+            return pre_uptime != result.stdout
+
         if hard:
             self.log.debug('Hardly rebooting node')
             self._instance_wait_safe(self._instance.reboot)
         else:
             self.log.debug('Softly rebooting node')
             self.remoter.run('sudo reboot', ignore_status=True)
+
+        # wait until the reboot is executed
+        wait.wait_for(func=uptime_changed, step=1, timeout=60, throw_exc=True)
+
         if verify_ssh:
             self.wait_ssh_up()
 


### PR DESCRIPTION
The hard reboot is async action, sometimes the system is still live a while
after reboot call returns, it's easy to occur if system load is heavy.

This patch checked uptime to know the system reboot is executed.

Fixes #759


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (`hydra unit-tests`)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
