### PR TITLE
Add support to raise critical events on thread failures

### DIFF
--- a/longevity_in_memory_test.py
+++ b/longevity_in_memory_test.py
@@ -2,9 +2,6 @@ from longevity_test import LongevityTest
 
 
 class InMemoryLongevetyTest(LongevityTest):
-    def __init__(self, *args, **kwargs):
-        super(InMemoryLongevetyTest, self).__init__(*args, **kwargs)
-
     def test_in_mem_longevity(self):
         self._pre_create_schema(in_memory=True)
         self.test_custom_time()

--- a/longevity_large_partition_test.py
+++ b/longevity_large_partition_test.py
@@ -2,8 +2,6 @@ from longevity_test import LongevityTest
 
 
 class LargePartitionLongevetyTest(LongevityTest):
-    def __init__(self, *args, **kwargs):
-        super(LargePartitionLongevetyTest, self).__init__(*args, **kwargs)
 
     def test_large_partition_longevity(self):
         self._pre_create_schema()

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -45,6 +45,7 @@ from sdcm.remote import RemoteCmdRunner, LocalCmdRunner
 from sdcm import wait
 from sdcm.utils.common import log_run_info, retrying, get_data_dir_path, Distro, verify_scylla_repo_file, S3Storage, \
     get_latest_gemini_version, get_my_ip, makedirs
+from sdcm.utils.thread import raise_event_on_failure
 from sdcm.sct_events import Severity, CoreDumpEvent, CassandraStressEvent, DatabaseLogEvent, \
     ClusterHealthValidatorEvent
 from sdcm.sct_events import EVENTS_PROCESSES
@@ -782,6 +783,7 @@ class BaseNode():  # pylint: disable=too-many-instance-attributes,too-many-publi
             self.log.error('Error retrieving remote node DB service log: %s',
                            details)
 
+    @raise_event_on_failure
     def journal_thread(self):
         read_from_timestamp = None
         while True:
@@ -900,6 +902,7 @@ class BaseNode():  # pylint: disable=too-many-instance-attributes,too-many-publi
                 self._notify_backtrace(last=False)
             self.n_coredumps = new_n_coredumps
 
+    @raise_event_on_failure
     def backtrace_thread(self):
         """
         Keep reporting new coredumps found, every 30 seconds.
@@ -908,6 +911,7 @@ class BaseNode():  # pylint: disable=too-many-instance-attributes,too-many-publi
             self.termination_event.wait(15)
             self.get_backtraces()
 
+    @raise_event_on_failure
     def db_log_reader_thread(self):
         """
         Keep reporting new events from db log, every 30 seconds.
@@ -2483,6 +2487,7 @@ def wait_for_init_wrap(method):
 
         _queue = queue.Queue()
 
+        @raise_event_on_failure
         def node_setup(node):
             status = True
             try:

--- a/sdcm/sct_events.py
+++ b/sdcm/sct_events.py
@@ -211,6 +211,18 @@ class InfoEvent(SctEvent):
         return "{0}: message={1.message}".format(super(InfoEvent, self).__str__(), self)
 
 
+class ThreadFailedEvent(SctEvent):
+    def __init__(self, message, traceback):
+        super(ThreadFailedEvent, self).__init__()
+        self.message = message
+        self.severity = Severity.ERROR
+        self.traceback = str(traceback)
+        self.publish()
+
+    def __str__(self):
+        return f"{super().__str__()}: message={self.message}\n{self.traceback}"
+
+
 class CoreDumpEvent(SctEvent):
     def __init__(self, corefile_url, download_instructions, backtrace, node):
         super(CoreDumpEvent, self).__init__()

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -140,9 +140,8 @@ def teardown_on_exception(method):
 
 
 class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disable=too-many-instance-attributes,too-many-public-methods
-
-    def __init__(self, methodName='test'):  # pylint: disable=too-many-statements
-        super(ClusterTester, self).__init__(methodName=methodName)
+    def __init__(self, *args):  # pylint: disable=too-many-statements
+        super(ClusterTester, self).__init__(*args)
         self.result = None
         self.status = "RUNNING"
         self.params = SCTConfiguration()

--- a/sdcm/utils/thread.py
+++ b/sdcm/utils/thread.py
@@ -1,0 +1,23 @@
+from functools import wraps
+import os
+import traceback
+
+
+def raise_event_on_failure(func):
+    """
+    Decorate a function that is running inside a thread,
+    when exception is raised in this function,
+    will raise an Error severity event
+    """
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        result = None
+        _test_pid = os.getpid()
+        from sdcm.sct_events import ThreadFailedEvent
+        try:
+            result = func(*args, **kwargs)
+        except Exception as ex:  # pylint: disable=broad-except
+            ThreadFailedEvent(message=str(ex), traceback=traceback.format_exc())
+
+        return result
+    return wrapper

--- a/unit_tests/test_events.py
+++ b/unit_tests/test_events.py
@@ -11,7 +11,7 @@ import datetime
 from sdcm.prometheus import start_metrics_server
 from sdcm.sct_events import (start_events_device, stop_events_device, Event, TestKiller,
                              InfoEvent, CassandraStressEvent, CoreDumpEvent, DatabaseLogEvent, DisruptionEvent, DbEventsFilter, SpotTerminationEvent,
-                             KillTestEvent, Severity)
+                             KillTestEvent, Severity, ThreadFailedEvent)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -78,6 +78,14 @@ class SctEventsTests(unittest.TestCase):
         str(CoreDumpEvent(corefile_url='http://', backtrace="asfasdfsdf",
                           node="node xy",
                           download_instructions="gsutil cp gs://upload.scylladb.com/core.scylla-jmx.996.d173729352e34c76aaf8db3342153c3e.3968.1566979933000/core.scylla-jmx.996.d173729352e34c76aaf8db3342153c3e.3968.1566979933000000 ."))
+
+    def test_thread_failed_event(self):  # pylint: disable=no-self-use
+        try:
+            1 / 0
+        except ZeroDivisionError:
+            _full_traceback = traceback.format_exc()
+
+        str(ThreadFailedEvent(message='thread failed', traceback=_full_traceback))
 
     @staticmethod
     def test_scylla_log_event():


### PR DESCRIPTION
the feature that was reverted (#1361)

(cherry picked from commit 4348223651e1ac9fe5d24fdbd58b6904d90be7ab)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
