### PR TITLE
improvement(gemini tests):gemini tests to run with all nemesis

### DIFF
--- a/gemini_test.py
+++ b/gemini_test.py
@@ -61,7 +61,7 @@ class GeminiTest(ClusterTester):
         test_queue = self.run_gemini(cmd=cmd)
 
         # sleep before run nemesis test_duration * .25
-        sleep_before_start = float(self.params.get('test_duration', 5)) * 60 * .25
+        sleep_before_start = float(self.params.get('test_duration', 5)) * 60 * .1
         self.log.info('Sleep interval {}'.format(sleep_before_start))
         time.sleep(sleep_before_start)
 
@@ -76,11 +76,14 @@ class GeminiTest(ClusterTester):
 
     def get_email_data(self):
         scylla_version = self.db_cluster.nodes[0].scylla_version
+        config_file_name = ";".join([os.path.splitext(os.path.basename(f))[0] for f in self.params['config_files']])
         oracle_db_version = self.cs_db_cluster.nodes[0].scylla_version if self.cs_db_cluster else ""
         start_time = format_timestamp(self.start_time)
         critical = self.get_critical_events()
+        job_name = os.environ.get('JOB_NAME')
+        subject_name = job_name if job_name else config_file_name
         return {
-            "subject": 'Gemini - test results: {}'.format(start_time),
+            "subject": 'Result {} {}'.format(subject_name, start_time),
             "username": get_username(),
             "gemini_cmd": self.gemini_results['cmd'],
             "gemini_version": self.loaders.gemini_version,

--- a/jenkins-pipelines/gemini-1tb-10h.jenkinsfile
+++ b/jenkins-pipelines/gemini-1tb-10h.jenkinsfile
@@ -12,5 +12,5 @@ longevityPipeline(
     test_config: 'test-cases/gemini/gemini-1tb-10h.yaml',
 
     timeout: [time: 6530, unit: 'MINUTES'],
-    email_recipients: 'rnd-internal@scylladb.com'
+    email_recipients: 'qa@scylladb.com'
 )

--- a/jenkins-pipelines/gemini-3h-with-nemesis.jenkinsfile
+++ b/jenkins-pipelines/gemini-3h-with-nemesis.jenkinsfile
@@ -7,9 +7,9 @@ longevityPipeline(
     params: params,
 
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    aws_region: 'us-east-1',
     test_name: 'gemini_test.GeminiTest.test_load_random_with_nemesis',
-    test_config: 'test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml',
+    test_config: 'test-cases/gemini/gemini-3h-with-nemesis.yaml',
 
     timeout: [time: 530, unit: 'MINUTES'],
     email_recipients: 'qa@scylladb.com'

--- a/jenkins-pipelines/gemini-3h.jenkinsfile
+++ b/jenkins-pipelines/gemini-3h.jenkinsfile
@@ -12,5 +12,5 @@ longevityPipeline(
     test_config: 'test-cases/gemini/gemini-basic-3h.yaml',
 
     timeout: [time: 530, unit: 'MINUTES'],
-    email_recipients: 'rnd-internal@scylladb.com'
+    email_recipients: 'qa@scylladb.com'
 )

--- a/test-cases/gemini/gemini-1tb-10h.yaml
+++ b/test-cases/gemini/gemini-1tb-10h.yaml
@@ -10,7 +10,11 @@ store_results_in_elasticsearch: False
 # gemini
 # cmd: gemini -d -n [NUM_OF_TEST_ITERATIONS] -c [NUM_OF_THREADS] -m mixed -f
 # the below cmd runs about 10 hours
-gemini_cmd: "gemini -d --duration 36000s --warmup 7200s -c 100 -m mixed -f --non-interactive --cql-features normal"
+gemini_cmd: "gemini -d --duration 36000s --warmup 7200s -c 100 \
+-m mixed -f --non-interactive --cql-features normal \
+--replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '3'}\"
+--oracle-replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '1'}\""
+
 gemini_version: 'latest'
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 

--- a/test-cases/gemini/gemini-3h-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nemesis.yaml
@@ -1,11 +1,11 @@
-test_duration: 500
+test_duration: 300
 n_db_nodes: 3
 n_test_oracle_db_nodes: 1
 n_loaders: 1
 n_monitor_nodes: 1
 instance_type_db: 'i3.large'
 
-user_prefix: 'gemini-basic-3h'
+user_prefix: 'gemini-with-nemesis-3h-normal'
 store_results_in_elasticsearch: False
 
 nemesis_class_name: 'GeminiChaosMonkey'
@@ -13,15 +13,18 @@ nemesis_interval: 5
 
 # gemini
 # cmd: gemini -d -n [NUM_OF_TEST_ITERATIONS] -c [NUM_OF_THREADS] -p [NUM_OF_PARTITION_KEYS_PER_THREAD] -m mixed -f
+#--async-objects-stabilization-backoff duration   Duration between attempts to validate result sets from MV and SI for example 10ms or 1s (default 10ms)
 # the below cmd runs about 3 hours
-gemini_cmd: "gemini -d --duration 10800s --warmup 1800s -c 200 -m mixed -f --non-interactive --cql-features normal"
+gemini_cmd: "gemini -d --duration 3h --warmup 30m \
+-c 100 -m mixed -f --non-interactive \
+--cql-features normal --async-objects-stabilization-backoff 100ms \
+--replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '3'}\" \
+--oracle-replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '1'}\""
+
 gemini_version: 'latest'
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 
 db_type: mixed_scylla
 instance_type_db_oracle: 'i3.8xlarge'
-ami_id_db_oracle: 'ami-0081311880c437b65' # ScyllaDB 2.3.3 us-east-1 AMI
+oracle_scylla_version: '3.0.11'
 append_scylla_args_oracle: '--enable-cache false'
-
-send_email: true
-email_recipients: ['rnd-internal@scylladb.com']

--- a/test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml
@@ -14,7 +14,12 @@ nemesis_interval: 5
 # gemini
 # cmd: gemini -d -n [NUM_OF_TEST_ITERATIONS] -c [NUM_OF_THREADS] -p [NUM_OF_PARTITION_KEYS_PER_THREAD] -m mixed -f
 # the below cmd runs about 3 hours
-gemini_cmd: "gemini -d --duration 10800s --warmup 1800s -c 100 -m mixed -f --non-interactive --cql-features normal"
+gemini_cmd: "gemini -d --duration 10800s --warmup 1800s -c 100 \
+-m mixed -f --non-interactive \
+--cql-features normal --async-objects-stabilization-backoff 100ms \
+--replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '3'}\" \
+--oracle-replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '1'}\""
+
 gemini_version: 'latest'
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 

--- a/test-cases/gemini/gemini-basic-3h.yaml
+++ b/test-cases/gemini/gemini-basic-3h.yaml
@@ -11,7 +11,10 @@ store_results_in_elasticsearch: False
 # gemini
 # cmd: gemini -d -n [NUM_OF_TEST_ITERATIONS] -c [NUM_OF_THREADS] -m mixed -f
 # the below cmd runs about 3 hours
-gemini_cmd: "gemini -d --duration 10800s --warmup 1800s -c 100 -m mixed -f --non-interactive --cql-features normal"
+gemini_cmd: "gemini -d --duration 10800s --warmup 1800s -c 100 \
+-m mixed -f --non-interactive --cql-features normal \
+--replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '3'}\" \
+--oracle-replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '1'}\""
 
 gemini_version: 'latest'
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used


### PR DESCRIPTION
Added new gemini test config and jenkins job files to execute gemini
test with all nemesis (disruptive and non disruptive) in regular way

 - test with gemini basic cql-features ( only table)
 - test with gemini normal cql-features ( table, MV, SI)
Trello: https://trello.com/c/1b6HfHmI

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
