### PR TITLE
always recover system tables in rollback as recommended by upgrade guides

### DIFF
--- a/data_dir/recover_system_tables.sh
+++ b/data_dir/recover_system_tables.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
-DIR='/var/lib/scylla/data/system';
-for i in `sudo ls $DIR`;
-do
-    sudo test -e $DIR/$i/snapshots/$1 && sudo find $DIR/$i/snapshots/$1 -type f -exec sudo /bin/cp {} $DIR/$i/ \;
+for DIR in '/var/lib/scylla/data/system' '/var/lib/scylla/data/system_schema'; do
+    for i in `sudo ls $DIR`;
+    do
+        sudo test -e $DIR/$i/snapshots/$1 && (sudo rm -f $DIR/$i/* || true) && sudo find $DIR/$i/snapshots/$1 -type f -exec sudo -u scylla /bin/cp {} $DIR/$i/ \;
+    done
 done
+
 
 # Some new table may not exist in old version, `test -e` might failed (return -1),
 # it might be return to this script.

--- a/test-cases/upgrades/rolling-upgrade.yaml
+++ b/test-cases/upgrades/rolling-upgrade.yaml
@@ -26,6 +26,7 @@ authenticator_password: 'cassandra'
 
 authorization_in_upgrade: 'CassandraAuthorizer'
 remove_authorization_in_rollback: true
+recover_system_tables: true
 
 # those are needed to be give by the job, via environment variable
 # for the base version


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
