### PR TITLE
fix(upgrade_test.py): fill test data at the beginning of each subtest

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -412,7 +412,11 @@ class UpgradeTest(FillDatabaseData):
         self.verify_db_data()
         self.verify_stress_thread(stress_queue)
 
-    def fill_and_verify_db_data(self, note, pre_fill=False, rewrite_data=True):
+    # There is a known scylla issue in truncate, the timeout exception will break the subtest,
+    # and test data won't be prepared for next subtest. Let's change to prepare data at the
+    # beginning of each subtest. We can change this back when the issue is fixed.
+    # https://github.com/scylladb/scylla/issues/4924
+    def fill_and_verify_db_data(self, note, pre_fill=True, rewrite_data=False):
         if pre_fill:
             self.log.info('Populate DB with many types of tables and data')
             self.fill_db_data()
@@ -440,7 +444,7 @@ class UpgradeTest(FillDatabaseData):
         with self.subTest('pre-test - prepare test kesyapces and tables'):
             # prepare test keyspaces and tables before upgrade to avoid schema change during mixed cluster.
             self.prepare_keyspaces_and_tables()
-            self.fill_and_verify_db_data('BEFORE UPGRADE', pre_fill=True)
+            self.fill_and_verify_db_data('BEFORE UPGRADE')
 
             # write workload during entire test
             self.log.info('Starting c-s write workload during entire test')


### PR DESCRIPTION
There is a known scylla issue in truncate, the timeout exception will break the
subtest, and test data won't be prepared for next subtest. Let's change to
prepare data at the beginning of each subtest. We can change this back when the
issue is fixed.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
