### PR TITLE
feature(upgrade_test.py): add repair in a mixed cluster

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -537,6 +537,8 @@ class UpgradeTest(FillDatabaseData):
 
         with self.subTest('Step4 - Verify data during mixed cluster mode '):
             self.fill_and_verify_db_data('after rollback the second node')
+            self.log.info('Repair the first upgraded Node')
+            self.db_cluster.nodes[indexes[0]].run_nodetool(sub_cmd='repair')
 
         with DbEventsFilter(type='DATABASE_ERROR', line='Failed to load schema'), \
                 DbEventsFilter(type='SCHEMA_FAILURE', line='Failed to load schema'), \


### PR DESCRIPTION
We want to test repair in mixed cluster, this PR only added a repair test after upgraded first db node.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
