### PR TITLE
Add support to fail test on thread failures

### DIFF
--- a/longevity_in_memory_test.py
+++ b/longevity_in_memory_test.py
@@ -2,9 +2,6 @@ from longevity_test import LongevityTest
 
 
 class InMemoryLongevetyTest(LongevityTest):
-    def __init__(self, *args, **kwargs):
-        super(InMemoryLongevetyTest, self).__init__(*args, **kwargs)
-
     def test_in_mem_longevity(self):
         self._pre_create_schema(in_memory=True)
         self.test_custom_time()

--- a/longevity_large_partition_test.py
+++ b/longevity_large_partition_test.py
@@ -2,8 +2,6 @@ from longevity_test import LongevityTest
 
 
 class LargePartitionLongevetyTest(LongevityTest):
-    def __init__(self, *args, **kwargs):
-        super(LargePartitionLongevetyTest, self).__init__(*args, **kwargs)
 
     def test_large_partition_longevity(self):
         self._pre_create_schema()

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -44,6 +44,7 @@ from sdcm.remote import RemoteCmdRunner, LocalCmdRunner
 from sdcm import wait
 from sdcm.utils.common import log_run_info, retrying, get_data_dir_path, Distro, verify_scylla_repo_file, S3Storage, \
     get_latest_gemini_version, get_my_ip, makedirs
+from sdcm.utils.thread import test_failing_function
 from sdcm.sct_events import Severity, CoreDumpEvent, CassandraStressEvent, DatabaseLogEvent, \
     ClusterHealthValidatorEvent
 from sdcm.sct_events import EVENTS_PROCESSES
@@ -180,6 +181,7 @@ class Setup(object):
     _test_name = None
     TAGS = dict()
     _logdir = None
+    _tester_obj = None
 
     @classmethod
     def test_id(cls):
@@ -208,6 +210,15 @@ class Setup(object):
                 test_id_file.write(str(test_id))
         else:
             LOGGER.warning("TestID already set!")
+
+    @classmethod
+    def tester_obj(cls):
+        return cls._tester_obj
+
+    @classmethod
+    def set_tester_obj(cls, tester_obj):
+        if not cls._tester_obj:
+            cls._tester_obj = tester_obj
 
     @classmethod
     def logdir(cls):
@@ -780,6 +791,7 @@ class BaseNode(object):  # pylint: disable=too-many-instance-attributes,too-many
             self.log.error('Error retrieving remote node DB service log: %s',
                            details)
 
+    @test_failing_function
     def journal_thread(self):
         read_from_timestamp = None
         while True:
@@ -898,6 +910,7 @@ class BaseNode(object):  # pylint: disable=too-many-instance-attributes,too-many
                 self._notify_backtrace(last=False)
             self.n_coredumps = new_n_coredumps
 
+    @test_failing_function
     def backtrace_thread(self):
         """
         Keep reporting new coredumps found, every 30 seconds.
@@ -906,6 +919,7 @@ class BaseNode(object):  # pylint: disable=too-many-instance-attributes,too-many
             self.termination_event.wait(15)
             self.get_backtraces()
 
+    @test_failing_function
     def db_log_reader_thread(self):
         """
         Keep reporting new events from db log, every 30 seconds.
@@ -2428,6 +2442,7 @@ def wait_for_init_wrap(method):
 
         queue = Queue.Queue()
 
+        @test_failing_function
         def node_setup(node):
             status = True
             try:

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -142,8 +142,9 @@ def teardown_on_exception(method):
 
 class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disable=too-many-instance-attributes,too-many-public-methods
 
-    def __init__(self, methodName='test'):
-        super(ClusterTester, self).__init__(methodName=methodName)
+    def __init__(self, *args):
+        super(ClusterTester, self).__init__(*args)
+        self.result = None
         self.status = "RUNNING"
         self.params = SCTConfiguration()
         self.params.verify_configuration()
@@ -163,6 +164,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         ip_ssh_connections = self.params.get(key='ip_ssh_connections', default='public')
         self.log.debug("IP used for SSH connections is '%s'",
                        ip_ssh_connections)
+        cluster.Setup.set_tester_obj(self)
         cluster.set_ip_ssh_connections(ip_ssh_connections)
         self.log.debug("Behavior on failure/post test is '%s'",
                        self._failure_post_behavior)
@@ -197,6 +199,11 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         start_events_device(cluster.Setup.logdir())
         time.sleep(0.5)
         InfoEvent('TEST_START test_id=%s' % cluster.Setup.test_id())
+
+    def run(self, result=None):
+        self.result = self.defaultTestResult() if result is None else result
+        result = super(ClusterTester, self).run(self.result)
+        return result
 
     @property
     def test_id(self):

--- a/sdcm/utils/thread.py
+++ b/sdcm/utils/thread.py
@@ -1,0 +1,34 @@
+import sys
+from functools import wraps
+import os
+import signal
+
+
+def background_failure_handler(signum, frame):  # pylint: disable=unused-argument
+    raise Exception("Failure/Error in background threads")
+
+
+signal.signal(signal.SIGUSR2, background_failure_handler)
+
+
+def test_failing_function(func):
+    """
+    Decorate a function that is running inside a thread,
+    when exception is raised in this function,
+    will cause the test to fail by sending a SIGUSR2 signal
+    """
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        result = None
+        _test_pid = os.getpid()
+        from sdcm.cluster import Setup
+        try:
+            result = func(*args, **kwargs)
+        except AssertionError:
+            Setup.tester_obj().result.addFailure(Setup.tester_obj(), sys.exc_info())
+            os.kill(_test_pid, signal.SIGUSR2)
+        except Exception:  # pylint: disable=broad-except
+            Setup.tester_obj().result.addError(Setup.tester_obj(), sys.exc_info())
+            os.kill(_test_pid, signal.SIGUSR2)
+        return result
+    return wrapper


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- ~~[ ] New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- ~~[ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- ~~[ ] I have updated the Readme/doc folder accordingly (if needed)~~
