### PR TITLE
fix set_hostname: Remove single quotes from command

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -462,8 +462,8 @@ class AWSNode(cluster.BaseNode):
             self.log.debug('Hostname has been changed succesfully. Apply')
             apply_hostname_change_script = dedent(f"""
                 systemctl restart rsyslog
-                sed -ri 's/127.0.0.1[ \t]+localhost[^\n]*$/127.0.0.1\tlocalhost\t{self.name}/' /etc/hosts
-                grep 'preserve_hostname: true' /etc/cloud/cloud.cfg 1>/dev/null 2>&1 || echo "preserve_hostname: true" >> /etc/cloud/cloud.cfg
+                grep -P "127.0.0.1[^\\\\n]+{self.name}" || sed -ri "s/(127.0.0.1[ \\t]+localhost[^\\n]*)$/\\1\\t{self.name}/" /etc/hosts
+                grep "preserve_hostname: true" /etc/cloud/cloud.cfg 1>/dev/null 2>&1 || echo "preserve_hostname: true" >> /etc/cloud/cloud.cfg
             """)
             self.remoter.run(f"sudo bash -cxe '{apply_hostname_change_script}'")
             self.log.debug('Continue node %s set up', self.name)


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
