### PR TITLE
improvement(run_nodetool): Add timeout and coredump generation

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -409,7 +409,7 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
 
     def disrupt_nodetool_drain(self):
         self._set_current_disruption('Drainer %s' % self.target_node)
-        result = self.target_node.run_nodetool("drain")
+        result = self.target_node.run_nodetool("drain", timeout=3600, coredump_on_timeout=True)
         self.cluster.check_cluster_health()
         if result is not None:
             self.target_node.stop_scylla_server(verify_up=False, verify_down=True)
@@ -2078,7 +2078,7 @@ class UpgradeNemesis(Nemesis):
     #         node.remoter.run('sudo yum install scylla{0} scylla-server{0} scylla-jmx{0} scylla-tools{0}'
     #                          ' scylla-conf{0} scylla-kernel-conf{0} scylla-debuginfo{0} -y'.format(ver_suffix))
     #     # flush all memtables to SSTables
-    #     node.run_nodetool("drain")
+    #     node.run_nodetool("drain", timeout=3600, coredump_on_timeout=True)
     #     node.remoter.run('sudo systemctl restart scylla-server.service')
     #     node.wait_db_up(verbose=True)
     #     new_ver = node.remoter.run('rpm -qa scylla-server')
@@ -2129,7 +2129,7 @@ class RollbackNemesis(Nemesis):
         node.remoter.run(
             'sudo yum downgrade scylla scylla-server scylla-jmx scylla-tools scylla-conf scylla-kernel-conf scylla-debuginfo -y')
         # flush all memtables to SSTables
-        node.run_nodetool("drain")
+        node.run_nodetool("drain", timeout=3600, coredump_on_timeout=True)
         node.remoter.run('sudo cp {0}-backup {0}'.format(SCYLLA_YAML_PATH))
         node.remoter.run('sudo systemctl restart scylla-server.service')
         node.wait_db_up(verbose=True)

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -132,7 +132,7 @@ class UpgradeTest(FillDatabaseData):
             # replace the packages
             node.remoter.run(r'rpm -qa scylla\*')
             # flush all memtables to SSTables
-            node.run_nodetool("drain")
+            node.run_nodetool("drain", timeout=3600, coredump_on_timeout=True)
             node.run_nodetool("snapshot")
             node.stop_scylla_server()
             # update *development* packages
@@ -154,7 +154,7 @@ class UpgradeTest(FillDatabaseData):
             assert new_scylla_repo.startswith('http')
             node.download_scylla_repo(new_scylla_repo)
             # flush all memtables to SSTables
-            node.run_nodetool("drain")
+            node.run_nodetool("drain", timeout=3600, coredump_on_timeout=True)
             node.run_nodetool("snapshot")
             node.stop_scylla_server(verify_down=False)
 
@@ -220,7 +220,7 @@ class UpgradeTest(FillDatabaseData):
         result = node.remoter.run('scylla --version')
         orig_ver = result.stdout
         # flush all memtables to SSTables
-        node.run_nodetool("drain")
+        node.run_nodetool("drain", timeout=3600, coredump_on_timeout=True)
         # backup the data
         node.run_nodetool("snapshot")
         node.stop_scylla_server(verify_down=False)


### PR DESCRIPTION
Set a timeout for "nodetool" and produce coredump if it didn't finish on time
for any nodetool command by setting specified parameters

Trello: https://trello.com/c/sYpsIJZR
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (CI)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
