### PR TITLE
Handle error: mv: cannot move ‘/tmp/ssl_conf/’ to ‘/etc/scylla/ssl_conf’: File exists

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1559,7 +1559,7 @@ server_encryption_options:
             mkdir -p ~/.cassandra/
             cp /tmp/ssl_conf/client/cqlshrc ~/.cassandra/
             sudo mkdir -p /etc/scylla/
-            sudo mv /tmp/ssl_conf/ /etc/scylla/
+            sudo mv -f /tmp/ssl_conf/ /etc/scylla/
         """)
         self.remoter.run('bash -cxe "%s"' % setup_script)
 


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)

longevity-50gb-4days (Scylla master branch), terminate_and_replace_node nemesis. 
Adding new node failed (3 times) with error:
```
< t:2019-10-23 20:03:44,318 f:cluster.py      l:2470 c:sdcm.cluster         p:ERROR > + sudo mv /tmp/ssl_conf/ /etc/scylla/
< t:2019-10-23 20:03:44,318 f:cluster.py      l:2470 c:sdcm.cluster         p:ERROR > mv: cannot move ‘/tmp/ssl_conf/’ to ‘/etc/scylla/ssl_conf’: File exists
```