### PR TITLE
GCE: use self-adaptive ip_address for intra node communication

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1335,14 +1335,13 @@ class BaseNode():  # pylint: disable=too-many-instance-attributes,too-many-publi
             scylla_yaml_contents = pattern.sub('seeds: "{0}"'.format(seed_address),
                                                scylla_yaml_contents)
 
-            # NOTICE: the following configuration always have to use private_ip_address for multi-region to work
             # Set listen_address
             pattern = re.compile('listen_address:.*')
-            scylla_yaml_contents = pattern.sub('listen_address: {0}'.format(self.private_ip_address),
+            scylla_yaml_contents = pattern.sub('listen_address: {0}'.format(self.ip_address),
                                                scylla_yaml_contents)
             # Set rpc_address
             pattern = re.compile('\n[# ]*rpc_address:.*')
-            scylla_yaml_contents = pattern.sub('\nrpc_address: {0}'.format(self.private_ip_address),
+            scylla_yaml_contents = pattern.sub('\nrpc_address: {0}'.format(self.ip_address),
                                                scylla_yaml_contents)
 
         if listen_on_all_interfaces:
@@ -3401,7 +3400,7 @@ class BaseLoaderSet():
             log_file_name = os.path.join(logdir,
                                          'scylla-bench-l%s-%s.log' %
                                          (loader_idx, uuid.uuid4()))
-            ips = ",".join([n.private_ip_address for n in node_list])
+            ips = ",".join([n.ip_address for n in node_list])
             bench_log = tempfile.NamedTemporaryFile(prefix='scylla-bench-', suffix='.log').name
             result = node.remoter.run(cmd="/$HOME/go/bin/{} -nodes {} | tee {}".format(stress_cmd.strip(), ips, bench_log),
                                       timeout=timeout,

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1473,8 +1473,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     @retrying(n=60, sleep_time=60, allowed_exceptions=(AssertionError,))
     def wait_data_dir_reaching(self, size, node):
         query = '(sum(node_filesystem_size{{mountpoint="{0.scylla_dir}", ' \
-            'instance=~"{1.private_ip_address}"}})-sum(node_filesystem_avail{{mountpoint="{0.scylla_dir}", ' \
-            'instance=~"{1.private_ip_address}"}}))'.format(self, node)
+            'instance=~"{1.ip_address}"}})-sum(node_filesystem_avail{{mountpoint="{0.scylla_dir}", ' \
+            'instance=~"{1.ip_address}"}}))'.format(self, node)
         res = self.prometheus_db.query(query=query, start=time.time(), end=time.time())
         assert res, "No results from Prometheus"
         used = int(res[0]["values"][0][1]) / (2 ** 10)


### PR DESCRIPTION
Currently we always use (ipv4) private ip for intra communication
of db nodes. But self-adaptive ip_address is used for seeds parameter.

Scylla-server fails to start when public intra communication is enabled.
- export SCT_INTRA_NODE_COMM_PUBLIC=true

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
