### PR TITLE
Added a flag named store_perf_results

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -49,6 +49,7 @@ backtrace_decoding: true
 
 logs_transport: "rsyslog"
 
+store_perf_results: false
 send_email: false
 email_recipients: ['qa@scylladb.com']
 

--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -549,7 +549,8 @@ class TestStatsMixin(Stats):
             self._stats['test_details']['time_completed'] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
             if self.monitors and self.monitors.nodes:
                 test_start_time = self._stats['test_details']['start_time']
-                update_data['results'] = self.get_prometheus_stats()
+                if self.params.get('store_perf_results'):
+                    update_data['results'] = self.get_prometheus_stats()
                 grafana_dataset = self.monitors.get_grafana_screenshot_and_snapshot(test_start_time)
                 self._stats['test_details']['grafana_screenshots'] = grafana_dataset.get('screenshots', [])
                 self._stats['test_details']['grafana_snapshots'] = grafana_dataset.get('snapshots', [])

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -790,6 +790,10 @@ class SCTConfiguration(dict):
 
         dict(name="loader_swap_size", env="SCT_LOADER_SWAP_SIZE", type=int,
              help="Swap file size in bytes calculated by x * 1MB"),
+
+        dict(name="store_perf_results", env="SCT_STORE_PERF_RESULTS", type=bool,
+             help="""A flag that indicates whether or not to gather the prometheus stats at the end of the run.
+                Intended to be used in performance testing"""),
     ]
 
     required_params = ['cluster_backend', 'test_duration', 'n_db_nodes', 'n_loaders', 'user_credentials_path']

--- a/test-cases/performance/perf-regression-2mv.yaml
+++ b/test-cases/performance/perf-regression-2mv.yaml
@@ -19,5 +19,6 @@ instance_type_monitor: 't3.small'
 
 user_prefix: 'perf-regression-mv'
 
+store_perf_results: true
 send_email: true
 email_recipients: ['roy@scylladb.com', 'bentsi@scylladb.com']

--- a/test-cases/performance/perf-regression-latency-1TB.yaml
+++ b/test-cases/performance/perf-regression-latency-1TB.yaml
@@ -23,5 +23,6 @@ space_node_threshold: 644245094
 round_robin: true
 append_scylla_args: '--blocked-reactor-notify-ms 4'
 
+store_perf_results: true
 send_email: true
 email_recipients: ['qa@scylladb.com', 'rnd-internal@scylladb.com']

--- a/test-cases/performance/perf-regression-latency-500gb-30min.yaml
+++ b/test-cases/performance/perf-regression-latency-500gb-30min.yaml
@@ -23,5 +23,6 @@ ami_id_db_scylla_desc: 'VERSION_DESC'
 round_robin: true
 append_scylla_args: '--blocked-reactor-notify-ms 4'
 
+store_perf_results: true
 send_email: true
 email_recipients: ['qa@scylladb.com', 'rnd-internal@scylladb.com']

--- a/test-cases/performance/perf-regression-latency-in-memory.yaml
+++ b/test-cases/performance/perf-regression-latency-in-memory.yaml
@@ -25,5 +25,6 @@ user_prefix: 'perf-regression-latency-in-memory'
 # 80GB in-memory storage - 36GB table is 45% of total in-memory store
 append_scylla_args: "--in-memory-storage-size-mb 80000 --blocked-reactor-notify-ms 4"
 
+store_perf_results: true
 send_email: true
 email_recipients: ['qa@scylladb.com', 'rnd-internal@scylladb.com']

--- a/test-cases/performance/perf-regression-user-profiles.yaml
+++ b/test-cases/performance/perf-regression-user-profiles.yaml
@@ -32,4 +32,5 @@ cs_user_profiles:
     - scylla-qa-internal/cust_s/case1.yaml
     - scylla-qa-internal/cust_s/case2.yaml
 
+store_perf_results: true
 append_scylla_args: '--blocked-reactor-notify-ms 4'

--- a/test-cases/performance/perf-regression.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys.yaml
@@ -16,5 +16,6 @@ instance_type_monitor: 't3.small'
 user_prefix: 'perf-regression'
 space_node_threshold: 644245094
 
+store_perf_results: true
 send_email: true
 email_recipients: ['qa@scylladb.com', 'rnd-internal@scylladb.com']

--- a/test-cases/performance/perf-row-level-repair-1TB.yaml
+++ b/test-cases/performance/perf-row-level-repair-1TB.yaml
@@ -22,4 +22,5 @@ pre_create_schema: True
 round_robin: 'true'
 append_scylla_args: '--blocked-reactor-notify-ms 50'
 
+store_perf_results: true
 send_email: 'true'


### PR DESCRIPTION
that indicates whether or not he prometheus stats will be gathered at the end of the run.

Its default value is false, and in all of the performance test cases its value is true.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
