### PR TITLE
Fix None result during creating prometheous snapshot

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3790,7 +3790,7 @@ class BaseMonitorSet(object):
     def create_prometheus_snapshot(self, node):
         ps = PrometheusDBStats(host=node.external_address)
         result = ps.create_snapshot()
-        if "success" in result['status']:
+        if result and "success" in result['status']:
             snapshot_dir = os.path.join(self.monitoring_data_dir,
                                         "snapshots",
                                         result['data']['name'])


### PR DESCRIPTION
Fix issue #1286 https://github.com/scylladb/scylla-cluster-tests/issues/1286

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
