### PR TITLE
feature(cloud-monitor): split report by instance lifecyle

### DIFF
--- a/sdcm/utils/cloud_monitor/report.py
+++ b/sdcm/utils/cloud_monitor/report.py
@@ -70,10 +70,14 @@ class PerUserSummaryReport(BaseReport):
                 user_type = self.user_type(instance.owner)
                 results = self.report["results"]
                 if instance.owner not in results[user_type]:
-                    stats = dict(num_running_instances=0, num_stopped_instances=0)
+                    stats = dict(num_running_instances_spot=0, num_running_instances_on_demand=0,
+                                 num_stopped_instances=0)
                     results[user_type][instance.owner] = {cp: deepcopy(stats) for cp in self.report["cloud_providers"]}
                 if instance.state == "running":
-                    results[user_type][instance.owner][cloud]["num_running_instances"] += 1
+                    if instance.lifecycle == "spot":
+                        results[user_type][instance.owner][cloud]["num_running_instances_spot"] += 1
+                    else:
+                        results[user_type][instance.owner][cloud]["num_running_instances_on_demand"] += 1
                 if instance.state == "stopped":
                     results[user_type][instance.owner][cloud]["num_stopped_instances"] += 1
         return self.render_template()

--- a/sdcm/utils/cloud_monitor/templates/per_user_summary.html
+++ b/sdcm/utils/cloud_monitor/templates/per_user_summary.html
@@ -3,16 +3,25 @@
 
     <table id="results_table">
         <tr>
-            <th>User</th>
+            <th rowspan="2">User</th>
             {% for cloud_provider in report.cloud_providers %}
-            <th>{{ cloud_provider.upper() }} Running/Stopped</th>
+            <th colspan="3">{{ cloud_provider.upper() }}</th>
+            {% endfor %}
+        </tr>
+        <tr>
+            {% for _ in report.cloud_providers %}
+                {% for state in ["On-demand: running", "Spot: running", "Stopped"] %}
+            <th>{{ state }}</th>
+                {% endfor %}
             {% endfor %}
         </tr>
         {% for user, stat in user_report|dictsort %}
         <tr>
             <td>{{ user }}</td>
             {% for cloud_provider in report.cloud_providers %}
-            <td>{{ stat[cloud_provider].num_running_instances }}/{{ stat[cloud_provider].num_stopped_instances }}</td>
+            <td>{{ stat[cloud_provider].num_running_instances_on_demand }}</td>
+            <td>{{ stat[cloud_provider].num_running_instances_spot }}</td>
+            <td>{{ stat[cloud_provider].num_stopped_instances }}</td>
             {% endfor %}
         </tr>
         {% endfor %}


### PR DESCRIPTION
for each per user table showing instances by the lifecycle(spot, on-demand).

![image](https://user-images.githubusercontent.com/5269241/74687834-9dcce400-51e6-11ea-85d9-fce7cb14a675.png)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
