### PR TITLE
Add support for using reverse tunnel for rsyslog

### DIFF
--- a/sdcm/auto_ssh.py
+++ b/sdcm/auto_ssh.py
@@ -1,0 +1,55 @@
+import atexit
+import logging
+
+from sdcm.remote import LocalCmdRunner
+
+LOGGER = logging.getLogger(__name__)
+
+RSYSLOG_SSH_TUNNEL_LOCAL_PORT = 5000
+
+
+def start_auto_ssh(docker_name, node, local_port, remote_port):
+    """
+    Starts a reverse port forwarding with autossh inside a docker container
+
+    :param docker_name: prefix of the docker name (cluster.Setup.test_id() usually would be used)
+    :param node: an instance of a class derived from BaseNode that has _ssh_login_info
+    :param local_port: the destination port on local machine
+    :param remote_port: the source port on the remote
+    :return: None
+    """
+
+    host_name = node._ssh_login_info['hostname']
+    user_name = node._ssh_login_info['user']
+    key_path = node._ssh_login_info['key_file']
+
+    local_runner = LocalCmdRunner()
+    res = local_runner.run('''
+           docker run -d --network=host \
+           -e SSH_HOSTNAME={host_name} \
+           -e SSH_HOSTUSER={user_name} \
+           -e SSH_TUNNEL_HOST=127.0.0.1 \
+           -e SSH_TUNNEL_LOCAL={local_port} \
+           -e SSH_TUNNEL_REMOTE={remote_port} \
+           -e AUTOSSH_GATETIME=0 \
+           -v {key_path}:/id_rsa  \
+           --restart always \
+           --name {docker_name}-{host_name}-autossh jnovack/autossh
+       '''.format(**locals()))
+
+    atexit.register(stop_auto_ssh, docker_name, node)
+    LOGGER.debug('{docker_name}-{host_name}-autossh {res.stdout}'.format(**locals()))
+
+
+def stop_auto_ssh(docker_name, node):
+    """
+    stops an autossh docker instance
+    :param docker_name: prefix of the docker name (cluster.Setup.test_id() usually would be used)
+    :param node: an instance of a class derived from BaseNode that has _ssh_login_info
+    :return: None
+    """
+    host_name = node._ssh_login_info['hostname']
+
+    LOGGER.debug("killing {docker_name}-{host_name}-autossh".format(**locals()))
+    local_runner = LocalCmdRunner()
+    local_runner.run("docker kill {docker_name}-{host_name}-autossh".format(**locals()), ignore_status=True)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -54,7 +54,7 @@ from .db_stats import PrometheusDBStats
 from sdcm.sct_events import Severity, CoreDumpEvent, CassandraStressEvent, DatabaseLogEvent, FullScanEvent, \
     ClusterHealthValidatorEvent
 from sdcm.sct_events import EVENTS_PROCESSES
-
+from sdcm.auto_ssh import start_auto_ssh, RSYSLOG_SSH_TUNNEL_LOCAL_PORT
 
 SCYLLA_CLUSTER_DEVICE_MAPPINGS = [{"DeviceName": "/dev/xvdb",
                                    "Ebs": {"VolumeSize": 40,
@@ -271,10 +271,17 @@ class Setup(object):
     def get_startup_script(cls):
         post_boot_script = '#!/bin/bash'
         if cls.RSYSLOG_ADDRESS:
-            post_boot_script += dedent('''
-                   sudo echo 'action(type="omfwd" Target="{0}" Port="{1}" Protocol="tcp")'>> /etc/rsyslog.conf
-                   sudo systemctl restart rsyslog
-                   '''.format(*cls.RSYSLOG_ADDRESS))
+            if IP_SSH_CONNECTIONS == 'public' or Setup.MULTI_REGION:
+                post_boot_script += dedent('''
+                       sudo echo 'action(type="omfwd" Target="{0}" Port="{1}" Protocol="tcp")'>> /etc/rsyslog.conf
+                       sudo systemctl restart rsyslog
+                       '''.format('127.0.0.1', RSYSLOG_SSH_TUNNEL_LOCAL_PORT))
+            else:
+                post_boot_script += dedent('''
+                       sudo echo 'action(type="omfwd" Target="{0}" Port="{1}" Protocol="tcp")'>> /etc/rsyslog.conf
+                       sudo systemctl restart rsyslog
+                       '''.format(*cls.RSYSLOG_ADDRESS))
+
         return post_boot_script
 
 
@@ -417,6 +424,9 @@ class BaseNode(object):
         self._distro = None
         self._cassandra_stress_version = None
         self.lock = threading.Lock()
+
+        if IP_SSH_CONNECTIONS == 'public' or Setup.MULTI_REGION:
+            start_auto_ssh(Setup.test_id(), self, Setup.RSYSLOG_ADDRESS[1], RSYSLOG_SSH_TUNNEL_LOCAL_PORT)
 
     @property
     def short_hostname(self):
@@ -2192,10 +2202,18 @@ class BaseCluster(object):
     def destroy(self):
         self.log.info('Destroy nodes')
         for node in self.nodes:
+            if IP_SSH_CONNECTIONS == 'public' or Setup.MULTI_REGION:
+                from sdcm.auto_ssh import stop_auto_ssh
+                stop_auto_ssh(Setup.test_id(), node)
+
             node.destroy()
 
     def terminate_node(self, node):
         self.nodes.remove(node)
+        if IP_SSH_CONNECTIONS == 'public' or Setup.MULTI_REGION:
+            from sdcm.auto_ssh import stop_auto_ssh
+            stop_auto_ssh(Setup.test_id(), node)
+
         node.destroy()
 
     def get_db_auth(self):

--- a/sdcm/cluster_baremetal.py
+++ b/sdcm/cluster_baremetal.py
@@ -1,5 +1,6 @@
-import re
+import tempfile
 import logging
+from textwrap import dedent
 
 import cluster
 
@@ -28,6 +29,7 @@ class PhysicalMachineNode(cluster.BaseNode):
                                                   ssh_login_info=ssh_login_info,
                                                   node_prefix=node_prefix)
         self.set_hostname()
+        self.run_startup_script()
 
     @property
     def public_ip_address(self):
@@ -59,6 +61,22 @@ class PhysicalMachineNode(cluster.BaseNode):
 
     def destroy(self):
         self.stop_task_threads()  # For future implementation of destroy
+
+    def run_startup_script(self):
+        startup_script_remote_path = '/tmp/sct-startup.sh'
+
+        with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
+            tmp_file.write(cluster.Setup.get_startup_script())
+            tmp_file.flush()
+            self.remoter.send_files(src=tmp_file.name, dst=startup_script_remote_path)
+
+        cmds = dedent("""
+                chmod +x {0}
+                {0}
+            """.format(startup_script_remote_path))
+
+        result = self.remoter.run("sudo bash -ce '%s'" % cmds)
+        logger.debug(result.stdout)
 
 
 class PhysicalMachineCluster(cluster.BaseCluster):

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -181,7 +181,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
         self._logs = {}
 
         if self.params.get("logs_transport") == 'rsyslog':
-            cluster.Setup.configure_rsyslog(self.params.get('sct_ngrok_name', default=False))
+            cluster.Setup.configure_rsyslog(enable_ngrok=False)
 
         start_events_device(cluster.Setup.logdir())
         time.sleep(0.5)


### PR DESCRIPTION
## TODOs:
- [x] Test with scylla-cloud
- [x] Test with multi-region

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- ~~[ ] New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- ~~[ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (`hydra unit-tests`)
- ~~[ ] I have updated the Readme/doc folder accordingly (if needed)~~
