### PR TITLE
Fix refresh nemesis: prepare test ks/table if it doesn't exist

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -415,7 +415,8 @@ class Nemesis(object):
                             hash_expected=sstable_md5, retries=2,
                             user_agent=creds['user_agent'])
 
-        self.log.debug('Make sure keyspace1.standard1 exists')
+        self.log.debug('Prepare keyspace1.standard1 if it does not exist')
+        self._prepare_test_table(ks='keyspace1')
         result = self.target_node.run_nodetool(sub_cmd="cfstats", args="keyspace1.standard1")
         if result is not None and result.exit_status == 0:
             result = self.target_node.remoter.run("sudo ls -t /var/lib/scylla/data/keyspace1/")

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -395,9 +395,14 @@ class Nemesis(object):
         self._set_current_disruption('Refresh keyspace1.standard1 on {}'.format(self.target_node.name))
         if big_sstable:
             # 100G, the big file will be saved to GCE image
+            # Fixme: It's very slow and unstable to download 100G files from S3 to GCE instances,
+            #        currently we actually uploaded a small file (3.6 K) to S3.
+            #        We had a solution to save the file in GCE image, it requires bigger boot disk.
+            #        In my old test, the instance init is easy to fail. We can try to use a
+            #        split shared disk to save the 100GB file.
             sstable_url = 'https://s3.amazonaws.com/scylla-qa-team/keyspace1.standard1.tar.gz'
             sstable_file = "/tmp/keyspace1.standard1.tar.gz"
-            sstable_md5 = 'f64ab85111e817f22f93653a4a791b1f'
+            sstable_md5 = '76cca3135e175d859c0efb67c6a7b233'
         else:
             # 100M (300000 rows)
             sstable_url = 'https://s3.amazonaws.com/scylla-qa-team/keyspace1.standard1.100M.tar.gz'

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -177,7 +177,7 @@ def remote_get_file(remoter, src, dst, hash_expected=None, retries=1, user_agent
     while retries > 0 and _remote_get_hash(remoter, dst) != hash_expected:
         _remote_get_file(remoter, src, dst, user_agent)
         retries -= 1
-    #assert _remote_get_hash(remoter, dst) == hash_expected
+    assert _remote_get_hash(remoter, dst) == hash_expected
 
 
 class retrying(object):


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
