### PR TITLE
upgrade: fix wait_for_sstable_upgrade

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -330,8 +330,8 @@ class UpgradeTest(FillDatabaseData):
                     1) for f in all_sstable_files if sstable_version_regex.search(f)}
 
                 assert len(sstable_versions) == 1, "expected all table format to be the same found {}".format(sstable_versions)
-                assert sstable_versions[0] == self.expected_sstable_format_version, "expected to format version to be '{}', found '{}'".format(
-                    self.expected_sstable_format_version, sstable_versions[0])
+                assert list(sstable_versions)[0] == self.expected_sstable_format_version, "expected to format version to be '{}', found '{}'".format(
+                    self.expected_sstable_format_version, list(sstable_versions)[0])
             except Exception as ex:  # pylint: disable=broad-except
                 self.log.warning(ex)
                 return False


### PR DESCRIPTION
Step7 of upgrade always fails, it's caused by code issue.
`sstable_versions` is a set, it doesn't support indexing,
this patch converted it to list.

  WARNING > 'set' object does not support indexing

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
