### PR TITLE
New `tag_ami_with_result` option

### DIFF
--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -347,11 +347,11 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
                     v blob,
                     PRIMARY KEY (pk, ck)
                 ) WITH CLUSTERING ORDER BY (ck ASC)
+                    AND compaction = {'class': 'TimeWindowCompactionStrategy', 'compaction_window_size': '60',
+                    'compaction_window_unit': 'MINUTES'}
                     AND bloom_filter_fp_chance = 0.01
                     AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
                     AND comment = ''
-                    AND compaction = {'class': 'TimeWindowCompactionStrategy', 'compaction_window_size': '60',
-                    'compaction_window_unit': 'MINUTES'}
                     AND compression = {}
                     AND crc_check_chance = 1.0
                     AND dclocal_read_repair_chance = 0.1

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -80,6 +80,7 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
         self.aws_extra_network_interface = aws_extra_network_interface
         self.params = params
         self.node_type = node_type
+
         super(AWSCluster, self).__init__(cluster_uuid=cluster_uuid,
                                          cluster_prefix=cluster_prefix,
                                          node_prefix=node_prefix,
@@ -367,6 +368,7 @@ class AWSNode(cluster.BaseNode):
         LOGGER.debug("Waiting until instance {0._instance} starts running...".format(self))
         self._instance_wait_safe(self._instance.wait_until_running)
         self._eth1_private_ip_address = None
+        self.eip_allocation_id = None
         if len(self._instance.network_interfaces) == 2:
             self.allocate_and_attach_elastic_ip()
 
@@ -375,6 +377,7 @@ class AWSNode(cluster.BaseNode):
                           'user': ami_username,
                           'key_file': credentials.key_file}
         self._spot_aws_termination_task = None
