### PR TITLE
Fix #1622: send_email command to handle empty email_recipients

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -456,7 +456,10 @@ def send_email(test_id=None, email_recipients=None, logdir=None):
     from sdcm.send_email import (GeminiEmailReporter, LongevityEmailReporter,
                                  get_running_instances_for_email_report,
                                  read_email_data_from_file)
-
+    if not email_recipients:
+        LOGGER.warning("No email recipients. Email will not be sent")
+        return
+    LOGGER.info('Email will be sent to next recipients: %s', email_recipients)
     if not logdir:
         logdir = os.path.expanduser('~/sct-results')
     testrun_dir = get_testrun_dir(test_id=test_id, base_dir=logdir)


### PR DESCRIPTION
Add to sct.py send_email checks:
if email-recipients is empty, don't send email

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
