### PR TITLE
Added a fix that deletes the automatic repair task

### DIFF
--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -345,6 +345,19 @@ class ManagerCluster(ScyllaManagerBase):
             cmd += " --ssl-user-cert-file {} --ssl-user-key-file {}".format(SSL_USER_CERT_FILE, SSL_USER_KEY_FILE)
         res = self.sctool.run(cmd=cmd, is_verify_errorless_result=True)
 
+    def delete_task(self, task_id):
+        cmd = "-c {} task delete {}".format(self.id, task_id)
+        logger.debug("Task Delete command to execute is: {}".format(cmd))
+        stdout, stderr = self.sctool.run(cmd=cmd, parse_table_res=False)
+        if stderr:
+            logger.warning("stderr:\n" + stderr)
+            raise ScyllaManagerError("Unknown failure for sctool '{}' command".format(cmd))
+        logger.debug("Deleted the task '{}' successfully!". format(task_id))
+
+    def delete_automatic_repair_task(self):
+        repair_task = self.repair_task_list[0]
+        self.delete_task(repair_task.id)
+
     @property
     def _cluster_list(self):
         """
@@ -570,7 +583,8 @@ class ScyllaManagerTool(ScyllaManagerBase):
         ip_addr_attr = 'public_ip_address'
         return [[n, getattr(n, ip_addr_attr)] for n in db_cluster.nodes]
 
-    def add_cluster(self, name, host=None, db_cluster=None, client_encrypt=None, user=None, create_user=None, single_node=False):
+    def add_cluster(self, name, host=None, db_cluster=None, client_encrypt=None, user=None, create_user=None,
+                    single_node=False, disable_automatic_repair=False):
         """
         :param name: cluster name
         :param host: cluster node IP
@@ -607,14 +621,16 @@ class ScyllaManagerTool(ScyllaManagerBase):
         host = host or self._get_cluster_hosts_ip(db_cluster=db_cluster)[0]
         user = user or self.DEFAULT_USER
         logger.debug("Configuring ssh setup for cluster using {} node before adding the cluster: {}".format(host, name))
-        res_ssh_setup, ssh_identity_file = self.scylla_mgr_ssh_setup(node_ip=host, user=user, create_user=create_user, single_node=single_node)
+        res_ssh_setup, ssh_identity_file = self.scylla_mgr_ssh_setup(node_ip=host, user=user, create_user=create_user,
+                                                                     single_node=single_node)
         ssh_user = create_user or 'scylla-manager'
         cmd = 'cluster add --host={} --ssh-identity-file={} --ssh-user={} --name={}'.format(host, ssh_identity_file,
                                                                                             ssh_user, name)
         # Adding client-encryption parameters if required
-        if client_encrypt != False:
+        if client_encrypt:
             if not db_cluster:
-                logger.warning("db_cluster is not given. Scylla-Manager connection to cluster may fail since not using client-encryption parameters.")
+                logger.warning("db_cluster is not given. Scylla-Manager connection to cluster may "
+                               "fail since not using client-encryption parameters.")
             else:  # check if scylla-node has client-encrypt
                 db_node, _ip = self._get_cluster_hosts_with_ips(db_cluster=db_cluster)[0]
                 if client_encrypt or db_node.is_client_encrypt:
@@ -622,9 +638,15 @@ class ScyllaManagerTool(ScyllaManagerBase):
                                                                                     SSL_USER_KEY_FILE)
         res_cluster_add = self.sctool.run(cmd, parse_table_res=False)
         if not res_cluster_add or 'Cluster added' not in res_cluster_add.stderr:
-            raise ScyllaManagerError("Encountered an error on 'sctool cluster add' command response: {}".format(res_cluster_add))
-        cluster_id = res_cluster_add.stdout.split('\n')[0]  # return ManagerCluster instance with the manager's new cluster-id
-        return ManagerCluster(manager_node=self.manager_node, cluster_id=cluster_id, client_encrypt=client_encrypt, ssh_identity_file=ssh_identity_file)
+            raise ScyllaManagerError("Encountered an error on 'sctool cluster add' command response: {}".format(
+                res_cluster_add))
+        cluster_id = res_cluster_add.stdout.split('\n')[0]
+        # return ManagerCluster instance with the manager's new cluster-id
+        manager_cluster = ManagerCluster(manager_node=self.manager_node, cluster_id=cluster_id,
+                                         client_encrypt=client_encrypt, ssh_identity_file=ssh_identity_file)
+        if disable_automatic_repair:
+            manager_cluster.delete_automatic_repair_task()
+        return manager_cluster
 
     def upgrade(self, scylla_mgmt_upgrade_to_repo):
         manager_from_version = self.version

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -764,8 +764,7 @@ class Nemesis(object):
             ip_addr_attr = 'public_ip_address' if self.cluster.params.get('cluster_backend') != 'gce' and \
                 Setup.INTRA_NODE_COMM_PUBLIC else 'private_ip_address'
             targets = [getattr(n, ip_addr_attr) for n in self.cluster.nodes]
-            mgr_cluster = manager_tool.add_cluster(name=cluster_name, host=targets[0])
-
+            mgr_cluster = manager_tool.add_cluster(name=cluster_name, host=targets[0], disable_automatic_repair=True)
         mgr_task = mgr_cluster.create_repair_task()
         task_final_status = mgr_task.wait_and_get_final_status()
         assert task_final_status == TaskStatus.DONE, 'Task: {} final status is: {}.'.format(mgr_task.id, str(mgr_task.status))
@@ -774,6 +773,7 @@ class Nemesis(object):
         self.log.debug("sctool version is : {}".format(manager_tool.version))
 
     def disrupt_mgmt_repair_api(self):
+        self.log.warning("If ever used, add the deletion of the automatic repair task first")  # TODO
         self._set_current_disruption('ManagementRepair')
         if not self.cluster.params.get('use_mgmt', default=None):
             self.log.warning('Scylla-manager configuration is not defined!')


### PR DESCRIPTION
that the manager creates when a cluster is added, so it won't interfere with the rest of the nemesis

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
~~- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)~~
~~- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (`hydra unit-tests`)
~~- [ ] I have updated the Readme/doc folder accordingly (if needed)~~
