### PR TITLE
Changing AbortRepair from non-disruptive nemesis to Disruptive.

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1639,7 +1639,7 @@ class MgmtRepair(Nemesis):
 
 class AbortRepairMonkey(Nemesis):
 
-    disruptive = False
+    disruptive = True
 
     @log_time_elapsed_and_status
     def disrupt(self):
@@ -1755,7 +1755,6 @@ class NonDisruptiveMonkey(Nemesis):
         #  - RefreshBigMonkey -
         #  - NoCorruptRepairMonkey
         #  - MgmtRepair
-        #  - AbortRepairMonkey
 
     def __init__(self, *args, **kwargs):
         super(NonDisruptiveMonkey, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Although abort repair is not a disruptive operation for the node, it's a disruptive operation for the repair operation.
Running it in parallel to other disruptive operations like CorruptThenRepair can cause issues.