### PR TITLE
fix(mgr_cli_test): load must finish before other mgr actions

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -44,7 +44,7 @@ class MgmtCliTest(ClusterTester):
             1) Run cassandra stress on cluster.
             2) Add cluster to Manager and run full repair via Nemesis
         """
-        self._generate_load()
+        self.generate_load_and_wait_for_results()
         self.log.debug("test_mgmt_cli: initialize MgmtRepair nemesis")
         mgmt_nemesis = MgmtRepair(tester_obj=self, termination_event=self.db_cluster.termination_event)
         mgmt_nemesis.disrupt()
@@ -282,7 +282,7 @@ class MgmtCliTest(ClusterTester):
         manager_tool = mgmt.get_scylla_manager_tool(manager_node=self.monitors.nodes[0])
         mgr_cluster = manager_tool.add_cluster(name=self.CLUSTER_NAME+"_encryption", db_cluster=self.db_cluster,
                                                auth_token=self.monitors.mgmt_auth_token)
-        self._generate_load()
+        self.generate_load_and_wait_for_results()
         repair_task = mgr_cluster.create_repair_task()
         dict_host_health = mgr_cluster.get_hosts_health()
         for host_health in dict_host_health.values():


### PR DESCRIPTION
test changed client encryption but load was still running
and then it failed.
now, the load must stop before any other mgr actions are
taken.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
