### PR TITLE
Fix wait_for() verbosity to be clearer

### DIFF
--- a/unit_tests/test_wait.py
+++ b/unit_tests/test_wait.py
@@ -37,6 +37,16 @@ class TestSdcmWait(unittest.TestCase):
         wait_for(callback, timeout=1, step=0.5, arg1=1, arg2=3)
         self.assertEqual(len(calls), 3)
 
+    def test_03_false_return_rerise(self):
+        calls = []
+
+        def callback(arg1, arg2):
+            calls.append((arg1, arg2))
+            return False
+
+        self.assertRaisesRegexp(Exception, "callback: timeout - 2 seconds - expired", wait_for, callback, timeout=2, throw_exc=True, step=0.5, arg1=1, arg2=3)
+        self.assertEqual(len(calls), 5)
+
     def test_03_return_value(self):
         calls = []
 


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- ~~[ ] New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- ~~[ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- ~~[ ] I have updated the Readme/doc folder accordingly (if needed)~~
