### PR TITLE
Enable email report send functionlity for longvity test

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -35,3 +35,6 @@ cloud_credentials_path: '~/.ssh/support'
 backtrace_decoding: false
 
 logs_transport: "rsyslog"
+
+send_email: false
+email_recipients: ['qa@scylladb.com']

--- a/test-cases/longevity/longevity-100GB-48h-cloud-CloudLimitedChaosMonkey-tls.yaml
+++ b/test-cases/longevity/longevity-100GB-48h-cloud-CloudLimitedChaosMonkey-tls.yaml
@@ -27,3 +27,6 @@ authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra
 authenticator_password: cassandra
 authorizer: 'CassandraAuthorizer'
+
+send_email: true
+email_recipients: ['qa@scylladb.com']

--- a/test-cases/longevity/longevity-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-100gb-4h.yaml
@@ -17,3 +17,6 @@ nemesis_interval: 5
 
 user_prefix: 'longevity-100gb-4h'
 space_node_threshold: 64424
+
+send_email: true
+email_recipients: ['qa@scylladb.com']

--- a/test-cases/longevity/longevity-10gb-3h.yaml
+++ b/test-cases/longevity/longevity-10gb-3h.yaml
@@ -13,3 +13,6 @@ nemesis_interval: 5
 
 user_prefix: 'longevity-10gb-3h'
 space_node_threshold: 64424
+
+send_email: true
+email_recipients: ['qa@scylladb.com']

--- a/test-cases/longevity/longevity-1TB-7days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-1TB-7days-authorization-and-tls-ssl.yaml
@@ -41,3 +41,6 @@ authenticator_password: cassandra
 authorizer: 'CassandraAuthorizer'
 
 use_mgmt: true
+
+send_email: true
+email_recipients: ['qa@scylladb.com']

--- a/test-cases/longevity/longevity-200GB-48h-network-monkey.yaml
+++ b/test-cases/longevity/longevity-200GB-48h-network-monkey.yaml
@@ -29,3 +29,6 @@ authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra
 authenticator_password: cassandra
 authorizer: 'CassandraAuthorizer'
+
+send_email: true
+email_recipients: ['qa@scylladb.com']

--- a/test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
+++ b/test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
@@ -28,3 +28,6 @@ authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra
 authenticator_password: cassandra
 authorizer: 'CassandraAuthorizer'
+
+send_email: true
+email_recipients: ['qa@scylladb.com']

--- a/test-cases/longevity/longevity-2TB-4days-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
+++ b/test-cases/longevity/longevity-2TB-4days-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
@@ -40,3 +40,6 @@ authenticator_password: cassandra
 authorizer: 'CassandraAuthorizer'
 
 use_mgmt: true
+
+send_email: true
+email_recipients: ['qa@scylladb.com']

--- a/test-cases/longevity/longevity-50GB-4days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-50GB-4days-authorization-and-tls-ssl.yaml
@@ -40,3 +40,6 @@ authenticator_password: cassandra
 authorizer: 'CassandraAuthorizer'
 
 use_mgmt: true
+
+send_email: true
+email_recipients: ['qa@scylladb.com']

--- a/test-cases/longevity/longevity-alternator-3h.yaml
+++ b/test-cases/longevity/longevity-alternator-3h.yaml
@@ -17,3 +17,6 @@ user_prefix: 'alternator-3h'
 alternator_port: 8080
 
 store_results_in_elasticsearch: false
+
+send_email: true
+email_recipients: ['qa@scylladb.com']

--- a/test-cases/longevity/longevity-counters-4days-multidc.yaml
+++ b/test-cases/longevity/longevity-counters-4days-multidc.yaml
@@ -21,3 +21,6 @@ nemesis_interval: 15
 nemesis_during_prepare: 'false'
 
 use_mgmt: true
+
+send_email: true
+email_recipients: ['qa@scylladb.com']

--- a/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
+++ b/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
@@ -29,3 +29,6 @@ authorizer: 'CassandraAuthorizer'
 
 pre_create_schema: True
 scylla_encryption_options: "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'LocalFileSystemKeyProviderFactory', 'secret_key_file': '/tmp/secret_key'}"
+
+send_email: true
+email_recipients: ['qa@scylladb.com']

--- a/test-cases/longevity/longevity-in-memory-36GB-4days.yaml
+++ b/test-cases/longevity/longevity-in-memory-36GB-4days.yaml
@@ -26,3 +26,6 @@ client_encrypt: 'false'
 append_scylla_args: '--blocked-reactor-notify-ms 500  --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --in-memory-storage-size-mb 80000'
 
 use_mgmt: true
+
+send_email: true
+email_recipients: ['qa@scylladb.com']

--- a/test-cases/longevity/longevity-large-partition-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-4days.yaml
@@ -27,3 +27,6 @@ primary_key_column: "pk"
 # scylla-manager configuration
 # if running on aws and use_mgmt is true, the monitor image should not contain scylla
 use_mgmt: true
+
+send_email: true
+email_recipients: ['qa@scylladb.com']

--- a/test-cases/longevity/longevity-multi-keyspaces.yaml
+++ b/test-cases/longevity/longevity-multi-keyspaces.yaml
@@ -31,3 +31,6 @@ append_scylla_args: '--blocked-reactor-notify-ms 500'
 
 # Manager
 use_mgmt: true
+
+send_email: true
+email_recipients: ['qa@scylladb.com']

--- a/test-cases/longevity/longevity-mv-si-4days.yaml
+++ b/test-cases/longevity/longevity-mv-si-4days.yaml
@@ -27,3 +27,6 @@ space_node_threshold: 644245
 # scylla-manager configuration
 # if running on aws and use_mgmt is true, the monitor image should not contain scylla
 use_mgmt: true
+
+send_email: true
+email_recipients: ['qa@scylladb.com']


### PR DESCRIPTION
Adding to each yaml config file for longevity jobs config
parameters:

send_email: true
email_recipients: ['qa@scylladb.com']

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
