### PR TITLE
Remove coredump splitting logic

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -794,31 +794,8 @@ class BaseNode(object):
                          "'%s' '%s'" % (coredump, upload_url))
         download_url = 'https://storage.cloud.google.com/%s' % upload_url
         self.log.info("You can download it by %s (available for ScyllaDB employee)", download_url)
-        return download_url
-
-    def _try_split_coredump(self, coredump):
-        """
-        Compress coredump file, try to split the compressed file if it's too big
-
-        :param coredump: coredump file path
-        :return: coredump files list
-        """
-        # max limit of coredump file can be uploaded (5 GB)
-        COREDUMP_MAX_SIZE = '5G'
-
-        core_files = []
-        try:
-            self.remoter.run('sudo yum install -y pigz')
-            self.remoter.run('sudo pigz --fast {}'.format(coredump))
-            file_name = '{}.gz'.format(coredump)
-            core_files.append(file_name)
-            self.log.debug('Splitting coredump to {} files'.format(COREDUMP_MAX_SIZE))
-            res = self.remoter.run('sudo split -b {} {} {}.;ls {}.*'.format(
-                COREDUMP_MAX_SIZE, file_name, file_name, file_name))
-            core_files = [f.strip() for f in res.stdout.split()]
-        except Exception as ex:
-            self.log.error('Failed splitting coredump file: %s', ex)
-        return core_files or [coredump]
+        download_instructions = 'gsutil cp gs://%s .' % upload_url
+        return download_url, download_instructions
 
     def _notify_backtrace(self, last):
         """
@@ -834,25 +811,14 @@ class BaseNode(object):
         for line in output.splitlines():
             line = line.strip()
             if line.startswith('Coredump:'):
-                urls = []
-                download_instructions = ''
+                url = ""
+                download_instructions = "failed to upload"
                 try:
                     coredump = line.split()[-1]
                     self.log.debug('Found coredump file: {}'.format(coredump))
-                    coredump_files = self._try_split_coredump(coredump)
-                    for f in coredump_files:
-                        urls.append(self._upload_coredump(f))
-                    if len(coredump_files) > 1 or coredump_files[0].endswith('.gz'):
-                        for url in urls:
-                            download_instructions += 'wget {}\n'.format(url)
-                        base_name = os.path.basename(coredump)
-                        if len(coredump_files) > 1:
-                            download_instructions += "\n# To join coredump pieces, you may use:\n"
-                            download_instructions += "cat {}.gz.* > {}.gz\n".format(base_name, base_name)
-                        download_instructions += "# To decompress you may use:\nunpigz --fast {}.gz".format(base_name)
-                        self.log.info(download_instructions)
+                    url, download_instructions = self._upload_coredump(coredump)
                 finally:
-                    CoreDumpEvent(corefile_urls=urls, download_instructions=download_instructions, backtrace=output, node=self)
+                    CoreDumpEvent(corefile_url=url, download_instructions=download_instructions, backtrace=output, node=self)
 
         with open(log_file, 'a') as log_file_obj:
             log_file_obj.write(output)

--- a/sdcm/sct_events.py
+++ b/sdcm/sct_events.py
@@ -192,9 +192,9 @@ class InfoEvent(SctEvent):
 
 
 class CoreDumpEvent(SctEvent):
-    def __init__(self, corefile_urls, download_instructions, backtrace, node):
+    def __init__(self, corefile_url, download_instructions, backtrace, node):
         super(CoreDumpEvent, self).__init__()
-        self.corefile_urls = corefile_urls
+        self.corefile_url = corefile_url
         self.download_instructions = download_instructions
         self.backtrace = backtrace
         self.severity = Severity.CRITICAL
@@ -202,8 +202,8 @@ class CoreDumpEvent(SctEvent):
         self.publish()
 
     def __str__(self):
-        return "{0}: node={1.node}\ncorefile_urls=\n{2}\nbacktrace={1.backtrace}\ndownload_instructions=\n{1.download_instructions}".format(
-            super(CoreDumpEvent, self).__str__(), self,  "\n".join(self.corefile_urls))
+        return "{0}: node={1.node}\ncorefile_url=\n{1.corefile_url}\nbacktrace={1.backtrace}\ndownload_instructions=\n{1.download_instructions}".format(
+            super(CoreDumpEvent, self).__str__(), self)
 
 
 class KillTestEvent(SctEvent):

--- a/unit_tests/test_events.py
+++ b/unit_tests/test_events.py
@@ -70,8 +70,8 @@ class SctEventsTests(unittest.TestCase):
                                  log_file_name="/filename/"))
 
     def test_coredump_event(self):
-        str(CoreDumpEvent(corefile_urls=['http://', "fsdfs", "sdsfgfg"], backtrace="asfasdfsdf",
-                          download_instructions="", node="node xy"))
+        str(CoreDumpEvent(corefile_url='http://', backtrace="asfasdfsdf",
+                          node="node xy", download_instructions="gsutil cp gs://upload.scylladb.com/core.scylla-jmx.996.d173729352e34c76aaf8db3342153c3e.3968.1566979933000/core.scylla-jmx.996.d173729352e34c76aaf8db3342153c3e.3968.1566979933000000 ."))
 
     def test_scylla_log_event(self):
         str(DatabaseLogEvent(type="A", regex="B"))


### PR DESCRIPTION
google storage limit is big enough for our needs, no need to split anymore