### PR TITLE
Fix for a small issue during reuse_cluster

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3501,6 +3501,7 @@ class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-inst
         node.wait_ssh_up()
         # update repo cache and system after system is up
         node.update_repo_cache()
+        self.mgmt_auth_token = kwargs["auth_token"]  # pylint: disable=attribute-defined-outside-init
 
         if Setup.REUSE_CLUSTER:
             self.configure_scylla_monitoring(node)
@@ -3524,10 +3525,9 @@ class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-inst
         else:
             node.remoter.run('sudo apt-get install screen -y')
         if self.params.get("use_mgmt", default=None):
-            self.install_scylla_manager(node, auth_token=kwargs["auth_token"])
+            self.install_scylla_manager(node, auth_token=self.mgmt_auth_token)
 
     def install_scylla_manager(self, node, auth_token):
-        self.mgmt_auth_token = auth_token  # pylint: disable=attribute-defined-outside-init
         if self.params.get('use_mgmt', default=None):
             node.install_mgmt(scylla_repo=self.params.get('scylla_repo_m'),
                               scylla_mgmt_repo=self.params.get('scylla_mgmt_repo'), auth_token=auth_token,


### PR DESCRIPTION
issue reported at #1536

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
