### PR TITLE
Fixed collect_partitions_info

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1289,7 +1289,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):
         with open(self.partitions_stats_file, 'a') as f:
             for i in pk_list:
                 self.log.debug("Next PK: {}".format(i))
-                count_partition_keys_cmd = 'select count(*) from {table_name} where {pk} = {i}'.format(**locals())
+                count_partition_keys_cmd = 'select count(*) from {table_name} where {primary_key_column} = {i}'.format(
+                    **locals())
                 out = self.db_cluster.nodes[0].run_cqlsh(cmd=count_partition_keys_cmd, timeout=600, split=True)
                 self.log.debug('Count result: {}'.format(out))
                 partitions[i] = out[3] if len(out) > 3 else None


### PR DESCRIPTION
by changing the count_partition_keys_cmd query

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
~~- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)~~
~~- [ ] I gave variables/functions meaningful self-explanatory names~~
- [x] I didn't leave commented-out/debugging code
~~- [ ] I didn't copy-paste code~~
- [x] I added the relevant `backport` labels
~~- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)~~
~~- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
~~- [ ] All new and existing unit tests passed (CI)~~
~~- [ ] I have updated the Readme/doc folder accordingly (if needed)~~
