### PR TITLE
improvement(backup nemesis): improved the success verfication mechanism

### DIFF
--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -243,6 +243,16 @@ class ManagerTask(ScyllaManagerBase):
         relevant_key = [key for key in parsed_progress_table.keys() if parsed_progress_table[key]][0]
         return parsed_progress_table[relevant_key]
 
+    def wait_for_task_done_status(self, timeout=10800):
+        start_time = time.time()
+        while start_time + timeout > time.time():
+            if 'ERROR (4/4)' in self.manager_node.remoter.run(f'sctool -c {self.cluster_id} task list | grep {self.id}').stdout.strip():
+                return False, TaskStatus.ERROR
+            if self.status == TaskStatus.DONE:
+                return True, self.status
+            time.sleep(5)
+        return False, self.status
+
     def is_status_in_list(self, list_status, check_task_progress=False):
         """
         Check if the status of a given task is in list


### PR DESCRIPTION
following the review of original PR, this item was postponed
to have this nemesis running already. This current PR comes
to fix the success verification, where in case of failure,
we had in the previous PR, to wait the whole timeout.

We still might want to increase the timeout, as bigger
data and metadata setups could take more than current 3 hours.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
