### PR TITLE
Fixed the identification of an ERROR status

### DIFF
--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -167,7 +167,10 @@ class ManagerTask(ScyllaManagerBase):
         cmd = "task list -c {}".format(self.cluster_id)
         res = self.sctool.run(cmd=cmd, is_verify_errorless_result=True)
         str_status = self.get_property(parsed_table=res, column_name='status')
-        return TaskStatus.from_str(str_status)
+        str_accurate_status = str_status.split()[0]
+        # The manager will sometimes retry a task a few times if it's defined this way, and so in the case of
+        # a failure in the task the manager can present the task's status as 'ERROR (#/4)'
+        return TaskStatus.from_str(str_accurate_status)
 
         # expecting output of:
         # ╭─────────────────────────────────────────────┬───────────────────────────────┬──────┬────────────┬────────╮


### PR DESCRIPTION
of manager tasks

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
~~- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)~~
~~- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
~~- [ ] All new and existing unit tests passed (`hydra unit-tests`)~~
~~- [ ] I have updated the Readme/doc folder accordingly (if needed)~~
