### PR TITLE
db_stats - create_test_stats check flag before starting

### DIFF
--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -406,6 +406,8 @@ class TestStatsMixin(Stats):
                 'sys_info': self.db_cluster.nodes[0].get_system_info()}
 
     def create_test_stats(self, sub_type=None):
+        if not self.create_stats:
+            return
         self._test_index = self.__class__.__name__.lower()
         self._test_id = self._create_test_id()
         self._stats = self._init_stats()


### PR DESCRIPTION
* as the default flag to collect stats is True
* few tests don't check what the flag is set
* and it fails in some cases when it is set False
* hence the first thing before starting to run
* create_test_stats is to check if flag is True