### PR TITLE
improvement(db-events): reduce severity to warning for cql_server con…

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -369,26 +369,25 @@ class BaseNode():  # pylint: disable=too-many-instance-attributes,too-many-publi
         self._alert_manager = None
 
         self._database_log_errors_index = []
-        self._database_error_events = [DatabaseLogEvent(type='NO_SPACE_ERROR', regex='No space left on device'),
-                                       DatabaseLogEvent(type='UNKNOWN_VERB',
-                                                        regex='unknown verb exception',
-                                                        severity=Severity.WARNING),
-                                       DatabaseLogEvent(type='DATABASE_ERROR', regex='Exception '),
-                                       DatabaseLogEvent(type='BAD_ALLOC', regex='std::bad_alloc'),
-                                       DatabaseLogEvent(type='SCHEMA_FAILURE', regex='Failed to load schema version'),
-                                       DatabaseLogEvent(type='RUNTIME_ERROR', regex='std::runtime_error'),
-                                       DatabaseLogEvent(type='FILESYSTEM_ERROR', regex='filesystem_error'),
-                                       DatabaseLogEvent(type='STACKTRACE', regex='stacktrace'),
-                                       DatabaseLogEvent(type='BACKTRACE', regex='backtrace', severity=Severity.ERROR),
-                                       DatabaseLogEvent(type='SEGMENTATION', regex='segmentation'),
-                                       DatabaseLogEvent(type='INTEGRITY_CHECK', regex='integrity check failed'),
-                                       DatabaseLogEvent(type='REACTOR_STALLED', regex='Reactor stalled',
-                                                        severity=Severity.WARNING),
-                                       DatabaseLogEvent(type='SEMAPHORE_TIME_OUT', regex='semaphore_timed_out'),
-                                       DatabaseLogEvent(type='BOOT', regex='Starting Scylla Server',
-                                                        severity=Severity.NORMAL),
-                                       DatabaseLogEvent(type='SUPPRESSED_MESSAGES', regex='journal: Suppressed',
-                                                        severity=Severity.WARNING)]
+        self._database_error_events = [
+            DatabaseLogEvent(type='NO_SPACE_ERROR', regex='No space left on device'),
+            DatabaseLogEvent(type='UNKNOWN_VERB', regex='unknown verb exception', severity=Severity.WARNING),
+            DatabaseLogEvent(type='CQL_SERVER_CONN_SYSTEM_ERROR', severity=Severity.WARNING,
+                             regex='cql_server - exception while processing connection: std::system_error'),
+            DatabaseLogEvent(type='DATABASE_ERROR', regex='Exception '),
+            DatabaseLogEvent(type='BAD_ALLOC', regex='std::bad_alloc'),
+            DatabaseLogEvent(type='SCHEMA_FAILURE', regex='Failed to load schema version'),
+            DatabaseLogEvent(type='RUNTIME_ERROR', regex='std::runtime_error'),
+            DatabaseLogEvent(type='FILESYSTEM_ERROR', regex='filesystem_error'),
+            DatabaseLogEvent(type='STACKTRACE', regex='stacktrace'),
+            DatabaseLogEvent(type='BACKTRACE', regex='backtrace', severity=Severity.ERROR),
+            DatabaseLogEvent(type='SEGMENTATION', regex='segmentation'),
+            DatabaseLogEvent(type='INTEGRITY_CHECK', regex='integrity check failed'),
+            DatabaseLogEvent(type='REACTOR_STALLED', regex='Reactor stalled'),
+            DatabaseLogEvent(type='SEMAPHORE_TIME_OUT', regex='semaphore_timed_out'),
+            DatabaseLogEvent(type='BOOT', regex='Starting Scylla Server', severity=Severity.NORMAL),
+            DatabaseLogEvent(type='SUPPRESSED_MESSAGES', regex='journal: Suppressed', severity=Severity.WARNING),
+        ]
 
         self.termination_event = threading.Event()
         self._running_nemesis = None


### PR DESCRIPTION
…nection processing error

Reduce severity to warning for the error message:
'cql_server - exception while processing connection: std::system_error'

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
