### PR TITLE
fix(artifact-ami): make the pipeline save 100 builds

### DIFF
--- a/jenkins-pipelines/artifacts-ami.jenkinsfile
+++ b/jenkins-pipelines/artifacts-ami.jenkinsfile
@@ -11,5 +11,6 @@ artifactsPipeline(
     instance_provision: 'spot_low_price',
 
     timeout: [time: 30, unit: 'MINUTES'],
-    post_behavior_db_nodes: 'destroy'
+    post_behavior_db_nodes: 'destroy',
+    builds_to_keep: '100'
 )

--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -52,7 +52,7 @@ def call(Map pipelineParams) {
         options {
             timestamps()
             timeout(pipelineParams.timeout)
-            buildDiscarder(logRotator(numToKeepStr: '20'))
+            buildDiscarder(logRotator(numToKeepStr: "${pipelineParams.get('builds_to_keep', '20')}",))
         }
         stages {
             stage('Checkout') {


### PR DESCRIPTION
20 build isn't enough when scylla-pkg is calling this pipeline 11 times each build

Fixes #1984

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
