### PR TITLE
fix(manager): Added handling of empty manager cql/rest status

### DIFF
--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -57,6 +57,8 @@ class HostStatus(Enum):
     def from_str(cls, output_str):
         try:
             output_str = output_str.upper()
+            if output_str == "-":
+                return cls.DOWN
             return getattr(cls, output_str)
         except AttributeError:
             raise ScyllaManagerError("Could not recognize returned host status: {}".format(output_str))
@@ -73,6 +75,8 @@ class HostRestStatus(Enum):
     def from_str(cls, output_str):
         try:
             output_str = output_str.upper()
+            if output_str == "-":
+                return cls.DOWN
             return getattr(cls, output_str)
         except AttributeError:
             raise ScyllaManagerError("Could not recognize returned host rest status: {}".format(output_str))
@@ -567,7 +571,10 @@ class ManagerCluster(ScyllaManagerBase):
                     status = list_cql[0]
                     rtt = self._extract_value_with_regex(string=list_cql[-1], regex_pattern=r"\(([^)]+ms)")
                     rest_value = line[rest_col_idx]
-                    rest_status = rest_value[:rest_value.find("(")].strip()
+                    if rest_value == '-':
+                        rest_status = rest_value
+                    else:
+                        rest_status = rest_value[:rest_value.find("(")].strip()
                     rest_rtt = self._extract_value_with_regex(string=rest_value, regex_pattern=r"\(([^)]+ms)")
                     rest_http_status_code = self._extract_value_with_regex(string=rest_value,
                                                                            regex_pattern=r"\(([0-9]*?)\)")


### PR DESCRIPTION
Due to recent changes in the manager,
the manager does not query nodes that are properly down (DN) for rest and cql status
and instead of the usual DOWN status prints '-' as the status.
I updated the code to parse the '-' status as DOWN

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
