### PR TITLE
refactor(test config): change region for gemini jobs to us-east-1

### DIFF
--- a/jenkins-pipelines/gemini-1tb-10h.jenkinsfile
+++ b/jenkins-pipelines/gemini-1tb-10h.jenkinsfile
@@ -7,10 +7,10 @@ longevityPipeline(
     params: params,
 
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    aws_region: 'us-east-1',
     test_name: 'gemini_test.GeminiTest.test_random_load',
     test_config: 'test-cases/gemini/gemini-1tb-10h.yaml',
 
     timeout: [time: 6530, unit: 'MINUTES'],
-    email_recipients: 'rnd-internal@scylladb.com'
+    email_recipients: 'qa@scylladb.com'
 )

--- a/jenkins-pipelines/gemini-3h-nondisruptive-nemesis.jenkinsfile
+++ b/jenkins-pipelines/gemini-3h-nondisruptive-nemesis.jenkinsfile
@@ -7,10 +7,10 @@ longevityPipeline(
     params: params,
 
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    aws_region: 'us-east-1',
     test_name: 'gemini_test.GeminiTest.test_load_random_with_nemesis',
     test_config: 'test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml',
 
     timeout: [time: 530, unit: 'MINUTES'],
-    email_recipients: 'rnd-internal@scylladb.com'
+    email_recipients: 'qa@scylladb.com'
 )

--- a/test-cases/gemini/gemini-1tb-10h.yaml
+++ b/test-cases/gemini/gemini-1tb-10h.yaml
@@ -16,5 +16,5 @@ gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json'
 
 db_type: mixed_scylla
 instance_type_db_oracle: 'i3.16xlarge'
-ami_id_db_oracle: 'ami-0535c88b85b914499' # ScyllaDB 3.0.11 eu-west-1
+ami_id_db_oracle: 'ami-0a49c99b529429c18' # ScyllaDB 3.0.11 us-east-1
 append_scylla_args_oracle: '--enable-cache false'

--- a/test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml
@@ -20,5 +20,5 @@ gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json'
 
 db_type: mixed_scylla
 instance_type_db_oracle: 'i3.8xlarge'
-ami_id_db_oracle: 'ami-0535c88b85b914499' # ScyllaDB 3.0.11 eu-west-1
+ami_id_db_oracle: 'ami-0a49c99b529429c18' # ScyllaDB 3.0.11 us-east-1
 append_scylla_args_oracle: '--enable-cache false'


### PR DESCRIPTION
Run gemini tests on us-east-1 region for regular manner.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
