### PR TITLE
feature(lwt basic longevity): LWT 3 hours longevity test

### DIFF
--- a/data_dir/c-s_lwt_basic.yaml
+++ b/data_dir/c-s_lwt_basic.yaml
@@ -1,0 +1,72 @@
+# Based on https://gist.github.com/tjake/8995058fed11d9921e31
+### DML ###
+
+# Keyspace Name
+keyspace: cqlstress_lwt_example
+
+# The CQL for creating a keyspace (optional if it already exists)
+keyspace_definition: |
+  CREATE KEYSPACE cqlstress_lwt_example WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};
+
+# Table name
+table: blogposts
+
+# The CQL for creating a table you wish to stress (optional if it already exists)
+table_definition: |
+  CREATE TABLE blogposts (
+        domain int,
+        published_date int,
+        lwt_ind int,
+        url text,
+        author text,
+        title text,
+        PRIMARY KEY(domain, published_date)
+  ) WITH compaction = { 'class':'LeveledCompactionStrategy' }
+    AND comment='A table to hold blog posts'
+
+### Column Distribution Specifications ###
+
+columnspec:
+  - name: domain
+    population: seq(1..10000000)  #10M possible domains to pick from
+
+  - name: published_date
+    cluster: uniform(1..1000)         #under each domain we will have max 1000 posts
+
+  - name: lwt_ind
+    population: seq(1..1000000)   #10M possible domains to pick from
+
+  - name: url
+    size: uniform(30..30)
+
+  - name: title                  #titles shouldn't go beyond 200 chars
+    size: gaussian(10..20)
+
+  - name: author
+    size: uniform(5..20)         #author names should be short
+
+### Batch Ratio Distribution Specifications ###
+
+insert:
+  partitions: fixed(1)            # Our partition key is the domain so only insert one per batch
+
+  select:    fixed(1)/1000        # We have 1000 posts per domain so 1/1000 will allow 1 post per batch
+
+  batchtype: UNLOGGED             # Unlogged batches
+
+  condition: IF title = NULL       # LWT: Do not override
+
+
+#
+# A list of queries you wish to run against the schema
+#
+queries:
+   select:
+      cql: select * from blogposts where domain = ? LIMIT 1
+      fields: samerow
+   lwt_update_one_column:
+      cql: update blogposts set lwt_ind = 10000001 where domain = ? and published_date = ? if lwt_ind < 0
+      fields: samerow
+   lwt_update_two_columns:
+      cql: update blogposts set lwt_ind = 20000001, author = 'text' where domain = ? and published_date = ? if lwt_ind > 0 and lwt_ind < 10000001 and author != 'text'
+      fields: samerow

--- a/jenkins-pipelines/longevity-lwt-3h.jenkinsfile
+++ b/jenkins-pipelines/longevity-lwt-3h.jenkinsfile
@@ -1,0 +1,15 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    params: params,
+
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/longevity/longevity-lwt-basic-3h.yaml',
+
+    timeout: [time: 300, unit: 'MINUTES']
+)

--- a/test-cases/longevity/longevity-lwt-basic-3h.yaml
+++ b/test-cases/longevity/longevity-lwt-basic-3h.yaml
@@ -1,0 +1,20 @@
+test_duration: 180
+prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml n=10000000 ops'(insert=1)' cl=SERIAL -mode native cql3 -rate threads=50" ]
+stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=SERIAL duration=160m -mode native cql3 -rate threads=50" ]
+stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(select=1)' cl=SERIAL duration=160m -mode native cql3 -rate threads=50" ]
+
+n_db_nodes: 4
+n_loaders: 2
+n_monitor_nodes: 1
+experimental: true
+
+instance_type_db: 'i3.2xlarge'
+cluster_health_check: false
+
+ami_id_loader: 'ami-0dc7edd6fba3da2fb' # loader AMI with c-s ver. 4 and fix of NoSuchElementException
+
+nemesis_class_name: 'ChaosMonkey'
+nemesis_interval: 5
+space_node_threshold: 64424
+
+user_prefix: 'longevity-lwt-3h'


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)

New LWT 3 hours longevity:
with cassandra-stress user profile, run longevity test that:
1. insert data using "UPDATE .. IF.." syntax
2. run updates of non-PK columns using "UPDATE .. IF.." syntax
3. read the data

Run nemesis in parallel

If it will be approved, I could add data validation in the end of test.

[Jenkins job in the master](https://jenkins.scylladb.com/view/master/job/scylla-master/job/longevity/job/longevity-lwt-3h/)