### PR TITLE
node_setup/deb: disable apt daily services

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2517,6 +2517,11 @@ class BaseScyllaCluster(object):
         :param verbose:
         """
         node.wait_ssh_up(verbose=verbose)
+        if node.init_system == 'systemd' and (node.is_ubuntu() or node.is_debian()):
+            node.remoter.run('sudo systemctl disable apt-daily.timer')
+            node.remoter.run('sudo systemctl disable apt-daily-upgrade.timer')
+            node.remoter.run('sudo systemctl stop apt-daily.timer')
+            node.remoter.run('sudo systemctl stop apt-daily-upgrade.timer')
         endpoint_snitch = self.params.get('endpoint_snitch')
         seed_address = self.get_seed_nodes_by_flag()
 


### PR DESCRIPTION
The apt daily services might automatically run in background,
which will hold apt lock, then our apt commands in test will fail.


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (`hydra unit-tests`)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
