### PR TITLE
fix(gemini_report): Dont display oracle cluster description

### DIFF
--- a/sdcm/report_templates/results_gemini.html
+++ b/sdcm/report_templates/results_gemini.html
@@ -31,6 +31,7 @@
             <li>Number of scylladb nodes: {{ number_of_db_nodes }}</li>
         </ul>
     </div>
+    {% if oracle_db_version != "N/A" %}
     <h3>
         <span>Test oracle</span>
     </h3>
@@ -41,6 +42,7 @@
             <li>Number of test oracle db nodes: {{ number_of_oracle_nodes }}</li>
         </ul>
     </div>
+    {% endif %}
 {% endblock %}
 
 {% block test_results %}


### PR DESCRIPTION
If gemini test runs without oracle cluster, don't display
section in html report described the oracle node

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
