### PR TITLE
Fixed the ManagerCluster's delete_task function

### DIFF
--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -351,10 +351,7 @@ class ManagerCluster(ScyllaManagerBase):
     def delete_task(self, task_id):
         cmd = "-c {} task delete {}".format(self.id, task_id)
         logger.debug("Task Delete command to execute is: {}".format(cmd))
-        stdout, stderr = self.sctool.run(cmd=cmd, parse_table_res=False)
-        if stderr:
-            logger.warning("stderr:\n" + stderr)
-            raise ScyllaManagerError("Unknown failure for sctool '{}' command".format(cmd))
+        self.sctool.run(cmd=cmd, parse_table_res=False)
         logger.debug("Deleted the task '{}' successfully!". format(task_id))
 
     def delete_automatic_repair_task(self):


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
