### PR TITLE
Fix pullRequestContainsLabels for case when no PR associated #2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,7 @@ def runCleanupResource(String backend){
 
     export SCT_CONFIG_FILES="test-cases/PR-provision-test.yaml"
     export SCT_CLUSTER_BACKEND="${backend}"
-    export SCT_REGION_NAME="aws-eu-west-1"
+    export SCT_REGION_NAME="eu-west-1"
 
     echo "start clean resources ..."
     ./docker/env/hydra.sh clean-resources --logdir /sct

--- a/vars/pullRequestContainsLabels.groovy
+++ b/vars/pullRequestContainsLabels.groovy
@@ -1,7 +1,7 @@
 #!groovy
 
 def call(String labels){
-	if (!changeRequest()){
+	if (!changeRequest() || !env.CHANGE_ID){
 		return false
 	}
 	def labels_to_look_for = labels.split(',')


### PR DESCRIPTION
Unfortunately due to the lack of ability to test things prior fix (https://github.com/scylladb/scylla-cluster-tests/pull/1700) did not address the issue.

https://trello.com/c/z3C7uD2o/1534-fix-issue-with-pullrequestcontainslabelsgroovy

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
