### PR TITLE
fix(cluster health check): ignore status shutdown of node

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2441,7 +2441,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             # and they will remain in the gossipinfo 3 days.
             # It's expected behaviour and we won't send the error in this case
             if schema and ip and status:
-                if status not in ['LEFT', 'removed', 'BOOT']:
+                if status not in ['LEFT', 'removed', 'BOOT', 'shutdown']:
                     gossip_node_schemas[ip] = {'schema': schema, 'status': status}
                 schema, ip, status = '', '', ''
 


### PR DESCRIPTION
After we replace a dead node, it can still appears in gossipstatus.
It states will be shutdown and it's ok from scylla perspective.
So node with this staus will be ignored when comparing the list of nodes
in system.peers to gossip status.
Issues:
[#6135 ](https://github.com/scylladb/scylla/issues/6135)
[#1421 ](https://github.com/scylladb/scylla-cluster-tests/issues/1421)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
