### PR TITLE
feature(lightweight transaction): new longevity with big data set

### DIFF
--- a/data_dir/c-s_lwt_big_data.yaml
+++ b/data_dir/c-s_lwt_big_data.yaml
@@ -1,0 +1,122 @@
+# LWT test: create and update data using LWT.
+### DML ###
+
+# Keyspace Name
+keyspace: cqlstress_lwt_example
+
+# The CQL for creating a keyspace (optional if it already exists)
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS cqlstress_lwt_example WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};
+
+# Table name
+table: blogposts
+
+# The CQL for creating a table you wish to stress (optional if it already exists)
+table_definition: |
+  CREATE TABLE IF NOT EXISTS blogposts (
+        domain int,
+        published_date int,
+        lwt_indicator int,
+        url blob,
+        url1 blob,
+        url2 blob,
+        url3 blob,
+        url4 blob,
+        author text,
+        title text,
+        c ascii,
+        d varchar,
+        e boolean,
+        f inet,
+        g int,
+        h bigint,
+        char ascii,
+        vchar varchar,
+        finished boolean,
+        osirisjson blob,
+        ip inet,
+        size int,
+        imagebase bigint,
+        small_num smallint,
+        tiny_num tinyint,
+        vint varint,
+        decimal_num decimal,
+        double_num double,
+        float_num float,
+        start_date date,
+        start_time time,
+        check_date timestamp,
+        pass_date timestamp,
+        upload_time timeuuid,
+        user_uid uuid,
+        name_set set<text>,
+        name_list list<text>,
+        PRIMARY KEY(domain, published_date)
+  ) WITH compaction = { 'class':'LeveledCompactionStrategy' }
+    AND comment='A table to hold blog posts'
+
+extra_definitions:
+  - create MATERIALIZED VIEW blogposts_update_one_column_lwt_indicator as select domain, lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator < 0 PRIMARY KEY(lwt_indicator, domain, published_date);
+  - create MATERIALIZED VIEW blogposts_update_one_column_lwt_indicator_upd as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator = 30000000 PRIMARY KEY(lwt_indicator, domain, published_date);
+  - create MATERIALIZED VIEW blogposts_update_two_columns_lwt_indicator as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator > 0 and lwt_indicator <= 1000000 PRIMARY KEY(lwt_indicator, domain, published_date);
+  - create MATERIALIZED VIEW blogposts_update_two_columns_lwt_indicator_upd as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator = 20000000 PRIMARY KEY(lwt_indicator, domain, published_date);
+  - create MATERIALIZED VIEW blogposts_not_updated_lwt_indicator as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator > 1005000 and lwt_indicator < 20000000 PRIMARY KEY(lwt_indicator, domain, published_date);
+
+### Column Distribution Specifications ###
+
+columnspec:
+  - name: domain
+    population: seq(1..500000000)  #500M possible domains to pick from
+
+  - name: published_date
+    cluster: uniform(1..2000)         #under each domain we will have max 2000 posts
+
+  - name: lwt_indicator
+    population: seq(1..1001000)
+
+  - name: url
+    size: fixed(200)
+
+  - name: url1
+    size: fixed(200)
+
+  - name: url2
+    size: fixed(200)
+
+  - name: url3
+    size: fixed(200)
+
+  - name: url4
+    size: fixed(200)
+
+  - name: title                  #titles shouldn't go beyond 20 chars
+    size: gaussian(10..20)
+
+  - name: author
+    size: uniform(5..20)         #author names should be short
+
+### Batch Ratio Distribution Specifications ###
+
+insert:
+  partitions: fixed(1)            # Our partition key is the domain so only insert one per batch
+
+  select:    fixed(1)/2000        # We have 2000 posts per domain so 1/2000 will allow 1 post per batch
+
+  batchtype: UNLOGGED             # Unlogged batches
+
+  condition: IF title = NULL       # LWT: Do not override
+
+
+#
+# A list of queries you wish to run against the schema
+#
+queries:
+   select:
+      cql: select * from blogposts where domain = ? LIMIT 1
+      fields: samerow
+   lwt_update_one_column:
+      cql: update blogposts set lwt_indicator = 30000000 where domain = ? and published_date = ? if lwt_indicator < 0
+      fields: samerow
+   lwt_update_two_columns:
+      cql: update blogposts set lwt_indicator = 20000000, author = 'text' where domain = ? and published_date = ? if lwt_indicator > 0 and lwt_indicator <= 1005000 and author != 'text'
+      fields: samerow

--- a/jenkins-pipelines/longevity-lwt-500G-3d.jenkinsfile
+++ b/jenkins-pipelines/longevity-lwt-500G-3d.jenkinsfile
@@ -1,0 +1,15 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    params: params,
+
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_lwt_test.LWTLongevityTest.test_lwt_longevity',
+    test_config: 'test-cases/longevity/longevity-lwt-500G-3d.yaml',
+
+    timeout: [time: 5000, unit: 'MINUTES']
+)

--- a/test-cases/longevity/longevity-lwt-500G-3d.yaml
+++ b/test-cases/longevity/longevity-lwt-500G-3d.yaml
@@ -1,0 +1,34 @@
+# Test duration 15 hours temporary. Should be 3 days. Will be changed later
+test_duration: 1500
+prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml n=400000000 ops'(insert=1)' cl=QUORUM -mode native cql3 -rate threads=50" ]
+stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml ops'(lwt_update_one_column=1)' cl=QUORUM duration=600m -mode native cql3 -rate threads=30" ,
+             "cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml ops'(lwt_update_two_columns=1)' cl=QUORUM duration=600m -mode native cql3 -rate threads=30"
+            ]
+stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml ops'(select=1)' cl=SERIAL duration=600m -mode native cql3 -rate threads=20" ]
+
+n_db_nodes: 4
+n_loaders: 3
+n_monitor_nodes: 1
+round_robin: true
+
+instance_type_db: 'i3.4xlarge'
+instance_type_loader: 'c5.2xlarge'
+
+# loader AMI with c-s ver. 4 and few fixes:
+#  - fix NoSuchElementException
+#  - enable control over both consistency levels: regular and serial
+#  - bring shard awareness
+regions_data:
+  us-east-1:
+    ami_id_loader: 'ami-0b94f0e897d884b1b'
+  eu-west-1:
+    ami_id_loader: 'ami-0ea704a8c9ec08e57'
+  us-west-2:
+    ami_id_loader: 'ami-063a97bde47353690'
+
+nemesis_class_name: 'ChaosMonkey'
+nemesis_interval: 5
+nemesis_during_prepare: false
+space_node_threshold: 64424
+
+user_prefix: 'longevity-lwt-500G-3d'


### PR DESCRIPTION
1. New LWT logevity with bigger data set 500GB.
It's planned to be run for 3 days. For now I defined it
temporary for 15 hours. It still under developing.

2. Remove running repair before data validation because of
it's not needed

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
