### PR TITLE
System auth rf now used the credentials.

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -16,6 +16,8 @@ append_scylla_args: '--blocked-reactor-notify-ms 500 --abort-on-lsa-bad-alloc 1 
 scylla_linux_distro: 'centos'
 scylla_linux_distro_loader: 'centos'
 
+system_auth_rf: 3
+
 monitor_branch: 'branch-3.0'
 store_results_in_elasticsearch: true
 

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -327,13 +327,13 @@ class BaseNode():  # pylint: disable=too-many-instance-attributes,too-many-publi
         self.parent_cluster = parent_cluster  # reference to the Cluster object that the node belongs to
         self.logdir = os.path.join(base_logdir, self.name)
         makedirs(self.logdir)
+        self.log = SDCMAdapter(LOGGER, extra={'prefix': str(self)})
 
         ssh_login_info['hostname'] = self.external_address
 
         self.remoter = RemoteCmdRunner(**ssh_login_info)
         self._ssh_login_info = ssh_login_info
 
-        self.log = SDCMAdapter(LOGGER, extra={'prefix': str(self)})
         self.log.debug(self.remoter.ssh_debug_cmd())
 
         self._journal_thread = None

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -436,7 +436,6 @@ class AWSNode(cluster.BaseNode):
                                       base_logdir=base_logdir,
                                       node_prefix=node_prefix,
                                       dc_idx=dc_idx)
-
         if not cluster.Setup.REUSE_CLUSTER:
             tags_list = create_tags_list()
             tags_list.append({'Key': 'Name', 'Value': name})


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
