### PR TITLE
Fix  to use absolute paths to .yaml files

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -80,6 +80,11 @@ def boolean(value):
         raise ValueError("{} isn't a boolean".format(type(value)))
 
 
+def sct_abs_path(relative_filename):
+    sct_root = os.path.dirname(os.path.dirname(__file__))
+    return os.path.join(sct_root, relative_filename)
+
+
 class SCTConfiguration(dict):
     """
     Class the hold the SCT configuration
@@ -842,13 +847,13 @@ class SCTConfiguration(dict):
     }
 
     defaults_config_files = {
-        "aws": ['defaults/aws_config.yaml'],
-        "gce": ['defaults/gce_config.yaml'],
-        "docker": ['defaults/docker_config.yaml'],
-        "libvirt": ['defaults/libvirt_config.yaml'],
-        "baremetal": ['defaults/baremetal_config.yaml'],
-        "openstack": ['defaults/openstack_config.yaml'],
-        "aws-siren": ['defaults/aws_config.yaml']
+        "aws": [sct_abs_path('defaults/aws_config.yaml')],
+        "gce": [sct_abs_path('defaults/gce_config.yaml')],
+        "docker": [sct_abs_path('defaults/docker_config.yaml')],
+        "libvirt": [sct_abs_path('defaults/libvirt_config.yaml')],
+        "baremetal": [sct_abs_path('defaults/baremetal_config.yaml')],
+        "openstack": [sct_abs_path('defaults/openstack_config.yaml')],
+        "aws-siren": [sct_abs_path('defaults/aws_config.yaml')]
     }
 
     multi_region_params = [
@@ -860,10 +865,11 @@ class SCTConfiguration(dict):
 
         env = self._load_environment_variables()
         config_files = env.get('config_files', [])
+        config_files = [sct_abs_path(f) for f in config_files]
 
         # prepend to the config list the defaults the config files
         backend = env.get('cluster_backend')
-        backend_config_files = ['defaults/test_default.yaml']
+        backend_config_files = [sct_abs_path('defaults/test_default.yaml')]
         if backend:
             backend_config_files += self.defaults_config_files[str(backend)]
 
@@ -992,7 +998,7 @@ class SCTConfiguration(dict):
 
     def get_default_value(self, key, include_backend=False):
 
-        default_config_files = ['defaults/test_default.yaml']
+        default_config_files = [sct_abs_path('defaults/test_default.yaml')]
         backend = self['cluster_backend']
         if backend and include_backend:
             default_config_files += self.defaults_config_files[str(backend)]


### PR DESCRIPTION
since this is sometimes break the unittests on the PRs

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- ~~[ ] New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- ~~[ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (`hydra unit-tests`)
- ~~[ ] I have updated the Readme/doc folder accordingly (if needed)~~
