### PR TITLE
feature(hydra): cleaning up unused Docker resources

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -25,6 +25,16 @@ if ! docker --version; then
     exit 1
 fi
 
+echo "Cleaning unused Docker resources..."
+# will clean
+#  - all stopped containers
+#  - all networks not used by at least one container
+#  - all volumes not used by at least one container
+#  - all dangling images
+#  - all dangling build cache
+docker system prune --volumes -f
+
+
 if [[ ! -z "`docker images scylladb/hydra:${VERSION} -q`" ]]; then
     echo "Image up-to-date"
 else


### PR DESCRIPTION
Currently, when hydra finished running improperly a lot of containers
are left running or stop. This causes a disk to be filled up with GBs of
data, and very fast we get into situation when builders doesn't have disk
space to run

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
