### PR TITLE
fix(docker): load all container attributes for send_email

### DIFF
--- a/sdcm/send_email.py
+++ b/sdcm/send_email.py
@@ -438,6 +438,7 @@ def get_running_instances_for_email_report(test_id):
     resources = list_resources_docker(tags_dict=tags, running=True, group_as_builder=True)
     for builder_name, containers in resources.get("containers", {}).items():
         for container in containers:
+            container.reload()
             nodes.append([container.name,
                           container.attrs["NetworkSettings"]["IPAddress"],
                           container.status,


### PR DESCRIPTION
Fix for the problem with `send_email` reported by Dmitry:

```python
Traceback (most recent call last):
  File "./sct.py", line 562, in <module>
    cli()
  File "/usr/local/lib64/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib64/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib64/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib64/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib64/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "./sct.py", line 526, in send_email
    test_results['nodes'] = get_running_instances_for_email_report(test_results['test_id'])
  File "/sct/sdcm/send_email.py", line 389, in get_running_instances_for_email_report
    container.attrs["NetworkSettings"]["IPAddress"],
KeyError: 'IPAddress'
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
