### PR TITLE
fix(test cleanup): TestResultEvent default to ERROR on test failure

### DIFF
--- a/sdcm/sct_events.py
+++ b/sdcm/sct_events.py
@@ -272,7 +272,7 @@ class TestResultEvent(SctEvent):
         self.error = error
         self.failure = failure
         self.ok = not error and not failure
-        self.severity = Severity.NORMAL if self.ok else Severity.CRITICAL
+        self.severity = Severity.NORMAL if self.ok else Severity.ERROR
 
     def __str__(self):
         header = dedent(f"""

--- a/unit_tests/test_events.py
+++ b/unit_tests/test_events.py
@@ -353,7 +353,7 @@ class TesterFailure(BaseEventsTest):
     def tearDown(self) -> None:
         test_error, test_failure = ClusterTester.get_test_failures(self)
         tre = TestResultEvent(test_name=self.id(), error=test_error, failure=test_failure)
-        assert tre.severity == Severity.CRITICAL
+        assert tre.severity == Severity.ERROR
         tre.publish(guaranteed=True)
         print(str(tre))
         assert test_failure
@@ -372,7 +372,7 @@ class TesterError(BaseEventsTest):
     def tearDown(self) -> None:
         test_error, test_failure = ClusterTester.get_test_failures(self)
         tre = TestResultEvent(test_name=self.id(), error=test_error, failure=test_failure)
-        assert tre.severity == Severity.CRITICAL
+        assert tre.severity == Severity.ERROR
         tre.publish(guaranteed=True)
         print(str(tre))
         assert not test_failure
@@ -413,7 +413,7 @@ class TesterErrorDuringSetUp(unittest.TestCase):
         assert test_failure is None
         assert test_error is not None
         tre = TestResultEvent(test_name=self.id(), error=test_error, failure=test_failure)
-        assert tre.severity == Severity.CRITICAL
+        assert tre.severity == Severity.ERROR
 
 
 class TesterMultiSubTest(unittest.TestCase):


### PR DESCRIPTION
Since TestResultEvent was alway creating CRITICAL events, we have lots of
cases when the logic of `keep-on-failure` were broken cause of this event.

we don't want to keep every test that failed, only ones that had critical events

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
