### PR TITLE
fix(artifacts test): provide default region_name for OEL test

### DIFF
--- a/jenkins-pipelines/artifacts-oel76.jenkinsfile
+++ b/jenkins-pipelines/artifacts-oel76.jenkinsfile
@@ -8,6 +8,7 @@ artifactsPipeline(
 
     test_config: 'test-cases/artifacts/oel76.yaml',
     backend: 'aws',
+    region_name: 'eu-west-1',
     instance_provision: 'spot_low_price',
 
     timeout: [time: 30, unit: 'MINUTES'],

--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -21,7 +21,7 @@ def call(Map pipelineParams) {
             string(defaultValue: '',
                    description: 'a Scylla AMI to run against (for AMI test, should be blank otherwise)',
                    name: 'scylla_ami_id')
-            string(defaultValue: '',
+            string(defaultValue: "${pipelineParams.get('region_name', '')}",
                    description: 'AWS region with Scylla AMI (for AMI test, ignored otherwise)',
                    name: 'region_name')
             string(defaultValue: '',


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
