### PR TITLE
fix(validate partitions): Don't validate partitions in the large partition test if nemesises run during writes

### DIFF
--- a/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
@@ -67,12 +67,6 @@ user_prefix: 'longevity-large-partitions-200k-pks-4d'
 
 space_node_threshold: 644245094
 
-# To validate rows in partitions: collect data about partitions and their rows amount
-# before and after running nemesis and compare it
-validate_partitions: true
-table_name: "scylla_bench.test"
-primary_key_column: "pk"
-
 # scylla-manager configuration
 # if running on aws and use_mgmt is true, the monitor image should not contain scylla
 use_mgmt: true

--- a/test-cases/longevity/longevity-large-partition-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-4days.yaml
@@ -1,9 +1,10 @@
 test_duration: 6480
 
 bench_run: true
-prepare_write_cmd:  ["scylla-bench -workload=sequential -mode=write -max-rate=300 -replication-factor=3 -partition-count=10 -clustering-row-count=10000000 -clustering-row-size=5120 -consistency-level=quorum -concurrency=7 -rows-per-request=10",
-                     "scylla-bench -workload=uniform -mode=read -replication-factor=3 -partition-count=10 -clustering-row-count=10000000 -clustering-row-size=5120 -consistency-level=quorum -rows-per-request=10 -concurrency=7 -max-rate=32000 -duration=5760m"
-                    ]
+
+prepare_write_cmd:  ["scylla-bench -workload=sequential -mode=write -max-rate=300 -replication-factor=3 -partition-count=10 -clustering-row-count=10000000 -clustering-row-size=5120 -concurrency=7 -rows-per-request=10"]
+stress_cmd: ["scylla-bench -workload=uniform -mode=read -replication-factor=3 -partition-count=10 -clustering-row-count=10000000 -clustering-row-size=5120 -rows-per-request=10 -concurrency=7 -max-rate=32000 -duration=5760m"]
+
 n_db_nodes: 4
 n_loaders: 3
 n_monitor_nodes: 1
@@ -12,6 +13,7 @@ instance_type_db: 'i3en.3xlarge'
 
 nemesis_class_name: 'ChaosMonkey'
 nemesis_interval: 30
+nemesis_during_prepare: false
 
 user_prefix: 'longevity-large-partitions-4d'
 


### PR DESCRIPTION
[Task](https://trello.com/c/BUcmQ6zz/1636-dont-validate-partitions-for-the-new-longevity-large-partition-200k-pks-4days)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] ~~I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)~~
- [ ] ~~I gave variables/functions meaningful self-explanatory names~~
- [ ] ~~I didn't leave commented-out/debugging code~~
- [ ] ~~I didn't copy-paste code~~
- [x ] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~

For large partition we can validate the partition keys.

Partition validation assumes that prefill is finished and validate that  partition keys are same before and after nemesises that were run during reads only.

longevity-large-partition-200k-pks-4days was failed because partition keys before and after the nemesises are not same.

It happened because of in the test we run the inserts during all test, so we can't validate the partitions on this way.

Also I fixed the first basic test - separated writes and reads and run nemesis during reads only - to be able to validate the data.