### PR TITLE
Adding gemini seed config parameter

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2932,7 +2932,7 @@ class BaseLoaderSet(object):
 
     @property
     def gemini_version(self):
-        result = self.nodes[0].run('cd $HOME; ./gemini --version')  # pylint: disable=no-member
+        result = self.nodes[0].remoter.run('cd $HOME; ./gemini --version')  # pylint: disable=no-member
         # result : gemini version 1.0.1, commit ef7c6f422c78ef6b84a6f3bccf52ea9ec846bba0, date 2019-05-16T09:56:16Z
         # take only version number - 1.0.1
         self._gemini_version = result.stdout.split(',')[0].split(' ')[2]

--- a/sdcm/gemini_thread.py
+++ b/sdcm/gemini_thread.py
@@ -60,7 +60,7 @@ class GeminiEventsPublisher(FileFollowerThread):
 
 class GeminiStressThread(object):  # pylint: disable=too-many-instance-attributes
 
-    def __init__(self, test_cluster, oracle_cluster, loaders, gemini_cmd, timeout=None, outputdir=None):  # pylint: disable=too-many-arguments
+    def __init__(self, test_cluster, oracle_cluster, loaders, gemini_cmd, timeout=None, outputdir=None, params=None):  # pylint: disable=too-many-arguments
         self.loaders = loaders
         self.gemini_cmd = gemini_cmd
         self.test_cluster = test_cluster
@@ -70,9 +70,12 @@ class GeminiStressThread(object):  # pylint: disable=too-many-instance-attribute
         self.gemini_log = None
         self.outputdir = outputdir
         self.gemini_commands = []
+        self.params = params if params else {}
 
     def _generate_gemini_command(self, loader_idx):
-        seed = random.randint(1, 100)
+        seed = self.params.get('gemini_seed', None)
+        if not seed:
+            seed = random.randint(1, 100)
         test_node = random.choice(self.test_cluster.nodes)
         oracle_node = random.choice(self.oracle_cluster.nodes) if self.oracle_cluster else None
         self.gemini_log = '/tmp/gemini-l{}-{}.log'.format(loader_idx, uuid.uuid4())

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -336,6 +336,8 @@ class SCTConfiguration(dict):
         dict(name="gemini_cmd", env="SCT_GEMINI_CMD", type=str,
              help="""gemini command to run (for now used only in GeminiTest)"""),
 
+        dict(name="gemini_seed", env="SCT_GEMINI_SEED", type=int,
+             help="Seed number for gemini command"),
         # AWS config options
 
         dict(name="instance_type_loader", env="SCT_INSTANCE_TYPE_LOADER", type=str,

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -863,7 +863,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                   loaders=self.loaders,
                                   gemini_cmd=cmd,
                                   timeout=timeout,
-                                  outputdir=self.logdir).run()
+                                  outputdir=self.logdir,
+                                  params=self.params).run()
 
     def kill_stress_thread(self):
         if self.loaders:  # the test can fail on provision step and loaders are still not provisioned


### PR DESCRIPTION
If gemini_seed parameter is not provided, then seed will be set
randomly.
Required for reproduced issue in easier way

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
