### PR TITLE
Removed one more time wrong scylla_mgmt_agent_repo

### DIFF
--- a/jenkins-pipelines/manager/ubuntu16-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu16-manager-sanity.jenkinsfile
@@ -13,7 +13,6 @@ longevityPipeline(
     test_config: 'test-cases/manager/manager-regression-multiDC-set-distro.yaml',
     ami_id_monitor: 'ami-092d0d014b7b31a08', // Canonical, Ubuntu, 16.04 LTS, amd64 xenial image build on 2019-02-12
     ami_monitor_user: 'ubuntu',
-    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/branch-2.0/24/scylla-manager.repo',
     scylla_repo_m: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-2019.1-xenial.list',
 
     timeout: [time: 500, unit: 'MINUTES'],

--- a/jenkins-pipelines/manager/ubuntu18-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu18-manager-sanity.jenkinsfile
@@ -13,7 +13,6 @@ longevityPipeline(
     test_config: 'test-cases/manager/manager-regression-multiDC-set-distro.yaml',
     ami_id_monitor: 'ami-08b314ce48a790a19', // Canonical, Ubuntu, 18.04 LTS, amd64 bionic image build on 2019-07-22
     ami_monitor_user: 'ubuntu',
-    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/branch-2.0/24/scylla-manager.repo',
     scylla_repo_m: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-2019.1-bionic.list',
 
     timeout: [time: 500, unit: 'MINUTES'],


### PR DESCRIPTION
It appeared in the ubuntu16 and ubuntu18 jenkinsfiles.
It must be passed when trigger calls the job, or entered
manually. If the latest will be fixed, it could be added
back in the future.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
