### PR TITLE
fix(gemini_config): Fix gemini config to use cql-feature normal

### DIFF
--- a/test-cases/gemini/gemini-3h-cdc-postimage-write.yaml
+++ b/test-cases/gemini/gemini-3h-cdc-postimage-write.yaml
@@ -8,8 +8,9 @@ store_results_in_elasticsearch: False
 user_prefix: "gemini-cdc-preimage-write"
 
 gemini_cmd: "gemini -d --duration 3h \
--c 50 -m write -f --non-interactive \
---cql-features all \
+-c 50 -m write -f --non-interactive --cql-features normal \
+--max-mutation-retries 5 --max-mutation-retries-backoff 500ms \
+--async-objects-stabilization-attempts 5 --async-objects-stabilization-backoff 500ms \
 --replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '3'}\" "
 
 gemini_version: 'latest'

--- a/test-cases/gemini/gemini-3h-cdc-preimage-write.yaml
+++ b/test-cases/gemini/gemini-3h-cdc-preimage-write.yaml
@@ -8,8 +8,9 @@ store_results_in_elasticsearch: False
 user_prefix: "gemini-cdc-preimage-write"
 
 gemini_cmd: "gemini -d --duration 3h \
--c 50 -m write -f --non-interactive \
---cql-features all \
+-c 50 -m write -f --non-interactive --cql-features normal \
+--max-mutation-retries 5 --max-mutation-retries-backoff 500ms \
+--async-objects-stabilization-attempts 5 --async-objects-stabilization-backoff 500ms \
 --replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '3'}\" "
 
 gemini_version: 'latest'

--- a/test-cases/gemini/gemini-3h-cdc-write.yaml
+++ b/test-cases/gemini/gemini-3h-cdc-write.yaml
@@ -8,8 +8,9 @@ store_results_in_elasticsearch: False
 user_prefix: "gemini-cdc-write"
 
 gemini_cmd: "gemini -d --duration 3h \
--c 50 -m write -f --non-interactive \
---cql-features all \
+-c 50 -m write -f --non-interactive --cql-features normal \
+--max-mutation-retries 5 --max-mutation-retries-backoff 500ms \
+--async-objects-stabilization-attempts 5 --async-objects-stabilization-backoff 500ms \
 --replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '3'}\" "
 
 gemini_table_options:


### PR DESCRIPTION
Gemini tool has an issue https://github.com/scylladb/gemini/issues/230
which block to use cql-feature param with value all to test cdc-feature
Switching to use cql-feature=normal

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I gave variables/functions meaningful self-explanatory names
- [ ] I didn't leave commented-out/debugging code
- [ ] I didn't copy-paste code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
