### PR TITLE
Improved the fix that fixes an sctool output string

### DIFF
--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -787,7 +787,7 @@ class SCTool():
             raise ScyllaManagerError("Encountered an error on sctool command: {}: {}".format(cmd, ex))
 
         if replace_broken_unicode_values:
-            res.stdout = res.stdout.replace('���', '│')
+            res.stdout = self.replace_broken_unicode_values(res.stdout)
             # Minor band-aid to fix a unique error with the output of some sctool command
             # (So far - specifically cluster status)
 
@@ -800,6 +800,21 @@ class SCTool():
                 return dict_res_tables
         LOGGER.debug('sctool res after parsing: %s', str(res))
         return res
+
+    @staticmethod
+    def replace_chars_with_line_character(string, chars_to_replace_index_range):
+        replaced_string = string[:chars_to_replace_index_range[0]] + '│' + string[chars_to_replace_index_range[1] + 1:]
+        return replaced_string
+
+    def replace_broken_unicode_values(self, string):
+        while string.find("�") != -1:
+            first_broken_char_index = string.find("�")
+            for index in range(first_broken_char_index + 1, len(string)):
+                if string[index] != "�":
+                    break
+            broken_character_index_range = [first_broken_char_index, index - 1]
+            string = self.replace_chars_with_line_character(string, broken_character_index_range)
+        return string
 
     @staticmethod
     def parse_result_table(res):


### PR DESCRIPTION
when the unicode values break

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
