### PR TITLE
Fix screenshot for per-server-metrics-nemesis dashboard

### DIFF
--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -582,3 +582,6 @@ class TestStatsMixin(Stats):
 
             return result['_source'].get(key, None)
         return None
+
+    def get_test_start_time(self):
+        return self._stats['test_details'].get('start_time', None)

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -258,6 +258,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
         if self.create_stats:
             self.create_test_stats()
+            # sync test_start_time with ES
+            self.start_time = self.get_test_start_time()
 
         # change RF of system_auth
         system_auth_rf = self.params.get('system_auth_rf', default=3)


### PR DESCRIPTION
The screenshot with missing data periodically created for master/branch-3.2
after investigation, only reason why this could happened, is small
difference in test_stat_time timestamp for screenshots in update_test_details
and screenshots for emails.

Now use the same timestamp. This should fix the issue probably.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
