### PR TITLE
fix(scylla-bench): send scylla-bench cmds to one node only

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3660,7 +3660,8 @@ class BaseLoaderSet():
             log_file_name = os.path.join(node.logdir,
                                          'scylla-bench-l%s-%s.log' %
                                          (loader_idx, uuid.uuid4()))
-            ips = ",".join([n.private_ip_address for n in node_list])
+            # Select first seed node to send the scylla-bench cmds
+            ips = node_list[0].private_ip_address
             bench_log = tempfile.NamedTemporaryFile(prefix='scylla-bench-', suffix='.log').name
 
             result = node.remoter.run(cmd="/$HOME/go/bin/{name} -nodes {ips} |tee {log}".format(name=stress_cmd.strip(),


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)

We get evenly distributed load when send scylla-bench command just to one db node, not to list of all db nodes
