### PR TITLE
Introducing `GrafanaEventAggragator` thread

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -45,8 +45,7 @@ from sdcm.utils.common import log_run_info, retrying, get_data_dir_path, Distro,
     get_latest_gemini_version, get_my_ip, makedirs
 from sdcm.utils.thread import raise_event_on_failure
 from sdcm.sct_events import Severity, CoreDumpEvent, CassandraStressEvent, DatabaseLogEvent, \
-    ClusterHealthValidatorEvent
-from sdcm.sct_events import EVENTS_PROCESSES
+    ClusterHealthValidatorEvent, set_grafana_url
 from sdcm.auto_ssh import start_auto_ssh, RSYSLOG_SSH_TUNNEL_LOCAL_PORT
 from sdcm.logcollector import GrafanaSnapshot, GrafanaScreenShot, PrometheusSnapshots, MonitoringStack
 
@@ -3493,8 +3492,7 @@ class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-inst
         if Setup.REUSE_CLUSTER:
             self.configure_scylla_monitoring(node)
             self.restart_scylla_monitoring(sct_metrics=True)
-            EVENTS_PROCESSES['EVENTS_GRAFANA_ANNOTATOR'].set_grafana_url(
-                "http://[{0.external_address}]:{1.grafana_port}".format(node, self))
+            set_grafana_url("http://[{0.external_address}]:{1.grafana_port}".format(node, self))
             return
 
         self.install_scylla_monitoring(node)
@@ -3507,8 +3505,7 @@ class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-inst
         # the data from this point to the end of test will
         # be captured.
         self.grafana_start_time = time.time()
-        EVENTS_PROCESSES['EVENTS_GRAFANA_ANNOTATOR'].set_grafana_url(
-            "http://[{0.external_address}]:{1.grafana_port}".format(node, self))
+        set_grafana_url("http://[{0.external_address}]:{1.grafana_port}".format(node, self))
         if node.is_rhel_like():
             node.remoter.run('sudo yum install screen -y')
         else:

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -425,7 +425,6 @@ class AWSNode(cluster.BaseNode):
                           'user': ami_username,
                           'key_file': credentials.key_file}
         self._spot_aws_termination_task = None
-
         if len(self._instance.network_interfaces) == 2:
             # first we need to configure the both networks so we'll have public ip
             self.allocate_and_attach_elastic_ip(parent_cluster, dc_idx)

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -190,7 +190,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         if self.params.get("logs_transport") == 'rsyslog':
             cluster.Setup.configure_rsyslog(enable_ngrok=False)
 
-        start_events_device(cluster.Setup.logdir(), params=self.params)
+        start_events_device(cluster.Setup.logdir())
         time.sleep(0.5)
         InfoEvent('TEST_START test_id=%s' % cluster.Setup.test_id())
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -190,7 +190,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         if self.params.get("logs_transport") == 'rsyslog':
             cluster.Setup.configure_rsyslog(enable_ngrok=False)
 
-        start_events_device(cluster.Setup.logdir())
+        start_events_device(cluster.Setup.logdir(), params=self.params)
         time.sleep(0.5)
         InfoEvent('TEST_START test_id=%s' % cluster.Setup.test_id())
 

