### PR TITLE
upgrade_test: only verify one sstable file by sstabledump to reduce test time

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -365,7 +365,7 @@ class UpgradeTest(FillDatabaseData):
         self.verify_stress_thread(sst3_stress_queue)
 
         self.log.debug('start sstabledump verify')
-        self.db_cluster.nodes[0].remoter.run('for i in `sudo find /var/lib/scylla/data/keyspace_sst3/ -type f |grep -v manifest.json |grep -v snapshots`; do echo $i; sudo sstabledump $i 1>/tmp/sstabledump.output || exit 1; done', verbose=True)
+        self.db_cluster.nodes[0].remoter.run('for i in `sudo find /var/lib/scylla/data/keyspace_sst3/ -type f |grep -v manifest.json |grep -v snapshots |head -n 1`; do echo $i; sudo sstabledump $i 1>/tmp/sstabledump.output || exit 1; done', verbose=True)
 
         self.log.info('all nodes were upgraded, and last workaround is verified.')
 


### PR DESCRIPTION
…est time

It took more than 6 hours to verify all sstable files of keyspace_complex.

Signed-off-by: Amos Kong <amos@scylladb.com>
(cherry picked from commit fd1007feb3ca6b3f67dff700ec4d7d7c7aeb7117)

Conflicts:
	upgrade_test.py

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (`hydra unit-tests`)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
