### PR TITLE
Fixing cql_connection to use external IPs instead of hard coded publi…

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2232,6 +2232,9 @@ class BaseCluster(object):
     def get_node_public_ips(self):
         return [node.public_ip_address for node in self.nodes]
 
+    def get_node_external_ips(self):
+        return [node.external_address for node in self.nodes]
+
     def get_node_database_errors(self):
         errors = {}
         for node in self.nodes:

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -959,7 +959,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
                        password=None, compression=True, protocol_version=None,
                        port=None, ssl_opts=None):
 
-        wlrr = WhiteListRoundRobinPolicy(self.db_cluster.get_node_public_ips())
+        wlrr = WhiteListRoundRobinPolicy(self.db_cluster.get_node_external_ips())
         return self._create_session(node, keyspace, user, password,
                                     compression, protocol_version, wlrr,
                                     port=port, ssl_opts=ssl_opts)


### PR DESCRIPTION
…c IPs

<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)## PR pre-checks (self review)

