### PR TITLE
for-3.2: fix event filter in upgrade test

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2890,7 +2890,7 @@ class BaseScyllaCluster(object):  # pylint: disable=too-many-public-methods
     def check_nodes_up_and_normal(self, nodes=None, verification_node=None):
         """Checks via nodetool that node joined the cluster and reached 'UN' state"""
         if not nodes:
-            nodes = self.nodes
+            nodes = self.nodes  # pylint: disable=no-member
         status = self.get_nodetool_status(verification_node=verification_node)
         up_statuses = []
         for node in nodes:

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -921,7 +921,7 @@ class Nemesis(object):  # pylint: disable=too-many-instance-attributes,too-many-
 
         # Wait until all other nodes see the target node as UN
         # Only then we can expect that hint sending started on all nodes
-        def target_node_reported_un_by_others():
+        def target_node_reported_un_by_others():  # pylint: disable=invalid-name
             for node in self.cluster.nodes:
                 if node is not self.target_node:
                     self.cluster.check_nodes_up_and_normal(nodes=[self.target_node], verification_node=node)

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -416,13 +416,12 @@ class UpgradeTest(FillDatabaseData):
         well, upgrade all nodes to new version in the end.
         """
 
-        filter_errors = [{'line': 'Failed to load schema', 'type': 'DATABASE_ERROR'},
-                         {'line': 'Failed to load schema', 'type': 'SCHEMA_FAILURE'},
-                         {'line': 'Failed to pull schema', 'type': 'DATABASE_ERROR'},
-                         {'line': 'Backtrace:', 'type': 'BACKTRACE'}]
-
-        for error in filter_errors:
-            DbEventsFilter(type=error['type'], line=error['line'])
+        # pylint: disable=expression-not-assigned
+        DbEventsFilter(type='RUNTIME_ERROR', line='Failed to load schema'), \
+            DbEventsFilter(type='SCHEMA_FAILURE', line='Failed to load schema'), \
+            DbEventsFilter(type='DATABASE_ERROR', line='Failed to load schema'), \
+            DbEventsFilter(type='DATABASE_ERROR',
+                           line='Failed to pull schema')
 
         # In case the target version >= 3.1 we need to perform test for truncate entries
         target_upgrade_version = self.params.get('target_upgrade_version', default='')


### PR DESCRIPTION
Currently only the last event filter works. This patch moved all events into
one line, then they will all affect. And removed unused Backtrace filter.

This problem doesn't exist in master, so the patch is for sct 3.2

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)

Fixes https://github.com/scylladb/scylla-cluster-tests/issues/1628