### PR TITLE
sdcm/fill_db_data: fix delay for each insert to workaround list order issue

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -2918,7 +2918,7 @@ class FillDatabaseData(ClusterTester):
                         raise ex
                     # Add delay on client side for inserts of list to avoid list order issue
                     # Referencing https://github.com/scylladb/scylla-enterprise/issues/1177#issuecomment-568762357
-                    if 'list<' in item['create_tables']:
+                    if 'list<' in item['create_tables'][0]:
                         time.sleep(1)
 
     def run_db_queries(self, session, default_fetch_size):


### PR DESCRIPTION
This patch fixed a script bug in bda7beb9b5d87ca5233da066119f7b9af2226876,
the delay isn't successfully added.

This patch is tested with debug message, the delay is truly added.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
