### PR TITLE
improvement(email-template): removed duplicate build url link

### DIFF
--- a/sdcm/report_templates/results_base.html
+++ b/sdcm/report_templates/results_base.html
@@ -138,18 +138,17 @@
 
 {% block test_info %}
 
-    <h3>Test: {{ test_name }}</h3>
-
-    <h3>Test-id: {{ test_id }}</h3>
-
     <h3>Test details</h3>
     <div>
         <ul>
+            <li>Test: {{ test_name }}</li>
+            <li>Test-id: {{ test_id }}</li>
             <li>Start time: {{ start_time }}</li>
             <li>End time: {{ end_time }}</li>
-            <li>Build URL: <a href="{{ build_url }}">link</a></li>
-            <li>Test run by User: <b>{{ username }}</b></li>
+            <li>Started by user: {{ username }}</li>
+            {% if scylla_repo %}
             <li>Private repo: {{ scylla_repo }}</li>
+            {% endif %}
             {% if repo_uuid %}
             <li>Private repo UUID: {{ repo_uuid }}</li>
             {% endif %}
@@ -173,7 +172,7 @@
 
 {% block test_results %}
     <h3>
-        <span>Test results </span>
+        <span>Test result</span>
     </h3>
     {% if test_status == "SUCCESS" %}
         <span class='green'>{{ test_status }}</span>


### PR DESCRIPTION
since build url is displayed in the links section we can remove
the duplication from test details.
Also moved test name and test id into the test details section

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~

example:
![image](https://user-images.githubusercontent.com/5269241/78891750-cc419f80-7a70-11ea-8914-e9a0ab827004.png)
