### PR TITLE
Fix `hydra investigate show-monitor` (fixes #1351)

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -338,7 +338,6 @@ def restore_monitoring_stack(test_id):
             LOGGER.warning("During restoring file {} next errors occured:\n {}".format(arch['link'], result))
             return False
         LOGGER.info("Extracting data finished")
-        return True
 
     LOGGER.info('Monitoring stack files available {}'.format(monitor_stack_workdir))
 


### PR DESCRIPTION
when applying pylint across the code, I've wrongly add a return inside this code, which cased it to exit prematurely.