### PR TITLE
Fix cassandra-stress commands calls

### DIFF
--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -146,9 +146,9 @@ class CassandraStressThread():  # pylint: disable=too-many-instance-attributes
         tag = f'TAG: loader_idx:{loader_idx}-cpu_idx:{cpu_idx}-keyspace_idx:{keyspace_idx}'
 
         if self.stress_num > 1:
-            node_cmd = f'taskset -c {cpu_idx} bash -c "STRESS_TEST_MARKER={self.shell_marker}; {stress_cmd}"'
+            node_cmd = f'STRESS_TEST_MARKER={self.shell_marker}; taskset -c {cpu_idx} {stress_cmd}'
         else:
-            node_cmd = f'bash -c "STRESS_TEST_MARKER={self.shell_marker}; {stress_cmd};" '
+            node_cmd = f'STRESS_TEST_MARKER={self.shell_marker}; {stress_cmd}'
 
         node_cmd = f'echo {tag}; {node_cmd}'
 


### PR DESCRIPTION
since the change to add `STRESS_TEST_MARKER` to the command line,
seams like it's breaking the call to cassandra-stress when
client-encryption is used.

this simplifiy the command a bit, to a working state also for encrpytion.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
