### PR TITLE
fix(get_nodetool_status): fix status parse of multiple datacenter

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3143,12 +3143,15 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods
         status = self.get_nodetool_status(verification_node=verification_node)
         up_statuses = []
         for node in nodes:
+            found_node_status = False
             for dc_status in status.values():
                 ip_status = dc_status.get(node.ip_address)
-                if ip_status and ip_status["state"] == "UN":
-                    up_statuses.append(True)
-                else:
-                    up_statuses.append(False)
+                if ip_status:
+                    found_node_status = True
+                    up_statuses.append(ip_status["state"] == "UN")
+                    break
+            if not found_node_status:
+                up_statuses.append(False)
         if not all(up_statuses):
             raise ClusterNodesNotReady("Not all nodes joined the cluster")
 


### PR DESCRIPTION
When test with multiple datacenters, the get_nodetool_status() always
fails for ClusterNodesNotReady("Not all nodes joined the cluster").

The current result parse of status only works with single datacenter,
if a node status isn't found in the status result of one datacenter, it
will always append a 'False' to up_statuses list, even the node doesn't
belong to the datacenter.

This patch fixed the issue and it works with multiple datacenter now.

---- Example ----

Wrong up_statuses: [True, False, False, True, False, False, False, True, False, False, True, False, False, True, False, False, True, False, False, False, True, False, False, True, False, False, True, False, False, True]
Fixed up_statuses: [True, True, True, True, True, True, True, True, True, True]

Nodetool status result:
 ```
 Datacenter: eu-westscylla_node_west
 ===================================
 Status=Up/Down
 |/ State=Normal/Leaving/Joining/Moving
 --  Address         Load       Tokens       Owns    Host ID                               Rack
 UN  34.243.163.86   2.4 GB     256          ?       a748bcdf-9803-4c31-a713-891a6cdab2c1  1a
 UN  3.250.11.130    2.5 GB     256          ?       0f7e00e8-8e9f-43bd-9a2c-18a508fee591  1a
 UN  63.33.206.106   2.35 GB    256          ?       1f237635-8d80-4f39-8da3-59db486c798d  1a
 UN  3.250.22.229    2.63 GB    256          ?       5b1cf3fa-61ce-4ab6-a1be-4681920b7c71  1a
 Datacenter: us-eastscylla_node_east
 ===================================
 Status=Up/Down
 |/ State=Normal/Leaving/Joining/Moving
 --  Address         Load       Tokens       Owns    Host ID                               Rack
 UN  54.152.8.10     1.21 GB    256          ?       4e38dcd3-4b23-44d6-8d6c-5d3e46b066b5  1b
 UN  3.85.235.150    1.75 GB    256          ?       b6066cd0-6c59-44d3-8751-d5d47cb019d6  1b
 Datacenter: us-west-2scylla_node_west
 =====================================
 Status=Up/Down
 |/ State=Normal/Leaving/Joining/Moving
 --  Address         Load       Tokens       Owns    Host ID                               Rack
 UN  54.218.79.206   2.25 GB    256          ?       d2a17d3b-a2cf-4600-9f76-f7e15c95ccf7  2b
 UN  54.202.8.156    1.39 GB    256          ?       0df0f18f-8176-4925-8517-4851ad5d5a6b  2b
 UN  54.189.161.34   2.19 GB    256          ?       75e4f537-a6d0-4046-b046-6b9d653fe37a  2b
 UN  18.236.156.115  2.15 GB    256          ?       b2e4a3d8-eace-4538-b9f2-5b7005940def  2b

 Note: Non-system keyspaces don't have the same replication settings, effective ownership information is meaningless
 ```

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
