### PR TITLE
fix(lightweight transaction): use new longevity_lwt_test module

### DIFF
--- a/jenkins-pipelines/longevity-lwt-1loader-3h.jenkinsfile
+++ b/jenkins-pipelines/longevity-lwt-1loader-3h.jenkinsfile
@@ -8,7 +8,7 @@ longevityPipeline(
 
     backend: 'aws',
     aws_region: 'eu-west-1',
-    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_name: 'longevity_lwt_test.LWTLongevityTest.test_lwt_longevity',
     test_config: 'test-cases/longevity/longevity-lwt-1loader-3h.yaml',
 
     timeout: [time: 300, unit: 'MINUTES']

--- a/jenkins-pipelines/longevity-lwt-24h.jenkinsfile
+++ b/jenkins-pipelines/longevity-lwt-24h.jenkinsfile
@@ -8,7 +8,7 @@ longevityPipeline(
 
     backend: 'aws',
     aws_region: 'eu-west-1',
-    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_name: 'longevity_lwt_test.LWTLongevityTest.test_lwt_longevity',
     test_config: 'test-cases/longevity/longevity-lwt-basic-24h.yaml',
 
     timeout: [time: 2000, unit: 'MINUTES']


### PR DESCRIPTION
New longevity_lwt_test module performs data validation after the test (PR #1846 ).
Use it for all LWT pipelines

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
