### PR TITLE
Build list of Disruptive and NonDisruptive methods one time

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1477,10 +1477,14 @@ class DisruptiveMonkey(Nemesis):
         #  - DecommissionMonkey
         #  - NodeRestartWithResharding
         #  - DrainerMonkey
+
+    def __init__(self, *args, **kwargs):
+        super(DisruptiveMonkey, self).__init__(*args, **kwargs)
+        self.disrupt_methods_list = self.get_list_of_disrupt_methods_for_nemesis_subclasses(disruptive=True)
+
     @log_time_elapsed_and_status
     def disrupt(self):
-        disrupt_methods_list = self.get_list_of_disrupt_methods_for_nemesis_subclasses(disruptive=True)
-        self.call_random_disrupt_method(disrupt_methods=disrupt_methods_list)
+        self.call_random_disrupt_method(disrupt_methods=self.disrupt_methods_list)
 
 
 class NonDisruptiveMonkey(Nemesis):
@@ -1492,22 +1496,27 @@ class NonDisruptiveMonkey(Nemesis):
         #  - NoCorruptRepairMonkey
         #  - MgmtRepair
         #  - AbortRepairMonkey
+
+    def __init__(self, *args, **kwargs):
+        super(NonDisruptiveMonkey, self).__init__(*args, **kwargs)
+        self.disrupt_methods_list = self.get_list_of_disrupt_methods_for_nemesis_subclasses(disruptive=False)
+
     @log_time_elapsed_and_status
     def disrupt(self):
-        disrupt_methods_list = self.get_list_of_disrupt_methods_for_nemesis_subclasses(disruptive=False)
-        self.call_random_disrupt_method(disrupt_methods=disrupt_methods_list)
+        self.call_random_disrupt_method(disrupt_methods=self.disrupt_methods_list)
 
 
 class GeminiChaosMonkey(Nemesis):
     # Limit the nemesis scope to use with gemini
         # - StopStartMonkey
         # - RestartThenRepairNodeMonkey
+    def __init__(self, *args, **kwargs):
+        super(GeminiChaosMonkey, self).__init__(*args, **kwargs)
+        self.disrupt_methods_list = self.get_list_of_disrupt_methods_for_nemesis_subclasses(run_with_gemini=True)
 
     @log_time_elapsed_and_status
     def disrupt(self):
-        disrupt_methods_list = self.get_list_of_disrupt_methods_for_nemesis_subclasses(run_with_gemini=True)
-        self.log.info(disrupt_methods_list)
-        self.call_random_disrupt_method(disrupt_methods=disrupt_methods_list)
+        self.call_random_disrupt_method(disrupt_methods=self.disrupt_methods_list)
 
 
 RELATIVE_NEMESIS_SUBCLASS_LIST = [NotSpotNemesis]


### PR DESCRIPTION
List of methods to use in Disruptive and NonDisruptive Monkey
built each time with disrupt method is runing.

Move building list of method to constructor.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels

