### PR TITLE
upgrade_test: check reload systemd config

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -55,6 +55,14 @@ def truncate_entries(func):
     return inner
 
 
+def check_reload_systemd_config(node):
+    reload_conf = False
+    for i in ['scylla-server', 'scylla-jmx']:
+        result = node.remoter.run('systemctl status %s' % i, ignore_status=True)
+        if ".service changed on disk. Run 'systemctl daemon-reload' to reload units" in result.stderr:
+            raise Exception("Systemd config is changed, but not reload automatically")
+
+
 class UpgradeTest(FillDatabaseData):
     """
     Test a Scylla cluster upgrade.
@@ -193,6 +201,7 @@ class UpgradeTest(FillDatabaseData):
         if authorization_in_upgrade:
             node.remoter.run("echo 'authorizer: \"%s\"' |sudo tee --append /etc/scylla/scylla.yaml" %
                              authorization_in_upgrade)
+        check_reload_systemd_config(node)
         node.start_scylla_server()
         node.wait_db_up(verbose=True)
         result = node.remoter.run('scylla --version')


### PR DESCRIPTION
We expect Scylla would automatically reload the systemd config if it's
changed during upgrade or rollback.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
