### PR TITLE
feature(event_analyzer): stopping the test on critical event

### DIFF
--- a/docs/sct-events.md
+++ b/docs/sct-events.md
@@ -3,3 +3,18 @@
 ## Overview
 
 ![Overview](./sct_events.png?raw=true "Overview")
+
+### Event Analyzer
+
+Recently we introduced a background thread (`sdcm/sct_events_analyzer.py`) that stops the test on:
+ * critical events
+ * stress commands failures
+
+Cause of that `DatabaseLogEvent` default severity was lowered to `ERROR` level
+
+### Event Levels
+
+* `NORMAL = 1` - as example, start of a Nemesis or start of a Stress Thread
+* `WARNING = 2` - event that we should consider checking, but not fail the tests cause of them.
+* `ERROR = 3` - will fail the test, but isn't considered for `keep-on-failure`, i.e. resources would be deleted.
+* `CRITICAL = 4` - will send a signal (SIGUSR2) and would stop the test immediately, when `keep-on-failure` is used instances will be saved

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -118,6 +118,7 @@ class Setup:
     _test_name = None
     TAGS = dict()
     _logdir = None
+    _tester_obj = None
 
     @classmethod
     def test_id(cls):
@@ -132,6 +133,15 @@ class Setup:
                 test_id_file.write(str(test_id))
         else:
             LOGGER.warning("TestID already set!")
+
+    @classmethod
+    def tester_obj(cls):
+        return cls._tester_obj
+
+    @classmethod
+    def set_tester_obj(cls, tester_obj):
+        if not cls._tester_obj:
+            cls._tester_obj = tester_obj
 
     @classmethod
     def logdir(cls):

--- a/sdcm/ndbench_thread.py
+++ b/sdcm/ndbench_thread.py
@@ -99,7 +99,7 @@ class NdBenchStressThread(DockerBasedStressThread):  # pylint: disable=too-many-
 
         def raise_event_callback(sentinal, line):  # pylint: disable=unused-argument
             if line:
