### PR TITLE
fix(sdcm/send_email.py): Increasing event message body limit

### DIFF
--- a/sdcm/send_email.py
+++ b/sdcm/send_email.py
@@ -123,7 +123,7 @@ class BaseEmailReporter():
     _fields = ()
     email_template_file = 'results_base.html'
     last_events_limit = 5
-    last_events_body_limit = 200
+    last_events_body_limit = 400
 
     def __init__(self, email_recipients=(), email_template_fp=None, logger=None, logdir=None):
         self.email_recipients = email_recipients
@@ -252,7 +252,7 @@ class BaseEmailReporter():
                 output[severity] = severity_events = []
                 for event in reversed(events):
                     severity_events.insert(0, event[:self.last_events_body_limit])
-                    if len(severity_events) > self.last_events_limit:
+                    if len(severity_events) >= self.last_events_limit:
                         severity_events.append('There are more events. See log file.')
                         break
         return output


### PR DESCRIPTION
Increasing event message body limit

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
