### PR TITLE
convert EaR longevity to pipeline

### DIFF
--- a/configurations/kmip-ear.yaml
+++ b/configurations/kmip-ear.yaml
@@ -2,7 +2,7 @@
 scylla_encryption_options: "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'KmipKeyProviderFactory', 'kmip_host': 'kmip_test'}"
 
 # enable system_info_encryption, config kmip_hosts
-append_conf: |
+append_scylla_yaml: |
   system_key_directory: /etc/encrypt_conf/
   system_info_encryption:
       enabled: True  # system_info_encryption

--- a/configurations/kmip-ear.yaml
+++ b/configurations/kmip-ear.yaml
@@ -1,0 +1,18 @@
+
+scylla_encryption_options: "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'KmipKeyProviderFactory', 'kmip_host': 'kmip_test'}"
+
+# enable system_info_encryption, config kmip_hosts
+append_conf: |
+  system_key_directory: /etc/encrypt_conf/
+  system_info_encryption:
+      enabled: True  # system_info_encryption
+      key_provider: LocalFileSystemKeyProviderFactory  # system_info_encryption
+      secret_key_file: '/tmp/system_info_encryption_keyfile'
+
+  kmip_hosts:
+       kmip_test:
+           hosts: kmip-interop1.cryptsoft.com
+           certificate: /etc/encrypt_conf/SCYLLADB.pem
+           keyfile: /etc/encrypt_conf/SCYLLADB.pem
+           truststore: /etc/encrypt_conf/CA.pem
+           priority_string: 'SECURE128:+RSA:-VERS-TLS1.0:-ECDHE-ECDSA'

--- a/configurations/local-ear.yaml
+++ b/configurations/local-ear.yaml
@@ -1,0 +1,2 @@
+
+scylla_encryption_options: "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'LocalFileSystemKeyProviderFactory', 'secret_key_file': '/tmp/secret_key'}"

--- a/configurations/replicated-ear.yaml
+++ b/configurations/replicated-ear.yaml
@@ -1,0 +1,2 @@
+
+scylla_encryption_options: "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'ReplicatedKeyProviderFactory'}"

--- a/jenkins-pipelines/EaR-longevity-kmip-200gb-6h.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-kmip-200gb-6h.jenkinsfile
@@ -1,0 +1,16 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    params: params,
+
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: ['test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml', 'configurations/kmip-ear.yaml'],
+
+    timeout: [time: 550, unit: 'MINUTES'],
+    post_behaviour: 'destroy'
+)

--- a/jenkins-pipelines/EaR-longevity-kmip-200gb-6h.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-kmip-200gb-6h.jenkinsfile
@@ -9,7 +9,7 @@ longevityPipeline(
     backend: 'aws',
     aws_region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: ['test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml', 'configurations/kmip-ear.yaml'],
+    test_config: '''["test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml", "configurations/kmip-ear.yaml"]''',
 
     timeout: [time: 550, unit: 'MINUTES'],
     post_behaviour: 'destroy'

--- a/jenkins-pipelines/EaR-longevity-kmip-50gb-4d.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-kmip-50gb-4d.jenkinsfile
@@ -9,7 +9,7 @@ longevityPipeline(
     backend: 'aws',
     aws_region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: ['test-cases/longevity/longevity-50GB-4days-authorization-and-tls-ssl.yaml', 'configurations/kmip-ear.yaml'],
+    test_config: '''["test-cases/longevity/longevity-50GB-4days-authorization-and-tls-ssl.yaml", "configurations/kmip-ear.yaml"]''',
 
     timeout: [time: 6550, unit: 'MINUTES'],
     post_behaviour: 'destroy',

--- a/jenkins-pipelines/EaR-longevity-kmip-50gb-4d.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-kmip-50gb-4d.jenkinsfile
@@ -1,0 +1,16 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    params: params,
+
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: ['test-cases/longevity/longevity-50GB-4days-authorization-and-tls-ssl.yaml', 'configurations/kmip-ear.yaml'],
+
+    timeout: [time: 6550, unit: 'MINUTES'],
+    post_behaviour: 'destroy',
+)

--- a/jenkins-pipelines/EaR-longevity-local-200gb-6h.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-local-200gb-6h.jenkinsfile
@@ -1,0 +1,16 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    params: params,
+
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: ['test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml', 'configurations/local-ear.yaml'],
+
+    timeout: [time: 550, unit: 'MINUTES'],
+    post_behaviour: 'destroy'
+)

--- a/jenkins-pipelines/EaR-longevity-local-200gb-6h.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-local-200gb-6h.jenkinsfile
@@ -9,7 +9,7 @@ longevityPipeline(
     backend: 'aws',
     aws_region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: ['test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml', 'configurations/local-ear.yaml'],
+    test_config: '''["test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml", "configurations/local-ear.yaml"]''',
 
     timeout: [time: 550, unit: 'MINUTES'],
     post_behaviour: 'destroy'

--- a/jenkins-pipelines/EaR-longevity-local-50gb-4d.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-local-50gb-4d.jenkinsfile
@@ -1,0 +1,16 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    params: params,
+
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: ['test-cases/longevity/longevity-50GB-4days-authorization-and-tls-ssl.yaml', 'configurations/local-ear.yaml'],
+
+    timeout: [time: 6550, unit: 'MINUTES'],
+    post_behaviour: 'destroy',
+)

