### PR TITLE
Fix all booleans defined as strings in config

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -6,7 +6,8 @@ mgmt_port: 10090
 scylla_repo_m: 'http://repositories.scylladb.com/scylla/repo/qa-test/centos/scylladb-2019.1.repo'
 scylla_mgmt_repo: 'http://repositories.scylladb.com/scylla/repo/qa-test/centos/scylladb-manager-1.4.repo'
 
-experimental: 'true'
+experimental: true
+round_robin: false
 
 append_scylla_args: '--blocked-reactor-notify-ms 500 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc'
 
@@ -21,7 +22,7 @@ space_node_threshold: 0
 
 reuse_cluster: false
 nemesis_class_name: 'NoOpMonkey'
-nemesis_during_prepare: 'true'
+nemesis_during_prepare: true
 nemesis_interval: 5
 
 nemesis_filter_seeds: true

--- a/internal_test_data/complex_test_case_with_version.yaml
+++ b/internal_test_data/complex_test_case_with_version.yaml
@@ -20,7 +20,7 @@ user_prefix: 'longevity-50gb-4d-not-jenkins'
 failure_post_behavior: keep
 space_node_threshold: 644245094
 ip_ssh_connections: 'private'
-experimental: 'true'
+experimental: true
 append_scylla_args: '--blocked-reactor-notify-ms 500  --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc'
 instance_provision: 'on_demand'
 

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -124,7 +124,7 @@ class LongevityTest(ClusterTester):
 
             # When the load is too heavy for one lader when using MULTI-KEYSPACES, the load is spreaded evenly across
             # the loaders (round_robin).
-            if keyspace_num > 1 and self.params.get('round_robin', default='false').lower() == 'true':
+            if keyspace_num > 1 and self.params.get('round_robin'):
                 self.log.debug("Using round_robin for multiple Keyspaces...")
                 for i in xrange(1, keyspace_num + 1):
                     keyspace_name = self._get_keyspace_name(i)
@@ -138,7 +138,7 @@ class LongevityTest(ClusterTester):
 
             # In some cases we don't want the nemesis to run during the "prepare" stage in order to be 100% sure that
             # all keys were written succesfully
-            if self.params.get('nemesis_during_prepare', default='true').lower() == 'true':
+            if self.params.get('nemesis_during_prepare'):
                 # Wait for some data (according to the param in the yal) to be populated, for multi keyspace need to
                 # pay attention to the fact it checks only on keyspace1
                 self.db_cluster.wait_total_space_used_per_node(keyspace=None)
@@ -179,7 +179,7 @@ class LongevityTest(ClusterTester):
         stress_cmd = self.params.get('stress_cmd', default=None)
         if stress_cmd:
             # Stress: Same as in prepare_write - allow the load to be spread across all loaders when using multi ks
-            if keyspace_num > 1 and self.params.get('round_robin', default='false').lower() == 'true':
+            if keyspace_num > 1 and self.params.get('round_robin'):
                 self.log.debug("Using round_robin for multiple Keyspaces...")
                 for i in xrange(1, keyspace_num + 1):
                     keyspace_name = self._get_keyspace_name(i)
@@ -214,7 +214,7 @@ class LongevityTest(ClusterTester):
             self.run_fullscan_thread(ks_cf=fullscan['ks.cf'], interval=fullscan['interval'])
 
         # Check if we shall wait for total_used_space or if nemesis wasn't started
-        if not prepare_write_cmd or self.params.get('nemesis_during_prepare', default='true').lower() == 'false':
+        if not prepare_write_cmd or not self.params.get('nemesis_during_prepare'):
             self.db_cluster.wait_total_space_used_per_node(keyspace=None)
             self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
 

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -153,7 +153,7 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
             # Check if the prepare_cmd is a list of commands
             if not isinstance(prepare_write_cmd, basestring) and len(prepare_write_cmd) > 1:
                 # Check if it should be round_robin across loaders
