### PR TITLE
fix(cluster): rework BaseNode.get_scylla_version to support Debian/Ubuntu too

### DIFF
--- a/sdcm/sct_events.py
+++ b/sdcm/sct_events.py
@@ -210,6 +210,8 @@ class StartupTestEvent(SystemEvent):
 
 
 class TestFrameworkEvent(SctEvent):  # pylint: disable=too-many-instance-attributes
+    __test__ = False  # Mark this class to be not collected by pytest.
+
     def __init__(self, source, source_method,  # pylint: disable=redefined-builtin,too-many-arguments
                  exception=None, message=None, args=None, kwargs=None, severity=None):
         super().__init__()
@@ -649,6 +651,8 @@ class PrometheusAlertManagerEvent(SctEvent):  # pylint: disable=too-many-instanc
 
 
 class TestKiller(Process):
+    __test__ = False  # Mark this class to be not collected by pytest.
+
     def __init__(self, timeout_before_kill=2, test_callback=None):
         super(TestKiller, self).__init__()
         self._test_pid = os.getpid()

--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -5,6 +5,13 @@ from pkg_resources import parse_version
 from repodataParser.RepoParser import Parser
 
 
+# Examples of ScyllaDB version strings:
+#   - 666.development-0.20200205.2816404f575
+#   - 3.3.rc1-0.20200209.0d0c1d43188
+#   - 2019.1.4-0.20191217.b59e92dbd
+SCYLLA_VERSION_RE = re.compile(r"\d+(\.\d+)?\.[\d\w]+([.~][\d\w]+)?")
+
+
 def get_branch_version(url):
     try:
         return get_branch_version_from_list(url)


### PR DESCRIPTION
Trello: https://trello.com/c/jdAXjVv5/1684-add-scylla-version-check-to-debian

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
