### PR TITLE
Determine hinted handoff state in absolute way: enabled/disabled

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -36,7 +36,7 @@
 | **<a name="enable_tc">enable_tc</a>**  | when enable scylla will use traffic control | N/A | SCT_ENABLE_TC
 | **<a name="server_encrypt">server_encrypt</a>**  | when enable scylla will use encryption on the server side | N/A | SCT_SERVER_ENCRYPT
 | **<a name="client_encrypt">client_encrypt</a>**  | when enable scylla will use encryption on the client side | N/A | SCT_CLIENT_ENCRYPT
-| **<a name="hinted_handoff_disabled">hinted_handoff_disabled</a>**  | when enable scylla will disable hinted handoffs | N/A | SCT_HINTED_HANDOFF_DISABLED
+| **<a name="hinted_handoff">hinted_handoff</a>**  | when enable or disable scylla hinted handoff | N/A | SCT_HINTED_HANDOFF
 | **<a name="authenticator">authenticator</a>**  | which authenticator scylla will use AllowAllAuthenticator/PasswordAuthenticator | N/A | SCT_AUTHENTICATOR
 | **<a name="append_scylla_args">append_scylla_args</a>**  | More arguments to append to scylla command line | N/A | SCT_APPEND_SCYLLA_ARGS
 | **<a name="nemesis_class_name">nemesis_class_name</a>**  | Nemesis class to use (possible types in sdcm.nemesis). | NoOpMonkey | SCT_NEMESIS_CLASS_NAME

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1304,10 +1304,9 @@ class BaseNode(object):
         self.remoter.run(cmd)
 
     def config_setup(self, seed_address=None, cluster_name=None, enable_exp=True, endpoint_snitch=None,
-                     yaml_file=SCYLLA_YAML_PATH, broadcast=None, authenticator=None,
-                     server_encrypt=None, client_encrypt=None, append_conf=None, append_scylla_args=None,
-                     debug_install=False, hinted_handoff_disabled=False, murmur3_partitioner_ignore_msb_bits=None,
-                     authorizer=None):
+                     yaml_file=SCYLLA_YAML_PATH, broadcast=None, authenticator=None, server_encrypt=None,
+                     client_encrypt=None, append_conf=None, append_scylla_args=None, debug_install=False,
+                     hinted_handoff='enabled', murmur3_partitioner_ignore_msb_bits=None, authorizer=None):
         yaml_dst_path = os.path.join(tempfile.mkdtemp(prefix='scylla-longevity'), 'scylla.yaml')
         self.remoter.receive_files(src=yaml_file, dst=yaml_dst_path)
 
@@ -1343,18 +1342,11 @@ class BaseNode(object):
             p = re.compile('[# ]*cluster_name:.*')
             scylla_yaml_contents = p.sub('cluster_name: {0}'.format(cluster_name),
                                          scylla_yaml_contents)
-        if hinted_handoff_disabled:  # disable hinted handoff (it is enabled by default in Scylla)
-            p = re.compile('[# ]*hinted_handoff_enabled:.*')
-            scylla_yaml_contents = p.sub('hinted_handoff_enabled: false', scylla_yaml_contents)
 
-        if murmur3_partitioner_ignore_msb_bits:
-            self.log.debug('Change murmur3_partitioner_ignore_msb_bits to {}'.format(murmur3_partitioner_ignore_msb_bits))
-            p = re.compile('murmur3_partitioner_ignore_msb_bits:.*')
-            if p.findall(scylla_yaml_contents):
-                scylla_yaml_contents = p.sub('murmur3_partitioner_ignore_msb_bits: {0}'.format(murmur3_partitioner_ignore_msb_bits),
-                                             scylla_yaml_contents)
-            else:
-                scylla_yaml_contents += "\nmurmur3_partitioner_ignore_msb_bits: {0}\n".format(murmur3_partitioner_ignore_msb_bits)
+        # disable hinted handoff (it is enabled by default in Scylla). Expected values: "enabled"/"disabled"
+        if hinted_handoff == 'disabled':
+            p = re.compile('[# ]*hinted_handoff_enabled:.*')
+            scylla_yaml_contents = p.sub('hinted_handoff_enabled: false', scylla_yaml_contents, count=1)
 
         if murmur3_partitioner_ignore_msb_bits:
             self.log.debug('Change murmur3_partitioner_ignore_msb_bits to {}'.format(murmur3_partitioner_ignore_msb_bits))
@@ -2741,16 +2733,13 @@ class BaseScyllaCluster(object):
         self.nemesis_threads = []
 
     def node_config_setup(self, node, seed_address, endpoint_snitch):
