### PR TITLE
fix(sdcm/db_stats.py): Fix issue with submitting errors to the test

### DIFF
--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -326,7 +326,15 @@ class TestStatsMixin(Stats):
     """
     This mixin is responsible for saving test details and statistics in database.
     """
-    KEYS = ['test_details', 'setup_details', 'versions', 'results', 'nemesis', 'errors', 'coredumps']
+    KEYS = {
+        'test_details': dict(),
+        'setup_details': dict(),
+        'versions': dict(),
+        'results': dict(),
+        'nemesis': dict(),
+        'errors': list(),
+        'coredumps': dict(),
+    }
     PROMETHEUS_STATS = ('throughput', 'latency_read_99', 'latency_write_99')
     PROMETHEUS_STATS_UNITS = {'throughput': "op/s", 'latency_read_99': "us", 'latency_write_99': "us"}
     STRESS_STATS = ('op rate', 'latency mean', 'latency 99th percentile')
@@ -353,7 +361,7 @@ class TestStatsMixin(Stats):
         return doc_id
 
     def _init_stats(self):
-        return {k: {} for k in self.KEYS}
+        return {k: v.copy() for k, v in self.KEYS.items()}
 
     def get_scylla_versions(self):
         versions = {}


### PR DESCRIPTION
https://trello.com/c/Mwl7VKsd/1892-fix-issue-on-submitting-errors-into-test

Fixes following error:
20:16:14  < t:2020-04-22 13:16:08,067 f:db_stats.py     l:322  c:sdcm.db_stats        p:ERROR > Failed to update test stats: test_id: 0398b4a0-39f2-49d6-8f93-40e1a2b9deed_20200422_122130_040250, error: TransportError(400, 'mapper_parsing_exception', 'object mapping for [errors] tried to parse field [null] as object, but found a concrete value')

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
