### PR TITLE
fix(scylla-bench): make sure output is saved to log

### DIFF
--- a/sdcm/ndbench_thread.py
+++ b/sdcm/ndbench_thread.py
@@ -11,6 +11,7 @@ from sdcm.utils.common import FileFollowerThread
 from sdcm.remote import FailuresWatcher
 from sdcm.utils.thread import DockerBasedStressThread
 from sdcm.utils.docker import RemoteDocker
+from sdcm.stress_thread import format_stress_cmd_error
 
 LOGGER = logging.getLogger(__name__)
 
@@ -127,7 +128,7 @@ class NdBenchStressThread(DockerBasedStressThread):  # pylint: disable=too-many-
 
                 return result
             except Exception as exc:  # pylint: disable=broad-except
-                errors_str = self.format_error(exc)
+                errors_str = format_stress_cmd_error(exc)
                 NdbenchStressEvent(type='failure', node=str(loader), stress_cmd=self.stress_cmd,
                                    log_file_name=log_file_name, severity=Severity.ERROR,
                                    errors=errors_str)

--- a/sdcm/utils/thread.py
+++ b/sdcm/utils/thread.py
@@ -96,21 +96,3 @@ class DockerBasedStressThread:
             loader.remoter.run(cmd=f"docker rm -f `docker ps -a -q --filter label=shell_marker={self.shell_marker}`",
                                timeout=60,
                                ignore_status=True)
-
-    @staticmethod
-    def format_error(exc):
-        """
-        format nicely the excpetion we get from stress command failures
-
-        :param exc: the exception
-        :return: string to add to the event
-        """
-        if hasattr(exc, 'result') and exc.result.failed:
-            stderr = exc.result.stderr
-            if len(stderr) > 100:
-                stderr = stderr[:100]
-            errors_str = f'Stress command completed with bad status {exc.result.exited}: {stderr}'
-        else:
-            errors_str = f'Stress command execution failed with: {str(exc)}'
-
-        return errors_str

--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -13,6 +13,7 @@ from sdcm.utils.common import FileFollowerThread
 from sdcm.utils.thread import DockerBasedStressThread
 from sdcm.utils.docker import RemoteDocker
 from sdcm.utils.common import generate_random_string
+from sdcm.stress_thread import format_stress_cmd_error
 
 LOGGER = logging.getLogger(__name__)
 
@@ -195,7 +196,7 @@ class YcsbStressThread(DockerBasedStressThread):  # pylint: disable=too-many-ins
                                     watchers=[FailuresWatcher(r'\sERROR|=UNEXPECTED_STATE', callback=raise_event_callback, raise_exception=False)])
                 return result
             except Exception as exc:  # pylint: disable=broad-except
-                errors_str = self.format_error(exc)
+                errors_str = format_stress_cmd_error(exc)
                 YcsbStressEvent(type='failure', node=str(loader), stress_cmd=self.stress_cmd,
                                 log_file_name=log_file_name, severity=Severity.ERROR,
                                 errors=[errors_str])


### PR DESCRIPTION
for historical reasons the scylla-bench logs were tee into a temporary file.
this fix also raise an ScyllaBenchEvent with failure when command fails.

Trello: https://trello.com/c/QDkiJrcO

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
