### PR TITLE
improvement(remoter): moved NETWORK_EXCEPTIONS to the remoter, added stop method and improved run

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -40,7 +40,7 @@ from sdcm.mgmt import ScyllaManagerError, get_scylla_manager_tool
 from sdcm.prometheus import start_metrics_server, PrometheusAlertManagerListener
 from sdcm.rsyslog_daemon import start_rsyslog
 from sdcm.log import SDCMAdapter
-from sdcm.remote import RemoteCmdRunner, LocalCmdRunner, SSHConnectTimeoutError
+from sdcm.remote import RemoteCmdRunner, LocalCmdRunner, NETWORK_EXCEPTIONS
 from sdcm import wait
 from sdcm.utils.common import log_run_info, retrying, get_data_dir_path, Distro, verify_scylla_repo_file, S3Storage, \
     get_latest_gemini_version, get_my_ip, makedirs, normalize_ipv6_url
@@ -78,8 +78,6 @@ SPOT_TERMINATION_CHECK_DELAY = 5
 
 LOGGER = logging.getLogger(__name__)
 LOCALRUNNER = LocalCmdRunner()
-NETWORK_EXCEPTIONS = (NoValidConnectionsError, SSHException, SSHConnectTimeoutError,
-                      ConnectionResetError, ConnectionAbortedError, ConnectionError, ConnectionRefusedError)
 
 
 def set_ip_ssh_connections(ip_type):

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -22,7 +22,7 @@ from sdcm.cluster import INSTANCE_PROVISION_ON_DEMAND
 from sdcm.utils.common import retrying, list_instances_aws, get_ami_tags
 from sdcm.sct_events import SpotTerminationEvent, DbEventsFilter
 from sdcm import wait
-from sdcm.remote import LocalCmdRunner
+from sdcm.remote import LocalCmdRunner, NETWORK_EXCEPTIONS
 
 LOGGER = logging.getLogger(__name__)
 
@@ -451,7 +451,7 @@ class AWSNode(cluster.BaseNode):
             self._ec2_service.create_tags(Resources=[self._instance.id],
                                           Tags=tags_list)
 
-    @retrying(n=10, sleep_time=5, allowed_exceptions=cluster.NETWORK_EXCEPTIONS, message="Retrying set_hostname")
+    @retrying(n=10, sleep_time=5, allowed_exceptions=NETWORK_EXCEPTIONS, message="Retrying set_hostname")
     def set_hostname(self):
         self.log.info('Changing hostname to %s', self.name)
         # Using https://aws.amazon.com/premiumsupport/knowledge-center/linux-static-hostname-rhel7-centos7/


### PR DESCRIPTION
- Since NETWORK_EXCEPTIONS logically belong to handling Remoter object error
  the correct place to store them is in sdcm.remote module
- added stop method that will stop the ssh_up thread when remoter object
  is deleted or when eplicitly called and closing the connection
- removed connect_timeout from run due to ambiguity - it should be set in constructor only
- fixed run signature in the base class
- added mising functionality to local run

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
