### PR TITLE
fix(aws.restart): rename scylla-cloud-image to scylla-machine-image

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -658,7 +658,7 @@ class AWSNode(cluster.BaseNode):
                 # the scylla_create_devices has been moved to the '/opt/scylladb' folder in the master branch
                 for create_devices_file in ['/usr/lib/scylla/scylla-ami/scylla_create_devices',
                                             '/opt/scylladb/scylla-ami/scylla_create_devices',
-                                            '/opt/scylladb/scylla-cloud-image/scylla_create_devices']:
+                                            '/opt/scylladb/scylla-machine-image/scylla_create_devices']:
                     result = self.remoter.run('sudo test -e %s' % create_devices_file, ignore_status=True)
                     if result.exit_status == 0:
                         self.remoter.run('sudo %s' % create_devices_file)


### PR DESCRIPTION
since we are renaming scylla-cloud-image repo to scylla-machine-image
direcoty name is also changing

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
