### PR TITLE
perf(artifacts test): disable backtrace decoding

### DIFF
--- a/test-cases/artifacts/ami.yaml
+++ b/test-cases/artifacts/ami.yaml
@@ -1,5 +1,6 @@
 ami_id_db_scylla: 'ami-067787e9ea5433c78'
 aws_root_disk_size_db: 50
+backtrace_decoding: false
 cluster_backend: 'aws'
 instance_type_db: 'i3.large'
 instance_provision: "spot_low_price"

--- a/test-cases/artifacts/centos8.yaml
+++ b/test-cases/artifacts/centos8.yaml
@@ -1,3 +1,4 @@
+backtrace_decoding: false
 cluster_backend: 'gce'
 gce_image: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-8'
 gce_instance_type_db: 'n1-standard-2'

--- a/test-cases/artifacts/debian10.yaml
+++ b/test-cases/artifacts/debian10.yaml
@@ -1,3 +1,4 @@
+backtrace_decoding: false
 cluster_backend: 'gce'
 gce_image: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-10'
 gce_instance_type_db: 'n1-standard-2'

--- a/test-cases/artifacts/debian9.yaml
+++ b/test-cases/artifacts/debian9.yaml
@@ -1,3 +1,4 @@
+backtrace_decoding: false
 cluster_backend: 'gce'
 gce_image: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-9'
 gce_instance_type_db: 'n1-standard-2'

--- a/test-cases/artifacts/docker.yaml
+++ b/test-cases/artifacts/docker.yaml
@@ -1,3 +1,4 @@
+backtrace_decoding: false
 cluster_backend: 'docker'
 docker_image: 'scylladb/scylla'
 logs_transport: 'ssh'

--- a/test-cases/artifacts/oel76.yaml
+++ b/test-cases/artifacts/oel76.yaml
@@ -1,6 +1,7 @@
 ami_db_scylla_user: 'clckwrk'
 ami_id_db_scylla: 'ami-0d6a24fe35fdf5dc4'
 aws_root_disk_size_db: 50
+backtrace_decoding: false
 cluster_backend: 'aws'
 instance_type_db: 'i3.large'
 instance_provision: "spot_low_price"

--- a/test-cases/artifacts/rhel7.yaml
+++ b/test-cases/artifacts/rhel7.yaml
@@ -1,3 +1,4 @@
+backtrace_decoding: false
 cluster_backend: 'gce'
 gce_image: 'https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/family/rhel-7'
 gce_instance_type_db: 'n1-standard-2'

--- a/test-cases/artifacts/rhel8.yaml
+++ b/test-cases/artifacts/rhel8.yaml
@@ -1,3 +1,4 @@
+backtrace_decoding: false
 cluster_backend: 'gce'
 gce_image: 'https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/family/rhel-8'
 gce_instance_type_db: 'n1-standard-2'

--- a/test-cases/artifacts/ubuntu1604.yaml
+++ b/test-cases/artifacts/ubuntu1604.yaml
@@ -1,3 +1,4 @@
+backtrace_decoding: false
 cluster_backend: 'gce'
 gce_image: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts'
 gce_instance_type_db: 'n1-standard-2'

--- a/test-cases/artifacts/ubuntu1804.yaml
+++ b/test-cases/artifacts/ubuntu1804.yaml
@@ -1,3 +1,4 @@
+backtrace_decoding: false
 cluster_backend: 'gce'
 gce_image: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-1804-lts'
 gce_instance_type_db: 'n1-standard-2'


### PR DESCRIPTION
Trello: https://trello.com/c/aUOFfMAF/1713-artifact-test-leftovers

Disabling backtrace decoding will speed up artifacts test by avoiding installing the debuginfo package.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
