### PR TITLE
fix(stream_err): don't publish event in searching streaming log

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1351,12 +1351,13 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             log_file.seek(0, os.SEEK_END)
             return log_file.tell()
 
-    def search_database_log(self, search_pattern=None, start_from_beginning=False, publish_events=True):
+    def search_database_log(self, search_pattern=None, start_from_beginning=False, publish_events=True, severity=Severity.ERROR):
         """
         Search for all known patterns listed in  `_database_error_events`
 
         :param start_from_beginning: if True will search log from first line
         :param publish_events: if True will publish events
+        :param severity: event severity if search_pattern is assigned
         :return: list of (line, error) tuples
         """
         # pylint: disable=too-many-branches,too-many-locals,too-many-statements
@@ -1368,7 +1369,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         index = 0
         # prepare/compile all regexes
         if search_pattern:
-            expression = DatabaseLogEvent(type="user-query", regex=search_pattern, severity=Severity.CRITICAL)
+            expression = DatabaseLogEvent(type="user-query", regex=search_pattern, severity=severity)
             patterns += [(re.compile(expression.regex, re.IGNORECASE), expression)]
         else:
             for expression in self._database_error_events:

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1724,7 +1724,7 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
         Stop streaming task in middle and rebuild the data on the node.
         """
         def decommission_post_action():
-            decommission_done = self.target_node.search_database_log('DECOMMISSIONING: done', start_from_beginning=True)
+            decommission_done = self.target_node.search_database_log('DECOMMISSIONING: done', start_from_beginning=True, publish_events=False)
 
             ips = []
             seed_nodes = [node for node in self.cluster.nodes if node.is_seed]
@@ -1762,13 +1762,13 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
 
         def is_streaming_started():
             stream_pattern = "range_streamer - Unbootstrap starts|range_streamer - Rebuild starts"
-            streaming_logs = self.target_node.search_database_log(stream_pattern, start_from_beginning=False)
+            streaming_logs = self.target_node.search_database_log(stream_pattern, start_from_beginning=False, publish_events=False)
             self.log.debug(streaming_logs)
             if streaming_logs:
                 self.task_used_streaming = True
 
             # In latest master, repair always won't use streaming
-            repair_logs = self.target_node.search_database_log('repair - Repair 1 out of', start_from_beginning=False)
+            repair_logs = self.target_node.search_database_log('repair - Repair 1 out of', start_from_beginning=False, publish_events=False)
             self.log.debug(repair_logs)
             return len(streaming_logs) > 0 and len(repair_logs) > 0
 


### PR DESCRIPTION
The nemesis searches the log to know the task status, it's not real
error.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/2059

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
