### PR TITLE
fix(backup nemesis): adjust to changes in original commit

### DIFF
--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -243,13 +243,14 @@ class ManagerTask(ScyllaManagerBase):
         relevant_key = [key for key in parsed_progress_table.keys() if parsed_progress_table[key]][0]
         return parsed_progress_table[relevant_key]
 
-    def wait_for_task_success_status(self, timeout=10800):
+    def wait_for_task_done_status(self, timeout=10800):
         start_time = time.time()
         while start_time + timeout > time.time():
             if 'ERROR (4/4)' in self.manager_node.remoter.run(f'sctool -c {self.cluster_id} task list | grep {self.id}').stdout.strip():
                 return False, TaskStatus.ERROR
             if self.status == TaskStatus.DONE:
                 return True, self.status
+            time.sleep(5)
         return False, self.status
 
     def is_status_in_list(self, list_status, check_task_progress=False):

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1244,21 +1244,15 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
             update_config_file(node=node, region=region[0])
         mgr_task = mgr_cluster.create_backup_task({'location': ['s3:{}'.format(bucket_location_name[0])]})
 
-        succeeded, status = mgr_task.wait_for_task_success_status(54000)
+        succeeded, status = mgr_task.wait_for_task_done_status(timeout=54000)
         if succeeded and status == TaskStatus.DONE:
             self.log.info('Task: {} is done.'.format(mgr_task.id))
         if not succeeded:
             if status == TaskStatus.ERROR:
-                assert succeeded, f'Backup task {mgr_task} failed'
+                assert succeeded, f'Backup task {mgr_task.id} failed'
             else:
                 mgr_task.stop()
-                assert succeeded, f'Backup task {mgr_task} timed out - while on status {status}'
-
-        # mgr_task.wait_for_status([TaskStatus.DONE], timeout=43200)  # timeout is 12 hours
-        # task_final_status = mgr_task.wait_and_get_final_status()
-        # assert task_final_status == TaskStatus.DONE, 'Task: {} final status is: {}.'.format(
-        #     mgr_task.id, str(mgr_task.status))
-        # self.log.info('Task: {} is done.'.format(mgr_task.id))
+                assert succeeded, f'Backup task {mgr_task.id} timed out - while on status {status}'
 
     def disrupt_mgmt_repair_cli(self):
         self._set_current_disruption('ManagementRepair')


### PR DESCRIPTION
the original commit was cherry picked to branch-3.3 before
full review and changes were done, so there was still a
difference that is being fixed with this commit.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
