### PR TITLE
Remove duplicated string '-autossh' from container name

### DIFF
--- a/sdcm/auto_ssh.py
+++ b/sdcm/auto_ssh.py
@@ -38,12 +38,12 @@ def start_auto_ssh(docker_name, node, local_port, remote_port, ssh_mode="-R"):
            -e AUTOSSH_GATETIME=0 \
            -v {key_path}:/id_rsa  \
            --restart always \
-           --name {container_name}-autossh jnovack/autossh
+           --name {container_name} jnovack/autossh
        '''.format(container_name=container_name, user_name=user_name, ssh_mode=ssh_mode, local_port=local_port,
                   remote_port=remote_port, key_path=key_path, host_name=host_name))
 
     atexit.register(stop_auto_ssh, docker_name, node)
-    LOGGER.debug('{container_name}-autossh {res.stdout}'.format(container_name=container_name, res=res))
+    LOGGER.debug('{container_name} {res.stdout}'.format(container_name=container_name, res=res))
 
 
 def stop_auto_ssh(docker_name, node):


### PR DESCRIPTION
Small fix for fix :)
https://github.com/scylladb/scylla-cluster-tests/pull/1747

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
