### PR TITLE
fix(lightweight transaction): not fail the test when more immutable rows

### DIFF
--- a/longevity_lwt_test.py
+++ b/longevity_lwt_test.py
@@ -257,13 +257,22 @@ class LWTLongevityTest(LongevityTest):
             actual_result = self.rows_to_list(session.execute("SELECT * FROM %s" % self.mv_for_not_updated_data))
             expected_result = self.rows_to_list(session.execute("SELECT * FROM %s" % self.expected_data_table_name))
 
-            self.assertEqual(len(actual_result), len(expected_result),
-                             'One or more rows are not as expected, suspected LWT wrong update. '
-                             'Actual dataset length: {}, Expected dataset length: {}'.format(len(actual_result),
-                                                                                             len(expected_result)))
+            # Issue https://github.com/scylladb/scylla/issues/6181
+            # Not fail the test if unexpected additional rows where found in actual result table
+            if len(actual_result) > len(expected_result):
+                self.log.warning('Actual dataset length {} more '
+                                 'then expected dataset length: {}. '
+                                 'Issue #6181'.format(len(actual_result),
+                                                      len(expected_result)))
+            else:
 
-            self.assertEqual(actual_result, expected_result,
-                             'One or more rows are not as expected, suspected LWT wrong update')
+                self.assertEqual(len(actual_result), len(expected_result),
+                                 'One or more rows are not as expected, suspected LWT wrong update. '
+                                 'Actual dataset length: {}, Expected dataset length: {}'.format(len(actual_result),
+                                                                                                 len(expected_result)))
+
+                self.assertEqual(actual_result, expected_result,
+                                 'One or more rows are not as expected, suspected LWT wrong update')
 
     def validate_updated_data(self, session):
         """


### PR DESCRIPTION
Issue https://github.com/scylladb/scylla/issues/6181
Not fail the test if unexpected additional rows where found in actual result table

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
