### PR TITLE
Remove scylla debug files from builders after decode backtraces finished

### DIFF
--- a/unit_tests/test_decode_backtrace.py
+++ b/unit_tests/test_decode_backtrace.py
@@ -20,7 +20,7 @@ from unit_tests.test_cluster import DummyNode
 
 class DecodeDummyNode(DummyNode):  # pylint: disable=abstract-method
 
-    def copy_scylla_debug_info(self, node, scylla_debug_file):
+    def copy_scylla_debug_info(self, node, debug_file):
         return "scylla_debug_info_file"
 
     def get_scylla_debuginfo_file(self):


### PR DESCRIPTION
Trello: https://trello.com/c/4O0a3RsI
    Remove scylla debug files from builders after decode backtraces finished
    
    When decode backtrace enabled, the scylla bin debug file downloaded
    from node to node folder on builder and them uploaded to monitor node.
    This procedur could happened for each node, and could eat all place on builder.
    
    After fix, scylla debug file will be downloaded from one node to cluster db-set folder
    one time, and during stopping threads will be cleaned.


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
