### PR TITLE
fix(stress_thread): remove duplicate code

### DIFF
--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -26,6 +26,7 @@ from sdcm.cluster import BaseLoaderSet
 from sdcm.sct_events import CassandraStressEvent
 from sdcm.utils.common import FileFollowerThread, makedirs, generate_random_string
 from sdcm.sct_events import CassandraStressLogEvent, Severity
+from sdcm.utils.thread import DockerBasedStressThread
 
 LOGGER = logging.getLogger(__name__)
 
@@ -164,14 +165,7 @@ class CassandraStressThread():  # pylint: disable=too-many-instance-attributes
                                           timeout=self.timeout,
                                           log_file=log_file_name)
             except Exception as exc:  # pylint: disable=broad-except
-                #  pylint: disable=no-member
-                if hasattr(exc, 'result') and exc.result.failed:
-                    stderr = exc.result.stderr
-                    if len(stderr) > 100:
-                        stderr = stderr[:100]
-                    errors_str = f'Stress command completed with bad status {exc.result.exited}: {stderr}'
-                else:
-                    errors_str = f'Stress command execution failed with: {str(exc)}'
+                errors_str = DockerBasedStressThread.format_error(exc)
                 CassandraStressEvent(type='failure', node=str(node), stress_cmd=stress_cmd,
                                      log_file_name=log_file_name, severity=Severity.CRITICAL,
                                      errors=[errors_str])


### PR DESCRIPTION
fixing a duplicate code the introduced in sdcm.utils.thread applying
the same logic

```
19:45:26 ************* Module multiple_dc_test
19:45:26 multiple_dc_test.py:1:0: R0801: Similar lines in 2 files
19:45:26 ==sdcm.stress_thread:167
19:45:26 ==sdcm.utils.thread:112
19:45:26 if hasattr(exc, 'result') and exc.result.failed:
19:45:26 stderr = exc.result.stderr
19:45:26 if len(stderr) > 100:
19:45:26 stderr = stderr[:100]
19:45:26 errors_str = f'Stress command completed with bad status {exc.result.exited}: {stderr}'
19:45:26 else:
19:45:26 errors_str = f'Stress command execution failed with: {str(exc)}' (duplicate-code)
19:45:26
19:45:26 --------------------------------------------------------------------
19:45:26 Your code has been rated at 10.00/10 (previous run: 10.00/10, -0.00)
```

﻿## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
