### PR TITLE
Support to configure Encryption at rest

### DIFF
--- a/data_dir/encrypt_conf/system_key
+++ b/data_dir/encrypt_conf/system_key
@@ -1,0 +1,1 @@
+AES/ECB/PKCS5Padding:128:E0zewvdUx81Ka9HGGVMhWg==

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -39,6 +39,7 @@
 | **<a name="hinted_handoff">hinted_handoff</a>**  | when enable or disable scylla hinted handoff | N/A | SCT_HINTED_HANDOFF
 | **<a name="authenticator">authenticator</a>**  | which authenticator scylla will use AllowAllAuthenticator/PasswordAuthenticator | N/A | SCT_AUTHENTICATOR
 | **<a name="append_scylla_args">append_scylla_args</a>**  | More arguments to append to scylla command line | N/A | SCT_APPEND_SCYLLA_ARGS
+| **<a name="append_scylla_yaml">append_scylla_yaml</a>**  | More configuration to append to /etc/scylla/scylla.yaml | N/A | SCT_APPEND_SCYLLA_YAML
 | **<a name="nemesis_class_name">nemesis_class_name</a>**  | Nemesis class to use (possible types in sdcm.nemesis). | NoOpMonkey | SCT_NEMESIS_CLASS_NAME
 | **<a name="nemesis_interval">nemesis_interval</a>**  | Nemesis sleep interval to use if None provided specifically in the test | N/A | SCT_NEMESIS_CLASS_NAME
 | **<a name="nemesis_during_prepare">nemesis_during_prepare</a>**  | Run nemesis during prepare stage of the test | False | SCT_NEMESIS_CLASS_NAME

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1367,7 +1367,7 @@ class BaseNode(object):  # pylint: disable=too-many-instance-attributes,too-many
     # pylint: disable=invalid-name,too-many-arguments,too-many-locals,too-many-branches,too-many-statements
     def config_setup(self, seed_address=None, cluster_name=None, enable_exp=True, endpoint_snitch=None,
                      yaml_file=SCYLLA_YAML_PATH, broadcast=None, authenticator=None, server_encrypt=None,
-                     client_encrypt=None, append_conf=None, append_scylla_args=None, debug_install=False,
+                     client_encrypt=None, append_scylla_yaml=None, append_scylla_args=None, debug_install=False,
                      hinted_handoff='enabled', murmur3_partitioner_ignore_msb_bits=None, authorizer=None,
                      alternator_port=None, listen_on_all_interfaces=False):
         yaml_dst_path = os.path.join(tempfile.mkdtemp(prefix='scylla-longevity'), 'scylla.yaml')
@@ -1507,7 +1507,7 @@ server_encryption_options:
                 scylla_yaml_contents += "\nalternator_port: %s\n" % alternator_port
 
         # system_key must be pre-created, kmip keys will be used for kmip server auth
-        if append_conf and ('system_key_directory' in append_conf or 'system_info_encryption' in append_conf or 'kmip_hosts:' in append_conf):
+        if append_scylla_yaml and ('system_key_directory' in append_scylla_yaml or 'system_info_encryption' in append_scylla_yaml or 'kmip_hosts:' in append_scylla_yaml):
             self.remoter.send_files(src='./data_dir/encrypt_conf',
                                     dst='/tmp/')
             self.remoter.run('sudo mv /tmp/encrypt_conf /etc/')
@@ -1515,8 +1515,8 @@ server_encryption_options:
             self.remoter.run('sudo chown -R scylla:scylla /etc/encrypt_conf/')
             self.remoter.run('sudo md5sum /etc/encrypt_conf/*.pem', ignore_status=True)
 
-        if append_conf:
-            scylla_yaml_contents += append_conf
+        if append_scylla_yaml:
+            scylla_yaml_contents += append_scylla_yaml
 
         with open(yaml_dst_path, 'w') as scylla_yaml_file:
             scylla_yaml_file.write(scylla_yaml_contents)
@@ -2881,7 +2881,7 @@ class BaseScyllaCluster(object):  # pylint: disable=too-many-public-methods
                           authenticator=self.params.get('authenticator'),  # pylint: disable=no-member
                           server_encrypt=self._param_enabled('server_encrypt'),  # pylint: disable=no-member
                           client_encrypt=self._param_enabled('client_encrypt'),  # pylint: disable=no-member
-                          append_conf=self.params.get('append_conf'), append_scylla_args=self.get_scylla_args(),  # pylint: disable=no-member
+                          append_scylla_yaml=self.params.get('append_scylla_yaml'), append_scylla_args=self.get_scylla_args(),  # pylint: disable=no-member
                           hinted_handoff=self.params.get('hinted_handoff'),  # pylint: disable=no-member
                           authorizer=self.params.get('authorizer'),  # pylint: disable=no-member
                           alternator_port=self.params.get('alternator_port'))  # pylint: disable=no-member

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1505,6 +1505,15 @@ server_encryption_options:
                                              scylla_yaml_contents)
             else:
                 scylla_yaml_contents += "\nalternator_port: %s\n" % alternator_port
