### PR TITLE
fix(snapshot nemesis): check status code instead of stderr

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1362,20 +1362,16 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
         self._set_current_disruption('SnapshotOperations')
         result = self.target_node.run_nodetool('snapshot')
         self.log.debug(result)
-        if result.stderr:
-            self.tester.fail(result.stderr)
         snapshot_name = re.findall(r'(\d+)', result.stdout, re.MULTILINE)[0]
         result = self.target_node.run_nodetool('listsnapshots')
         self.log.debug(result)
-        if snapshot_name in result.stdout and not result.stderr:
+        if snapshot_name in result.stdout:
             self.log.info('Snapshot %s created' % snapshot_name)
         else:
-            self.tester.fail('Snapshot %s creating failed %s' % (snapshot_name, result.stderr))
+            raise Exception(f"Snapshot {snapshot_name} wasn't found in: \n{result.stdout}")
 
         result = self.target_node.run_nodetool('clearsnapshot')
         self.log.debug(result)
-        if result.stderr:
-            self.tester.fail(result.stderr)
 
     def disrupt_show_toppartitions(self):
         def _parse_toppartitions_output(output):


### PR DESCRIPTION
Since a recent change in scylla-java-tools, we are seeing those
failures below, the nemesis is wrong checking the stderr, which
could have all kind of things printed in it doesn't mean the
command failed.

status code is check by default by `run_nodetool()`

```
Traceback (most recent call last):
  File "/sct/sdcm/nemesis.py", line 1910, in wrapper
    result = method(*args, **kwargs)
  File "/sct/sdcm/nemesis.py", line 2124, in disrupt
    self.call_random_disrupt_method()
  File "/sct/sdcm/nemesis.py", line 656, in call_random_disrupt_method
    disrupt_method()
  File "/sct/sdcm/nemesis.py", line 1366, in disrupt_snapshot_operations
    self.tester.fail(result.stderr)
  File "/usr/lib64/python3.6/unittest/case.py", line 687, in fail
    raise self.failureException(msg)
AssertionError: mkdir: cannot create directory ‘/opt/scylladb/share/cassandra/logs’:
Permission denied
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
