### PR TITLE
workaround: Install the python36 version of PyYAML

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -915,6 +915,7 @@ client_encryption_options:
             self.remoter.run('sudo yum update -y --skip-broken', retry=3)
         self.remoter.run('sudo yum install -y rsync tcpdump screen wget net-tools')
         self.download_scylla_repo(scylla_repo)
+        self.remoter.run('sudo yum install -y python36-PyYAML')
         self.remoter.run('sudo yum install -y {}'.format(self.scylla_pkg()))
         self.remoter.run('sudo yum install -y {}-gdb'.format(self.scylla_pkg()), ignore_status=True)
 


### PR DESCRIPTION
In 2.3 upgrade test, we need to prepare 2.2 cluster, scylla installation will
fail for dependency issue. So we need this workaround.

Reference:
- https://docs.scylladb.com/troubleshooting/python-error-no-module-named-yaml/
- https://github.com/scylladb/scylla-cluster-tests/pull/890


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
