### PR TITLE
fix(manager_sanity): destroy monitor at end of the test

### DIFF
--- a/test-cases/manager/manager-regression-multiDC-set-distro.yaml
+++ b/test-cases/manager/manager-regression-multiDC-set-distro.yaml
@@ -10,7 +10,7 @@ n_monitor_nodes: 1
 
 post_behavior_db_nodes: "destroy"
 post_behavior_loader_nodes: "destroy"
-post_behavior_monitor_nodes: "keep-on-failure"
+post_behavior_monitor_nodes: "destroy"
 
 user_prefix: manager-regression
 space_node_threshold: 6442


### PR DESCRIPTION
changed the value of post_behavior_monitor_nodes in manager sanity
(and manager backup feature test) to 'destroy',
since there's no point in keeping the monitor of every automatic run

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
