### PR TITLE
New SLA test: read:write - 1:1

### DIFF
--- a/jenkins-pipelines/features-sla-read-50perc-write-50perc-load.jenkinsfile
+++ b/jenkins-pipelines/features-sla-read-50perc-write-50perc-load.jenkinsfile
@@ -1,0 +1,15 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    params: params,
+
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'sla_per_user_system_test.SlaPerUserTest.test_read_50perc_write_50perc_load',
+    test_config: 'test-cases/features/system-sla-test.yaml',
+
+    timeout: [time: 480, unit: 'MINUTES']
+)


### PR DESCRIPTION
Trello task: https://trello.com/c/CUFZrUky/1248-range-scans-do-not-observe-workload-prioritization-for-i-o-1052

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)

1. Few small fixes
2. Added new test with mixed workflow: 50% read : 50% write