### PR TITLE
terminate_and_replace_node: fix problem in cleaning replace_address parameter

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3003,7 +3003,7 @@ class BaseScyllaCluster():  # pylint: disable=too-many-public-methods
             # If this is a replacement node, we need to set back configuration in case
             # when scylla-server process will be restarted
             node.replacement_node_ip = None
-            self.node_config_setup(node, seed_address, endpoint_snitch)
+            node.remoter.run('sudo sed -i -e "s/^replace_address_first_boot:/# replace_address_first_boot:/g" /etc/scylla/scylla.yaml')
 
     @staticmethod
     def verify_logging_from_nodes(nodes_list):

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2937,7 +2937,7 @@ class BaseScyllaCluster():  # pylint: disable=too-many-public-methods
                           enable_exp=self._param_enabled('experimental'), endpoint_snitch=endpoint_snitch,
                           authenticator=self.params.get('authenticator'),
                           server_encrypt=self._param_enabled('server_encrypt'),
-                          client_encrypt=client_encrypt if client_encrypt is None else self._param_enabled(
+                          client_encrypt=client_encrypt if client_encrypt is not None else self._param_enabled(
                               'client_encrypt'),
                           append_scylla_yaml=self.params.get('append_scylla_yaml'), append_scylla_args=self.get_scylla_args(),
                           hinted_handoff=self.params.get('hinted_handoff'),

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1590,6 +1590,7 @@ server_encryption_options:
             mkdir -p ~/.cassandra/
             cp /tmp/ssl_conf/client/cqlshrc ~/.cassandra/
             sudo mkdir -p /etc/scylla/
+            sudo rm -rf /etc/scylla/ssl_conf/
             sudo mv -f /tmp/ssl_conf/ /etc/scylla/
         """)
         self.remoter.run('bash -cxe "%s"' % setup_script)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2419,17 +2419,6 @@ class BaseCluster():  # pylint: disable=too-many-instance-attributes
                 errors.update({node.name: node_errors})
         return errors
 
-    def _param_enabled(self, param):
-        param = self.params.get(param)
-        if isinstance(param, str):
-            return bool(param and param.lower() == 'true')
-        elif isinstance(param, bool):
-            return param
-        elif param is None:
-            return False
-        else:
-            raise ValueError('Unsupported type: {}'.format(type(param)))
-
     def destroy(self):
         self.log.info('Destroy nodes')
         for node in self.nodes:
@@ -2934,10 +2923,10 @@ class BaseScyllaCluster():  # pylint: disable=too-many-public-methods
 
     def node_config_setup(self, node, seed_address=None, endpoint_snitch=None, murmur3_partitioner_ignore_msb_bits=None, client_encrypt=None):  # pylint: disable=too-many-arguments,invalid-name
         node.config_setup(seed_address=seed_address, cluster_name=self.name,  # pylint: disable=no-member
-                          enable_exp=self._param_enabled('experimental'), endpoint_snitch=endpoint_snitch,
+                          enable_exp=self.params.get('experimental'), endpoint_snitch=endpoint_snitch,
                           authenticator=self.params.get('authenticator'),
-                          server_encrypt=self._param_enabled('server_encrypt'),
-                          client_encrypt=client_encrypt if client_encrypt is not None else self._param_enabled(
+                          server_encrypt=self.params.get('server_encrypt'),
+                          client_encrypt=client_encrypt if client_encrypt is not None else self.params.get(
                               'client_encrypt'),
                           append_scylla_yaml=self.params.get('append_scylla_yaml'), append_scylla_args=self.get_scylla_args(),
                           hinted_handoff=self.params.get('hinted_handoff'),
@@ -2996,14 +2985,16 @@ class BaseScyllaCluster():  # pylint: disable=too-many-public-methods
 
         node.wait_db_up(timeout=timeout)
         node.wait_jmx_up()
-        self.clean_replacement_node_ip(node, seed_address, endpoint_snitch)
+        self.clean_replacement_node_ip(node)
 
-    def clean_replacement_node_ip(self, node, seed_address, endpoint_snitch):
+    @staticmethod
+    def clean_replacement_node_ip(node):
         if node.replacement_node_ip:
             # If this is a replacement node, we need to set back configuration in case
             # when scylla-server process will be restarted
             node.replacement_node_ip = None
-            node.remoter.run('sudo sed -i -e "s/^replace_address_first_boot:/# replace_address_first_boot:/g" /etc/scylla/scylla.yaml')
+            node.remoter.run(
+                'sudo sed -i -e "s/^replace_address_first_boot:/# replace_address_first_boot:/g" /etc/scylla/scylla.yaml')
 
     @staticmethod
     def verify_logging_from_nodes(nodes_list):

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -620,7 +620,7 @@ class AWSNode(cluster.BaseNode):
 
                 self.start_scylla_server(verify_up=False)
                 self.remoter.run(
-                    'sudo sed -i -e "s/replace_address_first_boot:/# replace_address_first_boot:/g" /etc/scylla/scylla.yaml')
+                    'sudo sed -i -e "s/^replace_address_first_boot:/# replace_address_first_boot:/g" /etc/scylla/scylla.yaml')
                 self.remoter.run("sudo sed -e '/auto_bootstrap:.*/s/True/False/g' -i /etc/scylla/scylla.yaml")
             finally:
                 if event_filters:

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -803,11 +803,11 @@ class ScyllaAWSCluster(cluster.BaseScyllaCluster, AWSCluster):
 
     def node_config_setup(self, node, seed_address=None, endpoint_snitch=None, murmur3_partitioner_ignore_msb_bits=None, client_encrypt=None):  # pylint: disable=too-many-arguments
         setup_params = dict(
-            enable_exp=self._param_enabled('experimental'),
+            enable_exp=self.params.get('experimental'),
             endpoint_snitch=endpoint_snitch,
             authenticator=self.params.get('authenticator'),
-            server_encrypt=self._param_enabled('server_encrypt'),
-            client_encrypt=client_encrypt if client_encrypt is not None else self._param_enabled('client_encrypt'),
+            server_encrypt=self.params.get('server_encrypt'),
+            client_encrypt=client_encrypt if client_encrypt is not None else self.params.get('client_encrypt'),
             append_scylla_args=self.get_scylla_args(),
             authorizer=self.params.get('authorizer'),
             hinted_handoff=self.params.get('hinted_handoff'),
@@ -884,7 +884,7 @@ class ScyllaAWSCluster(cluster.BaseScyllaCluster, AWSCluster):
 
         node.wait_db_up(verbose=verbose, timeout=timeout)
         node.check_nodes_status()
-        self.clean_replacement_node_ip(node, seed_address, endpoint_snitch)
+        self.clean_replacement_node_ip(node)
 
     def destroy(self):
         self.stop_nemesis()


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)

Terminate_and_replace_node nemesis failed in https://jenkins.scylladb.com/job/scylla-3.2/job/longevity/job/longevity-1tb-7days/2/console

```
INFO  > sdcm.nemesis.ChaosMonkey: >>>>>>>>>>>>>Started random_disrupt_method terminate_and_replace_node
DEBUG > sdcm.nemesis.ChaosMonkey: Set current_disruption -> TerminateAndReplaceNode Node longevity-tls-1tb-7d-3-2-db-node-21b00c31-3 [

INFO  > sdcm.nemesis.ChaosMonkey: TerminateAndReplaceNode Node longevity-tls-1tb-7d-3-2-db-node-21b00c31-3 [34.253.81.6 | 10.0.163.101

INFO  > sdcm.nemesis.ChaosMonkey: Adding new node to cluster..

WARNING > sdcm.nemesis.ChaosMonkey: Setup of the 'Node longevity-tls-1tb-7d-3-2-db-node-21b00c31-5 [63.35.237.163 | 10.0.29.182] (seed: False)' failed, removing it from list of nodes
WARNING > sdcm.nemesis.ChaosMonkey: Node will not be terminated. Please terminate manually!!!

ERROR >     self.remoter.run('bash -cxe "%s"' % setup_script)
ERROR >   File "/sct/sdcm/remote.py", line 239, in run
ERROR >     result = _run()
ERROR >   File "/sct/sdcm/utils/common.py", line 88, in inner
ERROR >     return func(*args, **kwargs)
ERROR >   File "/sct/sdcm/remote.py", line 230, in _run
ERROR >     watchers=watchers, timeout=timeout)
ERROR >   File "<decorator-gen-3>", line 2, in run
ERROR >   File "/usr/lib/python2.7/site-packages/fabric/connection.py", line 30, in opens
ERROR >     return method(self, *args, **kwargs)
ERROR >   File "/usr/lib/python2.7/site-packages/fabric/connection.py", line 721, in run
ERROR >     return self._run(self._remote_runner(), command, **kwargs)
ERROR >   File "/usr/lib/python2.7/site-packages/invoke/context.py", line 101, in _run
ERROR >     return runner.run(command, **kwargs)
ERROR >   File "/usr/lib/python2.7/site-packages/invoke/runners.py", line 291, in run
ERROR >     return self._run_body(command, **kwargs)
ERROR >   File "/usr/lib/python2.7/site-packages/invoke/runners.py", line 442, in _run_body
ERROR >     raise UnexpectedExit(result)
ERROR > UnexpectedExit: Encountered a bad command exit code!
ERROR > 
ERROR > Command: 'bash -cxe "\nmkdir -p ~/.cassandra/\ncp /tmp/ssl_conf/client/cqlshrc ~/.cassandra/\nsudo mkdir -p /etc/scylla/\nsudo

ERROR > 
ERROR > Exit code: 1
ERROR > 
ERROR > Stdout:
ERROR > 
ERROR > 
ERROR > 
ERROR > Stderr:
ERROR > 
ERROR > + mkdir -p /home/centos/.cassandra/
ERROR > + cp /tmp/ssl_conf/client/cqlshrc /home/centos/.cassandra/
ERROR > + sudo mkdir -p /etc/scylla/
ERROR > + sudo mv -f /tmp/ssl_conf/ /etc/scylla/
ERROR > mv: cannot move ‘/tmp/ssl_conf/’ to ‘/etc/scylla/ssl_conf’: File exists
```