### PR TITLE
Fix: adding aws extra interface for networking nemesis

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -416,10 +416,6 @@ class AWSNode(cluster.BaseNode):
         self._instance_wait_safe(self._instance.wait_until_running)
         self._eth1_private_ip_address = None
         self.eip_allocation_id = None
-        if len(self._instance.network_interfaces) == 2:
-            self.allocate_and_attach_elastic_ip()
-
-        self._wait_public_ip()
         ssh_login_info = {'hostname': None,
                           'user': ami_username,
                           'key_file': credentials.key_file}
@@ -431,6 +427,9 @@ class AWSNode(cluster.BaseNode):
                                       base_logdir=base_logdir,
                                       node_prefix=node_prefix,
                                       dc_idx=dc_idx)
+        if len(self._instance.network_interfaces) == 2:
+            self.allocate_and_attach_elastic_ip()
+        self._wait_public_ip()
         if not cluster.Setup.REUSE_CLUSTER:
             tags_list = create_tags_list()
             tags_list.append({'Key': 'Name', 'Value': name})

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1037,7 +1037,8 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
 
         # get the last 10min avg network bandwidth used, and limit  30% to 70% of it
         prometheus_stats = PrometheusDBStats(host=self.monitoring_set.nodes[0].external_address)
-        query = 'avg(irate(node_network_receive_bytes_total{instance=~"%s", device="eth0"}[30s]))' % self.target_node.ip_address
+        query = 'avg(irate(node_network_receive_bytes_total{instance=~".*?%s.*?", device="eth0"}[30s]))' % \
+                self.target_node.ip_address
         now = time.time()
         results = prometheus_stats.query(query=query, start=now - 600, end=now)
         avg_bitrate_per_node = max([float(avg_rate) for _, avg_rate in results[0]["values"]])


### PR DESCRIPTION
call to `self.allocate_and_attach_elastic_ip()` before super() causes crash since `allocate_and_attach_elastic_ip` use `self.parent_cluster` that is not available before the init is complete.
```
Exception in setUp. Will call tearDown
 Traceback (most recent call last):
   File "/sct/sdcm/tester.py", line 135, in wrapper
     return method(*args, **kwargs)
   File "/sct/sdcm/utils/common.py", line 135, in inner
     res = func(*args, **kwargs)
   File "/sct/sdcm/tester.py", line 260, in setUp
     self.init_resources()
   File "/sct/sdcm/tester.py", line 800, in init_resources
     monitor_info=monitor_info)
   File "/sct/sdcm/tester.py", line 621, in get_cluster_aws
     self.db_cluster = create_cluster(db_type)
   File "/sct/sdcm/tester.py", line 587, in create_cluster
     **cl_params)
   File "/sct/sdcm/cluster_aws.py", line 778, in __init__
     aws_extra_network_interface=params.get('aws_extra_network_interface'))
   File "/sct/sdcm/cluster.py", line 2555, in __init__
     super(BaseScyllaCluster, self).__init__(*args, **kwargs)
   File "/sct/sdcm/cluster_aws.py", line 95, in __init__
     region_names=self.region_names)
   File "/sct/sdcm/cluster.py", line 2354, in __init__
     self.add_nodes(num, dc_idx=dc_idx)
   File "/sct/sdcm/cluster_aws.py", line 801, in add_nodes
     enable_auto_bootstrap=enable_auto_bootstrap)
   File "/sct/sdcm/cluster_aws.py", line 382, in add_nodes
     enumerate(instances, start=self._node_index + 1)]
   File "/sct/sdcm/cluster_aws.py", line 396, in _create_node
     base_logdir=base_logdir, dc_idx=dc_idx, node_type=self.node_type)
   File "/sct/sdcm/cluster_aws.py", line 417, in __init__
     self.allocate_and_attach_elastic_ip()
   File "/sct/sdcm/cluster_aws.py", line 508, in allocate_and_attach_elastic_ip
     client = boto3.client('ec2', region_name=self.parent_cluster.region_names[self.dc_idx])
 AttributeError: 'AWSNode' object has no attribute 'parent_cluster'
```
Running a job to test:
https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/bentsi-staging/job/bentsi-byo-network-nemesis/4/console

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
