### PR TITLE
fix(longevity reporting): add last N events

### DIFF
--- a/sdcm/results_longevity.html
+++ b/sdcm/results_longevity.html
@@ -106,7 +106,19 @@
             {% endfor %}
         </div>
     {% endif %}
-
+    {% if last_events %}
+        <h3>
+            <span>Last events</span>
+        </h3>
+        {% for severity, events in last_events.items() %}
+            <h4>
+            {{ severity }}
+            </h4>
+            {% for event in events %}
+                {{event}} <br/>
+            {% endfor %}
+        {% endfor %}
+    {% endif %}
     <h3>
         <span>Events summary</span>
     </h3>

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -845,10 +845,10 @@ class SCTConfiguration(dict):
 
     # those can be added to a json scheme to validate / or write the validation code for it to be a bit clearer output
     backend_required_params = {
-        'aws':  ['user_prefix', "instance_type_loader", "instance_type_monitor", "instance_type_db",
-                 "region_name", "security_group_ids", "subnet_id", "ami_id_db_scylla", "ami_id_loader",
-                 "ami_id_monitor", "aws_root_disk_size_monitor", "aws_root_disk_name_monitor",  "ami_db_scylla_user",
-                 "ami_monitor_user"],
+        'aws': ['user_prefix', "instance_type_loader", "instance_type_monitor", "instance_type_db",
+                "region_name", "security_group_ids", "subnet_id", "ami_id_db_scylla", "ami_id_loader",
+                "ami_id_monitor", "aws_root_disk_size_monitor", "aws_root_disk_name_monitor", "ami_db_scylla_user",
+                "ami_monitor_user"],
 
         'gce': ['user_prefix', 'gce_network', 'gce_image', 'gce_image_username', 'gce_instance_type_db', 'gce_root_disk_type_db',
                 'gce_root_disk_size_db', 'gce_n_local_ssd_disk_db', 'gce_instance_type_loader',


### PR DESCRIPTION
    Add last N events of each severity category into the longevity report
      - limit eventy body
      - limit number of events per category

https://trello.com/c/2Iw7Oc1J/1665-add-last-n-error-warning-critical-events-to-the-longevity-emailreporthtml

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~


[example_report.zip](https://github.com/scylladb/scylla-cluster-tests/files/4298318/example_report.zip)
