### PR TITLE
[For branch-3.1] Revert "Disabled show_toppartitions Nemesis on 3.1-rc8"

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -921,9 +921,6 @@ class Nemesis(object):
             self.tester.fail(result.stderr)
 
     def disrupt_show_toppartitions(self):
-        if "rc8" in self.target_node.scylla_version:
-            raise Exception("Disabled on 3.1-rc8 due to Avi and Shlomi request. Should be re-enabled on future RCs")
-
         def _parse_toppartitions_output(output):
             """parsing output of toppartitions
 


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
