### PR TITLE
Fixing pullRequestContainsLabels.groovy for case when no PR associated

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -179,7 +179,7 @@ pipeline {
                                         try {
                                             wrap([$class: 'BuildUser']) {
                                                 dir('scylla-cluster-tests') {
-                                                    runCleanupResource()
+                                                    runCleanupResource(backend)
                                                 }
                                             }
                                         } catch(Exception err) {

--- a/vars/pullRequestContainsLabels.groovy
+++ b/vars/pullRequestContainsLabels.groovy
@@ -1,14 +1,13 @@
 #!groovy
 
 def call(String labels){
-	def tmp = labels.split(',')
-	labels_from_request = pullRequest.labels.join(',')
 	if (!changeRequest()){
 		return false
 	}
+	def labels_to_look_for = labels.split(',')
 	def result = false
 	pullRequest.labels.each {
-		if (tmp.contains(it)){
+		if (labels_to_look_for.contains(it)){
 			result = true
 		}
 	}


### PR DESCRIPTION
https://trello.com/c/z3C7uD2o/1534-fix-issue-with-pullrequestcontainslabelsgroovy
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
