### PR TITLE
fix(sdcm/report_templates/results_base.html): move test_result block up

### DIFF
--- a/sdcm/report_templates/results_base.html
+++ b/sdcm/report_templates/results_base.html
@@ -171,20 +171,20 @@
 
 {% endblock %}
 
-{% block body %}
-{% endblock %}
-
 {% block test_results %}
     <h3>
         <span>Test results </span>
     </h3>
     {% if test_status == "SUCCESS" %}
         <span class='green'>{{ test_status }}</span>
-    {% elif status == 'FAILED' %}
+    {% elif test_status == 'FAILED' %}
         <span class='red'>{{ test_status }}</span>
     {% else %}
         <span>{{ test_status }}</span>
     {% endif %}
+{% endblock %}
+
+{% block body %}
 {% endblock %}
 
 {% block events_summary %}


### PR DESCRIPTION
Move test status block up, so that you could see it right after test details.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
