### PR TITLE
Fix #1462: SCT failed to clean the resources when job ends

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -106,9 +106,9 @@ def clean_resources(ctx, user, test_id, logdir, config_file, backend):  # pylint
 
         for _test_id in test_id:
             params['TestId'] = _test_id
-            if backend == 'aws':
+            if 'aws' in backend:
                 clean_aws_instances_according_post_behavior(params, config, logdir)
-            if backend == 'gce':
+            if 'gce' in backend:
                 clean_gce_instances_according_post_behavior(params, config, logdir)
 
     else:

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1344,7 +1344,10 @@ def clean_aws_instances_according_post_behavior(params, config, logdir):  # pyli
         if action == 'destroy':
             instances_ids = [instance['InstanceId'] for instance in instances]
             LOGGER.info('Clean next instances %s', instances_ids)
-            client.terminate_instances(InstanceIds=instances_ids)
+            try:
+                client.terminate_instances(InstanceIds=instances_ids)
+            except Exception as details:  # pylint: disable=broad-except
+                LOGGER.error("Error during instance termination: %s", details)
         elif action == 'keep-on-failure':
             if status:
                 LOGGER.info('Run failed. Leave instances running')
@@ -1375,7 +1378,7 @@ def clean_gce_instances_according_post_behavior(params, config, logdir):  # pyli
 
     def apply_action(instances, action):
         if action == 'destroy':
-            for instance in filtered_instances['db_nodes']:
+            for instance in instances:
                 LOGGER.info('Destroying instance: %s', instance.name)
                 instance.destroy()
                 LOGGER.info('Destroyed instance: %s', instance.name)


### PR DESCRIPTION
Trello: https://trello.com/c/40wn98PT
Fix issue #1462 https://github.com/scylladb/scylla-cluster-tests/issues/1462
minor inhancement

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
