### PR TITLE
 Fix truncate nemesis, to always create stress via loaders

### DIFF
--- a/longevity_test.py
+++ b/longevity_test.py
@@ -513,7 +513,7 @@ class LongevityTest(ClusterTester):
             prefix, suffix = os.path.splitext(os.path.basename(cs_profile))
             table_name = "table%s" % idx
 
-            with tempfile.NamedTemporaryFile(prefix=prefix, suffix=suffix, delete=False) as file_obj:
+            with tempfile.NamedTemporaryFile(mode='w+', prefix=prefix, suffix=suffix, delete=False, encoding='utf-8') as file_obj:
                 output = template.substitute(table_name=table_name)
                 file_obj.write(output)
                 profile_dst = file_obj.name

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2290,7 +2290,7 @@ server_encryption_options:
     def run_startup_script(self):
         startup_script_remote_path = '/tmp/sct-startup.sh'
 
-        with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
+        with tempfile.NamedTemporaryFile(mode='w+', delete=False, encoding='utf-8') as tmp_file:
             tmp_file.write(Setup.get_startup_script())
             tmp_file.flush()
             self.remoter.send_files(src=tmp_file.name, dst=startup_script_remote_path)

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -29,8 +29,6 @@ import re
 import traceback
 from collections import OrderedDict
 
-from cassandra import InvalidRequest
-
 from sdcm.cluster_aws import ScyllaAWSCluster
 from sdcm.cluster import SCYLLA_YAML_PATH, NodeSetupTimeout, NodeSetupFailed, Setup
 from sdcm.mgmt import TaskStatus
@@ -643,41 +641,17 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
 
         # if keyspace doesn't exist, create it by cassandra-stress
         if ks not in test_keyspaces:
-            ip = self.target_node.ip_address
-            stress_cmd = 'cassandra-stress write n=400000 cl=QUORUM -port jmx=6868 -mode native cql3 ' \
-                         '-schema keyspace="{}" -node {}'.format(ks, ip)
-            # create with stress tool
-            cql_auth = self.cluster.get_db_auth()
-            if cql_auth and 'user=' not in stress_cmd:
-                # put the credentials into the right place into -mode section
-                stress_cmd = re.sub(r'(-mode.*?)-', r'\1 user={} password={} -'.format(*cql_auth), stress_cmd)
-
-            self.target_node.remoter.run(stress_cmd, verbose=True, ignore_status=True)
+            stress_cmd = "cassandra-stress write n=400000 cl=QUORUM -port jmx=6868 -mode native cql3 -schema 'replication(factor=3)' -log interval=5"
+            cs_thread = self.tester.run_stress_thread(stress_cmd=stress_cmd, keyspace_name=ks)
+            cs_thread.verify_results()
 
     def disrupt_truncate(self):
         self._set_current_disruption('TruncateMonkey {}'.format(self.target_node))
 
         keyspace_truncate = 'ks_truncate'
         table = 'standard1'
-        table_truncate_count = 0
 
-        # get the count of the truncate table
-        test_keyspaces = self.cluster.get_test_keyspaces()
-        cql = "SELECT COUNT(*) FROM {}.{}".format(keyspace_truncate, table)
-        with self.tester.cql_connection_patient(self.target_node) as session:
-            try:
-                data = session.execute(cql)
-                table_truncate_count = data[0].count
-            except InvalidRequest:
-                self.log.warning("Keyspace ks_truncate does not exist")
-        self.log.debug("table_truncate_count=%d", table_truncate_count)
-
-        # if key space doesn't exist or the table is empty, create it using c-s
-        if not (keyspace_truncate in test_keyspaces and table_truncate_count >= 1):
-            try:
-                self._prepare_test_table(ks=keyspace_truncate)
-            except:
-                raise ValueError('stress command failed, not trying to truncate because ks_truncate may not created')
+        self._prepare_test_table(ks=keyspace_truncate)
 
         # do the actual truncation
         self.target_node.run_cqlsh(cmd='TRUNCATE {}.{}'.format(keyspace_truncate, table), timeout=120)

--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -91,12 +91,12 @@ class YcsbStressThread():  # pylint: disable=too-many-instance-attributes
                 secretKey =
             """)
 
-            with tempfile.NamedTemporaryFile() as tmp_file:
+            with tempfile.NamedTemporaryFile(mode='w+', encoding='utf-8') as tmp_file:
                 tmp_file.write(dynamodb_teample)
                 tmp_file.flush()
                 loader.remoter.send_files(tmp_file.name, os.path.join('/tmp', 'dynamodb.properties'))
 
-            with tempfile.NamedTemporaryFile() as tmp_file:
+            with tempfile.NamedTemporaryFile(mode='w+', encoding='utf-8') as tmp_file:
                 tmp_file.write(aws_empty_file)
                 tmp_file.flush()
                 loader.remoter.send_files(tmp_file.name, os.path.join('/tmp', 'aws_empty_file'))


### PR DESCRIPTION
since truncate was using it's own commands to run c-s, it was failing to take into account all the possible params needed based on scylla configuration.

switched to using the stress_command function from the tester object, same as the other stress commands being using by SCT

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
