### PR TITLE
fix(auto_bootstrap): change sed command to use true/false

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -600,7 +600,7 @@ class AWSNode(cluster.BaseNode):
 
             clean_script = dedent("""
                 sudo sed -e '/.*scylla/s/^/#/g' -i /etc/fstab
-                sudo sed -e '/auto_bootstrap:.*/s/False/True/g' -i /etc/scylla/scylla.yaml
+                sudo sed -e '/auto_bootstrap:.*/s/false/true/g' -i /etc/scylla/scylla.yaml
             """)
             self.remoter.run("sudo bash -cxe '%s'" % clean_script)
             output = self.remoter.run('sudo grep replace_address: /etc/scylla/scylla.yaml', ignore_status=True)
@@ -635,7 +635,7 @@ class AWSNode(cluster.BaseNode):
                 self.start_scylla_server(verify_up=False)
                 self.remoter.run(
                     'sudo sed -i -e "s/^replace_address_first_boot:/# replace_address_first_boot:/g" /etc/scylla/scylla.yaml')
-                self.remoter.run("sudo sed -e '/auto_bootstrap:.*/s/True/False/g' -i /etc/scylla/scylla.yaml")
+                self.remoter.run("sudo sed -e '/auto_bootstrap:.*/s/true/false/g' -i /etc/scylla/scylla.yaml")
             finally:
                 if event_filters:
                     for event_filter in event_filters:


### PR DESCRIPTION
Since the move to using prorper yaml library to do changes to scylla.yaml
some sed command were replacing True/False, in the scylla.yaml, and
not the yaml lower case values for booleans.

Fixes: scylladb/scylla#6120 
Fixes: scylladb/scylla#6121
Ref: https://github.com/scylladb/scylla-cluster-tests/pull/1952/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
