### PR TITLE
improvement(aws_config.yaml): change loader type, disk and swap size

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -27,6 +27,8 @@ regions_data:
 
 aws_root_disk_size_monitor: 50  # GB, remove this field if default disk size should be used
 aws_root_disk_size_db: 15
+aws_root_disk_size_loader: 30  # GB, Increase loader disk in order to have extra space for a larger swap
+loader_swap_size: 10240  #10GB SWAP space
 aws_root_disk_name_monitor: "/dev/sda1"  # use "/dev/xvda" for Debian 8 image
 ami_db_scylla_user: 'centos'
 ami_loader_user: 'centos'

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -88,6 +88,8 @@
 | **<a name="aws_root_disk_name_db">aws_root_disk_name_db</a>**  |  | N/A | SCT_AWS_ROOT_DISK_NAME_DB
 | **<a name="aws_root_disk_size_monitor">aws_root_disk_size_monitor</a>**  |  | N/A | SCT_AWS_ROOT_DISK_SIZE_MONITOR
 | **<a name="aws_root_disk_name_monitor">aws_root_disk_name_monitor</a>**  |  | N/A | SCT_AWS_ROOT_DISK_NAME_MONITOR
+| **<a name="aws_root_disk_size_loader">aws_root_disk_size_loader</a>**  |  | N/A | SCT_AWS_ROOT_DISK_SIZE_MONITOR
+| **<a name="aws_root_disk_name_loader">aws_root_disk_name_loader</a>**  |  | N/A | SCT_AWS_ROOT_DISK_SIZE_MONITOR
 | **<a name="ami_db_scylla_user">ami_db_scylla_user</a>**  |  | N/A | SCT_AMI_DB_SCYLLA_USER
 | **<a name="ami_monitor_user">ami_monitor_user</a>**  |  | N/A | SCT_AMI_MONITOR_USER
 | **<a name="ami_loader_user">ami_loader_user</a>**  |  | N/A | SCT_AMI_LOADER_USER

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -429,6 +429,12 @@ class SCTConfiguration(dict):
         dict(name="aws_root_disk_name_monitor", env="SCT_AWS_ROOT_DISK_NAME_MONITOR", type=str,
              help=""),
 
+        dict(name="aws_root_disk_size_loader", env="SCT_AWS_ROOT_DISK_SIZE_LOADER", type=int,
+             help=""),
+
+        dict(name="aws_root_disk_name_loader", env="SCT_AWS_ROOT_DISK_NAME_LOADER", type=str,
+             help=""),
+
         dict(name="ami_db_scylla_user", env="SCT_AMI_DB_SCYLLA_USER", type=str,
              help=""),
 
