### PR TITLE
Enable clear_resources by sct #1545

### DIFF
--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -83,6 +83,7 @@ def call(Map pipelineParams) {
                                                 export SCT_WORKAROUND_KERNEL_BUG_FOR_IOTUNE=${pipelineParams.workaround_kernel_bug_for_iotune}
 
                                                 export SCT_COLLECT_LOGS=true
+                                                export SCT_EXECUTE_POST_BEHAVIOR=true
                                                 echo "start test ......."
                                                 ./docker/env/hydra.sh run-test ${pipelineParams.test_name} --backend ${params.backend}  --logdir /sct
                                                 echo "end test ....."


### PR DESCRIPTION
Fix for bug: https://github.com/scylladb/scylla-cluster-tests/issues/1545

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
