### PR TITLE
extend test duration of rolling upgrade to 180 mins

### DIFF
--- a/test-cases/upgrades/rolling-upgrade.yaml
+++ b/test-cases/upgrades/rolling-upgrade.yaml
@@ -1,6 +1,6 @@
 # TODO: need to qualify on GCE and AWS
 
-test_duration: 65
+test_duration: 180
 
 # workloads
 write_stress_during_entire_test: cassandra-stress write no-warmup cl=QUORUM n=60000000 -schema 'keyspace=keyspace_entire_test replication(factor=3) compression=LZ4Compressor' -port jmx=6868 -mode cql3 native compression=lz4 -rate threads=1000 -pop seq=1..60000000 -log interval=5

--- a/tests/rolling-upgrade-gce.yaml
+++ b/tests/rolling-upgrade-gce.yaml
@@ -1,4 +1,4 @@
-test_duration: 65
+test_duration: 180
 
 n_db_nodes: 4
 n_loaders: 1


### PR DESCRIPTION
Some 3.1 upgrade test failed for timeout.
 - CommandTimedOut: Command did not complete within 4500 seconds!

The workload runs for the whole upgrade process, it takes about 60~70 mins.
Referenced the real executed time in jenkins, it's safe to set the test
duration to 3 hours (180 mins).


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
