### PR TITLE
Fixing broken longevity pipeline

### DIFF
--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -52,6 +52,22 @@ def call(Map pipelineParams) {
                    description: 'email recipients of email report',
                    name: 'email_recipients')
 
+            string(defaultValue: "${pipelineParams.get('ami_id_monitor', '')}",
+                   description: 'AMI ID of monitor node',
+                   name: 'ami_id_monitor')
+
+            string(defaultValue: "${pipelineParams.get('ami_monitor_user', '')}",
+                   description: 'user for monitor node',
+                   name: 'ami_monitor_user')
+
+            string(defaultValue: "${pipelineParams.get('scylla_mgmt_agent_repo', '')}",
+                   description: 'manager agent repo',
+                   name: 'scylla_mgmt_agent_repo')
+
+            string(defaultValue: "${pipelineParams.get('scylla_repo_m', '')}",
+                   description: 'backend scylla repo for manager',
+                   name: 'scylla_repo_m')
+
         }
         options {
             timestamps()


### PR DESCRIPTION
broken due to adding parameters partially

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
