### PR TITLE
fix (install_scylla): adjust the dependency repos for debian10

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1931,10 +1931,10 @@ server_encryption_options:
                     apt-get update
                     apt-get install apt-transport-https -y
                     apt-get install gnupg1-curl dirmngr -y
-                    apt-key adv --fetch-keys https://download.opensuse.org/repositories/home:/scylladb:/scylla-3rdparty-buster/Debian_10.0/Release.key
-                    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 17723034C56D4B19
                     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5E08FBD8B5D6EC9C
-                    echo 'deb http://download.opensuse.org/repositories/home:/scylladb:/scylla-3rdparty-buster/Debian_10.0/ /' > /etc/apt/sources.list.d/scylla-3rdparty.list
+                    curl https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | sudo apt-key add -
+                    apt-get install software-properties-common -y
+                    add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
                 """)
                 self.remoter.run('sudo bash -cxe "%s"' % install_debian_10_prereqs)
 

--- a/unit_tests/test_prometheus.py
+++ b/unit_tests/test_prometheus.py
@@ -1,7 +1,6 @@
 import os
 import time
 import unittest
-import tempfile
 import shutil
 import json
 import requests
@@ -126,16 +125,6 @@ class PrometheusAlertManagerListenerRealTest(PrometheusAlertManagerListener):
 
 
 class PrometheusAlertManagerTest(unittest.TestCase):
-    temp_dir = None
-
-    @classmethod
-    def setUpClass(cls):
-        cls.temp_dir = tempfile.mkdtemp()
-
-    @classmethod
-    def tearDownClass(cls):
-        # stop_events_device()
-        shutil.rmtree(cls.temp_dir)
 
     def test_alert_manager_listener_artificial_run(self):
         with open(os.path.join(os.path.dirname(__file__),

--- a/unit_tests/test_send_email.py
+++ b/unit_tests/test_send_email.py
@@ -16,12 +16,11 @@ class EmailReporterTest(unittest.TestCase):
     temp_dir = None
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls):  # pylint: disable=invalid-name
         cls.temp_dir = tempfile.mkdtemp()
 
     @classmethod
-    def tearDownClass(cls):
-        # stop_events_device()
+    def tearDownClass(cls):  # pylint: disable=invalid-name
         shutil.rmtree(cls.temp_dir)
 
     def _get_report_data(self, zipfile_path):


### PR DESCRIPTION
There is 3rdparty repositorie for Debian 10, the installation doesn't
require it. The openjdk-8-jre dependency can be solved by adoptopenjdk
repositorie.

This patch removed invalid 3rdparty repositorie for Debian 10, and added
adoptopenjdk repositorie.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
