### PR TITLE
Fix truncate_entries() to exclude enterprise version

### DIFF
--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -1,5 +1,7 @@
-import requests
 import re
+
+import requests
+from pkg_resources import parse_version
 from repodataParser.RepoParser import Parser
 
 
@@ -53,3 +55,11 @@ def get_branch_version_from_repo(url):
     major_versions = [package['version'][1]['ver'] for package in p.getList()]
 
     return max(set(major_versions), key=major_versions.count)
+
+
+def is_enterprise(version):
+    """
+    :param version: version string
+    :return: True if this version string passed is a scylla enterprise version
+    """
+    return parse_version(version) > parse_version('2000')

--- a/unit_tests/test_version_utils.py
+++ b/unit_tests/test_version_utils.py
@@ -1,6 +1,6 @@
 import unittest
 
-from sdcm.utils.version_utils import get_branch_version_from_list, get_branch_version_from_repo, get_branch_version
+from sdcm.utils.version_utils import get_branch_version_from_list, get_branch_version_from_repo, get_branch_version, is_enterprise
 
 deb_url = 'https://s3.amazonaws.com/downloads.scylladb.com/enterprise/deb/unstable/stretch/9f724fedb93b4734fcfaec1156806921ff46e956-2bdfa9f7ef592edaf15e028faf3b7f695f39ebc1-525a0255f73d454f8f97f32b8bdd71c8dec35d3d/68/scylladb-2019.1/scylla.list'
 rpm_url = 'https://s3.amazonaws.com/downloads.scylladb.com/enterprise/rpm/unstable/centos/9f724fedb93b4734fcfaec1156806921ff46e956-2bdfa9f7ef592edaf15e028faf3b7f695f39ebc1-525a0255f73d454f8f97f32b8bdd71c8dec35d3d-a6b2b2355c666b1893f702a587287da978aeec22/71/scylla.repo'
@@ -23,3 +23,9 @@ class TestVersionUtils(unittest.TestCase):
         self.assertRaisesRegexp(ValueError, "url isn't a correct", get_branch_version, broken_url)
         self.assertRaisesRegexp(ValueError, "url isn't a correct", get_branch_version_from_list, broken_url)
         self.assertRaisesRegexp(ValueError, "url isn't a correct", get_branch_version_from_repo, broken_url)
+
+    def test_05_is_enterprise(self):
+        self.assertEqual(is_enterprise('2019.1.1'), True)
+        self.assertEqual(is_enterprise('2018'), True)
+        self.assertEqual(is_enterprise('3.1'), False)
+        self.assertEqual(is_enterprise('2.2'), False)


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- ~~[ ] New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- ~~[ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (`hydra unit-tests`)
- ~~[ ] I have updated the Readme/doc folder accordingly (if needed)~~
