### PR TITLE
fix(cluster_aws): _need_to_install_scylla always set to True on master

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1958,6 +1958,15 @@ server_encryption_options:
             self.remoter.run(r'sudo apt-get install -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --force-yes --allow-unauthenticated {0}-server-dbg={1}\*'
                              .format(self.scylla_pkg(), self.scylla_version), ignore_status=True)
 
+    def is_scylla_installed(self):
+        if self.distro.is_rhel_like:
+            result = self.remoter.run(f'rpm -q {self.scylla_pkg()}', verbose=False, ignore_status=True)
+        elif self.distro.is_ubuntu or self.distro.is_debian:
+            result = self.remoter.run(f'dpkg-query --show {self.scylla_pkg()}', verbose=False, ignore_status=True)
+        else:
+            raise ValueError(f"Unsupported Linux distribution: {self.distro}")
+        return result.exit_status == 0
+
     def get_scylla_version(self):
         version_commands = ["scylla --version", "rpm -q {}".format(self.scylla_pkg())]
         for version_cmd in version_commands:

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -838,7 +838,7 @@ class ScyllaAWSCluster(cluster.BaseScyllaCluster, AWSCluster):
     def _scylla_pre_install(self, node):
         # Assume that all nodes in the cluster use the same AMI. So, need to check the availability of Scylla once.
         if self._need_to_install_scylla is None:
-            self._need_to_install_scylla = node.get_scylla_version() is None
+            self._need_to_install_scylla = not node.is_scylla_installed()
 
         if self._need_to_install_scylla:
             self.log.info("Can't find Scylla on the %s (%s), will try to install", node, node.image)


### PR DESCRIPTION
_need_to_install_scylla logic was based on `node.get_scylla_version()`
which return None on `666.development` versions, in this fix we will retrun the version
regardless if it's matching or not.