### PR TITLE
Fix 5000 table in one keyspace, to pre_create new tables

### DIFF
--- a/longevity_test.py
+++ b/longevity_test.py
@@ -352,7 +352,10 @@ class LongevityTest(ClusterTester):
             # add few stress threads with tables that weren't pre-created
             customer_profiles = self.params.get('cs_user_profiles', default=[])
             for cs_profile in customer_profiles:
-                for i in range(4):
+                num_of_newly_created_table = 4
+                self._pre_create_templated_user_schema(batch_start=extra_tables_idx,
+                                                       batch_end=extra_tables_idx+(num_of_newly_created_table-1))
+                for i in range(num_of_newly_created_table):
                     batch += self.create_templated_user_stress_params(extra_tables_idx + i, cs_profile=cs_profile)
 
             for params in batch:


### PR DESCRIPTION
Trello: https://trello.com/c/g7WAGkuw

Currently the longevity fails due to timeout when creating the new tables (beyond 5000).
1. Add only 1 table instead of 4 in parallel.
2. Create the table manually before the c-s using driver with bigger timeout.

It'll be good to measure the time it takes to add the new table so we can open issue if it's very long time.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
