### PR TITLE
fix(sdcm/stress_thread.py): Fix it to not fail when stress cmd got exception

### DIFF
--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -244,6 +244,9 @@ class CassandraStressThread():  # pylint: disable=too-many-instance-attributes
             results.append(future.result())
 
         for node, result in results:
+            if not result:
+                continue
+
             output = result.stdout + result.stderr
             lines = output.splitlines()
             node_cs_res = BaseLoaderSet._parse_cs_summary(lines)  # pylint: disable=protected-access


### PR DESCRIPTION
Fix it to not fail when stress cmd got exception
When it happens you can get following error:

```
< t:2020-02-23 13:47:04,984 f:tester.py       l:1640 c:sdcm.tester          p:ERROR > Traceback (most recent call last):
< t:2020-02-23 13:47:04,984 f:tester.py       l:1640 c:sdcm.tester          p:ERROR >   File "/sct/longevity_test.py", line 244, in test_custom_time
< t:2020-02-23 13:47:04,984 f:tester.py       l:1640 c:sdcm.tester          p:ERROR >     self.verify_stress_thread(cs_thread_pool=stress)
< t:2020-02-23 13:47:04,984 f:tester.py       l:1640 c:sdcm.tester          p:ERROR >   File "/sct/sdcm/tester.py", line 797, in verify_stress_thread
< t:2020-02-23 13:47:04,984 f:tester.py       l:1640 c:sdcm.tester          p:ERROR >     results, errors = cs_thread_pool.verify_results()
< t:2020-02-23 13:47:04,984 f:tester.py       l:1640 c:sdcm.tester          p:ERROR >   File "/sct/sdcm/stress_thread.py", line 247, in verify_results
< t:2020-02-23 13:47:04,984 f:tester.py       l:1640 c:sdcm.tester          p:ERROR >     output = result.stdout + result.stderr
< t:2020-02-23 13:47:04,984 f:tester.py       l:1640 c:sdcm.tester          p:ERROR > AttributeError: 'NoneType' object has no attribute 'stdout'

```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
