### PR TITLE
get_monitoring_data_stack: only save valid annotations to file

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3771,10 +3771,11 @@ class BaseMonitorSet(object):
         node.remoter.send_files(src=sct_dashboard_file, dst=sct_monitoring_addons_dir)
 
         annotations_json = self.get_grafana_annotations(node)
-        tmp_dir = tempfile.mkdtemp()
-        with io.open(os.path.join(tmp_dir, 'annotations.json'), 'w', encoding='utf-8') as f:
-            f.write(annotations_json)
-        node.remoter.send_files(src=os.path.join(tmp_dir, 'annotations.json'), dst=sct_monitoring_addons_dir)
+        if annotations_json:
+            tmp_dir = tempfile.mkdtemp()
+            with io.open(os.path.join(tmp_dir, 'annotations.json'), 'w', encoding='utf-8') as f:
+                f.write(annotations_json)
+            node.remoter.send_files(src=os.path.join(tmp_dir, 'annotations.json'), dst=sct_monitoring_addons_dir)
 
         node.remoter.run("cd {}; tar -czvf {} {}/".format(self.monitor_install_path_base,
                                                           archive_name,


### PR DESCRIPTION
get_grafana_annotations() might fail, we need check the returned annotations.
Currently if get_grafana_annotations() doesn't return valid annotations, it
will cause `TypeError: must be unicode, not None` in writing file.

Fixes #1270


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
