### PR TITLE
ClusterHealthValidator: node in status BOOT doesn't exist in the cluster

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2053,10 +2053,11 @@ server_encryption_options:
                 status = line.replace('STATUS:', '').split(',')[0]
             # STATUS is "LEFT": in case the node was decommissioned
             # STATUS is "removed": in case the node was removed by nodetool removenode
+            # STATUS is "BOOT": node during boot and not exists in the cluster yet
             # and they will remain in the gossipinfo 3 days.
             # It's expected behaviour and we won't send the error in this case
             if schema and ip and status:
-                if status not in ['LEFT', 'removed']:
+                if status not in ['LEFT', 'removed', 'BOOT']:
                     gossip_node_schemas[ip] = {'schema': schema, 'status': status}
                 schema, ip, status = '', '', ''
 


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
