### PR TITLE
fix(cqlsh run): increase connect-timeout for cqlsh command

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2577,11 +2577,15 @@ server_encryption_options:
         auth_params = '-u {} -p {}'.format(*credentials) if credentials else ''
         use_keyspace = "--keyspace {}".format(keyspace) if keyspace else ""
         ssl_params = '--ssl' if self.parent_cluster.params.get("client_encrypt") else ''
-        options = "--no-color {auth_params} {use_keyspace} --request-timeout={timeout} --connect-timeout={connect_timeout} {ssl_params}".format(
-            auth_params=auth_params, use_keyspace=use_keyspace, timeout=timeout, connect_timeout=connect_timeout, ssl_params=ssl_params)
-        return 'cqlsh {options} -e "{command}" {host} {port}'.format(options=options, command=command, host=host, port=port)
+        options = "--no-color {auth_params} {use_keyspace} --request-timeout={timeout} " \
+                  "--connect-timeout={connect_timeout} {ssl_params}".format(
+                      auth_params=auth_params, use_keyspace=use_keyspace, timeout=timeout,
+                      connect_timeout=connect_timeout, ssl_params=ssl_params)
+        return 'cqlsh {options} -e "{command}" {host} {port}'.format(options=options, command=command, host=host,
+                                                                     port=port)
 
-    def run_cqlsh(self, cmd, keyspace=None, port=None, timeout=120, verbose=True, split=False, target_db_node=None, connect_timeout=5):
+    def run_cqlsh(self, cmd, keyspace=None, port=None, timeout=120, verbose=True, split=False, target_db_node=None,
+                  connect_timeout=60):
         """Runs CQL command using cqlsh utility"""
         cmd = self._gen_cqlsh_cmd(command=cmd, keyspace=keyspace, timeout=timeout,
                                   host=self.ip_address if not target_db_node else target_db_node.ip_address,


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)

ClusterHealthValidation: validate schema version fails when the node is busy and cqlsh connect took more then 5 sec. If increase the connect-timeout parameter, it allows to connect and run the validation
