### PR TITLE
Remove `get_node_database_errors()` from test tearDown

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -820,8 +820,9 @@ class Nemesis(object):
                       text='Wait for repair starts')
 
         self.log.debug("Abort repair streaming by storage_service/force_terminate_repair API")
-        with DbEventsFilter(type='DATABASE_ERROR', line="repair's stream failed: streaming::stream_exception"), \
-                DbEventsFilter(type='RUNTIME_ERROR', line='Can not find stream_manager'):
+        with DbEventsFilter(type='DATABASE_ERROR', line="repair's stream failed: streaming::stream_exception", node=self.target_node), \
+                DbEventsFilter(type='RUNTIME_ERROR', line='Can not find stream_manager', node=self.target_node), \
+                DbEventsFilter(type='RUNTIME_ERROR', line='is aborted', node=self.target_node):
 
             self.target_node.remoter.run('curl -X POST --header "Content-Type: application/json" --header "Accept: application/json" "http://127.0.0.1:10000/storage_service/force_terminate_repair"')
             thread1.join(timeout=120)

--- a/sdcm/sct_events.py
+++ b/sdcm/sct_events.py
@@ -25,17 +25,15 @@ manager = Manager()
 
 class EventsDevice(Process):
 
-    def __init__(self):
+    def __init__(self, log_dir):
         super(EventsDevice, self).__init__()
         self.ready_event = Event()
         self.pub_port = Value('d', 0)
         self.sub_port = Value('d', 0)
 
-        self.raw_events_filename = None
-
-    def start(self, log_dir):
-        self.raw_events_filename = os.path.join(log_dir, 'raw_events.log')
-        super(EventsDevice, self).start()
+        self.event_log_base_dir = os.path.join(log_dir, 'events_log')
+        os.makedirs(self.event_log_base_dir)
+        self.raw_events_filename = os.path.join(self.event_log_base_dir, 'raw_events.log')
 
     def run(self):
         try:
@@ -432,15 +430,14 @@ class TestKiller(Process):
 
 
 class EventsFileLogger(Process):
-    def __init__(self):
+    def __init__(self, log_dir):
         super(EventsFileLogger, self).__init__()
         self._test_pid = os.getpid()
-        self.events_filename = None
-        self.raw_events_filename = None
-
-    def start(self, log_dir):
-        self.events_filename = os.path.join(log_dir, 'events.log')
-        super(EventsFileLogger, self).start()
+        self.event_log_base_dir = os.path.join(log_dir, 'events_log')
+        self.events_filename = os.path.join(self.event_log_base_dir, 'events.log')
+        self.critical_events_filename = os.path.join(self.event_log_base_dir, 'critical.log')
+        with open(self.critical_events_filename, 'a'):
+            pass
 
     def run(self):
         LOGGER.info("writing to %s", self.events_filename)
@@ -449,6 +446,12 @@ class EventsFileLogger(Process):
             msg = "{}: {}".format(message_data.formatted_timestamp(), str(message_data).strip())
             with open(self.events_filename, 'a+') as log_file:
                 log_file.write(msg + '\n')
+
+            if (message_data.severity == Severity.CRITICAL or message_data.severity == Severity.ERROR) \
+                    and not event_type == 'ClusterHealthValidatorEvent':
+                with open(self.critical_events_filename, 'a+') as critical_file:
+                    critical_file.write(msg + '\n')
+
             LOGGER.info(msg)
 
 
@@ -533,14 +536,14 @@ EVENTS_PROCESSES = dict()
 
 
 def start_events_device(log_dir, timeout=5):
-    EVENTS_PROCESSES['MainDevice'] = EventsDevice()
-    EVENTS_PROCESSES['MainDevice'].start(log_dir)
+    EVENTS_PROCESSES['MainDevice'] = EventsDevice(log_dir)
+    EVENTS_PROCESSES['MainDevice'].start()
     EVENTS_PROCESSES['MainDevice'].ready_event.wait(timeout=timeout)
 
-    EVENTS_PROCESSES['EVENTS_FILE_LOOGER'] = EventsFileLogger()
+    EVENTS_PROCESSES['EVENTS_FILE_LOOGER'] = EventsFileLogger(log_dir)
     EVENTS_PROCESSES['EVENTS_GRAFANA_ANNOTATOR'] = GrafanaAnnotator()
 
-    EVENTS_PROCESSES['EVENTS_FILE_LOOGER'].start(log_dir)
+    EVENTS_PROCESSES['EVENTS_FILE_LOOGER'].start()
     EVENTS_PROCESSES['EVENTS_GRAFANA_ANNOTATOR'].start()
 
     # default filters


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- ~~[ ] New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (`hydra unit-tests`)
- ~~[ ] I have updated the Readme/doc folder accordingly (if needed)~~
