### PR TITLE
fix(large-collections): limit list items number

### DIFF
--- a/data_dir/large_collections.yaml
+++ b/data_dir/large_collections.yaml
@@ -38,7 +38,10 @@ table_definition: |
     testflag int,
     pid text,
     ppid text,
-    users_task list<text>
+    users_task list<text>,
+    nums_list list<int>,
+    nums_set set<int>,
+    names_set set<text>,
   ) WITH bloom_filter_fp_chance = 0.01
     AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
     AND comment = 'Request for unit level UIs'
@@ -77,6 +80,16 @@ columnspec:
   - name: users_task
     size: fixed(2)
 
+  - name: nums_list
+    population: exp(1..10000)
+
+  - name: nums_set
+    size: fixed(100)
+    population: exp(1..10000)
+
+  - name: names_set
+    size: fixed(500)
+
 insert:
   partitions: fixed(1)
   batchtype: UNLOGGED
@@ -84,4 +97,7 @@ insert:
 queries:
   read1:
     cql: select * from large_collection_test.table_with_large_collection where pk_id = ?
+    fields: samerow
+  update1:
+    cql: update large_collection_test.table_with_large_collection set users_name=?,users_desc=?,users_comment=?,users_task=?,nums_list=?,nums_set=?,names_set=? where pk_id = ?
     fields: samerow

--- a/test-cases/longevity/longevity-large-collections-12h.yaml
+++ b/test-cases/longevity/longevity-large-collections-12h.yaml
@@ -1,6 +1,6 @@
 test_duration: 780
 stress_cmd: [
-"JVM_OPTION='-Xms8033M -Xmx8033M -Xmn400M' cassandra-stress user profile=/tmp/large_collections.yaml ops'(insert=3, read1=1)' cl=QUORUM duration=720m -port jmx=6868 -mode cql3 native -rate threads=10"
+"JVM_OPTION='-Xms8033M -Xmx8033M -Xmn400M' cassandra-stress user profile=/tmp/large_collections.yaml ops'(insert=3,read1=1,update1=0.1)' cl=QUORUM duration=720m -port jmx=6868 -mode cql3 native -rate threads=10"
              ]
 
 n_db_nodes: 4


### PR DESCRIPTION
Currently the items number in list is unlimited, the list is too big
during the test. This patch added an update ops which will reset the
list and make it small again. In one real job, I see some 30M column,
it's acceptable. We might adjust the update ops probability or list size
in future according the feedback in reported scylla issue.

This patch also added limited set columns for large collections test.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
