### PR TITLE
fix(large partition): Not read with -validate-data for the data that wasn't insert with validation

### DIFF
--- a/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
@@ -45,7 +45,7 @@ stress_cmd: ["scylla-bench -workload=sequential -mode=write -replication-factor=
 stress_read_cmd: [
                   "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=1000 -clustering-row-count=200000 -clustering-row-size=uniform:10..10240 -partition-offset=1001 -concurrency=10 -connection-count=10 -rows-per-request=10 -iterations=10 -timeout=30s",
                   "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=250 -clustering-row-count=100000 -clustering-row-size=uniform:3072..5120 -concurrency=10 -connection-count=10 -rows-per-request=10 -iterations=10 -timeout=30s -validate-data",
-                  "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=1000 -clustering-row-count=100000 -clustering-row-size=uniform:3072..5120 -rows-per-request=10 -timeout=30s -concurrency=100 -connection-count=100 -duration=6420m -validate-data",
+                  "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=1000 -clustering-row-count=100000 -clustering-row-size=uniform:3072..5120 -rows-per-request=10 -timeout=30s -concurrency=100 -connection-count=100 -duration=6420m",
                   "scylla-bench -workload=uniform -mode=read -replication-factor=3 -partition-count=1000 -clustering-row-count=200000 -clustering-row-size=uniform:10..10240 -rows-per-request=10 -timeout=30s -partition-offset=1001 -concurrency=100 -connection-count=100 -duration=6420m"
                  ]
 


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] ~~I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)~~
- [ ] ~~I gave variables/functions meaningful self-explanatory names~~
- [ ] ~~I didn't leave commented-out/debugging code~~
- [ ] ~~I didn't copy-paste code~~
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~

Scylla-bench is able to validate the data during reads (using --validate-data parameter) just when this data was inserted with --validate-data parameter.
In this test just 250 first partitions from 1000 were inserted with --validate-data.
I mistakenly put --validate-data in the command that read all 1000 partitions. Remove it