### PR TITLE
fix(lightweight transaction): add back print outs for data validation

### DIFF
--- a/longevity_lwt_test.py
+++ b/longevity_lwt_test.py
@@ -189,9 +189,11 @@ class LWTLongevityTest(LongevityTest):
     def run_prepare_write_cmd(self):
         super(LWTLongevityTest, self).run_prepare_write_cmd()
 
-        # TODO: Temporary print. Will be removed
+        # TODO: Temporary print. Will be removed later
         self.log.debug('Get rows count in {} MV before sleep'.format(self.mv_for_not_updated_data))
-        self.get_rows_count(self.db_cluster.nodes[0])
+        self.get_rows_count(self.db_cluster.nodes[0],
+                            keyspace_name='cqlstress_lwt_example',
+                            table_name='blogposts_not_updated_lwt_indicator')
 
         # Wait for MVs data will be fully inserted (running on background)
         time.sleep(300)
@@ -215,17 +217,21 @@ class LWTLongevityTest(LongevityTest):
         if self.db_cluster.nemesis_threads:
             self.db_cluster.stop_nemesis()
 
-        # TODO: Temporary print. Will be removed
+        # TODO: Temporary print. Will be removed later
         self.log.debug('Get rows count in {} MV after sleep and before repair'.format(self.mv_for_not_updated_data))
-        self.get_rows_count(self.db_cluster.nodes[0])
+        self.get_rows_count(self.db_cluster.nodes[0],
+                            keyspace_name='cqlstress_lwt_example',
+                            table_name='blogposts_not_updated_lwt_indicator')
 
         for node in self.db_cluster.nodes:
             self.log.debug('Start nodetool repair on {} node'.format(node.name))
             node.run_nodetool("repair")
 
-        # TODO: Temporary print. Will be removed
+        # TODO: Temporary print. Will be removed later
         self.log.debug('Get rows count in {} MV after repair'.format(self.mv_for_not_updated_data))
-        self.get_rows_count(self.db_cluster.nodes[0])
+        self.get_rows_count(self.db_cluster.nodes[0],
+                            keyspace_name='cqlstress_lwt_example',
+                            table_name='blogposts_not_updated_lwt_indicator')
 
     def test_lwt_longevity(self):
         self.test_custom_time()

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1887,6 +1887,18 @@ def log_time_elapsed_and_status(method):  # pylint: disable=too-many-statements
     :return: Wrapped method.
     """
 
+    # TODO: Temporary function. Will be removed later
+    def data_validation_prints(args):
+        view_count = args[0].tester.get_rows_count(args[0].cluster.nodes[0],
+                                                   keyspace_name='cqlstress_lwt_example',
+                                                   table_name='blogposts_not_updated_lwt_indicator')
+        table_count = args[0].tester.get_rows_count(args[0].cluster.nodes[0],
+                                                    keyspace_name='cqlstress_lwt_example',
+                                                    table_name='blogposts_not_updated_lwt_indicator_expect')
+        if view_count and table_count and view_count != table_count:
+            args[0].log.error('One or more rows are not as expected, suspected LWT wrong update. '
+                              'Actual dataset length: {}, Expected dataset length: {}'.format(view_count, table_count))
+
     def wrapper(*args, **kwargs):  # pylint: disable=too-many-statements
         # pylint: disable=too-many-locals
         args[0].cluster.check_cluster_health()
@@ -1906,6 +1918,9 @@ def log_time_elapsed_and_status(method):  # pylint: disable=too-many-statements
             'node': str(args[0].target_node),
             'type': 'end',
         }
+        # TODO: Temporary print. Will be removed later
+        data_validation_prints(args=args)
+
         try:
             result = method(*args, **kwargs)
         except UnsupportedNemesis as exp:
@@ -1943,6 +1958,8 @@ def log_time_elapsed_and_status(method):  # pylint: disable=too-many-statements
             if num_nodes_before != num_nodes_after:
                 args[0].log.error('num nodes before %s and nodes after %s does not match' %
                                   (num_nodes_before, num_nodes_after))
+            # TODO: Temporary print. Will be removed later
+            data_validation_prints(args=args)
         return result
 
     return wrapper

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1007,15 +1007,15 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                     connect_timeout=connect_timeout)
 
     # TODO: Temporary function. Will be removed
-    def get_rows_count(self, node, name='blogposts_not_updated_lwt_indicator'):
-        with self.cql_connection_patient(node, keyspace='cqlstress_lwt_example') as session:
-            try:
+    def get_rows_count(self, node, keyspace_name, table_name):
+        try:
+            with self.cql_connection_patient(node, keyspace=keyspace_name) as session:
                 session.default_consistency_level = ConsistencyLevel.QUORUM
-                result = session.execute('select count(*) as cnt from %s' % name)
-                self.log.debug("Rows in {}: {}".format(name, result[0].cnt))
+                result = session.execute('select count(*) as cnt from %s' % table_name)
+                self.log.debug("Rows in {}: {}".format(table_name, result[0].cnt))
                 return result[0].cnt
-            except:  # pylint: disable=bare-except
-                return None
+        except:  # pylint: disable=bare-except
+            return None
 
     @retrying(n=8, sleep_time=15, allowed_exceptions=(NoHostAvailable,))
     def cql_connection_patient(self, node, keyspace=None,  # pylint: disable=too-many-arguments
@@ -1313,7 +1313,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         """
         self.log.debug('Start copying data')
         # TODO: Temporary print. Will be removed
-        count = self.get_rows_count(self.db_cluster.nodes[0])
+        count = self.get_rows_count(self.db_cluster.nodes[0], keyspace_name=src_keyspace,
+                                    table_name=src_table)
         self.log.debug('Count rows in the {} MV before saving: {}'.format(src_table, count))
 
         with self.cql_connection_patient(self.db_cluster.nodes[0]) as session:


### PR DESCRIPTION
The print outs were removed by https://github.com/scylladb/scylla-cluster-tests/pull/2044
It was removed because of bug that cause to nemesis threads
haven't been started. Fix the issue.

Running staging job with longevity-100gb-4h to validate this fix.
Nemesis started, no errors:

![Screenshot from 2020-04-19 19-25-28](https://user-images.githubusercontent.com/34435448/79693521-ce2b1000-8273-11ea-8b61-6cb15d2b9264.png)


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
