### PR TITLE
Replace 'hinted_handoff_disabled' param to 'hinted_handoff' in 2mv-backpressure-4d.yaml

### DIFF
--- a/test-cases/features/2mv-backpressure-4d.yaml
+++ b/test-cases/features/2mv-backpressure-4d.yaml
@@ -14,4 +14,4 @@ instance_type_loader: 'c5.2xlarge'
 
 nemesis_during_prepare: false
 
-hinted_handoff_disabled: true
+hinted_handoff: 'disabled'


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)

The parameter "hinted_handoff_disabled" was replaced with "hinted_handoff". But the 2mv-backpressure-4d.yaml was not updated. Change it now