### PR TITLE
fix(sct_config): make sure AMIs are tagged with 'user_data_format_ver…

### DIFF
--- a/internal_test_data/minimal_test_case.yaml
+++ b/internal_test_data/minimal_test_case.yaml
@@ -15,4 +15,4 @@ stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_profile_4mv_5queries.y
 
 db_type: scylla
 instance_type_db: 'i3.large'
-ami_id_db_scylla: 'ami-b4f8b4cb'
+ami_id_db_scylla: 'ami-06f919eb'

--- a/internal_test_data/stress_cmd_with_bad_profile.yaml
+++ b/internal_test_data/stress_cmd_with_bad_profile.yaml
@@ -6,5 +6,5 @@ n_monitor_nodes: 1
 user_prefix: 'fruch-testing'
 db_type: scylla
 instance_type_db: 'i3.large'
-ami_id_db_scylla: 'ami-b4f8b4cb'
+ami_id_db_scylla: 'ami-06f919eb'
 stress_cmd: ["cassandra-stress user profile=/tmp/1232123123123123123.yaml ops'(insert=100)' no-warmup cl=ONE duration=10m -port jmx=6868 -mode cql3 native -rate threads=3000 -errors ignore"]

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -15,7 +15,7 @@ from distutils.util import strtobool  # pylint: disable=import-error,no-name-in-
 
 import anyconfig
 
-from sdcm.utils.common import get_s3_scylla_repos_mapping, get_scylla_ami_versions, get_branched_ami
+from sdcm.utils.common import get_s3_scylla_repos_mapping, get_scylla_ami_versions, get_branched_ami, get_ami_tags
 from sdcm.utils.version_utils import get_branch_version
 
 logging.getLogger("anyconfig").setLevel(logging.ERROR)
@@ -1219,6 +1219,18 @@ class SCTConfiguration(dict):
 
             if int(partition_range_splitted[1]) < int(partition_range_splitted[0]):
                 raise ValueError(error_message_template.format('<max PK value> should be bigger then <min PK value>. '))
+
+        # verify that the AMIs used all have 'user_data_format_version' tag
+        ami_id_db_scylla = self.get('ami_id_db_scylla', default='').split()
+        region_names = self.get('region_name', default='').split()
+        ami_id_db_oracle = self.get('ami_id_db_oracle', default='').split()
+
+        for ami_list in [ami_id_db_scylla, ami_id_db_oracle]:
+            if ami_list:
+                for ami_id, region_name in zip(ami_list, region_names):
+                    tags = get_ami_tags(ami_id, region_name)
+                    assert 'user_data_format_version' in tags.keys(), \
+                        f"\n\t'user_data_format_version' tag missing from [{ami_id}] on {region_name}\n\texisting tags: {tags}"
 
     def dump_config(self):
         """

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -48,7 +48,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         os.environ['SCT_REGION_NAME'] = '["eu-west-1", "us-east-1"]'
         os.environ['SCT_N_DB_NODES'] = '2 2'
         os.environ['SCT_INSTANCE_TYPE_DB'] = 'i3.large'
-        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-b4f8b4cb ami-b4f8b4cb'
+        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-06f919eb ami-eae4f795'
 
         conf = SCTConfiguration()
         conf.verify_configuration()
@@ -127,7 +127,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
     @staticmethod
     def test_10_mananger_regression():
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
-        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-b4f8b4cb ami-b4f8b4cb'
+        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-06f919eb ami-eae4f795'
 
         os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/multi_region_dc_test_case.yaml'
         conf = SCTConfiguration()
@@ -147,7 +147,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
     def test_12_scylla_version_ami_case1():  # pylint: disable=invalid-name
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
         os.environ['SCT_SCYLLA_VERSION'] = '3.0.3'
-        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-b4f8b4cb ami-b4f8b4cb'
+        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-06f919eb ami-eae4f795'
 
         os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/multi_region_dc_test_case.yaml'
         conf = SCTConfiguration()
@@ -171,7 +171,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
     def test_12_scylla_version_repo_case1():  # pylint: disable=invalid-name
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
         os.environ['SCT_SCYLLA_VERSION'] = '3.0.3'
-        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-b4f8b4cb'
+        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-06f919eb'
 
         conf = SCTConfiguration()
         conf.verify_configuration()
@@ -215,13 +215,13 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         os.environ['SCT_SCYLLA_VERSION'] = 'branch-3.1:9'
         os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/multi_region_dc_test_case.yaml'
         conf = SCTConfiguration()
-        conf.verify_configuration()
 
         self.assertEqual(conf.get('ami_id_db_scylla'), 'ami-00b5ac462978479c9 ami-0d911e53781d8a542')
+        self.assertRaisesRegex(AssertionError, r".*tag missing.*", conf.verify_configuration)
 
     def test_13_scylla_version_ami_branch_latest(self):  # pylint: disable=invalid-name
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
-        os.environ['SCT_SCYLLA_VERSION'] = 'branch-3.1:latest'
+        os.environ['SCT_SCYLLA_VERSION'] = 'branch-4.0:latest'
         os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/multi_region_dc_test_case.yaml'
         conf = SCTConfiguration()
         conf.verify_configuration()
@@ -284,7 +284,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         os.environ['SCT_REGION_NAME'] = 'us-east-1'
         os.environ['SCT_N_DB_NODES'] = '2'
         os.environ['SCT_INSTANCE_TYPE_DB'] = 'i3.large'
-        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-b4f8b4cb'
+        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-eae4f795'
 
         conf = SCTConfiguration()
         conf.verify_configuration()
@@ -310,6 +310,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
         os.environ['SCT_ORACLE_SCYLLA_VERSION'] = "3.0.11"
         os.environ['SCT_REGION_NAME'] = 'us-east-1'
+        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-eae4f795'
         os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/minimal_test_case.yaml'
 
         conf = SCTConfiguration()
@@ -336,6 +337,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
         os.environ['SCT_ORACLE_SCYLLA_VERSION'] = "3.0.11"
         os.environ['SCT_REGION_NAME'] = 'us-east-1'
+        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-eae4f795'
         os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/minimal_test_case.yaml'
 
         conf = SCTConfiguration()


### PR DESCRIPTION
…sion'

since we had lot of case the new 'user_data_format_version' tag was missing
from AMIs, we are adding this check to make sure the tag is there before running

Ref: https://trello.com/c/Xph7v6eS
Ref: https://trello.com/c/dKSsyg1f

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
