### PR TITLE
fix(BaseNode): start task threads after ssh is up

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -405,6 +405,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         if self.ssh_login_info:
             self.ssh_login_info["hostname"] = self.external_address
         self._init_remoter(self.ssh_login_info)
+        # Start task threads after ssh is up, otherwise the dense ssh attempts from task
+        # threads will make SCT builder to be blocked by sshguard of gce instance.
+        self.wait_ssh_up(verbose=True)
         if not Setup.REUSE_CLUSTER:
             self.set_hostname()
 


### PR DESCRIPTION
Start task threads after ssh is up, otherwise the dense ssh attempts from task
threads will make SCT builder to be blocked by sshguard of gce instance,
because scylla-test user might be not created at that time.

Bad Example:
!INFO    | sshd[3531]: Connection closed by 10.142.0.9 port 48464 [preauth]
!NOTICE  | sshguard[1586]: Blocking 10.142.0.9 for 840 secs (4 attacks in 2 secs, after 1 abuses over 2 secs)

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
