### PR TITLE
Removed network related exceptions that doesn't exist in Python 2

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -80,8 +80,7 @@ SCYLLA_DIR = "/var/lib/scylla"
 
 LOGGER = logging.getLogger(__name__)
 LOCALRUNNER = LocalCmdRunner()
-NETWORK_EXCEPTIONS = (NoValidConnectionsError, SSHException, SSHConnectTimeoutError,
-                      ConnectionResetError, ConnectionAbortedError, ConnectionError, ConnectionRefusedError)
+NETWORK_EXCEPTIONS = (NoValidConnectionsError, SSHException, SSHConnectTimeoutError)
 
 
 def set_ip_ssh_connections(ip_type):

--- a/test-cases/PR-provision-test.yaml
+++ b/test-cases/PR-provision-test.yaml
@@ -20,4 +20,4 @@ instance_provision: 'spot_low_price'
 
 use_mgmt: true
 
-scylla_version: 3.1.0.rc2
+scylla_version: 3.2.rc1


### PR DESCRIPTION
following backport of <Add network errors handling> commit

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
