### PR TITLE
upgrade_test: ignore backtrace of stall

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -382,7 +382,8 @@ class UpgradeTest(FillDatabaseData):
 
         filter_errors = [{'line': 'Failed to load schema', 'type': 'DATABASE_ERROR'},
                          {'line': 'Failed to load schema', 'type': 'SCHEMA_FAILURE'},
-                         {'line': 'Failed to pull schema', 'type': 'DATABASE_ERROR'}]
+                         {'line': 'Failed to pull schema', 'type': 'DATABASE_ERROR'},
+                         {'line': 'Backtrace:', 'type': 'BACKTRACE'}]
 
         for error in filter_errors:
             DbEventsFilter(type=error['type'], line=error['line'])


### PR DESCRIPTION
The prompt of all backtrace followed by stall is `Backtrace:`, others are
`backtrace:`.

Some 3.1 upgrade_test failed for finding DB errors (backtrace) in log, but it's
just one backtrace from stall (500 ms). Let's ignore backtrace of stall in
final log checking, we have effect checking for stall log itself.


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)

Fixed issue #1261 