### PR TITLE
Add event that when journald suppress Scylla log messages

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -434,7 +434,10 @@ class BaseNode(object):  # pylint: disable=too-many-instance-attributes,too-many
                                        DatabaseLogEvent(type='INTEGRITY_CHECK', regex='integrity check failed'),
                                        DatabaseLogEvent(type='REACTOR_STALLED', regex='Reactor stalled'),
                                        DatabaseLogEvent(type='SEMAPHORE_TIME_OUT', regex='semaphore_timed_out'),
-                                       DatabaseLogEvent(type='BOOT', regex='Starting Scylla Server', severity=Severity.NORMAL)]
+                                       DatabaseLogEvent(type='BOOT', regex='Starting Scylla Server',
+                                                        severity=Severity.NORMAL),
+                                       DatabaseLogEvent(type='SUPPRESSED_MESSAGES', regex='journal: Suppressed',
+                                                        severity=Severity.WARNING)]
 
         self.termination_event = threading.Event()
         self._running_nemesis = None

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -107,3 +107,19 @@ class TestBaseNode(unittest.TestCase):
         assert event_a["line_number"] == 1
         assert event_b["type"] == "REACTOR_STALLED"
         assert event_b["line_number"] == 4
+
+    def test_search_database_suppressed_messages(self):  # pylint: disable=invalid-name
+        self.node.database_log = os.path.join(os.path.dirname(
+            __file__), 'test_data', 'database_suppressed_messages.log')
+
+        _ = self.node.search_database_log(start_from_beginning=True)
+
+        events_file = open(EVENTS_PROCESSES['MainDevice'].raw_events_filename, 'r')
+
+        events = [json.loads(line) for line in events_file.readlines()]
+
+        event_a = events[-1]
+        print event_a
+
+        assert event_a["type"] == "SUPPRESSED_MESSAGES", 'Not expected event type {}'.format(event_a["type"])
+        assert event_a["line_number"] == 6, 'Not expected event line number {}'.format(event_a["line_number"])

--- a/unit_tests/test_data/database_suppressed_messages.log
+++ b/unit_tests/test_data/database_suppressed_messages.log
@@ -1,0 +1,13 @@
+2019-09-09T13:10:41+00:00  rolling-upgrade-2019-1-n-centos-db-node-b50af2f8-0-3 !INFO    | scylla: Reactor stalled for 500 ms on shard 4.
+leapis.com:443 "GET /compute/v1/projects/skilled-adapter-452/zones/us-east1-b/instances/rolling-upgrade-2019-1-n-centos-db-node-b50af2f8-0-3 HTTP/1.1" 200 None
+leapis.com:443 "GET /compute/v1/projects/skilled-adapter-452/zones/us-east1-b/instances/rolling-upgrade-2019-1-n-centos-db-node-b50af2f8-0-3 HTTP/1.1" 200 None
+2019-09-09T13:10:41+00:00  rolling-upgrade-2019-1-n-centos-db-node-b50af2f8-0-3 !INFO    | scylla: Reactor stalled for 500 ms on shard 4.
+leapis.com:443 "GET /compute/v1/projects/skilled-adapter-452/zones/us-east1-b/instances/rolling-upgrade-2019-1-n-centos-db-node-b50af2f8-0-3 HTTP/1.1" 200 None
+leapis.com:443 "GET /compute/v1/projects/skilled-adapter-452/zones/us-east1-b/instances/rolling-upgrade-2019-1-n-centos-db-node-b50af2f8-0-3 HTTP/1.1" 200 None
+2019-08-23T08:04:45+00:00  ip-172-30-0-243 !INFO    | journal: Suppressed 1363 messages from /system.slice/scylla-server.service
+leapis.com:443 "GET /compute/v1/projects/skilled-adapter-452/zones/us-east1-b/instances/rolling-upgrade-2019-1-n-centos-db-node-b50af2f8-0-3 HTTP/1.1" 200 None
+leapis.com:443 "GET /compute/v1/projects/skilled-adapter-452/zones/us-east1-b/instances/rolling-upgrade-2019-1-n-centos-db-node-b50af2f8-0-3 HTTP/1.1" 200 None
+leapis.com:443 "GET /compute/v1/projects/skilled-adapter-452/zones/us-east1-b/instances/rolling-upgrade-2019-1-n-centos-db-node-b50af2f8-0-3 HTTP/1.1" 200 None
+leapis.com:443 "GET /compute/v1/projects/skilled-adapter-452/zones/us-east1-b/instances/rolling-upgrade-2019-1-n-centos-db-node-b50af2f8-0-3 HTTP/1.1" 200 None
+2019-09-09T13:10:41+00:00  rolling-upgrade-2019-1-n-centos-db-node-b50af2f8-0-3 !INFO    | scylla: [shard 4] schema_tables - Creating keyspace keyspace_entire_test
+2019-09-09T13:10:41+00:00  rolling-upgrade-2019-1-n-centos-db-node-b50af2f8-0-3 !INFO    | scylla: [shard 4] schema_tables - Creating keyspace keyspace_entire_test


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)

Task https://trello.com/c/O0A8gEGT/1235-add-event-that-when-journald-suppress-scylla-log-messages:

```
Following discussion with Benny, we need to add an event when journal suppresses messages since it is a potential bug that DB produces too many logs 
Example:
2019-08-23T08:04:45+00:00  ip-172-30-0-243 !INFO    | journal: Suppressed 1363 messages from /system.slice/scylla-server.service
```