### PR TITLE
fix(disruption event label): event label for disrupt_restart_with_resharding was printed partially

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -286,7 +286,7 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
         self.target_node.wait_jmx_up()
 
     def disrupt_restart_with_resharding(self):
-        self._set_current_disruption('RestartNode with resharding %s' % self.target_node)
+        self._set_current_disruption('RestartNodeWithResharding %s' % self.target_node)
         murmur3_partitioner_ignore_msb_bits = 15  # pylint: disable=invalid-name
         self.log.info(f'Restart node with resharding. New murmur3_partitioner_ignore_msb_bits value: '
                       f'{murmur3_partitioner_ignore_msb_bits}')


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)

For disrupt_restart_with_resharding nemesis event name was set using name with blanks : 
```
self._set_current_disruption(label='RestartNode with resharding %s' % self.target_node)
```

Disrupt name for event is taken as ```label.split()[0]```

So instead of receive event "RestartNodeWithResharding", we get event "RestartNode"