### PR TITLE
fix(scylla config): replace experimental flag

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1639,7 +1639,11 @@ class BaseNode():  # pylint: disable=too-many-instance-attributes,too-many-publi
                     murmur3_partitioner_ignore_msb_bits)
 
         if enable_exp:
-            scylla_yaml_contents += "\nexperimental: true\n"
+            pattern = re.compile('experimental:.*')
+            if pattern.findall(scylla_yaml_contents):
+                scylla_yaml_contents = pattern.sub('experimental: true', scylla_yaml_contents)
+            else:
+                scylla_yaml_contents += "\nexperimental: true\n"
 
         if endpoint_snitch:
             pattern = re.compile('endpoint_snitch:.*')


### PR DESCRIPTION
recently scylla.yaml was changed to include `experimental: false` explicitly
we need to apapt SCT code to replace it, and not just add it

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
