### PR TITLE
fix(manager ipv6): configuration of ipv6 on manager

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1812,7 +1812,6 @@ server_encryption_options:
             scyllamgr_ssl_cert_gen
             sed -i 's/#tls_cert_file/tls_cert_file/' /etc/scylla-manager-agent/scylla-manager-agent.yaml
             sed -i 's/#tls_key_file/tls_key_file/' /etc/scylla-manager-agent/scylla-manager-agent.yaml
-            sed -i 's/#https/https/' /etc/scylla-manager-agent/scylla-manager-agent.yaml
             systemctl restart scylla-manager-agent
             systemctl enable scylla-manager-agent
         """.format(package_name, auth_token))

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -67,6 +67,10 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('scylla_repo_m', '')}",
                    description: 'backend scylla repo for manager',
                    name: 'scylla_repo_m')
+
+            string(defaultValue: "${pipelineParams.get('scylla_mgmt_pkg', '')}",
+                   description: 'Url to the scylla manager packages',
+                   name: 'scylla_mgmt_pkg')
         }
         options {
             timestamps()
@@ -148,6 +152,10 @@ def call(Map pipelineParams) {
 
                                     if [[ ! -z "${params.scylla_repo_m}" ]] ; then
                                         export SCT_SCYLLA_REPO_M="${params.scylla_repo_m}"
+                                    fi
+
+                                    if [[ ! -z "${params.scylla_mgmt_pkg}" ]] ; then
+                                        export SCT_SCYLLA_MGMT_PKG="${params.scylla_mgmt_pkg}"
                                     fi
 
                                     echo "start test ......."


### PR DESCRIPTION
happened that we hardcoded bind ipv4, so ipv6 wasn't working

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