--- a/sdcm/utils/grafana.py
+++ b/sdcm/utils/grafana.py
@@ -1,0 +1,108 @@
+import datetime
+import threading
+from collections import defaultdict
+from string import digits
+import logging
+
+import requests
+
+LOGGER = logging.getLogger(__name__)
+
+
+def normalize_text(text):
+    """
+    clearing digit from text, so it would be usable as a key to find duplicate events
+    :param text:
+    :return: text without digit
+    """
+    res = text.translate(str.maketrans('', '', digits))
+    return res
+
+
+class GrafanaEventAggragator(threading.Thread):
+    """
+    This is a background thread that scans grafana annotations in a `time_window` (in minutes)
+    find `max_duplicated events in that time windows, and delete all of the others similar events
+    """
+
+    def __init__(self, params):
+        self.stop_event = threading.Event()
+        self.url_set = threading.Event()
+        self.grafana_base_url = ''
+        # TODO: add those to sct_events.py
+        if params is None:
+            params = dict()
+        self.time_window = params.get('event_aggregator_time_window', 5)
+        self.max_duplicates = params.get('event_aggregator_max_duplicates', 5)
+        self.auth = ('admin', 'admin')
+        super(GrafanaEventAggragator, self).__init__()
+
+    def set_grafana_url(self, grafana_base_url):
+        self.grafana_base_url = grafana_base_url
+        self.url_set.set()
+
+    def run(self):
+        current_time = datetime.datetime.now()
+
+        while self.stop_event is None or not self.stop_event.isSet():
+            # waiting until the monitor url is set, and we can start using the api
+            self.url_set.wait()
+            if self.grafana_base_url:
+                try:
+                    duplication_counter = defaultdict(int)  # counter for specific message per this time window
+                    # get a time window of events
+                    annotations = self.get_grafana_annotations_by_time(current_time - datetime.timedelta(minutes=self.time_window),
+                                                                       current_time)
+                    current_time = current_time + datetime.timedelta(minutes=self.time_window)
+
+                    # scan for duplicates and mark get ids for deletion
+                    id_for_deletions = []
+                    for annotation in annotations:
+                        duplication_counter[self.unique_key(annotation)] += 1
+                        if duplication_counter[self.unique_key(annotation)] > self.max_duplicates:
+                            id_for_deletions.append(annotation['id'])
+
+                    # delete extra annotation by id
+                    LOGGER.debug(f"ids for deletions = {id_for_deletions}")
+                    self.delete_grafana_annotations(id_for_deletions)
+
+                except Exception as ex:  # pylint: disable=broad-except
+                    LOGGER.warning("GrafanaEventAggragator failed [%s]", str(ex))
+
+                # wait `time_window` time in minutes
+                LOGGER.debug(f"GrafanaEventAggragator sleeping for {self.time_window}min")
+                self.stop_event.wait(60 * self.time_window)
+
+    @staticmethod
+    def unique_key(annotation):
+        return tuple(annotation['tags']), normalize_text(annotation['text'])
+
+    def terminate(self):
+        self.url_set.set()
+        self.stop_event.set()
+
+    def get_grafana_annotations_by_time(self, start, end):
+        annotations_url = "{0.grafana_base_url}/api/annotations"
+        try:
+            res = requests.get(annotations_url.format(self), params={'from': int(start.timestamp() * 1000), 'to': int(end.timestamp() * 1000)},
+                               headers={'Content-Type': 'application/json'}, auth=self.auth)
+
+            res.raise_for_status()
+            if res.json():
+                return res.json()
+            else:
+                LOGGER.warning('empty data')
+        except Exception as ex:  # pylint: disable=broad-except
+            LOGGER.warning("unable to get grafana annotations [%s]", str(ex))
+            raise
+        return dict()
+
+    def delete_grafana_annotations(self, ids):
+        annotations_url = "{0.grafana_base_url}/api/annotations/{id}"
+        for _id in ids:
+            try:
+                requests.get(annotations_url.format(self, id=_id),
+                             headers={'Content-Type': 'application/json'},
+                             auth=self.auth)
+            except Exception as ex:  # pylint: disable=broad-except
+                LOGGER.warning("unable to delete grafana annotations [%s]", str(ex))

--- a/sdcm/utils/grafana.py
+++ b/sdcm/utils/grafana.py
@@ -1,22 +1,36 @@
-import datetime
 import threading
 from collections import defaultdict
-from string import digits
 import logging
 
 import requests
 
+from sdcm.sct_events import EVENTS_PROCESSES
+
 LOGGER = logging.getLogger(__name__)
 
 
-def normalize_text(text):
-    """
-    clearing digit from text, so it would be usable as a key to find duplicate events
-    :param text:
-    :return: text without digit
-    """
-    res = text.translate(str.maketrans('', '', digits))
-    return res
+class GrafanaAnnotator(threading.Thread):
+    def __init__(self):
+        self.stop_event = threading.Event()
+        super(GrafanaAnnotator, self).__init__()
+
+    def run(self):
+        for event_class, message_data in EVENTS_PROCESSES['MainDevice'].subscribe_events(stop_event=self.stop_event):
+
+            event_type = getattr(message_data, 'type', None)
+            tags = [event_class, message_data.severity.name, 'events']
+            if event_type:
+                tags += [event_type]
+            annotate_data = {
+                "time": int(message_data.timestamp * 1000.0),
+                "tags": tags,
+                "isRegion": False,
+                "text": str(message_data)
+            }
+            EVENTS_PROCESSES['EVENTS_GRAFANA_AGGRAGATOR'].store_annotation(annotate_data)
+
+    def terminate(self):
+        self.stop_event.set()
 
 
 class GrafanaEventAggragator(threading.Thread):
