### PR TITLE
Fix issue #1733: missing key events_summary for jinja template

### DIFF
--- a/sdcm/send_email.py
+++ b/sdcm/send_email.py
@@ -225,7 +225,7 @@ class LongevityEmailReporter(BaseEmailReporter):
               'build_url', 'scylla_version', 'scylla_ami_id',
               'scylla_instance_type', 'number_of_db_nodes',
               'nemesis_name', 'nemesis_details', 'test_id',
-              'username', 'nodes']
+              'username', 'nodes', 'events_summary']
 
     def cut_report_data(self, report_data, attachments_data, reason):
         if ['test_status'] in attachments_data and len(attachments_data['test_status']) > 2 and len(
@@ -259,7 +259,7 @@ class GeminiEmailReporter(BaseEmailReporter):
               "results", "status", 'test_name', 'test_id', 'test_status',
               'start_time', 'end_time', 'username',
               'build_url', 'nemesis_name', 'nemesis_details',
-              'test_id', 'nodes']
+              'test_id', 'nodes', 'events_summary']
 
     def build_report(self, report_data, template_str=None):
         self.log.info('Prepare result to send in email')
@@ -274,7 +274,7 @@ class UpgradeEmailReporter(BaseEmailReporter):
               'scylla_instance_type', 'number_of_db_nodes',
               "results", "status", 'test_name', 'test_id', 'test_status',
               'start_time', 'end_time', 'username',
-              'build_url', 'test_id', 'nodes']
+              'build_url', 'test_id', 'nodes', 'events_summary']
 
     def build_report(self, report_data, template_str=None):
         self.log.info('Prepare result to send in email')


### PR DESCRIPTION
For each EmailReporter type currently we should define in class property
the list of jinja template pattern.
New events_summary was missed in list of patterns.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
