### PR TITLE
Fix all DbEventsFilter to use a specific node

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -582,8 +582,10 @@ class AWSNode(cluster.BaseNode):
         event_filters = ()
         if any(ss in self._instance.instance_type for ss in ['i3', 'i2']):
             # since there's no disk yet in those type, lots of the errors here are acceptable, and we'll ignore them
-            event_filters = DbEventsFilter(type="DATABASE_ERROR"), DbEventsFilter(type="SCHEMA_FAILURE"), \
-                DbEventsFilter(type="NO_SPACE_ERROR"), DbEventsFilter(type="FILESYSTEM_ERROR")
+            event_filters = DbEventsFilter(type="DATABASE_ERROR", node=self), \
+                DbEventsFilter(type="SCHEMA_FAILURE", node=self), \
+                DbEventsFilter(type="NO_SPACE_ERROR", node=self), \
+                DbEventsFilter(type="FILESYSTEM_ERROR", node=self)
 
             clean_script = dedent("""
                 sudo sed -e '/.*scylla/s/^/#/g' -i /etc/fstab

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -536,11 +536,12 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
                 self.log.error(str(details))
             return search_database_enospc(node) > orig_errors
 
-        with DbEventsFilter(type='NO_SPACE_ERROR'), \
-                DbEventsFilter(type='BACKTRACE', line='No space left on device'), \
-                DbEventsFilter(type='DATABASE_ERROR', line='No space left on device'), \
-                DbEventsFilter(type='FILESYSTEM_ERROR', line='No space left on device'):
-            for node in nodes:
+        for node in nodes:
+            with DbEventsFilter(type='NO_SPACE_ERROR', node=node), \
+                    DbEventsFilter(type='BACKTRACE', line='No space left on device', node=node), \
+                    DbEventsFilter(type='DATABASE_ERROR', line='No space left on device', node=node), \
+                    DbEventsFilter(type='FILESYSTEM_ERROR', line='No space left on device', node=node):
+
                 result = node.remoter.run('cat /proc/mounts')
                 if '/var/lib/scylla' not in result.stdout:
                     self.log.error("Scylla doesn't use an individual storage, skip enospc test")


### PR DESCRIPTION
The new mechanize to wait for the right time in the log for filtering works only if there a node passed to the filter.
