### PR TITLE
fix(alternator mails): mails wasn't sent to qa@scylladb.com

### DIFF
--- a/jenkins-pipelines/longevity-alternator-3h.jenkinsfile
+++ b/jenkins-pipelines/longevity-alternator-3h.jenkinsfile
@@ -12,5 +12,5 @@ longevityPipeline(
     test_config: 'test-cases/longevity/longevity-alternator-3h.yaml',
 
     timeout: [time: 300, unit: 'MINUTES'],
-    email_recipients: '["qa@scylladb.com","alternator@scylladb.com"]'
+    email_recipients: 'qa@scylladb.com,alternator@scylladb.com'
 )


### PR DESCRIPTION
pipeline was wrong passing down json, while the `hydra send-mail`
command was expecting comma seperated values

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
