### PR TITLE
get_branch_version_from_list: fix pattern of apt repo

### DIFF
--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -20,7 +20,7 @@ def get_branch_version(url):
 def get_branch_version_from_list(url):
     page = requests.get(url).text
     list_regex = re.compile(
-        r'deb\s\[arch=(?P<arch>.*?)\]\s(?P<url>http.*?)\s(?P<version_code_name>.*?)\s(?P<component>.*?)\n', re.DOTALL)
+        r'deb\s+\[arch=(?P<arch>.*?)\]\s(?P<url>http.*?)\s(?P<version_code_name>.*?)\s(?P<component>.*?)\n', re.DOTALL)
     match = list_regex.search(page)
     if not match:
         raise ValueError("url isn't a correct deb list\n\turl:[{}] ".format(url))


### PR DESCRIPTION
The private repos of debian9/ubuntu16/ubuntu18 have one more space before
`[arch=*]` than regular repo, get_branch_version_from_list() doesn't
work with those private repos.

This patch fixed the pattern.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
