### PR TITLE
fix(nemesis): disable scrub nemesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1839,6 +1839,9 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
                 'sudo dd if=/dev/urandom of={} count=1024'.format(sstable_file))
             self.log.debug('File {} was corrupted by dd'.format(sstable_file))
 
+    """
+    disable scrub nemesis, it's unstable
+
     def disrupt_corrupt_then_scrub(self):
 
         # Flush data to sstable
@@ -1857,6 +1860,7 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
         self.log.debug('Refreshing the cache by restart the node, and verify the rebuild sstable can be loaded successfully.')
         self.target_node.stop_scylla_server(verify_up=False, verify_down=True)
         self.target_node.start_scylla_server(verify_up=True, verify_down=False)
+    """   # pylint: disable=pointless-string-statement
 
 
 class NotSpotNemesis(Nemesis):
@@ -2601,9 +2605,13 @@ COMPLEX_NEMESIS = [NoOpMonkey, ChaosMonkey,
                    GeminiChaosMonkey, NetworkMonkey]
 
 
+"""
+disable scrub nemesis, it's unstable
+
 class CorruptThenScrubMonkey(Nemesis):
     disruptive = False
 
     @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_corrupt_then_scrub()
+"""


### PR DESCRIPTION
This patch disabled the unstable nemesis.
Requested by @roydahan 

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
