### PR TITLE
Fix CorruptThen* nemesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -283,7 +283,7 @@ class Nemesis(object):  # pylint: disable=too-many-instance-attributes,too-many-
         ks_cf_for_destroy = random.choice(ks_cfs)  # expected value as: 'keyspace1.standard1'
 
         ks_cf_for_destroy = ks_cf_for_destroy.replace('.', '/')
-        files = self.target_node.remoter.run("sudo find /var/lib/scylla/data/%s-* -type f" % ks_cf_for_destroy,
+        files = self.target_node.remoter.run("sudo sh -c 'find /var/lib/scylla/data/%s-* -type f'" % ks_cf_for_destroy,
                                              verbose=False)
         if files.stderr:
             raise NoFilesFoundToDestroy('Failed to get data files for destroy in {}. Error: {}'.format(ks_cf_for_destroy,


### PR DESCRIPTION
In some braches (i.e. 2019.1) the scylla data dir permissions
are more strict, and not visiable by the centos user.

hence we need to make sure we run everything via sudo
(i.e. not globbing files in the centos user)