### PR TITLE
fix(mgr backup workaround): because of mermaid issue #1794

### DIFF
--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -338,6 +338,8 @@ class ManagerCluster(ScyllaManagerBase):
 
     def create_backup_task(self, param_dict):
         arguments = []
+        if 'rate-limit' not in param_dict:
+            param_dict['rate-limit'] = 30
         for arg, value in param_dict.items():
             if isinstance(value, (str, int)) and value:
                 arguments.append('--{} {}'.format(arg, str(value)))
@@ -345,7 +347,6 @@ class ManagerCluster(ScyllaManagerBase):
                 arguments.append('--{}'.format(arg))
             if isinstance(value, list) and value:
                 arguments.append('--{} {}'.format(arg, ','.join(value)))
-
         command = "backup -c {} ".format(self.id) + ' '.join(arguments)
         res = self.sctool.run(cmd=command, parse_table_res=False)
         if not res.stdout:


### PR DESCRIPTION
Backups are failing with timeouts when moving files, and the
suspection is that the network usage is in the limit.
Lowering the rate limit shall allow the backup to finish,
as it will demand less bandwidth.
Only a workaround, until fix is released (apparently on 2.0.2)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
