### PR TITLE
fix(perf-regression-latency-1tb): add missing pipeline file for perf-regression-latency-1TB

### DIFF
--- a/jenkins-pipelines/perf-regression-latency-1TB.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-1TB.jenkinsfile
@@ -1,0 +1,16 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    params: params,
+
+    backend: "aws",
+    aws_region: "us-east-1",
+    test_name: "performance_regression_test.PerformanceRegressionTest",
+    test_config: "test-cases/performance/perf-regression-latency-1TB.yaml",
+    sub_tests: ["test_latency"],
+
+    timeout: [time: 400, unit: "MINUTES"]
+)


### PR DESCRIPTION


We have two modes of the perf-regression-latency one for master which is 500gb
and one for releases with 1TB dataset (longer).
The pipeline for 1TB was missing and the release job was using incorrectly the 500gb test yaml.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
