### PR TITLE
Hydra containers are named with test_id

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -8,6 +8,7 @@ PY_PREREQS_FILE=requirements-python.txt
 CENTOS_PREREQS_FILE=install-prereqs.sh
 WORK_DIR=/sct
 HOST_NAME=SCT-CONTAINER
+export SCT_TEST_ID=${SCT_TEST_ID:-$(uuidgen)}
 
 # if running on Build server
 if [[ ${USER} == "jenkins" ]]; then
@@ -77,5 +78,6 @@ docker run --rm ${TTY_STDIN} --privileged \
     ${BUILD_OPTIONS} \
     ${AWS_OPTIONS} \
     --net=host \
+    --name=${SCT_TEST_ID} \
     scylladb/hydra:v${VERSION} \
     /bin/bash -c "${TERM_SET_SIZE} eval '${CMD}'"

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -174,20 +174,24 @@ class Setup(object):
 
     @classmethod
     def test_id(cls):
-        if not cls._test_id:
-            cls._test_id = uuid.uuid4()
         return cls._test_id
 
     @classmethod
-    def set_test_id(cls, new_test_id):
-        if new_test_id:
-            cls._test_id = new_test_id
+    def set_test_id(cls, test_id):
+        if not cls._test_id:
+            cls._test_id = test_id
+            test_id_file_path = os.path.join(cls.logdir(), "test_id")
+            with open(test_id_file_path, "w") as test_id_file:
+                test_id_file.write(test_id)
+        else:
+            logger.warning("TestID already set!")
 
     @classmethod
     def logdir(cls):
         if not cls._logdir:
             sct_base = os.path.expanduser(os.environ.get('_SCT_LOGDIR', '~/sct-results'))
-            cls._logdir = os.path.join(sct_base, str(cls.test_id()))
+            date_time_formatted = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
+            cls._logdir = os.path.join(sct_base, str(date_time_formatted))
             os.makedirs(cls._logdir)
 
             latest_symlink = os.path.join(sct_base, 'latest')

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -229,7 +229,7 @@ class AWSCluster(cluster.BaseCluster):
 
     def _get_instances(self, dc_idx):
 
-        test_id = self.params.get('test_id', default=None)
+        test_id = cluster.Setup.test_id()
         if not test_id:
             raise ValueError("test_id should be configured for using reuse_cluster")
 

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -214,21 +214,12 @@ class SCTConfiguration(dict):
 
         dict(name="reuse_cluster", env="SCT_REUSE_CLUSTER", type=str,
              help="""
-            If true `test_id` would be used to run a test with existing cluster.
-            You have to define all the nodes ip addresses both public and private:
-
-            `reuse_cluster: True`
-            `test_id: 7dc6db84-eb01-4b61-a946-b5c72e0f6d71`
-            `db_nodes_public_ip: []`
-            `db_nodes_private_ip: []`
-            `loaders_public_ip: []`
-            `loaders_private_ip: []`
-            `monitor_nodes_public_ip: []`
-            `monitor_nodes_private_ip: []`
+            If reuse_cluster is set it should hold test_id of the cluster that will be reused.
+            `reuse_cluster: 7dc6db84-eb01-4b61-a946-b5c72e0f6d71`
          """),
 
         dict(name="test_id", env="SCT_TEST_ID",  type=str,
-             help="""see [`reuse_cluster`](#reuse_cluster) for more info on usage."""),
+             help="""Set the test_id of the run manually. Use only from the env before running Hydra"""),
 
         dict(name="seeds_first", env="SCT_SEEDS_FIRST",  type=boolean,
              help="""If true would start and wait for the seed nodes to finish booting"""),


### PR DESCRIPTION
Naming the Hydra containers with Test ID.
In future, we can easily find/kill jobs by test id, list resources used by all test/s
 ```
bentsi@bentsi-Latitude-5480:~/devel/scylladb$ docker ps
CONTAINER ID        IMAGE                  COMMAND                  CREATED              STATUS              PORTS               NAMES
1d63441359b9        scylladb/hydra:v0.39   "/bin/bash -c 'expor…"   About a minute ago   Up About a minute                       296f7f9a-f8b8-49dd-b935-d625be1069bf
```
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels`
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (`hydra unit-tests`)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
