### PR TITLE
Large collection: disable hinted_handoff and remove unlimited list

### DIFF
--- a/data_dir/large_collections.yaml
+++ b/data_dir/large_collections.yaml
@@ -12,36 +12,13 @@ table_definition: |
     pk_id text PRIMARY KEY,
     init_time timestamp,
     user_name text,
-    device_id text,
-    start_time timestamp,
-    field_id text,
     new_num int,
-    self_desc text,
-    age int,
-    comment text,
-    message1 text,
-    message2 text,
-    message3 text,
-    message4 text,
-    country_id text,
-    area_id text,
-    type_name text,
-    types_num int,
-    process_num int,
     weight decimal,
-    users_name list<text>,
-    users_desc list<text>,
-    users_comment list<text>,
-    pay_num int,
-    question text,
-    messageid text,
-    testflag int,
-    pid text,
-    ppid text,
-    users_task list<text>,
     nums_list list<int>,
+    users_name list<text>,
     nums_set set<int>,
     names_set set<text>,
+    books_set set<text>,
   ) WITH bloom_filter_fp_chance = 0.01
     AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
     AND comment = 'Request for unit level UIs'
@@ -59,10 +36,7 @@ table_definition: |
 
 columnspec:
   - name: pk_id
-    population: seq(1..10000000)
-
-  - name: clientappname
-    size: fixed(5)
+    population: seq(1..8000000)
 
 # Need to populate the list field with big elements and many of them (about 40MB per list).
 # >>> math.sqrt(40 * 1024 * 1024)
@@ -70,35 +44,33 @@ columnspec:
 # large partition: 16M, large row: 4M, large cell: 1M
 # >>> math.sqrt(16 * 1024 * 1024)
 # 4096.0
+# >>> math.sqrt(1024 * 1024 * 15.5 / 2)
+# 2850.695353768971
 # >>> math.sqrt(4 * 1024 * 1024)
 # 2048.0
+# >>> math.sqrt(1024 * 1024 * 4 / 2)
+# 1448.1546878700494
 # >>> math.sqrt(1 * 1024 * 1024)
 # 1024.0
+
+  - name: nums_list
+    size: fixed(2)
+    population: uniform(1..10000)
 
   - name: users_name
     size: fixed(5)
 
-  - name: users_desc
-    size: exp(1..2048)
-    population: exp(1..2048)
-
-  - name: users_comment
-    size: fixed(1)
-
-  - name: users_task
-    size: fixed(2)
-
-  - name: nums_list
-    size: fixed(2)
-    population: exp(1..10000)
-
   - name: nums_set
     size: fixed(100)
-    population: exp(1..10000)
+    population: uniform(1..10000)
 
   - name: names_set
-    size: exp(1..2048)
-    population: exp(1..2048)
+    size: fixed(1024)
+    population: uniform(1..1024)
+
+  - name: books_set
+    size: fixed(1024)
+    population: uniform(1..1024)
 
 insert:
   batchtype: UNLOGGED
@@ -108,5 +80,5 @@ queries:
     cql: select * from large_collection_test.table_with_large_collection where pk_id = ?
     fields: samerow
   update1:
-    cql: update large_collection_test.table_with_large_collection set users_name=?,users_desc=?,users_comment=?,users_task=?,nums_list=?,nums_set=?,names_set=? where pk_id = ?
+    cql: update large_collection_test.table_with_large_collection set users_name=?,nums_list=?,nums_set=?,names_set=?,books_set=? where pk_id = ?
     fields: samerow

--- a/data_dir/large_collections_update.yaml
+++ b/data_dir/large_collections_update.yaml
@@ -67,20 +67,12 @@ columnspec:
 # Need to populate the list field with big elements and many of them (about 40MB per list).
 # >>> math.sqrt(40 * 1024 * 1024)
 # 6476.344648024841
