### PR TITLE
Fix issue running on jenkins for longevity pipeline

### DIFF
--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -88,7 +88,7 @@ def call(Map pipelineParams) {
                                 export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$GIT_BRANCH | sed -E 's+(origin/|origin/branch-)++')
                                 export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$SCT_AMI_ID_DB_SCYLLA_DESC | tr ._ - | cut -c1-8 )
 
-                                export SCT_TAG_AMI_WITH_RESULT=${params.tag_ami_with_result}"
+                                export SCT_TAG_AMI_WITH_RESULT="${params.tag_ami_with_result}"
 
                                 echo "start test ......."
                                 ./docker/env/hydra.sh run-test ${pipelineParams.test_name} --backend ${params.backend}  --logdir /sct


### PR DESCRIPTION
adding " to export command. 
otherwise jenkins job is failed with error:
_20:06:57  /jenkins/slave/workspace/scylla-staging/longevity-abykov-staging/longevity-1tb-7days-2Disruptive-Nemesises/scylla-cluster-tests@tmp/durable-e4ff9708/script.sh: line 31: unexpected EOF while looking for matching `"'_

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
