### PR TITLE
feature(alerts): add a way to silence alerts for a duration of time

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -38,7 +38,7 @@ from paramiko.ssh_exception import NoValidConnectionsError
 
 from sdcm.collectd import ScyllaCollectdSetup
 from sdcm.mgmt import ScyllaManagerError, get_scylla_manager_tool
-from sdcm.prometheus import start_metrics_server, PrometheusAlertManagerListener
+from sdcm.prometheus import start_metrics_server, PrometheusAlertManagerListener, AlertSilencer
 from sdcm.log import SDCMAdapter
 from sdcm.remote import RemoteCmdRunner, LOCALRUNNER, NETWORK_EXCEPTIONS
 from sdcm import wait
@@ -1024,6 +1024,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
     def start_alert_manager_thread(self):
         self._alert_manager = PrometheusAlertManagerListener(self.external_address, stop_flag=self.termination_event)
         self._alert_manager.start()
+
+    def silence_alert(self, alert_name, duration=None, start=None, end=None):
+        return AlertSilencer(self._alert_manager, alert_name, duration, start, end)
 
     def __str__(self):
         return 'Node %s [%s | %s%s] (seed: %s)' % (self.name,


### PR DESCRIPTION
since in alternator case, some specific nemesis can raise those alerts
and it's acceptable, we want to silence them specificly for that nemesis

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