-                NdbenchStressEvent(type='error', severity=Severity.CRITICAL,
+                NdbenchStressEvent(type='error', severity=Severity.ERROR,
                                    node=loader, stress_cmd=self.stress_cmd, errors=[str(line)])
 
         LOGGER.debug("running: %s", self.stress_cmd)
@@ -129,7 +129,7 @@ class NdBenchStressThread(DockerBasedStressThread):  # pylint: disable=too-many-
             except Exception as exc:  # pylint: disable=broad-except
                 errors_str = self.format_error(exc)
                 NdbenchStressEvent(type='failure', node=str(loader), stress_cmd=self.stress_cmd,
-                                   log_file_name=log_file_name, severity=Severity.CRITICAL,
+                                   log_file_name=log_file_name, severity=Severity.ERROR,
                                    errors=errors_str)
             finally:
                 NdbenchStressEvent('finish', node=loader, stress_cmd=self.stress_cmd, log_file_name=log_file_name)

--- a/sdcm/sct_events_analyzer.py
+++ b/sdcm/sct_events_analyzer.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import threading
+import signal
+import logging
+
+from sdcm.sct_events import EVENTS_PROCESSES, Severity
+from sdcm.cluster import Setup
+from sdcm.utils.thread import raise_event_on_failure
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TestFailure(Exception):
+    pass
+
+
+class EventsAnalyzer(threading.Thread):
+
+    def __init__(self):
+        self.stop_event = threading.Event()
+        self.signal_sent = False
+        super(EventsAnalyzer, self).__init__()
+
+    @raise_event_on_failure
+    def run(self):
+        for event_class, message_data in EVENTS_PROCESSES['MainDevice'].subscribe_events(
+                stop_event=self.stop_event):
+            try:
+                if event_class == 'TestResultEvent':
+                    # don't send kill test cause of those event, test is already done when those are sent out
+                    continue
+
+                if event_class in ['CassandraStressEvent', 'ScyllaBenchEvent', 'YcsbStressEvent', 'NdbenchStressEvent'] \
+                        and message_data.type == 'failure':
+                    raise TestFailure(f"Stress Command failed: {message_data}")
+
+                if message_data.severity == Severity.CRITICAL:
+                    raise TestFailure(f"Got critical event: {message_data}")
+
+            except TestFailure:
+                self.kill_test(sys.exc_info())
+
+            except Exception:  # pylint: disable=broad-except
+                LOGGER.exception("analyzer logic failed")
+
+    def terminate(self):
+        self.stop_event.set()
+
+    def kill_test(self, backtrace_with_reason):
+        if not Setup.tester_obj():
+            LOGGER.error("no test was register using 'Setup.set_tester_obj()', not killing")
+            return
+        if not self.signal_sent:
+            _test_pid = os.getpid()
+            Setup.tester_obj().result.addFailure(Setup.tester_obj(), backtrace_with_reason)
+            os.kill(_test_pid, signal.SIGUSR2)
+        else:
+            raise Exception(f"stop test signal already sent once, ignoreing: {str(backtrace_with_reason[1])}")

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -36,7 +36,7 @@ class CassandraStressEventsPublisher(FileFollowerThread):
         super(CassandraStressEventsPublisher, self).__init__()
         self.cs_log_filename = cs_log_filename
         self.node = str(node)
-        self.cs_events = [CassandraStressLogEvent(type='IOException', regex=r'java\.io\.IOException', severity=Severity.CRITICAL),
+        self.cs_events = [CassandraStressLogEvent(type='IOException', regex=r'java\.io\.IOException', severity=Severity.ERROR),
                           CassandraStressLogEvent(type='ConsistencyError', regex=r'Cannot achieve consistency level', severity=Severity.ERROR)]
 
     def run(self):

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1503,7 +1503,7 @@ def get_post_behavior_actions(config):
 
 
 def clean_resources_according_post_behavior(params, config, logdir):
-    success = get_testrun_status(params.get('TestId'), logdir)
+    success = get_testrun_status(params.get('TestId'), logdir, only_critical=True)
     actions_per_type = get_post_behavior_actions(config)
     LOGGER.debug(actions_per_type)
     for cluster_nodes_type, action_type in actions_per_type.items():
@@ -1557,13 +1557,16 @@ def get_testrun_dir(base_dir, test_id=None):
     return None
 
 
-def get_testrun_status(test_id=None, logdir=None):
-
+def get_testrun_status(test_id=None, logdir=None, only_critical=False):
     testrun_dir = get_testrun_dir(logdir, test_id)
     status = None
     if testrun_dir:
         with open(os.path.join(testrun_dir, 'events_log/critical.log')) as f:  # pylint: disable=invalid-name
             status = f.readlines()
+
+        if not only_critical:
+            with open(os.path.join(testrun_dir, 'events_log/error.log')) as f:  # pylint: disable=invalid-name
+                status += f.readlines()
 
     return status
 

--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -173,7 +173,7 @@ class YcsbStressThread(DockerBasedStressThread):  # pylint: disable=too-many-ins
 
         def raise_event_callback(sentinal, line):  # pylint: disable=unused-argument
             if line:
-                YcsbStressEvent('error', severity=Severity.CRITICAL, node=loader,
+                YcsbStressEvent('error', severity=Severity.ERROR, node=loader,
                                 stress_cmd=stress_cmd, errors=[line, ])
 
         LOGGER.debug("running: %s", stress_cmd)
@@ -197,7 +197,7 @@ class YcsbStressThread(DockerBasedStressThread):  # pylint: disable=too-many-ins
             except Exception as exc:  # pylint: disable=broad-except
                 errors_str = self.format_error(exc)
                 YcsbStressEvent(type='failure', node=str(loader), stress_cmd=self.stress_cmd,
-                                log_file_name=log_file_name, severity=Severity.CRITICAL,
+                                log_file_name=log_file_name, severity=Severity.ERROR,
                                 errors=[errors_str])
                 raise
             finally:

--- a/unit_tests/test_ycsb_thread.py
+++ b/unit_tests/test_ycsb_thread.py
@@ -55,7 +55,7 @@ def test_01_dynamodb_api(request, docker_scylla, prom_address):
 def test_02_dynamodb_api_dataintegrity(request, docker_scylla, prom_address, events):
     loader_set = LocalLoaderSetDummy()
 
-    critical_log_content_before = events.get_event_log_file('critical.log')
+    error_log_content_before = events.get_event_log_file('error.log')
 
     # 2. do write without dataintegrity=true
     cmd = 'bin/ycsb load dynamodb -P workloads/workloada -threads 5 -p recordcount=10000 -p fieldcount=10 -p fieldlength=512'
@@ -94,5 +94,5 @@ def test_02_dynamodb_api_dataintegrity(request, docker_scylla, prom_address, eve
     ycsb_thread2.get_results()
 
     # 5. check that events with the expected error were raised
-    critical_log_content_after = events.wait_for_event_log_change('critical.log', critical_log_content_before)
-    assert 'UNEXPECTED_STATE' in critical_log_content_after
+    error_log_content_after = events.wait_for_event_log_change('error.log', error_log_content_before)
+    assert 'UNEXPECTED_STATE' in error_log_content_after


### PR DESCRIPTION
Sending a signal to stop the test, when a critial event is recived
or when one of the stress commands end with failure.

Ref: [Trello Task](https://trello.com/c/SOTSJHw1)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
