### PR TITLE
Adding functionality to show running instances per user

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -94,13 +94,11 @@ def clean_resources(ctx, user, test_id):
 def list_resources(ctx, user, test_id, get_all, get_all_running):
     params = dict()
 
-    if get_all or get_all_running:
-        params = None
-    elif user:
+    if user:
         params['RunByUser'] = user
-    elif test_id:
+    if test_id:
         params['TestId'] = test_id
-    else:
+    if all([not get_all, not get_all_running, not user, not test_id]):
         click.echo(list_resources.get_help(ctx))
 
     if get_all_running:


### PR DESCRIPTION
This PR add functionality to show only running instances
per user or per test-id.

$hydra list-resources --user alex.bykov --get-all-running

this command show only instances which are running and for specific
user.
will allow to find public ip of running instances faster.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)

- [ x ] I added the relevant `backport` labels
