### PR TITLE
improvement(cloud-monitor): display zeros as empty strings

### DIFF
--- a/sdcm/utils/cloud_monitor/report.py
+++ b/sdcm/utils/cloud_monitor/report.py
@@ -19,7 +19,8 @@ class BaseReport:
 
     def _jinja_render_template(self, **kwargs):
         loader = jinja2.FileSystemLoader(self.templates_dir)
-        env = jinja2.Environment(loader=loader, autoescape=True, extensions=['jinja2.ext.loopcontrols'])
+        env = jinja2.Environment(loader=loader, autoescape=True, extensions=['jinja2.ext.loopcontrols'],
+                                 finalize=lambda x: x if x != 0 else "")
         template = env.get_template(self.html_template)
         html = template.render(**kwargs)
         return html


### PR DESCRIPTION
Currently in the email report when ther no used
instances we use '0' that makes the report less
readable. To improve this we convert '0' to empty
strings.

![image](https://user-images.githubusercontent.com/5269241/75251190-2d782100-57eb-11ea-9b91-e5e6508dd5d7.png)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
