### PR TITLE
fix(unit-tests): remove call to Remote from unit tests

### DIFF
--- a/sdcm/sct_events.py
+++ b/sdcm/sct_events.py
@@ -746,7 +746,7 @@ def start_events_device(log_dir, timeout=5):  # pylint: disable=redefined-outer-
 
 
 def stop_events_device():
-    LOGGER.info("Stopping Events consumers...")
+    LOGGER.debug("Stopping Events consumers...")
     processes = ['EVENTS_FILE_LOOGER', 'EVENTS_GRAFANA_ANNOTATOR', 'EVENTS_GRAFANA_AGGRAGATOR', 'MainDevice']
     LOGGER.debug("Signalling events consumers to terminate...")
     for proc_name in processes:
@@ -756,7 +756,7 @@ def stop_events_device():
     for proc_name in processes:
         if proc_name in EVENTS_PROCESSES:
             EVENTS_PROCESSES[proc_name].join(timeout=60)
-    LOGGER.info("All Events consumers stopped.")
+    LOGGER.debug("All Events consumers stopped.")
 
 
 def set_grafana_url(url):

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -18,6 +18,10 @@ from unit_tests.dummy_remote import DummyRemote
 class DummyNode(BaseNode):  # pylint: disable=abstract-method
     _database_log = None
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.remoter.stop()
+
     @property
     def private_ip_address(self):
         return '127.0.0.1'

--- a/unit_tests/test_events.py
+++ b/unit_tests/test_events.py
@@ -72,28 +72,25 @@ class SctEventsTests(unittest.TestCase):  # pylint: disable=too-many-public-meth
             process.join()
         stop_events_device()
 
-    @staticmethod
-    def test_event_info():
+    def test_event_info(self):  # pylint: disable=no-self-use
         InfoEvent(message='jkgkjgl')
 
-    @staticmethod
-    def test_cassandra_stress():
+    def test_cassandra_stress(self):  # pylint: disable=no-self-use
         str(CassandraStressEvent(type='start', node="node xy", stress_cmd="adfadsfsdfsdfsdf"))
         str(CassandraStressEvent(type='start', node="node xy", stress_cmd="adfadsfsdfsdfsdf",
                                  log_file_name="/filename/"))
 
-    @staticmethod
-    def test_scylla_bench():
+    def test_scylla_bench(self):  # pylint: disable=no-self-use
         str(ScyllaBenchEvent(type='start', node="node xy", stress_cmd="adfadsfsdfsdfsdf"))
         str(ScyllaBenchEvent(type='start', node="node xy", stress_cmd="adfadsfsdfsdfsdf",
                              log_file_name="/filename/"))
 
-    @staticmethod
-    def test_coredump_event():
+    def test_coredump_event(self):  # pylint: disable=no-self-use
         str(CoreDumpEvent(corefile_url='http://', backtrace="asfasdfsdf",
                           node="node xy",
                           download_instructions="gsutil cp gs://upload.scylladb.com/core.scylla-jmx.996.d173729352e34c76aaf8db3342153c3e.3968.1566979933000/core.scylla-jmx.996.d173729352e34c76aaf8db3342153c3e.3968.1566979933000000 .",
-                          timestamp="Tue 2020-01-14 10:40:25 UTC"
+                          timestamp=time.mktime(datetime.datetime.strptime(
+                              "Tue 2020-01-14 10:40:25 UTC", "%a %Y-%m-%d %H:%M:%S UTC").timetuple())
                           ))
 
     def test_thread_failed_event(self):  # pylint: disable=no-self-use
@@ -104,8 +101,7 @@ class SctEventsTests(unittest.TestCase):  # pylint: disable=too-many-public-meth
 
         str(ThreadFailedEvent(message='thread failed', traceback=_full_traceback))
 
-    @staticmethod
-    def test_scylla_log_event():
+    def test_scylla_log_event(self):  # pylint: disable=no-self-use
         str(DatabaseLogEvent(type="A", regex="B"))
 
         event = DatabaseLogEvent(type="A", regex="B")
@@ -115,8 +111,7 @@ class SctEventsTests(unittest.TestCase):  # pylint: disable=too-many-public-meth
 
         str(event)
 
-    @staticmethod
-    def test_disruption_event():
+    def test_disruption_event(self):  # pylint: disable=no-self-use
         try:
             1 / 0
         except ZeroDivisionError:
@@ -262,8 +257,7 @@ class SctEventsTests(unittest.TestCase):  # pylint: disable=too-many-public-meth
                                    line="[99.80.124.204] [stdout] Mar 31 09:08:10 warning|  reactor stall 5000 ms")
         self.assertTrue(event.severity == Severity.CRITICAL)
 
-    @staticmethod
-    def test_spot_termination():
+    def test_spot_termination(self):  # pylint: disable=no-self-use
         str(SpotTerminationEvent(node='test', message='{"action": "terminate", "time": "2017-09-18T08:22:00Z"}'))
 
     def test_default_filters(self):

--- a/unit_tests/test_seed_selector.py
+++ b/unit_tests/test_seed_selector.py
@@ -11,6 +11,9 @@ from unit_tests.dummy_remote import DummyRemote
 
 
 class DummyNode(sdcm.cluster.BaseNode):  # pylint: disable=abstract-method
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.remoter.stop()
 
     @property
     def private_ip_address(self):


### PR DESCRIPTION
Some test were creating object that inherits `BaseNode`,
which start the ssh thread at `__init__`, that was filling
the unit tests logs with lots of errors

Also fixed a fix minor test issues that were failing in background threads

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
