### PR TITLE
Fix multi-region / public support

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1401,13 +1401,14 @@ class BaseNode():  # pylint: disable=too-many-instance-attributes,too-many-publi
             scylla_yaml_contents = pattern.sub('seeds: "{0}"'.format(seed_address),
                                                scylla_yaml_contents)
 
+            # NOTICE: the following configuration always have to use private_ip_address for multi-region to work
             # Set listen_address
             pattern = re.compile('listen_address:.*')
-            scylla_yaml_contents = pattern.sub('listen_address: {0}'.format(self.ip_address),
+            scylla_yaml_contents = pattern.sub('listen_address: {0}'.format(self.private_ip_address),
                                                scylla_yaml_contents)
             # Set rpc_address
             pattern = re.compile('\n[# ]*rpc_address:.*')
-            scylla_yaml_contents = pattern.sub('\nrpc_address: {0}'.format(self.ip_address),
+            scylla_yaml_contents = pattern.sub('\nrpc_address: {0}'.format(self.private_ip_address),
                                                scylla_yaml_contents)
 
         if listen_on_all_interfaces:
@@ -1455,6 +1456,15 @@ class BaseNode():  # pylint: disable=too-many-instance-attributes,too-many-publi
             # Set broadcast_rpc_address
             pattern = re.compile('\n[# ]*broadcast_rpc_address:.*')
             scylla_yaml_contents = pattern.sub('\nbroadcast_rpc_address: {0}'.format(self.ip_address),
+                                               scylla_yaml_contents)
+
+            # Set listen_address
+            pattern = re.compile('listen_address:.*')
+            scylla_yaml_contents = pattern.sub('listen_address: {0}'.format(self.ip_address),
+                                               scylla_yaml_contents)
+            # Set rpc_address
+            pattern = re.compile('\n[# ]*rpc_address:.*')
+            scylla_yaml_contents = pattern.sub('\nrpc_address: {0}'.format(self.ip_address),
                                                scylla_yaml_contents)
 
         if murmur3_partitioner_ignore_msb_bits:


### PR DESCRIPTION
In the work done for ipv6, we mistakly change the listen_address
to a value that can't work when using public addresses

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
