### PR TITLE
sdcm/cluster: fix get_nodetool_status

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2813,17 +2813,19 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods
             verification_node = random.choice(self.nodes)
         status = {}
         res = verification_node.run_nodetool('status')
-        data_centers = res.stdout.strip().split("Data center: ")
+        data_centers = res.stdout.strip().split("Datacenter: ")
         for dc in data_centers:
             if dc:
                 lines = dc.splitlines()
                 dc_name = lines[0]
                 status[dc_name] = {}
                 for line in lines[1:]:
+                    if line.startswith('--'):  # ignore the title line in result
+                        continue
                     try:
-                        state, ip, load, _, tokens, owns, host_id, rack = line.split()
+                        state, ip, load, load_unit, tokens, owns, host_id, rack = line.split()
                         node_info = {'state': state,
-                                     'load': load,
+                                     'load': '%s%s' % (load, load_unit),
                                      'tokens': tokens,
                                      'owns': owns,
                                      'host_id': host_id,


### PR DESCRIPTION
Related ticket: https://trello.com/c/LK4DbYrT/1192-streaming-error-handling-scenarios-nemesis

get_nodetool_status() is used when I completed above task, so send this PR to fix the function first.

This patch fixed the split pattern of datacenter, currently all nodes status
will be wrongly merged into one datacenter. Ignored the spare title line
from result, and added the load unit to result.

```
@#### Expected return of example status:
{
   'datacenter2':{
      '172.17.0.3':{
         'load':'456.53KB',  <<<<<  load unit is added
         'tokens':'256',
         'state':'UN',
         'owns':'?',
         'host_id':'70d17de8-2839-4f30-829a-504d1a06176f',
         'rack':'rack1'
      }
   },
   'datacenter1':{
      '172.17.0.2':{
         'load':'456.53KB',
         'tokens':'256',
         'state':'UN',
         'owns':'?',
         'host_id':'70d17de8-2839-4f30-829a-504d1a06176f',
         'rack':'rack1'
      }
   }
}

@#### Actually return of example status:
{
   'Datacenter: datacenter1':{    <<<<<< wrong datacenter name
      '172.17.0.2':{
         'load':'456.53',
         'tokens':'256',
         'state':'UN',
         'owns':'?',
         'host_id':'70d17de8-2839-4f30-829a-504d1a06176f',
         'rack':'rack1'
      },
      '172.17.0.3':{
         'load':'456.53',
         'tokens':'256',
         'state':'UN',
         'owns':'?',
         'host_id':'70d17de8-2839-4f30-829a-504d1a06176f',
         'rack':'rack1'
      },
      'Address':{                   <<<<< spare title line
         'load':'Load Tokens',
         'tokens':'Owns',
         'state':'--',
         'owns':'Host',
         'host_id':'ID',
         'rack':'Rack'
      }
   }
}

Example status:

"""
Datacenter: datacenter1
=======================
Status=Up/Down
|/ State=Normal/Leaving/Joining/Moving
--  Address     Load       Tokens       Owns    Host ID                               Rack
UN  172.17.0.2  456.53 KB  256          ?       70d17de8-2839-4f30-829a-504d1a06176f  rack1

Datacenter: datacenter2
=======================
Status=Up/Down
|/ State=Normal/Leaving/Joining/Moving
--  Address     Load       Tokens       Owns    Host ID                               Rack
UN  172.17.0.3  456.53 KB  256          ?       70d17de8-2839-4f30-829a-504d1a06176f  rack1

Note: Non-system keyspaces don't have the same replication settings, effective ownership information is meaningless
"""
```

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