+
+        # system_key must be pre-created, kmip keys will be used for kmip server auth
+        if append_conf and ('system_key_directory' in append_conf or 'system_info_encryption' in append_conf or 'kmip_hosts:' in append_conf):
+            self.remoter.send_files(src='./data_dir/encrypt_conf',
+                                    dst='/tmp/')
+            self.remoter.run('sudo mv /tmp/encrypt_conf /etc/')
+            self.remoter.run('sudo mkdir /etc/encrypt_conf/system_key_dir/')
+            self.remoter.run('sudo chown -R scylla:scylla /etc/encrypt_conf/')
+
         if append_conf:
             scylla_yaml_contents += append_conf
 

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1513,6 +1513,7 @@ server_encryption_options:
             self.remoter.run('sudo mv /tmp/encrypt_conf /etc/')
             self.remoter.run('sudo mkdir /etc/encrypt_conf/system_key_dir/')
             self.remoter.run('sudo chown -R scylla:scylla /etc/encrypt_conf/')
+            self.remoter.run('sudo md5sum /etc/encrypt_conf/*.pem', ignore_status=True)
 
         if append_conf:
             scylla_yaml_contents += append_conf

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -717,7 +717,8 @@ class ScyllaAWSCluster(cluster.BaseScyllaCluster, AWSCluster):
             authorizer=self.params.get('authorizer'),
             hinted_handoff=self.params.get('hinted_handoff'),
             alternator_port=self.params.get('alternator_port'),
