### PR TITLE
SSH proto banner fix

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -252,6 +252,8 @@ class Setup:
         post_boot_script = '#!/bin/bash'
         post_boot_script += dedent(r'''
                sudo sed -i 's/#MaxSessions \(.*\)$/MaxSessions 1000/' /etc/ssh/sshd_config
+               sudo sed -i 's/#MaxStartups \(.*\)$/MaxStartups 60/' /etc/ssh/sshd_config
+               sudo sed -i 's/#LoginGraceTime \(.*\)$/LoginGraceTime 15s/' /etc/ssh/sshd_config
                sudo systemctl restart sshd
                ''')
         if cls.RSYSLOG_ADDRESS:

--- a/sdcm/remote.py
+++ b/sdcm/remote.py
@@ -250,6 +250,7 @@ class RemoteCmdRunner(CommandRunner):  # pylint: disable=too-many-instance-attri
                                  'ServerAliveInterval': 300,
                                  'StrictHostKeyChecking': 'no'})
         self.connect_config = {'pkey': RSAKey(filename=os.path.expanduser(self.key_file))}
+        self.auth_sleep_time = 30  # sleep time between failed authentication attempts
         super(RemoteCmdRunner, self).__init__(hostname, user, password)
         self.start_ssh_up_thread()
 
@@ -343,6 +344,12 @@ class RemoteCmdRunner(CommandRunner):  # pylint: disable=too-many-instance-attri
             with self._create_connection() as connection:
                 result = connection.run("true", timeout=30, warn=False, encoding='utf-8', hide=True)
                 return result.ok
+        except AuthenticationException as auth_exception:
+            # in order not to overwhelm SSH server with connection attempts that can cause further connection drops
+            # we will slow down our tries. We need this due to "MaxStartups 10:30:100" that is default for sshd
+            self.log.debug(f"{auth_exception}: sleeping {self.auth_sleep_time} seconds before next retry")
+            self._ssh_up_thread_termination.wait(self.auth_sleep_time)
+            return False
         except Exception as details:  # pylint: disable=broad-except
             self.log.debug(details)
             return False


### PR DESCRIPTION
Issue: https://trello.com/c/R7yRpzFV/1830-ssh-protocol-banner-error

After looking for the instances of the problem I found that it happened mostly in GCE in the artifact and rolling upgrade tests. So my investigation was focused there. I ran centos8 artifact test with SSH server configured to the most verbose debug level 3.That's what I found out:
Instance started at 20:55