-        node.config_setup(seed_address=seed_address,
-                          cluster_name=self.name,
-                          enable_exp=self._param_enabled('experimental'),
-                          endpoint_snitch=endpoint_snitch,
+        node.config_setup(seed_address=seed_address, cluster_name=self.name,
+                          enable_exp=self._param_enabled('experimental'), endpoint_snitch=endpoint_snitch,
                           authenticator=self.params.get('authenticator'),
                           server_encrypt=self._param_enabled('server_encrypt'),
                           client_encrypt=self._param_enabled('client_encrypt'),
-                          append_conf=self.params.get('append_conf'),
-                          hinted_handoff_disabled=self._param_enabled('hinted_handoff_disabled'),
-                          append_scylla_args=self.get_scylla_args(),
+                          append_conf=self.params.get('append_conf'), append_scylla_args=self.get_scylla_args(),
+                          hinted_handoff=self.params.get('hinted_handoff'),
                           authorizer=self.params.get('authorizer'))
 
     def node_setup(self, node, verbose=False, timeout=3600):

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -614,6 +614,7 @@ class ScyllaAWSCluster(cluster.BaseScyllaCluster, AWSCluster):
             client_encrypt=self._param_enabled('client_encrypt'),
             append_scylla_args=self.get_scylla_args(),
             authorizer=self.params.get('authorizer'),
+            hinted_handoff=self.params.get('hinted_handoff'),
         )
         if cluster.Setup.INTRA_NODE_COMM_PUBLIC:
             setup_params.update(dict(

--- a/sdcm/cluster_libvirt.py
+++ b/sdcm/cluster_libvirt.py
@@ -214,7 +214,7 @@ class ScyllaLibvirtCluster(LibvirtCluster, cluster.BaseScyllaCluster):
                           cluster_name=self.name,
                           enable_exp=self._param_enabled('experimental'),
                           append_conf=self.params.get('append_conf'),
-                          hinted_handoff_disabled=self._param_enabled('hinted_handoff_disabled'))
+                          hinted_handoff=self.params.get('hinted_handoff'))
 
         node.remoter.run(
             'sudo /usr/lib/scylla/scylla_setup --nic eth0 --no-raid-setup')

--- a/sdcm/cluster_openstack.py
+++ b/sdcm/cluster_openstack.py
@@ -233,7 +233,7 @@ class ScyllaOpenStackCluster(OpenStackCluster, cluster.BaseScyllaCluster):
                           cluster_name=self.name,
                           enable_exp=self._param_enabled('experimental'),
                           append_conf=self.params.get('append_conf'),
-                          hinted_handoff_disabled=self._param_enabled('hinted_handoff_disabled'))
+                          hinted_handoff=self.params.get('hinted_handoff'))
 
         node.remoter.run('sudo /usr/lib/scylla/scylla_setup --nic eth0 --no-raid-setup')
         # Work around a systemd bug in RHEL 7.3 -> https://github.com/scylladb/scylla/issues/1846

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -265,8 +265,8 @@ class SCTConfiguration(dict):
         dict(name="client_encrypt", env="SCT_CLIENT_ENCRYPT",  type=boolean,
              help="when enable scylla will use encryption on the client side"),
 
-        dict(name="hinted_handoff_disabled", env="SCT_HINTED_HANDOFF_DISABLED",  type=boolean,
-             help="when enable scylla will disable hinted handoffs"),
+        dict(name="hinted_handoff", env="SCT_HINTED_HANDOFF",  type=str,
+             help="when enable or disable scylla hinted handoff (enabled/disabled)"),
 
         dict(name="authenticator", env="SCT_AUTHENTICATOR",  type=str,
              help="which authenticator scylla will use AllowAllAuthenticator/PasswordAuthenticator"),

--- a/test-cases/features/hinted-handoff.yaml
+++ b/test-cases/features/hinted-handoff.yaml
@@ -11,7 +11,8 @@ instance_type_db: 'i3.2xlarge'
 # Options
 user_prefix: 'hinted-handoff'
 
-hinted_handoff_disabled: false
+hinted_handoff: 'enabled'
+
 space_node_threshold: 644245094
 server_encrypt: 'true'
 

--- a/tests/hinted-handoff.yaml
+++ b/tests/hinted-handoff.yaml
@@ -8,7 +8,7 @@ n_monitor_nodes: 1
 # Options
 user_prefix: 'hinted-handoff-VERSION'
 
-hinted_handoff_disabled: false
+hinted_handoff: 'enabled'
 failure_post_behavior: 'keep'
 space_node_threshold: 644245094
 ip_ssh_connections: 'private'

--- a/tests/sample.yaml
+++ b/tests/sample.yaml
@@ -28,7 +28,9 @@ store_results_in_elasticsearch: false
 # if enabling sst3 feature during upgrade test
 test_sst3: False
 
-hinted_handoff_disabled: false
+# Enable/disable hinted handoff feature (it is enabled by default in Scylla)
+# Expected valued: enabled/disabled
+hinted_handoff: 'disabled'
 
 # Authenticator configuration
 # authenticator: 'PasswordAuthenticator'


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [x] I have updated the Readme/doc folder accordingly (if needed)


Task [1182](https://trello.com/c/IHMNsYSu/1196-hintedhandoffenabled-parameter-is-not-configured-by-sct-hintedhandoffdisabled-1182)