### PR TITLE
fix(clusterhealth): ClusterHealthValidatorEvent severity from error to warning

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2511,7 +2511,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                           .format(' SYSTEM.PEERS content: {}\n'.format(peers_details) if peers_details else '', str(ex)))
 
         if errors:
-            ClusterHealthValidatorEvent(type='error', name='NodeSchemaVersion', status=Severity.ERROR,
+            ClusterHealthValidatorEvent(type='warning', name='NodeSchemaVersion', status=Severity.WARNING,
                                         node=self.name, error='\n'.join(errors))
 
     def _gen_cqlsh_cmd(self, command, keyspace, timeout, host, port, connect_timeout):


### PR DESCRIPTION
Switching severity of event from error to severity

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
