### PR TITLE
Changing longevity-1tb-7days-1Dis-2NonDis-Nemesis (parallel nemesis) to i3en and adjuest some of the workloads.

### DIFF
--- a/jenkins-pipelines/longevity-2tb-4days-1Dis-2NonDis-Nemesises.jenkinsfile
+++ b/jenkins-pipelines/longevity-2tb-4days-1Dis-2NonDis-Nemesises.jenkinsfile
@@ -9,7 +9,7 @@ longevityPipeline(
     backend: 'aws',
     aws_region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-1TB-7days-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml',
+    test_config: 'test-cases/longevity/longevity-2TB-4days-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml',
 
     timeout: [time: 10960, unit: 'MINUTES'],
     post_behaviour: 'destroy'

--- a/test-cases/longevity/longevity-1TB-7days-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
+++ b/test-cases/longevity/longevity-1TB-7days-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
@@ -1,27 +1,27 @@
 test_duration: 10900
-prepare_write_cmd: ["cassandra-stress write cl=QUORUM n=1100200300 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native  -rate threads=200 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..1100200300",
-                    "cassandra-stress counter_write cl=QUORUM n=10000000 -schema 'replication(factor=3) compaction(strategy=DateTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..10000000"]
+prepare_write_cmd: ["cassandra-stress write cl=QUORUM n=536870912 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native  -rate threads=100 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..536870912",
+                    "cassandra-stress write cl=QUORUM n=536870912 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native  -rate threads=100 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=536870913..1073741824",
+                    "cassandra-stress write cl=QUORUM n=536870912 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native  -rate threads=100 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1073741825..1610612736",
+                    "cassandra-stress write cl=QUORUM n=536870912 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native  -rate threads=100 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1610612737..2147483648",
+                    "cassandra-stress counter_write cl=QUORUM n=10000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..10000000"]
 
-stress_cmd: ["cassandra-stress mixed         cl=QUORUM duration=10080m -schema 'replication(factor=3)                               compaction(strategy=LeveledCompactionStrategy)'    -port jmx=6868 -mode cql3 native  -rate threads=20 -pop seq=1..1100200300  -log interval=5 -col 'size=FIXED(1024) n=FIXED(1)'",
-             "cassandra-stress write         cl=QUORUM duration=10010m -schema 'replication(factor=3) compression=LZ4Compressor     compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=lz4                   -rate threads=50 -pop seq=1..50000000    -log interval=5",
-             "cassandra-stress write         cl=QUORUM duration=10020m -schema 'replication(factor=3) compression=SnappyCompressor  compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=snappy                -rate threads=50 -pop seq=1..50000000    -log interval=5",
-             "cassandra-stress write         cl=QUORUM duration=10030m -schema 'replication(factor=3) compression=DeflateCompressor compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=none                  -rate threads=50 -pop seq=1..50000000    -log interval=5",
-             "cassandra-stress counter_write cl=QUORUM duration=10080m -schema 'replication(factor=3) compaction(strategy=DateTieredCompactionStrategy)'                               -port jmx=6868 -mode cql3 native                                   -rate threads=10 -pop seq=1..10000000",
-             "cassandra-stress user profile=/tmp/cs_mv_profile.yaml ops'(insert=3,read1=1,read2=1,read3=1)' cl=QUORUM duration=10080m                                                  -port jmx=6868 -mode cql3 native                                   -rate threads=10"]
+stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=10080m -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=50 -pop seq=1..2147483648  -log interval=5 -col 'size=FIXED(64) n=FIXED(16)' ",
+             "cassandra-stress counter_write cl=QUORUM duration=10080m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native  -rate threads=10 -pop seq=1..90000000",
+             "cassandra-stress user profile=/tmp/cs_mv_profile.yaml ops'(insert=3,read1=1,read2=1,read3=1)' cl=QUORUM duration=10080m -port jmx=6868 -mode cql3 native -rate threads=10"]
 
-stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=10080m                                                                                                                 -port jmx=6868 -mode cql3 native  -rate threads=10 -pop seq=1..1100200300  -log interval=5 -col 'size=FIXED(1024) n=FIXED(1)'",
-                  "cassandra-stress read cl=QUORUM duration=10010m -schema 'replication(factor=3) compression=LZ4Compressor compaction(strategy=SizeTieredCompactionStrategy)'     -port jmx=6868 -mode cql3 native compression=lz4                   -rate threads=20 -pop seq=1..50000000    -log interval=5",
-                  "cassandra-stress read cl=QUORUM duration=10020m -schema 'replication(factor=3) compression=SnappyCompressor compaction(strategy=SizeTieredCompactionStrategy)'  -port jmx=6868 -mode cql3 native compression=snappy                -rate threads=20 -pop seq=1..50000000    -log interval=5",
-                  "cassandra-stress read cl=QUORUM duration=10030m -schema 'replication(factor=3) compression=DeflateCompressor compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=none                  -rate threads=20 -pop seq=1..50000000    -log interval=5",
+stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=10080m -port jmx=6868 -mode cql3 native  -rate threads=10 -pop seq=1..2147483648  -log interval=5 -col 'size=FIXED(64) n=FIXED(16)'",
                   "cassandra-stress counter_read cl=QUORUM duration=10080m -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..10000000"]
