### PR TITLE
Add space_node_threshold to test defaults

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -17,6 +17,7 @@ scylla_linux_distro_loader: 'centos'
 monitor_branch: 'branch-2.4'
 store_results_in_elasticsearch: true
 
+space_node_threshold: 0
 
 reuse_cluster: false
 nemesis_class_name: 'NoOpMonkey'

--- a/test-cases/longevity/longevity-multi-keyspaces.yaml
+++ b/test-cases/longevity/longevity-multi-keyspaces.yaml
@@ -7,6 +7,8 @@ run_fullscan: 'random, 30'
 keyspace_num: 1000
 batch_size: 100
 
+space_node_threshold: 10485760
+
 nemesis_class_name: 'ChaosMonkey'
 nemesis_interval: 30
 


### PR DESCRIPTION
1. Set as 0 in defaults to avoid failures in yamls that didn't define it.
2. Add 10MB threshold for multi-keyspace-test.