### PR TITLE
Add support for selecting branch AMIs by tags

### DIFF
--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -198,6 +198,25 @@ class ConfigurationTests(unittest.TestCase):
         self.assertEqual(conf.get('scylla_repo'), "https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-3.0-xenial.list")
         self.assertEqual(conf.get('scylla_repo_loader'), "https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-3.0.repo")
 
+    def test_13_scylla_version_ami_branch(self):
+        os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
+        os.environ['SCT_SCYLLA_VERSION'] = 'branch-3.1:60'
+        os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/multi_region_dc_test_case.yaml'
+        conf = SCTConfiguration()
+        conf.verify_configuration()
+
+        self.assertEqual(conf.get('ami_id_db_scylla'), 'ami-0fd79a6f4ca83b0d6 ami-03d6caf668ad59911')
+
+    def test_13_scylla_version_ami_branch_latest(self):
+        os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
+        os.environ['SCT_SCYLLA_VERSION'] = 'branch-3.1:latest'
+        os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/multi_region_dc_test_case.yaml'
+        conf = SCTConfiguration()
+        conf.verify_configuration()
+
+        self.assertIsNotNone(conf.get('ami_id_db_scylla'))
+        self.assertEqual(len(conf.get('ami_id_db_scylla').split(' ')), 2)
+
     def test_config_dupes(self):
         def get_dupes(c):
             '''sort/tee/izip'''


### PR DESCRIPTION
Now we support things like selecting ami based on branch version:
```bash
# specific version build-id / job-id
export SCT_SCYLLA_VERSION branch-3.1:60
# lastest
export SCT_SCYLLA_VERSION branch-3.1:latest
```

and new command line:

```bash
  0 fruch@fruch-syclla-laptop ~/ $ ./sct.py list-ami-branch branch-3.1:all
+----------------------------------------------------------------------------------------------------+
|                                     Scylla AMI branch versions                                     |
+---------------------------------------+-----------------------+--------------------------+---------+
| Name                                  | ImageId               | CreationDate             | BuildId |
+---------------------------------------+-----------------------+--------------------------+---------+
| jenkins-scylla-3.1-ami-test-label-60  | ami-0fd79a6f4ca83b0d6 | 2019-07-14T00:57:22.000Z | 60      |
| jenkins-scylla-3.1-ami-test-label-58  | ami-0db4cbf5a7970abc6 | 2019-07-12T00:34:59.000Z | 58      |
| jenkins-scylla-3.1-ami-test-label-57  | ami-0d5a423ede1415b21 | 2019-07-11T00:46:08.000Z | 57      |
| jenkins-scylla-3.1-ami-test-label-56  | ami-00f24e41fa9f416dd | 2019-07-10T01:12:01.000Z | 56      |
| jenkins-scylla-3.1-ami-test-label-55  | ami-0714b3c5e1fbba84b | 2019-07-09T06:08:57.000Z | 55      |
| jenkins-scylla-3.1-ami-test-label-54  | ami-063c015bf0b0ff1e3 | 2019-07-08T23:06:46.000Z | 54      |
| jenkins-scylla-3.1-ami-test-label-47  | ami-0f1ea365632fab3b6 | 2019-07-02T06:45:12.000Z | 47      |
| jenkins-scylla-3.1-ami-tests-label-40 | ami-0fa09aae5cdbe5d6f | 2019-06-26T07:30:10.000Z | 40      |
| jenkins-scylla-3.1-ami-tests-label-39 | ami-0e126224ddd01f170 | 2019-06-25T12:33:25.000Z | 39      |
| jenkins-scylla-3.1-ami-tests-label-38 | ami-0ac07c9630d9e4eea | 2019-06-25T00:30:59.000Z | 38      |

```
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (`hydra unit-tests`)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
