### PR TITLE
Fix: call to get_backtraces crashes TearDown when one of node is down

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1966,9 +1966,12 @@ class BaseCluster(object):
 
     def get_backtraces(self):
         for node in self.nodes:
-            node.get_backtraces()
-            if node.n_coredumps > 0:
-                self.coredumps[node.name] = node.n_coredumps
+            try:
+                node.get_backtraces()
+                if node.n_coredumps > 0:
+                    self.coredumps[node.name] = node.n_coredumps
+            except Exception as ex:
+                self.log.warning("Unable to get coredump status from node {node}: {ex}".format(**locals()))
 
     def node_setup(self, node, verbose=False, timeout=3600):
         raise NotImplementedError("Derived class must implement 'node_setup' method!")


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (`hydra unit-tests`)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
