### PR TITLE
fix(logcollector): Collectlogs and restore monitor stack for large data

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -62,6 +62,7 @@ class BaseLogEntity():  # pylint: disable=too-few-public-methods
     which require to be logged, stored locally, uploaded to
     S3 storage
     """
+    collect_timeout = 300
 
     def __init__(self, name, command="", search_locally=False):
         self.name = name
@@ -90,7 +91,10 @@ class CommandLog(BaseLogEntity):  # pylint: disable=too-few-public-methods
                                                            cmd=self.cmd,
                                                            log_filename=os.path.join(remote_dst, self.name))
         archive_logfile = LogCollector.archive_log_remotely(node=node, log_filename=remote_logfile)
-        LogCollector.receive_log(node=node, remote_log_path=archive_logfile, local_dir=local_dst)
+        LogCollector.receive_log(node=node,
+                                 remote_log_path=archive_logfile,
+                                 local_dir=local_dst,
+                                 timeout=self.collect_timeout)
         return os.path.join(local_dst, os.path.basename(archive_logfile))
 
 
@@ -153,7 +157,7 @@ class FileLog(CommandLog):
         if not file_path:
             return None
         archive = LogCollector.archive_log_remotely(builder, file_path)
-        builder.remoter.receive_files(archive, local_dst)
+        builder.remoter.receive_files(archive, local_dst, timeout=self.collect_timeout)
         return os.path.join(local_dst, os.path.basename(file_path))
 
 
@@ -167,6 +171,7 @@ class PrometheusSnapshots(BaseLogEntity):
         BaseLogEntity
     """
     monitoring_data_dir_name = "scylla-monitoring-data"
+    collect_timeout = 3000
 
     def __init__(self, *args, **kwargs):
         self.monitoring_data_dir = kwargs.pop('monitoring_data_dir', None)
@@ -216,7 +221,8 @@ class PrometheusSnapshots(BaseLogEntity):
         LogCollector.receive_log(
             node,
             remote_log_path=remote_snapshot_archive,
-            local_dir=local_dst)
+            local_dir=local_dst,
+            timeout=self.collect_timeout)
         return os.path.join(local_dst, os.path.basename(remote_snapshot_archive))
 
 
@@ -232,6 +238,7 @@ class MonitoringStack(BaseLogEntity):
         grafana_port {number} -- Grafana server port
     """
     grafana_port = 3000
+    collect_timeout = 1800
 
     @staticmethod
     def get_monitoring_base_dir(node):
@@ -262,7 +269,7 @@ class MonitoringStack(BaseLogEntity):
                                                           monitor_install_dir_name),
                          ignore_status=True)
         node.remoter.receive_files(src=os.path.join(monitor_base_dir, archive_name),
-                                   dst=local_dist)
+                                   dst=local_dist, timeout=self.collect_timeout)
         local_archive_path = os.path.join(local_dist, archive_name)
         return local_archive_path
 
@@ -539,6 +546,7 @@ class LogCollector:
     cluster_log_type = 'base'
     log_entities = []
     node_remote_dir = '/tmp'
+    collect_timeout = 300
 
     @property
     def current_run(self):
@@ -603,10 +611,12 @@ class LogCollector:
         return "{}.tar.gz".format(archive_name)
 
     @staticmethod
-    def receive_log(node, remote_log_path, local_dir):
+    def receive_log(node, remote_log_path, local_dir, timeout=300):
         os.makedirs(local_dir, exist_ok=True)
         if node.remoter:
-            node.remoter.receive_files(src=remote_log_path, dst=local_dir)
+            node.remoter.receive_files(src=remote_log_path,
+                                       dst=local_dir,
+                                       timeout=timeout)
         return local_dir
 
     @staticmethod
@@ -633,7 +643,7 @@ class LogCollector:
         try:
             workers_number = int(len(self.nodes) / 2)
             workers_number = len(self.nodes) if workers_number < 2 else workers_number
-            ParallelObject(self.nodes, num_workers=workers_number, timeout=300).run(
+            ParallelObject(self.nodes, num_workers=workers_number, timeout=self.collect_timeout).run(
                 collect_logs_per_node, ignore_exceptions=True)
         except Exception as details:  # pylint: disable=broad-except
             LOGGER.error('Error occured during collecting logs %s', details)
@@ -720,6 +730,7 @@ class ScyllaLogCollector(LogCollector):
                                command='sudo coredumpctl info')
                     ]
     cluster_log_type = "db-cluster"
+    collect_timeout = 600
 
     def collect_logs(self, local_search_path=None):
         self.collect_logs_for_inactive_nodes(local_search_path)
@@ -763,6 +774,7 @@ class MonitorLogCollector(LogCollector):
         GrafanaSnapshot(name='grafana-snapshot')
     ]
     cluster_log_type = "monitor-set"
+    collect_timeout = 3600
 
 
 class SCTLogCollector(LogCollector):

--- a/sdcm/utils/monitorstack.py
+++ b/sdcm/utils/monitorstack.py
@@ -23,6 +23,7 @@ ALERT_DOCKER_NAME = "aalert"
 GRAFANA_DOCKER_PORT = get_free_port()
 ALERT_DOCKER_PORT = get_free_port()
 PROMETHEUS_DOCKER_PORT = get_free_port()
+COMMAND_TIMEOUT = 1800
 
 
 class ErrorUploadSCTDashboard(Exception):
@@ -144,7 +145,7 @@ def create_monitoring_data_dir(base_dir, archive):
         """.format(data_dir=monitoring_data_base_dir,
                    archive=archive,
                    archive_name=os.path.basename(archive)))
-    result = LocalCmdRunner().run(cmd, ignore_status=True)
+    result = LocalCmdRunner().run(cmd, timeout=COMMAND_TIMEOUT, ignore_status=True)
     if result.exited > 0:
         LOGGER.error("Error during extracting prometheus snapshot. Switch to next archive")
         return False
@@ -161,7 +162,7 @@ def create_monitoring_stack_dir(base_dir, archive):
                    archive_name=os.path.basename(archive),
                    archive=archive))
 
-    result = LocalCmdRunner().run(cmd, ignore_status=True)
+    result = LocalCmdRunner().run(cmd, timeout=COMMAND_TIMEOUT, ignore_status=True)
     if result.exited > 0:
         LOGGER.error("Error during extracting monitoring stack")
         return False


### PR DESCRIPTION
For long run 48h/2d/7d prometheus snapshot file could be very large,
Archiving and downloading such large snapshot take more than preconfigured
time 300 seconds. Added timeouts for required operation
Should fix issue https://github.com/scylladb/scylla-cluster-tests/issues/1961

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
