### PR TITLE
refactor(clean_by_post_behavior): use one function to clean resources

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -12,12 +12,11 @@ from prettytable import PrettyTable
 from sdcm.results_analyze import PerformanceResultsAnalyzer
 from sdcm.sct_config import SCTConfiguration
 from sdcm.utils.cloud_monitor import cloud_report
-from sdcm.utils.common import (list_instances_aws, list_instances_gce, clean_cloud_instances,
+from sdcm.utils.common import (list_instances_aws, list_instances_gce, clean_cloud_resources,
                                AWS_REGIONS, get_scylla_ami_versions, get_s3_scylla_repos_mapping,
                                list_logs_by_test_id, get_branched_ami, gce_meta_to_dict,
                                aws_tags_to_dict, list_elastic_ips_aws, get_builder_by_test_id,
-                               clean_aws_instances_according_post_behavior,
-                               clean_gce_instances_according_post_behavior,
+                               clean_resources_according_post_behavior,
                                search_test_id_in_latest, get_testrun_dir)
 from sdcm.utils.monitorstack import (restore_monitoring_stack, get_monitoring_stack_services,
                                      kill_running_monitoring_stack_services)
@@ -76,9 +75,8 @@ def provision(**kwargs):
 @sct_option('--test-id', 'test_id', help='test id to filter by. Could be used multiple times', multiple=True)
 @click.option('--logdir', type=str, help='directory with test run')
 @click.option('--config-file', multiple=True, type=click.Path(exists=True), help="Test config .yaml to use, can have multiple of those")
-@click.option('--backend', type=str, help="")
 @click.pass_context
-def clean_resources(ctx, user, test_id, logdir, config_file, backend):  # pylint: disable=too-many-arguments,too-many-branches
+def clean_resources(ctx, user, test_id, logdir, config_file):  # pylint: disable=too-many-arguments,too-many-branches
     params = dict()
 
     if config_file or logdir:
@@ -93,11 +91,9 @@ def clean_resources(ctx, user, test_id, logdir, config_file, backend):  # pylint
             click.echo(clean_resources.get_help(ctx))
             return
 
-        if not backend:
-            backend = "aws"
-
-        if not os.environ.get('SCT_CLUSTER_BACKEND', None):
-            os.environ['SCT_CLUSTER_BACKEND'] = backend
+        # need to pass SCTConfigration verification,
+        # but not affect on result
+        os.environ['SCT_CLUSTER_BACKEND'] = "aws"
 
         if config_file:
             os.environ['SCT_CONFIG_FILES'] = str(list(config_file))
@@ -106,11 +102,8 @@ def clean_resources(ctx, user, test_id, logdir, config_file, backend):  # pylint
 
         for _test_id in test_id:
             params['TestId'] = _test_id
-            if 'aws' in backend:
-                clean_aws_instances_according_post_behavior(params, config, logdir)
-            if 'gce' in backend:
-                clean_gce_instances_according_post_behavior(params, config, logdir)
 
+            clean_resources_according_post_behavior(params, config, logdir)
     else:
         if not (user or test_id):
             click.echo(clean_resources.get_help(ctx))
@@ -122,10 +115,10 @@ def clean_resources(ctx, user, test_id, logdir, config_file, backend):  # pylint
         if test_id:
             for _test_id in test_id:
                 params['TestId'] = _test_id
-                clean_cloud_instances(params)
+                clean_cloud_resources(params)
                 click.echo('cleaned instances for {}'.format(params))
         else:
-            clean_cloud_instances(params)
+            clean_cloud_resources(params)
             click.echo('cleaned instances for {}'.format(params))
 
 

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -413,7 +413,7 @@ class AWSNode(cluster.BaseNode):
                           'key_file': credentials.key_file}
         if len(self._instance.network_interfaces) == 2:
             # first we need to configure the both networks so we'll have public ip
