### PR TITLE
Move remotecmdrunner out of class initialization to __init__

### DIFF
--- a/unit_tests/test_manual.py
+++ b/unit_tests/test_manual.py
@@ -19,7 +19,7 @@ from sdcm.ycsb_thread import YcsbStressThread
 logging.basicConfig(format="%(asctime)s - %(levelname)-8s - %(name)-10s: %(message)s", level=logging.DEBUG)
 
 
-class Node():  # pylint: disable=no-init,too-few-public-methods
+class Node:  # pylint: disable=no-init,too-few-public-methods
     ssh_login_info = {'hostname': '34.253.205.91',
                       'user': 'centos',
                       'key_file': '~/.ssh/scylla-qa-ec2'}
@@ -29,18 +29,20 @@ class Node():  # pylint: disable=no-init,too-few-public-methods
     cassandra_stress_version = '3.11'
 
 
-class DbNode():  # pylint: disable=no-init,too-few-public-methods
+class DbNode:  # pylint: disable=no-init,too-few-public-methods
     ip_address = "34.244.157.61"
     dc_idx = 1
 
 
-class LoaderSetDummy():  # pylint: disable=no-init,too-few-public-methods
+class LoaderSetDummy:  # pylint: disable=no-init,too-few-public-methods
+    def __init__(self):
+        self.nodes = [Node()]
+
     @staticmethod
     def get_db_auth():
         return None
 
     name = 'LoaderSetDummy'
-    nodes = [Node()]
 
 
 @unittest.skip("manual tests")


### PR DESCRIPTION
https://trello.com/c/SmFuBR88/1459-fix-ssh-protocal-banner-error-in-unit-tests

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
