### PR TITLE
Modified ics-toggle-strategy nemesis to use new large-partitions

### DIFF
--- a/jenkins-pipelines/longevity-ics-toggle-strategy-large-partitions-24h.jenkinsfile
+++ b/jenkins-pipelines/longevity-ics-toggle-strategy-large-partitions-24h.jenkinsfile
@@ -1,0 +1,14 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    params: params,
+
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
+    test_config: '''["test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml", "test-cases/longevity/longevity-ics-toggle-strategy-large-partitions-24h.yaml"]''',
+    timeout: [time: 6540, unit: 'MINUTES'],
+)

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2164,7 +2164,8 @@ class ToggleTableIcsMonkey(Nemesis):
 
     @log_time_elapsed_and_status
     def disrupt(self):
-        self.disrupt_toggle_table_ics()
+        self.call_random_disrupt_method(
+            disrupt_methods=['disrupt_toggle_table_ics', 'disrupt_hard_reboot_node'])
 
 
 class MgmtBackup(Nemesis):

--- a/test-cases/longevity/longevity-ics-toggle-strategy-large-partitions-24h.yaml
+++ b/test-cases/longevity/longevity-ics-toggle-strategy-large-partitions-24h.yaml
@@ -1,0 +1,4 @@
+compaction_strategy: 'IncrementalCompactionStrategy'
+nemesis_class_name: 'ToggleTableIcsMonkey'
+nemesis_interval: 30
+user_prefix: 'longevity-ics-toggle-strategy-large-partitions-1d'


### PR DESCRIPTION
Runs in job: 
https://jenkins.scylladb.com/view/enterprise-2019.1/job/enterprise-2019.1/job/SCT_Enterprise_Feature/job/ICS/job/longevity-ics-toggle-strategy-large-partitions-24h/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
