### PR TITLE
fix(docker): check for aio_max_nr after SSH is up

### DIFF
--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -286,12 +286,13 @@ class ScyllaDockerCluster(cluster.BaseScyllaCluster, DockerCluster):  # pylint: 
                                                   **kwargs)
 
     def node_setup(self, node, verbose=False, timeout=3600):
-        self.check_aio_max_nr(node)
-
         endpoint_snitch = self.params.get('endpoint_snitch')
         seed_address = ','.join(self.seed_nodes_ips)
 
         node.wait_ssh_up(verbose=verbose)
+
+        self.check_aio_max_nr(node)
+
         if cluster.Setup.BACKTRACE_DECODING:
             node.install_scylla_debuginfo()
 


### PR DESCRIPTION
Got failure [here](https://jenkins.scylladb.com/view/master/job/scylla-master/job/artifacts/job/artifacts-docker/16/) because of this issue.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