-                if self.params.get('round_robin', default='').lower() == 'true':
+                if self.params.get('round_robin'):
                     self.log.debug('Populating data using round_robin')
                     params.update({'stress_num': 1, 'round_robin': True})
 

--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -390,7 +390,7 @@ class FillDatabaseData(ClusterTester):
                 [[-4]]
             ],
             'min_version': '1.7',
-            'skip_condition': "self.params.get('experimental', default='false').lower() == 'true'",
+            'skip_condition': "self.params.get('experimental')",
             'max_version': '',
             'skip': ''},
         # indexed_with_eq_test: Check that you can query for an indexed column even with a key EQ clause

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -313,7 +313,7 @@ class SCTConfiguration(dict):
         dict(name="nemesis_interval", env="SCT_NEMESIS_INTERVAL", type=int,
              help="""Nemesis sleep interval to use if None provided specifically in the test"""),
 
-        dict(name="nemesis_during_prepare", env="SCT_NEMESIS_DURING_PREPARE", type=str,
+        dict(name="nemesis_during_prepare", env="SCT_NEMESIS_DURING_PREPARE", type=boolean,
              help="""Run nemesis during prepare stage of the test"""),
 
         dict(name="space_node_threshold", env="SCT_SPACE_NODE_THRESHOLD", type=int,
@@ -623,7 +623,7 @@ class SCTConfiguration(dict):
              help=""),
         dict(name="keyspace_num", env="SCT_KEYSPACE_NUM", type=int,
              help=""),
-        dict(name="round_robin", env="SCT_ROUND_ROBIN", type=str,
+        dict(name="round_robin", env="SCT_ROUND_ROBIN", type=boolean,
              help=""),
         dict(name="batch_size", env="SCT_BATCH_SIZE", type=int,
              help=""),
@@ -706,7 +706,7 @@ class SCTConfiguration(dict):
             multiple commands can passed as a list"""),
 
         # RefreshTest
-        dict(name="skip_download", env="SCT_SKIP_DOWNLOAD", type=str,
+        dict(name="skip_download", env="SCT_SKIP_DOWNLOAD", type=boolean,
              help=""),
         dict(name="sstable_file", env="SCT_SSTABLE_FILE", type=str,
              help=""),

--- a/test-cases/features/corrupt-then-rebuild.yaml
+++ b/test-cases/features/corrupt-then-rebuild.yaml
@@ -14,4 +14,4 @@ instance_type_db: 'i3.2xlarge'
 user_prefix: 'cases-rebuild'
 failure_post_behavior: destroy
 
-round_robin: 'true'
+round_robin: true

--- a/test-cases/features/hinted-handoff.yaml
+++ b/test-cases/features/hinted-handoff.yaml
@@ -14,9 +14,9 @@ user_prefix: 'hinted-handoff'
 hinted_handoff: 'enabled'
 
 space_node_threshold: 644245094
-server_encrypt: 'true'
+server_encrypt: true
 
 # Nemesis
 nemesis_class_name: 'ValidateHintedHandoffShortDowntime'
 nemesis_interval: 20
-nemesis_during_prepare: 'true'
+nemesis_during_prepare: true

--- a/test-cases/features/refresh-30mins-120gb.yaml
+++ b/test-cases/features/refresh-30mins-120gb.yaml
@@ -17,4 +17,4 @@ failure_post_behavior: destroy
 sstable_url: 'https://s3.amazonaws.com/scylla-qa-team/keyspace1.standard1.tar.gz'
 sstable_file: '/var/tmp/keyspace1.standard1.tar.gz'
 sstable_md5: 'f64ab85111e817f22f93653a4a791b1f'
-skip_download: 'true'
+skip_download: true

--- a/test-cases/features/system-sla-test.yaml
+++ b/test-cases/features/system-sla-test.yaml
@@ -12,7 +12,7 @@ failure_post_behavior: keep
 space_node_threshold: 644
 
 # We want to run each user load on its own loader
-round_robin: 'true'
+round_robin: true
 
 authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra

--- a/test-cases/longevity/longevity-100GB-48h-cloud-CloudLimitedChaosMonkey-tls.yaml
+++ b/test-cases/longevity/longevity-100GB-48h-cloud-CloudLimitedChaosMonkey-tls.yaml
@@ -13,7 +13,7 @@ instance_type_db: 'i3.large' # instance type is defined in the jenkins job (with
 
 nemesis_class_name: 'LimitedChaosMonkey'
 nemesis_interval: 30
-nemesis_during_prepare: 'false'
+nemesis_during_prepare: false
 
 user_prefix: 'longevity-100gb-48h-cloud-limited-tls'
 
@@ -22,7 +22,7 @@ space_node_threshold: 644245094
 
 use_mgmt: true
 
-server_encrypt: 'true'
+server_encrypt: true
 authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra
 authenticator_password: cassandra

--- a/test-cases/longevity/longevity-200GB-48h-network-monkey.yaml
+++ b/test-cases/longevity/longevity-200GB-48h-network-monkey.yaml
@@ -15,7 +15,7 @@ nemesis_class_name: 'NetworkMonkey'
 nemesis_interval: 10
 aws_extra_network_interface: true
 
-nemesis_during_prepare: 'false'
+nemesis_during_prepare: false
 
 user_prefix: 'longevity-200gb-48h-network'
 
@@ -24,7 +24,7 @@ space_node_threshold: 644245094
 
 use_mgmt: true
 
-server_encrypt: 'true'
+server_encrypt: true
 authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra
 authenticator_password: cassandra

--- a/test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
+++ b/test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
@@ -14,7 +14,7 @@ instance_type_db: 'i3.4xlarge'
 
 nemesis_class_name: 'LimitedChaosMonkey'
 nemesis_interval: 30
-nemesis_during_prepare: 'false'
+nemesis_during_prepare: false
 
 user_prefix: 'longevity-200gb-48h-verify-limited-tls'
 

--- a/test-cases/longevity/longevity-2TB-4days-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
+++ b/test-cases/longevity/longevity-2TB-4days-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
@@ -14,7 +14,7 @@ stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=5760m -port jmx=6868
 
 run_fullscan: 'random, 240'  # 'ks.cf|random, interval(min)''
 
-round_robin: 'true'
+round_robin: true
 
 n_db_nodes: 5
 n_loaders: 4
@@ -26,13 +26,13 @@ instance_type_monitor: 't3.large'
 
 nemesis_class_name: 'DisruptiveMonkey:1 NonDisruptiveMonkey:2'
 nemesis_interval: 30
-nemesis_during_prepare: 'true'
+nemesis_during_prepare: true
 
 user_prefix: 'longevity-tls-2tb-4d-1dis-2nondis'
 failure_post_behavior: destroy
 space_node_threshold: 644245094
-server_encrypt: 'true'
-client_encrypt: 'true'
+server_encrypt: true
+client_encrypt: true
 
 authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra

--- a/test-cases/longevity/longevity-50GB-4days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-50GB-4days-authorization-and-tls-ssl.yaml
@@ -30,9 +30,9 @@ user_prefix: 'longevity-tls-50gb-4d'
 failure_post_behavior: keep
 space_node_threshold: 644245094
 
-server_encrypt: 'true'
+server_encrypt: true
 # Setting client encryption to false for now, till we will find the way to make c-s work with that
-client_encrypt: 'false'
+client_encrypt: false
 
 authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra

--- a/test-cases/longevity/longevity-counters-4days-multidc.yaml
+++ b/test-cases/longevity/longevity-counters-4days-multidc.yaml
@@ -18,6 +18,6 @@ space_node_threshold: 6442
 
 nemesis_class_name: 'ChaosMonkey'
 nemesis_interval: 15
-nemesis_during_prepare: 'false'
+nemesis_during_prepare: false
 
 use_mgmt: true

--- a/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
+++ b/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
@@ -13,7 +13,7 @@ instance_type_db: 'i3.4xlarge'
 
 nemesis_class_name: 'LimitedChaosMonkey'
 nemesis_interval: 30
-# nemesis_during_prepare: 'false'
+# nemesis_during_prepare: false
 
 user_prefix: 'longevity-encrypt-at-rest-200gb-6h-tls'
 
@@ -22,7 +22,7 @@ space_node_threshold: 644245094
 
 use_mgmt: true
 
-server_encrypt: 'true'
+server_encrypt: true
 authenticator_user: cassandra
 authenticator_password: cassandra
 authorizer: 'CassandraAuthorizer'

--- a/test-cases/longevity/longevity-in-memory-36GB-4days.yaml
+++ b/test-cases/longevity/longevity-in-memory-36GB-4days.yaml
@@ -19,8 +19,8 @@ failure_post_behavior: keep
 space_node_threshold: 644245094
 ip_ssh_connections: 'private'
 
-server_encrypt: 'true'
-client_encrypt: 'false'
+server_encrypt: true
+client_encrypt: false
 
 # 80GB in-memory storage - 36GB table is 45% of total in-memory store as recommended
 append_scylla_args: '--blocked-reactor-notify-ms 500  --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --in-memory-storage-size-mb 80000'

--- a/test-cases/longevity/longevity-large-partition-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-4days.yaml
@@ -1,6 +1,6 @@
 test_duration: 6480
 
-bench_run: 'true'
+bench_run: true
 prepare_write_cmd:  ["scylla-bench -workload=sequential -mode=write -max-rate=300 -replication-factor=3 -partition-count=10 -clustering-row-count=10000000 -clustering-row-size=5120 -concurrency=7 -rows-per-request=10",
                      "scylla-bench -workload=uniform -mode=read -replication-factor=3 -partition-count=10 -clustering-row-count=10000000 -clustering-row-size=5120 -rows-per-request=10 -concurrency=7 -max-rate=32000 -duration=5760m"
                     ]

--- a/test-cases/performance/perf-regression-latency-1TB.yaml
+++ b/test-cases/performance/perf-regression-latency-1TB.yaml
@@ -21,7 +21,7 @@ user_prefix: 'perf-regression-latency'
 failure_post_behavior: destroy
 space_node_threshold: 644245094
 
-round_robin: 'true'
+round_robin: true
 append_scylla_args: '--blocked-reactor-notify-ms 4'
 
 send_email: true

--- a/test-cases/performance/perf-regression-latency-500gb-30min.yaml
+++ b/test-cases/performance/perf-regression-latency-500gb-30min.yaml
@@ -21,7 +21,7 @@ failure_post_behavior: destroy
 space_node_threshold: 644245094
 ami_id_db_scylla_desc: 'VERSION_DESC'
 
-round_robin: 'true'
+round_robin: true
 append_scylla_args: '--blocked-reactor-notify-ms 4'
 
 send_email: true

--- a/test-cases/performance/perf-regression-latency-in-memory.yaml
+++ b/test-cases/performance/perf-regression-latency-in-memory.yaml
@@ -18,7 +18,7 @@ instance_type_monitor: 't2.small'
 instance_type_db: 'i3.4xlarge'
 
 failure_post_behavior: 'destroy'
-round_robin: 'true'
+round_robin: true
 space_node_threshold: 644245094
 
 user_prefix: 'perf-regression-latency-in-memory'

--- a/test-cases/upgrades/rolling-upgrade.yaml
+++ b/test-cases/upgrades/rolling-upgrade.yaml
@@ -21,7 +21,6 @@ n_monitor_nodes: 1
 user_prefix: 'rolling-upgrade'
 failure_post_behavior: destroy
 
-experimental: 'true'
 authenticator: 'PasswordAuthenticator'
 authenticator_user: 'cassandra'
 authenticator_password: 'cassandra'


### PR DESCRIPTION
Leftover from days we supported both sct_config and avocado configurations.
now all boolean should be defined as such in sct_config.py and used a boolean in yaml config files
