### PR TITLE
fix(parallel nemesis): disable cluster_health_check

### DIFF
--- a/test-cases/longevity/longevity-2TB-4days-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
+++ b/test-cases/longevity/longevity-2TB-4days-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
@@ -23,6 +23,7 @@ n_monitor_nodes: 1
 instance_type_db: 'i3en.3xlarge'
 instance_type_loader: 'c4.2xlarge'
 
+cluster_health_check: false
 nemesis_class_name: 'DisruptiveMonkey:1 NonDisruptiveMonkey:2'
 nemesis_interval: 30
 nemesis_during_prepare: false


### PR DESCRIPTION
since during parallel nemesis, some node can be unreachable.
good changes are the cluster healthcheck would fail.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
