### PR TITLE
Remove old document_id and related functionality

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -173,7 +173,6 @@ class Setup(object):
     BACKTRACE_DECODING = False
     INTRA_NODE_COMM_PUBLIC = False
     RSYSLOG_ADDRESS = None
-    ES_DOC_ID = None
 
     _test_id = None
     _es_doc_id = None
@@ -184,20 +183,6 @@ class Setup(object):
     @classmethod
     def test_id(cls):
         return cls._test_id
-
-    @classmethod
-    def es_doc_id(cls):
-        return cls._es_doc_id
-
-    @classmethod
-    def set_es_doc_id(cls, es_doc_id):
-        if not cls._es_doc_id:
-            cls._es_doc_id = es_doc_id
-            es_doc_id_file_path = os.path.join(cls.logdir(), 'es_doc_id')
-            with open(es_doc_id_file_path, "w") as es_doc_id_file:
-                es_doc_id_file.write(str(es_doc_id))
-        else:
-            LOGGER.warning("ES DocID already set!")
 
     @classmethod
     def set_test_id(cls, test_id):

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -257,8 +257,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
         if self.create_stats:
             self.create_test_stats()
-            # Need to clarify with Performance tests
-            cluster.Setup.set_es_doc_id(self.get_doc_id())
+
         # change RF of system_auth
         system_auth_rf = self.params.get('system_auth_rf', default=3)
         if system_auth_rf and not cluster.Setup.REUSE_CLUSTER:
@@ -1485,8 +1484,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                     self.update({'test_details': {'log_files': {'job_log': s3_link}}})
             stop_rsyslog()
             self.log.info('Test ID: {}'.format(cluster.Setup.test_id()))
-            if self.create_stats:
-                self.log.info("ES document id: {}".format(self.get_doc_id()))
 
     def populate_data_parallel(self, size_in_gb, blocking=True, read=False):
 


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
