### PR TITLE
get_branch_version: support repo out of downloads.scylladb.com

### DIFF
--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -20,7 +20,7 @@ def get_branch_version(url):
 def get_branch_version_from_list(url):
     page = requests.get(url).text
     list_regex = re.compile(
-        r'deb\s\[arch=(?P<arch>.*?)\]\s(?P<url>http://downloads.scylladb.com/.*?)\s(?P<version_code_name>.*?)\s(?P<component>.*?)\n', re.DOTALL)
+        r'deb\s\[arch=(?P<arch>.*?)\]\s(?P<url>http.*?)\s(?P<version_code_name>.*?)\s(?P<component>.*?)\n', re.DOTALL)
     match = list_regex.search(page)
     if not match:
         raise ValueError("url isn't a correct deb list\n\turl:[{}] ".format(url))
@@ -37,7 +37,7 @@ def get_branch_version_from_list(url):
 
 def get_branch_version_from_repo(url):
     page = requests.get(url).text
-    repo_regex = re.compile(r'baseurl=(http://downloads.scylladb.com/.*?)\$basearch')
+    repo_regex = re.compile(r'baseurl=(http.*?)\$basearch')
 
     match = repo_regex.search(page)
     if not match:

--- a/unit_tests/test_version_utils.py
+++ b/unit_tests/test_version_utils.py
@@ -12,6 +12,8 @@ RPM_URL = 'https://s3.amazonaws.com/downloads.scylladb.com/enterprise/rpm/unstab
           '9f724fedb93b4734fcfaec1156806921ff46e956-2bdfa9f7ef592edaf15e028faf3b7f695f39ebc1'\
           '-525a0255f73d454f8f97f32b8bdd71c8dec35d3d-a6b2b2355c666b1893f702a587287da978aeec22/71/scylla.repo'
 
+ISSUE_5288_RPM_URL = 'http://scratch.scylladb.com/amos/yum_repos/master/piotrj_issue5288_v3/scylla.repo'
+
 BROKEN_URL = 'https://www.google.com'
 
 
@@ -21,6 +23,7 @@ class TestVersionUtils(unittest.TestCase):
 
     def test_02_get_branch_version_from_repo(self):
         self.assertEqual(get_branch_version_from_repo(RPM_URL), '2019.1.1')
+        self.assertEqual(get_branch_version_from_repo(ISSUE_5288_RPM_URL), '666.development')
 
     def test_03_get_branch_version(self):
         self.assertEqual(get_branch_version(RPM_URL), '2019.1.1')
@@ -36,3 +39,4 @@ class TestVersionUtils(unittest.TestCase):
         self.assertEqual(is_enterprise('2018'), True)
         self.assertEqual(is_enterprise('3.1'), False)
         self.assertEqual(is_enterprise('2.2'), False)
+        self.assertEqual(is_enterprise('666.development'), False)


### PR DESCRIPTION
Currently we strictly to parse the repo url with downloads.scylladb.com,
the repo out of downloads.scylladb.com doesn't work.

eg: http://scratch.scylladb.com/amos/yum_repos/master/piotrj_issue5288_v3/scylla.repo

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
