### PR TITLE
Fix instance's search for email report by test_id

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -472,7 +472,7 @@ def send_email(test_id=None, email_recipients=None, logdir=None):
     if not reporter:
         LOGGER.warning("No reporter found")
     else:
-        test_results['nodes'] = get_running_instances_for_email_report(test_id)
+        test_results['nodes'] = get_running_instances_for_email_report(test_results['test_id'])
         if "Gemini" in reporter:
             reporter = GeminiEmailReporter(email_recipients, logdir=testrun_dir)
             reporter.send_report(test_results)


### PR DESCRIPTION
pipelines call the hydra send_email command without test-id.
Wrong test-id was passed to function for search instances

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
