### PR TITLE
upgrade: get version from suffix of branch name

### DIFF
--- a/vars/supportedUpgradeFromVersions.groovy
+++ b/vars/supportedUpgradeFromVersions.groovy
@@ -1,7 +1,7 @@
 #!groovy
 
 def call(String git_branch, List base_versions_list) {
-    def clean_branch_name = git_branch - 'origin/' - 'branch-'
+    def clean_branch_name = git_branch.tokenize('-')[-1]
     if (is_enterprise_version(clean_branch_name)) {
         return base_versions_list
     } else {


### PR DESCRIPTION
Currently we assume the branch name is origin/branch-xxx.x, it works well in
formal jobs. When I test with personal branch origin/upgrade-ipv6-2019.1, the
version can't be identified correctly.

This patch changed to get version from suffix of branch name, it's more
flexible.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
