### PR TITLE
perf-regression-user-profiles.yaml: fix wrong path to user profiles

### DIFF
--- a/test-cases/performance/perf-regression-user-profiles.yaml
+++ b/test-cases/performance/perf-regression-user-profiles.yaml
@@ -16,23 +16,20 @@ space_node_threshold: 644245094
 
 cs_duration: '60m'
 cs_user_profiles:
-    - cust_a/analytics/counters.yaml
-    - cust_a/analytics/timeseries.yaml
-    - cust_a/features/doc1.yaml
-    - cust_a/offline/ctrs.yaml
-    - cust_a/online/doc1.yaml
-    - cust_a/online/doc2.yaml
-    - cust_a/online/doc3.yaml
-    - cust_a/users/users1.yaml
-    - cust_a/users/users2.yaml
-    - cust_b/events.yaml
-    - cust_c/group.yaml
-    - cust_d/short.yaml
-    - cust_e/events.yaml
-    - cust_s/case1.yaml
-    - cust_s/case2.yaml
+    - scylla-qa-internal/cust_a/analytics/counters.yaml
+    - scylla-qa-internal/cust_a/analytics/timeseries.yaml
+    - scylla-qa-internal/cust_a/features/doc1.yaml
+    - scylla-qa-internal/cust_a/offline/ctrs.yaml
+    - scylla-qa-internal/cust_a/online/doc1.yaml
+    - scylla-qa-internal/cust_a/online/doc2.yaml
+    - scylla-qa-internal/cust_a/online/doc3.yaml
+    - scylla-qa-internal/cust_a/users/users1.yaml
+    - scylla-qa-internal/cust_a/users/users2.yaml
+    - scylla-qa-internal/cust_b/events.yaml
+    - scylla-qa-internal/cust_c/group.yaml
+    - scylla-qa-internal/cust_d/short.yaml
+    - scylla-qa-internal/cust_e/events.yaml
+    - scylla-qa-internal/cust_s/case1.yaml
+    - scylla-qa-internal/cust_s/case2.yaml
 
 append_scylla_args: '--blocked-reactor-notify-ms 4'
-
-send_email: true
-email_recipients: ['roy@scylladb.com', 'bentsi@scylladb.com']


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
