### PR TITLE
Fix `wait_ami_available` code failing for scylla-cloud-run

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -531,7 +531,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             services.append(service)
             self.credentials.append(UserRemoteCredentials(key_file=user_credentials))
 
-        ami_ids = self.params.get('ami_id_db_scylla').split()
+        ami_ids = self.params.get('ami_id_db_scylla', default='').split()
         for idx, service in enumerate(services):
             wait_ami_available(service.meta.client, ami_ids[idx])
 


### PR DESCRIPTION
It should have used default='', since `split()` can be run on None