### PR TITLE
Fix undefined variable in `node.check_nodes_status()`

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1959,7 +1959,7 @@ server_encryption_options:
         except Exception as ex:
             ClusterHealthValidatorEvent(type='end', name='NodesStatus', status=False,
                                         node=self.name,
-                                        error="Unable to get nodetool status from '{node}': {ex}".format(**locals()))
+                                        error="Unable to get nodetool status from '{node}': {ex}".format(ex=ex, node=self.name))
 
     def check_schema_version(self):
         # Get schema version


### PR DESCRIPTION
@bentsi, please consider stop using `**locals()`, it's really hard to stop those error during reviews.

while testing on the branch-2019.1-next, I've encounter this failure, which broke the nemesis thread
```
16:15:37  Exception in thread Thread-21976:
16:15:37  Traceback (most recent call last):
16:15:37    File "/usr/lib64/python2.7/threading.py", line 812, in __bootstrap_inner
16:15:37      self.run()
16:15:37    File "/usr/lib64/python2.7/threading.py", line 765, in run
16:15:37      self.__target(*self.__args, **self.__kwargs)
16:15:37    File "/sct/sdcm/nemesis.py", line 117, in run
16:15:37      self.disrupt()
16:15:37    File "/sct/sdcm/nemesis.py", line 1032, in wrapper
16:15:37      args[0].cluster.check_cluster_health()
16:15:37    File "/sct/sdcm/cluster.py", line 2522, in check_cluster_health
16:15:37      node.check_node_health()
16:15:37    File "/sct/sdcm/cluster.py", line 1949, in check_node_health
16:15:37      self.check_nodes_status()
16:15:37    File "/sct/sdcm/cluster.py", line 1962, in check_nodes_status
16:15:37      error="Unable to get nodetool status from '{node}': {ex}".format(**locals()))
16:15:37  KeyError: 'node'
16:15:37  
```