### PR TITLE
fix(tester_setup): Return loader init to Setup

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -251,7 +251,11 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         try:
             self.init_resources()
 
-            self.init_nodes(db_cluster=self.db_cluster)
+            if self.db_cluster.nodes:
+                self.init_nodes(db_cluster=self.db_cluster)
+                self.set_system_auth_rf()
+                db_node_address = self.db_cluster.nodes[0].ip_address
+                self.loaders.wait_for_init(db_node_address=db_node_address)
 
             # cs_db_cluster is created in case MIXED_CLUSTER. For example, gemini test
             if self.cs_db_cluster:


### PR DESCRIPTION
For some reasons the loader set initializtion code iwas removed
which cause the misconfiguration loader nodes

Backport code from master branch

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
