### PR TITLE
Verify if stress commands have all files to be executed

### DIFF
--- a/internal_test_data/stress_cmd_with_bad_profile.yaml
+++ b/internal_test_data/stress_cmd_with_bad_profile.yaml
@@ -1,0 +1,10 @@
+test_duration: 5
+
+n_db_nodes: 3
+n_loaders: 1
+n_monitor_nodes: 1
+user_prefix: 'fruch-testing'
+db_type: scylla
+instance_type_db: 'i3.large'
+ami_id_db_scylla: 'ami-b4f8b4cb'
+stress_cmd: ["cassandra-stress user profile=/tmp/1232123123123123123.yaml ops'(insert=100)' no-warmup cl=ONE duration=10m -port jmx=6868 -mode cql3 native -rate threads=3000 -errors ignore"]

--- a/sct.py
+++ b/sct.py
@@ -283,6 +283,7 @@ def conf(config_file, backend):
     config = SCTConfiguration()
     try:
         config.verify_configuration()
+        config.check_required_files()
     except Exception as ex:  # pylint: disable=broad-except
         click.secho(str(ex), fg='red')
         sys.exit(1)

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -139,6 +139,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         self.status = "RUNNING"
         self.params = SCTConfiguration()
         self.params.verify_configuration()
+        self.params.check_required_files()
         reuse_cluster_id = self.params.get('reuse_cluster', default=False)
         if reuse_cluster_id:
             cluster.Setup.reuse_cluster(True)


### PR DESCRIPTION
https://trello.com/c/iHuKBX0F/1565-verify-that-userprofile-file-exist-before-the-tests-starts-and-resources-provisioned

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
