### PR TITLE
Fixed the automatic repair task deletion

### DIFF
--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -384,8 +384,10 @@ class ManagerCluster(ScyllaManagerBase):
         LOGGER.debug("Deleted the task '{}' successfully!". format(task_id))
 
     def delete_automatic_repair_task(self):
-        repair_task = self.repair_task_list[0]
-        self.delete_task(repair_task.id)
+        repair_tasks_list = self.repair_task_list
+        if repair_tasks_list:
+            automatic_repair_task = repair_tasks_list[0]
+            self.delete_task(automatic_repair_task.id)
 
     @property
     def _cluster_list(self):


### PR DESCRIPTION
of the manager's add_cluster function.

Fixes sct issue #1609

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
