### PR TITLE
Truncate nemesis - Flushing files before truncate

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -665,6 +665,8 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
 
         self._prepare_test_table(ks=keyspace_truncate)
 
+        # In order to workaround issue #4924 when truncate timeouts, we try to flush before truncate.
+        self.target_node.run_nodetool("flush")
         # do the actual truncation
         self.target_node.run_cqlsh(cmd='TRUNCATE {}.{}'.format(keyspace_truncate, table), timeout=120)
 


### PR DESCRIPTION
In order to workaround issue #4924, try to flush memtables.
This should allow truncate to finish quicker.