### PR TITLE
improvement(perf_result_templ): Adding sign to percent result < 4%

### DIFF
--- a/sdcm/report_templates/results_base.html
+++ b/sdcm/report_templates/results_base.html
@@ -7,6 +7,7 @@
         .fbold  { font-weight: bold; }
         .red    { color: red; }
         .green  { color: green; }
+        .lightgreen { color: #90EE90; }
         .orange { color: orange; }
         .black  { color: black; }
         .fnormal { font-weight: normal; }

--- a/sdcm/report_templates/results_base_custom.html
+++ b/sdcm/report_templates/results_base_custom.html
@@ -7,6 +7,7 @@
         .fbold  { font-weight: bold; }
         .red    { color: red; }
         .green  { color: green; }
+        .lightgreen { color: #90EE90; }
         .orange { color: orange; }
         .black  { color: black; }
         .fnormal { font-weight: normal; }

--- a/sdcm/report_templates/results_performance.html
+++ b/sdcm/report_templates/results_performance.html
@@ -81,8 +81,12 @@
                    percent_abs = best_stat.percent|replace('%', '')|int %}
                     {% if status == 'Regression' and percent_abs > 4 %}
                         <span class="red fbold">-{{ percent }}</span>
+                    {% elif status == 'Regression' and percent_abs <= 4 %}
+                        <span class="black fbold">-{{ percent }}</span>
                     {% elif status == 'Progress' and percent_abs > 4 %}
                         <span class="green fbold">+{{ percent }}</span>
+                    {% elif status == 'Progress' and percent_abs <= 4 %}
+                        <span class="black fbold">+{{ percent }}</span>
                     {% else %}
                         <span>{{ percent }}</span>
                     {% endif %}
@@ -98,8 +102,12 @@
                    percent_abs = last_stat.percent|replace('%', '')|int %}
                     {% if status == 'Regression' and percent_abs > 4 %}
                         <span class="red fbold">-{{ percent }}</span>
+                    {% elif status == 'Regression' and percent_abs <= 4 %}
+                        <span class="black fbold">-{{ percent }}</span>
                     {% elif status == 'Progress' and percent_abs > 4 %}
                         <span class="green fbold">+{{ percent }}</span>
+                    {% elif status == 'Progress' and percent_abs <= 4 %}
+                        <span class="black fbold">+{{ percent }}</span>
                     {% else %}
                         <span>{{ percent }}</span>
                     {% endif %}

--- a/sdcm/report_templates/results_performance_baseline.html
+++ b/sdcm/report_templates/results_performance_baseline.html
@@ -91,15 +91,17 @@
                              {% with status = stat.status, percent = stat.percent,
                                     percent_abs = stat.percent|replace('%', '')|int %}
                                 {% if status == 'Regression' and percent_abs > 4 %}
-                                    <span class="red fbold">-
+                                    <span class="red fbold">-{{ percent }}</span>
+                                {% elif status == 'Regression' and percent_abs <= 4 %}
+                                    <span class="black fbold">-{{ percent }}</span>
                                 {% elif status == 'Progress' and percent_abs > 4 %}
-                                    <span class="green fbold">+
+                                    <span class="green fbold">+{{ percent }}</span>
+                                {% elif status == 'Progress' and percent_abs <= 4 %}
+                                    <span class="black fbold">+{{ percent }}</span>
                                 {% else %}
-                                    <span>
+                                    <span>{{ percent }}</span>
                                 {% endif %}
-                                    {{ percent }}
-                                {% endwith %}
-                                    </span>
+                             {% endwith %}
                             )
                         </td>
                 {% endfor %}
@@ -147,13 +149,16 @@
                 {% with status = stat.status, percent = stat.percent,
                    percent_abs = stat.percent|replace('%', '')|int %}
                     {% if status == 'Regression' and percent_abs > 4 %}
-                        <span class="red fbold">-
+                        <span class="red fbold">-{{ percent }}</span>
+                    {% elif status == 'Regression' and percent_abs <= 4 %}
+                        <span class="black fbold">-{{ percent }}</span>
                     {% elif status == 'Progress' and percent_abs > 4 %}
-                        <span class="green fbold">+
+                        <span class="green fbold">+{{ percent }}</span>
+                    {% elif status == 'Progress' and percent_abs <= 4 %}
+                        <span class="black fbold">+{{ percent }}</span>
                     {% else %}
-                        <span>
+                        <span>{{ percent }}</span>
                     {% endif %}
-                    {{ percent }}
                 {% endwith %}
                 </span>
             </td>


### PR DESCRIPTION
Regression result for difference less than 4% doesn't have sign and color.
Adding sign to percent result in performance template

Trello: https://trello.com/c/xrxfsKdu

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- ~[ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)~
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (CI)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
