### PR TITLE
fix(manager agent installation): changed installation

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -286,22 +286,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 # sync test_start_time with ES
                 self.start_time = self.get_test_start_time()
 
-            if self.db_cluster.nodes and self.params.get("use_mgmt", default=None):
-                pkgs_url = self.params.get('scylla_mgmt_pkg', None)
-                pkg_path = None
-                if pkgs_url:
-                    pkg_path = download_dir_from_cloud(pkgs_url)
-                    self.params['scylla_mgmt_pkg'] = pkg_path
-                mgmt_auth_token = str(uuid4())
-                for node in self.db_cluster.nodes:
-                    repo = self.params.get("scylla_mgmt_agent_repo", self.params.get("scylla_mgmt_repo", None))
-                    if pkgs_url:
-                        node.remoter.run('mkdir -p {}'.format(pkg_path))
-                        node.remoter.send_files(src='{}*.rpm'.format(pkg_path), dst=pkg_path)
-                    node.install_manager_agent(mgmt_auth_token, repo, package_path=pkg_path)
-                self.monitors.wait_for_init(auth_token=mgmt_auth_token)
-            else:
-                self.monitors.wait_for_init()
+            self.monitors.wait_for_init()
 
             # cancel reuse cluster - for new nodes added during the test
             cluster.Setup.reuse_cluster(False)


### PR DESCRIPTION
manager-agent is now installed on a way to allow nodes
being added during a test (like on decommission or
terminate and replace) to have manager agent working.
It still a question if the manager server will know
how to deal with nodes being added and removed from
its cluster, or if extra actions will need to take
place inside the manager object.
At this point, the basic installation (on a new cluster)
works just as before, but being called from node_setup
instead of tester.py.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
