### PR TITLE
feature(monitoring node): enable node_exporter on monitoring node

### DIFF
--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -17,6 +17,7 @@
 import os
 import re
 import logging
+import pathlib
 from typing import Optional, Union, Dict
 
 from sdcm import cluster
@@ -370,6 +371,13 @@ class MonitorSetDocker(cluster.BaseMonitorSet, DockerCluster):  # pylint: disabl
     @staticmethod
     def install_scylla_monitoring_prereqs(node):  # pylint: disable=invalid-name
         pass  # since running local, don't install anything, just the monitor
+
+    @staticmethod
+    def get_monitor_install_path_base(node):
+        base_dir = os.environ.get("_SCT_BASE_DIR", None)
+        logdir = pathlib.Path(node.logdir)
+        logdir = pathlib.Path(base_dir).joinpath(*logdir.parts[2:]) if base_dir else logdir
+        return str(logdir)
 
     def get_backtraces(self):
         pass


### PR DESCRIPTION
since we had issue with monitoring, we want to collect cpu/mem and such from
the node running the monitoring

Ref: https://trello.com/c/qyttIBBi

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
