### PR TITLE
Fix max_rows_for_read parameter name in branch-2019.1

### DIFF
--- a/sla_per_user_system_test.py
+++ b/sla_per_user_system_test.py
@@ -268,7 +268,7 @@ class SlaPerUserTest(LongevityTest):
         # Read from cache and disk
         def mixed(max_rows_for_read):
             if not max_rows_for_read:
-                max_rows_for_cache_read = self.num_of_partitions
+                max_rows_for_read = self.num_of_partitions
             return "'dist=gauss(1..%d, %d, %d)'" % (max_rows_for_read,
                                                     max_rows_for_read / 2,
                                                     max_rows_for_read * 0.05)


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)


This is fix for branch 2019.1 only. In the master it's fixed