### PR TITLE
BaseNode: avoid ssh connect when user isn't created

### DIFF
--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -23,6 +23,9 @@ class GCENode(cluster.BaseNode):
         self._instance = gce_instance
         self._gce_service = gce_service
         self._wait_public_ip()
+        # sleep 10 seconds for waiting users are added to system
+        # related issue: https://github.com/scylladb/scylla-cluster-tests/issues/1121
+        time.sleep(10)
         ssh_login_info = {'hostname': None,
                           'user': gce_image_username,
                           'key_file': credentials.key_file,


### PR DESCRIPTION
In recent rolling upgrade test, some gce instances failed to setup for
wait_ssh_up timeout, and their network (ssh) got ready by using 600+
seconds.

It seems the problem only occurs if multiple instances initialize in the
same time.

Fixes #1121

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (`hydra unit-tests`)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
