### PR TITLE
Fix issue #1741

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -366,6 +366,7 @@ class BaseNode():  # pylint: disable=too-many-instance-attributes,too-many-publi
         self._init_system = None
         self.db_init_finished = False
 
+        self._distro = None
         self._short_hostname = None
         self._alert_manager = None
 
@@ -402,7 +403,7 @@ class BaseNode():  # pylint: disable=too-many-instance-attributes,too-many-publi
         self.scylla_version = ''
         self._is_enterprise = None
         self.replacement_node_ip = None  # if node is a replacement for a dead node, store dead node private ip here
-        self._distro = None
+
         self._kernel_version = None
         self._cassandra_stress_version = None
         self.lock = threading.Lock()


### PR DESCRIPTION
Fix for issue #1741, requesting object attribute before its initialization

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
