### PR TITLE
Don't start Decode on monitor thread if decoding is disabled

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -922,7 +922,7 @@ class BaseNode():  # pylint: disable=too-many-instance-attributes,too-many-publi
             self.start_journal_thread()
             self.start_backtrace_thread()
             self.start_db_log_reader_thread()
-        if 'monitor' in self.name:
+        if 'monitor' in self.name and Setup.DECODING_QUEUE:
             self.start_decode_on_monitor_node_thread()
 
     @log_run_info
@@ -939,7 +939,7 @@ class BaseNode():  # pylint: disable=too-many-instance-attributes,too-many-publi
             self._journal_thread.join(timeout)
         if self._scylla_manager_journal_thread:
             self.stop_scylla_manager_log_capture(timeout)
-        if self._decoding_backtraces_thread:
+        if self._decoding_backtraces_thread and Setup.DECODING_QUEUE:
             Setup.DECODING_QUEUE.put(None)
             Setup.DECODING_QUEUE.join()
             self._decoding_backtraces_thread.join(timeout)
@@ -1275,7 +1275,7 @@ class BaseNode():  # pylint: disable=too-many-instance-attributes,too-many-publi
                 backtraces = list(filter(filter_backtraces, backtraces))
 
             for backtrace in backtraces:
-                if Setup.BACKTRACE_DECODING:
+                if Setup.BACKTRACE_DECODING and Setup.DECODING_QUEUE:
                     if backtrace['event'].raw_backtrace:
                         scylla_debug_info = self.get_scylla_debuginfo_file()
                         self.log.debug('Debug info file %s', scylla_debug_info)


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
