### PR TITLE
fix(awsloaderami): New loader aws ami with golang 1.13

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -8,19 +8,19 @@ regions_data:
   us-east-1:
     security_group_ids: 'sg-c5e1f7a0'
     subnet_id: 'subnet-ec4a72c4'
-    ami_id_loader: 'ami-02174c53cd1bcc163' # Loader dedicated AMI
+    ami_id_loader: 'ami-01784b575d450e3b2' # Loader dedicated AMI v9 with golang 1.13
     ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
     backup_bucket_location: 'manager-backup-tests-us-east-1'
   eu-west-1:
     security_group_ids: 'sg-059a7f66a947d4b5c'
     subnet_id: 'subnet-088fddaf520e4c7a8'
-    ami_id_loader: 'ami-08488048283fc2ad2' # Loader dedicated AMI
+    ami_id_loader: 'ami-0cdfd6050090ab044' # Loader dedicated AMI v9 with golang 1.13
     ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
     backup_bucket_location: 'manager-backup-tests-eu-west-1'
   us-west-2:
     security_group_ids: 'sg-81703ae4'
     subnet_id: 'subnet-5207ee37'
-    ami_id_loader: 'ami-0414344fae7ac9919' # Loader dedicated AMI
+    ami_id_loader: 'ami-0d2703a09ffa20a1e' # Loader dedicated AMI v9 with golang 1.13
     ami_id_monitor: 'ami-01ed306a12b7d1c96' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
     backup_bucket_location: 'manager-backup-tests-eu-west-2'
 


### PR DESCRIPTION
Created new loader dedicated AMI with upgraded golang from
version 1.9 to 1.13

For CDC feature cdc-stresser tool require golang 1.10. Created new amis for loaders with golang 1.13
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
