### PR TITLE
improvement(cluster): backport cached_property from Python 3.8

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -44,7 +44,7 @@ from sdcm.log import SDCMAdapter
 from sdcm.remote import RemoteCmdRunner, LocalCmdRunner, NETWORK_EXCEPTIONS
 from sdcm import wait
 from sdcm.utils.common import log_run_info, retrying, get_data_dir_path, verify_scylla_repo_file, S3Storage, \
-    get_latest_gemini_version, get_my_ip, makedirs, normalize_ipv6_url, deprecation
+    get_latest_gemini_version, get_my_ip, makedirs, normalize_ipv6_url, deprecation, cached_property
 from sdcm.utils.distro import Distro
 from sdcm.utils.thread import raise_event_on_failure
 from sdcm.utils.remotewebbrowser import RemoteWebDriverContainer
@@ -363,7 +363,6 @@ class BaseNode():  # pylint: disable=too-many-instance-attributes,too-many-publi
         self._init_system = None
         self.db_init_finished = False
 
-        self._distro = None
         self._short_hostname = None
         self._alert_manager = None
 
@@ -469,12 +468,10 @@ class BaseNode():  # pylint: disable=too-many-instance-attributes,too-many-publi
         with self.lock:
             self._running_nemesis = nemesis
 
-    @property
+    @cached_property
     def distro(self):
-        if not self._distro:
-            self.log.info("Trying to detect Linux distribution...")
-            self._distro = Distro.from_os_release(self.remoter.run("cat /etc/os-release", ignore_status=True).stdout)
-        return self._distro
+        self.log.info("Trying to detect Linux distribution...")
+        return Distro.from_os_release(self.remoter.run("cat /etc/os-release", ignore_status=True).stdout)
 
     @property
     def is_client_encrypt(self):

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -50,6 +50,67 @@ LOGGER = logging.getLogger('utils')
 DEFAULT_AWS_REGION = "eu-west-1"
 
 
+try:
+    from functools import cached_property  # pylint: disable=unused-import,ungrouped-imports
+except ImportError:
+    # Copy/pasted from https://github.com/python/cpython/blob/3.8/Lib/functools.py#L923
+
+    # TODO: remove this code after switching to Python 3.8+
+
+    ################################################################################
+    # cached_property() - computed once per instance, cached as attribute
+    ################################################################################
+
+    _NOT_FOUND = object()
+
+    class cached_property:  # pylint: disable=invalid-name,too-few-public-methods
+        def __init__(self, func):
+            self.func = func
+            self.attrname = None
+            self.__doc__ = func.__doc__
+            self.lock = threading.RLock()
+
+        def __set_name__(self, owner, name):
+            if self.attrname is None:
+                self.attrname = name
+            elif name != self.attrname:
+                raise TypeError(
+                    "Cannot assign the same cached_property to two different names "
+                    f"({self.attrname!r} and {name!r})."
+                )
+
+        def __get__(self, instance, owner=None):
+            if instance is None:
+                return self
+            if self.attrname is None:
+                raise TypeError(
+                    "Cannot use cached_property instance without calling __set_name__ on it.")
+            try:
+                cache = instance.__dict__
+            except AttributeError:  # not all objects have __dict__ (e.g. class defines slots)
+                msg = (
+                    f"No '__dict__' attribute on {type(instance).__name__!r} "
+                    f"instance to cache {self.attrname!r} property."
+                )
+                raise TypeError(msg) from None
+            val = cache.get(self.attrname, _NOT_FOUND)
+            if val is _NOT_FOUND:
+                with self.lock:
+                    # check if another thread filled cache while we awaited lock
+                    val = cache.get(self.attrname, _NOT_FOUND)
+                    if val is _NOT_FOUND:
+                        val = self.func(instance)
+                        try:
+                            cache[self.attrname] = val
+                        except TypeError:
+                            msg = (
+                                f"The '__dict__' attribute on {type(instance).__name__!r} instance "
+                                f"does not support item assignment for caching {self.attrname!r} property."
+                            )
+                            raise TypeError(msg) from None
+            return val
+
+
 def deprecation(message):
     warnings.warn(message, DeprecationWarning, stacklevel=3)
 


### PR DESCRIPTION
Trello: https://trello.com/c/OL9IQkBD/1691-backport-cachedproperty-from-python-38-stdlib

...and provide an example of usage.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [ ] ~~I didn't copy-paste code~~ :smile:
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
