### PR TITLE
fix(annoations upload): download/upload grafana annoations that inclu…

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4232,7 +4232,7 @@ class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-inst
             res = requests.get(url=annotations_url.format(node_ip=normalize_ipv6_url(node.grafana_address),
                                                           grafana_port=self.grafana_port))
             if res.ok:
-                return res.text
+                return res.content
         except Exception as ex:  # pylint: disable=broad-except
             LOGGER.warning("unable to get grafana annotations [%s]", str(ex))
         return ""
@@ -4296,7 +4296,8 @@ class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-inst
                 annotations_url = S3Storage().generate_url('annotations.json', Setup.test_id())
                 self.log.info("Uploading 'annotations.json' to {s3_url}".format(
                     s3_url=annotations_url))
-                response = requests.put(annotations_url, data=annotations)
+                response = requests.put(annotations_url, data=annotations, headers={
+                                        'Content-type': 'application/json; charset=utf-8'})
                 response.raise_for_status()
         except Exception:  # pylint: disable=broad-except
             self.log.exception("failed to upload annotations to S3")


### PR DESCRIPTION
…de unicode

since annotation can include unicode, we should download them as res.content
and upload them without encoding/decoding anything stright to s3

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
