### PR TITLE
feature(cdc): enable postimage in cdc longevity

### DIFF
--- a/data_dir/cdc_profile.yaml
+++ b/data_dir/cdc_profile.yaml
@@ -14,10 +14,16 @@ table_definition: |
     number int,
     starttime timestamp,
     weight decimal,
+    steps float,
+    t_num tinyint,
+    bvalue blob,
+    boy boolean,
+    vname varchar,
+    vage varint,
     nums_set set<int>,
     names_set set<text>
   ) WITH bloom_filter_fp_chance = 0.01
-    AND cdc = {'enabled': true, 'preimage': false, 'ttl': 600}
+    AND cdc = {'enabled': true, 'preimage': false, 'postimage': false, 'ttl': 600}
     AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
     AND comment = 'Request for unit level UIs'
     AND compaction = {'class': 'SizeTieredCompactionStrategy'}

--- a/data_dir/cdc_profile_postimage.yaml
+++ b/data_dir/cdc_profile_postimage.yaml
@@ -4,11 +4,11 @@ keyspace_definition: |
 
   CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true;
 
-table: test_table_preimage
+table: test_table_postimage
 
 table_definition: |
 
-  CREATE TABLE cdc_test.test_table_preimage (
+  CREATE TABLE cdc_test.test_table_postimage (
     pkid text PRIMARY KEY,
     name text,
     number int,
@@ -23,7 +23,7 @@ table_definition: |
     nums_set set<int>,
     names_set set<text>
   ) WITH bloom_filter_fp_chance = 0.01
-    AND cdc = {'enabled': true, 'preimage': true, 'postimage': false, 'ttl': 600}
+    AND cdc = {'enabled': true, 'preimage': false, 'postimage': true, 'ttl': 600}
     AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
     AND comment = 'Request for unit level UIs'
     AND compaction = {'class': 'SizeTieredCompactionStrategy'}
@@ -56,14 +56,14 @@ insert:
 
 queries:
   read1:
-    cql: select * from cdc_test.test_table_preimage where pkid = ?
+    cql: select * from cdc_test.test_table_postimage where pkid = ?
     fields: samerow
   update_name:
-    cql: update cdc_test.test_table_preimage set name = ? where pkid = ?
+    cql: update cdc_test.test_table_postimage set name = ? where pkid = ?
     fields: samerow
   update_number:
-    cql: update cdc_test.test_table_preimage set number = ? where pkid = ?
+    cql: update cdc_test.test_table_postimage set number = ? where pkid = ?
     fields: samerow
   delete1:
-    cql: delete from cdc_test.test_table_preimage where pkid = ?
+    cql: delete from cdc_test.test_table_postimage where pkid = ?
     fields: samerow

--- a/data_dir/cdc_profile_preimage_postimage.yaml
+++ b/data_dir/cdc_profile_preimage_postimage.yaml
@@ -4,11 +4,11 @@ keyspace_definition: |
 
   CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true;
 
-table: test_table_preimage
+table: test_table_preimage_postimage
 
 table_definition: |
 
-  CREATE TABLE cdc_test.test_table_preimage (
+  CREATE TABLE cdc_test.test_table_preimage_postimage (
     pkid text PRIMARY KEY,
     name text,
     number int,
@@ -23,7 +23,7 @@ table_definition: |
     nums_set set<int>,
     names_set set<text>
   ) WITH bloom_filter_fp_chance = 0.01
-    AND cdc = {'enabled': true, 'preimage': true, 'postimage': false, 'ttl': 600}
+    AND cdc = {'enabled': true, 'preimage': true, 'postimage': true, 'ttl': 600}
     AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
     AND comment = 'Request for unit level UIs'
     AND compaction = {'class': 'SizeTieredCompactionStrategy'}
@@ -56,14 +56,14 @@ insert:
 
 queries:
   read1:
-    cql: select * from cdc_test.test_table_preimage where pkid = ?
+    cql: select * from cdc_test.test_table_preimage_postimage where pkid = ?
     fields: samerow
   update_name:
-    cql: update cdc_test.test_table_preimage set name = ? where pkid = ?
+    cql: update cdc_test.test_table_preimage_postimage set name = ? where pkid = ?
     fields: samerow
   update_number:
-    cql: update cdc_test.test_table_preimage set number = ? where pkid = ?
+    cql: update cdc_test.test_table_preimage_postimage set number = ? where pkid = ?
     fields: samerow
   delete1:
-    cql: delete from cdc_test.test_table_preimage where pkid = ?
+    cql: delete from cdc_test.test_table_preimage_postimage where pkid = ?
     fields: samerow

--- a/test-cases/longevity/longevity-cdc-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-cdc-100gb-4h.yaml
@@ -1,7 +1,9 @@
 test_duration: 260
 
-stress_cmd: [ "cassandra-stress user no-warmup profile=/tmp/cdc_profile.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=240m -port jmx=6868 -mode cql3 native -rate threads=200",
-              "cassandra-stress user no-warmup profile=/tmp/cdc_profile_preimage.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=240m -port jmx=6868 -mode cql3 native -rate threads=200"
+stress_cmd: [ "cassandra-stress user no-warmup profile=/tmp/cdc_profile.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=240m -port jmx=6868 -mode cql3 native -rate threads=100",
+              "cassandra-stress user no-warmup profile=/tmp/cdc_profile_preimage.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=240m -port jmx=6868 -mode cql3 native -rate threads=100",
+              "cassandra-stress user no-warmup profile=/tmp/cdc_profile_postimage.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=240m -port jmx=6868 -mode cql3 native -rate threads=100",
+              "cassandra-stress user no-warmup profile=/tmp/cdc_profile_preimage_postimage.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=240m -port jmx=6868 -mode cql3 native -rate threads=100"
              ]
 
 n_db_nodes: 6


### PR DESCRIPTION
`postimage` had been supported, this patch enabled it in one workload.
It's required by Shlomi.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
