### PR TITLE
Reuse cluster fix for test stats creation, in case if stats is already there

### DIFF
--- a/sdcm/es.py
+++ b/sdcm/es.py
@@ -34,7 +34,10 @@ class ES(elasticsearch.Elasticsearch):
         LOGGER.info('DOC_ID: %s', doc_id)
         LOGGER.info('BODY: %s', body)
         self._create_index(index)
-        self.create(index=index, doc_type=doc_type, id=doc_id, body=body)
+        if self.exists(index=index, doc_type=doc_type, id=doc_id):
+            self.update(index=index, doc_type=doc_type, id=doc_id, body={'doc': body})
+        else:
+            self.create(index=index, doc_type=doc_type, id=doc_id, body=body)
 
     def update_doc(self, index, doc_type, doc_id, body):
         """


### PR DESCRIPTION
https://trello.com/c/dXMdraa8/1438-test-is-failing-if-teststats-were-already-created
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
