### PR TITLE
improvement(test-result): support subtests

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1623,10 +1623,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             :param exc_list: unittest list of failures or errors
             :return: string of backtrace
             """
-            if exc_list and exc_list[-1][0] is self:
-                return exc_list[-1][1]
-            else:
-                return None
+            if exc_list:
+                return "\n--------\n".join(f"{i[0]}:\n{i[1]}" for i in exc_list)
+            return None
 
         if hasattr(self, '_outcome'):  # Python 3.4+
             result = self.defaultTestResult()  # these 2 methods have no side effects

--- a/unit_tests/test_events.py
+++ b/unit_tests/test_events.py
@@ -414,5 +414,30 @@ class TesterErrorDuringSetUp(unittest.TestCase):
         assert tre.severity == Severity.CRITICAL
 
 
+class TesterMultiSubTest(unittest.TestCase):
+    setup_failure = None
+    __unittest_expecting_failure__ = True
+
+    @unittest.skip("integration")
+    def test_multi_subtest(self):
+        with self.subTest("test1"):
+            print("test1")
+
+        with self.subTest("test2"):
+            assert 1 == 0
+
+        with self.subTest("test3"):
+            assert 1 == 0
+
+    def tearDown(self) -> None:
+        test_error, test_failure = ClusterTester.get_test_failures(self)
+        assert "test3" in test_failure
+        assert "test2" in test_failure
+        assert test_error is None
+        tre = TestResultEvent(test_name=self.id(), error=test_error, failure=test_failure)
+        assert tre.severity == Severity.CRITICAL
+        self._outcome.errors = []  # we don't want to fail test
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Current implementation used only last result ignoring others.
When there are multiple tests run or subTest context manager
is used we need to get all the failures/errors.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
