### PR TITLE
improvement(parallel-object): added ParallelObjectException, correct timeout handling and shutdown

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -13,6 +13,7 @@
 
 # pylint: disable=too-many-lines
 from __future__ import absolute_import
+import atexit
 import itertools
 import os
 import logging
@@ -27,13 +28,15 @@ import shutil
 import copy
 import string
 import sys
+from typing import Iterable, List, Callable
 from urllib.parse import urlparse
 
 from functools import wraps, partial
 from enum import Enum
 from collections import defaultdict
 import concurrent.futures
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
+from concurrent.futures.thread import _python_exit
 import hashlib
 
 import boto3
@@ -361,13 +364,13 @@ def all_aws_regions():
 AWS_REGIONS = all_aws_regions()
 
 
-class ParallelObject():  # pylint: disable=too-few-public-methods
+class ParallelObject:
     """
         Run function in with supplied args in parallel using thread.
     """
 
-    def __init__(self, objects, timeout=6, num_workers=None,  # pylint: disable=redefined-outer-name
-                 disable_logging=False):
+    def __init__(self, objects: Iterable, timeout: int = 6,  # pylint: disable=redefined-outer-name
+                 num_workers: int = None, disable_logging: bool = False):
         """Constructor for ParallelObject
 
         Build instances of Parallel object. Item of objects is used as parameter for
@@ -378,20 +381,17 @@ class ParallelObject():  # pylint: disable=too-few-public-methods
                 if item in object is any other type, will be passed to func as is.
                 if function accept list as parameter, the item shuld be list of list item = [[]]
 
-        :type objects: Any
-        :param timeout: timeout for running future, defaults to 6
-        :type timeout: number, optional
+        :param timeout: global timeout for running all
         :param num_workers: num of parallel threads, defaults to None
-        :type num_workers: int, optional
         :param disable_logging: disable logging for running func, defaults to False
-        :type disable_logging: bool, optional
         """
         self.objects = objects
         self.timeout = timeout
         self.num_workers = num_workers
         self.disable_logging = disable_logging
+        self._thread_pool = ThreadPoolExecutor(max_workers=self.num_workers)
 
-    def run(self, func, ignore_exceptions=False):
+    def run(self, func: Callable, ignore_exceptions=False, unpack_objects: bool = False):
         """Run callable object "func" in parallel
 
         Allow to run callable object in parallel.
@@ -405,9 +405,8 @@ class ParallelObject():  # pylint: disable=too-few-public-methods
         what has stepped first.
 
         :param func: Callable object to run in parallel
-        :type func: Callable
         :param ignore_exceptions: ignore exception and return result, defaults to False
-        :type ignore_exceptions: bool, optional
+        :param unpack_objects: set to True when unpacking of objects to the func as args or kwargs needed
         :returns: list of FutureResult object
         :rtype: {List[FutureResult]}
         """
@@ -429,53 +428,79 @@ class ParallelObject():  # pylint: disable=too-few-public-methods
             return inner
 
         results = []
-        with ThreadPoolExecutor(max_workers=self.num_workers) as pool:
+
+        if not self.disable_logging:
             LOGGER.debug("Executing in parallel: '{}' on {}".format(func.__name__, self.objects))
-            if not self.disable_logging:
-                func = func_wrap(func)
-            futures = []
+            func = func_wrap(func)
 
-            for obj in self.objects:
-                if isinstance(obj, (list, tuple)):
-                    futures.append(pool.submit(func, *obj))
-                elif isinstance(obj, dict):
-                    futures.append(pool.submit(func, **obj))
-                else:
-                    futures.append(pool.submit(func, obj))
+        futures = []
 
-            for future in futures:
-                try:
-                    result = future.result(self.timeout)
-                    results.append(FutureResult(exc=None, result=result))
-                except Exception as ex:  # pylint disable=broad-except
-                    LOGGER.warning('Error happened during running %s in %s:\n%s',
-                                   func.__name__,
-                                   future,
-                                   ex.__class__.__name__)
-                    if ignore_exceptions:
-                        results.append(FutureResult(exc=ex, result=None))
-                        continue
-                    raise
+        for obj in self.objects:
+            if unpack_objects and isinstance(obj, (list, tuple)):
+                futures.append(self._thread_pool.submit(func, *obj))
+            elif unpack_objects and isinstance(obj, dict):
+                futures.append(self._thread_pool.submit(func, **obj))
+            else:
+                futures.append(self._thread_pool.submit(func, obj))
+        time_out = self.timeout
+        for obj_idx, future in enumerate(futures):
+            try:
+                result = future.result(time_out)
+            except FuturesTimeoutError as exception:
+                results.append(ParallelObjectResult(obj=self.objects[obj_idx], exc=exception, result=None))
+                time_out = 0.001  # if there was a timeout on one of the futures there is no need to wait for all
+            except Exception as exception:  # pylint: disable=broad-except
+                results.append(ParallelObjectResult(obj=self.objects[obj_idx], exc=exception, result=None))
+            else:
+                results.append(ParallelObjectResult(obj=self.objects[obj_idx], exc=None, result=result))
+
+        self.clean_up(futures)
+
+        if ignore_exceptions:
+            return results
+
+        timed_out = [result for result in results if isinstance(result.exc, FuturesTimeoutError)]
+        if timed_out:
+            raise FuturesTimeoutError("when running on: %s" % [r.obj for r in results])
+        runs_that_finished_with_exception = [res for res in results if res.exc]
+        if runs_that_finished_with_exception:
+            raise ParallelObjectException(results=results)
         return results
 
