### PR TITLE
Revert "improvement(test_defaults): add a flag to abort on bad file descriptor"

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -10,7 +10,7 @@ mgmt_segments_per_repair: 10
 experimental: true
 round_robin: false
 
-append_scylla_args: '--blocked-reactor-notify-ms 500 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort_on_ebadf 1'
+append_scylla_args: '--blocked-reactor-notify-ms 500 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1'
 
 # for for version selection
 scylla_linux_distro: 'centos'


### PR DESCRIPTION
Reverts scylladb/scylla-cluster-tests#1792

since there's no such command line, this change was breaking anything running based on master