### PR TITLE
Fix issue with collecting logs if node is not available

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -497,12 +497,18 @@ class LogCollector(object):
     def create_remote_storage_dir(self, node, path=''):
         if not path:
             path = node.name
-        remote_dir = os.path.join(self.node_remote_dir, path)
-        result = node.remoter.run('mkdir -p {}'.format(remote_dir), ignore_status=True)
+        try:
+            remote_dir = os.path.join(self.node_remote_dir, path)
+            result = node.remoter.run('mkdir -p {}'.format(remote_dir), ignore_status=True)
 
-        if result.exited > 0:
-            LOGGER.error(
-                'Remote storing folder not created.\n{}'.format(result))
+            if result.exited > 0:
+                LOGGER.error(
+                    'Remote storing folder not created.\n{}'.format(result))
+                remote_dir = self.node_remote_dir
+
+        except Exception as details:  # pylint: disable=broad-except
+            LOGGER.error("Error during creating remote directory %s", details)
+            remote_dir = self.node_remote_dir
 
         return remote_dir
 


### PR DESCRIPTION
During log collecting, first command which is run is creating remote
directory. if node is not available for any reasons, this command failed
and all process of collection entities are interupted.
Fix is resolve this issue, and at least local files will be found
and collected.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
