### PR TITLE
fix(logcollector): Remove collected files and archives after collecting

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -457,8 +457,7 @@ def collect_logs(test_id=None, logdir=None, backend='aws', config_file=None):
     table.align = 'l'
     for cluster_type, s3_link in collected_logs.items():
         table.add_row([cluster_type, s3_link])
-    click.echo(table.get_string(title="Collected logs by test-id: {} Directory: {}".format(collector.test_id,
-                                                                                           collector.storage_dir,)))
+    click.echo(table.get_string(title="Collected logs by test-id: {}".format(collector.test_id)))
 
 
 @cli.command('send-email', help='Send email with results for testrun')

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -512,18 +512,18 @@ class GrafanaSnapshot(GrafanaEntity):
         return {'links': snapshots, 'file': snapshots_file}
 
 
-class LogCollector():
+class LogCollector:
     """Base class for LogCollector types
 
-    Base class implements interface for collecting
-    various LogEntities on different types of Clusters/RemoteHosts
+        Base class implements interface for collecting
+        various LogEntities on different types of Clusters/RemoteHosts
 
-    Variables:
-        node_remote_dir {str} -- name of remote dir on remote host
-        _current_run {str} -- DateTime of current collecting log run
-        cluster_log_type {str} -- Type of cluster
-        log_entities {list} -- List of log entities, which should be collected on remote hosts
-        USER {str} -- name of user, for which search local file log versions
+        Variables:
+            node_remote_dir {str} -- name of remote dir on remote host
+            _current_run {str} -- DateTime of current collecting log run
+            cluster_log_type {str} -- Type of cluster
+            log_entities {list} -- List of log entities, which should be collected on remote hosts
+            USER {str} -- name of user, for which search local file log versions
     """
     _current_run = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     cluster_log_type = 'base'
@@ -630,6 +630,8 @@ class LogCollector():
 
         final_archive = self.archive_dir_with_zip64(self.local_dir)
         s3_link = self.upload_logs(final_archive, "{0.test_id}/{0.current_run}".format(self))
+        remove_files(self.local_dir)
+        remove_files(final_archive)
         return s3_link
 
     def collect_logs_for_inactive_nodes(self, local_search_path=None):


### PR DESCRIPTION
LogCollector left on builders all archives and temp collected files,
this lead to No free space on builder. Added remove all collected
files after they uploaded to s3

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
