### PR TITLE
feature(longevity): add lwt longevity of multiple datacenters

### DIFF
--- a/data_dir/c-s_lwt_big_data_multidc.yaml
+++ b/data_dir/c-s_lwt_big_data_multidc.yaml
@@ -1,0 +1,126 @@
+# LWT test: create and update data using LWT.
+### DML ###
+
+# Keyspace Name
+keyspace: cqlstress_lwt_example
+
+# The CQL for creating a keyspace (optional if it already exists)
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS cqlstress_lwt_example WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-westscylla_node_west': 3, 'us-west-2scylla_node_west': 2, 'us-eastscylla_node_east': 1};
+
+# Table name
+table: blogposts
+
+# The CQL for creating a table you wish to stress (optional if it already exists)
+table_definition: |
+  CREATE TABLE IF NOT EXISTS blogposts (
+        domain int,
+        published_date int,
+        lwt_indicator int,
+        url blob,
+        url1 blob,
+        url2 blob,
+        url3 blob,
+        url4 blob,
+        author text,
+        title text,
+        c ascii,
+        d varchar,
+        e boolean,
+        f inet,
+        g int,
+        h bigint,
+        char ascii,
+        vchar varchar,
+        finished boolean,
+        osirisjson blob,
+        ip inet,
+        size int,
+        imagebase bigint,
+        small_num smallint,
+        tiny_num tinyint,
+        vint varint,
+        decimal_num decimal,
+        double_num double,
+        float_num float,
+        start_date date,
+        start_time time,
+        check_date timestamp,
+        pass_date timestamp,
+        upload_time timeuuid,
+        user_uid uuid,
+        name_set set<text>,
+        name_list list<text>,
+        PRIMARY KEY(domain, published_date)
+  ) WITH compaction = { 'class':'LeveledCompactionStrategy' }
+    AND comment='A table to hold blog posts'
+
+extra_definitions:
+  - create MATERIALIZED VIEW blogposts_update_one_column_lwt_indicator as select domain, lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator >=-2000 and lwt_indicator < 0 PRIMARY KEY(lwt_indicator, domain, published_date);
+  - create MATERIALIZED VIEW blogposts_update_one_column_lwt_indicator_after_update as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator = 30000000 PRIMARY KEY(lwt_indicator, domain, published_date);
+  - create MATERIALIZED VIEW blogposts_update_2_columns_lwt_indicator as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator > 0 and lwt_indicator <= 2000 PRIMARY KEY(lwt_indicator, domain, published_date);
+  - create MATERIALIZED VIEW blogposts_update_2_columns_lwt_indicator_after_update as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator = 20000000 PRIMARY KEY(lwt_indicator, domain, published_date);
+  - create MATERIALIZED VIEW blogposts_not_updated_lwt_indicator as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator > 1000000 and lwt_indicator < 20000000 PRIMARY KEY(lwt_indicator, domain, published_date);
+  - create MATERIALIZED VIEW blogposts_deletions as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator > 10000 and lwt_indicator < 100000 PRIMARY KEY(lwt_indicator, domain, published_date);
+
+### Column Distribution Specifications ###
+
+columnspec:
+  - name: domain
+    population: seq(1..500000000)  #500M possible domains to pick from
+
+  - name: published_date
+    cluster: uniform(1..2000)         #under each domain we will have max 2000 posts
+
+  - name: lwt_indicator
+    population: seq(1..1001000)
+
+  - name: url
+    size: fixed(200)
+
+  - name: url1
+    size: fixed(200)
+
+  - name: url2
+    size: fixed(200)
+
+  - name: url3
+    size: fixed(200)
+
+  - name: url4
+    size: fixed(200)
+
+  - name: title                  #titles shouldn't go beyond 20 chars
+    size: gaussian(10..20)
+
+  - name: author
+    size: uniform(5..20)         #author names should be short
+
+### Batch Ratio Distribution Specifications ###
+
+insert:
+  partitions: fixed(1)            # Our partition key is the domain so only insert one per batch
+
+  select:    fixed(1)/2000        # We have 2000 posts per domain so 1/2000 will allow 1 post per batch
+
+  batchtype: UNLOGGED             # Unlogged batches
+
+  condition: IF title = NULL       # LWT: Do not override
+
+
+#
+# A list of queries you wish to run against the schema
+#
+queries:
+   select:
+      cql: select * from blogposts where domain = ? LIMIT 1
+      fields: samerow
+   lwt_update_one_column:
+      cql: update blogposts set lwt_indicator = 30000000 where domain = ? and published_date = ? if lwt_indicator >=-2000 and lwt_indicator < 0
+      fields: samerow
+   lwt_update_two_columns:
+      cql: update blogposts set lwt_indicator = 20000000, author = 'text' where domain = ? and published_date = ? if lwt_indicator > 0 and lwt_indicator <= 2000 and author != 'text'
+      fields: samerow
+   lwt_deletes:
+     cql: delete from blogposts where domain = ? and published_date = ? if lwt_indicator > 10000 and lwt_indicator < 100000
+     fields: samerow

