### PR TITLE
Change the number of partitions and rows to something more realistic

### DIFF
--- a/test-cases/longevity/longevity-large-partition-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-4days.yaml
@@ -1,8 +1,8 @@
 test_duration: 6480
 
 bench_run: 'true'
-prepare_write_cmd:  ["scylla-bench -workload=sequential -mode=write -max-rate=300 -replication-factor=3 -partition-count=10 -clustering-row-count=10000000 -clustering-row-size=5120 -concurrency=7 -rows-per-request=10",
-                     "scylla-bench -workload=uniform -mode=read -replication-factor=3 -partition-count=10 -clustering-row-count=10000000 -clustering-row-size=5120 -rows-per-request=10 -concurrency=7 -max-rate=32000 -duration=5760m"
+prepare_write_cmd:  ["scylla-bench -workload=sequential -mode=write -max-rate=300 -replication-factor=3 -partition-count=1000 -clustering-row-count=100000 -clustering-row-size=5120 -concurrency=7 -rows-per-request=10",
+                     "scylla-bench -workload=uniform -mode=read -replication-factor=3 -partition-count=1000 -clustering-row-count=100000 -clustering-row-size=5120 -rows-per-request=10 -concurrency=7 -max-rate=32000 -duration=5760m"
                     ]
 n_db_nodes: 4
 n_loaders: 3

--- a/tests/longevity-large-partition-4days.yaml
+++ b/tests/longevity-large-partition-4days.yaml
@@ -1,6 +1,6 @@
 test_duration: 6480
-prepare_write_cmd:  ["scylla-bench -workload=sequential -mode=write -max-rate=300 -replication-factor=3 -partition-count=10 -clustering-row-count=10000000 -clustering-row-size=5120 -concurrency=7 -rows-per-request=10",
-                     "scylla-bench -workload=uniform -mode=read -replication-factor=3 -partition-count=10 -clustering-row-count=10000000 -clustering-row-size=5120 -rows-per-request=10 -concurrency=7 -max-rate=32000 -duration=5760m"
+prepare_write_cmd:  ["scylla-bench -workload=sequential -mode=write -max-rate=300 -replication-factor=3 -partition-count=1000 -clustering-row-count=100000 -clustering-row-size=5120 -concurrency=7 -rows-per-request=10",
+                     "scylla-bench -workload=uniform -mode=read -replication-factor=3 -partition-count=1000 -clustering-row-count=100000 -clustering-row-size=5120 -rows-per-request=10 -concurrency=7 -max-rate=32000 -duration=5760m"
                     ]
 n_db_nodes: 4
 n_loaders: 3


### PR DESCRIPTION
The current number of partitions (10) is very low, while the current number of rows is very very high (10M)

I would prefer to see that high number of rows works fine, but let’s start with lower number (100K).

This change was not tested.
It’s a suggestion that need to be tested, if works without any issue let’s increase the 100K to 1M.
