### PR TITLE
Make sure we append scylla args only once

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1530,11 +1530,17 @@ server_encryption_options:
 
         if append_scylla_args:
             if self.is_rhel_like():
-                self.remoter.run(
-                    "sudo sed -i -e 's/SCYLLA_ARGS=\"/SCYLLA_ARGS=\"%s /' /etc/sysconfig/scylla-server" % append_scylla_args)
+                result = self.remoter.run("sudo grep '\\%s' /etc/sysconfig/scylla-server" %
+                                          append_scylla_args, ignore_status=True)
+                if result.exit_status == 1:
+                    self.remoter.run(
+                        "sudo sed -i -e 's/SCYLLA_ARGS=\"/SCYLLA_ARGS=\"%s /' /etc/sysconfig/scylla-server" % append_scylla_args)
             elif self.is_debian() or self.is_ubuntu():
-                self.remoter.run(
-                    "sudo sed -i -e 's/SCYLLA_ARGS=\"/SCYLLA_ARGS=\"%s /'  /etc/default/scylla-server" % append_scylla_args)
+                result = self.remoter.run("sudo grep '\\%s' /etc/default/scylla-server" %
+                                          append_scylla_args, ignore_status=True)
+                if result.exit_status == 1:
+                    self.remoter.run(
+                        "sudo sed -i -e 's/SCYLLA_ARGS=\"/SCYLLA_ARGS=\"%s /'  /etc/default/scylla-server" % append_scylla_args)
 
         if debug_install and self.is_rhel_like():
             self.remoter.run('sudo yum install -y scylla-gdb', verbose=True, ignore_status=True)


### PR DESCRIPTION
Fixes #1429

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