--- a/jenkins-pipelines/longevity-lwt-24h-multidc.jenkinsfile
+++ b/jenkins-pipelines/longevity-lwt-24h-multidc.jenkinsfile
@@ -1,0 +1,15 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    params: params,
+
+    backend: 'aws',
+    aws_region: '''["eu-west-1", "us-west-2", "us-east-1"]''',
+    test_name: 'longevity_lwt_test.LWTLongevityTest.test_lwt_longevity',
+    test_config: 'test-cases/longevity/longevity-lwt-24h-multidc.yaml',
+
+    timeout: [time: 1600, unit: 'MINUTES']
+)

--- a/test-cases/longevity/longevity-lwt-24h-multidc.yaml
+++ b/test-cases/longevity/longevity-lwt-24h-multidc.yaml
@@ -1,0 +1,29 @@
+test_duration: 1560
+prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data_multidc.yaml n=10000000 ops'(insert=1)' cl=QUORUM -mode native cql3 -rate threads=1000" ]
+stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data_multidc.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1,lwt_deletes=1)' cl=QUORUM duration=1440m -mode native cql3 -rate threads=30" ]
+stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data_multidc.yaml ops'(select=1)' cl=SERIAL duration=1440m -mode native cql3 -rate threads=30" ]
+
+n_db_nodes: '4 3 2'
+n_loaders: 3
+n_monitor_nodes: 1
+
+instance_type_db: 'i3.xlarge'
+
+# loader AMI with c-s ver. 4 and few fixes:
+#  - fix NoSuchElementException
+#  - enable control over both consistency levels: regular and serial
+#  - bring shard awareness
+regions_data:
+  us-east-1:
+    ami_id_loader: 'ami-0b94f0e897d884b1b'
+  eu-west-1:
+    ami_id_loader: 'ami-0ea704a8c9ec08e57'
+  us-west-2:
+    ami_id_loader: 'ami-063a97bde47353690'
+
+nemesis_class_name: 'ChaosMonkey'
+nemesis_interval: 5
+nemesis_during_prepare: false
+space_node_threshold: 64424
+
+user_prefix: 'lwt-longevity-multi-dc-24h'


### PR DESCRIPTION
3 datacenters are used in the job, a special loader is used for lwt.

Signed-off-by: Amos Kong <amos@scylladb.com>

Staging job:
- https://jenkins.scylladb.com/job/scylla-staging/job/amos/job/longevity-lwt-24h-multidc/

Just created jobs for branch-4.0/4.1/master:
- https://jenkins.scylladb.com/job/scylla-4.0/job/longevity/job/longevity-lwt-24h-multidc/
- https://jenkins.scylladb.com/job/scylla-4.1/job/longevity/job/longevity-lwt-24h-multidc/
- https://jenkins.scylladb.com/job/scylla-master/job/longevity/job/longevity-lwt-24h-multidc/


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
