### PR TITLE
Fix timeout for jenkins-pipelines/ics-longevity-200gb-48h.jenkinsfile

### DIFF
--- a/jenkins-pipelines/ics-longevity-200gb-48h.jenkinsfile
+++ b/jenkins-pipelines/ics-longevity-200gb-48h.jenkinsfile
@@ -11,5 +11,5 @@ longevityPipeline(
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml", "test-cases/enterprise-features/ics/longevity/ics-longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml"]''',
 
-    timeout: [time: 2940, unit: 'MINUTES']
+    timeout: [time: 3060, unit: 'MINUTES']
 )


### PR DESCRIPTION
Timeout fix for jenkins-pipelines/ics-longevity-200gb-48h.jenkinsfile