+    def clean_up(self, futures):
+        # if there are futures that didn't run  we cancel them
+        for future in futures:
+            future.cancel()
+        self._thread_pool.shutdown(wait=False)
+        # we need to unregister internal function that waits for all threads to finish when interpreter exits
+        atexit.unregister(_python_exit)
 
-class FutureResult:
+
+class ParallelObjectResult:  # pylint: disable=too-few-public-methods
     """Object for result of future in ParallelObject
 
     Return as a result of ParallelObject.run method
     and contain result of func was run in parallel
-    and exception if it happend during run.
+    and exception if it happened during run.
     """
 
-    def __init__(self, result=None, exc=None):
+    def __init__(self, obj, result=None, exc=None):
+        self.obj = obj
         self.result = result
         self.exc = exc
 
-    def __getitem__(self, key):
-        return self.__dict__[key]
 
-    def __setitem__(self, key, value):
-        self.__dict__[key] = value
+class ParallelObjectException(Exception):
+    def __init__(self, results: List[ParallelObjectResult]):
+        super(ParallelObjectException, self).__init__()
+        self.results = results
+
+    def __str__(self):
+        ex_str = ""
+        for res in self.results:
+            if res.exc:
+                ex_str += f"{res.obj}: {res.exc}"
+        return ex_str
 
 
 def clean_cloud_instances(tags_dict):

--- a/unit_tests/test_parallelobject.py
+++ b/unit_tests/test_parallelobject.py
@@ -5,8 +5,7 @@ import random
 import concurrent.futures
 
 
-from sdcm.utils.common import ParallelObject
-
+from sdcm.utils.common import ParallelObject, ParallelObjectException
 
 LOGGER = logging.getLogger(name=__name__)
 
@@ -56,60 +55,54 @@ def dummy_func_with_several_parameters(timeout, msg):
 
 
 class ParallelObjectTester(unittest.TestCase):
-
-    rand_timeouts = [10, 15, 20, 25, 5]
-    unpacking_args = [
-        [10, "test1"],
-        [15, "test2"],
-        [20, "test3"],
-    ]
-    list_as_arg = [
-        [[10, "test1"]],
-        [[15, "test2"]],
-        [[20, "test3"]],
-    ]
-    unpacking_kwargs = [
-        {"timeout": 10, "msg": "test1"},
-        {"timeout": 15, "msg": "test2"},
-        {"timeout": 20, "msg": "test3"},
-    ]
+    max_timout = 3
+    rand_timeouts = random.sample(range(1, max_timout + 1), max_timout)
+    unpacking_args = [[t, f"test{i}"] for i, t in enumerate(rand_timeouts)]
+    list_as_arg = [[[t, f"test{i}"]] for i, t in enumerate(rand_timeouts)]
+    unpacking_kwargs = [{"timeout": t, "msg": f"test{i}"} for i, t in enumerate(rand_timeouts)]
 
     def test_successful_parallel_run_func_returning_tuple(self):
-        parallel_object = ParallelObject(self.rand_timeouts, timeout=30, num_workers=len(self.rand_timeouts))
+        parallel_object = ParallelObject(self.rand_timeouts, timeout=self.max_timout + 2,
+                                         num_workers=len(self.rand_timeouts))
         results = parallel_object.run(dummy_func_return_tuple)
         returned_results = [r.result for r in results]
         expected_results = [(timeout, 'test') for timeout in self.rand_timeouts]
         self.assertListEqual(returned_results, expected_results)
 
     def test_successful_parallel_run_func_returning_single_value(self):
-        parallel_object = ParallelObject(self.rand_timeouts, timeout=30, num_workers=len(self.rand_timeouts))
+        parallel_object = ParallelObject(self.rand_timeouts, timeout=self.max_timout + 2)
         results = parallel_object.run(dummy_func_return_single)
         returned_results = [r.result for r in results]
         self.assertListEqual(returned_results, self.rand_timeouts)
 
     def test_raised_exception_by_timeout(self):
+        test_timeout = min(self.rand_timeouts)
+        start_time = time.time()
         with self.assertRaises(concurrent.futures.TimeoutError):
-            parallel_object = ParallelObject(self.rand_timeouts, timeout=9, num_workers=len(self.rand_timeouts))
+            parallel_object = ParallelObject(self.rand_timeouts, timeout=test_timeout)
             parallel_object.run(dummy_func_return_tuple)
+        run_time = int(time.time() - start_time)
+        self.assertAlmostEqual(first=test_timeout, second=run_time, delta=1)
 
