### PR TITLE
ignore error in reporting housekeeping uuid

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1184,7 +1184,10 @@ class BaseNode(object):  # pylint: disable=too-many-instance-attributes,too-many
             text = '%s: Waiting for DB services to be up' % self
         wait.wait_for(func=self.db_up, step=60, text=text, timeout=timeout, throw_exc=True)
         self.db_init_finished = True
-        self._report_housekeeping_uuid()
+        try:
+            self._report_housekeeping_uuid()
+        except Exception as details:  # pylint: disable=broad-except
+            self.log.error('Failed to report housekeeping uuid. Error details: %s', details)
 
     def apt_running(self):
         try:


### PR DESCRIPTION
The error in reporting housekeeping uuid has low probability, but we don't want
it fail the job, the error won't effect the test itself.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
