### PR TITLE
don't use --abort-on-internal-error for upgrade test

### DIFF
--- a/longevity_large_partition_test.py
+++ b/longevity_large_partition_test.py
@@ -11,6 +11,7 @@ class LargePartitionLongevityTest(LongevityTest):
         self.pre_create_large_partitions_schema(compaction_strategy=compaction_strategy)
         self.test_custom_time()
 
+    # pylint: disable=invalid-name
     def pre_create_large_partitions_schema(self, compaction_strategy=CompactionStrategy.SIZE_TIERED.value):
         node = self.db_cluster.nodes[0]
         compaction_strategy_option = "AND compaction = {{'class': '{}'}};".format(compaction_strategy)

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -27,7 +27,6 @@ import threading
 import os
 import re
 import traceback
-from collections import OrderedDict
 
 from invoke import UnexpectedExit
 
@@ -669,7 +668,7 @@ class Nemesis(object):  # pylint: disable=too-many-instance-attributes,too-many-
         # do the actual truncation
         self.target_node.run_cqlsh(cmd='TRUNCATE {}.{}'.format(keyspace_truncate, table), timeout=120)
 
-    def _modify_table_property(self, name, val, filter_out_table_with_counter=False, modify_all_tables=False):
+    def _modify_table_property(self, name, val, filter_out_table_with_counter=False):
         disruption_name = "".join([p.strip().capitalize() for p in name.split("_")])
         self._set_current_disruption('ModifyTableProperties%s %s' % (disruption_name, self.target_node))
 

--- a/test-cases/upgrades/rolling-upgrade.yaml
+++ b/test-cases/upgrades/rolling-upgrade.yaml
@@ -32,3 +32,5 @@ remove_authorization_in_rollback: true
 # SCT_SCYLLA_VERSION=3.0 or SCT_SCYLLA_REPO=
 # for the upgrading version you need:
 # SCT_NEW_SCYLLA_REPO=https://s3.amazonaws.com/downloads.scylladb.com/enterprise/rpm/unstable/centos/e438e3e3ce41f6c878b111f5c19bf2b28aa51098-2bdfa9f7ef592edaf15e028faf3b7f695f39ebc1-e616363bdc0e7a0d193a157851d7c15d952a0aad-a6b2b2355c666b1893f702a587287da978aeec22/53/scylla.repo
+
+append_scylla_args: '--blocked-reactor-notify-ms 500 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc'

--- a/test_lib/compaction.py
+++ b/test_lib/compaction.py
@@ -45,6 +45,7 @@ def get_compaction_strategy(node, keyspace, table):
     return compaction
 
 
+# pylint: disable=invalid-name
 def get_compaction_random_additional_params():
     """
 


### PR DESCRIPTION
We need to test upgrade from 2018.1, which doesn't support option
`--abort-on-internal-error`. The default append_scylla_args contains
this option.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
