### PR TITLE
Remove as much of the disable=no-memeber as possible

### DIFF
--- a/longevity_test.py
+++ b/longevity_test.py
@@ -385,7 +385,6 @@ class LongevityTest(ClusterTester):
         """
         node = self.db_cluster.nodes[0]
         with self.cql_connection_patient(node) as session:
-            # pylint: disable=no-member
             session.execute("""
                 CREATE KEYSPACE IF NOT EXISTS keyspace1
                 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'} AND durable_writes = true;
@@ -443,7 +442,7 @@ class LongevityTest(ClusterTester):
 
             with self.cql_connection_patient(node=self.db_cluster.nodes[0]) as session:
                 try:
-                    session.execute(keyspace_definition)  # pylint: disable=no-member
+                    session.execute(keyspace_definition)
                 except AlreadyExists:
                     self.log.debug("keyspace [{}] exists".format(keyspace_name))
 
@@ -456,7 +455,7 @@ class LongevityTest(ClusterTester):
                     table_name = 'table{}'.format(i)
                     query = table_template.substitute(table_name=table_name)
                     try:
-                        session.execute(query)  # pylint: disable=no-member
+                        session.execute(query)
                     except AlreadyExists:
                         self.log.debug('table [{}] exists'.format(table_name))
                     self.log.debug('{} Created'.format(table_name))
@@ -464,7 +463,7 @@ class LongevityTest(ClusterTester):
                     for definition in profile_yaml.get('extra_definitions', []):
                         query = string.Template(definition).substitute(table_name=table_name)
                         try:
-                            session.execute(query)  # pylint: disable=no-member
+                            session.execute(query)
                         except (AlreadyExists, InvalidRequest) as exc:
                             self.log.debug('extra definition for [{}] exists [{}]'.format(table_name, str(exc)))
 

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -335,7 +335,6 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
     def _scylla_bench_prepare_table(self):
         node = self.db_cluster.nodes[0]
         with self.cql_connection_patient(node) as session:
