### PR TITLE
Revert part of "archive SCT logs to jenkins server (#1377)"

### DIFF
--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -167,10 +167,5 @@ def call(Map pipelineParams) {
                 }
             }
         }
-        post {
-            always {
-                archiveArtifacts artifacts: 'scylla-cluster-tests/latest/**'
-            }
-        }
     }
 }


### PR DESCRIPTION
This reverts part of commit 5b5ffadd59fe9ebe6444d1407b351c96b2737ab7.

Rolling upgrade has multiple parallel tasks running on different
builders, the archiveArtifacts only uploads files from one builder where
we run the pipeline, it's wrong. Let's revert the change of rolling
upgrade.

The archiveArtifacts of longevity works well, we can reserve it.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
