### PR TITLE
feature(lightweight transactions): run lwt basic longevity during 24 hours

### DIFF
--- a/jenkins-pipelines/longevity-lwt-24h.jenkinsfile
+++ b/jenkins-pipelines/longevity-lwt-24h.jenkinsfile
@@ -1,0 +1,15 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    params: params,
+
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/longevity/longevity-lwt-basic-24h.yaml',
+
+    timeout: [time: 2000, unit: 'MINUTES']
+)

--- a/test-cases/longevity/longevity-lwt-basic-24h.yaml
+++ b/test-cases/longevity/longevity-lwt-basic-24h.yaml
@@ -1,0 +1,28 @@
+test_duration: 1500
+prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml n=10000000 ops'(insert=1)' cl=QUORUM -mode native cql3 -rate threads=50" ]
+stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=QUORUM duration=1440m -mode native cql3 -rate threads=30" ]
+stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(select=1)' cl=SERIAL duration=1440m -mode native cql3 -rate threads=30" ]
+
+n_db_nodes: 4
+n_loaders: 3
+n_monitor_nodes: 1
+experimental: true
+
+instance_type_db: 'i3.2xlarge'
+cluster_health_check: false
+
+# loader AMI with c-s ver. 4 and fix of NoSuchElementException
+regions_data:
+  us-east-1:
+    ami_id_loader: 'ami-0946a8d8159a15b2c'
+  eu-west-1:
+    ami_id_loader: 'ami-0dc7edd6fba3da2fb'
+  us-west-2:
+    ami_id_loader: 'ami-010284f401d8933a2'
+
+nemesis_class_name: 'ChaosMonkey'
+nemesis_interval: 5
+nemesis_during_prepare: false
+space_node_threshold: 64424
+
+user_prefix: 'longevity-lwt-24h'


### PR DESCRIPTION
Same longevity as test-cases/longevity/longevity-lwt-basic-3h.yaml, but longer running: 24 hours

Jenkins job on master: [master longevity-lwt-24h](https://jenkins.scylladb.com/view/master/job/scylla-master/job/longevity/job/longevity-lwt-24h/)

Jenkins job on branch-4.0: [branch-4.0 longevity-lwt-24h](https://jenkins.scylladb.com/view/scylla-4.0/job/scylla-4.0/job/longevity/job/longevity-lwt-24h/)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
