### PR TITLE
improvement(longevity_test): configurable sstable size

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -58,3 +58,5 @@ collect_logs: false
 
 loader_swap_size: 1024 # Size of swap file for loader node in bytes 1024 * 1MB
 monitor_swap_size: 8192 # Size of swap file for monitor node in bytes 8192 * 1MB
+
+compaction_strategy: 'SizeTieredCompactionStrategy'

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -567,6 +567,9 @@ class SCTConfiguration(dict):
         dict(name="compaction_strategy", env="SCT_COMPACTION_STRATEGY", type=str,
              help="Choose a specific compaction strategy to pre-create schema with."),
 
+        dict(name="sstable_size", env="SSTABLE_SIZE", type=int,
+             help="Configure sstable size for the usage of pre-create-schema mode"),
+
         dict(name="cluster_health_check", env="SCT_CLUSTER_HEALTH_CHECK", type=boolean,
              help="When true, start cluster health checker for all nodes"),
 

--- a/test-cases/longevity/longevity-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-100gb-4h.yaml
@@ -19,3 +19,5 @@ user_prefix: 'longevity-100gb-4h'
 space_node_threshold: 64424
 
 use_mgmt: true
+pre_create_schema: True
+sstable_size: 100


### PR DESCRIPTION
	Added a new yaml param of 'sstable_size' in order to have smaller sstable size,
	hence higher number of sstables

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
