### PR TITLE
fix(artifact-test): disable changing rf of system_auth

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -302,7 +302,7 @@ class SCTConfiguration(dict):
         dict(name="authorizer", env="SCT_AUTHORIZER", type=str,
              help="which authorizer scylla will use AllowAllAuthorizer/CassandraAuthorizer"),
 
-        dict(name="system_auth_rf", env="SCT_SYSTEM_AUTH_RF", type=str,
+        dict(name="system_auth_rf", env="SCT_SYSTEM_AUTH_RF", type=int,
              help="Replication factor will be set to system_auth"),
 
         dict(name="alternator_port", env="SCT_ALTERNATOR_PORT", type=int,

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -305,7 +305,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     def set_system_auth_rf(self):
         # change RF of system_auth
         system_auth_rf = self.params.get('system_auth_rf')
-        if system_auth_rf and not cluster.Setup.REUSE_CLUSTER:
+        if system_auth_rf > 1 and not cluster.Setup.REUSE_CLUSTER:
             self.log.info('change RF of system_auth to %s', system_auth_rf)
             node = self.db_cluster.nodes[0]
             credentials = self.db_cluster.get_db_auth()

--- a/test-cases/artifacts/ami.yaml
+++ b/test-cases/artifacts/ami.yaml
@@ -13,3 +13,4 @@ scylla_linux_distro: 'centos'
 store_results_in_elasticsearch: False
 test_duration: 600
 user_prefix: 'artifacts-ami'
+system_auth_rf: 1

--- a/test-cases/artifacts/centos7.yaml
+++ b/test-cases/artifacts/centos7.yaml
@@ -15,3 +15,4 @@ scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-
 store_results_in_elasticsearch: False
 test_duration: 600
 user_prefix: 'artifacts-centos7'
+system_auth_rf: 1

--- a/test-cases/artifacts/centos8.yaml
+++ b/test-cases/artifacts/centos8.yaml
@@ -15,3 +15,4 @@ scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-
 store_results_in_elasticsearch: False
 test_duration: 600
 user_prefix: 'artifacts-centos8'
+system_auth_rf: 1

--- a/test-cases/artifacts/debian10.yaml
+++ b/test-cases/artifacts/debian10.yaml
@@ -15,3 +15,4 @@ scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/debian/scylla-
 store_results_in_elasticsearch: False
 test_duration: 600
 user_prefix: 'artifacts-debian10'
+system_auth_rf: 10

--- a/test-cases/artifacts/debian9.yaml
+++ b/test-cases/artifacts/debian9.yaml
@@ -15,3 +15,4 @@ scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/debian/scylla-
 store_results_in_elasticsearch: False
 test_duration: 600
 user_prefix: 'artifacts-debian9'
+system_auth_rf: 10

--- a/test-cases/artifacts/docker.yaml
+++ b/test-cases/artifacts/docker.yaml
@@ -10,3 +10,4 @@ scylla_version: '3.3.rc1'
 store_results_in_elasticsearch: False
 test_duration: 600
 user_prefix: 'artifacts-docker'
+system_auth_rf: 1

--- a/test-cases/artifacts/oel76.yaml
+++ b/test-cases/artifacts/oel76.yaml
@@ -15,3 +15,4 @@ scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-
 store_results_in_elasticsearch: False
 test_duration: 600
 user_prefix: 'artifacts-oel76'
+system_auth_rf: 1

--- a/test-cases/artifacts/rhel7.yaml
+++ b/test-cases/artifacts/rhel7.yaml
@@ -15,3 +15,4 @@ scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-
 store_results_in_elasticsearch: False
 test_duration: 600
 user_prefix: 'artifacts-rhel7'
+system_auth_rf: 1

--- a/test-cases/artifacts/rhel8.yaml
+++ b/test-cases/artifacts/rhel8.yaml
@@ -15,3 +15,4 @@ scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-
 store_results_in_elasticsearch: False
 test_duration: 600
 user_prefix: 'artifacts-rhel8'
+system_auth_rf: 1

--- a/test-cases/artifacts/ubuntu1604.yaml
+++ b/test-cases/artifacts/ubuntu1604.yaml
@@ -15,3 +15,4 @@ scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-
 store_results_in_elasticsearch: False
 test_duration: 600
 user_prefix: 'artifacts-ubuntu1604'
+system_auth_rf: 1

--- a/test-cases/artifacts/ubuntu1804.yaml
+++ b/test-cases/artifacts/ubuntu1804.yaml
@@ -15,3 +15,4 @@ scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-
 store_results_in_elasticsearch: False
 test_duration: 600
 user_prefix: 'artifacts-ubuntu1804'
+system_auth_rf: 1


### PR DESCRIPTION
Artifact-tests only have one db node, so we don't need to change rf of
system_auth.

Fixes #1883

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
