### PR TITLE
ClusterHealthValidator: use node.ip_address instead of node.private_ip_address

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2168,7 +2168,7 @@ server_encryption_options:
         self.log.info('Gossipinfo schema version and status of all nodes: {}'.format(gossip_node_schemas))
 
         # Validate that ALL initiated nodes in the gossip
-        cluster_nodes = [node.private_ip_address for node in self.parent_cluster.nodes if node.db_init_finished]
+        cluster_nodes = [node.ip_address for node in self.parent_cluster.nodes if node.db_init_finished]
 
         not_in_gossip = list(set(cluster_nodes) - set(gossip_node_schemas.keys()))
         if not_in_gossip:
@@ -2203,7 +2203,7 @@ server_encryption_options:
         peers_details = ''
         try:
             gossip_node_schemas = self.validate_gossip_nodes_info()
-            status = gossip_node_schemas[self.private_ip_address]['status']
+            status = gossip_node_schemas[self.ip_address]['status']
             if status != 'NORMAL':
                 self.log.debug('Node status is {status}. Schema version can\'t be validated'. format(status=status))
                 return
@@ -2222,7 +2222,7 @@ server_encryption_options:
                     errors.append('Found nulls in system.peers on the node %s: %s' % (current_node_ip, peers_details))
 
                 peer_schema_version = line_splitted[6].strip()
-                gossip_node_schema_version = gossip_node_schemas[self.private_ip_address]['schema']
+                gossip_node_schema_version = gossip_node_schemas[self.ip_address]['schema']
                 if gossip_node_schema_version and peer_schema_version != gossip_node_schema_version:
                     errors.append('Expected schema version: %s. Wrong schema version found on the '
                                   'node %s: %s' % (gossip_node_schema_version, current_node_ip, peer_schema_version))


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)

In the cloud test we use SCT_INTRA_NODE_COMM_PUBLIC=True. In this case we need to use public IP instead of private IP