### PR TITLE
improvement(limited_chaos_monkey): adding other disruptions

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2101,13 +2101,22 @@ class LimitedChaosMonkey(Nemesis):
         #  - SoftRebootMonkey
         #  - TruncateMonkey
         #  - ToppartitionsMonkey
+        #  - MgmtRepair
+        #  - NoCorruptRepairMonkey
+        #  - SnapshotOperations
+        #  - AbortRepairMonkey
+        #  - MgmtBackup
+        #  - AddDropColumnMonkey
         self.call_random_disrupt_method(disrupt_methods=['disrupt_nodetool_cleanup', 'disrupt_nodetool_decommission',
                                                          'disrupt_nodetool_drain', 'disrupt_nodetool_refresh',
                                                          'disrupt_stop_start_scylla_server', 'disrupt_major_compaction',
                                                          'disrupt_modify_table', 'disrupt_nodetool_enospc',
                                                          'disrupt_stop_wait_start_scylla_server',
                                                          'disrupt_hard_reboot_node', 'disrupt_soft_reboot_node',
-                                                         'disrupt_truncate', 'disrupt_show_toppartitions'])
+                                                         'disrupt_truncate', 'disrupt_show_toppartitions',
+                                                         'disrupt_mgmt_repair_cli', 'disrupt_no_corrupt_repair',
+                                                         'disrupt_snapshot_operations', 'disrupt_abort_repair',
+                                                         'disrupt_mgmt_backup', 'disrupt_add_drop_column'])
 
 
 class ScyllaCloudLimitedChaosMonkey(Nemesis):


### PR DESCRIPTION
adding mgmt_repair, no_corrupt_repair and abort_repair to
see some repair tasks on this nemesis.
also, adding few other non disruptive tests:
snapshot_operations, mgmt_backup and add_drop_column.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
