### PR TITLE
start_scylla_server: adjust wait_db_up timeout to 500 seconds

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2207,7 +2207,7 @@ server_encryption_options:
         else:
             self.remoter.run('sudo systemctl restart scylla-manager.service')
 
-    def start_scylla_server(self, verify_up=True, verify_down=False, timeout=300):
+    def start_scylla_server(self, verify_up=True, verify_down=False, timeout=300, verify_up_timeout=300):
         if verify_down:
             self.wait_db_down(timeout=timeout)
         if not self.is_ubuntu14():
@@ -2215,9 +2215,9 @@ server_encryption_options:
         else:
             self.remoter.run('sudo service scylla-server start', timeout=timeout)
         if verify_up:
-            self.wait_db_up(timeout=timeout)
+            self.wait_db_up(timeout=verify_up_timeout)
 
-    def start_scylla_jmx(self, verify_up=True, verify_down=False, timeout=300):
+    def start_scylla_jmx(self, verify_up=True, verify_down=False, timeout=300, verify_up_timeout=300):
         if verify_down:
             self.wait_jmx_down(timeout=timeout)
         if not self.is_ubuntu14():
@@ -2225,7 +2225,7 @@ server_encryption_options:
         else:
             self.remoter.run('sudo service scylla-jmx start', timeout=timeout)
         if verify_up:
-            self.wait_jmx_up(timeout=timeout)
+            self.wait_jmx_up(timeout=verify_up_timeout)
 
     @log_run_info
     def start_scylla(self, verify_up=True, verify_down=False, timeout=300):

--- a/sdcm/docker.py
+++ b/sdcm/docker.py
@@ -96,12 +96,12 @@ class DockerNode(cluster.BaseNode):  # pylint: disable=abstract-method
         force_param = '-f' if force else ''
         _cmd('rm {} -v {}'.format(force_param, self.name))
 
-    def start_scylla_server(self, verify_up=True, verify_down=False, timeout=300):
+    def start_scylla_server(self, verify_up=True, verify_down=False, timeout=300, verify_up_timeout=300):
         if verify_down:
             self.wait_db_down(timeout=timeout)
         self.remoter.run('supervisorctl start scylla', timeout=timeout)
         if verify_up:
-            self.wait_db_up(timeout=timeout)
+            self.wait_db_up(timeout=verify_up_timeout)
 
     @cluster.log_run_info
     def start_scylla(self, verify_up=True, verify_down=False, timeout=300):

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -202,7 +202,9 @@ class UpgradeTest(FillDatabaseData):
             node.remoter.run("echo 'authorizer: \"%s\"' |sudo tee --append /etc/scylla/scylla.yaml" %
                              authorization_in_upgrade)
         check_reload_systemd_config(node)
-        node.start_scylla_server()
+        # Current default 300s aren't enough for upgrade test of Debian 9.
+        # Related issue: https://github.com/scylladb/scylla-cluster-tests/issues/1726
+        node.start_scylla_server(verify_up_timeout=500)
         result = node.remoter.run('scylla --version')
         new_ver = result.stdout
         assert self.orig_ver != self.new_ver, "scylla-server version isn't changed"
@@ -286,7 +288,9 @@ class UpgradeTest(FillDatabaseData):
                 r'sudo sed -i -e "s/enable_3_1_0_compatibility_mode:/#enable_3_1_0_compatibility_mode:/g" /etc/scylla/scylla.yaml')
         if self.params.get('remove_authorization_in_rollback', default=None):
             node.remoter.run('sudo sed -i -e "s/authorizer:/#authorizer:/g" /etc/scylla/scylla.yaml')
-        node.start_scylla_server()
+        # Current default 300s aren't enough for upgrade test of Debian 9.
+        # Related issue: https://github.com/scylladb/scylla-cluster-tests/issues/1726
+        node.start_scylla_server(verify_up_timeout=500)
         result = node.remoter.run('scylla --version')
         new_ver = result.stdout
         self.log.info('original scylla-server version is %s, latest: %s', orig_ver, new_ver)

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -203,7 +203,6 @@ class UpgradeTest(FillDatabaseData):
                              authorization_in_upgrade)
         check_reload_systemd_config(node)
         node.start_scylla_server()
-        node.wait_db_up(verbose=True)
         result = node.remoter.run('scylla --version')
         new_ver = result.stdout
         assert self.orig_ver != self.new_ver, "scylla-server version isn't changed"


### PR DESCRIPTION
The default timeout in start_scylla_server() is 300 seconds, it's not
enough in upgrade test, some new Debian nodes take about 345 seconds to
get ready.

Fixes https://github.com/scylladb/scylla-cluster-tests/issues/1726

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
