### PR TITLE
fix(perftests): disable backtrace decoding for perf tests

### DIFF
--- a/jenkins-pipelines/perf-regression-latency-30min.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-30min.jenkinsfile
@@ -12,5 +12,5 @@ perfRegressionParallelPipeline(
     test_config: "test-cases/performance/perf-regression-latency-500gb-30min.yaml",
     sub_tests: ["test_latency"],
 
-    timeout: [time: 300, unit: "MINUTES"]
+    timeout: [time: 350, unit: "MINUTES"]
 )

--- a/jenkins-pipelines/perf-regression-throughput-30min.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-throughput-30min.jenkinsfile
@@ -12,5 +12,5 @@ perfRegressionParallelPipeline(
     test_config: "test-cases/performance/perf-regression.100threads.30M-keys.yaml",
     sub_tests: ["test_write", "test_read", "test_mixed"],
 
-    timeout: [time: 300, unit: "MINUTES"]
+    timeout: [time: 350, unit: "MINUTES"]
 )

--- a/test-cases/performance/perf-regression-2mv.yaml
+++ b/test-cases/performance/perf-regression-2mv.yaml
@@ -22,3 +22,4 @@ user_prefix: 'perf-regression-mv'
 store_perf_results: true
 send_email: true
 email_recipients: ['roy@scylladb.com', 'bentsi@scylladb.com']
+backtrace_decoding: false

--- a/test-cases/performance/perf-regression-latency-1TB.yaml
+++ b/test-cases/performance/perf-regression-latency-1TB.yaml
@@ -26,3 +26,4 @@ append_scylla_args: '--blocked-reactor-notify-ms 4'
 store_perf_results: true
 send_email: true
 email_recipients: ['qa@scylladb.com', 'rnd-internal@scylladb.com']
+backtrace_decoding: false

--- a/test-cases/performance/perf-regression-latency-500gb-30min.yaml
+++ b/test-cases/performance/perf-regression-latency-500gb-30min.yaml
@@ -19,6 +19,7 @@ instance_type_db: 'i3.4xlarge'
 user_prefix: 'perf-regression-latency'
 space_node_threshold: 644245094
 ami_id_db_scylla_desc: 'VERSION_DESC'
+backtrace_decoding: false
 
 round_robin: true
 append_scylla_args: '--blocked-reactor-notify-ms 4'

--- a/test-cases/performance/perf-regression-latency-in-memory.yaml
+++ b/test-cases/performance/perf-regression-latency-in-memory.yaml
@@ -28,3 +28,4 @@ append_scylla_args: "--in-memory-storage-size-mb 80000 --blocked-reactor-notify-
 store_perf_results: true
 send_email: true
 email_recipients: ['qa@scylladb.com', 'rnd-internal@scylladb.com']
+backtrace_decoding: false

--- a/test-cases/performance/perf-regression-user-profiles.yaml
+++ b/test-cases/performance/perf-regression-user-profiles.yaml
@@ -34,3 +34,5 @@ cs_user_profiles:
 
 store_perf_results: true
 append_scylla_args: '--blocked-reactor-notify-ms 4'
+
+backtrace_decoding: false

--- a/test-cases/performance/perf-regression.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys.yaml
@@ -16,6 +16,8 @@ instance_type_monitor: 't3.small'
 user_prefix: 'perf-regression'
 space_node_threshold: 644245094
 
+backtrace_decoding: false
+
 store_perf_results: true
 send_email: true
 email_recipients: ['qa@scylladb.com']

--- a/test-cases/performance/perf-row-level-repair-1TB.yaml
+++ b/test-cases/performance/perf-row-level-repair-1TB.yaml
@@ -24,3 +24,5 @@ append_scylla_args: '--blocked-reactor-notify-ms 50'
 
 store_perf_results: true
 send_email: 'true'
+
+backtrace_decoding: false


### PR DESCRIPTION
Perf tests produces a lot of reactor stalls (4ms, 6ms etc) not critical
By default decoding backtraces enabled, and this cause monitoring node stack

- Disabled backtrace decoding for performances tests

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
