### PR TITLE
fix(200gb-48h): Lengthen the timeout of the job to 51 hours

### DIFF
--- a/jenkins-pipelines/longevity-200gb-48h.jenkinsfile
+++ b/jenkins-pipelines/longevity-200gb-48h.jenkinsfile
@@ -11,5 +11,5 @@ longevityPipeline(
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml',
 
-    timeout: [time: 2940, unit: 'MINUTES']
+    timeout: [time: 3060, unit: 'MINUTES']
 )


### PR DESCRIPTION
Since the current 49 hours doesn't seem to cut it, I lengthened the timeout by 2 hours.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)

## I'm not sure if it needs to be backported or not, since this is and issue I had only in the master jobs