### PR TITLE
fix(manager): fix parsing of cluster list

### DIFF
--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -650,14 +650,14 @@ class ScyllaManagerTool(ScyllaManagerBase):
         """
         Returns Manager Cluster object by a given name if exist, else returns none.
         """
-        # ╭──────────────────────────────────────┬──────────┬─────────────┬────────────────╮
-        # │ cluster id                           │ name     │ host        │ ssh user       │
-        # ├──────────────────────────────────────┼──────────┼─────────────┼────────────────┤
-        # │ 1de39a6b-ce64-41be-a671-a7c621035c0f │ Dev_Test │ 10.142.0.25 │ scylla-manager │
-        # │ bf6571ef-21d9-4cf1-9f67-9d05bc07b32e │ Prod     │ 10.142.0.26 │ scylla-manager │
-        # ╰──────────────────────────────────────┴──────────┴─────────────┴────────────────╯
+        # ╭──────────────────────────────────────┬──────────╮
+        # │ ID                                   │ name     │
+        # ├──────────────────────────────────────┼──────────┤
+        # │ 1de39a6b-ce64-41be-a671-a7c621035c0f │ Dev_Test │
+        # │ bf6571ef-21d9-4cf1-9f67-9d05bc07b32e │ Prod     │
+        # ╰──────────────────────────────────────┴──────────╯
         try:
-            cluster_id = self.sctool.get_table_value(parsed_table=self.cluster_list, column_name="cluster id",
+            cluster_id = self.sctool.get_table_value(parsed_table=self.cluster_list, column_name="ID",
                                                      identifier=cluster_name)
         except ScyllaManagerError as ex:
             LOGGER.warning("Cluster name not found in Scylla-Manager: {}".format(ex))


### PR DESCRIPTION
The output of the manager's cluster list command changed,
and now the name of the 'cluster id' column was changed to 'ID',
so I changed the code accordingly

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
