### PR TITLE
Enlarge timeout in `RestartThenRepairNode` nemesis to 8 hours

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -231,7 +231,7 @@ class Nemesis(object):  # pylint: disable=too-many-instance-attributes,too-many-
         self._set_current_disruption('RestartThenRepairNode %s' % self.target_node)
         self.target_node.restart()
         self.log.info('Waiting scylla services to start after node restart')
-        self.target_node.wait_db_up(timeout=14400)
+        self.target_node.wait_db_up(timeout=28800)  # 8 hours
         self.log.info('Waiting JMX services to start after node restart')
         self.target_node.wait_jmx_up()
         self.repair_nodetool_repair()


### PR DESCRIPTION
In multiple nemesis test when we have 2TB of data steaming can
more then 4 hours, raising the limit above that.