### PR TITLE
fix(unittests): stub BaseNode.wait_ssh_up() in tests

### DIFF
--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -53,6 +53,9 @@ class DummyNode(BaseNode):  # pylint: disable=abstract-method
     def set_hostname(self):
         pass
 
+    def wait_ssh_up(self, verbose=True, timeout=500):
+        pass
+
 
 logging.basicConfig(format="%(asctime)s - %(levelname)-8s - %(name)-10s: %(message)s", level=logging.DEBUG)
 


### PR DESCRIPTION
since #2079 was merged, a call to wait_ssh_up was cause unittest to timeout
on a few tests that inherit from BaseNode

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
