### PR TITLE
fix(loader ami for lwt test): copy dedicated loader AMI to other regions

### DIFF
--- a/test-cases/longevity/longevity-lwt-basic-3h.yaml
+++ b/test-cases/longevity/longevity-lwt-basic-3h.yaml
@@ -11,7 +11,13 @@ experimental: true
 instance_type_db: 'i3.2xlarge'
 cluster_health_check: false
 
-ami_id_loader: 'ami-0dc7edd6fba3da2fb' # loader AMI with c-s ver. 4 and fix of NoSuchElementException
+regions_data:
+  us-east-1:
+    ami_id_loader: 'ami-0946a8d8159a15b2c' # loader AMI with c-s ver. 4 and fix of NoSuchElementException
+  eu-west-1:
+    ami_id_loader: 'ami-0dc7edd6fba3da2fb' # loader AMI with c-s ver. 4 and fix of NoSuchElementException
+  us-west-2:
+    ami_id_loader: 'ami-043895fcddca63d1f' # loader AMI with c-s ver. 4 and fix of NoSuchElementException
 
 nemesis_class_name: 'ChaosMonkey'
 nemesis_interval: 5


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)


LWT longevity use specific loader AMI, with cassandra-stress ver. 4 and few fixes (done by @dkropachev ), that existed only in eu-west-1.
Copied this AMI to us-east-1 and eu-west-2 and updated test yaml