### PR TITLE
Backport-3.2: fix(base node): start task threads after ssh is up

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -414,6 +414,10 @@ class BaseNode(object):  # pylint: disable=too-many-instance-attributes,too-many
 
         self.log.debug(self.remoter.ssh_debug_cmd())
 
+        # Start task threads after ssh is up, otherwise the dense ssh attempts from task
+        # threads will make SCT builder to be blocked by sshguard of gce instance.
+        self.wait_ssh_up(verbose=True)
+
         self._journal_thread = None
         self.n_coredumps = 0
         self.last_line_no = 1

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -34,6 +34,9 @@ class DummyNode(BaseNode):  # pylint: disable=abstract-method
     def database_log(self, x):
         self._database_log = x
 
+    def wait_ssh_up(self, verbose=True, timeout=500):
+        pass
+
 
 logging.basicConfig(format="%(asctime)s - %(levelname)-8s - %(name)-10s: %(message)s", level=logging.DEBUG)
 


### PR DESCRIPTION
Start task threads after ssh is up, otherwise the dense ssh attempts from task
threads will make SCT builder to be blocked by sshguard of gce instance,
because scylla-test user might be not created at that time.

Bad Example:
!INFO    | sshd[3531]: Connection closed by 10.142.0.9 port 48464 [preauth]
!NOTICE  | sshguard[1586]: Blocking 10.142.0.9 for 840 secs (4 attacks in 2
           secs, after 1 abuses over 2 secs)

Signed-off-by: Amos Kong <amos@scylladb.com>
(cherry picked from commit 9ed8deeac58b723f3601a3dd8d91baac01a65f45)

Conflicts:
	sdcm/cluster.py

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
