### PR TITLE
Fix issue #1589 for clean-resources with multiple config files

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -76,13 +76,13 @@ def provision(**kwargs):
 @click.option('--user', type=str, help='user name to filter instances by')
 @sct_option('--test-id', 'test_id', help='test id to filter by. Could be used multiple times', multiple=True)
 @click.option('--logdir', type=str, help='directory with test run')
-@click.option('--config-file', type=str, help='config test file path')
+@click.option('--config-file', multiple=True, type=click.Path(exists=True), help="Test config .yaml to use, can have multiple of those")
 @click.option('--backend', type=str, help="")
 @click.pass_context
 def clean_resources(ctx, user, test_id, logdir, config_file, backend):  # pylint: disable=too-many-arguments,too-many-branches
     params = dict()
 
-    if config_file:
+    if config_file or logdir:
 
         if not logdir:
             logdir = os.path.expandvars("$HOME/sct-results")
@@ -90,7 +90,7 @@ def clean_resources(ctx, user, test_id, logdir, config_file, backend):  # pylint
         if logdir and not test_id:
             test_id = (search_test_id_in_latest(logdir), )
 
-        if not logdir or not test_id:
+        if not logdir or not all(test_id):
             click.echo(clean_resources.get_help(ctx))
             return
 
@@ -100,7 +100,8 @@ def clean_resources(ctx, user, test_id, logdir, config_file, backend):  # pylint
         if not os.environ.get('SCT_CLUSTER_BACKEND', None):
             os.environ['SCT_CLUSTER_BACKEND'] = backend
 
-        os.environ['SCT_CONFIG_FILES'] = config_file
+        if config_file:
+            os.environ['SCT_CONFIG_FILES'] = str(list(config_file))
 
         config = SCTConfiguration()
 

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -192,6 +192,7 @@ def call(Map pipelineParams) {
                                     set -xe
                                     env
 
+                                    export SCT_CONFIG_FILES=${test_config}
                                     export SCT_CLUSTER_BACKEND="${params.backend}"
                                     export SCT_REGION_NAME=${aws_region}
                                     export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
@@ -199,7 +200,7 @@ def call(Map pipelineParams) {
                                     export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"
 
                                     echo "start clean resources ..."
-                                    ./docker/env/hydra.sh clean-resources --config-file "${test_config}" --logdir /sct
+                                    ./docker/env/hydra.sh clean-resources --logdir /sct
                                     echo "end clean resources"
                                     """
                                 }


### PR DESCRIPTION
Fix issue in sct.py: clean-resources to use logdir and use multiple
config-files

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
