### PR TITLE
cluster_aws: fix permmsion problem in writing scylla.yaml

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -518,7 +518,7 @@ class AWSNode(cluster.BaseNode):
             self.remoter.run("sudo bash -cxe '%s'" % clean_script)
             output = self.remoter.run('sudo grep replace_address: /etc/scylla/scylla.yaml', ignore_status=True)
             if 'replace_address_first_boot:' not in output.stdout:
-                self.remoter.run('sudo echo replace_address_first_boot: %s >> /etc/scylla/scylla.yaml' %
+                self.remoter.run('echo replace_address_first_boot: %s |sudo tee --append /etc/scylla/scylla.yaml' %
                                  self._instance.private_ip_address)
         self._instance.stop()
         self._instance_wait_safe(self._instance.wait_until_stopped)


### PR DESCRIPTION
Command: 'sudo echo replace_address_first_boot: 172.30.0.160 >> /etc/scylla/scylla.yaml'
Exit code: 1

Stderr:
bash: /etc/scylla/scylla.yaml: Permission denied

Signed-off-by: Amos Kong <amos@scylladb.com>

Test job where I found this problem:
- http://jenkins.scylladb.com/job/scylla-staging/job/amos/job/longevity-10gb-3h-3.1/11/console

Introduced by:
- https://github.com/scylladb/scylla-cluster-tests/commit/443d45445
- https://github.com/scylladb/scylla-cluster-tests/commit/1fb7523f9

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
