### PR TITLE
fix(nemesis): empty return from get_non_system_ks_cf_list() raise UnsupporttedNemesis

### DIFF
--- a/sdcm/sct_events.py
+++ b/sdcm/sct_events.py
@@ -688,7 +688,7 @@ class EventsFileLogger(Process):  # pylint: disable=too-many-instance-attributes
             Severity.CRITICAL: self.critical_events_filename,
             Severity.ERROR: self.error_events_filename,
             Severity.WARNING: self.warning_events_filename,
-            Severity.NORMAL: self.warning_events_filename,
+            Severity.NORMAL: self.normal_events_filename,
         }
         self.level_summary = collections.defaultdict(int)
 


### PR DESCRIPTION
In some case we don't have CQL based tables in nemesis (i.e. alternator tests),
and we want those to be skipped automaticlly, and not reported as errors.

﻿## PR pre-checks (self review)
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- ~~[ ] New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- ~~[ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- ~~[ ] I have updated the Readme/doc folder accordingly (if needed)~~
