### PR TITLE
Add availability to send email reports to all tests

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -36,3 +36,6 @@ cloud_credentials_path: '~/.ssh/support'
 backtrace_decoding: false
 
 logs_transport: "rsyslog"
+
+send_email: true
+email_recipients: ['qa@scylladb.com']

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1756,13 +1756,17 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         The method is used to send email with test results.
         Child class should implement the method get_mail_data
         which return the dict with 2 required fields:
-        email_template, email_subject
+            email_template, email_subject
+        and set the self.email_reporter to appropriate reporter object
         """
         send_email = self.params.get('send_email', default=False)
         if send_email:
             try:
                 email_data = self.get_email_data()
-                self.email_reporter.send_report(email_data)
+                if self.email_reporter:
+                    self.email_reporter.send_report(email_data)
+                else:
+                    self.log.warning('Tests is not configured with email reporter')
 
             except Exception as details:  # pylint: disable=broad-except
                 self.log.error("Error during sending email: {}".format(details))


### PR DESCRIPTION
Added config parameters to send email with results
to test_default.yaml.
Test which implement the Tester.get_email_data() method will be
send email report ( LongevityTest, GeminiTest) others will write
warning messages to log file that email could not be send

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
