### PR TITLE
fix(alternator): name of alternator keyspaces were changed

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -100,7 +100,7 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
         self._add_drop_column_target_table = []
         self._add_drop_column_tables_to_ignore = {
             'scylla_bench': '*',  # Ignore scylla-bench tables
-            'a#usertable': '*',  # Ignore alternator tables
+            'alternator_usertable': '*',  # Ignore alternator tables
             'mview': 'users',  # Ignore MV user-profile tables
             'sec_index': 'users',  # Ignore SI user-profile tables
         }

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1174,7 +1174,7 @@ def get_non_system_ks_cf_list(loader_node, db_node, request_timeout=300, filter_
         for row in result[4:]:
             if '|' not in row:
                 continue
-            if row.startswith('system') or row.startswith('a#usertable'):
+            if row.startswith('system') or row.startswith('alternator_usertable'):
                 continue
             splitter_result.append(row.split('|'))
         return splitter_result


### PR DESCRIPTION
Now those keyspaces are prefixed with `alternator_`, and we still want to
exclude them from several nemesis

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
