### PR TITLE
fix(add_node on nemesis): Node addition to monitor before bootstrap

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -419,6 +419,7 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
         """When old_node_private_ip is not None replacement node procedure is initiated"""
         self.log.info("Adding new node to cluster...")
         new_node = self.cluster.add_nodes(count=1, dc_idx=self.target_node.dc_idx, enable_auto_bootstrap=True)[0]
+        self.monitoring_set.reconfigure_scylla_monitoring()
         self.set_current_running_nemesis(node=new_node)  # prevent to run nemesis on new node when running in parallel
         new_node.replacement_node_ip = old_node_ip
         try:
@@ -429,7 +430,6 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
             self.log.warning("Node will not be terminated. Please terminate manually!!!")
             raise
         self.cluster.wait_for_nodes_up_and_normal(nodes=[new_node])
-        self.monitoring_set.reconfigure_scylla_monitoring()
         return new_node
 
     def _terminate_cluster_node(self, node):


### PR DESCRIPTION
We had an issue, and we didn't have the data during bootstrap, as the
node was added to monitor only after the DB was already UP and NORMAL.
Here is a minor fix to do it earlier, then we will be able to have
more data, the earliest as possible in the monitor.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
