### PR TITLE
MBM: Fix wrong reporting upon metric is 0

### DIFF
--- a/sdcm/microbenchmarking.py
+++ b/sdcm/microbenchmarking.py
@@ -158,7 +158,15 @@ class MicroBenchmarkingResultsAnalyzer(BaseResultsAnalyzer):
                     return list_of_results_from_db[0]
 
             def count_diff(cur_val, dif_val):
-                if cur_val is None or dif_val is None:
+                try:
+                    cur_val = float(cur_val) if cur_val else None
+                except ValueError:
+                    cur_val = None
+
+                if not cur_val:
+                    return None
+
+                if dif_val is None:
                     return None
 
                 ret_dif = ((cur_val - dif_val) / dif_val) * 100 if dif_val > 0 else cur_val * 100

--- a/unit_tests/test_data/MBM/PFF_with_AVGAIO_0/perf_fast_forward_output/large-partition-forwarding/large-part-ds1/no.1.json
+++ b/unit_tests/test_data/MBM/PFF_with_AVGAIO_0/perf_fast_forward_output/large-partition-forwarding/large-part-ds1/no.1.json
@@ -1,0 +1,51 @@
+{
+	"results" :
+	{
+		"parameters" :
+		{
+			"pk-scan" : "no",
+			"pk-scan,test_run_count" : "no,1",
+			"test_run_count" : 1
+		},
+		"stats" :
+		{
+			"(KiB)" : 136,
+			"aio" : 4,
+			"avg aio" : 0,
+			"blocked" : 3,
+			"c blk" : 1,
+			"c hit" : 0,
+			"c miss" : 0,
+			"cpu" : 58.507186889648438,
+			"dropped" : 1,
+			"frag/s" : 3598.345480747952,
+			"frags" : 2,
+			"idx blk" : 1,
+			"idx hit" : 0,
+			"idx miss" : 1,
+			"iterations" : 609,
+			"mad f/s" : 181.68687632902493,
+			"max f/s" : 3886.974553921083,
+			"min f/s" : 1238.7452254113718,
+			"time (s)" : 0.00055581100000000002
+		}
+	},
+	"test_group_properties" :
+	{
+		"dataset" : "large-part-ds1",
+		"message" : "Testing forwarding with clustering restriction in a large partition",
+		"name" : "large-partition-forwarding",
+		"needs_cache" : false,
+		"partition_type" : "large"
+	},
+	"versions" :
+	{
+		"scylla-server" :
+		{
+			"commit_id" : "7d14514b8",
+			"date" : "20190618",
+			"run_date_time" : "2019-06-21 15:00:26",
+			"version" : "3.1.0.rc2"
+		}
+	}
+}

--- a/unit_tests/test_data/MBM/PFF_with_AVGAIO_0/perf_fast_forward_output/large-partition-forwarding/large-part-ds1/yes.1.json
+++ b/unit_tests/test_data/MBM/PFF_with_AVGAIO_0/perf_fast_forward_output/large-partition-forwarding/large-part-ds1/yes.1.json
@@ -1,0 +1,51 @@
+{
+	"results" :
+	{
+		"parameters" :
+		{
+			"pk-scan" : "yes",
+			"pk-scan,test_run_count" : "yes,1",
+			"test_run_count" : 1
+		},
+		"stats" :
+		{
+			"(KiB)" : 136,
+			"aio" : 4,
+			"avg aio" : 0,
+			"blocked" : 3,
+			"c blk" : 1,
+			"c hit" : 0,
+			"c miss" : 1,
+			"cpu" : 62.194747924804688,
+			"dropped" : 1,
+			"frag/s" : 3303.2571767391237,
+			"frags" : 2,
+			"idx blk" : 1,
+			"idx hit" : 0,
+			"idx miss" : 1,
+			"iterations" : 99,
+			"mad f/s" : 317.85171543692741,
+			"max f/s" : 3772.958452181525,
+			"min f/s" : 198.30078044246653,
+			"time (s)" : 0.00060546299999999999
+		}
+	},
+	"test_group_properties" :
+	{
+		"dataset" : "large-part-ds1",
+		"message" : "Testing forwarding with clustering restriction in a large partition",
+		"name" : "large-partition-forwarding",
+		"needs_cache" : false,
+		"partition_type" : "large"
+	},
+	"versions" :
+	{
+		"scylla-server" :
+		{
+			"commit_id" : "7d14514b8",
+			"date" : "20190618",
+			"run_date_time" : "2019-06-21 15:00:26",
+			"version" : "3.1.0.rc2"
+		}
+	}
+}

--- a/unit_tests/test_data/MBM/PFF_with_AVGAIO_0/perf_fast_forward_output/small-partition-slicing/small-part/0-256.1.json
+++ b/unit_tests/test_data/MBM/PFF_with_AVGAIO_0/perf_fast_forward_output/small-partition-slicing/small-part/0-256.1.json
@@ -1,0 +1,52 @@
+{
+	"results" :
+	{
+		"parameters" :
+		{
+			"offset" : "0",
+			"offset,read,test_run_count" : "0,256,1",
+			"read" : "256",
+			"test_run_count" : 1
+		},
+		"stats" :
+		{
+			"(KiB)" : 72,
+			"aio" : 3,
+			"avg aio" : 0.0,
+			"blocked" : 2,
+			"c blk" : 256,
+			"c hit" : 0,
+			"c miss" : 256,
+			"cpu" : 81.305854797363281,
+			"dropped" : 0,
+			"frag/s" : 211048.73082218322,
+			"frags" : 256,
+			"idx blk" : 1,
+			"idx hit" : 0,
+			"idx miss" : 1,
+			"iterations" : 818,
+			"mad f/s" : 3797.4778975515801,
+			"max f/s" : 229505.22796772223,
+			"min f/s" : 113327.99157123062,
+			"time (s)" : 0.0012129899999999999
+		}
+	},
+	"test_group_properties" :
+	{
+		"dataset" : "small-part",
+		"message" : "Testing slicing small partitions",
+		"name" : "small-partition-slicing",
+		"needs_cache" : false,
+		"partition_type" : "small"
+	},
+	"versions" :
+	{
+		"scylla-server" :
+		{
+			"commit_id" : "7d14514b8",
+			"date" : "20190618",
+			"run_date_time" : "2019-06-21 15:00:26",
+			"version" : "3.1.0.rc2"
+		}
+	}
+}

