### PR TITLE
fix(upgrade): don't always skip io setup for kernel 3.10.0-1062

### DIFF
--- a/jenkins-pipelines/rolling-upgrade-centos7.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-centos7.jenkinsfile
@@ -13,7 +13,7 @@ rollingUpgradePipeline(
 
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
     test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
-    workaround_kernel_bug_for_iotune: true,
+    workaround_kernel_bug_for_iotune: false,
 
     timeout: [time: 360, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/rolling-upgrade-debian9.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-debian9.jenkinsfile
@@ -13,7 +13,7 @@ rollingUpgradePipeline(
 
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
     test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
-    workaround_kernel_bug_for_iotune: true,
+    workaround_kernel_bug_for_iotune: false,
 
     timeout: [time: 360, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/rolling-upgrade-ubuntu16.04.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-ubuntu16.04.jenkinsfile
@@ -13,7 +13,7 @@ rollingUpgradePipeline(
 
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
     test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
-    workaround_kernel_bug_for_iotune: true,
+    workaround_kernel_bug_for_iotune: false,
 
     timeout: [time: 360, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/rolling-upgrade-ubuntu18.04.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-ubuntu18.04.jenkinsfile
@@ -13,7 +13,7 @@ rollingUpgradePipeline(
 
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
     test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
-    workaround_kernel_bug_for_iotune: true,
+    workaround_kernel_bug_for_iotune: false,
 
     timeout: [time: 360, unit: 'MINUTES']
 )

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1980,7 +1980,7 @@ class BaseNode():  # pylint: disable=too-many-instance-attributes,too-many-publi
         result = self.remoter.run('/sbin/ip -o link show |grep ether |awk -F": " \'{print $2}\'', verbose=True)
         devname = result.stdout.strip()
         extra_setup_args = self.parent_cluster.params.get('append_scylla_setup_args')
-        if self.parent_cluster.params.get('workaround_kernel_bug_for_iotune') or "3.10.0-1062" in self.kernel_version:
+        if self.parent_cluster.params.get('workaround_kernel_bug_for_iotune'):
             self.log.warning(dedent("""
                 Kernel version is {}. Due to known kernel bug in this version using predefined iotune.
                 related issue: https://github.com/scylladb/scylla/issues/5181


### PR DESCRIPTION
Currently we always skip io setup for kernel 3.10.0-1062-*, even
workaround_kernel_bug_for_iotune is set to false.

In latest test, the iotune issue doesn't exist with kernel 3.10.0-1062.12.1.el7
This patch removed the kernel version condition, and disable
workaround_kernel_bug_for_iotune option in upgrade pipelines.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
