### PR TITLE
Disable send email if testrun is executed by job/pipeline

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1776,6 +1776,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             with open(f, "w") as fp:  # pylint: disable=invalid-name
                 json.dump(email_data, fp)  # pylint: disable=invalid-name
 
+        if cluster.get_username() == "jenkins":
+            self.log.info("Email will be sent by pipeline stage")
+            return
+
         if send_email and email_data:
             try:
                 if self.email_reporter:


### PR DESCRIPTION
if sct run by job/pipeline == jenkins user, email will be sent
only by appropriate stage in pipeline.
Running sct from local machine will be controlled by config parameter
send_email.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
