### PR TITLE
rollingUpgrade: make email_recipients configurable from jenkins

### DIFF
--- a/vars/byoLongevityPipeline.groovy
+++ b/vars/byoLongevityPipeline.groovy
@@ -59,6 +59,10 @@ def call() {
             string(defaultValue: '',
                    description: 'cloud path for RPMs, s3:// or gs://',
                    name: 'update_db_packages')
+
+            string(defaultValue: "${pipelineParams.get('email_recipients', 'qa@scylladb.com')}",
+                   description: 'email recipients of email report',
+                   name: 'email_recipients')
         }
         options {
             timestamps()
@@ -91,6 +95,7 @@ def call() {
                                 // handle params which can be a json list
                                 def aws_region = groovy.json.JsonOutput.toJson(params.aws_region)
                                 def test_config = groovy.json.JsonOutput.toJson(params.test_config)
+                                def email_recipients = groovy.json.JsonOutput.toJson(params.email_recipients)
 
                                 sh """
                                 #!/bin/bash
@@ -121,6 +126,7 @@ def call() {
                                 export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$GIT_BRANCH | sed -E 's+(origin/|origin/branch-)++')
                                 export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$SCT_AMI_ID_DB_SCYLLA_DESC | tr ._ - | cut -c1-8 )
 
+                                export SCT_EMAIL_RECIPIENTS="${email_recipients}"
                                 echo "start test ......."
                                 ./docker/env/hydra.sh run-test ${params.test_name} --backend ${params.backend}  --logdir /sct
                                 echo "end test ....."

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -46,6 +46,11 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('ip_ssh_connections', 'private')}",
                    description: 'private|public|ipv6',
                    name: 'ip_ssh_connections')
+
+            string(defaultValue: "${pipelineParams.get('email_recipients', 'qa@scylladb.com')}",
+                   description: 'email recipients of email report',
+                   name: 'email_recipients')
+
         }
         options {
             timestamps()
@@ -125,7 +130,7 @@ def call(Map pipelineParams) {
                         script {
                             wrap([$class: 'BuildUser']) {
                                 dir('scylla-cluster-tests') {
-                                    def email_recipients = groovy.json.JsonOutput.toJson(pipelineParams.get('email_recipients', 'qa@scylladb.com'))
+                                    def email_recipients = groovy.json.JsonOutput.toJson(params.email_recipients)
 
                                     sh """
                                     #!/bin/bash

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -34,6 +34,9 @@ def call(Map pipelineParams) {
             booleanParam(defaultValue: "${pipelineParams.get('workaround_kernel_bug_for_iotune', false)}",
                  description: 'Workaround a known kernel bug which causes iotune to fail in scylla_io_setup, only effect GCE backend',
                  name: 'workaround_kernel_bug_for_iotune')
+            string(defaultValue: "${pipelineParams.get('email_recipients', 'qa@scylladb.com')}",
+                   description: 'email recipients of email report',
+                   name: 'email_recipients')
         }
         options {
             timestamps()
@@ -46,9 +49,11 @@ def call(Map pipelineParams) {
                 steps {
                     script {
                         def tasks = [:]
+                        def email_recipients = groovy.json.JsonOutput.toJson(params.email_recipients)
 
                         for (version in supportedUpgradeFromVersions(env.GIT_BRANCH, pipelineParams.base_versions)) {
                             def base_version = version;
+
                             tasks["${base_version}"] = {
                                 node(getJenkinsLabels(params.backend, pipelineParams.aws_region)){
                                     withEnv(["AWS_ACCESS_KEY_ID=${env.AWS_ACCESS_KEY_ID}",


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylla-cluster-tests/issues/1634

Sending email fails in upgrade job of 3.2

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
