### PR TITLE
feature(cluster_aws): read user_data_format_version from AMI tags

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -758,9 +758,12 @@ class ScyllaAWSCluster(cluster.BaseScyllaCluster, AWSCluster):
         shortid = str(cluster_uuid)[:8]
         name = '%s-%s' % (cluster_prefix, shortid)
 
-        scylla_cloud_image_version = get_ami_tags(ec2_ami_id[0], region_name=params.get(
-            'region_name').split()[0]).get('sci_version', '1')
-        if LooseVersion(scylla_cloud_image_version) >= LooseVersion('2'):
+        ami_tags = get_ami_tags(ec2_ami_id[0], region_name=params.get('region_name').split()[0])
+        # TODO: remove once all other related code is merged in scylla-pkg and scylla-machine-image
+        user_data_format_version = ami_tags.get('sci_version', '1')
+        user_data_format_version = ami_tags.get('user_data_format_version', user_data_format_version)
+
+        if LooseVersion(user_data_format_version) >= LooseVersion('2'):
             user_data = dict(scylla_yaml=dict(cluster_name=name), start_scylla_on_first_boot=False)
         else:
             user_data = ('--clustername %s '


### PR DESCRIPTION
renaming the old `sci_version` tag to `user_data_format_version`

Ref: scylladb/scylla-machine-image#21

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
