### PR TITLE
Disable email report since it sent as separate stage in Jenkins pipeline

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -44,7 +44,7 @@ backtrace_decoding: false
 
 logs_transport: "rsyslog"
 
-send_email: true
+send_email: false
 email_recipients: ['qa@scylladb.com']
 
 collect_logs: false


### PR DESCRIPTION
Disabling send email report as part of the test since we have a separate stage in Jenkins pipeline.
(We receive two email reports due to this issue)