### PR TITLE
Replace the current version tagging of resources

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -268,12 +268,19 @@ def get_username():
 
 def create_common_tags():
     build_tag = os.environ.get('BUILD_TAG', None)
+    job_name = os.environ.get('JOB_NAME', None)
     tags = dict(RunByUser=get_username(),
                 TestName=str(Setup.test_name()),
                 TestId=str(Setup.test_id()))
 
     if build_tag:
         tags["JenkinsJobTag"] = build_tag
+
+    # In order to calculate costs by version in AWS, we will use the root dir of the job in jenkins as the version.
+    if job_name:
+        tags["version"] = job_name.split('/')[0]
+    else:
+        tags["version"] = "unknown"
 
     tags.update(Setup.TAGS)
     return tags

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -178,9 +178,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         cluster.Setup.set_intra_node_comm_public(self.params.get(
             'intra_node_comm_public') or cluster.Setup.MULTI_REGION)
 
-        version_tag = self.params.get('ami_id_db_scylla_desc')
-        if version_tag:
-            cluster.Setup.tags('version', version_tag)
         # for saving test details in DB
         self.create_stats = self.params.get(key='store_results_in_elasticsearch', default=True)
         self.scylla_dir = SCYLLA_DIR


### PR DESCRIPTION
Till now the version tag was based on GIT_BRANCH which created a mess when people used their private branches.
We would like to have it better tracked in our AWS reports and track a version cost.
In order to do that, we will use the root dir of job name to identify which job it's related to.
For example,
JOB_NAME=scylla-master/longevity/longevity-50gb-4days
The job will be tagged with version scylla-master.
In case of a missing JOB_NAME (can happen when one run test locally and doesn't pass the JOB_NAME param), it'll be tagged as "unknown".