### PR TITLE
Adding email_recipients as job UI parameter

### DIFF
--- a/vars/byoLongevityPipeline.groovy
+++ b/vars/byoLongevityPipeline.groovy
@@ -59,6 +59,10 @@ def call() {
             string(defaultValue: '',
                    description: 'cloud path for RPMs, s3:// or gs://',
                    name: 'update_db_packages')
+
+            string(defaultValue: "${pipelineParams.get('email_recipients', 'qa@scylladb.com')}",
+                   description: 'email recipients of email report',
+                   name: 'email_recipients')
         }
         options {
             timestamps()
@@ -91,6 +95,7 @@ def call() {
                                 // handle params which can be a json list
                                 def aws_region = groovy.json.JsonOutput.toJson(params.aws_region)
                                 def test_config = groovy.json.JsonOutput.toJson(params.test_config)
+                                def email_recipients = groovy.json.JsonOutput.toJson(params.email_recipients)
 
                                 sh """
                                 #!/bin/bash
@@ -121,6 +126,7 @@ def call() {
                                 export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$GIT_BRANCH | sed -E 's+(origin/|origin/branch-)++')
                                 export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$SCT_AMI_ID_DB_SCYLLA_DESC | tr ._ - | cut -c1-8 )
 
+                                export SCT_EMAIL_RECIPIENTS="${email_recipients}"
                                 echo "start test ......."
                                 ./docker/env/hydra.sh run-test ${params.test_name} --backend ${params.backend}  --logdir /sct
                                 echo "end test ....."

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -47,6 +47,11 @@ def call(Map pipelineParams) {
                    description: 'private|public|ipv6',
                    name: 'ip_ssh_connections')
             string(defaultValue: '', description: 'If empty - the default manager version will be taken', name: 'scylla_mgmt_repo')
+
+            string(defaultValue: "${pipelineParams.get('email_recipients', 'qa@scylladb.com')}",
+                   description: 'email recipients of email report',
+                   name: 'email_recipients')
+
         }
         options {
             timestamps()
@@ -114,6 +119,7 @@ def call(Map pipelineParams) {
                                         export SCT_SCYLLA_MGMT_REPO="${params.scylla_mgmt_repo}"
                                     fi
 
+
                                     echo "start test ......."
                                     ./docker/env/hydra.sh run-test ${pipelineParams.test_name} --backend ${params.backend}  --logdir /sct
                                     echo "end test ....."
@@ -130,7 +136,7 @@ def call(Map pipelineParams) {
                         script {
                             wrap([$class: 'BuildUser']) {
                                 dir('scylla-cluster-tests') {
-                                    def email_recipients = groovy.json.JsonOutput.toJson(pipelineParams.get('email_recipients', 'qa@scylladb.com'))
+                                    def email_recipients = groovy.json.JsonOutput.toJson(params.email_recipients)
 
                                     sh """
                                     #!/bin/bash


### PR DESCRIPTION
- longevity
- rollingupgrade
- byolongevity

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
