### PR TITLE
fix(support region_data in test yaml): add possibilty to change any of region_data values for one test

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -896,13 +896,13 @@ class SCTConfiguration(dict):
         files = anyconfig.load(list(backend_config_files))
         anyconfig.merge(self, files)
 
-        regions_data = self.get('regions_data', {})
-        if regions_data:
-            del self['regions_data']
-
         # 2) load the config files
         files = anyconfig.load(list(config_files))
         anyconfig.merge(self, files)
+
+        regions_data = self.get('regions_data', {})
+        if regions_data:
+            del self['regions_data']
 
         # 2.2) load the region data
         region_names = self.get('region_name', '').split()

--- a/test-cases/longevity/longevity-lwt-basic-3h.yaml
+++ b/test-cases/longevity/longevity-lwt-basic-3h.yaml
@@ -19,8 +19,6 @@ regions_data:
     ami_id_loader: 'ami-0dc7edd6fba3da2fb'
   us-west-2:
     ami_id_loader: 'ami-010284f401d8933a2'
-  eu-west-2:
-    ami_id_loader: 'ami-043895fcddca63d1f'
 
 nemesis_class_name: 'ChaosMonkey'
 nemesis_interval: 5


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
