### PR TITLE
improvement(cluster): keep instances on failure 72h

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -8,7 +8,7 @@ import os
 import tempfile
 import json
 import base64
-from typing import List, Dict
+from typing import List, Dict, Optional
 from textwrap import dedent
 from datetime import datetime
 from distutils.version import LooseVersion  # pylint: disable=no-name-in-module,import-error
@@ -416,8 +416,9 @@ class AWSNode(cluster.BaseNode):
         return {**super().tags,
                 "NodeIndex": str(self.node_index), }
 
-    def _set_keep_alive(self):
-        self._ec2_service.create_tags(Resources=[self._instance.id], Tags=[{"Key": "keep", "Value": "alive"}])
+    def _set_keep_alive(self, until: Optional[datetime] = None) -> bool:
+        value = "alive" if until is None else until.strftime(cluster.KEEP_DATETIME_TAG_FORMAT)
+        self._ec2_service.create_tags(Resources=[self._instance.id], Tags=[{"Key": "keep", "Value": value}])
         return super()._set_keep_alive()
 
     @property

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -15,8 +15,9 @@ import os
 import time
 import logging
 from textwrap import dedent
-from typing import Dict
+from typing import Dict, Optional
 from functools import cached_property
+from datetime import datetime
 
 from libcloud.common.google import GoogleBaseError, ResourceNotFoundError
 
@@ -77,8 +78,9 @@ class GCENode(cluster.BaseNode):
         return {**super().tags,
                 "NodeIndex": str(self.node_index), }
 
-    def _set_keep_alive(self) -> bool:
-        return self._instance_wait_safe(self._gce_service.ex_set_node_labels, self._instance, {"keep": "alive"}) and \
+    def _set_keep_alive(self, until: Optional[datetime] = None) -> bool:
+        value = "alive" if until is None else until.strftime(cluster.KEEP_DATETIME_TAG_FORMAT)
+        return self._instance_wait_safe(self._gce_service.ex_set_node_labels, self._instance, {"keep": value}) and \
             super()._set_keep_alive()
 
     def _instance_wait_safe(self, instance_method, *args, **kwargs):


### PR DESCRIPTION
Trello: https://trello.com/c/YxLby7KQ/1502-keep-alive-when-test-finish-and-set-to-keep-set-to-keep-for-72-hours

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
