### PR TITLE
Fixed manager ubuntu16-sanity

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3858,7 +3858,6 @@ class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-inst
                 apt-get update
                 apt-get install -y python3.6 python3.6-dev
                 apt-get install -y python-setuptools unzip wget
-                update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1
                 apt install -y python3-pip
                 python3 -m pip install --upgrade pip
                 python3 -m pip install pyyaml
@@ -3898,6 +3897,8 @@ class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-inst
             unzip {0.monitor_branch}.zip
         """.format(self))
         node.remoter.run("bash -ce '%s'" % install_script)
+        if node.is_ubuntu():
+            node.remoter.run(f'sed -i "s/python3/python3.6/g" {self.monitor_install_path}/*.py')
 
     def configure_scylla_monitoring(self, node, sct_metrics=True, alert_manager=True):  # pylint: disable=too-many-locals
         cloud_prom_bearer_token = self.params.get('cloud_prom_bearer_token')


### PR DESCRIPTION
if was failing, as the code changed the default python3
and were failing to use apt_pkg, that was dependent
on the previous python3 (python3.5) instead python3.6
that the monitoring packages require.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
