### PR TITLE
Don't print system.peers output into the loge is the validation not failed

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2071,6 +2071,7 @@ server_encryption_options:
     def check_schema_version(self):
         # Get schema version
         errors = []
+        peers_details = ''
         try:
             gossip_node_schemas = self.validate_gossip_nodes_info()
             status = gossip_node_schemas[self.private_ip_address]['status']
@@ -2081,7 +2082,7 @@ server_encryption_options:
             # Search for nulls in system.peers
             peers_details = self.run_cqlsh('select peer, data_center, host_id, rack, release_version, '
                                            'rpc_address, schema_version, supported_features from system.peers',
-                                           split=True)
+                                           split=True, verbose=False)
 
             for line in peers_details[3:-2]:
                 line_splitted = line.split('|')
@@ -2097,7 +2098,8 @@ server_encryption_options:
                     errors.append('Expected schema version: %s. Wrong schema version found on the '
                                   'node %s: %s' % (gossip_node_schema_version, current_node_ip, peer_schema_version))
         except Exception as e:
-            errors.append('Validate schema version failed. Error: {}'.format(str(e)))
+            errors.append('Validate schema version failed.{} Error: {}'
+                          .format(' SYSTEM.PEERS content: {}\n'.format(peers_details) if peers_details else '', str(e)))
 
         if errors:
             ClusterHealthValidatorEvent(type='error', name='NodeSchemaVersion', status=Severity.CRITICAL,


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
