### PR TITLE
fix(config_setup): clean old encrypt_conf

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1708,7 +1708,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         if append_scylla_yaml and ('system_key_directory' in append_scylla_yaml or 'system_info_encryption' in append_scylla_yaml or 'kmip_hosts:' in append_scylla_yaml):
             self.remoter.send_files(src='./data_dir/encrypt_conf',  # pylint: disable=not-callable
                                     dst='/tmp/')
-            self.remoter.run('sudo mv /tmp/encrypt_conf /etc/')
+            self.remoter.run('sudo rm -rf /etc/encrypt_conf')
+            self.remoter.run('sudo mv -f /tmp/encrypt_conf /etc/')
             self.remoter.run('sudo mkdir /etc/encrypt_conf/system_key_dir/')
             self.remoter.run('sudo chown -R scylla:scylla /etc/encrypt_conf/')
             self.remoter.run('sudo md5sum /etc/encrypt_conf/*.pem', ignore_status=True)


### PR DESCRIPTION
In some nemesis, node.config_setup() is called for updating the
node configuration (prepare config files and update scylla.yaml).
Some configuration has been done in cluster init.

In restart_with_resharding nemesis:
|
|  Command: 'sudo mv /tmp/encrypt_conf /etc/'
|  Exit code: 1
|
|  Stderr:
|  mv: cannot move ‘/tmp/encrypt_conf’ to ‘/etc/encrypt_conf’: File exists

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
