### PR TITLE
Fix error during hydra collect-log for monitoring

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3714,11 +3714,14 @@ class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-inst
         self.phantomjs_installed = False
         self.grafana_start_time = 0
 
+    @staticmethod
+    def get_monitor_install_path_base(node):
+        return node.remoter.run("echo $HOME").stdout.strip()
+
     @property
     def monitor_install_path_base(self):
         if not self._monitor_install_path_base:
-            self._monitor_install_path_base = self.nodes[0].remoter.run(
-                "echo $HOME").stdout.strip()
+            self._monitor_install_path_base = self.get_monitor_install_path_base(self.nodes[0])
         return self._monitor_install_path_base
 
     @property

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -188,7 +188,7 @@ class PrometheusSnapshots(BaseLogEntity):
     def setup_monitor_data_dir(self, node):
         if self.monitoring_data_dir:
             return
-        base_dir = node.parent_cluster.monitor_install_path_base
+        base_dir = MonitoringStack.get_monitoring_base_dir(node)
 
         self.monitoring_data_dir = os.path.join(base_dir, self.monitoring_data_dir_name)
 
@@ -220,7 +220,12 @@ class MonitoringStack(BaseLogEntity):
 
     @staticmethod
     def get_monitoring_base_dir(node):
-        return node.parent_cluster.monitor_install_path_base
+        # Avoid cyclic dependencies
+        from sdcm.cluster import BaseMonitorSet
+        if hasattr(node, "parent_cluster") and node.parent_cluster:
+            return node.parent_cluster.monitor_install_path_base
+        else:
+            return BaseMonitorSet.get_monitor_install_path_base(node)
 
     def get_monitoring_data_stack(self, node, local_dist):
         monitor_base_dir = self.get_monitoring_base_dir(node)


### PR DESCRIPTION
During hydra collect-log for monitoring node, error happened:
Error occured during collecting on host: abykov-gemini-staging-abykov-monitor-node-098e3319-1
'CollectingNode' object has no attribute 'parent_cluster'

This happened because of hydra collect-log running independently from sct run
and logcollector doesn't now anything about parent cluster

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
