### PR TITLE
improvement(remoter): making socket time out retriable

### DIFF
--- a/sdcm/remote.py
+++ b/sdcm/remote.py
@@ -54,7 +54,8 @@ class SSHConnectTimeoutError(Exception):
 
 
 NETWORK_EXCEPTIONS = (NoValidConnectionsError, SSHException, SSHConnectTimeoutError, EOFError, AuthenticationException,
-                      ConnectionResetError, ConnectionAbortedError, ConnectionError, ConnectionRefusedError)
+                      ConnectionResetError, ConnectionAbortedError, ConnectionError, ConnectionRefusedError,
+                      socket.timeout)
 
 
 class RetriableNetworkException(Exception):
@@ -68,6 +69,7 @@ def is_error_retriable(err_str):
     exceptions = ("Authentication timeout", "Error reading SSH protocol banner", "Timeout opening channel",
                   "Unable to open channel", "Key-exchange timed out waiting for key negotiation",
                   "ssh_exchange_identification: Connection closed by remote host", "No existing session",
+                  "timed out",
                   )
     for exception_str in exceptions:
         if exception_str in err_str:


### PR DESCRIPTION
opening/connecting to a socket can be safely retried

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
