### PR TITLE
fix(backup nemesis timeout): increasing backup timeout

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1244,7 +1244,7 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
             update_config_file(node=node, region=region[0])
         mgr_task = mgr_cluster.create_backup_task({'location': ['s3:{}'.format(bucket_location_name[0])]})
 
-        succeeded, status = mgr_task.wait_for_task_success_status(10800)
+        succeeded, status = mgr_task.wait_for_task_success_status(54000)
         if succeeded and status == TaskStatus.DONE:
             self.log.info('Task: {} is done.'.format(mgr_task.id))
         if not succeeded:


### PR DESCRIPTION
to allow backups on large data sets to finish, specially
after using the workaround to rate limit to 30 mb/s

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
