### PR TITLE
fix(sdcm/nemesis.py): ToggleTableICS: use command of alter materialized view for MV table

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1072,12 +1072,15 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
             Alters a non-system table compaction strategy from ICS to any-other and vise versa.
         """
         list_additional_params = get_compaction_random_additional_params()
-        ks_cfs = get_non_system_ks_cf_list(db_node=self.target_node)
-        if not ks_cfs:
+        all_ks_cfs = get_non_system_ks_cf_list(db_node=self.target_node)
+        non_mview_ks_cfs = get_non_system_ks_cf_list(db_node=self.target_node, filter_out_mv=True)
+
+        if not all_ks_cfs:
             raise UnsupportedNemesis(
                 'Non-system keyspace and table are not found. toggle_tables_ics nemesis can\'t run')
 
-        keyspace_table = random.choice(ks_cfs)
+        mview_ks_cfs = list(set(all_ks_cfs) - set(non_mview_ks_cfs))
+        keyspace_table = random.choice(all_ks_cfs)
         keyspace, table = keyspace_table.split('.')
         cur_compaction_strategy = get_compaction_strategy(node=self.target_node, keyspace=keyspace,
                                                           table=table)
@@ -1091,7 +1094,9 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
         if new_compaction_strategy in [CompactionStrategy.INCREMENTAL, CompactionStrategy.SIZE_TIERED]:
             for param in list_additional_params:
                 new_compaction_strategy_as_dict.update(param)
-        cmd = "ALTER TABLE {keyspace_table} WITH compaction = {new_compaction_strategy_as_dict};".format(**locals())
+        alter_command_prefix = 'ALTER TABLE ' if keyspace_table not in mview_ks_cfs else 'ALTER MATERIALIZED VIEW '
+        cmd = alter_command_prefix + \
+            " {keyspace_table} WITH compaction = {new_compaction_strategy_as_dict};".format(**locals())
         self.log.debug("Toggle table ICS query to execute: {}".format(cmd))
         try:
             self.target_node.run_cqlsh(cmd)


### PR DESCRIPTION


	fixes #1730
fixes https://github.com/scylladb/scylla-cluster-tests/issues/1730

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I gave variables/functions meaningful self-explanatory names
- [x] I didn't leave commented-out/debugging code
- [x] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
