### PR TITLE
fix(logcollector): Change log levels for messages

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -26,6 +26,7 @@ from sdcm.utils.docker import get_docker_bridge_gateway
 
 
 LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.DEBUG)
 
 
 class CollectingNode():  # pylint: disable=too-few-public-methods
@@ -624,8 +625,10 @@ class LogCollector:
                 except Exception as details:  # pylint: disable=unused-variable, broad-except
                     LOGGER.error("Error occured during collecting on host: %s\n%s", node.name, details)
 
+        LOGGER.debug("Nodes list %s", [node.name for node in self.nodes])
+
         if not self.nodes:
-            LOGGER.warning(f'No nodes found for in {self.cluster_log_type} cluster')
+            LOGGER.warning(f'No nodes found for {self.cluster_log_type} cluster. Logs will not be collected')
             return None
         try:
             workers_number = int(len(self.nodes) / 2)


### PR DESCRIPTION
For some jobs, logcollector don't collect logs for monitoring
and loader clusters. Main reason is appropriate nodes was terminated
by aws termination.
Added new log message priority to and message list for future investigation
trello: https://trello.com/c/o1M9dc1B
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
