### PR TITLE
pipeline: remove repeat define of email_recipients

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -288,6 +288,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             credentials = self.db_cluster.get_db_auth()
             username, password = credentials if credentials else (None, None)
             with self.cql_connection_patient(node, user=username, password=password) as session:
+                # pylint: disable=no-member
                 session.execute("ALTER KEYSPACE system_auth WITH replication = "
                                 "{'class': 'org.apache.cassandra.locator.SimpleStrategy', "
                                 "'replication_factor': %s};" % system_auth_rf)

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -49,7 +49,6 @@ def call(Map pipelineParams) {
                 steps {
                     script {
                         def tasks = [:]
-                        def email_recipients = groovy.json.JsonOutput.toJson(params.email_recipients)
 
                         for (version in supportedUpgradeFromVersions(env.GIT_BRANCH, pipelineParams.base_versions)) {
                             def base_version = version;


### PR DESCRIPTION
Commit a3b0d49 added a repeat define of
email_recipients to vars/rollingUpgradePipeline.groovy, which we expected to
removed by commit f32edde

Job error:

```
01:55:58  org.jenkinsci.plugins.workflow.cps.CpsCompilationErrorsException: startup failed:
01:55:58  /var/lib/jenkins/jobs/scylla-3.2/jobs/rolling-upgrade/jobs/rolling-upgrade-centos7/builds/67/libs/sct/vars/rollingUpgradePipeline.groovy: 145: The current scope already contains a variable of the name email_recipients
01:55:58   @ line 145, column 49.
01:55:58                               def email_reci
01:55:58                                   ^
01:55:58  
01:55:58  1 error
```


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
