### PR TITLE
fix(events_analyzer): stop EventAnalyzer during tearDown

### DIFF
--- a/sdcm/sct_events.py
+++ b/sdcm/sct_events.py
@@ -973,4 +973,11 @@ def get_logger_event_summary():
     return output
 
 
+def stop_events_analyzer():
+    analyzer = EVENTS_PROCESSES.get('EVENTS_ANALYZER')
+    if analyzer:
+        analyzer.terminate()
+        analyzer.join(timeout=60)
+
+
 atexit.register(stop_events_device)

--- a/sdcm/sct_events_analyzer.py
+++ b/sdcm/sct_events_analyzer.py
@@ -19,8 +19,7 @@ class EventsAnalyzer(threading.Thread):
 
     def __init__(self):
         self.stop_event = threading.Event()
-        self.signal_sent = False
-        super(EventsAnalyzer, self).__init__()
+        super().__init__()
 
     @raise_event_on_failure
     def run(self):
@@ -51,9 +50,7 @@ class EventsAnalyzer(threading.Thread):
         if not Setup.tester_obj():
             LOGGER.error("no test was register using 'Setup.set_tester_obj()', not killing")
             return
-        if not self.signal_sent:
-            _test_pid = os.getpid()
-            Setup.tester_obj().result.addFailure(Setup.tester_obj(), backtrace_with_reason)
-            os.kill(_test_pid, signal.SIGUSR2)
-        else:
-            raise Exception(f"stop test signal already sent once, ignoreing: {str(backtrace_with_reason[1])}")
+        test_pid = os.getpid()
+        Setup.tester_obj().result.addFailure(Setup.tester_obj(), backtrace_with_reason)
+        os.kill(test_pid, signal.SIGUSR2)
+        self.terminate()

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -59,7 +59,7 @@ from sdcm.db_stats import PrometheusDBStats
 from sdcm.results_analyze import PerformanceResultsAnalyzer, SpecifiedStatsPerformanceAnalyzer
 from sdcm.sct_config import SCTConfiguration
 from sdcm.sct_events import start_events_device, stop_events_device, InfoEvent, FullScanEvent, Severity, \
-    TestFrameworkEvent, TestResultEvent, get_logger_event_summary, EVENTS_PROCESSES
+    TestFrameworkEvent, TestResultEvent, get_logger_event_summary, EVENTS_PROCESSES, stop_events_analyzer
 from sdcm.stress_thread import CassandraStressThread
 from sdcm.gemini_thread import GeminiStressThread
 from sdcm.ycsb_thread import YcsbStressThread
@@ -1489,6 +1489,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     def tearDown(self):
         InfoEvent('TEST_END')
         self.log.info('TearDown is starting...')
+
+        with self.subTest("Stop EventsAnalyzer"):
+            stop_events_analyzer()
 
         with self.subTest("Check for Error/Critical Events"):
             test_failing_events = self.get_test_failing_events()


### PR DESCRIPTION
Since during tearDown we are stopping the stress threads,
we should stop trying looking for those an critical events
to stop the test, the test is already in it's way down

Ref: https://trello.com/c/WgfaRqzJ

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
