### PR TITLE
improvement(clean_instances_gce): cleaning GCE instances faster

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -729,13 +729,14 @@ def clean_instances_gce(tags_dict):
     :return: None
     """
     assert tags_dict, "tags_dict not provided (can't clean all instances)"
-    all_gce_instances = list_instances_gce(tags_dict=tags_dict)
+    gce_instances_to_clean = list_instances_gce(tags_dict=tags_dict)
 
-    for instance in all_gce_instances:
+    def delete_instance(instance):
         LOGGER.info("Going to delete: {}".format(instance.name))
         # https://libcloud.readthedocs.io/en/latest/compute/api.html#libcloud.compute.base.Node.destroy
         res = instance.destroy()
-        LOGGER.info("{} deleted. res={}".format(instance.name, res))
+        LOGGER.info("{} deleted={}".format(instance.name, res))
+    ParallelObject(gce_instances_to_clean, timeout=60).run(delete_instance, ignore_exceptions=True)
 
 
 _SCYLLA_AMI_CACHE = defaultdict(dict)


### PR DESCRIPTION
It takes between 20 to 50 seconds to delete one instance in GCE.
Running delete operation in parallel on all instances makes
it much faster.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
