### PR TITLE
sdcm/fill_db_data: fix expect result bype of empty blob

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -2171,7 +2171,7 @@ class FillDatabaseData(ClusterTester):
             'truncates': ["TRUNCATE empty_blob_test"],
             'inserts': ["INSERT INTO empty_blob_test (k, b) VALUES (0, 0x)"],
             'queries': ["SELECT * FROM empty_blob_test"],
-            'results': [[[0, '']]],
+            'results': [[[0, b'']]],
             'min_version': '',
             'max_version': '',
             'skip': ''},


### PR DESCRIPTION
In Python3 the driver returns blob as byte object.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
