### PR TITLE
Create new doc in ES with document_id as test-id

### DIFF
--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -333,7 +333,15 @@ class TestStatsMixin(Stats):
 
     @staticmethod
     def _create_test_id():
-        return datetime.datetime.now().strftime("%Y%m%d-%H%M%S-%f")
+        """return unified test-id
+
+        Returns:
+            str -- generated test-id for whole run.
+        """
+        # avoid cyclic-decencies between cluster and db_stats
+        from sdcm.cluster import Setup
+
+        return Setup.test_id()
 
     def _init_stats(self):
         return {k: {} for k in self.KEYS}

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1597,7 +1597,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                                       email_recipients=self.params.get('email_recipients', default=None))
         is_gce = True if self.params.get('cluster_backend') == 'gce' else False
         try:
-            results_analyzer.check_regression(self._test_id, is_gce)
+            results_analyzer.check_regression(self.test_id, is_gce)
         except Exception as ex:  # pylint: disable=broad-except
             self.log.exception('Failed to check regression: %s', ex)
 


### PR DESCRIPTION
before each sct run with storing results in es enabled
generate document-id from datetimestamp.
now document-id will same as test-id generated by hydra

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