@@ -838,7 +844,7 @@ class SCTConfiguration(dict):
     backend_required_params = {
         'aws':  ['user_prefix', "instance_type_loader", "instance_type_monitor", "instance_type_db",
                  "region_name", "security_group_ids", "subnet_id", "ami_id_db_scylla", "ami_id_loader",
-                 "ami_id_monitor", "aws_root_disk_size_monitor", "aws_root_disk_name_monitor", "ami_db_scylla_user",
+                 "ami_id_monitor", "aws_root_disk_size_monitor", "aws_root_disk_name_monitor",  "ami_db_scylla_user",
                  "ami_monitor_user"],
 
         'gce': ['user_prefix', 'gce_network', 'gce_image', 'gce_image_username', 'gce_instance_type_db', 'gce_root_disk_type_db',

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -456,6 +456,21 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             loader_info['n_nodes'] = int(self.params.get('n_loaders'))
         if loader_info['type'] is None:
             loader_info['type'] = self.params.get('instance_type_loader')
+        if loader_info['disk_size'] is None:
+            loader_info['disk_size'] = self.params.get('aws_root_disk_size_loader', default=None)
+        if loader_info['device_mappings'] is None:
+            if loader_info['disk_size']:
+                loader_info['device_mappings'] = [{
+                    "DeviceName": self.params.get("aws_root_disk_name_loader", default="/dev/sda1"),
+                    "Ebs": {
+                        "VolumeSize": loader_info['disk_size'],
+                        "VolumeType": "gp2"
+                    }
+                }]
+            else:
+                loader_info['device_mappings'] = []
+
+
         if db_info['n_nodes'] is None:
             n_db_nodes = self.params.get('n_db_nodes')
             if isinstance(n_db_nodes, int):  # legacy type

--- a/test-cases/longevity/longevity-1TB-7days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-1TB-7days-authorization-and-tls-ssl.yaml
@@ -30,7 +30,6 @@ n_monitor_nodes: 1
 
 instance_type_db: 'i3.4xlarge'
 instance_type_loader: 'c5.4xlarge'
-loader_swap_size: 10240  #10GB SWAP space
 
 nemesis_class_name: 'ChaosMonkey'
 nemesis_interval: 30

--- a/test-cases/longevity/longevity-1TB-7days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-1TB-7days-authorization-and-tls-ssl.yaml
@@ -1,6 +1,10 @@
 test_duration: 10900
-prepare_write_cmd: ["cassandra-stress write cl=QUORUM n=1100200300 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native  -rate threads=1000 -col 'size=FIXED(200) n=FIXED(5)' -pop seq=1..1100200300",
-                    "cassandra-stress counter_write cl=QUORUM n=10000000 -schema 'replication(factor=3) compaction(strategy=DateTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..10000000"]
+prepare_write_cmd: ["cassandra-stress write         cl=QUORUM n=1100200300 -schema 'replication(factor=3)                               compaction(strategy=LeveledCompactionStrategy)'    -port jmx=6868 -mode cql3 native                     -rate threads=1000 -col 'size=FIXED(200) n=FIXED(5)' -pop seq=1..1100200300",
+                    "cassandra-stress counter_write cl=QUORUM n=10000000   -schema 'replication(factor=3)                               compaction(strategy=DateTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native                     -rate threads=10 -pop seq=1..10000000",
+                    "cassandra-stress write         cl=QUORUM n=50000000   -schema 'replication(factor=3) compression=LZ4Compressor     compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=lz4     -rate threads=50 -pop seq=1..50000000 -log interval=5",
+                    "cassandra-stress write         cl=QUORUM n=50000000   -schema 'replication(factor=3) compression=SnappyCompressor  compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=snappy  -rate threads=50 -pop seq=1..50000000 -log interval=5",
+                    "cassandra-stress write         cl=QUORUM n=50000000   -schema 'replication(factor=3) compression=DeflateCompressor compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=none    -rate threads=50 -pop seq=1..50000000 -log interval=5",
+                    "cassandra-stress write         cl=QUORUM n=50000000   -schema 'replication(factor=3) compression=ZstdCompressor    compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=none    -rate threads=50 -pop seq=1..50000000 -log interval=5"]
 
 stress_cmd: ["cassandra-stress mixed         cl=QUORUM duration=10080m -schema 'replication(factor=3)                               compaction(strategy=LeveledCompactionStrategy)'    -port jmx=6868 -mode cql3 native  -rate threads=20 -pop seq=1..1100200300  -log interval=5 -col 'size=FIXED(200) n=FIXED(5)'",
              "cassandra-stress write         cl=QUORUM duration=10010m -schema 'replication(factor=3) compression=LZ4Compressor     compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=lz4                   -rate threads=50 -pop seq=1..50000000    -log interval=5",
@@ -25,7 +29,8 @@ n_loaders: 2
 n_monitor_nodes: 1
 
 instance_type_db: 'i3.4xlarge'
-instance_type_loader: 'c5.2xlarge'
+instance_type_loader: 'c5.4xlarge'
+loader_swap_size: 10240  #10GB SWAP space
 
 nemesis_class_name: 'ChaosMonkey'
 nemesis_interval: 30


### PR DESCRIPTION
	1) in order to avoid java memory issues that failed stresses, the instance type is increased
	   to c5.4xl and swap is changed to 10GB.

	2) Added write stress commands to prepare, to make sure that later read command will not fail
	   for reading a yet-non-written data.

        3) Added parameters of aws_root_disk_size_loader and aws_root_disk_name_loader
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
