### PR TITLE
sct_event: TestFrameworkEvent was casing Circular reference

### DIFF
--- a/sdcm/sct_events.py
+++ b/sdcm/sct_events.py
@@ -170,19 +170,19 @@ class TestFrameworkEvent(SctEvent):  # pylint: disable=too-many-instance-attribu
             self.severity = Severity.CRITICAL
         else:
             self.severity = severity
-        self.source = source
-        self.source_method = source_method
-        self.exception = exception
-        self.message = message
+        self.source = str(source)
+        self.source_method = str(source_method)
+        self.exception = str(exception)
+        self.message = str(message)
         self.args = args
         self.kwargs = kwargs
 
     def __str__(self):
         message = f'message={self.message}' if self.message else ''
-        message = f' got {self.exception}({message})={self.exception}' if self.exception else f' {message}'
+        message += f'\nexception={self.exception}' if self.exception else ''
         args = f' args={self.args}' if self.args else ''
         kwargs = f' kwargs={self.kwargs}' if self.kwargs else ''
-        params = ','.join([args, kwargs])
+        params = ','.join([args, kwargs]) if kwargs or args else ''
         return f"{super().__str__()}, source={self.source}.{self.source_method}({params}){message}"
 
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -23,6 +23,7 @@ import unittest
 import warnings
 from uuid import uuid4
 from functools import wraps
+import traceback
 
 import boto3.session
 from libcloud.compute.providers import get_driver
@@ -280,11 +281,11 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self.start_time = time.time()
 
             self.db_cluster.validate_seeds_on_all_nodes()
-        except Exception as exc:
+        except Exception:
             TestFrameworkEvent(
                 source=self.__class__.__name__,
                 source_method='SetUp',
-                exception=exc
+                exception=traceback.format_exc()
             ).publish()
             raise
 

--- a/unit_tests/test_events.py
+++ b/unit_tests/test_events.py
@@ -11,14 +11,14 @@ import datetime
 from sdcm.prometheus import start_metrics_server
 from sdcm.sct_events import (start_events_device, stop_events_device, Event, TestKiller,
                              InfoEvent, CassandraStressEvent, CoreDumpEvent, DatabaseLogEvent, DisruptionEvent, DbEventsFilter, SpotTerminationEvent,
-                             KillTestEvent, Severity, ThreadFailedEvent)
+                             KillTestEvent, Severity, ThreadFailedEvent, TestFrameworkEvent)
 
 LOGGER = logging.getLogger(__name__)
 
 logging.basicConfig(format="%(asctime)s - %(levelname)-8s - %(name)-10s: %(message)s", level=logging.DEBUG)
 
 
-class SctEventsTests(unittest.TestCase):
+class SctEventsTests(unittest.TestCase):  # pylint: disable=too-many-public-methods
 
     def get_event_logs(self):
         log_file = os.path.join(self.temp_dir, 'events_log', 'events.log')
@@ -112,6 +112,15 @@ class SctEventsTests(unittest.TestCase):
                             node='test'))
 
         print(str(DisruptionEvent(type='start', name="ChaosMonkeyLimited", status=True, node='test')))
+
+    def test_test_framework_event(self):  # pylint: disable=no-self-use
+        try:
+            1 / 0
+        except ZeroDivisionError:
+            _full_traceback = traceback.format_exc()
+        event = TestFrameworkEvent(source="Tester", source_method="setUp", exception=_full_traceback)
+        print(str(event))
+        event.publish()
 
     def test_filter(self):
         log_content_before = self.get_event_logs()


### PR DESCRIPTION
since TestFrameworkEvent was passing the exception as is,
we can't pass is as ZMQ messgae or turn it to json.

and the following failure happens:

Traceback (most recent call last):
  File "/sct/sdcm/tester.py", line 127, in wrapper
    return method(*args, **kwargs)
  File "/sct/sdcm/utils/common.py", line 139, in inner
    res = func(*args, **kwargs)
  File "/sct/sdcm/tester.py", line 287, in setUp
    exception=exc
  File "/sct/sdcm/sct_events.py", line 152, in publish
    EVENTS_PROCESSES['MainDevice'].publish_event(self)
ValueError: Circular reference detected

changed the code to stringify the excption, and pass the traceback as string
also change __str__ function a bit, and added a unittest

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
