### PR TITLE
Journal thread utc

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2471,7 +2471,6 @@ class BaseScyllaCluster(object):
     @log_run_info("Start nemesis threads on cluster")
     def start_nemesis(self, interval=30):
         for nemesis in self.nemesis:
-            nemesis.set_target_node(is_running=True)
             nemesis_thread = threading.Thread(target=nemesis.run,
                                               args=(interval, ), verbose=True)
             nemesis_thread.daemon = True

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -54,12 +54,6 @@ class Nemesis(object):
         self.target_node = None
         logger = logging.getLogger(__name__)
         self.log = SDCMAdapter(logger, extra={'prefix': str(self)})
-        self.set_target_node()
-        result = self.target_node.remoter.run('rpm -qa | grep scylla | sort', verbose=False,
-                                              ignore_status=True)
-        self.db_software_version = ['not available (using cassandra)']
-        if result.stdout:
-            self.db_software_version = result.stdout.splitlines()
         self.termination_event = termination_event
         self.operation_log = []
         self.current_disruption = None
@@ -130,9 +124,7 @@ class Nemesis(object):
             avg_duration = 0
 
         self.log.info('Report')
-        self.log.info('DB Version:')
-        for line in self.db_software_version:
-            self.log.info(line)
+        self.log.info('DB Version: %s', getattr(self.cluster.nodes[0], "scylla_version", "n/a"))
         self.log.info('Interval: %s s', self.interval)
         self.log.info('Average duration: %s s', avg_duration)
         self.log.info('Total execution time: %s s', int(time.time() - self.start_time))


### PR DESCRIPTION
- Adding `--utc` to `journalctl` command and starting the thread from the timestamp it finsihed reading last time it was running, this fixes situations when node got rebooted by different Nemesis
- removing unnecessary calls to set_target_node
- Nemesis: getting Scylla version using a new method introduced by Israel

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (`hydra unit-tests`)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