--- a/unit_tests/test_data/MBM/PFF_with_AVGAIO_0/perf_fast_forward_output/small-partition-slicing/small-part/500000-4096.1.json
+++ b/unit_tests/test_data/MBM/PFF_with_AVGAIO_0/perf_fast_forward_output/small-partition-slicing/small-part/500000-4096.1.json
@@ -1,0 +1,52 @@
+{
+	"results" :
+	{
+		"parameters" :
+		{
+			"offset" : "500000",
+			"offset,read,test_run_count" : "500000,4096,1",
+			"read" : "4096",
+			"test_run_count" : 1
+		},
+		"stats" :
+		{
+			"(KiB)" : 784,
+			"aio" : 13,
+			"avg aio" : 0.0,
+			"blocked" : 5,
+			"c blk" : 4096,
+			"c hit" : 0,
+			"c miss" : 4096,
+			"cpu" : 97.920425415039062,
+			"dropped" : 1,
+			"frag/s" : 251719.6953700046,
+			"frags" : 4096,
+			"idx blk" : 2,
+			"idx hit" : 0,
+			"idx miss" : 2,
+			"iterations" : 55,
+			"mad f/s" : 5305.8848875192343,
+			"max f/s" : 263995.19343126332,
+			"min f/s" : 213251.47586577444,
+			"time (s)" : 0.016272068000000001
+		}
+	},
+	"test_group_properties" :
+	{
+		"dataset" : "small-part",
+		"message" : "Testing slicing small partitions",
+		"name" : "small-partition-slicing",
+		"needs_cache" : false,
+		"partition_type" : "small"
+	},
+	"versions" :
+	{
+		"scylla-server" :
+		{
+			"commit_id" : "7d14514b8",
+			"date" : "20190618",
+			"run_date_time" : "2019-06-21 15:00:26",
+			"version" : "3.1.0.rc2"
+		}
+	}
+}

--- a/unit_tests/test_microbenchmarking.py
+++ b/unit_tests/test_microbenchmarking.py
@@ -142,6 +142,35 @@ class TestMBM(unittest.TestCase):
         self.assertIn('large-partition-forwarding', report_html)
         self.assertIn('large-partition-slicing-single-key-reader', report_html)
 
+    def test_generate_html_report_for_avg_aio_with_zero_value(self):
+        result_path = os.path.join(os.path.dirname(__file__), 'test_data/MBM/PFF_with_AVGAIO_0')
+        result_obj = self.mbra.get_results(results_path=result_path, update_db=False)
+        self.mbra.cur_version_info = result_obj[result_obj.keys()[0]]['versions']['scylla-server']
+        report_results = self.mbra.check_regression(result_obj)
+
+        self.assertEqual(report_results['small-partition-slicing_0-256.1']['avg aio']['Current'], 0.0)
+        self.assertEqual(report_results['small-partition-slicing_0-256.1']['avg aio']['Diff best [%]'], None)
+        self.assertEqual(report_results['small-partition-slicing_0-256.1']['avg aio']['Diff last [%]'], None)
+        self.assertEqual(report_results['large-partition-forwarding_no.1']['avg aio']['Current'], 0.0)
+        self.assertEqual(report_results['large-partition-forwarding_no.1']['avg aio']['Diff best [%]'], None)
+        self.assertEqual(report_results['large-partition-forwarding_no.1']['avg aio']['Diff last [%]'], None)
+        self.assertEqual(report_results['large-partition-forwarding_yes.1']['avg aio']['Current'], 0.0)
+        self.assertEqual(report_results['large-partition-forwarding_yes.1']['avg aio']['Diff best [%]'], None)
+        self.assertEqual(report_results['large-partition-forwarding_yes.1']['avg aio']['Diff last [%]'], None)
+        self.assertEqual(report_results['small-partition-slicing_500000-4096.1']['avg aio']['Current'], 0.0)
+        self.assertEqual(report_results['small-partition-slicing_500000-4096.1']['avg aio']['Diff best [%]'], None)
+        self.assertEqual(report_results['small-partition-slicing_500000-4096.1']['avg aio']['Diff last [%]'], None)
+
+        html_report = tempfile.mkstemp(suffix=".html", prefix="microbenchmarking-")[1]
+        report_file, report_html = self.mbra.send_html_report(report_results, html_report_path=html_report, send=False)
+
+        self.assertTrue(os.path.exists(report_file))
+        self.assertGreater(os.path.getsize(report_file), 0)
+        self.assertTrue(report_html)
+        self.assertIn('large-partition-forwarding', report_html)
+        # no regression for small-partition-slicing tests
+        self.assertNotIn('small-partition-slicing', report_html)
+
     def test_empty_current_result(self):
         result_obj = {}
         report_results = self.mbra.check_regression(result_obj)


### PR DESCRIPTION
Fix wrong regression reporting if current result for metric is 0, and
best or latest result is present in DB.

 - fix logic
 - adding unit test

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (`hydra unit-tests`)
```
Ran 20 tests in 38.264s

OK
```