```-- Logs begin at Sun 2020-04-05 20:55:13 UTC, end at Sun 2020-04-05 21:21:32 UTC. --
Apr 05 20:55:13 localhost kernel: Linux version 4.18.0-147.5.1.el8_1.x86_64 (mockbuild@kbuilder.bsys.centos.org) (gcc version 8.3.1 20190507 (Red Hat 8.3.1-4) (GCC)) #1 SMP Wed Feb 5 02:00:39 UTC 2020
Apr 05 20:55:13 localhost kernel: Command line: BOOT_IMAGE=(hd0,msdos1)/boot/vmlinuz-4.18.0-147.5.1.el8_1.x86_64 root=UUID=eec2f2c1-729f-4281-a954-8a1eed31d866 ro net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y crashkernel=auto console=ttyS0,38400n8
```
During init of node we start the task threads that wait for the SSH to become available. We see ssh ping thread trying to connect every 5 sec to the instance and fails with "Authentication failed" exception (10 times, this number is important).
```< t:2020-04-05 20:55:23,724 f:cluster.py      l:2789 c:sdcm.cluster         p:DEBUG > Class instance: GCE Cluster artifacts-centos8-jenkins-db-cluster-5cc29a94 | Image: centos-8 | Root Disk: pd-ssd 50 GB | Local SSD: 1 | Type: n1-standard-2
< t:2020-04-05 20:55:23,727 f:cluster.py      l:2790 c:sdcm.cluster         p:DEBUG > Method kwargs: {'node_list': [<sdcm.cluster_gce.GCENode object at 0x7fba20f4c668>]}
< t:2020-04-05 20:55:26,006 f:remote.py       l:347  c:sdcm.remote          p:DEBUG > RemoteCmdRunner [scylla-test@10.142.0.17]: Authentication failed.
< t:2020-04-05 20:55:31,132 f:remote.py       l:347  c:sdcm.remote          p:DEBUG > RemoteCmdRunner [scylla-test@10.142.0.17]: Authentication failed.
< t:2020-04-05 20:55:36,332 f:remote.py       l:347  c:sdcm.remote          p:DEBUG > RemoteCmdRunner [scylla-test@10.142.0.17]: Authentication failed.
< t:2020-04-05 20:55:41,539 f:remote.py       l:347  c:sdcm.remote          p:DEBUG > RemoteCmdRunner [scylla-test@10.142.0.17]: Authentication failed.
< t:2020-04-05 20:55:46,856 f:remote.py       l:347  c:sdcm.remote          p:DEBUG > RemoteCmdRunner [scylla-test@10.142.0.17]: Authentication failed.
< t:2020-04-05 20:55:51,959 f:remote.py       l:347  c:sdcm.remote          p:DEBUG > RemoteCmdRunner [scylla-test@10.142.0.17]: Authentication failed.
< t:2020-04-05 20:55:52,757 f:wait.py         l:50   c:sdcm.wait            p:DEBUG > wait_for: Retrying is_up: attempt 1 ended with: False
< t:2020-04-05 20:55:52,757 f:wait.py         l:50   c:sdcm.wait            p:DEBUG > wait_for: Retrying is_up: attempt 1 ended with: False
< t:2020-04-05 20:55:53,729 f:wait.py         l:50   c:sdcm.wait            p:DEBUG > wait_for: Retrying is_up: attempt 1 ended with: False
< t:2020-04-05 20:55:57,086 f:remote.py       l:347  c:sdcm.remote          p:DEBUG > RemoteCmdRunner [scylla-test@10.142.0.17]: Authentication failed.
< t:2020-04-05 20:56:02,191 f:remote.py       l:347  c:sdcm.remote          p:DEBUG > RemoteCmdRunner [scylla-test@10.142.0.17]: Authentication failed.
< t:2020-04-05 20:56:07,317 f:remote.py       l:347  c:sdcm.remote          p:DEBUG > RemoteCmdRunner [scylla-test@10.142.0.17]: Authentication failed.
< t:2020-04-05 20:56:07,758 f:wait.py         l:50   c:sdcm.wait            p:DEBUG > wait_for: Retrying is_up: attempt 1 ended with: False
< t:2020-04-05 20:56:12,406 f:remote.py       l:347  c:sdcm.remote          p:DEBUG > RemoteCmdRunner [scylla-test@10.142.0.17]: Authentication failed.
```
at 20:56:13 we see that GCEGuestAgent adds scylla-test user to the system (in this run it took about a minute to add the scylla-test user)
```
Apr 05 20:56:13 artifacts-centos8-jenkins-db-node-5cc29a94-0-1 GCEGuestAgent[1493]: 2020-04-05T20:56:13.4010Z GCEGuestAgent Info: Creating user scylla-test.
Apr 05 20:56:13 artifacts-centos8-jenkins-db-node-5cc29a94-0-1 useradd[5713]: new group: name=scylla-test, GID=1028
Apr 05 20:56:13 artifacts-centos8-jenkins-db-node-5cc29a94-0-1 useradd[5713]: new user: name=scylla-test, UID=1027, GID=1028, home=/home/scylla-test, shell=/bin/bash
Apr 05 20:56:14 artifacts-centos8-jenkins-db-node-5cc29a94-0-1 gpasswd[5720]: user scylla-test added by root to group adm
Apr 05 20:56:14 artifacts-centos8-jenkins-db-node-5cc29a94-0-1 google_guest_agent[1493]: 2020/04/05 20:56:14 logging client: rpc error: code = PermissionDenied desc = Request had insufficient authentication scopes.
Apr 05 20:56:14 artifacts-centos8-jenkins-db-node-5cc29a94-0-1 gpasswd[5730]: user scylla-test added by root to group video
Apr 05 20:56:14 artifacts-centos8-jenkins-db-node-5cc29a94-0-1 gpasswd[5736]: user scylla-test added by root to group google-sudoers
Apr 05 20:56:14 artifacts-centos8-jenkins-db-node-5cc29a94-0-1 GCEGuestAgent[1493]: 2020-04-05T20:56:14.9116Z GCEGuestAgent Info: Updating keys for user scylla-test.

```then we see that some commands start to execute and some fail with SSH protocol banner and No existing session errors```< t:2020-04-05 20:56:17,949 f:remote.py       l:305  c:sdcm.remote          p:DEBUG > RemoteCmdRunner [scylla-test@10.142.0.17]: Running command "journalctl --version"...
< t:2020-04-05 20:56:17,948 f:remote.py       l:305  c:sdcm.remote          p:DEBUG > RemoteCmdRunner [scylla-test@10.142.0.17]: Running command "cat /etc/os-release"...
< t:2020-04-05 20:56:17,966 f:remote.py       l:322  c:sdcm.remote          p:ERROR > Error reading SSH protocol banner[Errno 104] Connection reset by peer
< t:2020-04-05 20:56:17,966 f:decorators.py   l:123  c:sdcm.utils.decorators p:DEBUG > 'run': failed with 'RetriableNetworkException('Error reading SSH protocol banner[Errno 104] Connection reset by peer',)', retrying [#0]
```
in the SSHD log we see that connection attempt is dropped due to "past MaxStartups"
```Apr 05 20:56:17 artifacts-centos8-jenkins-db-node-5cc29a94-0-1 sshd[1735]: debug3: send_rexec_state: done
Apr 05 20:56:17 artifacts-centos8-jenkins-db-node-5cc29a94-0-1 sshd[1735]: debug3: fd 6 is not O_NONBLOCK
Apr 05 20:56:17 artifacts-centos8-jenkins-db-node-5cc29a94-0-1 sshd[1735]: debug1: drop_connection: p 30, r 7
Apr 05 20:56:17 artifacts-centos8-jenkins-db-node-5cc29a94-0-1 sshd[1735]: drop connection #11 from [10.142.0.5]:51068 on [10.142.0.17]:22 past MaxStartups
Apr 05 20:56:17 artifacts-centos8-jenkins-db-node-5cc29a94-0-1 sshd[5832]: debug3: oom_adjust_restore
Apr 05 20:56:17 artifacts-centos8-jenkins-db-node-5cc29a94-0-1 sshd[5832]: debug1: Set /proc/self/oom_score_adj to 0
Apr 05 20:56:17 artifacts-centos8-jenkins-db-node-5cc29a94-0-1 sshd[5832]: debug1: rexec start in 6 out 6 newsock 6 pipe 18 sock 19
```"journalctl --version" succeeds ```< t:2020-04-05 20:56:28,559 f:decorators.py   l:123  c:sdcm.utils.decorators p:DEBUG > 'run': failed with 'RetriableNetworkException('No existing session',)', retrying [#1]
< t:2020-04-05 20:56:29,169 f:remote.py       l:732  c:sdcm.remote          p:INFO  > RemoteCmdRunner [scylla-test@10.142.0.17]: systemd 239
< t:2020-04-05 20:56:29,169 f:remote.py       l:732  c:sdcm.remote          p:INFO  > RemoteCmdRunner [scylla-test@10.142.0.17]: +PAM +AUDIT +SELINUX +IMA -APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD +IDN2 -IDN +PCRE2 default-hierarchy=legacy
< t:2020-04-05 20:56:29,172 f:remote.py       l:156  c:sdcm.remote          p:INFO  > RemoteCmdRunner [scylla-test@10.142.0.17]: Command "journalctl --version" finished with status 0
```
After reading about "MaxStartups" option in the SSHD configuration man page and checking what is the default that is used in our servers I found outthat the default that is set is "10:30:100", that means that after 10 first unsuccessfull connection attempts SSH server starts dropping the packets with 30% probability until it reaches 100 and then drops every connection request. 
So in order to prevent this situation, I decided to do the following:
- Improve SSH ping thread by handling Authentication failures differently, by introducing 30 sec sleep time in such case 
- Instead of probabilistic MaxStartups use 60 connection attempts
- Decrease LoginGraceTime to 15 sec

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
