### PR TITLE
sdcm/cluster: ignore result if coredumpctl doesn't exist

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -743,7 +743,7 @@ class BaseNode(object):
         :return: Number of coredumps
         :rtype: int
         """
-        n_backtraces_cmd = 'sudo coredumpctl --no-pager --no-legend 2>&1 ||true'
+        n_backtraces_cmd = 'sudo coredumpctl --no-pager --no-legend 2>&1'
         result = self.remoter.run(n_backtraces_cmd, verbose=False, ignore_status=True)
         if "No coredumps found" in result.stdout:
             return 0

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -706,6 +706,8 @@ class BaseNode(object):
         :param last: Whether to show only the last backtrace.
         """
         result = self._get_coredump_backtraces(last=last)
+        if result.exit_status == 127:  # coredumpctl command not found
+            return
         log_file = os.path.join(self.logdir, 'coredump.log')
         output = result.stdout + result.stderr
         for line in output.splitlines():
@@ -745,7 +747,7 @@ class BaseNode(object):
         """
         n_backtraces_cmd = 'sudo coredumpctl --no-pager --no-legend 2>&1'
         result = self.remoter.run(n_backtraces_cmd, verbose=False, ignore_status=True)
-        if "No coredumps found" in result.stdout:
+        if "No coredumps found" in result.stdout or result.exit_status == 127:  # exit_status 127: coredumpctl command not found
             return 0
         return len(result.stdout.splitlines())
 


### PR DESCRIPTION
coredumpctl doesn't exist on Ubuntu 16/18 by default, it will be installed in
scylla_setup. But backtrace_thread would execute coredumpctl before
scylla_setup, so this patch installed systemd-coredump for ubuntu16/18.

Error in upgrade (ubuntu16) job:
  Error executing command: "sudo coredumpctl info -1"; Exit status: 1
  STDERR: sudo: coredumpctl: command not found

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- ~[ ] New configuration option are added and documented (in `sdcm/sct_config.py`)~
- ~[ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- ~[ ] All new and existing unit tests passed (`hydra unit-tests`)~
- ~[ ] I have updated the Readme/doc folder accordingly (if needed)~
