### PR TITLE
stop_task_threads: fix deadlock in stopping decoding thread

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -960,6 +960,7 @@ class BaseNode():  # pylint: disable=too-many-instance-attributes,too-many-publi
     def stop_task_threads(self, timeout=10):
         if self.termination_event.isSet():
             return
+        self.log.info('Set termination_event')
         self.termination_event.set()
         if self._backtrace_thread:
             self._backtrace_thread.join(timeout)
@@ -973,7 +974,6 @@ class BaseNode():  # pylint: disable=too-many-instance-attributes,too-many-publi
         if self._scylla_manager_journal_thread:
             self.stop_scylla_manager_log_capture(timeout)
         if self._decoding_backtraces_thread:
-            Setup.DECODING_QUEUE.put(None)
             Setup.DECODING_QUEUE.join()
             self._decoding_backtraces_thread.join(timeout)
             self._decoding_backtraces_thread = None
@@ -3096,6 +3096,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods
     def stop_nemesis(self, timeout=10):
         if self.termination_event.isSet():
             return
+        self.log.info('Set termination_event')
         self.termination_event.set()
         for nemesis_thread in self.nemesis_threads:
             nemesis_thread.join(timeout)

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -667,6 +667,7 @@ class AWSNode(cluster.BaseNode):
 
     def stop_task_threads(self, timeout=10):
         if self._spot_aws_termination_task and not self.termination_event.isSet():
+            self.log.info('Set termination_event')
             self.termination_event.set()
             self._spot_aws_termination_task.join(timeout)
         super(AWSNode, self).stop_task_threads(timeout)


### PR DESCRIPTION
Ticket: https://trello.com/c/moOA1HRY/1533-upgrade-test-sct-master-stuck-during-teardown

Currently we try to stop decoding thread by putting 'None' to the queue, but
the decoding thread has been terminated, because we set termination_event at
the beginning of stop_task_threads(). And the 'None' item can't be processed,
which causes the join() of queue stuck forever.

We should stop worker after all tasks in queue are done.


stuck jobs:  the jobs all used sct-master

- https://jenkins.scylladb.com/job/scylla-master/job/rolling-upgrade/job/rolling-upgrade-centos7/31/
- https://jenkins.scylladb.com/job/scylla-master/job/rolling-upgrade/job/rolling-upgrade-centos7/30/
- https://jenkins.scylladb.com/job/scylla-3.2/job/rolling-upgrade/job/rolling-upgrade-debian9/40/
- https://jenkins.scylladb.com/job/scylla-3.2/job/rolling-upgrade/job/rolling-upgrade-debian9/39/
- https://jenkins.scylladb.com/job/scylla-staging/job/amos/job/rolling-upgrade-3.2/job/rolling-upgrade-centos7/7/


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
