### PR TITLE
improvement(test-result): support exceptions during setUp

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -128,6 +128,7 @@ def teardown_on_exception(method):
             return method(*args, **kwargs)
         except Exception:
             TEST_LOG.exception("Exception in %s. Will call tearDown", method.__name__)
+            args[0].setup_failure = traceback.format_exc()
             args[0].tearDown()
             raise
     return wrapper
@@ -137,6 +138,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     def __init__(self, *args):  # pylint: disable=too-many-statements
         super(ClusterTester, self).__init__(*args)
         self.result = None
+        self.setup_failure = None  # is set when exception occurs during setUp
         self.status = "RUNNING"
         self.params = SCTConfiguration()
         self.params.verify_configuration()
@@ -1369,11 +1371,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         try:
             test_error, test_failure = self.get_test_failures()
             test_result_event = TestResultEvent(test_name=self.id(), error=test_error, failure=test_failure)
-            TEST_LOG.info(str(test_result_event))
         except Exception:  # pylint: disable=broad-except
             self.log.exception("Unable to get test result")
-        self.tag_ami_with_result(test_error, test_failure)
         test_result_event.publish()
+        self.tag_ami_with_result(test_error, test_failure)
         try:
             self.finalize_test()
         except Exception as details:
@@ -1608,7 +1609,12 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             since tearDown can take a while, or even fail on it's own, we want to know fast what the failure/error is.
             applied the idea from
             https://stackoverflow.com/questions/4414234/getting-pythons-unittest-results-in-a-teardown-method/39606065#39606065
+            :returns tuple(error, test_failure)
         """
+
+        if self.setup_failure:
+            return self.setup_failure, None
+
         def list2reason(exc_list):
             """
             Gets last backtrace string from `exc_list`

--- a/unit_tests/test_events.py
+++ b/unit_tests/test_events.py
@@ -9,7 +9,7 @@ import datetime
 from pathlib import Path
 from multiprocessing import Event
 
-from sdcm.tester import ClusterTester
+from sdcm.tester import ClusterTester, teardown_on_exception
 from sdcm.utils.common import timeout
 from sdcm.prometheus import start_metrics_server
 from sdcm.sct_events import (start_events_device, stop_events_device, TestKiller, InfoEvent, CassandraStressEvent,
@@ -23,6 +23,7 @@ logging.basicConfig(format="%(asctime)s - %(levelname)-8s - %(name)-10s: %(messa
 
 
 class BaseEventsTest(unittest.TestCase):
+
     @classmethod
     def get_event_log_file(cls, name):
         log_file = Path(cls.temp_dir, 'events_log', name)
@@ -323,6 +324,7 @@ class SctEventsTests(BaseEventsTest):
 
 
 class TesterFailure(BaseEventsTest):
+    setup_failure = None
 
     def test_failure_found(self):
         self.assertTrue(1 == 0)
@@ -341,6 +343,7 @@ class TesterFailure(BaseEventsTest):
 
 
 class TesterError(BaseEventsTest):
+    setup_failure = None
 
     def test_error_found(self):  # pylint: disable=no-self-use
         raise Exception("error in during test")
@@ -359,6 +362,7 @@ class TesterError(BaseEventsTest):
 
 
 class TesterNoErrors(BaseEventsTest):
+    setup_failure = None
 
     def test_no_errors_found(self):  # pylint: disable=no-self-use
         print("happy test")
@@ -373,6 +377,22 @@ class TesterNoErrors(BaseEventsTest):
         assert not test_error
         events_log = self.get_event_logs()
         assert "FAILURE" not in events_log and "ERROR" not in events_log
+
+
+class TesterErrorDuringSetUp(unittest.TestCase):
+    __unittest_expecting_failure__ = True
+
+    @teardown_on_exception
+    def test_noop(self):  # pylint: disable=no-self-use
+        raise Exception("Something bad happened during setUp!")
+
+    def tearDown(self) -> None:
+        assert self.setup_failure is not None, "setup_failure should contain traceback"  # pylint: disable=no-member
+        test_error, test_failure = ClusterTester.get_test_failures(self)
+        assert test_failure is None
+        assert test_error is not None
+        tre = TestResultEvent(test_name=self.id(), error=test_error, failure=test_failure)
+        assert tre.severity == Severity.CRITICAL
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
TestResultEvent will now include exceptions that happen
during setUp phase.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
