### PR TITLE
Change `db_log_reader_thread()` and backtrace_thread()` to wait better

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -758,26 +758,22 @@ class BaseNode(object):
         """
         Keep reporting new coredumps found, every 30 seconds.
         """
-        while True:
-            if self.termination_event.isSet():
-                break
+        while not self.termination_event.isSet():
+            self.termination_event.wait(15)
             self.get_backtraces()
-            time.sleep(30)
 
     def db_log_reader_thread(self):
         """
         Keep reporting new events from db log, every 30 seconds.
         """
-        while True:
-            if self.termination_event.isSet():
-                break
+        while not self.termination_event.isSet():
+            self.termination_event.wait(15)
             try:
                 self.search_database_log(start_from_beginning=False, publish_events=True)
             except Exception:
                 self.log.exception("failed to read db log")
             except (SystemExit, KeyboardInterrupt) as ex:
                 self.log.debug("db_log_reader_thread() stopped by %s", ex.__class__.__name__)
-            time.sleep(30)
 
     def start_backtrace_thread(self):
         self._backtrace_thread = threading.Thread(target=self.backtrace_thread)


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- ~~[ ] New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- ~~[ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (`hydra unit-tests`)
- ~~[ ] I have updated the Readme/doc folder accordingly (if needed)~~
