### PR TITLE
test(cdc longevity): add longevity test for cdc

### DIFF
--- a/data_dir/cdc_profile.yaml
+++ b/data_dir/cdc_profile.yaml
@@ -1,0 +1,63 @@
+keyspace: cdc_test
+
+keyspace_definition: |
+
+  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true;
+
+table: test_table
+
+table_definition: |
+
+  CREATE TABLE cdc_test.test_table (
+    pkid text PRIMARY KEY,
+    name text,
+    number int,
+    starttime timestamp,
+    weight decimal,
+    nums_set set<int>,
+    names_set set<text>
+  ) WITH bloom_filter_fp_chance = 0.01
+    AND cdc = {'enabled': true, 'preimage': false, 'ttl': 600}
+    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
+    AND comment = 'Request for unit level UIs'
+    AND compaction = {'class': 'SizeTieredCompactionStrategy'}
+    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
+    AND crc_check_chance = 1.0
+    AND dclocal_read_repair_chance = 0.1
+    AND default_time_to_live = 0
+    AND gc_grace_seconds = 864000
+    AND max_index_interval = 2048
+    AND memtable_flush_period_in_ms = 0
+    AND min_index_interval = 128
+    AND read_repair_chance = 0.0
+    AND speculative_retry = '99.0PERCENTILE';
+
+columnspec:
+  - name: pkid
+    population: exp(1..10000000)
+
+  - name: nums_set
+    size: fixed(5)
+    population: exp(1..5)
+
+  - name: names_set
+    size: fixed(5)
+    population: exp(1..5)
+
+insert:
+  partitions: fixed(1)
+  batchtype: UNLOGGED
+
+queries:
+  read1:
+    cql: select * from cdc_test.test_table where pkid = ?
+    fields: samerow
+  update_name:
+    cql: update cdc_test.test_table set name = ? where pkid = ?
+    fields: samerow
+  update_number:
+    cql: update cdc_test.test_table set number = ? where pkid = ?
+    fields: samerow
+  delete1:
+    cql: delete from cdc_test.test_table where pkid = ?
+    fields: samerow

--- a/data_dir/cdc_profile_preimage.yaml
+++ b/data_dir/cdc_profile_preimage.yaml
@@ -1,0 +1,69 @@
+keyspace: cdc_test
+
+keyspace_definition: |
+
+  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true;
+
+table: test_table_preimage
+
+table_definition: |
+
+  CREATE TABLE cdc_test.test_table_preimage (
+    pkid text PRIMARY KEY,
+    name text,
+    number int,
+    starttime timestamp,
+    weight decimal,
+    steps float,
+    t_num tinyint,
+    bvalue blob,
+    boy boolean,
+    vname varchar,
+    vage varint,
+    nums_set set<int>,
+    names_set set<text>
+  ) WITH bloom_filter_fp_chance = 0.01
+    AND cdc = {'enabled': true, 'preimage': true, 'ttl': 600}
+    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
+    AND comment = 'Request for unit level UIs'
+    AND compaction = {'class': 'SizeTieredCompactionStrategy'}
+    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
+    AND crc_check_chance = 1.0
+    AND dclocal_read_repair_chance = 0.1
+    AND default_time_to_live = 0
+    AND gc_grace_seconds = 864000
+    AND max_index_interval = 2048
+    AND memtable_flush_period_in_ms = 0
+    AND min_index_interval = 128
+    AND read_repair_chance = 0.0
+    AND speculative_retry = '99.0PERCENTILE';
+
+columnspec:
+  - name: pkid
+    population: exp(1..10000000)
+
+  - name: nums_set
+    size: fixed(5)
+    population: exp(1..5)
+
+  - name: names_set
+    size: fixed(5)
+    population: exp(1..5)
+
+insert:
+  partitions: fixed(1)
+  batchtype: UNLOGGED
+
+queries:
+  read1:
+    cql: select * from cdc_test.test_table_preimage where pkid = ?
+    fields: samerow
+  update_name:
+    cql: update cdc_test.test_table_preimage set name = ? where pkid = ?
+    fields: samerow
+  update_number:
+    cql: update cdc_test.test_table_preimage set number = ? where pkid = ?
+    fields: samerow
+  delete1:
+    cql: delete from cdc_test.test_table_preimage where pkid = ?
+    fields: samerow

--- a/jenkins-pipelines/longevity-cdc-4h.jenkinsfile
+++ b/jenkins-pipelines/longevity-cdc-4h.jenkinsfile
@@ -1,0 +1,15 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    params: params,
+
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/longevity/longevity-cdc-100gb-4h.yaml',
+
+    timeout: [time: 360, unit: 'MINUTES']
+)

--- a/test-cases/longevity/longevity-cdc-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-cdc-100gb-4h.yaml
@@ -1,0 +1,19 @@
+test_duration: 260
+
+stress_cmd: [ "cassandra-stress user no-warmup profile=/tmp/cdc_profile.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=240m -port jmx=6868 -mode cql3 native -rate threads=200",
+              "cassandra-stress user no-warmup profile=/tmp/cdc_profile_preimage.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=240m -port jmx=6868 -mode cql3 native -rate threads=200"
+             ]
+
+n_db_nodes: 6
+n_loaders: 2
+n_monitor_nodes: 1
+
+instance_type_db: 'i3.4xlarge'
+
+nemesis_class_name: 'ChaosMonkey'
+nemesis_interval: 5
+
+user_prefix: 'longevity-cdc-100gb-4h'
+space_node_threshold: 64424
+experimental: false
+append_scylla_args: '--blocked-reactor-notify-ms 500 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1 --experimental-features cdc'


### PR DESCRIPTION
This patch added a longevity test for cdc feature.
`experimental` is enabled by default, so cdc feature will always be enabled.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
