### PR TITLE
improvement(tagging): add keep_action tag

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2659,8 +2659,11 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes
 
     @cached_property
     def tags(self) -> Dict[str, str]:
+        key = self.node_type if "db" not in self.node_type else "db"
+        action = self.params.get(f"post_behavior_{key}_nodes")
         return {**Setup.common_tags(),
-                "NodeType": str(self.node_type), }
+                "NodeType": str(self.node_type),
+                "keep_action": "terminate" if action == "destroy" else "", }
 
     def init_log_directory(self):
         assert '_SCT_TEST_LOGDIR' in os.environ


### PR DESCRIPTION
Trello: https://trello.com/c/PlWoTtMR/1586-set-default-keepaction-to-terminate-when-destroy-postbehaviour-is-used

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
