### PR TITLE
fix(docker): add retry to check_aio_max_nr()

### DIFF
--- a/sdcm/remote.py
+++ b/sdcm/remote.py
@@ -67,7 +67,7 @@ def is_error_retriable(err_str):
     """Check that exception can be safely retried"""
     exceptions = ("Authentication timeout", "Error reading SSH protocol banner", "Timeout opening channel",
                   "Unable to open channel", "Key-exchange timed out waiting for key negotiation",
-                  "ssh_exchange_identification: Connection closed by remote host",
+                  "ssh_exchange_identification: Connection closed by remote host", "No existing session",
                   )
     for exception_str in exceptions:
         if exception_str in err_str:


### PR DESCRIPTION
Fix for [this](https://jenkins.scylladb.com/job/scylla-master/job/artifacts/job/artifacts-docker/20/) failure.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