+
         super(AWSNode, self).__init__(name=name,
                                       parent_cluster=parent_cluster,
                                       ssh_login_info=ssh_login_info,
@@ -421,6 +424,9 @@ class AWSNode(cluster.BaseNode):
             return self._eth1_private_ip_address
 
         return self._instance.private_ip_address
+
+    def _refresh_instance_state(self):
+        raise NotImplementedError()
 
     def allocate_and_attach_elastic_ip(self):
         primary_interface = [

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -78,34 +78,6 @@ class GCENode(cluster.BaseNode):
             raise cluster.NodeError('GCE instance %s method call error after '
                                     'exponential backoff wait' % self._instance.id)
 
-    @property
-    def public_ip_address(self):
-        return self._get_public_ip_address()
-
-    @property
-    def private_ip_address(self):
-        return self._get_private_ip_address()
-
-    def _get_public_ip_address(self):
-        public_ips, _ = self._refresh_instance_state()
-        if public_ips:
-            return public_ips[0]
-        else:
-            return None
-
-    def _get_private_ip_address(self):
-        _, private_ips = self._refresh_instance_state()
-        if private_ips:
-            return private_ips[0]
-        else:
-            return None
-
-    def _wait_public_ip(self):
-        public_ips, _ = self._refresh_instance_state()
-        while not public_ips:
-            time.sleep(1)
-            public_ips, _ = self._refresh_instance_state()
-
     def _refresh_instance_state(self):
         node_name = self._instance.name
         instance = self._instance_wait_safe(self._gce_service.ex_get_node, node_name)

--- a/sdcm/cluster_openstack.py
+++ b/sdcm/cluster_openstack.py
@@ -1,4 +1,3 @@
-import time
 import logging
 import atexit
 
@@ -67,34 +66,6 @@ class OpenStackNode(cluster.BaseNode):  # pylint: disable=abstract-method
                                             ssh_login_info=ssh_login_info,
                                             base_logdir=base_logdir,
                                             node_prefix=node_prefix)
-
-    @property
-    def public_ip_address(self):
-        return self._get_public_ip_address()
-
-    @property
-    def private_ip_address(self):
-        return self._get_private_ip_address()
-
-    def _get_public_ip_address(self):
-        public_ips, _ = self._refresh_instance_state()
-        if public_ips:
-            return public_ips[0]
-        else:
-            return None
-
-    def _get_private_ip_address(self):
-        _, private_ips = self._refresh_instance_state()
-        if private_ips:
-            return private_ips[0]
-        else:
-            return None
-
-    def _wait_private_ip(self):
-        _, private_ips = self._refresh_instance_state()
-        while not private_ips:
-            time.sleep(1)
-            _, private_ips = self._refresh_instance_state()
 
     def _refresh_instance_state(self):
         node_name = self._instance.name

--- a/sdcm/docker.py
+++ b/sdcm/docker.py
@@ -47,6 +47,7 @@ class DockerNode(cluster.BaseNode):  # pylint: disable=abstract-method
         ssh_login_info = {'hostname': None,
                           'user': 'scylla-test',
                           'key_file': credentials.key_file}
+        self._public_ip_address = None
         super(DockerNode, self).__init__(name=name,
                                          parent_cluster=parent_cluster,
                                          base_logdir=base_logdir,

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -407,6 +407,9 @@ class SCTConfiguration(dict):
         dict(name="aws_extra_network_interface", env="SCT_AWS_EXTRA_NETWORK_INTERFACE", type=boolean,
              help="if true, create extra network interface on each node"),
 
+        dict(name="tag_ami_with_result", env="SCT_TAG_AMI_WITH_RESULT", type=boolean,
+             help="If True, would tag the ami with the test final result"),
+
         # GCE config options
 
         dict(name="gce_datacenter", env="SCT_GCE_DATACENTER", type=str,

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -957,6 +957,17 @@ def get_branched_ami(ami_version, region_name):
         return amis[:1]
 
 
+def tag_ami(ami_id, tags_dict, region_name):
+    tags = [{'Key': key, 'Value': value} for key, value in tags_dict.items()]
+
+    ec2 = boto3.resource('ec2', region_name=region_name)
+    test_image = ec2.Image(ami_id)
+    tags += test_image.tags
+    test_image.create_tags(Tags=tags)
+
+    LOGGER.info("tagged %s with %s", ami_id, tags)
+
+
 def get_non_system_ks_cf_list(loader_node, db_node, request_timeout=300, filter_out_table_with_counter=False,
                               filter_out_mv=False):
     """Get all not system keyspace.tables pairs

--- a/unit_tests/test_utils_common.py
+++ b/unit_tests/test_utils_common.py
@@ -1,0 +1,13 @@
+import logging
+import unittest
+
+from sdcm.utils.common import tag_ami
+
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+class TestUtils(unittest.TestCase):
+    def test_tag_ami_01(self):  # pylint: disable=no-self-use
+        tag_ami(ami_id='ami-0876bfff890e17a06',
+                tags_dict={'JOB_longevity-multi-keyspaces-60h': 'PASSED'}, region_name='eu-west-1')

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -8,7 +8,7 @@ def call(Map pipelineParams) {
                 label getJenkinsLabels(params.backend, params.aws_region)
             }
         }
-         parameters {
+        parameters {
             string(defaultValue: "${pipelineParams.get('backend', 'aws')}",
                description: 'aws|gce',
                name: 'backend')
@@ -28,6 +28,10 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('post_behaviour', 'destroy')}",
                    description: 'keep|destroy',
                    name: 'post_behaviour')
+
+            string(defaultValue: "${pipelineParams.get('tag_ami_with_result', 'false')}",
+                   description: 'true|false',
+                   name: 'tag_ami_with_result')
         }
         options {
             timestamps()
@@ -83,6 +87,8 @@ def call(Map pipelineParams) {
                                 export SCT_INSTANCE_PROVISION="${pipelineParams.params.get('provision_type', '')}"
                                 export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$GIT_BRANCH | sed -E 's+(origin/|origin/branch-)++')
                                 export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$SCT_AMI_ID_DB_SCYLLA_DESC | tr ._ - | cut -c1-8 )
+
+                                export SCT_TAG_AMI_WITH_RESULT=${params.tag_ami_with_result}"
 
                                 echo "start test ......."
                                 ./docker/env/hydra.sh run-test ${pipelineParams.test_name} --backend ${params.backend}  --logdir /sct


### PR DESCRIPTION
with this new option, we tag the test final results ontop of the scylla ami being used
this way we could keep tab of what is the status regarding this AMI,
and if it's safe enough to publish

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
