### PR TITLE
fix(events-severity): classify ClusterHealthValidatorEvent, CoreDumpE…

### DIFF
--- a/sdcm/sct_events.py
+++ b/sdcm/sct_events.py
@@ -379,7 +379,7 @@ class CoreDumpEvent(SctEvent):
         self.corefile_url = corefile_url
         self.download_instructions = download_instructions
         self.backtrace = backtrace
-        self.severity = Severity.CRITICAL
+        self.severity = Severity.ERROR
         self.node = str(node)
         if timestamp is not None:
             self.timestamp = timestamp
@@ -429,7 +429,7 @@ class DisruptionEvent(SctEvent):  # pylint: disable=too-many-instance-attributes
 
 
 class ClusterHealthValidatorEvent(SctEvent):
-    def __init__(self, type, name, status=Severity.CRITICAL, node=None, message=None, error=None, **kwargs):  # pylint: disable=redefined-builtin,too-many-arguments
+    def __init__(self, type, name, status=Severity.ERROR, node=None, message=None, error=None, **kwargs):  # pylint: disable=redefined-builtin,too-many-arguments
         super(ClusterHealthValidatorEvent, self).__init__()
         self.name = name
         self.type = type


### PR DESCRIPTION
…vent as errors

As part of ed32cf54 we missed to lower sevirity of
ClusterHealthValidatorEvent, CoreDumpEvent as errors

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
