### PR TITLE
Fix to skip sending message on first retry

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -89,7 +89,7 @@ class retrying():  # pylint: disable=invalid-name,too-few-public-methods
                 return func(*args, **kwargs)
             for i in range(self.n):
                 try:
-                    if self.message:
+                    if self.message and i > 0:
                         LOGGER.info("%s [try #%s]", self.message, i)
                     return func(*args, **kwargs)
                 except self.allowed_exceptions as ex:


### PR DESCRIPTION
https://trello.com/c/KW0At0wL/1412-fix-sdcm-utils-commonpy-to-stop-message-issuing-on-very-first-try
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
