### PR TITLE
fix(method): local variable 'pkg_path' referenced before assignment

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -268,6 +268,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
             if self.params.get("use_mgmt", default=None):
                 pkgs_url = self.params.get('scylla_mgmt_pkg', None)
+                pkg_path = None
                 if pkgs_url:
                     pkg_path = download_dir_from_cloud(pkgs_url)
                     self.params['scylla_mgmt_pkg'] = pkg_path


### PR DESCRIPTION
sct failed in test-provision phase with error:
```
Traceback (most recent call last):
File "/sct/sdcm/tester.py", line 127, in wrapper
return method(*args, **kwargs)
File "/sct/sdcm/utils/common.py", line 153, in inner
res = func(*args, **kwargs)
File "/sct/sdcm/tester.py", line 280, in setUp
node.install_manager_agent(mgmt_auth_token, repo, package_path=pkg_path)
```
problem that 'scylla_mgmt_pkg' config parameter  is not configured. in this case the pkg_path
is not initialized before using

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
