### PR TITLE
fix(config_setup): listen_address wrongly configured in multi-dc

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1596,7 +1596,7 @@ class BaseNode():  # pylint: disable=too-many-instance-attributes,too-many-publi
 
         if broadcast:
             # Set broadcast_address
-            scylla_yml['rpc_address'] = broadcast
+            scylla_yml['broadcast_address'] = broadcast
 
             # Set broadcast_rpc_address
             scylla_yml['broadcast_rpc_address'] = broadcast


### PR DESCRIPTION
c77eefe4 changed the rpc_address wrongly in case of broadcast

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
