### PR TITLE
Add support for hydra collect-logs correctly found monitor branch

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3671,6 +3671,19 @@ class BaseMonitorSet(object):
         """.format(self))
         node.remoter.run("bash -ce '%s'" % run_script, verbose=True)
         self.add_sct_dashboards_to_grafana(node)
+        self.save_sct_dashboards_config(node)
+        self.save_monitoring_version(node)
+
+    def save_monitoring_version(self, node):
+        node.remoter.run(
+            'echo "{0.monitor_branch}:{0.monitoring_version}" > {0.monitor_install_path}/monitor_version'.format(self), ignore_status=True)
+
+    def save_sct_dashboards_config(self, node):
+        sct_monitoring_addons_dir = os.path.join(self.monitor_install_path, 'sct_monitoring_addons')
+
+        node.remoter.run('mkdir -p {}'.format(sct_monitoring_addons_dir), ignore_status=True)
+        sct_dashboard_file = self.get_sct_dashboards_config()
+        node.remoter.send_files(src=sct_dashboard_file, dst=sct_monitoring_addons_dir)
 
     def add_sct_dashboards_to_grafana(self, node):
         sct_dashboard_json = "scylla-dash-per-server-nemesis.{0.monitoring_version}.json".format(self)


### PR DESCRIPTION
Add support to save monitor and scylla version and appropriate files on monitor node for future collecting by hydra collect-log

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
