### PR TITLE
[backport-3.2] feature(upgrade_test.py): add repair in a mixed cluster

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -530,6 +530,8 @@ class UpgradeTest(FillDatabaseData):
         self.db_cluster.nodes[indexes[1]].check_node_health()
 
         self.fill_and_verify_db_data('after rollback the second node')
+        self.log.info('Repair the first upgraded Node')
+        self.db_cluster.nodes[indexes[0]].run_nodetool(sub_cmd='repair')
 
         for i in indexes[1:]:
             self.db_cluster.node_to_upgrade = self.db_cluster.nodes[i]


### PR DESCRIPTION
This PR backported https://github.com/scylladb/scylla-cluster-tests/pull/1860 to branch-3.2

Signed-off-by: Amos Kong <amos@scylladb.com>
(cherry picked from commit ce241dc003bb85ef1a3b06f4a403634b9a2952ab)

Conflicts:
	upgrade_test.py

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
