### PR TITLE
scylla-bench: update go to 1.13

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3029,8 +3029,8 @@ class BaseLoaderSet(object):
 
         # scylla-bench
         node.remoter.run('sudo yum install git -y')
-        node.remoter.run('curl -LO https://storage.googleapis.com/golang/go1.9.2.linux-amd64.tar.gz')
-        node.remoter.run('sudo tar -C /usr/local -xvzf go1.9.2.linux-amd64.tar.gz')
+        node.remoter.run('curl -LO https://storage.googleapis.com/golang/go1.13.linux-amd64.tar.gz')
+        node.remoter.run('sudo tar -C /usr/local -xvzf go1.13.linux-amd64.tar.gz')
         node.remoter.run("echo 'export GOPATH=$HOME/go' >> $HOME/.bashrc")
         node.remoter.run("echo 'export PATH=$PATH:/usr/local/go/bin' >> $HOME/.bashrc")
         node.remoter.run("source $HOME/.bashrc")

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -806,8 +806,8 @@ class FileFollowerIterator(object):  # pylint: disable=too-few-public-methods
         with open(self.filename, 'r') as input_file:
             line = ''
             while not self.thread_obj.stopped():
-                poller = select.poll()
-                poller.register(input_file, select.POLLIN)
+                poller = select.poll()  # pylint: disable=no-member
+                poller.register(input_file, select.POLLIN)  # pylint: disable=no-member
                 if poller.poll(100):
                     line += input_file.readline()
                 if not line or not line.endswith('\n'):


### PR DESCRIPTION
Currently we used go 1.9.2 for installing scylla-bench, but it doesn't work now.
Update go version to solve the problem.

Command: 'go get github.com/scylladb/scylla-bench'
Exit code: 2
Stderr:
  # github.com/gocql/gocql
  go/src/github.com/gocql/gocql/control.go:156:7: randr.Shuffle undefined (type *"math/rand".Rand has no field or method Shuffle)
  go/src/github.com/gocql/gocql/policies.go:352:6: rand.Shuffle undefined (type *"math/rand".Rand has no field or method Shuffle)
  go/src/github.com/gocql/gocql/policies.go:865:4: r.Shuffle undefined (type *"math/rand".Rand has no field or method Shuffle)

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
