### PR TITLE
fix(sdcm/stress_thread.py): Fix stress cmd error to not spliting error

### DIFF
--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -174,7 +174,7 @@ class CassandraStressThread():  # pylint: disable=too-many-instance-attributes
                     errors_str = f'Stress command execution failed with: {str(exc)}'
                 CassandraStressEvent(type='failure', node=str(node), stress_cmd=stress_cmd,
                                      log_file_name=log_file_name, severity=Severity.CRITICAL,
-                                     errors=errors_str)
+                                     errors=[errors_str])
 
         CassandraStressEvent(type='finish', node=str(node), stress_cmd=stress_cmd, log_file_name=log_file_name)
 
@@ -233,7 +233,7 @@ class CassandraStressThread():  # pylint: disable=too-many-instance-attributes
             except Exception as exc:  # pylint: disable=broad-except
                 CassandraStressEvent(
                     type='failure', node='', severity=Severity.CRITICAL,
-                    errors=f'Failed to proccess stress summary due to {exc}')
+                    errors=[f'Failed to proccess stress summary due to {exc}'])
 
         return ret
 


### PR DESCRIPTION
Fix stress cmd error to not spliting error to multiple lines

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
