### PR TITLE
cluster_aws: retry to stop scylla-server after instance restart

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -34,6 +34,7 @@ from invoke.exceptions import UnexpectedExit, Failure, CommandTimedOut
 import yaml
 import requests
 from paramiko import SSHException
+from paramiko.ssh_exception import NoValidConnectionsError
 
 
 from sdcm.collectd import ScyllaCollectdSetup
@@ -2027,7 +2028,7 @@ server_encryption_options:
         if verify_up:
             self.wait_jmx_up(timeout=timeout)
 
-    @retrying(n=3, sleep_time=5, allowed_exceptions=(CommandTimedOut,),
+    @retrying(n=3, sleep_time=5, allowed_exceptions=(CommandTimedOut, NoValidConnectionsError,),
               message="Failed to stop scylla.server, retrying...")
     def stop_scylla_server(self, verify_up=False, verify_down=True, timeout=300, ignore_status=False):
         if verify_up:

--- a/sdcm/remote.py
+++ b/sdcm/remote.py
@@ -270,7 +270,8 @@ class RemoteCmdRunner(CommandRunner):  # pylint: disable=too-many-instance-attri
 
     def stop_ssh_up_thread(self):
         self._ssh_up_thread_termination.set()
-        self._ssh_up_thread.join(5)
+        if self._ssh_up_thread:
+            self._ssh_up_thread.join(5)
         self._ssh_up_thread = None
 
     def receive_files(self, src, dst, delete_dst=False,  # pylint: disable=too-many-arguments


### PR DESCRIPTION
Currently we stop scylla-server when ssh is up after instance restarts.
It works well most of time, but in some special case, the instance network is
unavailable again in stopping scylla-server, it causes the nemesis fails and
leave a problem instance (no RAID setup).

This patch added a retry strategy for stopping scylla-server after instance
restart.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
