### PR TITLE
feature(alternator): a way to tag write_isolation for dynamodb tables

### DIFF
--- a/sdcm/utils/alternator.py
+++ b/sdcm/utils/alternator.py
@@ -8,6 +8,7 @@ LOGGER = logging.getLogger(__name__)
 
 def create_table(endpoint_url, test_params):
     dynamodb_primarykey_type = test_params.get('dynamodb_primarykey_type', 'HASH')
+    write_isolation = test_params.get('alternator_write_isolation')
 
     try:
         dynamodb = boto3.resource('dynamodb', endpoint_url=endpoint_url)
@@ -40,6 +41,21 @@ def create_table(endpoint_url, test_params):
         waiter.config.max_attempts = 100
         waiter.wait(TableName=name)
 
+        if write_isolation:
+            set_write_isolation(table, write_isolation)
+
     except ClientError as ex:
         LOGGER.warning(str(ex))
         assert 'already exists' in str(ex)
+
+
+def set_write_isolation(table, isolation):
+    got = table.meta.client.describe_table(TableName=table.name)['Table']
+    arn = got['TableArn']
+    tags = [
+        {
+            'Key': 'system:write_isolation',
+            'Value': isolation
+        }
+    ]
+    table.meta.client.tag_resource(ResourceArn=arn, Tags=tags)

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -64,8 +64,8 @@ def docker_scylla():
     entryfile_path = Path(base_dir) if base_dir else Path(__file__).parent.parent
     entryfile_path = entryfile_path.joinpath('./docker/scylla-sct/entry.sh')
 
-    scylla = RemoteDocker(LocalNode(), image_name="scylladb/scylla:3.2.0",
-                          command_line="--smp 1 --alternator-port 8000", extra_docker_opts=f'-p 8000 --cpus="1" -v {entryfile_path}:/entry.sh --entrypoint /entry.sh')
+    scylla = RemoteDocker(LocalNode(), image_name="scylladb/scylla-nightly:666.development-202002120417",
+                          command_line="--smp 1 --alternator-port 8000 --experimental 1", extra_docker_opts=f'-p 8000 --cpus="1" -v {entryfile_path}:/entry.sh --entrypoint /entry.sh')
 
     def db_up():
         try:


### PR DESCRIPTION
new SCT config `alternator_write_isolation` that can be controlled to tag
alternator table is using or not LWT

Ref: [alternator write-isolation-policies docs](https://github.com/scylladb/scylla/blob/master/docs/alternator/alternator.md#write-isolation-policies)
