### PR TITLE
Fix unittest to fail jenkins

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -320,7 +320,7 @@ cli.add_command(investigate)
 @click.option("-t", "--test", required=False, default="",
               help="Run specific test file from unit-tests directory")
 def unit_tests(test):
-    pytest.main(['-v', '-p', 'no:warnings', 'unit_tests/{}'.format(test)])
+    sys.exit(pytest.main(['-v', '-p', 'no:warnings', 'unit_tests/{}'.format(test)]))
 
 
 class OutputLogger(object):

--- a/sdcm/microbenchmarking.py
+++ b/sdcm/microbenchmarking.py
@@ -20,6 +20,7 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 setup_stdout_logger()
 
 LOGGER = logging.getLogger("microbenchmarking")
+LOGGER.setLevel(logging.DEBUG)
 
 
 class LargeNumberOfDatasetsException(Exception):

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -2,8 +2,6 @@ import os
 import logging
 import unittest
 import itertools
-import hashlib
-import shutil
 
 from sdcm.sct_config import SCTConfiguration
 
@@ -279,39 +277,6 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         conf = SCTConfiguration()
         conf.verify_configuration()
         self.assertEqual(conf.get('target_upgrade_version'), '2019.1.1')
-
-    @staticmethod
-    def clear_cloud_downloaded_path(url):
-        md5 = hashlib.md5()
-        md5.update(url)
-        tmp_dir = os.path.join('/tmp/download_from_cloud', md5.hexdigest())
-        shutil.rmtree(tmp_dir, ignore_errors=True)
-
-    def test_16_update_db_packages_s3(self):
-        os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
-        os.environ['SCT_UPDATE_DB_PACKAGES'] = 's3://downloads.scylladb.com/rpm/centos/scylladb-nightly/scylla/7/x86_64/repodata/'
-        os.environ['SCT_USER_PREFIX'] = 'testing'
-        os.environ['SCT_INSTANCE_TYPE_DB'] = 'i3.large'
-        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-b4f8b4cb'
-        self.clear_cloud_downloaded_path(os.environ['SCT_UPDATE_DB_PACKAGES'])
-
-        conf = SCTConfiguration()
-        conf.verify_configuration()
-        update_db_packages = conf.get('update_db_packages')
-        assert os.path.exists(os.path.join(update_db_packages, "repomd.xml"))
-
-    def test_16_update_db_packages_gce(self):
-        os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
-        os.environ['SCT_UPDATE_DB_PACKAGES'] = 'gs://scratch.scylladb.com/sct_test/'
-        os.environ['SCT_USER_PREFIX'] = 'testing'
-        os.environ['SCT_INSTANCE_TYPE_DB'] = 'i3.large'
-        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-b4f8b4cb'
-        self.clear_cloud_downloaded_path(os.environ['SCT_UPDATE_DB_PACKAGES'])
-
-        conf = SCTConfiguration()
-        conf.verify_configuration()
-        update_db_packages = conf.get('update_db_packages')
-        assert os.path.exists(os.path.join(update_db_packages, "text.txt"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
seem like it was broken in the move to pytest, and a few tests got broken unnoticed.
this PR addresses both