### PR TITLE
fix(db_stats): Fix update_test_details on SetUp failure

### DIFF
--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -559,51 +559,58 @@ class TestStatsMixin(Stats):
         self._stats['results']['stats_total'] = total_stats
 
     def update_test_details(self, errors=None, coredumps=None, scylla_conf=False, dict_specific_tested_stats=None):
-        if self.create_stats:
-            update_data = {}
-            if 'test_details' not in self._stats.keys():
-                self._stats['test_details'] = dict()
-                self._stats['setup_details'] = dict()
-            self._stats['test_details']['time_completed'] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
-            if self.monitors and self.monitors.nodes:
-                test_start_time = self._stats['test_details']['start_time']
-                if self.params.get('store_perf_results'):
-                    update_data['results'] = self.get_prometheus_stats()
-                grafana_dataset = self.monitors.get_grafana_screenshot_and_snapshot(test_start_time)
-                self._stats['test_details']['grafana_screenshots'] = grafana_dataset.get('screenshots', [])
-                self._stats['test_details']['grafana_snapshots'] = grafana_dataset.get('snapshots', [])
-                self._stats['test_details']['grafana_annotations'] = self.monitors.upload_annotations_to_s3()
-                self._stats['test_details']['prometheus_data'] = self.monitors.download_monitor_data()
+        if not self.create_stats:
+            return
 
-            if self.db_cluster:
-                self._stats['setup_details']['db_cluster_node_details'] = self.get_db_cluster_node_details()
+        if not self._stats:
+            self.log.error("Stats was not initialized. Could be error during Setup")
+            return
 
-            if self.db_cluster and scylla_conf and 'scylla_args' not in self._stats['setup_details'].keys():
-                node = self.db_cluster.nodes[0]
-                res = node.remoter.run('grep ^SCYLLA_ARGS /etc/sysconfig/scylla-server', verbose=True)
-                self._stats['setup_details']['scylla_args'] = res.stdout.strip()
-                res = node.remoter.run('cat /etc/scylla.d/io.conf', verbose=True)
-                self._stats['setup_details']['io_conf'] = remove_comments(res.stdout.strip())
-                res = node.remoter.run('cat /etc/scylla.d/cpuset.conf', verbose=True)
-                self._stats['setup_details']['cpuset_conf'] = remove_comments(res.stdout.strip())
+        update_data = {}
+        if 'test_details' not in self._stats.keys():
+            self._stats['test_details'] = dict()
+            self._stats['setup_details'] = dict()
+        self._stats['test_details']['time_completed'] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
 
-            self._stats['status'] = self.status
-            update_data.update(
-                {'status': self._stats['status'],
-                 'setup_details': self._stats['setup_details'],
-                 'test_details': self._stats['test_details']
-                 })
-            if errors:
-                update_data.update({'errors': errors})
-            if coredumps:
-                update_data.update({'coredumps': coredumps})
-            if dict_specific_tested_stats:
-                self.log.debug("Updating specific stats of: {}".format(dict_specific_tested_stats))
-                for key, value in dict_specific_tested_stats.items():
-                    self.log.debug("k: {} v: {}".format(key, value))
-                self._stats['results'].update(dict_specific_tested_stats)
-                update_data.update(dict_specific_tested_stats)
-            self.update(update_data)
+        if self.monitors and self.monitors.nodes:
+            test_start_time = self._stats['test_details']['start_time']
+            if self.params.get('store_perf_results'):
+                update_data['results'] = self.get_prometheus_stats()
+            grafana_dataset = self.monitors.get_grafana_screenshot_and_snapshot(test_start_time)
+            self._stats['test_details']['grafana_screenshots'] = grafana_dataset.get('screenshots', [])
+            self._stats['test_details']['grafana_snapshots'] = grafana_dataset.get('snapshots', [])
+            self._stats['test_details']['grafana_annotations'] = self.monitors.upload_annotations_to_s3()
+            self._stats['test_details']['prometheus_data'] = self.monitors.download_monitor_data()
+
+        if self.db_cluster:
+            self._stats['setup_details']['db_cluster_node_details'] = self.get_db_cluster_node_details()
+
+        if self.db_cluster and scylla_conf and 'scylla_args' not in self._stats['setup_details'].keys():
+            node = self.db_cluster.nodes[0]
+            res = node.remoter.run('grep ^SCYLLA_ARGS /etc/sysconfig/scylla-server', verbose=True)
+            self._stats['setup_details']['scylla_args'] = res.stdout.strip()
+            res = node.remoter.run('cat /etc/scylla.d/io.conf', verbose=True)
+            self._stats['setup_details']['io_conf'] = remove_comments(res.stdout.strip())
+            res = node.remoter.run('cat /etc/scylla.d/cpuset.conf', verbose=True)
+            self._stats['setup_details']['cpuset_conf'] = remove_comments(res.stdout.strip())
+
+        self._stats['status'] = self.status
+        update_data.update(
+            {'status': self._stats['status'],
+             'setup_details': self._stats['setup_details'],
+             'test_details': self._stats['test_details']
+             })
+        if errors:
+            update_data.update({'errors': errors})
+        if coredumps:
+            update_data.update({'coredumps': coredumps})
+        if dict_specific_tested_stats:
+            self.log.debug("Updating specific stats of: {}".format(dict_specific_tested_stats))
+            for key, value in dict_specific_tested_stats.items():
+                self.log.debug("k: {} v: {}".format(key, value))
+            self._stats['results'].update(dict_specific_tested_stats)
+            update_data.update(dict_specific_tested_stats)
+        self.update(update_data)
 
     def get_doc_data(self, key):
         if self.create_stats and self._test_index and self.get_doc_id():

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -286,8 +286,8 @@ class MonitoringStack(BaseLogEntity):
         try:
             monitor_version, scylla_version = result.stdout.strip().split(':')
         except ValueError:
-            monitor_version = "None"
-            scylla_version = "None"
+            monitor_version = None
+            scylla_version = None
         return name, monitor_version, scylla_version
 
     def get_grafana_annotations(self, grafana_ip):  # pylint: disable=inconsistent-return-statements
@@ -388,6 +388,9 @@ class GrafanaScreenShot(GrafanaEntity):
             Take screenshot of the Grafana per-server-metrics dashboard and upload to S3
         """
         _, _, monitoring_version = MonitoringStack.get_monitoring_version(node)
+        if not monitoring_version:
+            LOGGER.warning("Monitoring version was not found")
+            return []
         version = monitoring_version.replace('.', '-')
 
         try:
@@ -482,7 +485,9 @@ class GrafanaSnapshot(GrafanaEntity):
             Take snapshot of the Grafana per-server-metrics dashboard and upload to S3
         """
         _, _, monitoring_version = MonitoringStack.get_monitoring_version(node)
-
+        if not monitoring_version:
+            LOGGER.warning("Monitoring version was not found")
+            return []
         try:
             remote_browser = RemoteBrowser(node)
             snapshots = []


### PR DESCRIPTION
If SetUp failed during initializing db nodes or loader nodes,
several exception in finalize method could happened
- create screenshot by Log collector (monitor node is not yet created)
- no start time or stat object(ES doc is not created while db nodes are not started)
This cause, that email won't be sent

Job with example:

https://jenkins.scylladb.com/job/scylla-master/job/scylla-master-perf-regression-aws-test-throughput/4
https://jenkins.scylladb.com/job/scylla-master/job/scylla-master-perf-regression-aws-test-latency/4/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
