### PR TITLE
Support to workaround kernel bug in scylla setup

### DIFF
--- a/configurations/io.conf
+++ b/configurations/io.conf
@@ -1,0 +1,1 @@
+SEASTAR_IO="--num-io-queues=8 --io-properties-file=/etc/scylla.d/io_properties.yaml"

--- a/configurations/io_properties.yaml
+++ b/configurations/io_properties.yaml
@@ -1,0 +1,6 @@
+disks:
+  - mountpoint: /var/lib/scylla
+    read_iops: 540317
+    read_bandwidth: 1914761472
+    write_iops: 300319
+    write_bandwidth: 1162022400

--- a/jenkins-pipelines/rolling-upgrade-centos7.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-centos7.jenkinsfile
@@ -13,6 +13,7 @@ rollingUpgradePipeline(
 
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
     test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
+    workaround_kernel_bug_for_iotune: true,
 
     timeout: [time: 200, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/rolling-upgrade-debian9.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-debian9.jenkinsfile
@@ -13,6 +13,7 @@ rollingUpgradePipeline(
 
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
     test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
+    workaround_kernel_bug_for_iotune: true,
 
     timeout: [time: 200, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/rolling-upgrade-ubuntu16.04.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-ubuntu16.04.jenkinsfile
@@ -13,6 +13,7 @@ rollingUpgradePipeline(
 
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
     test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
+    workaround_kernel_bug_for_iotune: true,
 
     timeout: [time: 200, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/rolling-upgrade-ubuntu18.04.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-ubuntu18.04.jenkinsfile
@@ -13,6 +13,7 @@ rollingUpgradePipeline(
 
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
     test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
+    workaround_kernel_bug_for_iotune: true,
 
     timeout: [time: 200, unit: 'MINUTES']
 )

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -875,7 +875,9 @@ class SCTConfiguration(dict):
                 'keep' - Keep instances running and leave credentials alone
                 'keep-on-failure' - Keep instances if testrun failed
              """,
-             choices=("keep", "keep-on-failure", "destroy"))
+             choices=("keep", "keep-on-failure", "destroy")),
+        dict(name="workaround_kernel_bug_for_iotune", env="SCT_WORKAROUND_KERNEL_BUG_FOR_IOTUNE", type=bool,
+             help="Workaround a known kernel bug which causes iotune to fail in scylla_io_setup, only effect GCE backend")
     ]
 
     required_params = ['cluster_backend', 'test_duration', 'n_db_nodes', 'n_loaders', 'user_credentials_path']

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -31,6 +31,9 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('post_behavior_monitor_nodes', 'keep-on-failure')}",
                    description: 'keep|keep-on-failure|destroy',
                    name: 'post_behavior_monitor_nodes')
+            booleanParam(defaultValue: "${pipelineParams.get('workaround_kernel_bug_for_iotune', false)}",
+                 description: 'Workaround a known kernel bug which causes iotune to fail in scylla_io_setup, only effect GCE backend',
+                 name: 'workaround_kernel_bug_for_iotune')
         }
         options {
             timestamps()
@@ -74,6 +77,8 @@ def call(Map pipelineParams) {
                                             export SCT_GCE_IMAGE_DB=${pipelineParams.gce_image_db}
                                             export SCT_SCYLLA_LINUX_DISTRO=${pipelineParams.linux_distro}
                                             export SCT_AMI_ID_DB_SCYLLA_DESC="\$SCT_AMI_ID_DB_SCYLLA_DESC-\$SCT_SCYLLA_LINUX_DISTRO"
+
+                                            export SCT_WORKAROUND_KERNEL_BUG_FOR_IOTUNE=${pipelineParams.workaround_kernel_bug_for_iotune}
 
                                             echo "start test ......."
                                             ./docker/env/hydra.sh run-test ${pipelineParams.test_name} --backend ${params.backend}  --logdir /sct


### PR DESCRIPTION
Support to workaround kernel bug in scylla setup.



We don't want the kernel bug block our upgrade test, we always need to enable
it if gce backend is used. We can remove or disable this workaround when the
kernel bug is fixed in default kernel of GCE instance.
    
Bad kernel in gce instance:
- 3.10.0-1062.1.2.el7.x86_64
- 3.10.0-1062.4.3.el7.x86_64 (latest, still not fix)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
