### PR TITLE
EaR: reduce cs threads to avoid Semaphore timedout

### DIFF
--- a/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
+++ b/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
@@ -1,8 +1,8 @@
 test_duration: 550
 prepare_write_cmd: "cassandra-stress write cl=ALL n=200200300  -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=1000 -col 'size=FIXED(12) n=FIXED(100)' -pop seq=1..200200300 -log interval=15"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=360m  -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=250  -col 'size=FIXED(12) n=FIXED(100)' -pop seq=400200300..600200300 -log interval=15"]
-stress_read_cmd: ["cassandra-stress read cl=ONE duration=360m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=250  -col 'size=FIXED(12) n=FIXED(100)' -pop seq=1..200200300 -log interval=5"]
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=360m  -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=50  -col 'size=FIXED(12) n=FIXED(100)' -pop seq=400200300..600200300 -log interval=15"]
+stress_read_cmd: ["cassandra-stress read cl=ONE duration=360m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=50  -col 'size=FIXED(12) n=FIXED(100)' -pop seq=1..200200300 -log interval=5"]
 run_fullscan: 'keyspace1.standard1, 5' # 'ks.cf|random, interval(min)''
 
 n_db_nodes: 4

--- a/tests/longevity-encryption-at-rest-200GB-6h.yaml
+++ b/tests/longevity-encryption-at-rest-200GB-6h.yaml
@@ -1,8 +1,8 @@
 test_duration: 550
 prepare_write_cmd: "cassandra-stress write cl=ALL n=200200300  -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=1000 -col 'size=FIXED(12) n=FIXED(100)' -pop seq=1..200200300 -log interval=15"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=360m  -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=250  -col 'size=FIXED(12) n=FIXED(100)' -pop seq=400200300..600200300 -log interval=15"]
-stress_read_cmd: ["cassandra-stress read cl=ONE duration=360m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=250  -col 'size=FIXED(12) n=FIXED(100)' -pop seq=1..200200300 -log interval=5"]
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=360m  -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=50  -col 'size=FIXED(12) n=FIXED(100)' -pop seq=400200300..600200300 -log interval=15"]
+stress_read_cmd: ["cassandra-stress read cl=ONE duration=360m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=50  -col 'size=FIXED(12) n=FIXED(100)' -pop seq=1..200200300 -log interval=5"]
 
 run_fullscan: 'keyspace1.standard1, 5' # 'ks.cf|random, interval(min)''
 n_db_nodes: 4


### PR DESCRIPTION
The semaphore_timeout errors occurred in EaR longevity-200gb-6h, the load of
error node reaches to 100% for some hours, it's normal to see Semaphore
timedout. Let's reduce the c-s threads to avoid heavy load.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