-run_fullscan: 'random, 17'  # 'ks.cf|random, interval(min)''
+
+run_fullscan: 'random, 240'  # 'ks.cf|random, interval(min)''
+
+round_robin: 'true'
 
 n_db_nodes: 5
-n_loaders: 2
+n_loaders: 4
 n_monitor_nodes: 1
 
-instance_type_db: 'i3.4xlarge'
-instance_type_loader: 'c5.2xlarge'
+instance_type_db: 'i3en.3xlarge'
+instance_type_loader: 'c4.2xlarge'
 instance_type_monitor: 't3.large'
 
 nemesis_class_name: 'DisruptiveMonkey:1 NonDisruptiveMonkey:2'
@@ -32,8 +32,7 @@ user_prefix: 'longevity-tls-1tb-7d-1dis-2nondis'
 failure_post_behavior: destroy
 space_node_threshold: 644245094
 server_encrypt: 'true'
-# Setting client encryption to false for now, till we will find the way to make c-s work with that
-client_encrypt: 'false'
+client_encrypt: 'true'
 
 authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra

--- a/test-cases/longevity/longevity-2TB-4days-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
+++ b/test-cases/longevity/longevity-2TB-4days-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
@@ -1,16 +1,16 @@
-test_duration: 10900
+test_duration: 6550
 prepare_write_cmd: ["cassandra-stress write cl=QUORUM n=536870912 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native  -rate threads=100 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..536870912",
                     "cassandra-stress write cl=QUORUM n=536870912 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native  -rate threads=100 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=536870913..1073741824",
                     "cassandra-stress write cl=QUORUM n=536870912 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native  -rate threads=100 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1073741825..1610612736",
                     "cassandra-stress write cl=QUORUM n=536870912 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native  -rate threads=100 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1610612737..2147483648",
                     "cassandra-stress counter_write cl=QUORUM n=10000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..10000000"]
 
-stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=10080m -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=50 -pop seq=1..2147483648  -log interval=5 -col 'size=FIXED(64) n=FIXED(16)' ",
-             "cassandra-stress counter_write cl=QUORUM duration=10080m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native  -rate threads=10 -pop seq=1..90000000",
-             "cassandra-stress user profile=/tmp/cs_mv_profile.yaml ops'(insert=3,read1=1,read2=1,read3=1)' cl=QUORUM duration=10080m -port jmx=6868 -mode cql3 native -rate threads=10"]
+stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=5760m -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=50 -pop seq=1..2147483648  -log interval=5 -col 'size=FIXED(64) n=FIXED(16)' ",
+             "cassandra-stress counter_write cl=QUORUM duration=5760m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native  -rate threads=10 -pop seq=1..90000000",
+             "cassandra-stress user profile=/tmp/cs_mv_profile.yaml ops'(insert=3,read1=1,read2=1,read3=1)' cl=QUORUM duration=5760m -port jmx=6868 -mode cql3 native -rate threads=10"]
 
-stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=10080m -port jmx=6868 -mode cql3 native  -rate threads=10 -pop seq=1..2147483648  -log interval=5 -col 'size=FIXED(64) n=FIXED(16)'",
-                  "cassandra-stress counter_read cl=QUORUM duration=10080m -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..10000000"]
+stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=5760m -port jmx=6868 -mode cql3 native  -rate threads=10 -pop seq=1..2147483648  -log interval=5 -col 'size=FIXED(64) n=FIXED(16)'",
+                  "cassandra-stress counter_read cl=QUORUM duration=5760m -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..10000000"]
 
 run_fullscan: 'random, 240'  # 'ks.cf|random, interval(min)''
 
@@ -28,7 +28,7 @@ nemesis_class_name: 'DisruptiveMonkey:1 NonDisruptiveMonkey:2'
 nemesis_interval: 30
 nemesis_during_prepare: 'true'
 
-user_prefix: 'longevity-tls-1tb-7d-1dis-2nondis'
+user_prefix: 'longevity-tls-2tb-4d-1dis-2nondis'
 failure_post_behavior: destroy
 space_node_threshold: 644245094
 server_encrypt: 'true'


### PR DESCRIPTION
- Setting workload to 2TB (16 columns of 64 bytes each row)
- Replacing db_nodes to i3en.3xlarge
- Removing some of the background loads
- Increase num of loaders to 4 and use round_robin
- Run full scan every 240 mins instead of 17