### PR TITLE
fix(db_stat.py): make get_scylla_version work on Debian like distros

### DIFF
--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -357,7 +357,12 @@ class TestStatsMixin(Stats):
     def get_scylla_versions(self):
         versions = {}
         try:
-            versions_output = self.db_cluster.nodes[0].remoter.run('rpm -qa | grep scylla').stdout.splitlines()
+            node = self.db_cluster.nodes[0]
+            if node.is_rhel_like():
+                version_cmd = 'rpm -qa |grep scylla'
+            else:
+                version_cmd = "dpkg -l |grep scylla|awk '{print $2 \"-\" $3}'"
+            versions_output = node.remoter.run(version_cmd).stdout.splitlines()
             for line in versions_output:
                 for package in ['scylla-jmx', 'scylla-server', 'scylla-tools', 'scylla-enterprise-jmx',
                                 'scylla-enterprise-server', 'scylla-enterprise-tools']:


### PR DESCRIPTION
Currently get_scylla_version() uses rpm command to get packages list,
it doesn't work on Debian like distros.

Fixes #1868

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
