### PR TITLE
Add support for promproxy

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -135,6 +135,15 @@ class SCTConfiguration(dict):
         dict(name="cloud_credentials_path", env="SCT_CLOUD_CREDENTIALS_PATH", type=str,
              help="""Path to your user credentials. qa key are downloaded automatically from S3 bucket"""),
 
+        dict(name="cloud_prom_bearer_token", env="SCT_CLOUD_PROM_BEARER_TOKEN", type=str,
+             help="""scylla cloud promproxy bearer_token to federate monitoring data into our monitoring instance"""),
+
+        dict(name="cloud_prom_path", env="SCT_CLOUD_PROM_PATH", type=str,
+             help="""scylla cloud promproxy path to federate monitoring data into our monitoring instance"""),
+
+        dict(name="cloud_prom_host", env="SCT_CLOUD_PROM_HOST", type=str,
+             help="""scylla cloud promproxy hostname to federate monitoring data into our monitoring instance"""),
+
         dict(name="ip_ssh_connections", env="SCT_IP_SSH_CONNECTIONS", type=str,
              help="""
                 Type of IP used to connect to machine instances.


### PR DESCRIPTION
this is needed to be added to the scylla_cloud.yaml file for federation to work:
```
cloud_prom_bearer_token: 263069b3-6940-46ec-a1ed-2bc119871d62
cloud_prom_path: /api/v1/cluster/2005/proxy/federate
cloud_prom_host: [prom proxy address]
```

a change in siren-tests is need to actually supply this
 
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
