### PR TITLE
Cluster health check: don't send error if new node isn't initiated yet

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -401,6 +401,7 @@ class BaseNode(object):
         self._db_log_reader_thread = None
         self._scylla_manager_journal_thread = None
         self._init_system = None
+        self.db_init_finished = False
 
         self._short_hostname = None
 
@@ -1132,6 +1133,7 @@ class BaseNode(object):
         if verbose:
             text = '%s: Waiting for DB services to be up' % self
         wait.wait_for(func=self.db_up, step=60, text=text, timeout=timeout, throw_exc=True)
+        self.db_init_finished = True
         self._report_housekeeping_uuid()
 
     def apt_running(self):
@@ -2038,8 +2040,8 @@ server_encryption_options:
 
         self.log.info('Gossipinfo schema version and status of all nodes: {}'.format(gossip_node_schemas))
 
-        # Validate that ALL existent nodes in the gossip
-        cluster_nodes = [node.private_ip_address for node in self.parent_cluster.nodes]
+        # Validate that ALL initiated nodes in the gossip
+        cluster_nodes = [node.private_ip_address for node in self.parent_cluster.nodes if node.db_init_finished]
 
         not_in_gossip = list(set(cluster_nodes) - set(gossip_node_schemas.keys()))
         if not_in_gossip:


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)

This fix should prevent ClusterHealthCheck error appearance in case the Scylla is not started first time on the new node.
