### PR TITLE
fix(stream_err nemesis): rebuild new node after decommission finishes

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1743,6 +1743,8 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
                 self._terminate_cluster_node(self.target_node)
                 new_node = self._add_and_init_new_cluster_node()
                 new_node.running_nemesis = None
+                return new_node
+            return None
 
         def streaming_task_thread(nodetool_task='rebuild'):
             """
@@ -1789,7 +1791,7 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
             self.target_node.reboot(hard=True, verify_ssh=True)
         streaming_thread.join(60)
 
-        decommission_post_action()
+        new_node = decommission_post_action()
 
         if self.task_used_streaming:
             err = self.target_node.search_database_log(
@@ -1799,7 +1801,10 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
             self.log.debug(
                 'Streaming is not used. In latest Scylla, it is optional to use streaming for rebuild and decommission, and repair will not use streaming.')
         self.log.info('Recover the target node by a final rebuild')
-        self.repair_nodetool_rebuild()
+        if new_node:
+            new_node.run_nodetool('rebuild')
+        else:
+            self.target_node.run_nodetool('rebuild')
 
     def disrupt_decommission_streaming_err(self):
         """


### PR DESCRIPTION
Signed-off-by: Amos Kong <amos@scylladb.com>

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/2001

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
