### PR TITLE
fix(manager install on ubuntu failure): flag --force-yes is deprecated

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2071,7 +2071,8 @@ server_encryption_options:
         else:
             self.remoter.run(cmd="sudo apt-get update", ignore_status=True)
             self.remoter.run(
-                'sudo apt-get install -y scylla-manager{}'.format(' --force-yes' if not self.is_debian9() else ''))
+                'sudo apt-get install -y scylla-manager{}'.format(' --force-yes' if not self.is_debian9() and
+                                                                  not self.is_ubuntu18() else ''))
 
         if self.is_docker():
             try:


### PR DESCRIPTION
need to drop this flag, as ubuntu 18 installation of scylla-manager
fails because flag is deprecated.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