-# large partition: 16M, large row: 4M, large cell: 1M
-# >>> math.sqrt(16 * 1024 * 1024)
-# 4096.0
-# >>> math.sqrt(4 * 1024 * 1024)
-# 2048.0
-# >>> math.sqrt(1 * 1024 * 1024)
-# 1024.0
 
   - name: users_name
-    size: fixed(5)
+    size: fixed(500)
 
   - name: users_desc
-    size: exp(1..2048)
-    population: exp(1..2048)
+    size: fixed(1000)
 
   - name: users_comment
     size: fixed(1)
@@ -89,7 +81,6 @@ columnspec:
     size: fixed(2)
 
   - name: nums_list
-    size: fixed(2)
     population: exp(1..10000)
 
   - name: nums_set
@@ -97,10 +88,10 @@ columnspec:
     population: exp(1..10000)
 
   - name: names_set
-    size: exp(1..2048)
-    population: exp(1..2048)
+    size: fixed(500)
 
 insert:
+  partitions: fixed(1)
   batchtype: UNLOGGED
 
 queries:

--- a/test-cases/longevity/longevity-large-collections-12h.yaml
+++ b/test-cases/longevity/longevity-large-collections-12h.yaml
@@ -1,6 +1,6 @@
 test_duration: 780
 stress_cmd: [
-"JVM_OPTION='-Xms8033M -Xmx8033M -Xmn400M' cassandra-stress user profile=/tmp/large_collections.yaml ops'(insert=3,read1=1)' cl=QUORUM duration=720m -port jmx=6868 -mode cql3 native -rate threads=20"
+"JVM_OPTION='-Xms8033M -Xmx8033M -Xmn400M' cassandra-stress user profile=/tmp/large_collections.yaml ops'(insert=3,read1=1,update1=1)' cl=QUORUM duration=720m -port jmx=6868 -mode cql3 native -rate threads=20"
              ]
 
 n_db_nodes: 4

--- a/test-cases/longevity/longevity-large-collections-12h.yaml
+++ b/test-cases/longevity/longevity-large-collections-12h.yaml
@@ -14,3 +14,7 @@ nemesis_interval: 15
 
 user_prefix: 'longevity-large-collections-48h'
 space_node_threshold: 64424
+
+# Disable hinted handoff to avoid a known issue:
+# https://github.com/scylladb/scylla/issues/4935
+hinted_handoff: 'disabled'

--- a/test-cases/longevity/longevity-large-collections-12h.yaml
+++ b/test-cases/longevity/longevity-large-collections-12h.yaml
@@ -1,6 +1,6 @@
 test_duration: 780
 stress_cmd: [
-"JVM_OPTION='-Xms8033M -Xmx8033M -Xmn400M' cassandra-stress user profile=/tmp/large_collections.yaml ops'(insert=3,read1=1,update1=0.1)' cl=QUORUM duration=720m -port jmx=6868 -mode cql3 native -rate threads=10"
+"JVM_OPTION='-Xms8033M -Xmx8033M -Xmn400M' cassandra-stress user profile=/tmp/large_collections.yaml ops'(insert=3,read1=1)' cl=QUORUM duration=720m -port jmx=6868 -mode cql3 native -rate threads=20"
              ]
 
 n_db_nodes: 4
@@ -12,7 +12,7 @@ instance_type_db: 'i3.4xlarge'
 nemesis_class_name: 'ChaosMonkey'
 nemesis_interval: 15
 
-user_prefix: 'longevity-large-collections-48h'
+user_prefix: 'longevity-large-collections-12h'
 space_node_threshold: 64424
 
 # Disable hinted handoff to avoid a known issue:


### PR DESCRIPTION
ticket: https://trello.com/c/02QNmBHr/1401-large-collections-tests-longevity-testing-a-fix-for-customer-issue

list size is unlimited, it caused huge collections. Let's replace it with limited set.
There is a known issue of hinted_handoff, so disable it in this PR.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
