### PR TITLE
Explicitly set RSA key type + docker build fix

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -33,7 +33,7 @@ else
     cd ${DOCKER_ENV_DIR}
     cp -f ${SCT_DIR}/${PY_PREREQS_FILE} .
     cp -f ${SCT_DIR}/${CENTOS_PREREQS_FILE} .
-    docker build -t scylladb/hydra:${VERSION} .
+    docker build --network=host -t scylladb/hydra:${VERSION} .
     rm -f ${PY_PREREQS_FILE} ${CENTOS_PREREQS_FILE}
     cd -
 fi

--- a/sdcm/remote.py
+++ b/sdcm/remote.py
@@ -27,7 +27,7 @@ from shlex import quote
 from fabric import Connection, Config
 from invoke.exceptions import UnexpectedExit, Failure
 from invoke.watchers import StreamWatcher, Responder
-from paramiko import SSHException
+from paramiko import SSHException, RSAKey
 
 from sdcm.log import SDCMAdapter
 from sdcm.utils.common import retrying
@@ -187,7 +187,7 @@ class RemoteCmdRunner(CommandRunner):  # pylint: disable=too-many-instance-attri
                                  'UserKnownHostsFile': self.known_hosts_file,
                                  'ServerAliveInterval': 300,
                                  'StrictHostKeyChecking': 'no'})
-        self.connect_config = {'key_filename': os.path.expanduser(self.key_file)}
+        self.connect_config = {'pkey': RSAKey(filename=os.path.expanduser(self.key_file))}
         super(RemoteCmdRunner, self).__init__(hostname, user, password)
         self.start_ssh_up_thread()
 


### PR DESCRIPTION
Addressing the following error:
```
< t:2020-01-03 10:50:58,865 f:remote.py       l:251  c:sdcm.remote          p:ERROR > encountered RSA key, expected OPENSSH key
```
In some situations for unknown reason, Paramiko doesn't recognize the SSH key type. Trying to solve this as suggested in https://github.com/paramiko/paramiko/issues/1589


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