-            # pylint: disable=no-member
             session.execute("""
                 CREATE KEYSPACE scylla_bench WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}
                 AND durable_writes = true;
@@ -510,7 +509,6 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
 
             try:
                 with self.cql_connection_patient_exclusive(self.db_cluster.nodes[0], timeout=60) as session:
-                    # pylint: disable=no-member
                     self.log.debug('Run query: {}'.format(query))
                     session.execute(query)
             except Exception as ex:

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2566,13 +2566,13 @@ class BaseScyllaCluster():  # pylint: disable=too-many-public-methods
             self.params.get('append_scylla_args')
 
     def set_seeds(self, wait_for_timeout=300):
-        seeds_selector = self.params.get('seeds_selector')  # pylint: disable=no-member
-        seeds_num = self.params.get('seeds_num')  # pylint: disable=no-member
-        cluster_backend = self.params.get('cluster_backend')  # pylint: disable=no-member
+        seeds_selector = self.params.get('seeds_selector')
+        seeds_num = self.params.get('seeds_num')
+        cluster_backend = self.params.get('cluster_backend')
 
         seed_nodes_ips = None
         if seeds_selector == 'reflector' or Setup.REUSE_CLUSTER or cluster_backend == 'aws-siren':
-            node = self.nodes[0]  # pylint: disable=no-member
+            node = self.nodes[0]
             node.wait_ssh_up()
             # When cluster just started, seed IP in the scylla.yaml may be like '127.0.0.1'
             # In this case we want to ignore it and wait, when reflector will select real node and update scylla.yaml
@@ -2581,14 +2581,14 @@ class BaseScyllaCluster():  # pylint: disable=too-many-public-methods
                                            timeout=wait_for_timeout, throw_exc=True)
         else:
             if seeds_selector == 'random':
-                selected_nodes = random.sample(self.nodes, seeds_num)  # pylint: disable=no-member
+                selected_nodes = random.sample(self.nodes, seeds_num)
             # seeds_selector == 'first'
             else:
-                selected_nodes = self.nodes[:seeds_num]  # pylint: disable=no-member
+                selected_nodes = self.nodes[:seeds_num]
 
             seed_nodes_ips = [node.ip_address for node in selected_nodes]
 
-        for node in self.nodes:  # pylint: disable=no-member
+        for node in self.nodes:
             if node.ip_address in seed_nodes_ips:
                 node.is_seed = True
         assert seed_nodes_ips, "We should have at least one selected seed by now"
@@ -2596,25 +2596,25 @@ class BaseScyllaCluster():  # pylint: disable=too-many-public-methods
     @property
     def seed_nodes_ips(self):
         if not self._seed_nodes_ips:
-            self._seed_nodes_ips = [node.ip_address for node in self.nodes if node.is_seed]  # pylint: disable=no-member
+            self._seed_nodes_ips = [node.ip_address for node in self.nodes if node.is_seed]
             assert self._seed_nodes_ips, "We should have at least one selected seed by now"
         return self._seed_nodes_ips
 
     @property
     def seed_nodes(self):
         if not self._seed_nodes:
-            self._seed_nodes = [node for node in self.nodes if node.is_seed]  # pylint: disable=no-member
+            self._seed_nodes = [node for node in self.nodes if node.is_seed]
             assert self._seed_nodes, "We should have at least one selected seed by now"
         return self._seed_nodes
 
     @property
     def non_seed_nodes(self):
         if not self._non_seed_nodes:
-            self._non_seed_nodes = [node for node in self.nodes if not node.is_seed]  # pylint: disable=no-member
+            self._non_seed_nodes = [node for node in self.nodes if not node.is_seed]
         return self._non_seed_nodes
 
     def validate_seeds_on_all_nodes(self):
-        for node in self.nodes:  # pylint: disable=no-member
+        for node in self.nodes:
             yaml_seeds_ips = node.extract_seeds_from_scylla_yaml()
             for ip in yaml_seeds_ips:
                 assert ip in self.seed_nodes_ips, \
@@ -3048,12 +3048,12 @@ class BaseScyllaCluster():  # pylint: disable=too-many-public-methods
         Check if reflector updated the scylla.yaml with selected seed IP
         """
         if not node:
-            node = self.nodes[0]  # pylint: disable=no-member
+            node = self.nodes[0]
 
         seed_nodes_ips = node.extract_seeds_from_scylla_yaml()
         # When cluster just started, seed IP in the scylla.yaml may be like '127.0.0.1'
         # In this case we want to ignore it and wait, when reflector will select real node and update scylla.yaml
-        return [n.ip_address for n in self.nodes if n.ip_address in seed_nodes_ips]  # pylint: disable=no-member
+        return [n.ip_address for n in self.nodes if n.ip_address in seed_nodes_ips]
 
 
 class BaseLoaderSet():
@@ -3784,7 +3784,7 @@ class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-inst
         """.format(self))
         node.remoter.run("bash -ce '%s'" % kill_script)
 
-    def get_grafana_screenshot_and_snapshot(self, test_start_time=None):  # pylint: disable=invalid-name
+    def get_grafana_screenshot_and_snapshot(self, test_start_time=None):
         """
             Take screenshot of the Grafana per-server-metrics dashboard and upload to S3
         """
@@ -3792,14 +3792,14 @@ class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-inst
             self.log.error("No start time for test")
             return {}
 
-        for node in self.nodes:  # pylint: disable=no-member
+        for node in self.nodes:
             screenshot_collector = GrafanaScreenShot(name="grafana-screenshot",
                                                      test_start_time=test_start_time)
-            screenshots = screenshot_collector.collect(node, self.logdir)  # pylint: disable=no-member
+            screenshots = screenshot_collector.collect(node, self.logdir)
             screenshots = [S3Storage().upload_file(screenshot, Setup.test_id()) for screenshot in screenshots]
             snapshots_collector = GrafanaSnapshot(name="grafana-snapshot",
                                                   test_start_time=test_start_time)
-            snapshots = snapshots_collector.collect(node, self.logdir)  # pylint: disable=no-member
+            snapshots = snapshots_collector.collect(node, self.logdir)
         return {'screenshots': screenshots, 'snapshots': snapshots['links']}
 
     def upload_annotations_to_s3(self):
@@ -3825,29 +3825,25 @@ class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-inst
             try:
                 collector = PrometheusSnapshots(name='prometheus_snapshot')
 
-                snapshot_archive = collector.collect(node, self.logdir)  # pylint: disable=no-member
-                self.log.debug('Snapshot local path: {}'.format(snapshot_archive))  # pylint: disable=no-member
+                snapshot_archive = collector.collect(node, self.logdir)
+                self.log.debug('Snapshot local path: {}'.format(snapshot_archive))
 
                 return S3Storage().upload_file(snapshot_archive, dest_dir=Setup.test_id())
             except Exception as details:  # pylint: disable=broad-except
-                self.log.error('Error downloading prometheus data dir: %s',
-                               str(details))
+                self.log.error('Error downloading prometheus data dir: %s', str(details))
                 return ""
 
     def get_prometheus_snapshot(self, node):
         collector = PrometheusSnapshots(name="prometheus_data")
 
-        return collector.collect(node, self.logdir)  # pylint: disable=no-member
+        return collector.collect(node, self.logdir)
 
     def download_monitoring_data_stack(self):
 
-        for node in self.nodes:  # pylint: disable=no-member
+        for node in self.nodes:
             collector = MonitoringStack(name="monitoring-stack")
-
-            local_path_to_monitor_stack = collector.collect(node, self.logdir)  # pylint: disable=no-member
-            # pylint: disable=no-member
-            self.log.info('Path to monitoring stack {}'.format(
-                local_path_to_monitor_stack))
+            local_path_to_monitor_stack = collector.collect(node, self.logdir)
+            self.log.info('Path to monitoring stack {}'.format(local_path_to_monitor_stack))
 
             return S3Storage().upload_file(local_path_to_monitor_stack, dest_dir=Setup.test_id())
 

--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -2860,7 +2860,6 @@ class FillDatabaseData(ClusterTester):
     def fill_db_data_for_truncate_test(self, insert_rows):
         # Prepare connection and keyspace
         with self.cql_connection_patient(self.db_cluster.nodes[0]) as session:
-            # pylint: disable=no-member
             # override driver consistency level
             session.default_consistency_level = ConsistencyLevel.QUORUM
 
@@ -2951,7 +2950,6 @@ class FillDatabaseData(ClusterTester):
         # Prepare connection and keyspace
         node = self.db_cluster.nodes[0]
         with self.cql_connection_patient(node) as session:
-            # pylint: disable=no-member
             # override driver consistency level
             session.default_consistency_level = ConsistencyLevel.QUORUM
 
@@ -2971,7 +2969,6 @@ class FillDatabaseData(ClusterTester):
         # Prepare connection
         node = self.db_cluster.nodes[0]
         with self.cql_connection_patient(node) as session:
-            # pylint: disable=no-member
             # override driver consistency level
             session.default_consistency_level = ConsistencyLevel.QUORUM
 
@@ -2983,6 +2980,5 @@ class FillDatabaseData(ClusterTester):
         # Prepare connection
         node = self.db_cluster.nodes[0]
         with self.cql_connection_patient(node) as session:
-            # pylint: disable=no-member
             session.execute("DROP KEYSPACE keyspace1;")
             session.execute("DROP KEYSPACE ks_no_range_ghost_test;")

--- a/sdcm/keystore.py
+++ b/sdcm/keystore.py
@@ -10,8 +10,7 @@ class KeyStore():
         self.s3 = boto3.resource("s3")
 
     def _get_json(self, json_file):
-        # TODO: remove no-member when https://github.com/PyCQA/pylint/issues/3134 is fixed
-        obj = self.s3.Object(KEYSTORE_S3_BUCKET, json_file)  # pylint: disable=no-member
+        obj = self.s3.Object(KEYSTORE_S3_BUCKET, json_file)
         return json.loads(obj.get()["Body"].read())
 
     def download_file(self, filename, dest_filename):

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -18,7 +18,6 @@ import re
 import os
 import logging
 import time
-import types
 import random
 import unittest
 import json
@@ -274,7 +273,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self.log.info('change RF of system_auth to %s', system_auth_rf)
             node = self.db_cluster.nodes[0]
             with self.cql_connection_patient(node) as session:
-                # pylint: disable=no-member
                 session.execute("ALTER KEYSPACE system_auth WITH replication = "
                                 "{'class': 'org.apache.cassandra.locator.SimpleStrategy', "
                                 "'replication_factor': %s};" % system_auth_rf)
@@ -992,7 +990,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         cmd = random.choice([cmd_select_all, cmd_bypass_cache]).format(ks_cf)
         try:
             with self.cql_connection_patient(db_node) as session:
-                # pylint: disable=no-member
                 self.log.info('Will run command "{}"'.format(cmd))
                 result = session.execute(SimpleStatement(cmd, fetch_size=page_size,
                                                          consistency_level=ConsistencyLevel.ONE))
@@ -1168,8 +1165,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         query = 'CREATE KEYSPACE IF NOT EXISTS %s WITH replication={%s}'
         execution_node, validation_node = self.db_cluster.nodes[0], self.db_cluster.nodes[-1]
         with self.cql_connection_patient(execution_node) as session:
-            # pylint: disable=no-member
-            if isinstance(replication_factor, types.IntType):
+            if isinstance(replication_factor, int):
                 execution_result = session.execute(
                     query % (keyspace_name, "'class':'{}', 'replication_factor':{}".format(
                         replication_strategy if replication_strategy else "SimpleStrategy",
@@ -1233,7 +1229,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         if compact_storage:
             query += ' AND COMPACT STORAGE'
         with self.cql_connection_patient(node=self.db_cluster.nodes[0], keyspace=keyspace_name) as session:
-            # pylint: disable=no-member
             session.execute(query)
         time.sleep(0.2)
 
@@ -1560,7 +1555,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 query = "ALTER TABLE {table} WITH scylla_encryption_options = {scylla_encryption_options};".format(
                     table=table, scylla_encryption_options=scylla_encryption_options)
                 self.log.debug('enable encryption at-rest for table {table}, query:\n\t{query}'.format(**locals()))
-                session.execute(query)  # pylint: disable=no-member
+                session.execute(query)
             if upgradesstables:
                 self.log.debug('upgrade sstables after encryption update')
                 for node in self.db_cluster.nodes:


### PR DESCRIPTION
This cause on python3 issue to slip under the radar, remove most of the place it's not needed anymore since we more to newer pylint version.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
