### PR TITLE
Default for instance_type_monitor changed to t3.large

### DIFF
--- a/test-cases/manager/manager-regression-multiDC-set-distro.yaml
+++ b/test-cases/manager/manager-regression-multiDC-set-distro.yaml
@@ -2,7 +2,6 @@ stress_cmd: "cassandra-stress write cl=QUORUM n=1200300 -schema 'replication(str
 
 instance_type_db: 'i3.large'
 instance_type_loader: 'c4.large'
-instance_type_monitor: 't3.small'
 
 region_name: 'us-east-1 us-west-2'
 n_db_nodes: '2 1'


### PR DESCRIPTION
new changes on manager requires at least t3.medium to run,
so removing the definition in this test, and using the
default (the existing was t3.small)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