-            self.allocate_and_attach_elastic_ip(parent_cluster, dc_idx)
+            self.allocate_and_attach_elastic_ip(parent_cluster, dc_idx, node_type)
 
         self._wait_public_ip()
         super(AWSNode, self).__init__(name=name,
@@ -532,7 +532,7 @@ class AWSNode(cluster.BaseNode):
     def _refresh_instance_state(self):
         raise NotImplementedError()
 
-    def allocate_and_attach_elastic_ip(self, parent_cluster, dc_idx):
+    def allocate_and_attach_elastic_ip(self, parent_cluster, dc_idx, node_type=None):
         primary_interface = [
             interface for interface in self._instance.network_interfaces if interface.attachment['DeviceIndex'] == 0][0]
         if primary_interface.association_attribute is None:
@@ -541,12 +541,14 @@ class AWSNode(cluster.BaseNode):
             response = client.allocate_address(Domain='vpc')
 
             self.eip_allocation_id = response['AllocationId']
-
+            tags_list = create_tags_list()
+            if node_type:
+                tags_list.append({'Key': 'NodeType', 'Value': node_type})
             client.create_tags(
                 Resources=[
                     self.eip_allocation_id
                 ],
-                Tags=create_tags_list()
+                Tags=tags_list
             )
             client.associate_address(
                 AllocationId=self.eip_allocation_id,

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -495,13 +495,16 @@ class ParallelObjectException(Exception):
         return ex_str
 
 
-def clean_cloud_instances(tags_dict):
+def clean_cloud_resources(tags_dict):
     """
     Remove all instances with specific tags from both AWS/GCE
 
     :param tags_dict: a dict of the tag to select the instances,e.x. {"TestId": "9bc6879f-b1ef-47e1-99ab-020810aedbcc"}
     :return: None
     """
+    if "TestId" not in tags_dict or "RunByUser" not in tags_dict:
+        LOGGER.error("Can't clean cloud resources, TestId or RunByUser is missing")
+        return
     clean_instances_aws(tags_dict)
     clean_elastic_ips_aws(tags_dict)
     clean_instances_gce(tags_dict)
@@ -1414,84 +1417,40 @@ def get_builder_by_test_id(test_id):
 
 def get_post_behavior_actions(config):
     action_per_type = {
-        "db_nodes": None,
-        "monitor_nodes": None,
-        "loader_nodes": None
+        "db_nodes": {"NodeType": "scylla-db", "action": None},
+        "monitor_nodes": {"NodeType": "monitor", "action": None},
+        "loader_nodes": {"NodeType": "loader", "action": None},
     }
 
     for key in action_per_type:
         config_key = 'post_behavior_{}'.format(key)
-        action_per_type[key] = config.get(config_key)
+        action_per_type[key]["action"] = config.get(config_key)
 
     return action_per_type
 
 
-def clean_aws_instances_according_post_behavior(params, config, logdir):  # pylint: disable=invalid-name
-
-    status = get_testrun_status(params.get('TestId'), logdir)
-
-    def apply_action(instances, action):
-        if action == 'destroy':
-            instances_ids = [instance['InstanceId'] for instance in instances]
-            if not instances_ids:
-                LOGGER.warning("No InstanceId found for termination")
-                return
-            LOGGER.info('Clean next instances %s', instances_ids)
-            try:
-                client.terminate_instances(InstanceIds=instances_ids)
-            except Exception as details:  # pylint: disable=broad-except
-                LOGGER.error("Error during instance termination: %s", details)
-        elif action == 'keep-on-failure':
-            if status:
-                LOGGER.info('Run failed. Leave instances running')
-            else:
-                LOGGER.info('Run was Successful. Killing nodes')
-                apply_action(instances, action='destroy')
-        elif action == 'keep':
-            LOGGER.info('Leave instances running')
-        else:
-            LOGGER.warning('Unsupported action %s', action)
-
-    aws_instances = list_instances_aws(params, group_as_region=True)
-    for region, instances in aws_instances.items():
-        if not instances:
-            continue
-        client = boto3.client("ec2", region_name=region)
-        filtered_instances = filter_aws_instances_by_type(instances)
-        actions_per_type = get_post_behavior_actions(config)
-
-        for instance_set_type, action in actions_per_type.items():
-            LOGGER.info('Apply action "%s" for %s instances', action, instance_set_type)
-            apply_action(filtered_instances[instance_set_type], action)
-
-
-def clean_gce_instances_according_post_behavior(params, config, logdir):  # pylint: disable=invalid-name
-
-    status = get_testrun_status(params.get('TestId'), logdir)
-
-    def apply_action(instances, action):
-        if action == 'destroy':
-            for instance in instances:
-                LOGGER.info('Destroying instance: %s', instance.name)
-                instance.destroy()
-                LOGGER.info('Destroyed instance: %s', instance.name)
-        elif action == 'keep-on-failure':
-            if status:
-                LOGGER.info('Run failed. Leave instances running')
-            else:
-                LOGGER.info('Run wasSuccessful. Killing nodes')
-                apply_action(instances, action='destroy')
-        elif action == 'keep':
-            LOGGER.info('Leave instances runing')
-        else:
-            LOGGER.warning('Unsupported action %s', action)
-
-    gce_instances = list_instances_gce(params)
-    filtered_instances = filter_gce_instances_by_type(gce_instances)
+def clean_resources_according_post_behavior(params, config, logdir):
+    success = get_testrun_status(params.get('TestId'), logdir)
     actions_per_type = get_post_behavior_actions(config)
-
-    for instance_set_type, action in actions_per_type.items():
-        apply_action(filtered_instances[instance_set_type], action)
+    LOGGER.debug(actions_per_type)
+    for cluster_nodes_type, action_type in actions_per_type.items():
+        if action_type["action"] == "keep":
+            LOGGER.info("Post behavior %s for %s. Keep resources running", action_type["action"], cluster_nodes_type)
+        elif action_type["action"] == "destroy":
+            params["NodeType"] = action_type["NodeType"]
+            LOGGER.info("Post behavior %s for %s. Clean resources", action_type["action"], cluster_nodes_type)
+            clean_cloud_resources(params)
+            continue
+        elif action_type["action"] == "keep-on-failure" and not success:
+            params["NodeType"] = action_type["NodeType"]
+            LOGGER.info("Post behavior %s for %s. Test run Successful. Clean resources",
+                        action_type["action"], cluster_nodes_type)
+            clean_cloud_resources(params)
+            continue
+        else:
+            LOGGER.info("Post behavior %s for %s. Test run Failed. Keep resources running",
+                        action_type["action"], cluster_nodes_type)
+            continue
 
 
 def search_test_id_in_latest(logdir):


### PR DESCRIPTION
refactor code to use function clean_cloud_resources when
clean instances according configured post behavior. Before fix
Elastic IPs were not cleaned during instances cleaning.

Trello: https://trello.com/c/0n11H7Z6
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
