### PR TITLE
Added keyspace_name optional parameter to create_table()

### DIFF
--- a/longevity_test.py
+++ b/longevity_test.py
@@ -307,7 +307,7 @@ class LongevityTest(ClusterTester):
             keyspace_name = 'keyspace{}'.format(i)
             self.create_keyspace(keyspace_name=keyspace_name, replication_factor=3)
             self.log.debug('{} Created'.format(keyspace_name))
-            self.create_table(name='standard1', key_type='blob', read_repair=0.0, compact_storage=True,
+            self.create_table(name='standard1', keyspace_name=keyspace_name, key_type='blob', read_repair=0.0, compact_storage=True,
                               columns={'"C0"': 'blob', '"C1"': 'blob', '"C2"': 'blob', '"C3"': 'blob', '"C4"': 'blob'},
                               in_memory=in_memory, scylla_encryption_options=scylla_encryption_options)
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1095,9 +1095,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
             query = '%s AND scylla_encryption_options=%s' % (query, scylla_encryption_options)
         if compact_storage:
             query += ' AND COMPACT STORAGE'
-        with self.cql_connection_patient(node=self.db_cluster.nodes[0]) as session:
-            if keyspace_name:
-                session.execute('USE %s' % keyspace_name)
+        with self.cql_connection_patient(node=self.db_cluster.nodes[0], keyspace=keyspace_name) as session:
             session.execute(query)
         time.sleep(0.2)
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1058,7 +1058,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
     def create_table(self, name, key_type="varchar",
                      speculative_retry=None, read_repair=None, compression=None,
                      gc_grace=None, columns=None,
-                     compact_storage=False, in_memory=False, scylla_encryption_options=None):
+                     compact_storage=False, in_memory=False, scylla_encryption_options=None, keyspace_name=None):
 
         additional_columns = ""
         if columns is not None:
@@ -1096,6 +1096,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
         if compact_storage:
             query += ' AND COMPACT STORAGE'
         with self.cql_connection_patient(node=self.db_cluster.nodes[0]) as session:
+            if keyspace_name:
+                session.execute('USE %s' % keyspace_name)
             session.execute(query)
         time.sleep(0.2)
 


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
