### PR TITLE
debian9-sanity for manager

### DIFF
--- a/jenkins-pipelines/manager/debian9-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/debian9-manager-sanity.jenkinsfile
@@ -1,0 +1,22 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    params: params,
+
+    backend: 'aws',
+    ip_ssh_connections: 'public',
+    aws_region: '''["us-east-1", "us-west-2"]''',
+    test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
+    test_config: 'test-cases/manager/manager-regression-multiDC-set-distro.yaml',
+    ami_id_monitor: 'ami-0cfac3931b2a799d1', // Debian stretch image
+    ami_monitor_user: 'admin',
+    scylla_repo_m: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/debian/scylla-2019.1-stretch.list',
+
+    timeout: [time: 500, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'keep-on-failure'
+)

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -455,6 +455,9 @@ class AWSNode(cluster.BaseNode):
     def set_hostname(self):
         self.log.info('Changing hostname to %s', self.name)
         # Using https://aws.amazon.com/premiumsupport/knowledge-center/linux-static-hostname-rhel7-centos7/
+        # FIXME: workaround to avoid host rename generating errors on other commands
+        if self.is_debian():
+            return
         result = self.remoter.run(f"sudo hostnamectl set-hostname --static {self.name}", ignore_status=True)
         if result.ok:
             self.log.debug('Hostname has been changed succesfully. Apply')


### PR DESCRIPTION
added support to run manager on debian9

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
