### PR TITLE
Disabling HH for longevity 1TB

### DIFF
--- a/test-cases/longevity/longevity-1TB-7days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-1TB-7days-authorization-and-tls-ssl.yaml
@@ -17,6 +17,7 @@ stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=10080m              
 run_fullscan: 'random, 17'  # 'ks.cf|random, interval(min)''
 
 round_robin: true
+hinted_handoff: 'disabled'
 
 n_db_nodes: 4
 n_loaders: 2


### PR DESCRIPTION
* disabling it because of "Too many in flight hints" bug