### PR TITLE
fix(sct_config): Adding append_scylla_setup_args to config

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -191,3 +191,4 @@
 | **<a name="loader_swap_size">loader_swap_size</a>**  | The size of the swap file for the loaders. Its size in bytes calculated by x * 1MB | 1024 | SCT_LOADER_SWAP_SIZE
 | **<a name="monitor_swap_size">monitor_swap_size</a>**  | The size of the swap file for the monitors. Its size in bytes calculated by x * 1MB | 8192 | SCT_MONITOR_SWAP_SIZE
 | **<a name="store_perf_results">store_perf_results</a>**  | A flag that indicates whether or not to gather the prometheus stats at the end of the run.<br>Intended to be used in performance testing | N/A | SCT_STORE_PERF_RESULTS
+| **<a name="append_scylla_setup_args">append_scylla_setup_args</a>**  | More arguments to append to scylla_setup command line |  | SCT_APPEND_SCYLLA_SETUP_ARGS

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -819,6 +819,9 @@ class SCTConfiguration(dict):
         dict(name="store_perf_results", env="SCT_STORE_PERF_RESULTS", type=bool,
              help="""A flag that indicates whether or not to gather the prometheus stats at the end of the run.
                 Intended to be used in performance testing"""),
+        dict(name="append_scylla_setup_args", env="SCT_APPEND_SCYLLA_SETUP_ARGS", type=str,
+             help="More arguments to append to scylla_setup command line"),
+
     ]
 
     required_params = ['cluster_backend', 'test_duration', 'n_db_nodes', 'n_loaders', 'user_credentials_path']
@@ -827,7 +830,7 @@ class SCTConfiguration(dict):
     backend_required_params = {
         'aws':  ['user_prefix', "instance_type_loader", "instance_type_monitor", "instance_type_db",
                  "region_name", "security_group_ids", "subnet_id", "ami_id_db_scylla", "ami_id_loader",
-                 "ami_id_monitor", "aws_root_disk_size_monitor", "aws_root_disk_name_monitor",  "ami_db_scylla_user",
+                 "ami_id_monitor", "aws_root_disk_size_monitor", "aws_root_disk_name_monitor", "ami_db_scylla_user",
                  "ami_monitor_user"],
 
         'gce': ['user_prefix', 'gce_network', 'gce_image', 'gce_image_username', 'gce_instance_type_db', 'gce_root_disk_type_db',


### PR DESCRIPTION
pipelines failed because wrong config parameter appeared in default config
adding appropriate append_scylla_setup_args config parameter to sct_config

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
