### PR TITLE
fix(gemini_version): Fix gemini version for email report

### DIFF
--- a/gemini_test.py
+++ b/gemini_test.py
@@ -25,7 +25,7 @@ class GeminiTest(ClusterTester):
     https://github.com/scylladb/gemini
     """
     gemini_results = {
-        "cmd": "N/A",
+        "cmd": ["N/A"],
         "status": "Not Running",
         "results": [],
         'errors': {}

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -48,7 +48,7 @@ from sdcm.utils.common import log_run_info, retrying, get_data_dir_path, verify_
 from sdcm.utils.distro import Distro
 from sdcm.utils.thread import raise_event_on_failure
 from sdcm.utils.remotewebbrowser import RemoteWebDriverContainer
-from sdcm.utils.version_utils import SCYLLA_VERSION_RE
+from sdcm.utils.version_utils import SCYLLA_VERSION_RE, get_gemini_version
 from sdcm.sct_events import Severity, CoreDumpEvent, DatabaseLogEvent, \
     ClusterHealthValidatorEvent, set_grafana_url, ScyllaBenchEvent
 from sdcm.auto_ssh import start_auto_ssh, RSYSLOG_SSH_TUNNEL_LOCAL_PORT
@@ -3437,10 +3437,12 @@ class BaseLoaderSet():
     @property
     def gemini_version(self):
         if not self._gemini_version:
-            result = self.nodes[0].remoter.run('cd $HOME; ./gemini --version')
-            # result : gemini version 1.0.1, commit ef7c6f422c78ef6b84a6f3bccf52ea9ec846bba0, date 2019-05-16T09:56:16Z
-            # take only version number - 1.0.1
-            self._gemini_version = result.stdout.split(',')[0].split(' ')[2]
+            try:
+                result = self.nodes[0].remoter.run('cd $HOME; ./gemini --version', ignore_status=True)
+                if result.ok:
+                    self._gemini_version = get_gemini_version(result.stdout)
+            except Exception as details:  # pylint: disable=broad-except
+                self.log.error("Error get gemini version: %s", details)
         return self._gemini_version
 
     @property

--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -71,3 +71,17 @@ def is_enterprise(version):
     :return: True if this version string passed is a scylla enterprise version
     """
     return parse_version(version) > parse_version('2000')
+
+
+GEMINI_VERSION_RE = re.compile(r'\s(?P<gemini_version>([\d]+\.[\d]+\.[\d]+)?),')
+# gemini version 1.0.1, commit ef7c6f422c78ef6b84a6f3bccf52ea9ec846bba0, date 2019-05-16T09:56:16Z
+
+
+def get_gemini_version(output: str):
+
+    # take only version number - 1.0.1
+    result = GEMINI_VERSION_RE.search(output)
+
+    if result:
+        return result.groupdict().get("gemini_version", None)
+    return None


### PR DESCRIPTION
If test run failed on setup stage and loader node is not yet
install the gemini tool, building email report failed with
exception.
Trello: https://trello.com/c/6jNNpZDP
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] ~I gave variables/functions meaningful self-explanatory names~
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [x] All new and existing unit tests passed (CI)
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
