### PR TITLE
Add more log filtering to enospc nemesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -539,7 +539,8 @@ class Nemesis(object):  # pylint: disable=too-many-instance-attributes,too-many-
 
         with DbEventsFilter(type='NO_SPACE_ERROR'), \
                 DbEventsFilter(type='BACKTRACE', line='No space left on device'), \
-                DbEventsFilter(type='DATABASE_ERROR', line='No space left on device'):
+                DbEventsFilter(type='DATABASE_ERROR', line='No space left on device'), \
+                DbEventsFilter(type='FILESYSTEM_ERROR', line='No space left on device'):
             for node in nodes:
                 result = node.remoter.run('cat /proc/mounts')
                 if '/var/lib/scylla' not in result.stdout:


### PR DESCRIPTION
master 4h run, failed cause of this:
https://jenkins.scylladb.com/job/scylla-master/job/longevity/job/longevity-100gb-4h/35/