### PR TITLE
fix(#1761): changed reactor stalled event severity to warn

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -390,7 +390,7 @@ class BaseNode():  # pylint: disable=too-many-instance-attributes,too-many-publi
             DatabaseLogEvent(type='BACKTRACE', regex='backtrace', severity=Severity.ERROR),
             DatabaseLogEvent(type='SEGMENTATION', regex='segmentation'),
             DatabaseLogEvent(type='INTEGRITY_CHECK', regex='integrity check failed'),
-            DatabaseLogEvent(type='REACTOR_STALLED', regex='Reactor stalled'),
+            DatabaseLogEvent(type='REACTOR_STALLED', regex='Reactor stalled', severity=Severity.WARNING),
             DatabaseLogEvent(type='SEMAPHORE_TIME_OUT', regex='semaphore_timed_out'),
             DatabaseLogEvent(type='BOOT', regex='Starting Scylla Server', severity=Severity.NORMAL),
             DatabaseLogEvent(type='SUPPRESSED_MESSAGES', regex='journal: Suppressed', severity=Severity.WARNING),


### PR DESCRIPTION
reactor stalled event shouldn't keep instances up and stop the test

