### PR TITLE
update_scylla_packages: don't update scylla packages before replacement

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2550,7 +2550,7 @@ class BaseScyllaCluster(object):  # pylint: disable=too-many-public-methods
             node.log.info('Updating DB packages')
             node.remoter.run('mkdir /tmp/scylla')
             node.remoter.send_files(new_scylla_bin, '/tmp/scylla', verbose=True)
-            node.remoter.run('sudo yum update -y --skip-broken')
+            node.remoter.run(r'sudo yum update -y --skip-broken -x scylla\*')
             # replace the packages
             node.remoter.run('yum list installed | grep scylla')
             node.remoter.run('sudo rpm -URvh --replacefiles /tmp/scylla/*', ignore_status=False, verbose=True)


### PR DESCRIPTION
update_scylla_packages() only supports to replace scylla packages with rpms
that have same version (eg: 3.1.0.rc5) by `rpm -URvh --replacefiles xxx`.

Current update before replacement might change the scylla version, then
replacement will failed.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
