### PR TITLE
get username from Jenkins user id

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -305,6 +305,9 @@ def get_username():
     email = os.environ.get('BUILD_USER_EMAIL')
     if is_email_in_scylladb_domain(email):
         return get_email_user(email)
+    user_id = os.environ.get('BUILD_USER_ID')
+    if user_id:
+        return user_id
     current_linux_user = getpass.getuser()
     if current_linux_user == "jenkins":
         return current_linux_user


### PR DESCRIPTION
Currently we try to get username from Jenkins profile email, but it only
supports ScyllaDB email. The Jenkins user id might be same as github user id,
it's always meaningful.

Let's try to get username from Jenkins user id if it fails to get username from
Jenkins profile email.


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
