### PR TITLE
test(longevity): new lwt longevity with parallel nemesis

### DIFF
--- a/jenkins-pipelines/longevity-lwt-24h-1dis-2nondis.jenkinsfile
+++ b/jenkins-pipelines/longevity-lwt-24h-1dis-2nondis.jenkinsfile
@@ -1,0 +1,15 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    params: params,
+
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_lwt_test.LWTLongevityTest.test_lwt_longevity',
+    test_config: 'test-cases/longevity/longevity-lwt-basic-24h-1dis-2nondis.yaml',
+
+    timeout: [time: 2000, unit: 'MINUTES']
+)

--- a/test-cases/longevity/longevity-lwt-basic-24h-1dis-2nondis.yaml
+++ b/test-cases/longevity/longevity-lwt-basic-24h-1dis-2nondis.yaml
@@ -1,0 +1,29 @@
+test_duration: 1500
+prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml n=10000000 ops'(insert=1)' cl=QUORUM -mode native cql3 -rate threads=50" ]
+stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=QUORUM duration=1440m -mode native cql3 -rate threads=30" ]
+stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(select=1)' cl=SERIAL duration=1440m -mode native cql3 -rate threads=30" ]
+
+n_db_nodes: 4
+n_loaders: 3
+n_monitor_nodes: 1
+
+instance_type_db: 'i3.2xlarge'
+
+# loader AMI with c-s ver. 4 and few fixes:
+#  - fix NoSuchElementException
+#  - enable control over both consistency levels: regular and serial
+#  - bring shard awareness
+regions_data:
+  us-east-1:
+    ami_id_loader: 'ami-0b94f0e897d884b1b'
+  eu-west-1:
+    ami_id_loader: 'ami-0ea704a8c9ec08e57'
+  us-west-2:
+    ami_id_loader: 'ami-063a97bde47353690'
+
+nemesis_class_name: 'DisruptiveMonkey:1 NonDisruptiveMonkey:2'
+nemesis_interval: 5
+nemesis_during_prepare: false
+space_node_threshold: 64424
+
+user_prefix: 'longevity-lwt-24h-parallel-nemesis'


### PR DESCRIPTION
Added a new longevity that uses lwt and executes parallel nemesis

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
