### PR TITLE
improvement(coredump): raise CoreDumpEvent before core upload

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -949,6 +949,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             download_instructions = "failed to upload"
             try:
                 self.log.debug('Found coredump file: {}'.format(coredump))
+                CoreDumpEvent(corefile_url="", download_instructions=f"Coredump {coredump} upload in progress",
+                              backtrace=output, node=self, timestamp=timestamp)
                 url, download_instructions = self._upload_coredump(coredump)
                 result = True
             except Exception as exc:  # pylint: disable=broad-except


### PR DESCRIPTION
Trello: https://trello.com/c/aUOFfMAF/1713-artifact-test-leftovers

See #1879 

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
