### PR TITLE
Add a command to patch es mapping of old branches

### DIFF
--- a/utils/fix_es_mapping.py
+++ b/utils/fix_es_mapping.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+from sdcm.keystore import KeyStore
+import sys
+import os.path
+import requests
+import click
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+
+@click.command(help="Check test configuration file")
+@click.argument('index_name', type=str)
+def fix_es_mapping(index_name):
+    ks = KeyStore()
+    es_conf = ks.get_elasticsearch_credentials()
+
+    mapping_url = "{es_url}/{index_name}/_mapping".format(index_name=index_name, **es_conf)
+    res = requests.get(mapping_url, auth=(es_conf["es_user"], es_conf["es_password"]))
+    output = res.json()[index_name]
+
+    output['mappings']['test_stats']['dynamic'] = False
+
+    output['mappings']['test_stats']['properties']['coredumps'] = dict(type='object')
+    output['mappings']['test_stats']['properties']['setup_details']['properties']['db_cluster_details'] = dict(type='object')
+    output['mappings']['test_stats']['properties']['system_details'] = {"dynamic": False, "properties": {}}
+
+    res = requests.put(mapping_url + "/test_stats", json=output['mappings'], auth=(es_conf["es_user"], es_conf["es_password"]))
+    print(res.text)
+    res.raise_for_status()
+
+    click.secho("fixed {index_name}".format(index_name=index_name), fg='green')
+
+
+if __name__ == '__main__':
+    fix_es_mapping()


### PR DESCRIPTION
a command to fix issues like
```
{"error":{"root_cause":[{"type":"remote_transport_exception","reason":"[instance-0000000001][172.25.139.233:19784][indices:data/write/update[s]]"}],"type":"illegal_argument_exception","reason":"Limit of total fields [1000] in index [performanceregressiontest] has been exceeded"},"status":400}
```
