### PR TITLE
fix(email-template): format events in the email templates

### DIFF
--- a/sdcm/report_templates/results_base.html
+++ b/sdcm/report_templates/results_base.html
@@ -196,7 +196,8 @@
             {{ severity }} - [{{ events_summary.get(severity, 0) }}]
             </h4>
             {% for event in events %}
-                {{event}} <br/>
+                <pre>{{event}}</pre>
+                <hr>
             {% endfor %}
         {% endfor %}
     {% endif %}


### PR DESCRIPTION
events were not displayed with original format since were not wrapped
by the \<pre\> tag

Example:
![image](https://user-images.githubusercontent.com/5269241/79703025-b96d6d00-82b1-11ea-9d26-aa9ca14082d9.png)
