### PR TITLE
improvement(hydra): remove docker prune from hydra.sh

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -27,15 +27,6 @@ if ! docker --version; then
     exit 1
 fi
 
-echo "Cleaning unused Docker resources..."
-# will clean
-#  - all stopped containers
-#  - all networks not used by at least one container
-#  - all volumes not used by at least one container
-#  - all dangling images
-#  - all dangling build cache
-docker system prune --volumes -f
-
 
 if [[ ! -z "`docker images ${DOCKER_REPO}:${VERSION} -q`" ]]; then
     echo "Image up-to-date"


### PR DESCRIPTION
There is a Jenkins job that cleans all builder and runs
the docker cleanup command. Other reason for that is when
Hydra was run in parallel and docker prune command was
executed it exited with error code since it can't run
concurrently


