### PR TITLE
Adding functionality to clear instances by several test-ids

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -552,7 +552,7 @@ def clean_cloud_instances(tags_dict):
     """
     Remove all instances with specific tags from both AWS/GCE
 
-    :param tags_dict: a dict of the tag to select the instances, e.x. {"TestId": "9bc6879f-b1ef-47e1-99ab-020810aedbcc"}
+    :param tags_dict: a dict of the tag to select the instances,e.x. {"TestId": "9bc6879f-b1ef-47e1-99ab-020810aedbcc"}
     :return: None
     """
     clean_instances_aws(tags_dict)


### PR DESCRIPTION
clean-resources will be able to accept several --test-id params
and clean instances for all provided test-id

$hydra clean-resources --test-id 123-123 --test-id 123-45

- [x] I added the relevant `backport` labels
