### PR TITLE
fix(create-test-release-jobs): fix command to not use underscores

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -386,7 +386,7 @@ Creating pipeline jobs for new branch
 
 Once a new branch is create, we could build all the need job for this branch with the following script ::
 
-    JENKINS_USER=[jenkins username] JENKINS_PASS=[token from jenkins] hydra create_test_release_jobs scylla-4.0 --sct_branch branch-4.0
+    JENKINS_USER=[jenkins username] JENKINS_PASS=[token from jenkins] hydra create-test-release-jobs scylla-4.0 --sct_branch branch-4.0
 
 FAQ
 ====

--- a/sct.py
+++ b/sct.py
@@ -488,7 +488,7 @@ def send_email(test_id=None, email_recipients=None, logdir=None):
         LOGGER.warning("No reporter found")
 
 
-@cli.command('create_test_release_jobs', help="Create pipeline jobs for a new branch")
+@cli.command('create-test-release-jobs', help="Create pipeline jobs for a new branch")
 @click.argument('branch', type=str)
 @click.argument('username', envvar='JENKINS_USERNAME', type=str)
 @click.argument('password', envvar='JENKINS_PASSWORD', type=str)


### PR DESCRIPTION
`create-test-release-jobs` was created with underscore by mistake
not as the rest of hydra commands

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
