### PR TITLE
fix(basemonitorset.configure_scylla_monitoring): ignore exit status None

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3985,7 +3985,7 @@ class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-inst
                 yaml.safe_dump(templ_yaml, output_file, default_flow_style=False)  # to remove tag !!python/unicode
             node.remoter.send_files(src=local_template, dst=prometheus_yaml_template, delete_dst=True)
 
-            LOCALRUNNER.run(f"rm -rf {temp_dir}")
+            LOCALRUNNER.run(f"rm -rf {temp_dir}", ignore_status=True)
 
         self.reconfigure_scylla_monitoring()
         if alert_manager:


### PR DESCRIPTION
Periodically command "rm -rf tmpdr" finished with exit code None. This leads
to test run failed on Setup. Removing tmp dir where stored temp file with
config for monitoring stack is not critical operation on failed for testrun.
Added ignore status for LOCALRUNNER.run() command

Latest failed job: https://jenkins.scylladb.com/job/scylla-master/job/gemini-/job/gemini-3h-nondisruptive-nemesis/13/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
