### PR TITLE
Fix duplicate code in some of the unit-tests

### DIFF
--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -17,6 +17,7 @@ from unit_tests.dummy_remote import DummyRemote
 
 class DummyNode(BaseNode):  # pylint: disable=abstract-method
     _database_log = None
+
     @property
     def private_ip_address(self):
         return '127.0.0.1'
@@ -36,6 +37,9 @@ class DummyNode(BaseNode):  # pylint: disable=abstract-method
     @database_log.setter
     def database_log(self, x):
         self._database_log = x
+
+    def set_hostname(self):
+        pass
 
 
 logging.basicConfig(format="%(asctime)s - %(levelname)-8s - %(name)-10s: %(message)s", level=logging.DEBUG)

--- a/unit_tests/test_decode_backtrace.py
+++ b/unit_tests/test_decode_backtrace.py
@@ -10,38 +10,15 @@ import json
 import queue
 
 
-from sdcm.cluster import BaseNode, Setup
+from sdcm.cluster import Setup
 from sdcm.sct_events import start_events_device, stop_events_device
 from sdcm.sct_events import EVENTS_PROCESSES
 
 from unit_tests.dummy_remote import DummyRemote
+from unit_tests.test_cluster import DummyNode
 
 
-class DummyNode(BaseNode):  # pylint: disable=abstract-method
-    _database_log = None
-
-    @property
-    def private_ip_address(self):
-        return '127.0.0.1'
-
-    @property
-    def public_ip_address(self):
-        return '127.0.0.1'
-
-    def start_task_threads(self):
-        # disable all background threads
-        pass
-
-    def set_hostname(self):
-        pass
-
-    @property
-    def database_log(self):
-        return self._database_log
-
-    @database_log.setter
-    def database_log(self, x):
-        self._database_log = x
+class DecodeDummyNode(DummyNode):  # pylint: disable=abstract-method
 
     def copy_scylla_debug_info(self, node, scylla_debug_file):
         return "scylla_debug_info_file"
@@ -60,12 +37,12 @@ class TestDecodeBactraces(unittest.TestCase):
         cls.temp_dir = tempfile.mkdtemp()
         start_events_device(cls.temp_dir, timeout=5)
 
-        cls.node = DummyNode(name='test_node', parent_cluster=None,
-                             base_logdir=cls.temp_dir, ssh_login_info=dict(key_file='~/.ssh/scylla-test'))
+        cls.node = DecodeDummyNode(name='test_node', parent_cluster=None,
+                                   base_logdir=cls.temp_dir, ssh_login_info=dict(key_file='~/.ssh/scylla-test'))
         cls.node.remoter = DummyRemote()
 
-        cls.monitor_node = DummyNode(name='test_monitor_node', parent_cluster=None,
-                                     base_logdir=cls.temp_dir, ssh_login_info=dict(key_file='~/.ssh/scylla-test'))
+        cls.monitor_node = DecodeDummyNode(name='test_monitor_node', parent_cluster=None,
+                                           base_logdir=cls.temp_dir, ssh_login_info=dict(key_file='~/.ssh/scylla-test'))
         cls.monitor_node.remoter = DummyRemote()
 
     @classmethod

--- a/unit_tests/test_utils_version.py
+++ b/unit_tests/test_utils_version.py
@@ -4,8 +4,7 @@ import random
 from unittest import TestCase
 import logging
 
-from sdcm.utils.common import version
-
+from sdcm.utils.common import version, MethodVersionNotFound
 # pylint: disable=function-redefined
 
 
@@ -65,7 +64,6 @@ class TestUtilsVersionDecorator(TestCase):
         self.assertRaises(AttributeError, vclass.setup)
 
     def test_version_not_found(self):
-        from sdcm.utils.common import MethodVersionNotFound
         vclass = VersionedClass("1")
         self.assertRaises(MethodVersionNotFound, vclass.setup)
 


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
