### PR TITLE
fix(add remove column nemesis): ignore counter table

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -106,6 +106,8 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
             'alternator_usertable': '*',  # Ignore alternator tables
             'mview': 'users',  # Ignore MV user-profile tables
             'sec_index': 'users',  # Ignore SI user-profile tables
+            'ks_truncate': 'counter1',  # Ignore counter table
+            'keyspace1': 'counter1',  # Ignore counter table
         }
 
     def update_stats(self, disrupt, status=True, data=None):


### PR DESCRIPTION
Fails to add non counter column for counter column family.
To prevent it, ignore the counter1 table in the nemesis

This error was received in [longevity-lwt-mavenir-3loaders-3h](https://jenkins.scylladb.com/job/Mavenir-test/job/LWTLongevities/job/longevity-lwt-mavenir-3loaders-3h/1)

```
< t:2020-04-09 23:21:21,661 f:nemesis.py      l:811  c:sdcm.nemesis         p:DEBUG > sdcm.nemesis.ChaosMonkey: Add/Remove Column Nemesis: CQL query 'ALTER TABLE counter1 ADD ( S9ZUTBMV4W list<frozen<map<boolean,text>>> );' execution has failed with error '<Error from server: code=2300 [Query invalid because of configuration issue] message="Cannot add a non counter column (s9zutbmv4w) in a counter column family">'
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
