### PR TITLE
feature(cloud_monitor): separating QA instances from others

### DIFF
--- a/sdcm/keystore.py
+++ b/sdcm/keystore.py
@@ -30,6 +30,9 @@ class KeyStore():
     def get_scylladb_upload_credentials(self):
         return self._get_json("scylladb_upload.json")
 
+    def get_qa_users(self):
+        return self._get_json("qa_users.json")
+
     def get_qa_ssh_keys(self):
         # TODO
         pass

--- a/sdcm/utils/cloud_monitor/cloud_monitor.py
+++ b/sdcm/utils/cloud_monitor/cloud_monitor.py
@@ -6,7 +6,6 @@ from sdcm.utils.cloud_monitor.report import GeneralReport, DetailedReport
 
 
 LOGGER = getLogger(__name__)
-CLOUD_PROVIDERS = ("aws", "gce")
 
 
 class CloudInstance:  # pylint: disable=too-few-public-methods,too-many-instance-attributes
@@ -22,9 +21,10 @@ class CloudInstance:  # pylint: disable=too-few-public-methods,too-many-instance
 
 
 class CloudInstances:
+    CLOUD_PROVIDERS = ("aws", "gce")
 
     def __init__(self):
-        self.instances = {prov: [] for prov in CLOUD_PROVIDERS}
+        self.instances = {prov: [] for prov in self.CLOUD_PROVIDERS}
         self.all_instances = []
         self.get_all()
 

--- a/sdcm/utils/cloud_monitor/templates/cloud_resources.html
+++ b/sdcm/utils/cloud_monitor/templates/cloud_resources.html
@@ -1,10 +1,10 @@
-    <h3>Cloud resources</h3>
+    <h3>Cloud resources summary</h3>
 
     <table id="results_table">
         <tr>
             <th>Cloud</th>
-            <th>Running</th>
-            <th>Stopped</th>
+            <th>Instances running</th>
+            <th>Instances stopped</th>
         </tr>
         {% for cloud_provider in report %}
         <tr>

--- a/sdcm/utils/cloud_monitor/templates/per_user_summary.html
+++ b/sdcm/utils/cloud_monitor/templates/per_user_summary.html
@@ -1,17 +1,21 @@
-    <h3>Per user report</h3>
+    {% for user_type, user_report in report.results.items() %}
+    <h3>Instances used by {{ user_type.upper() }}</h3>
 
     <table id="results_table">
         <tr>
             <th>User</th>
-            <th>Running</th>
-            <th>Stopped</th>
+            {% for cloud_provider in report.cloud_providers %}
+            <th>{{ cloud_provider.upper() }} Running/Stopped</th>
+            {% endfor %}
         </tr>
-        {% for user, stat in report|dictsort %}
+        {% for user, stat in user_report|dictsort %}
         <tr>
             <td>{{ user }}</td>
-            <td>{{ stat.num_running_instances }}</td>
-            <td>{{ stat.num_stopped_instances }}</td>
+            {% for cloud_provider in report.cloud_providers %}
+            <td>{{ stat[cloud_provider].num_running_instances }}/{{ stat[cloud_provider].num_stopped_instances }}</td>
+            {% endfor %}
         </tr>
         {% endfor %}
     </table>
+    {% endfor %}
     <h2>For detailed report download and open attached html</h2>


### PR DESCRIPTION
In the email report instances will be shown separately in two tables: QA and others.
Also separating running/stopped instances into different columns by cloud provider.

https://trello.com/c/ntF2Q139/1503-cloud-report-update-report-layout

Example:
![image](https://user-images.githubusercontent.com/5269241/73371484-cd16c200-42c6-11ea-9b12-32c5a34ddb44.png)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
