### PR TITLE
fix uploading of job log (db/loader/monitor)

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1293,8 +1293,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
         return truncated_time[0]
 
     def finalize_test(self):
-        self.stop_resources()
-        self.collect_logs()
+        try:
+            self.stop_resources()
+        finally:
+            self.collect_logs()
         self.clean_resources()
 
     def stop_resources(self):


### PR DESCRIPTION
Currently db/loader/monitor logs won't be collected if stop_resources() raises
exception, eg: Errors found on DB node logs.

In one upgrade test, only sct log & event log was uploaded to S3:
- http://jenkins.scylladb.com/job/scylla-staging/job/amos/job/rolling-upgrade-clone-3.1/job/rolling-upgrade-centos7/6/console
- https://cloudius-jenkins-test.s3.amazonaws.com/4ea98e23-576d-4985-b1c6-828ccba3229f/job_log.zip
- test id: 4ea98e23-576d-4985-b1c6-828ccba3229f


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
