### PR TITLE
Hide StartupTestEvent from logs

### DIFF
--- a/sdcm/sct_events.py
+++ b/sdcm/sct_events.py
@@ -200,14 +200,14 @@ class SctEvent():
         return self.__dict__ == other.__dict__
 
 
-class StartupTestEvent(SctEvent):
-    def __init__(self):
-        super().__init__()
-        self.severity = Severity.WARNING
-
-
 class SystemEvent(SctEvent):
     pass
+
+
+class StartupTestEvent(SystemEvent):
+    def __init__(self):
+        super().__init__()
+        self.severity = Severity.NORMAL
 
 
 class TestFrameworkEvent(SctEvent):  # pylint: disable=too-many-instance-attributes


### PR DESCRIPTION
https://trello.com/c/im4nQhMX/1602-set-log-level-of-startuptestevent-to-debug

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