-    def test_exception_raised_in_thread_by_func(self):
-        with self.assertRaises(DummyException):
-            parallel_object = ParallelObject(self.rand_timeouts, timeout=30, num_workers=len(self.rand_timeouts))
+    def test_parallel_object_exception_raised(self):
+        with self.assertRaises(ParallelObjectException):
+            parallel_object = ParallelObject(self.rand_timeouts, timeout=self.max_timout + 2)
             parallel_object.run(dummy_func_raising_exception)
 
     def test_ignore_exception_raised_in_func_and_get_results(self):
-        parallel_object = ParallelObject(self.rand_timeouts, timeout=30, num_workers=len(self.rand_timeouts))
+        parallel_object = ParallelObject(self.rand_timeouts, timeout=self.max_timout + 2)
         results = parallel_object.run(dummy_func_raising_exception, ignore_exceptions=True)
         for res_obj in results:
+            self.assertIsNotNone(res_obj.obj)
             if res_obj.exc:
                 self.assertIsNone(res_obj.result)
                 self.assertIsInstance(res_obj.exc, DummyException)
             else:
                 self.assertIsNone(res_obj.exc)
-                self.assertListEqual(res_obj.result, "done")
+                self.assertEqual(res_obj.result, "done")
 
     def test_ignore_exception_by_timeout(self):
-        parallel_object = ParallelObject(self.rand_timeouts, timeout=9, num_workers=len(self.rand_timeouts))
+        parallel_object = ParallelObject(self.rand_timeouts, timeout=min(self.rand_timeouts))
         results = parallel_object.run(dummy_func_return_tuple, ignore_exceptions=True)
         for res_obj in results:
             if res_obj.exc:
@@ -120,30 +113,29 @@ class ParallelObjectTester(unittest.TestCase):
                 self.assertIn(res_obj.result, [(timeout, 'test') for timeout in self.rand_timeouts])
 
     def test_less_number_of_workers_than_length_of_iterable(self):
-        parallel_object = ParallelObject(self.rand_timeouts, timeout=30, num_workers=2)
+        parallel_object = ParallelObject(self.rand_timeouts, timeout=self.max_timout + 2, num_workers=2)
         results = parallel_object.run(dummy_func_return_tuple)
         returned_results = [r.result for r in results]
         expected_results = [(timeout, 'test') for timeout in self.rand_timeouts]
         self.assertListEqual(returned_results, expected_results)
 
     def test_unpack_args_for_func(self):
-        parallel_object = ParallelObject(self.unpacking_args, timeout=30, num_workers=2)
-        results = parallel_object.run(dummy_func_with_several_parameters)
+        parallel_object = ParallelObject(self.unpacking_args, timeout=self.max_timout + 2, num_workers=2)
+        results = parallel_object.run(dummy_func_with_several_parameters, unpack_objects=True)
         returned_results = [r.result for r in results]
-        expected_results = [(timeout, msg)
-                            for timeout, msg in self.unpacking_args]  # pylint: disable=unnecessary-comprehension
+        expected_results = [tuple(item) for item in self.unpacking_args]
         self.assertListEqual(returned_results, expected_results)
 
     def test_unpack_kwargs_for_func(self):
-        parallel_object = ParallelObject(self.unpacking_kwargs, timeout=30, num_workers=2)
-        results = parallel_object.run(dummy_func_with_several_parameters)
+        parallel_object = ParallelObject(self.unpacking_kwargs, timeout=self.max_timout + 2, num_workers=2)
+        results = parallel_object.run(dummy_func_with_several_parameters, unpack_objects=True)
         returned_results = [r.result for r in results]
         expected_results = [(d["timeout"], d["msg"]) for d in self.unpacking_kwargs]
         self.assertListEqual(returned_results, expected_results)
 
     def test_successfull_parallel_run_func_accepted_list_as_parameter(self):
-        parallel_object = ParallelObject(self.list_as_arg, timeout=30, num_workers=len(self.list_as_arg))
-        results = parallel_object.run(dummy_func_accepts_list_as_parameter)
+        parallel_object = ParallelObject(self.list_as_arg, timeout=self.max_timout + 2)
+        results = parallel_object.run(dummy_func_accepts_list_as_parameter, unpack_objects=True)
         returned_results = [r.result for r in results]
         expected_results = [r[0][1] for r in self.list_as_arg]
         self.assertListEqual(returned_results, expected_results)


### PR DESCRIPTION
Previous implementation of the ParallelObject had following issues:
- timeout was not interpreted as a global timeout, so if all of the func runs were stuck we would
  wait len(objects)*timeout seconds
- ParallelObject was stuck when one of the threads is stuck. The reason for that was since we used
  ThreadPoolExecutor as a context manager and when we exited from the context it ran implicitly
  shutdown with wait=True this caused executor to get stuck.
- Another issue was in the implementation of the ThreadPoolExecutor: when interpreter exits
  futures module waits for all threads that were ever run.
- when sending dict,list,tuple objects as args to the func, ParallelObject unpacked them
  automatically. This caused multiple issues, like complicated sending the mentioned types and
  unexpected behavior for the user. To solve this added unpack_objects arg to the run
  method signature
- when exception happened in multiple threads, only first exception was raised, hiding all
  others. To solve this ParallelObjectException was introduced

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
