### PR TITLE
fix(grafana_screenshot): increase timeout for taking screenshot

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -382,6 +382,7 @@ class GrafanaScreenShot(GrafanaEntity):
     Extends:
         GrafanaEntity
     """
+    collect_timeout = 150
 
     @retrying(n=5)
     def get_grafana_screenshot(self, node, local_dst):
@@ -420,7 +421,9 @@ class GrafanaScreenShot(GrafanaEntity):
                                                                     datetime.datetime.now().strftime("%Y%m%d_%H%M%S"),
                                                                     node.name))
                 LOGGER.debug("Get screenshot for url %s, save to %s", grafana_url, screenshot_path)
-                remote_browser.get_screenshot(grafana_url, screenshot_path, screenshot['resolution'])
+                remote_browser.get_screenshot(grafana_url, screenshot_path,
+                                              screenshot['resolution'],
+                                              load_page_screenshot_delay=self.collect_timeout)
                 screenshots.append(screenshot_path)
 
             return screenshots


### PR DESCRIPTION
timeout for taking screenshot for grafana increased up to 2 minutes.
this should fix issue with loading dashboards

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