@@ -25,15 +39,14 @@ class GrafanaEventAggragator(threading.Thread):
     find `max_duplicated events in that time windows, and delete all of the others similar events
     """
 
-    def __init__(self, params):
+    def __init__(self, time_window_in_secs=90, max_duplicates=5):
         self.stop_event = threading.Event()
         self.url_set = threading.Event()
         self.grafana_base_url = ''
-        # TODO: add those to sct_events.py
-        if params is None:
-            params = dict()
-        self.time_window = params.get('event_aggregator_time_window', 5)
-        self.max_duplicates = params.get('event_aggregator_max_duplicates', 5)
+
+        self.time_window_in_secs = time_window_in_secs
+        self.max_duplicates = max_duplicates
+        self.annotations = list()
         self.auth = ('admin', 'admin')
         super(GrafanaEventAggragator, self).__init__()
 
@@ -42,67 +55,44 @@ class GrafanaEventAggragator(threading.Thread):
         self.url_set.set()
 
     def run(self):
-        current_time = datetime.datetime.now()
-
         while self.stop_event is None or not self.stop_event.isSet():
             # waiting until the monitor url is set, and we can start using the api
             self.url_set.wait()
             if self.grafana_base_url:
                 try:
                     duplication_counter = defaultdict(int)  # counter for specific message per this time window
-                    # get a time window of events
-                    annotations = self.get_grafana_annotations_by_time(current_time - datetime.timedelta(minutes=self.time_window),
-                                                                       current_time)
-                    current_time = current_time + datetime.timedelta(minutes=self.time_window)
 
-                    # scan for duplicates and mark get ids for deletion
-                    id_for_deletions = []
+                    # get current time window of events
+                    annotations = self.annotations[:]
+                    self.annotations.clear()
+
+                    # scan for duplicates in this time window, and send out only `max_duplicates` of them
                     for annotation in annotations:
                         duplication_counter[self.unique_key(annotation)] += 1
-                        if duplication_counter[self.unique_key(annotation)] > self.max_duplicates:
-                            id_for_deletions.append(annotation['id'])
-
-                    # delete extra annotation by id
-                    LOGGER.debug(f"ids for deletions = {id_for_deletions}")
-                    self.delete_grafana_annotations(id_for_deletions)
+                        if duplication_counter[self.unique_key(annotation)] <= self.max_duplicates:
+                            self.post_annotation(annotation)
 
                 except Exception as ex:  # pylint: disable=broad-except
-                    LOGGER.warning("GrafanaEventAggragator failed [%s]", str(ex))
+                    LOGGER.warning(f"GrafanaEventAggragator failed [{str(ex)}]")
 
                 # wait `time_window` time in minutes
-                LOGGER.debug(f"GrafanaEventAggragator sleeping for {self.time_window}min")
-                self.stop_event.wait(60 * self.time_window)
+                LOGGER.debug(f"GrafanaEventAggragator sleeping for {self.time_window_in_secs}sec")
+                self.stop_event.wait(self.time_window_in_secs)
 
     @staticmethod
     def unique_key(annotation):
-        return tuple(annotation['tags']), normalize_text(annotation['text'])
+        return tuple(annotation['tags'])
 
     def terminate(self):
         self.url_set.set()
         self.stop_event.set()
 
-    def get_grafana_annotations_by_time(self, start, end):
-        annotations_url = "{0.grafana_base_url}/api/annotations"
+    def store_annotation(self, annotate_data):
+        self.annotations.append(annotate_data)
+
+    def post_annotation(self, annotate_data):
         try:
-            res = requests.get(annotations_url.format(self), params={'from': int(start.timestamp() * 1000), 'to': int(end.timestamp() * 1000)},
-                               headers={'Content-Type': 'application/json'}, auth=self.auth)
-
+            res = requests.post(self.grafana_base_url + '/api/annotations', json=annotate_data, auth=self.auth)
             res.raise_for_status()
-            if res.json():
-                return res.json()
-            else:
-                LOGGER.warning('empty data')
-        except Exception as ex:  # pylint: disable=broad-except
-            LOGGER.warning("unable to get grafana annotations [%s]", str(ex))
-            raise
-        return dict()
-
-    def delete_grafana_annotations(self, ids):
-        annotations_url = "{0.grafana_base_url}/api/annotations/{id}"
-        for _id in ids:
-            try:
-                requests.get(annotations_url.format(self, id=_id),
-                             headers={'Content-Type': 'application/json'},
-                             auth=self.auth)
-            except Exception as ex:  # pylint: disable=broad-except
-                LOGGER.warning("unable to delete grafana annotations [%s]", str(ex))
+        except requests.exceptions.RequestException as ex:
+            LOGGER.warning(f"Failed to annotate an event in grafana [{str(ex)}]")


### PR DESCRIPTION
This thread checks every few minute for duplication of events in grafana
and delete some of the similar event in that time window.

this is to allow us to clearly see what's going on in the granfa more clearly.

NOTE: those events are not removed from any of the event log files

Done as part of: https://trello.com/c/Z0IKl933

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
