### PR TITLE
Fix failing test_parallelobject.py

### DIFF
--- a/unit_tests/test_parallelobject.py
+++ b/unit_tests/test_parallelobject.py
@@ -89,7 +89,7 @@ class ParallelObjectTester(unittest.TestCase):
 
     def test_raised_exception_by_timeout(self):
         with self.assertRaises(concurrent.futures.TimeoutError):
-            parallel_object = ParallelObject(self.rand_timeouts, timeout=10, num_workers=len(self.rand_timeouts))
+            parallel_object = ParallelObject(self.rand_timeouts, timeout=9, num_workers=len(self.rand_timeouts))
             parallel_object.run(dummy_func_return_tuple)
 
     def test_exception_raised_in_thread_by_func(self):
@@ -109,7 +109,7 @@ class ParallelObjectTester(unittest.TestCase):
                 self.assertListEqual(res_obj.result, "done")
 
     def test_ignore_exception_by_timeout(self):
-        parallel_object = ParallelObject(self.rand_timeouts, timeout=10, num_workers=len(self.rand_timeouts))
+        parallel_object = ParallelObject(self.rand_timeouts, timeout=9, num_workers=len(self.rand_timeouts))
         results = parallel_object.run(dummy_func_return_tuple, ignore_exceptions=True)
         for res_obj in results:
             if res_obj.exc:


### PR DESCRIPTION
https://trello.com/c/Zucx8SQs/1597-fix-intermitenly-failing-testparallelobjectpy
Idea aroun this fix is that ParallelObject run commands and only than waits for them:
            for obj in self.objects:
                if isinstance(obj, (list, tuple)):
                    futures.append(pool.submit(func, *obj))
                elif isinstance(obj, dict):
                    futures.append(pool.submit(func, **obj))
                else:
                    futures.append(pool.submit(func, obj))

            for future in futures:
                try:
                    result = future.result(self.timeout)

So having 10 seconds timeout creates small possibility of test to tail. 

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
