### PR TITLE
fix(docker/env/hydra.sh): Fixing path escaping

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 set -e
 CMD=$@
-DOCKER_ENV_DIR=$(dirname $(readlink -f $0 ))
+DOCKER_ENV_DIR=$(readlink -f "$0")
+DOCKER_ENV_DIR=$(dirname "${DOCKER_ENV_DIR}")
 DOCKER_REPO=scylladb/hydra
-
-SCT_DIR=$(dirname $(dirname ${DOCKER_ENV_DIR}))
-VERSION=v$(cat ${DOCKER_ENV_DIR}/version)
+SCT_DIR=$(dirname "${DOCKER_ENV_DIR}")
+SCT_DIR=$(dirname "${SCT_DIR}")
+VERSION=v$(cat "${DOCKER_ENV_DIR}/version")
 WORK_DIR=/sct
 HOST_NAME=SCT-CONTAINER
 
@@ -27,15 +28,6 @@ if ! docker --version; then
     exit 1
 fi
 
-echo "Cleaning unused Docker resources..."
-# will clean
-#  - all stopped containers
-#  - all networks not used by at least one container
-#  - all volumes not used by at least one container
-#  - all dangling images
-#  - all dangling build cache
-docker system prune --volumes -f
-
 
 if [[ ! -z "`docker images ${DOCKER_REPO}:${VERSION} -q`" ]]; then
     echo "Image up-to-date"
@@ -44,12 +36,12 @@ else
     docker pull ${DOCKER_REPO}:${VERSION}
 fi
 # Check for SSH keys
-${SCT_DIR}/get-qa-ssh-keys.sh
+"${SCT_DIR}/get-qa-ssh-keys.sh"
 
 # change ownership of results directories
 echo "Making sure the ownerships of results directories are of the user"
 sudo chown -R `whoami`:`whoami` ~/sct-results &> /dev/null || true
-sudo chown -R `whoami`:`whoami` ${SCT_DIR}/sct-results &> /dev/null || true
+sudo chown -R `whoami`:`whoami` "${SCT_DIR}/sct-results" &> /dev/null || true
 
 subcommand="$1"
 if [[ ${subcommand} == 'bash'* ]] || [[ ${subcommand} == 'python'* ]]; then
@@ -78,21 +70,21 @@ done
 docker run --rm ${TTY_STDIN} --privileged \
     -h ${HOST_NAME} \
     -v /var/run:/run \
-    -v ${SCT_DIR}:${WORK_DIR} \
+    -v "${SCT_DIR}:${WORK_DIR}" \
     -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
     -v /tmp:/tmp \
     -v /var/tmp:/var/tmp \
-    -v ${HOME}:${HOME} \
+    -v "${HOME}:${HOME}" \
     -v /etc/passwd:/etc/passwd:ro \
     -v /etc/group:/etc/group:ro \
     -v /etc/sudoers:/etc/sudoers:ro \
     -v /etc/shadow:/etc/shadow:ro \
-    -w ${WORK_DIR} \
-    -e JOB_NAME=${JOB_NAME} \
-    -e BUILD_URL=${BUILD_URL} \
-    -e _SCT_BASE_DIR=${SCT_DIR} \
+    -w "${WORK_DIR}" \
+    -e JOB_NAME="${JOB_NAME}" \
+    -e BUILD_URL="${BUILD_URL}" \
+    -e _SCT_BASE_DIR="${SCT_DIR}" \
     -e GIT_USER_EMAIL \
-    -u $(id -u ${USER}) \
+    -u $(id -u "${USER}") \
     ${group_args[@]} \
     ${SCT_OPTIONS} \
     ${BUILD_OPTIONS} \


### PR DESCRIPTION
  Needed to fix issue when hydra is running from path that have characters needed to be escaped
Example of failed run is https://jenkins.scylladb.com/job/Mavenir-test/job/LWT%20Longevities/job/longevity-lwt-mavenir-1loader-3h/1/console

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
