### PR TITLE
Make sure we pass via `node_config_setup` when re-configuring scylla

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -738,19 +738,20 @@ class ScyllaAWSCluster(cluster.BaseScyllaCluster, AWSCluster):
                                                               enable_auto_bootstrap=enable_auto_bootstrap)
         return added_nodes
 
-    def node_config_setup(self, node, seed_address, endpoint_snitch):
+    def node_config_setup(self, node, seed_address, endpoint_snitch, murmur3_partitioner_ignore_msb_bits=None, client_encrypt=None):  # pylint: disable=too-many-arguments
         setup_params = dict(
             enable_exp=self._param_enabled('experimental'),
             endpoint_snitch=endpoint_snitch,
             authenticator=self.params.get('authenticator'),
             server_encrypt=self._param_enabled('server_encrypt'),
-            client_encrypt=self._param_enabled('client_encrypt'),
+            client_encrypt=client_encrypt if client_encrypt is not None else self._param_enabled('client_encrypt'),
             append_scylla_args=self.get_scylla_args(),
             authorizer=self.params.get('authorizer'),
             hinted_handoff=self.params.get('hinted_handoff'),
             alternator_port=self.params.get('alternator_port'),
             seed_address=seed_address,
             append_scylla_yaml=self.params.get('append_scylla_yaml'),
+            murmur3_partitioner_ignore_msb_bits=murmur3_partitioner_ignore_msb_bits,
         )
         if cluster.Setup.INTRA_NODE_COMM_PUBLIC:
             setup_params.update(dict(


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
