### PR TITLE
fix(gemini_config):  Fix gemini command to decrease false positives

### DIFF
--- a/test-cases/gemini/gemini-1tb-10h.yaml
+++ b/test-cases/gemini/gemini-1tb-10h.yaml
@@ -10,7 +10,13 @@ store_results_in_elasticsearch: False
 # gemini
 # cmd: gemini -d -n [NUM_OF_TEST_ITERATIONS] -c [NUM_OF_THREADS] -m mixed -f
 # the below cmd runs about 10 hours
-gemini_cmd: "gemini -d --duration 36000s --warmup 7200s -c 100 -m mixed -f --non-interactive --cql-features normal"
+gemini_cmd: "gemini -d --duration 36000s --warmup 7200s -c 100 \
+-m mixed -f --non-interactive --cql-features normal \
+--max-mutation-retries 5 --max-mutation-retries-backoff 500ms \
+--async-objects-stabilization-attempts 5 --async-objects-stabilization-backoff 500ms \
+--replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '3'}\" \
+--oracle-replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '1'}\" "
+
 gemini_version: 'latest'
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 

--- a/test-cases/gemini/gemini-3h-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nemesis.yaml
@@ -14,7 +14,13 @@ nemesis_interval: 5
 # gemini
 # cmd: gemini -d -n [NUM_OF_TEST_ITERATIONS] -c [NUM_OF_THREADS] -p [NUM_OF_PARTITION_KEYS_PER_THREAD] -m mixed -f
 # the below cmd runs about 3 hours
-gemini_cmd: "gemini -d --duration 10800s --warmup 1800s -c 200 -m mixed -f --non-interactive --cql-features normal"
+gemini_cmd: "gemini -d --duration 10800s --warmup 1800s -c 100 \
+-c 100 -m mixed -f --non-interactive --cql-features normal \
+--max-mutation-retries 5 --max-mutation-retries-backoff 500ms \
+--async-objects-stabilization-attempts 5 --async-objects-stabilization-backoff 500ms \
+--replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '3'}\" \
+--oracle-replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '1'}\" "
+
 gemini_version: 'latest'
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 

--- a/test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml
@@ -14,7 +14,13 @@ nemesis_interval: 5
 # gemini
 # cmd: gemini -d -n [NUM_OF_TEST_ITERATIONS] -c [NUM_OF_THREADS] -p [NUM_OF_PARTITION_KEYS_PER_THREAD] -m mixed -f
 # the below cmd runs about 3 hours
-gemini_cmd: "gemini -d --duration 10800s --warmup 1800s -c 100 -m mixed -f --non-interactive --cql-features normal"
+gemini_cmd: "gemini -d --duration 10800s --warmup 1800s -c 100 \
+-m mixed -f --non-interactive --cql-features normal \
+--max-mutation-retries 5 --max-mutation-retries-backoff 500ms \
+--async-objects-stabilization-attempts 5 --async-objects-stabilization-backoff 500ms \
+--replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '3'}\" \
+--oracle-replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '1'}\" "
+
 gemini_version: 'latest'
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 

--- a/test-cases/gemini/gemini-basic-3h.yaml
+++ b/test-cases/gemini/gemini-basic-3h.yaml
@@ -11,7 +11,12 @@ store_results_in_elasticsearch: False
 # gemini
 # cmd: gemini -d -n [NUM_OF_TEST_ITERATIONS] -c [NUM_OF_THREADS] -m mixed -f
 # the below cmd runs about 3 hours
-gemini_cmd: "gemini -d --duration 10800s --warmup 1800s -c 100 -m mixed -f --non-interactive --cql-features normal"
+gemini_cmd: "gemini -d --duration 10800s --warmup 1800s -c 100 \
+-m mixed -f --non-interactive --cql-features normal \
+--max-mutation-retries 5 --max-mutation-retries-backoff 500ms \
+--async-objects-stabilization-attempts 5 --async-objects-stabilization-backoff 500ms \
+--replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '3'}\" \
+--oracle-replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '1'}\" "
 
 gemini_version: 'latest'
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used


### PR DESCRIPTION
Under high load oracle cluster not always applys mutation
Adding the gemini command parameters for retry apply mutation
For branch-3.2
Only for branch 3.2

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
