### PR TITLE
test(ycsb unittest): disable flaky docker based integration test

### DIFF
--- a/unit_tests/test_ycsb_thread.py
+++ b/unit_tests/test_ycsb_thread.py
@@ -10,7 +10,8 @@ from sdcm.utils.docker import running_in_docker
 
 from unit_tests.dummy_remote import LocalLoaderSetDummy
 
-pytestmark = pytest.mark.usefixtures('events', 'create_table')
+pytestmark = [pytest.mark.usefixtures('events', 'create_table'),
+              pytest.mark.skip(reason="those are integration tests only")]
 
 ALTERNATOR_PORT = 8000
 TEST_PARAMS = dict(dynamodb_primarykey_type='HASH_AND_RANGE',


### PR DESCRIPTION
those tests keep failing in PRs, no real point of running them again
and again, keep them for when development on those stress tool is needed.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
