### PR TITLE
Search file for destroy just in table folder, not sub folders

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -305,8 +305,8 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
         ks_cf_for_destroy = random.choice(ks_cfs)  # expected value as: 'keyspace1.standard1'
 
         ks_cf_for_destroy = ks_cf_for_destroy.replace('.', '/')
-        files = self.target_node.remoter.run("sudo sh -c 'find /var/lib/scylla/data/%s-* -type f'" % ks_cf_for_destroy,
-                                             verbose=False)
+        files = self.target_node.remoter.run("sudo sh -c 'find /var/lib/scylla/data/%s-* -maxdepth 1 -type f'"
+                                             % ks_cf_for_destroy, verbose=False)
         if files.stderr:
             raise NoFilesFoundToDestroy(
                 'Failed to get data files for destroy in {}. Error: {}'.format(ks_cf_for_destroy,


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)

Search file for destroy just in table folder, not in sub folders like "snapshot"