### PR TITLE
fix(nemesis): disable corrupt_then_scrub nemesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1839,7 +1839,7 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
                 'sudo dd if=/dev/urandom of={} count=1024'.format(sstable_file))
             self.log.debug('File {} was corrupted by dd'.format(sstable_file))
 
-    def disrupt_corrupt_then_scrub(self):
+    def disable_disrupt_corrupt_then_scrub(self):
 
         # Flush data to sstable
         self.target_node.run_nodetool("flush")
@@ -2601,9 +2601,10 @@ COMPLEX_NEMESIS = [NoOpMonkey, ChaosMonkey,
                    GeminiChaosMonkey, NetworkMonkey]
 
 
-class CorruptThenScrubMonkey(Nemesis):
-    disruptive = False
-
-    @log_time_elapsed_and_status
-    def disrupt(self):
-        self.disrupt_corrupt_then_scrub()
+# TODO: https://trello.com/c/vwedwZK2/1881-corrupt-the-scrub-fails
+# class CorruptThenScrubMonkey(Nemesis):
+#     disruptive = False
+#
+#     @log_time_elapsed_and_status
+#     def disrupt(self):
+#         self.disable_disrupt_corrupt_then_scrub()


### PR DESCRIPTION
Due to issues with the nemesis, namely that the curroption isn't necessarily solved
we chose to temporarily disabel it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
