### PR TITLE
Fix error messages during clean resources

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1399,6 +1399,9 @@ def clean_aws_instances_according_post_behavior(params, config, logdir):  # pyli
     def apply_action(instances, action):
         if action == 'destroy':
             instances_ids = [instance['InstanceId'] for instance in instances]
+            if not instances_ids:
+                LOGGER.warning("No InstanceId found for termination")
+                return
             LOGGER.info('Clean next instances %s', instances_ids)
             try:
                 client.terminate_instances(InstanceIds=instances_ids)


### PR DESCRIPTION
Trello: https://trello.com/c/pYix6AY7
Added check, that instance_ids list is not empty
for filtered instances for next termination

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