--- a/jenkins-pipelines/EaR-longevity-local-50gb-4d.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-local-50gb-4d.jenkinsfile
@@ -9,7 +9,7 @@ longevityPipeline(
     backend: 'aws',
     aws_region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: ['test-cases/longevity/longevity-50GB-4days-authorization-and-tls-ssl.yaml', 'configurations/local-ear.yaml'],
+    test_config: '''["test-cases/longevity/longevity-50GB-4days-authorization-and-tls-ssl.yaml", "configurations/local-ear.yaml"]''',
 
     timeout: [time: 6550, unit: 'MINUTES'],
     post_behaviour: 'destroy',

--- a/jenkins-pipelines/EaR-longevity-replicated-200gb-6h.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-replicated-200gb-6h.jenkinsfile
@@ -9,7 +9,7 @@ longevityPipeline(
     backend: 'aws',
     aws_region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: ['test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml', 'configurations/replicated-ear.yaml'],
+    test_config: '''["test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml", "configurations/replicated-ear.yaml"]''',
 
     timeout: [time: 550, unit: 'MINUTES'],
     post_behaviour: 'destroy'

--- a/jenkins-pipelines/EaR-longevity-replicated-200gb-6h.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-replicated-200gb-6h.jenkinsfile
@@ -1,0 +1,16 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    params: params,
+
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: ['test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml', 'configurations/replicated-ear.yaml'],
+
+    timeout: [time: 550, unit: 'MINUTES'],
+    post_behaviour: 'destroy'
+)

--- a/jenkins-pipelines/EaR-longevity-replicated-50gb-4d.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-replicated-50gb-4d.jenkinsfile
@@ -1,0 +1,16 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    params: params,
+
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: ['test-cases/longevity/longevity-50GB-4days-authorization-and-tls-ssl.yaml', 'configurations/replicated-ear.yaml'],
+
+    timeout: [time: 6550, unit: 'MINUTES'],
+    post_behaviour: 'destroy',
+)

--- a/jenkins-pipelines/EaR-longevity-replicated-50gb-4d.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-replicated-50gb-4d.jenkinsfile
@@ -9,7 +9,7 @@ longevityPipeline(
     backend: 'aws',
     aws_region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: ['test-cases/longevity/longevity-50GB-4days-authorization-and-tls-ssl.yaml', 'configurations/replicated-ear.yaml'],
+    test_config: '''["test-cases/longevity/longevity-50GB-4days-authorization-and-tls-ssl.yaml", "configurations/replicated-ear.yaml"]''',
 
     timeout: [time: 6550, unit: 'MINUTES'],
     post_behaviour: 'destroy',

--- a/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
+++ b/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
@@ -1,8 +1,8 @@
 test_duration: 550
-prepare_write_cmd: "cassandra-stress write cl=ALL n=200200300  -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=1000 -col 'size=FIXED(12) n=FIXED(100)' -pop seq=1..200200300 -log interval=15"
+prepare_write_cmd: "cassandra-stress write cl=ALL n=200200300  -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=1000 -col 'size=FIXED(200) n=FIXED(5)' -pop seq=1..200200300 -log interval=15"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=360m  -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=50  -col 'size=FIXED(12) n=FIXED(100)' -pop seq=400200300..600200300 -log interval=15"]
-stress_read_cmd: ["cassandra-stress read cl=ONE duration=360m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=50  -col 'size=FIXED(12) n=FIXED(100)' -pop seq=1..200200300 -log interval=5"]
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=360m  -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=50  -col 'size=FIXED(200) n=FIXED(5)' -pop seq=400200300..600200300 -log interval=15"]
+stress_read_cmd: ["cassandra-stress read cl=ONE duration=360m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=50  -col 'size=FIXED(200) n=FIXED(5)' -pop seq=1..200200300 -log interval=5"]
 run_fullscan: 'keyspace1.standard1, 5' # 'ks.cf|random, interval(min)''
 
 n_db_nodes: 4

--- a/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
+++ b/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
@@ -12,8 +12,8 @@ n_monitor_nodes: 1
 instance_type_db: 'i3.4xlarge'
 
 nemesis_class_name: 'LimitedChaosMonkey'
-nemesis_interval: 30
-# nemesis_during_prepare: false
+nemesis_interval: 5
+nemesis_during_prepare: false
 
 user_prefix: 'longevity-encrypt-at-rest-200gb-6h-tls'
 
@@ -23,6 +23,7 @@ space_node_threshold: 644245094
 use_mgmt: true
 
 server_encrypt: true
+authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra
 authenticator_password: cassandra
 authorizer: 'CassandraAuthorizer'

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -71,7 +71,7 @@ def call(Map pipelineParams) {
 
                                     export SCT_CLUSTER_BACKEND="${params.backend}"
                                     export SCT_REGION_NAME=${aws_region}
-                                    export SCT_CONFIG_FILES="${test_config}"
+                                    export SCT_CONFIG_FILES=${test_config}
                                     export SCT_COLLECT_LOGS=false
 
                                     if [[ ! -z "${params.scylla_ami_id}" ]] ; then
@@ -119,7 +119,7 @@ def call(Map pipelineParams) {
 
                                     export SCT_CLUSTER_BACKEND="${params.backend}"
                                     export SCT_REGION_NAME=${aws_region}
-                                    export SCT_CONFIG_FILES="${test_config}"
+                                    export SCT_CONFIG_FILES=${test_config}
 
                                     echo "start collect logs ..."
                                     ./docker/env/hydra.sh collect-logs --logdir /sct


### PR DESCRIPTION
We want to run EaR longevity jobs by pipeline.

http://jenkins.scylladb.com/job/enterprise-2019.1/job/EncryptionAtRest/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
