### PR TITLE
Support rsyslog for reuse_cluster

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -190,12 +190,10 @@ Reuse Cluster (AWS)
 Running a test with already provisioned cluster, you can get the test_id in the AWS console of the one of the nodes tags tab::
 
     # add the following to your config yaml
-    test_id: 7c86f6de-f87d-45a8-9e7f-61fe7b7dbe84
-    reuse_cluster: true
+    reuse_cluster: 7c86f6de-f87d-45a8-9e7f-61fe7b7dbe84
 
     # or with using the new configuration, before the run test command
-    export SCT_TEST_ID=7c86f6de-f87d-45a8-9e7f-61fe7b7dbe84
-    export SCT_REUSE_CLUSTER=true
+    export SCT_REUSE_CLUSTER=7c86f6de-f87d-45a8-9e7f-61fe7b7dbe84
 
 
 Libvirt

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2112,6 +2112,22 @@ server_encryption_options:
         #      (10 rows)
         return cqlsh_out if not split else map(str.strip, cqlsh_out.stdout.splitlines())
 
+    def run_startup_script(self):
+        startup_script_remote_path = '/tmp/sct-startup.sh'
+
+        with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
+            tmp_file.write(Setup.get_startup_script())
+            tmp_file.flush()
+            self.remoter.send_files(src=tmp_file.name, dst=startup_script_remote_path)
+
+        cmds = dedent("""
+                chmod +x {0}
+                {0}
+            """.format(startup_script_remote_path))
+
+        result = self.remoter.run("sudo bash -ce '%s'" % cmds)
+        logger.debug(result.stdout)
+
 
 class BaseCluster(object):
 

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -667,6 +667,9 @@ class ScyllaAWSCluster(cluster.BaseScyllaCluster, AWSCluster):
 
             node.stop_scylla_server(verify_down=False)
             node.start_scylla_server(verify_up=False)
+        else:
+            # for reconfigure rsyslog
+            node.run_startup_script()
 
         node.wait_db_up(verbose=verbose, timeout=timeout)
         node.check_nodes_status()
@@ -749,6 +752,8 @@ class CassandraAWSCluster(ScyllaAWSCluster):
         node.wait_db_up(verbose=verbose)
 
         if cluster.Setup.REUSE_CLUSTER:
+            # for reconfigure rsyslog
+            node.run_startup_script()
             return
 
         node.wait_apt_not_running()

--- a/sdcm/cluster_baremetal.py
+++ b/sdcm/cluster_baremetal.py
@@ -62,22 +62,6 @@ class PhysicalMachineNode(cluster.BaseNode):
     def destroy(self):
         self.stop_task_threads()  # For future implementation of destroy
 
-    def run_startup_script(self):
-        startup_script_remote_path = '/tmp/sct-startup.sh'
-
-        with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
-            tmp_file.write(cluster.Setup.get_startup_script())
-            tmp_file.flush()
-            self.remoter.send_files(src=tmp_file.name, dst=startup_script_remote_path)
-
-        cmds = dedent("""
-                chmod +x {0}
-                {0}
-            """.format(startup_script_remote_path))
-
-        result = self.remoter.run("sudo bash -ce '%s'" % cmds)
-        logger.debug(result.stdout)
-
 
 class PhysicalMachineCluster(cluster.BaseCluster):
 

--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -351,7 +351,7 @@ class TestStatsMixin(Stats):
         return versions
 
     def get_setup_details(self):
-        exclude_details = ['send_email', 'email_recipients', 'es_url', 'es_password']
+        exclude_details = ['send_email', 'email_recipients', 'es_url', 'es_password', 'reuse_cluster']
         setup_details = {}
         is_gce = self.params.get('cluster_backend') == 'gce'
 


### PR DESCRIPTION
Fix #1195

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
