### PR TITLE
fix(nemesis_interval): Init nemesis interval in one place

### DIFF
--- a/gemini_test.py
+++ b/gemini_test.py
@@ -60,7 +60,7 @@ class GeminiTest(ClusterTester):
         self.log.info('Sleep interval {}'.format(sleep_before_start))
         time.sleep(sleep_before_start)
 
-        self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
+        self.db_cluster.start_nemesis()
 
         self.gemini_results = self.verify_gemini_results(queue=test_queue)
 

--- a/grow_cluster_test.py
+++ b/grow_cluster_test.py
@@ -106,7 +106,7 @@ class GrowClusterTest(ClusterTester):
         time.sleep(2 * 60)
 
         if self.params.get('nemesis_class_name').lower() != 'noopmonkey':
-            self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
+            self.db_cluster.start_nemesis()
 
         self.verify_stress_thread(cs_thread_pool=cs_thread_pool)
 

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -155,7 +155,7 @@ class LongevityTest(ClusterTester):
                 # Wait for some data (according to the param in the yal) to be populated, for multi keyspace need to
                 # pay attention to the fact it checks only on keyspace1
                 self.db_cluster.wait_total_space_used_per_node(keyspace=None)
-                self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
+                self.db_cluster.start_nemesis()
 
             # Wait on the queue till all threads come back.
             # todo: we need to improve this part for some cases that threads are being killed and we don't catch it.
@@ -232,7 +232,7 @@ class LongevityTest(ClusterTester):
         # Check if we shall wait for total_used_space or if nemesis wasn't started
         if not prepare_write_cmd or not self.params.get('nemesis_during_prepare'):
             self.db_cluster.wait_total_space_used_per_node(keyspace=None)
-            self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
+            self.db_cluster.start_nemesis()
 
         stress_read_cmd = self.params.get('stress_read_cmd', default=None)
         if stress_read_cmd:
@@ -274,7 +274,7 @@ class LongevityTest(ClusterTester):
             self._run_stress_in_batches(total_stress=total_stress, batch_size=batch_size,
                                         stress_cmd=prepare_write_cmd)
 
-        self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
+        self.db_cluster.start_nemesis()
 
         stress_cmd = self.params.get('stress_cmd', default=None)
         self._run_stress_in_batches(total_stress=batch_size, batch_size=batch_size,
@@ -314,7 +314,7 @@ class LongevityTest(ClusterTester):
                 self.monitors.reconfigure_scylla_monitoring()
                 self.db_cluster.wait_for_init(node_list=new_nodes)
 
-        self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
+        self.db_cluster.start_nemesis()
 
         stress_params_list = list()
 

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3275,7 +3275,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods
         self.nemesis = []
 
     @log_run_info("Start nemesis threads on cluster")
-    def start_nemesis(self, interval=30):
+    def start_nemesis(self, interval=None):
         for nemesis in self.nemesis:
             nemesis_thread = threading.Thread(target=nemesis.run,
                                               args=(interval, ))

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -87,7 +87,7 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
         self.current_disruption = None
         self.duration_list = []
         self.error_list = []
-        self.interval = 0
+        self.interval = 60 * self.tester.params.get('nemesis_interval')  # convert from min to sec
         self.start_time = time.time()
         self.stats = {}
         self.metrics_srv = nemesis_metrics_obj()
@@ -150,12 +150,12 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
 
         self.log.info('Current Target: %s with running nemesis: %s', self.target_node, self.target_node.running_nemesis)
 
-    def run(self, interval=30):
-        interval *= 60
-        self.log.info('Interval: %s s', interval)
-        self.interval = interval
+    def run(self, interval=None):
+        if interval:
+            self.interval = interval * 60
+        self.log.info('Interval: %s s', self.interval)
         while not self.termination_event.isSet():
-            cur_interval = interval
+            cur_interval = self.interval
             self.set_target_node()
             self._set_current_disruption(report=False)
             try:


### PR DESCRIPTION
Set nemesis interval in Nemesis constructor
if require another nemesis interval, differ from set in config file,
then could be passed as parameter to Nemesis.run method

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
