### PR TITLE
for 3.1: switch prepare of scylla monitor to python2

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3414,10 +3414,9 @@ class BaseMonitorSet(object):
             node.update_repo_cache()
             prereqs_script = dedent("""
                 yum install -y unzip wget
-                yum install -y python36
-                yum install -y python36-pip
-                python3 -m pip install --upgrade pip
-                python3 -m pip install pyyaml
+                easy_install pip
+                pip install --upgrade pip
+                pip install pyyaml
                 curl -fsSL get.docker.com -o get-docker.sh
                 sh get-docker.sh
                 systemctl start docker


### PR DESCRIPTION
We are still using scylla-monitoring branch-2.4 for SCT branch-3.1 and
branch-2019.1

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
