### PR TITLE
fix(logcollector): fix collect sct-runner log

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1476,7 +1476,7 @@ def get_builder_by_test_id(test_id):
             return None
 
     search_obj = ParallelObject(builders, timeout=30, num_workers=len(builders))
-    results = search_obj.run(search_test_id_on_builder, ignore_exceptions=True)
+    results = search_obj.run(search_test_id_on_builder, ignore_exceptions=True, unpack_objects=True)
     found_builders = [builder.result for builder in results if not builder.exc and builder.result]
     if not found_builders:
         LOGGER.info("Nothing found for %s", test_id)


### PR DESCRIPTION
After fix ParallelObject, logcollector stopped to collect
sct runner logs from localhost. Adding new parameter to
unpack objects fix issue.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
