### PR TITLE
fix(perf-throughput-test): Fix time duration for jenkins job

### DIFF
--- a/jenkins-pipelines/perf-regression-throughput-30min.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-throughput-30min.jenkinsfile
@@ -12,5 +12,5 @@ perfRegressionParallelPipeline(
     test_config: "test-cases/performance/perf-regression.100threads.30M-keys.yaml",
     sub_tests: ["test_write", "test_read", "test_mixed"],
 
-    timeout: [time: 180, unit: "MINUTES"]
+    timeout: [time: 300, unit: "MINUTES"]
 )


### PR DESCRIPTION
jenkins pipeline for perf-regression-throughput job aborted by jenkins
by timeout before parallel jobs are finished. Looks jenkins job timeout
is divided between all subtask in parallel.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
