### PR TITLE
fix(clean_cloud_resources): Fix error in if statement

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -563,12 +563,13 @@ def clean_cloud_resources(tags_dict):
     :param tags_dict: a dict of the tag to select the instances,e.x. {"TestId": "9bc6879f-b1ef-47e1-99ab-020810aedbcc"}
     :return: None
     """
-    if "TestId" not in tags_dict or "RunByUser" not in tags_dict:
+    if "TestId" not in tags_dict and "RunByUser" not in tags_dict:
         LOGGER.error("Can't clean cloud resources, TestId or RunByUser is missing")
-        return
+        return False
     clean_instances_aws(tags_dict)
     clean_elastic_ips_aws(tags_dict)
     clean_instances_gce(tags_dict)
+    return True
 
 
 def aws_tags_to_dict(tags_list):

--- a/unit_tests/test_clean_cloud_resources_func.py
+++ b/unit_tests/test_clean_cloud_resources_func.py
@@ -1,0 +1,37 @@
+import unittest
+from sdcm.utils.common import clean_cloud_resources
+
+
+class CleanCloudResourcesTest(unittest.TestCase):
+
+    def test_no_tag_testid_and_runbyuser(self):
+        params = {}
+        res = clean_cloud_resources(params)
+        self.assertFalse(res)
+
+    def test_other_tags_and_no_testid_and_runbyuser(self):
+        params = {"NodeType": "scylla-db"}
+        res = clean_cloud_resources(params)
+        self.assertFalse(res)
+
+    def test_tag_testid_only(self):
+        params = {"RunByUser": "test"}
+        res = clean_cloud_resources(params)
+        self.assertTrue(res)
+
+    def test_tag_runbyuser_only(self):
+        params = {"TestId": "1111"}
+        res = clean_cloud_resources(params)
+        self.assertTrue(res)
+
+    def test_tags_testid_and_runbyuser(self):
+        params = {"RunByUser": "test", "TestId": "1111"}
+        res = clean_cloud_resources(params)
+        self.assertTrue(res)
+
+    def test_tags_testid_and_runbyuser_with_other(self):
+        params = {"RunByUser": "test",
+                  "TestId": "1111",
+                  "NodeType": "monitor"}
+        res = clean_cloud_resources(params)
+        self.assertTrue(res)


### PR DESCRIPTION
hydra clean-resources with --test-id or --user not working
due to wrong expressison in if statement

Related to https://github.com/scylladb/scylla-cluster-tests/pull/1849

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
