### PR TITLE
nemesis: _modify_table_property: debug cqlsh statement

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -671,6 +671,7 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
 
         cmd = "ALTER TABLE {keyspace_table} WITH {name} = {val};".format(
             keyspace_table=keyspace_table, name=name, val=val)
+        self.log.info('_modify_table_property: {}'.format(cmd))
         with self.tester.cql_connection_patient(self.target_node) as session:
             session.execute(cmd)
 


### PR DESCRIPTION
Currently we randomly choose a modify_table method, and get random value for
some properties, we don't know what's exactly modified from log.


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