-            seed_address=seed_address
+            seed_address=seed_address,
+            append_conf=self.params.get('append_conf'),
         )
         if cluster.Setup.INTRA_NODE_COMM_PUBLIC:
             setup_params.update(dict(

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -718,7 +718,7 @@ class ScyllaAWSCluster(cluster.BaseScyllaCluster, AWSCluster):
             hinted_handoff=self.params.get('hinted_handoff'),
             alternator_port=self.params.get('alternator_port'),
             seed_address=seed_address,
-            append_conf=self.params.get('append_conf'),
+            append_scylla_yaml=self.params.get('append_scylla_yaml'),
         )
         if cluster.Setup.INTRA_NODE_COMM_PUBLIC:
             setup_params.update(dict(

--- a/sdcm/keystore.py
+++ b/sdcm/keystore.py
@@ -13,6 +13,11 @@ class KeyStore(object):
         obj = self.s3.Object(KEYSTORE_S3_BUCKET, json_file)
         return json.loads(obj.get()["Body"].read())
 
+    def download_file(self, filename, dest_filename):
+        obj = self.s3.Object(KEYSTORE_S3_BUCKET, filename)
+        with open(dest_filename, 'w') as file_obj:
+            file_obj.write(obj.get()["Body"].read())
+
     def get_email_credentials(self):
         return self._get_json("email_config.json")
 

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -297,8 +297,8 @@ class SCTConfiguration(dict):
         dict(name="append_scylla_args_oracle", env="SCT_APPEND_SCYLLA_ARGS_ORACLE", type=str,
              help="More arguments to append to oracle command line"),
 
-        dict(name="append_conf", env="SCT_APPEND_CONF", type=str,
-             help="More arguments to append to /etc/scylla/scylla.yaml"),
+        dict(name="append_scylla_yaml", env="SCT_APPEND_SCYLLA_YAML", type=str,
+             help="More configuration to append to /etc/scylla/scylla.yaml"),
 
         # Nemesis config options
 

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -296,6 +296,10 @@ class SCTConfiguration(dict):
 
         dict(name="append_scylla_args_oracle", env="SCT_APPEND_SCYLLA_ARGS_ORACLE", type=str,
              help="More arguments to append to oracle command line"),
+
+        dict(name="append_conf", env="SCT_APPEND_CONF", type=str,
+             help="More arguments to append to /etc/scylla/scylla.yaml"),
+
         # Nemesis config options
 
         dict(name="nemesis_class_name", env="SCT_NEMESIS_CLASS_NAME", type=str,

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1560,7 +1560,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             if upgradesstables:
                 self.log.debug('upgrade sstables after encryption update')
                 for node in self.db_cluster.nodes:
-                    node.remoter.run('nodetool upgradesstables', verbose=True)
+                    node.remoter.run('nodetool upgradesstables', verbose=True, ignore_status=True)
 
     def disable_table_encryption(self, table, upgradesstables=True):
         self.alter_table_encryption(

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1567,7 +1567,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             table, scylla_encryption_options="{'key_provider': 'none'}", upgradesstables=upgradesstables)
 
     def alter_test_tables_encryption(self, scylla_encryption_options=None, upgradesstables=True):
-        for table in get_non_system_ks_cf_list(self.loaders.nodes[0], self.db_cluster.nodes[0]):
+        for table in get_non_system_ks_cf_list(self.loaders.nodes[0], self.db_cluster.nodes[0], filter_out_mv=True):
             self.alter_table_encryption(
                 table, scylla_encryption_options=scylla_encryption_options, upgradesstables=upgradesstables)
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -59,7 +59,7 @@ from sdcm.cluster_aws import LoaderSetAWS
 from sdcm.cluster_aws import MonitorSetAWS
 from sdcm.utils.common import get_data_dir_path, log_run_info, retrying, ScyllaCQLSession, \
     get_non_system_ks_cf_list, makedirs, format_timestamp, wait_ami_available, tag_ami, update_certificates, \
-    download_dir_from_cloud, get_post_behavior_actions, get_testrun_status
+    download_dir_from_cloud, get_post_behavior_actions, get_testrun_status, download_encrypt_keys
 from sdcm.utils.log import configure_logging
 from sdcm.db_stats import PrometheusDBStats
 from sdcm.results_analyze import PerformanceResultsAnalyzer
@@ -245,6 +245,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         # download rpms for update_db_packages
         update_db_packages = self.params.get('update_db_packages', default=None)
         self.params['update_db_packages'] = download_dir_from_cloud(update_db_packages)
+
+        append_conf = self.params.get('append_conf')
+        if append_conf and ('system_key_directory' in append_conf or 'system_info_encryption' in append_conf or 'kmip_hosts:' in append_conf):
+            download_encrypt_keys()
 
         self.init_resources()
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -830,26 +830,38 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self.update_stress_cmd_details(stress_cmd, prefix, stresser="cassandra-stress",
                                            aggregate=stats_aggregate_cmds)
 
-        return CassandraStressThread(loader_set=self.loaders,
-                                     stress_cmd=stress_cmd,
-                                     timeout=timeout,
-                                     output_dir=cluster.Setup.logdir(),
-                                     stress_num=stress_num,
-                                     keyspace_num=keyspace_num,
-                                     profile=profile,
-                                     node_list=self.db_cluster.nodes,
-                                     round_robin=round_robin,
-                                     client_encrypt=self.db_cluster.nodes[0].is_client_encrypt,
-                                     keyspace_name=keyspace_name).run()
+        cs_thread = CassandraStressThread(loader_set=self.loaders,
+                                          stress_cmd=stress_cmd,
+                                          timeout=timeout,
+                                          output_dir=cluster.Setup.logdir(),
+                                          stress_num=stress_num,
+                                          keyspace_num=keyspace_num,
+                                          profile=profile,
+                                          node_list=self.db_cluster.nodes,
+                                          round_robin=round_robin,
+                                          client_encrypt=self.db_cluster.nodes[0].is_client_encrypt,
+                                          keyspace_name=keyspace_name).run()
+        scylla_encryption_options = self.params.get('scylla_encryption_options')
+        if scylla_encryption_options and 'write' in stress_cmd:
+            # Configure encryption at-rest for all test tables, sleep a while to wait the workload starts and test tables are created
+            time.sleep(60)
+            self.alter_test_tables_encryption(scylla_encryption_options=scylla_encryption_options)
+        return cs_thread
 
     def run_stress_thread_bench(self, stress_cmd, duration=None, stats_aggregate_cmds=True):
 
         timeout = self.get_duration(duration)
         if self.create_stats:
             self.update_stress_cmd_details(stress_cmd, stresser="scylla-bench", aggregate=stats_aggregate_cmds)
-        return self.loaders.run_stress_thread_bench(stress_cmd, timeout,
-                                                    cluster.Setup.logdir(),
-                                                    node_list=self.db_cluster.nodes)
+        bench_thread = self.loaders.run_stress_thread_bench(stress_cmd, timeout,
+                                                            cluster.Setup.logdir(),
+                                                            node_list=self.db_cluster.nodes)
+        scylla_encryption_options = self.params.get('scylla_encryption_options')
+        if scylla_encryption_options and 'write' in stress_cmd:
+            # Configure encryption at-rest for all test tables, sleep a while to wait the workload starts and test tables are created
+            time.sleep(60)
+            self.alter_test_tables_encryption(scylla_encryption_options=scylla_encryption_options)
+        return bench_thread
 
     def run_ycsb_thread(self, stress_cmd, duration=None, stress_num=1, prefix='',  # pylint: disable=too-many-arguments,unused-argument
                         round_robin=False, stats_aggregate_cmds=True,  # pylint: disable=too-many-arguments,unused-argument

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -246,8 +246,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         update_db_packages = self.params.get('update_db_packages', default=None)
         self.params['update_db_packages'] = download_dir_from_cloud(update_db_packages)
 
-        append_conf = self.params.get('append_conf')
-        if append_conf and ('system_key_directory' in append_conf or 'system_info_encryption' in append_conf or 'kmip_hosts:' in append_conf):
+        append_scylla_yaml = self.params.get('append_scylla_yaml')
+        if append_scylla_yaml and ('system_key_directory' in append_scylla_yaml or 'system_info_encryption' in append_scylla_yaml or 'kmip_hosts:' in append_scylla_yaml):
             download_encrypt_keys()
 
         self.init_resources()

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1297,3 +1297,15 @@ def get_testrun_status(test_id=None, logdir=None):
             status = f.read().split()
 
     return status
+
+
+def download_encrypt_keys():
+    """
+    Download certificate files of encryption at-rest from S3 KeyStore
+    """
+    from sdcm.keystore import KeyStore
+    ks = KeyStore()
+    if not os.path.exists('./data_dir/encrypt_conf/CA.pem'):
+        ks.download_file('CA.pem', './data_dir/encrypt_conf/CA.pem')
+    if not os.path.exists('./data_dir/encrypt_conf/SCYLLADB.pem'):
+        ks.download_file('SCYLLADB.pem', './data_dir/encrypt_conf/SCYLLADB.pem')

--- a/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
+++ b/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
@@ -29,3 +29,19 @@ authorizer: 'CassandraAuthorizer'
 
 pre_create_schema: True
 scylla_encryption_options: "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'LocalFileSystemKeyProviderFactory', 'secret_key_file': '/tmp/secret_key'}"
+
+# enable system_info_encryption, config kmip_hosts
+append_conf: |
+  system_key_directory: /etc/encrypt_conf/
+  system_info_encryption:
+      enabled: True  # system_info_encryption
+      key_provider: LocalFileSystemKeyProviderFactory  # system_info_encryption
+      secret_key_file: '/tmp/system_info_encryption_keyfile'
+
+  kmip_hosts:
+       kmip_test:
+           hosts: kmip-interop1.cryptsoft.com
+           certificate: /etc/encrypt_conf/SCYLLADB.pem
+           keyfile: /etc/encrypt_conf/SCYLLADB.pem
+           truststore: /etc/encrypt_conf/CA.pem
+           priority_string: 'SECURE128:+RSA:-VERS-TLS1.0:-ECDHE-ECDSA'

--- a/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
+++ b/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
@@ -31,7 +31,7 @@ pre_create_schema: True
 scylla_encryption_options: "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'LocalFileSystemKeyProviderFactory', 'secret_key_file': '/tmp/secret_key'}"
 
 # enable system_info_encryption, config kmip_hosts
-append_conf: |
+append_scylla_yaml: |
   system_key_directory: /etc/encrypt_conf/
   system_info_encryption:
       enabled: True  # system_info_encryption

--- a/test-cases/longevity/longevity-in-memory-36GB-4days.yaml
+++ b/test-cases/longevity/longevity-in-memory-36GB-4days.yaml
@@ -1,6 +1,7 @@
 test_duration: 6550
 prepare_write_cmd: ["cassandra-stress write                       cl=QUORUM n=21000000     -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=500 -pop seq=1..21000000 -col 'size=FIXED(200) n=FIXED(5)' -log interval=10",
                     "cassandra-stress counter_write               cl=QUORUM n=12345678     -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=1..12345678"]
+prepare_verify_cmd: ["cassandra-stress read                       cl=QUORUM n=21000000     -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=500 -pop seq=1..21000000 -col 'size=FIXED(200) n=FIXED(5)' -log interval=10"]
 stress_cmd:        ["cassandra-stress mixed 'ratio(write=1,read=8)' cl=QUORUM duration=5760m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -pop seq=1..21000000 -col 'size=FIXED(200) n=FIXED(5)' -log interval=10"]
 stress_read_cmd:   ["cassandra-stress read                        cl=QUORUM duration=5760m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=1..21000000 -col 'size=FIXED(200) n=FIXED(5)' -log interval=10",
                     "cassandra-stress counter_read                cl=QUORUM duration=5760m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=10  -pop seq=1..12345678"]


### PR DESCRIPTION
Encryption at-rest won't be configed by default, this PR supported to configure ALL 3 kinds of key providers and system_info_encryption.

system_info_encryption and kmip encryption require setup of scylla.yaml, you can use `append_conf` to append configuration into db_nodes's scylla.yaml in setup stage.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- ~[ ] New configuration option are added and documented (in `sdcm/sct_config.py`)~
- ~[ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- ~[ ] All new and existing unit tests passed (`hydra unit-tests`)~
- ~[ ] I have updated the Readme/doc folder accordingly (if needed)·~
