### PR TITLE
Changed post-reboot check's timeout to 180 seconds

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -459,7 +459,7 @@ class AWSNode(cluster.BaseNode):
             self.remoter.run('sudo reboot', ignore_status=True)
 
         # wait until the reboot is executed
-        wait.wait_for(func=uptime_changed, step=1, timeout=60, throw_exc=True)
+        wait.wait_for(func=uptime_changed, step=3, timeout=180, throw_exc=True)
 
         if verify_ssh:
             self.wait_ssh_up()


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
~~- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)~~
~~- [ ] I gave variables/functions meaningful self-explanatory names~~
~~- [ ] I didn't leave commented-out/debugging code~~
~~- [ ] I didn't copy-paste code~~
- [x] I added the relevant `backport` labels
~~- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)~~
~~- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
~~- [ ] I have updated the Readme/doc folder accordingly (if needed)~~
