### PR TITLE
improve email report for longevity test runs

### DIFF
--- a/gemini_test.py
+++ b/gemini_test.py
@@ -19,7 +19,6 @@ import os
 
 from sdcm.tester import ClusterTester
 from sdcm.utils.common import format_timestamp
-from sdcm.send_email import GeminiEmailReporter
 
 
 class GeminiTest(ClusterTester):
@@ -71,9 +70,8 @@ class GeminiTest(ClusterTester):
             self.fail(self.gemini_results['results'])
 
     def get_email_data(self):
-        email_recipients = self.params.get('email_recipients', default=None)
-        self.email_reporter = GeminiEmailReporter(email_recipients=email_recipients, logdir=self.logdir)
         scylla_version = self.db_cluster.nodes[0].scylla_version
+        oracle_db_version = self.cs_db_cluster.nodes[0].scylla_version if self.cs_db_cluster else ""
         start_time = format_timestamp(self.start_time)
 
         return {
@@ -85,7 +83,7 @@ class GeminiTest(ClusterTester):
             "scylla_instance_type": self.params.get('instance_type_db'),
             "number_of_db_nodes": self.params.get('n_db_nodes'),
             "number_of_oracle_nodes": self.params.get('n_test_oracle_db_nodes', 1),
-            "oracle_db_version": scylla_version,
+            "oracle_db_version": oracle_db_version,
             "oracle_ami_id": self.params.get('ami_id_db_oracle'),
             "oracle_instance_type": self.params.get('instance_type_db_oracle'),
             "results": self.gemini_results['results'],

--- a/sdcm/results_longevity.html
+++ b/sdcm/results_longevity.html
@@ -98,21 +98,24 @@
     </h3>
     <div> {{ test_status[0] }} </div>
     {% if test_status[1] and short_report %}
-        <div> Number of critical records : {{ test_status[1]|length }} </div>
+        <div> See attached html report for full details of critical errors </div>
     {% elif test_status[1] and not short_report %}
         <div>
-            <table class="longevity_critical_errors_table">
-                {% for line in test_status[1] %}
-                    <tr><td>{{ line }}</td></tr>
-                    {% if loop.index > 99 %}
-                        <tr><td> See more records in critical.log file</td></tr>
-                        {% break %}
-                    {% endif %}
-                {% endfor %}
-            </table>
+            {% for line in test_status[1] %}
+                <pre>{{ line }}</pre>
+            {% endfor %}
         </div>
     {% endif %}
-        <h3>Links:</h3>
+    <h3>
+        Hydra commands:
+    </h3>
+    <div>
+        <ul>
+            <li>Restore Monitor Stack command: $ hydra investigate show-monitor {{ test_id }}</li>
+            <li>Show all stored logs command: $ hydra investigate show-logs {{ test_id }}</li>
+        </ul>
+    </div>
+    <h3>Links:</h3>
     <ul>
         {% if grafana_screenshots %}
             {% if grafana_screenshots[0] %}
@@ -138,10 +141,4 @@
         {% endfor %}
     {% endif %}
     <h3> Access logs </h3>
-    <div>
-        <ul>
-            <li>Restore Monitor Stack command: $ hydra investigate show-monitor {{ test_id }}</li>
-            <li>Show all stored logs command: $ hydra investigate show-logs {{ test_id }}</li>
-        </ul>
-    </div>
 {% endblock %}

--- a/sdcm/send_email.py
+++ b/sdcm/send_email.py
@@ -163,3 +163,21 @@ class GeminiEmailReporter(BaseEmailReporter):
         self.log.info('Prepare result to send in email')
         html = self.render_to_html(email_data)
         return html, ()
+
+
+def build_reporter(tester):
+    """Build reporter
+
+    [description]
+
+    Arguments:
+        tester {ClusterTester} -- instance of ClusterTester for currrent test
+    """
+    email_recipients = tester.params.get('email_recipients', default=None)
+    logdir = tester.logdir
+    if "Gemini" in tester.__class__.__name__:
+        return GeminiEmailReporter(email_recipients=email_recipients, logdir=logdir)
+    elif "Longevity" in tester.__class__.__name__:
+        return LongevityEmailReporter(email_recipients=email_recipients, logdir=logdir)
+    else:
+        return None


### PR DESCRIPTION
- Adding job/configfile name to subject
- Change the error output for Longevity in attached file
- email_reporter property value set automatically

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
