### PR TITLE
Retry to update repo cache after system is up

### DIFF
--- a/partial_upgrade_downgrade_test.py
+++ b/partial_upgrade_downgrade_test.py
@@ -30,7 +30,7 @@ class PartialUpgradeDowngradeNemesis(UpgradeNemesis):
         node.remoter.run('sudo cp /tmp/scylla.repo /etc/yum.repos.d/scylla.repo')
         node.remoter.run('sudo chown root.root /etc/yum.repos.d/scylla.repo')
         node.remoter.run('sudo chmod 644 /etc/yum.repos.d/scylla.repo')
-        node.remoter.run('sudo yum clean all')
+        node.update_repo_cache()
         node.remoter.run('sudo yum downgrade scylla scylla-conf scylla-server scylla-jmx scylla-tools -y')
         node.remoter.run('sudo systemctl restart scylla-server.service')
         node.wait_db_up(verbose=True)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2798,7 +2798,6 @@ class BaseScyllaCluster(object):
         node.wait_ssh_up(verbose=verbose)
         # update repo cache and system after system is up
         node.update_repo_cache()
-        node.upgrade_system()
         if node.init_system == 'systemd' and (node.is_ubuntu() or node.is_debian()):
             node.remoter.run('sudo systemctl disable apt-daily.timer')
             node.remoter.run('sudo systemctl disable apt-daily-upgrade.timer')
@@ -2954,7 +2953,6 @@ class BaseLoaderSet(object):
         node.wait_ssh_up(verbose=verbose)
         # update repo cache and system after system is up
         node.update_repo_cache()
-        node.upgrade_system()
 
         if Setup.REUSE_CLUSTER:
             self.kill_stress_thread()
@@ -3342,7 +3340,6 @@ class BaseMonitorSet(object):
         node.wait_ssh_up()
         # update repo cache and system after system is up
         node.update_repo_cache()
-        node.upgrade_system()
 
         if Setup.REUSE_CLUSTER:
             self.configure_scylla_monitoring(node)

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -203,13 +203,11 @@ class UpgradeTest(FillDatabaseData):
             node.remoter.run('sudo cp ~/scylla.repo-backup /etc/yum.repos.d/scylla.repo')
             node.remoter.run('sudo chown root.root /etc/yum.repos.d/scylla.repo')
             node.remoter.run('sudo chmod 644 /etc/yum.repos.d/scylla.repo')
-            node.remoter.run('sudo yum clean all')
         else:
             node.remoter.run('sudo cp ~/scylla.list-backup /etc/apt/sources.list.d/scylla.list')
             node.remoter.run('sudo chown root.root /etc/apt/sources.list.d/scylla.list')
             node.remoter.run('sudo chmod 644 /etc/apt/sources.list.d/scylla.list')
-            node.remoter.run('sudo apt-get clean all')
-            node.remoter.run('sudo apt-get update')
+        node.update_repo_cache()
 
         if re.findall('\d+.\d+', self.orig_ver)[0] == re.findall('\d+.\d+', self.new_ver)[0]:
             self.upgrade_rollback_mode = 'minor_release'

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -104,6 +104,7 @@ class UpgradeTest(FillDatabaseData):
         new_version = self.params.get('new_version', default='')
         upgrade_node_packages = self.params.get('upgrade_node_packages', default=None)
         self.log.info('Upgrading a Node')
+        node.upgrade_system()
 
         # We assume that if update_db_packages is not empty we install packages from there.
         # In this case we don't use upgrade based on new_scylla_repo(ignored sudo yum update scylla...)


### PR DESCRIPTION
One 3.1 debug job failed for yum error:
- http://jenkins.scylladb.com/job/scylla-staging/job/amos/job/rolling-upgrade-clone-3.1/job/rolling-upgrade-centos7/1/
 - https://cloudius-jenkins-test.s3.amazonaws.com/0e54a1f0-152d-447e-aec3-61c8687f40ba/job_log.zip

```
failure: repodata/repomd.xml from google-cloud-sdk: [Errno 256] No more mirrors to try
https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64/repodata/repomd.xml: [Errno -1] repomd.xml signature could not be verified for google-cloud-sdk

Command "sudo yum search scylla-enterprise" finished with status 1
```

https://github.com/scylladb/scylla-cluster-tests/pull/1245 only tried to clean the cache, but didn't re-generate the cache with retry.

This is an additional fix for https://github.com/scylladb/scylla-cluster-tests/issues/1244

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
