### PR TITLE
Add `wait_for` ontop of call to `verify_logging_from_nodes()`

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2699,8 +2699,9 @@ class BaseScyllaCluster(object):
         for node in nodes_list:
             if not os.path.exists(node.database_log):
                 error_msg = "No db log from node [%s] " % node
-                logger.critical(error_msg)
+                logger.warning(error_msg)
                 raise Exception(error_msg)
+        return True
 
     @wait_for_init_wrap
     def wait_for_init(self, node_list=None, verbose=False, timeout=None):
@@ -2717,7 +2718,8 @@ class BaseScyllaCluster(object):
         self.get_seed_nodes()
         self.get_scylla_version()
         self.set_traffic_control()
-        self.verify_logging_from_nodes(node_list)
+        wait.wait_for(self.verify_logging_from_nodes, nodes_list=node_list,
+                      text="wait for db logs", step=20, timeout=300, throw_exc=True)
 
         self.log.info("All DB nodes configured and stated. ScyllaDB status:\n%s" % self.nodes[0].check_node_health())
 


### PR DESCRIPTION
Since in some case, like ssh transport, and reuse_cluster, logs aren't immediately available
we are waiting for them to be available in 5mins
 
also improving the retrying to actually print the failure in the retries, a bit similar to what was in the avocado version of our wait_for

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [x] All new and existing unit tests passed (`hydra unit-tests`)
