### PR TITLE
fix(database_error_events): change CQL_SERVER_CONN_SYSTEM_ERROR to BR…

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -389,8 +389,8 @@ class BaseNode():  # pylint: disable=too-many-instance-attributes,too-many-publi
         self._database_error_events = [
             DatabaseLogEvent(type='NO_SPACE_ERROR', regex='No space left on device'),
             DatabaseLogEvent(type='UNKNOWN_VERB', regex='unknown verb exception', severity=Severity.WARNING),
-            DatabaseLogEvent(type='CQL_SERVER_CONN_SYSTEM_ERROR', severity=Severity.WARNING,
-                             regex='cql_server - exception while processing connection: std::system_error'),
+            DatabaseLogEvent(type='BROKEN_PIPE', severity=Severity.WARNING,
+                             regex='cql_server - exception while processing connection:.*Broken pipe'),
             DatabaseLogEvent(type='SEMAPHORE_TIME_OUT', regex='semaphore_timed_out', severity=Severity.WARNING),
             DatabaseLogEvent(type='DATABASE_ERROR', regex='Exception '),
             DatabaseLogEvent(type='BAD_ALLOC', regex='std::bad_alloc'),


### PR DESCRIPTION
…OKEN_PIPE

`CQL_SERVER_CONN_SYSTEM_ERROR` was too wide, catching all system_error,
we just want to lower broken pipe errors to warning

Ref: https://github.com/scylladb/scylla/issues/5661

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
