### PR TITLE
fix(semaphore timed out severity): change severity of semaphore_timed_out event to WARNING

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -391,6 +391,7 @@ class BaseNode():  # pylint: disable=too-many-instance-attributes,too-many-publi
             DatabaseLogEvent(type='UNKNOWN_VERB', regex='unknown verb exception', severity=Severity.WARNING),
             DatabaseLogEvent(type='CQL_SERVER_CONN_SYSTEM_ERROR', severity=Severity.WARNING,
                              regex='cql_server - exception while processing connection: std::system_error'),
+            DatabaseLogEvent(type='SEMAPHORE_TIME_OUT', regex='semaphore_timed_out', severity=Severity.WARNING),
             DatabaseLogEvent(type='DATABASE_ERROR', regex='Exception '),
             DatabaseLogEvent(type='BAD_ALLOC', regex='std::bad_alloc'),
             DatabaseLogEvent(type='SCHEMA_FAILURE', regex='Failed to load schema version'),
@@ -401,7 +402,6 @@ class BaseNode():  # pylint: disable=too-many-instance-attributes,too-many-publi
             DatabaseLogEvent(type='SEGMENTATION', regex='segmentation'),
             DatabaseLogEvent(type='INTEGRITY_CHECK', regex='integrity check failed'),
             DatabaseLogEvent(type='REACTOR_STALLED', regex='Reactor stalled', severity=Severity.WARNING),
-            DatabaseLogEvent(type='SEMAPHORE_TIME_OUT', regex='semaphore_timed_out'),
             DatabaseLogEvent(type='BOOT', regex='Starting Scylla Server', severity=Severity.NORMAL),
             DatabaseLogEvent(type='SUPPRESSED_MESSAGES', regex='journal: Suppressed', severity=Severity.WARNING),
         ]


### PR DESCRIPTION
Semaphore timed out event shouldn't fail the test. So we decided to lower it's severity.
Semaphore timed out message includes Exception and backtrace words also:
seastar - Exceptional future ignored: seastar::named_semaphore_timed_out
(Semaphore timed out: _read_concurrency_sem), backtrace:  ...

So I set priority to the SEMAPHORE_TIME_OUT event if there are another event types
in the message

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
