### PR TITLE
Change hostname on aws instances from default to sct node name

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -368,6 +368,7 @@ class BaseNode():  # pylint: disable=too-many-instance-attributes,too-many-publi
 
         self.termination_event = threading.Event()
         self._running_nemesis = None
+        self.set_hostname()
         self.start_task_threads()
         # We should disable bootstrap when we create nodes to establish the cluster,
         # if we want to add more nodes when the cluster already exists, then we should
@@ -2324,6 +2325,9 @@ server_encryption_options:
         result = self.remoter.run("grep /sct_configured_swapfile /proc/swaps", ignore_status=True)
         if "sct_configured_swapfile" not in result.stdout:
             self.log.warning("Swap file is not used on loader node %s.\nError details: %s", self, result.stderr)
+
+    def set_hostname(self):
+        self.log.warning('Method is not implemented for %s' % self.__class__.__name__)
 
 
 class BaseCluster:  # pylint: disable=too-many-instance-attributes

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -101,6 +101,9 @@ class GCENode(cluster.BaseNode):
         ip_tuple = (instance.public_ips, instance.private_ips)
         return ip_tuple
 
+    def set_hostname(self):
+        self.log.debug("Hostname for node %s left as is", self.name)
+
     def restart(self):
         # When using local_ssd disks in GCE, there is no option to Stop and Start an instance.
         # So, for now we will keep restart the same as hard reboot.


### PR DESCRIPTION
Trello: https://trello.com/c/z6UKwDo1

Aws instances get default hostname based on private ip.
Now we change hostname right after node created and started
to sct node name.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
