### PR TITLE
Fix cases of broken stalls line break events filtering

### DIFF
--- a/sdcm/sct_events.py
+++ b/sdcm/sct_events.py
@@ -166,9 +166,11 @@ class DbEventsFilter(SystemEvent):
         self.cancel_filter()
 
     def eval_filter(self, event):
-        name = self.type and self.type == getattr(event, 'type', '')
-        string = self.line and self.line in getattr(event, 'line', '')
-        return (name and string) if self.line else name
+        line = getattr(event, 'line', '')
+        _type = getattr(event, 'type', '')
+        is_name_matching = self.type and _type and self.type == _type
+        is_line_matching = self.line and line and self.line in line
+        return (is_name_matching and is_line_matching) if self.line else is_name_matching
 
 
 class InfoEvent(SctEvent):
@@ -299,7 +301,7 @@ class DatabaseLogEvent(SctEvent):
                     self.severity = Severity.NORMAL
 
             except (ValueError, IndexError):
-                LOGGER.exception("failed to read REACTOR_STALLED line=[%s] ", line)
+                LOGGER.warning("failed to read REACTOR_STALLED line=[%s] ", line)
 
     def add_backtrace_info(self, backtrace=None, raw_backtrace=None):
         if backtrace:

--- a/unit_tests/test_events.py
+++ b/unit_tests/test_events.py
@@ -142,6 +142,16 @@ class SctEventsTests(unittest.TestCase):
             with open(log_file) as f:
                 self.assertNotIn('supressed', f.read())
 
+    def test_failed_stall_during_filter(self):
+
+        with DbEventsFilter(type="NO_SPACE_ERROR"), DbEventsFilter(type='BACKTRACE', line='No space left on device'):
+
+            event = DatabaseLogEvent(type="REACTOR_STALLED", regex="B")
+            event.add_info_and_publish(node="A", line_number=22,
+                                       line="[99.80.124.204] [stdout] Mar 31 09:08:10 warning|  reactor stall 20")
+            logging.info(event.severity)
+            self.assertTrue(event.severity == Severity.CRITICAL)
+
     @unittest.skip("this test need some more work")
     def test_kill_test_event(self):
         self.assertTrue(self.test_killer.is_alive())


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- ~~[ ] New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (`hydra unit-tests`)
- ~~[ ] I have updated the Readme/doc folder accordingly (if needed)~~

A broken line of stall, was breaking the event loops while filtering
```
raceback (most recent call last):
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/sct/sdcm/sct_events.py", line 383, in run
    for event_type, message_data in EVENTS_PROCESSES['MainDevice'].subscribe_events():
  File "/sct/sdcm/sct_events.py", line 82, in subscribe_events
    obj_filtered = any([f.eval_filter(obj) for f in filters.values()])
  File "/sct/sdcm/sct_events.py", line 170, in eval_filter
    string = self.line and self.line in getattr(event, 'line', '')
TypeError: argument of type 'NoneType' is not iterable
```