### PR TITLE
switch to use stable hytrust kmip server

### DIFF
--- a/configurations/hytrust-kmip-ear.yaml
+++ b/configurations/hytrust-kmip-ear.yaml
@@ -1,0 +1,18 @@
+
+scylla_encryption_options: "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'KmipKeyProviderFactory', 'kmip_host': 'kmip_test'}"
+
+# enable system_info_encryption, config kmip_hosts
+append_scylla_yaml: |
+  system_key_directory: /etc/encrypt_conf/
+  system_info_encryption:
+      enabled: True  # system_info_encryption
+      key_provider: LocalFileSystemKeyProviderFactory  # system_info_encryption
+      secret_key_file: '/tmp/system_info_encryption_keyfile'
+
+  kmip_hosts:
+       kmip_test:
+           hosts: 52.21.171.245
+           certificate: /etc/encrypt_conf/hytrust-kmip-scylla.pem
+           keyfile: /etc/encrypt_conf/hytrust-kmip-scylla.pem
+           truststore: /etc/encrypt_conf/hytrust-kmip-cacert.pem
+           priority_string: 'SECURE128:+RSA:-VERS-TLS1.0:-ECDHE-ECDSA'

--- a/jenkins-pipelines/EaR-longevity-kmip-200gb-6h.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-kmip-200gb-6h.jenkinsfile
@@ -9,7 +9,7 @@ longevityPipeline(
     backend: 'aws',
     aws_region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml", "configurations/kmip-ear.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml", "configurations/hytrust-kmip-ear.yaml"]''',
 
     timeout: [time: 550, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/EaR-longevity-kmip-50gb-4d.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-kmip-50gb-4d.jenkinsfile
@@ -9,7 +9,7 @@ longevityPipeline(
     backend: 'aws',
     aws_region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-50GB-4days-authorization-and-tls-ssl.yaml", "configurations/kmip-ear.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-50GB-4days-authorization-and-tls-ssl.yaml", "configurations/hytrust-kmip-ear.yaml"]''',
 
     timeout: [time: 6550, unit: 'MINUTES']
 )

--- a/sdcm/keystore.py
+++ b/sdcm/keystore.py
@@ -16,7 +16,7 @@ class KeyStore():
     def download_file(self, filename, dest_filename):
         obj = self.s3.Object(KEYSTORE_S3_BUCKET, filename)
         with open(dest_filename, 'w') as file_obj:
-            file_obj.write(obj.get()["Body"].read())
+            file_obj.write(obj.get()["Body"].read().decode())
 
     def get_email_credentials(self):
         return self._get_json("email_config.json")

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1449,7 +1449,6 @@ def download_encrypt_keys():
     """
     from sdcm.keystore import KeyStore
     ks = KeyStore()
-    if not os.path.exists('./data_dir/encrypt_conf/CA.pem'):
-        ks.download_file('CA.pem', './data_dir/encrypt_conf/CA.pem')
-    if not os.path.exists('./data_dir/encrypt_conf/SCYLLADB.pem'):
-        ks.download_file('SCYLLADB.pem', './data_dir/encrypt_conf/SCYLLADB.pem')
+    for pem_file in ['CA.pem', 'SCYLLADB.pem', 'hytrust-kmip-cacert.pem', 'hytrust-kmip-scylla.pem']:
+        if not os.path.exists('./data_dir/encrypt_conf/%s' % pem_file):
+            ks.download_file(pem_file, './data_dir/encrypt_conf/%s' % pem_file)


### PR DESCRIPTION
KMIP server of cryptsoft.com isn't stable during the test, the connection error
isn't real scylla issue. Let's switch to use self-deployed hytrust KMIP server
in AWS.


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
