### PR TITLE
fixing wrong assignment of hostname with public_ip always

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -430,7 +430,7 @@ class AWSNode(cluster.BaseNode):
         self._wait_public_ip()
         self.log.debug('Got new public IP %s',
                        self._instance.public_ip_address)
-        self.remoter.hostname = self._instance.public_ip_address
+        self.remoter.hostname = self.external_address
         self.wait_ssh_up()
 
         if any(ss in self._instance.instance_type for ss in ['i3', 'i2']):


### PR DESCRIPTION
@ShlomiBalalis faced an issue when using a new builder that its public IP wasn't open to SSH.
I found our that during "Restart" we wrongly assigned hostname again but always with public_ip instead of the logic we have behind "extranl_address" (ip_ssh_connection).
