### PR TITLE
issue #1504: Catch file with not expected name

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -305,7 +305,16 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
             # For corruption we need to remove all files that their names are started from "mc-220-" (MC format)
             # Old format: "system-truncated-ka-" (system-truncated-ka-7-Data.db)
             # Search for "<digit>-" substring
-            file_name_template = re.search(r"(.*-\d+)-", file_name).group(1)
+
+            try:
+                file_name_template = re.search(r"(.*-\d+)-", file_name).group(1)
+            except Exception as error:  # pylint: disable=broad-except
+                self.log.debug('File name "{file_name}" is not as expected for Scylla data files. '
+                               'Search files for "{ks_cf_for_destroy}" table'.format(file_name=file_name,
+                                                                                     ks_cf_for_destroy=ks_cf_for_destroy))
+                self.log.debug('Error: {}'.format(error))
+                continue
+
             file_for_destroy = one_file.replace(file_name, file_name_template + '-*')
             self.log.debug('Selected files for destroy: {}'.format(file_for_destroy))
             if file_for_destroy:


### PR DESCRIPTION
Trello task: https://trello.com/c/xCOUhWuV/1406-nemesis-corruptthenrepair-raise-exception-during-file-matching-1504

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)

It's not clear why it happened. I see in the log, that 3 times it was succeeded and at 4th time failed:
```
< t:2019-12-04 01:30:39,347 f:remote.py       l:237  c:sdcm.remote          p:DEBUG > RemoteCmdRunner [centos@172.30.0.220]: Running command "sudo rm -f /var/lib/scylla/data/keyspace1/standard1-c44b3990161511eaa1c5000000000001/mc-9088-*"...
< t:2019-12-04 01:30:39,419 f:remote.py       l:122  c:sdcm.remote          p:INFO  > RemoteCmdRunner [centos@172.30.0.220]: Command "sudo rm -f /var/lib/scylla/data/keyspace1/standard1-c44b3990161511eaa1c5000000000001/mc-9088-*" finished with status 0
< t:2019-12-04 01:30:39,472 f:remote.py       l:237  c:sdcm.remote          p:DEBUG > RemoteCmdRunner [centos@172.30.0.220]: Running command "sudo rm -f /var/lib/scylla/data/keyspace1/standard1-c44b3990161511eaa1c5000000000001/mc-8286-*"...
< t:2019-12-04 01:30:39,542 f:remote.py       l:122  c:sdcm.remote          p:INFO  > RemoteCmdRunner [centos@172.30.0.220]: Command "sudo rm -f /var/lib/scylla/data/keyspace1/standard1-c44b3990161511eaa1c5000000000001/mc-8286-*" finished with status 0
< t:2019-12-04 01:30:39,621 f:remote.py       l:237  c:sdcm.remote          p:DEBUG > RemoteCmdRunner [centos@172.30.0.220]: Running command "sudo rm -f /var/lib/scylla/data/keyspace1/standard1-c44b3990161511eaa1c5000000000001/mc-8774-*"...
< t:2019-12-04 01:30:39,678 f:remote.py       l:122  c:sdcm.remote          p:INFO  > RemoteCmdRunner [centos@172.30.0.220]: Command "sudo rm -f /var/lib/scylla/data/keyspace1/standard1-c44b3990161511eaa1c5000000000001/mc-8774-*" finished with status 0
< t:2019-12-04 01:31:41,960 f:nemesis.py      l:615  c:sdcm.nemesis         p:ERROR > sdcm.nemesis.ChaosMonkey: ('Exception in random_disrupt_method %s: %s', 'destroy_data_then_repair', AttributeError("'NoneType' object has no attribute 'group'",))
```

So I assume it was file with not expected name.
I added the code to catch it.