### PR TITLE
Fix screenshot creation due to wrong time_start

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3742,15 +3742,14 @@ class BaseMonitorSet(object):  # pylint: disable=too-many-public-methods,too-man
         if not test_start_time:
             self.log.error("No start time for test")  # pylint: disable=no-member
             return {}
-        start_time = str(test_start_time).split('.')[0] + '000'
 
         for node in self.nodes:  # pylint: disable=no-member
             screenshot_collector = GrafanaScreenShot(name="grafana-screenshot",
-                                                     test_start_time=start_time)
+                                                     test_start_time=test_start_time)
             screenshots = screenshot_collector.collect(node, self.logdir)  # pylint: disable=no-member
             screenshots = [S3Storage().upload_file(screenshot, Setup.test_id()) for screenshot in screenshots]
             snapshots_collector = GrafanaSnapshot(name="grafana-snapshot",
-                                                  test_start_time=start_time)
+                                                  test_start_time=test_start_time)
             snapshots = snapshots_collector.collect(node, self.logdir)  # pylint: disable=no-member
         return {'screenshots': screenshots, 'snapshots': snapshots['links']}
 


### PR DESCRIPTION
Test_time_start processed twice, and this cause that test_start_time
become far in future.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
