### PR TITLE
fix(artifacts test): increase timeout for OEL job

### DIFF
--- a/jenkins-pipelines/artifacts-oel76.jenkinsfile
+++ b/jenkins-pipelines/artifacts-oel76.jenkinsfile
@@ -10,6 +10,6 @@ artifactsPipeline(
     backend: 'aws',
     instance_provision: 'spot_low_price',
 
-    timeout: [time: 30, unit: 'MINUTES'],
+    timeout: [time: 60, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'
 )


### PR DESCRIPTION
Trello: https://trello.com/c/saCJwIfI/1718-oel-artifact-test-timeout-1889

Fixes #1889 

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
