### PR TITLE
Add support to run gemini without oracle cluster

### DIFF
--- a/sdcm/gemini_thread.py
+++ b/sdcm/gemini_thread.py
@@ -73,13 +73,14 @@ class GeminiStressThread(object):
     def _generate_gemini_command(self, loader_idx):
         seed = random.randint(1, 100)
         test_node = random.choice(self.test_cluster.nodes)
-        oracle_node = random.choice(self.oracle_cluster.nodes)
+        oracle_node = random.choice(self.oracle_cluster.nodes) if self.oracle_cluster else None
         self.gemini_log = '/tmp/gemini-l{}-{}.log'.format(loader_idx, uuid.uuid4())
-        cmd = "/$HOME/{} --test-cluster={} --oracle-cluster={} --outfile {} --seed {}".format(self.gemini_cmd.strip(),
-                                                                                              test_node.ip_address,
-                                                                                              oracle_node.ip_address,
-                                                                                              self.gemini_log,
-                                                                                              seed)
+        cmd = "/$HOME/{} --test-cluster={} --outfile {} --seed {}".format(self.gemini_cmd.strip(),
+                                                                          test_node.ip_address,
+                                                                          self.gemini_log,
+                                                                          seed)
+        if oracle_node:
+            cmd += " --oracle-cluster={}".format(oracle_node.ip_address)
         self.gemini_commands.append(cmd)
         return cmd
 


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
