### PR TITLE
improvement(build-n-push): added  more verbosity and docker login

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -375,12 +375,11 @@ For examples see utilities documentation
 Building Hydra Docker image
 ===========================
 
-Once you have changes in the requirements-python.txt or in hydra Dockerfile::
+Once you have changes in the requirements-python.txt or in Hydra Dockerfile
 
-    # change the version in docker/env/version
+- change the version in docker/env/version
+- run ``./docker/env/build_n_push.sh`` to build and push to Docker Hub
 
-    # this would build and push to dockerhub and to ECR on all regions we are using hydra
-    ./docker/env/build_n_push.sh
 
 FAQ
 ====

--- a/docker/env/build_n_push.sh
+++ b/docker/env/build_n_push.sh
@@ -1,4 +1,4 @@
-# !/usr/bin/env bash
+#!/usr/bin/env bash
 set -e
 
 DOCKER_ENV_DIR=$(dirname $(readlink -f $0 ))
@@ -8,17 +8,32 @@ SCT_DIR=$(dirname $(dirname ${DOCKER_ENV_DIR}))
 PY_PREREQS_FILE=requirements-python.txt
 CENTOS_PREREQS_FILE=install-prereqs.sh
 
-if [[ ! -z "`docker images scylladb/hydra:${VERSION} -q`" ]]; then
-    echo "Image up-to-date"
+function docker_tag_exists() {
+    echo "Contacting Docker Hub to check if Hydra image ${VERSION} already exists..."
+    curl --silent -f -lSL https://index.docker.io/v1/repositories/"$1"/tags/"$2"  > /dev/null 2>&1
+}
+
+if docker_tag_exists scylladb/hydra ${VERSION}; then
+    echo "Hydra ${VERSION} already exists in the Docker Hub. Nothing to do."
 else
-    echo "Image with version $VERSION not found. Building..."
-    cd ${DOCKER_ENV_DIR}
+    echo "Hydra ${VERSION} doesn't exist in the Docker Hub!"
+    echo "Will build locally and push."
+fi
+
+exit 0
+
+if [[ -n "$(docker images scylladb/hydra:${VERSION} -q)" ]]; then
+    echo "Local image exists. Not building."
+else
+    echo "Hydra image with version $VERSION not found locally. Building..."
+    cd "${DOCKER_ENV_DIR}"
     cp -f ${SCT_DIR}/${PY_PREREQS_FILE} .
     cp -f ${SCT_DIR}/${CENTOS_PREREQS_FILE} .
     docker build --network=host -t scylladb/hydra:${VERSION} .
     rm -f ${PY_PREREQS_FILE} ${CENTOS_PREREQS_FILE}
     cd -
+    docker login
+    echo "Tagging and pushing..."
+    docker push scylladb/hydra:${VERSION}
+    echo "Done."
 fi
-
-echo "Tagging and pushing"
-docker push scylladb/hydra:${VERSION}


### PR DESCRIPTION
there was a missing step in the Hydra container build script:
Authenticating with existing credentials...
Login Succeeded. In addition script almost didn't produce output
and didn't check if the image already exists in Docker Hub

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
