### PR TITLE
fix(get_non_system_ks_cf_list): filter empty tables for list

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -355,8 +355,7 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
 
     def _destroy_data_and_restart_scylla(self):
 
-        ks_cfs = get_non_system_ks_cf_list(loader_node=random.choice(self.loaders.nodes),
-                                           db_node=self.target_node)
+        ks_cfs = get_non_system_ks_cf_list(db_node=self.target_node)
         if not ks_cfs:
             raise UnsupportedNemesis(
                 'Non-system keyspace and table are not found. CorruptThenRepair nemesis can\'t be run')
@@ -702,8 +701,7 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
         disruption_name = "".join([p.strip().capitalize() for p in name.split("_")])
         self._set_current_disruption('ModifyTableProperties%s %s' % (disruption_name, self.target_node))
 
-        ks_cfs = get_non_system_ks_cf_list(loader_node=random.choice(self.loaders.nodes),
-                                           db_node=self.target_node,
+        ks_cfs = get_non_system_ks_cf_list(db_node=self.target_node,
                                            filter_out_table_with_counter=filter_out_table_with_counter,
                                            filter_out_mv=True)  # not allowed to modify MV
 
@@ -1074,8 +1072,7 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
             Alters a non-system table compaction strategy from ICS to any-other and vise versa.
         """
         list_additional_params = get_compaction_random_additional_params()
-        ks_cfs = get_non_system_ks_cf_list(loader_node=random.choice(self.loaders.nodes),
-                                           db_node=self.target_node)
+        ks_cfs = get_non_system_ks_cf_list(db_node=self.target_node)
         if not ks_cfs:
             raise UnsupportedNemesis(
                 'Non-system keyspace and table are not found. toggle_tables_ics nemesis can\'t run')
@@ -1435,7 +1432,7 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
             return toppartitions
 
         def generate_random_parameters_values():  # pylint: disable=invalid-name
-            ks_cf_list = get_non_system_ks_cf_list(self.loaders.nodes[0], self.cluster.nodes[0])
+            ks_cf_list = get_non_system_ks_cf_list(self.target_node)
             if not ks_cf_list:
                 raise UnsupportedNemesis('User-defined Keyspace and ColumnFamily are not found.')
             try:
@@ -1837,8 +1834,7 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
 
     def _corrupt_data_file(self):
         """Randomly corrupt data file by dd"""
-        ks_cfs = get_non_system_ks_cf_list(loader_node=random.choice(self.loaders.nodes),
-                                           db_node=self.target_node)
+        ks_cfs = get_non_system_ks_cf_list(db_node=self.target_node)
         if not ks_cfs:
             raise UnsupportedNemesis(
                 'Non-system keyspace and table are not found. Nemesis can\'t be run')
@@ -1860,7 +1856,7 @@ class Nemesis():  # pylint: disable=too-many-instance-attributes,too-many-public
         self._corrupt_data_file()
 
         self.log.debug("Rebuild sstable file by scrub, corrupted data file will be skipped.")
-        for ks_cf in get_non_system_ks_cf_list(self.loaders.nodes[0], self.cluster.nodes[0]):
+        for ks_cf in get_non_system_ks_cf_list(self.target_node):
             scrub_cmd = 'curl -s -X GET --header "Content-Type: application/json" --header ' \
                         '"Accept: application/json" "http://127.0.0.1:10000/storage_service/keyspace_scrub/{}?skip_corrupted=true"'.format(
                             ks_cf.split('.')[0])

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -858,7 +858,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                          'errors': stats['errors']})
         return stats
 
-    def run_fullscan(self, ks_cf, loader_node, db_node, page_size=100000):
+    def run_fullscan(self, ks_cf, db_node, page_size=100000):
         """Run cql select count(*) request
 
         if ks_cf is not random, use value from config
@@ -871,7 +871,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         Returns:
             object -- object with result of remoter.run command
         """
-        ks_cf_list = get_non_system_ks_cf_list(loader_node, db_node)
+        ks_cf_list = get_non_system_ks_cf_list(db_node)
         if ks_cf not in ks_cf_list:
             ks_cf = 'random'
 
@@ -926,9 +926,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         def run_in_thread():
             start = current = time.time()
             while current - start < duration:
-                loader_node = random.choice(self.loaders.nodes)
                 db_node = random.choice(self.db_cluster.nodes)
-                self.run_fullscan(ks_cf, loader_node, db_node)
+                self.run_fullscan(ks_cf, db_node)
                 time.sleep(interval)
                 current = time.time()
 
@@ -1588,7 +1587,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             table, scylla_encryption_options="{'key_provider': 'none'}", upgradesstables=upgradesstables)
 
     def alter_test_tables_encryption(self, scylla_encryption_options=None, upgradesstables=True):
-        for table in get_non_system_ks_cf_list(self.loaders.nodes[0], self.db_cluster.nodes[0], filter_out_mv=True):
+        for table in get_non_system_ks_cf_list(self.db_cluster.nodes[0], filter_out_mv=True):
             self.alter_table_encryption(
                 table, scylla_encryption_options=scylla_encryption_options, upgradesstables=upgradesstables)
 

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1124,7 +1124,7 @@ def get_db_tables(session, ks, with_compact_storage=True):
     return output
 
 
-def get_non_system_ks_cf_list(loader_node, db_node, request_timeout=300, filter_out_table_with_counter=False,  # pylint: disable=too-many-arguments
+def get_non_system_ks_cf_list(db_node, request_timeout=300, filter_out_table_with_counter=False,  # pylint: disable=too-many-arguments
                               filter_out_mv=False, filter_empty_tables=True):
     """Get all not system keyspace.tables pairs
 
@@ -1139,8 +1139,8 @@ def get_non_system_ks_cf_list(loader_node, db_node, request_timeout=300, filter_
             cmd = "paging off; SELECT keyspace_name, view_name FROM system_schema.views"
         else:
             cmd = "paging off; SELECT keyspace_name, table_name, type FROM system_schema.columns"
-        result = loader_node.run_cqlsh(cmd=cmd, timeout=request_timeout, verbose=False, target_db_node=db_node,
-                                       split=True, connect_timeout=request_timeout)
+        result = db_node.run_cqlsh(cmd=cmd, timeout=request_timeout, verbose=False,
+                                   split=True, connect_timeout=request_timeout)
         if not result:
             return []
 
@@ -1184,8 +1184,8 @@ def get_non_system_ks_cf_list(loader_node, db_node, request_timeout=300, filter_
         for ks_cf in list(avaialable_ks_cf.keys()):
             cmd = f'SELECT * FROM {ks_cf} LIMIT 1'
             # TODO: make this work with cql python driver, but would need to refactor the session of of tester class
-            result = loader_node.run_cqlsh(cmd=cmd, timeout=request_timeout, verbose=False, target_db_node=db_node,
-                                           split=False, connect_timeout=request_timeout)
+            result = db_node.run_cqlsh(cmd=cmd, timeout=request_timeout, verbose=False,
+                                       split=False, connect_timeout=request_timeout)
             if '(0 rows)' in result.stdout:
                 avaialable_ks_cf.pop(ks_cf)
 

--- a/unit_tests/test_get_non_system_ks_cf_list.py
+++ b/unit_tests/test_get_non_system_ks_cf_list.py
@@ -1,7 +1,11 @@
 from __future__ import absolute_import
+
+from collections import namedtuple
 import unittest
 
 from sdcm.utils.common import get_non_system_ks_cf_list
+
+RemoterResult = namedtuple('RemoterResult', ['stdout', 'stderr'])
 
 
 class DummyNode():  # pylint: disable=too-few-public-methods
@@ -48,6 +52,7 @@ class DummyNode():  # pylint: disable=too-few-public-methods
                       'keyspace1 |                       standard1 |                    text',
                       'keyspace1 |                       standard1 |                    blob',
                       'keyspace1 |                       standard1 |                    blob',
+                      'keyspace1 |                       empty_table |                    blob',
                       'mview |                           users |                    text',
                       'mview |                           users |                    text',
                       'mview |                           users |                timeuuid',
@@ -67,6 +72,10 @@ class DummyNode():  # pylint: disable=too-few-public-methods
                       'mview |              users_by_last_name |                    text',
                       'mview |              users_by_last_name |                    text',
                       '', '(293 rows)']
+        elif 'empty_table' in cmd:
+            return RemoterResult(stdout='(0 rows)', stderr='')
+        elif 'SELECT * FROM' in cmd:
+            return RemoterResult(stdout='(2 rows)', stderr='')
         return result
 
 

--- a/unit_tests/test_get_non_system_ks_cf_list.py
+++ b/unit_tests/test_get_non_system_ks_cf_list.py
@@ -9,7 +9,7 @@ RemoterResult = namedtuple('RemoterResult', ['stdout', 'stderr'])
 
 
 class DummyNode():  # pylint: disable=too-few-public-methods
-    def run_cqlsh(self, cmd, timeout, verbose, target_db_node, split, connect_timeout):  # pylint: disable=too-many-arguments,unused-argument,no-self-use
+    def run_cqlsh(self, cmd, timeout, verbose, split, connect_timeout):  # pylint: disable=too-many-arguments,unused-argument,no-self-use
         result = None
         if 'system_schema.views' in cmd:
             result = ['Disabled Query paging.', '',
@@ -81,13 +81,13 @@ class DummyNode():  # pylint: disable=too-few-public-methods
 
 class DummyNodeEmpty():  # pylint: disable=too-few-public-methods
 
-    def run_cqlsh(self, cmd, timeout, verbose, target_db_node, split, connect_timeout):  # pylint: disable=too-many-arguments,unused-argument,no-self-use
+    def run_cqlsh(self, cmd, timeout, verbose, split, connect_timeout):  # pylint: disable=too-many-arguments,unused-argument,no-self-use
         return ['Disabled Query paging.', '', '', '(2 rows)']
 
 
 class DummyNodeNone():  # pylint: disable=too-few-public-methods
 
-    def run_cqlsh(self, cmd, timeout, verbose, target_db_node, split, connect_timeout):  # pylint: disable=too-many-arguments,unused-argument,no-self-use
+    def run_cqlsh(self, cmd, timeout, verbose, split, connect_timeout):  # pylint: disable=too-many-arguments,unused-argument,no-self-use
         return None
 
 
@@ -97,38 +97,38 @@ class TestNonSystemEntityList(unittest.TestCase):
         dummy_node = DummyNode()
         expected_result = set(['mview.users', 'mview.users_by_first_name', 'keyspace1.standard1',
                                'mview.users_by_last_name', 'keyspace1.counter1'])
-        self.assertEqual(set(get_non_system_ks_cf_list(loader_node=dummy_node, db_node=dummy_node)), expected_result)
+        self.assertEqual(set(get_non_system_ks_cf_list(db_node=dummy_node)), expected_result)
 
     def test_filter_out_counter(self):
         dummy_node = DummyNode()
         expected_result = set(['mview.users', 'mview.users_by_first_name', 'keyspace1.standard1',
                                'mview.users_by_last_name'])
-        self.assertEqual(set(get_non_system_ks_cf_list(loader_node=dummy_node, db_node=dummy_node,
+        self.assertEqual(set(get_non_system_ks_cf_list(db_node=dummy_node,
                                                        filter_out_table_with_counter=True)), expected_result)
 
     def test_filter_out_mv(self):
         dummy_node = DummyNode()
         expected_result = set(['mview.users', 'keyspace1.standard1', 'keyspace1.counter1'])
-        self.assertEqual(set(get_non_system_ks_cf_list(loader_node=dummy_node, db_node=dummy_node,
+        self.assertEqual(set(get_non_system_ks_cf_list(db_node=dummy_node,
                                                        filter_out_mv=True)), expected_result)
 
     def test_filter_table_only_no_counter(self):  # pylint: disable=invalid-name
         dummy_node = DummyNode()
         expected_result = set(['mview.users', 'keyspace1.standard1'])
-        self.assertEqual(set(get_non_system_ks_cf_list(loader_node=dummy_node, db_node=dummy_node,
+        self.assertEqual(set(get_non_system_ks_cf_list(db_node=dummy_node,
                                                        filter_out_table_with_counter=True,
                                                        filter_out_mv=True)), expected_result)
 
     def test_empty_result(self):
         dummy_node = DummyNodeEmpty()
         expected_result = set([])
-        self.assertEqual(set(get_non_system_ks_cf_list(loader_node=dummy_node, db_node=dummy_node,
+        self.assertEqual(set(get_non_system_ks_cf_list(db_node=dummy_node,
                                                        filter_out_table_with_counter=True,
                                                        filter_out_mv=True)), expected_result)
 
     def test_none_result(self):
         dummy_node = DummyNodeNone()
         expected_result = set([])
-        self.assertEqual(set(get_non_system_ks_cf_list(loader_node=dummy_node, db_node=dummy_node,
+        self.assertEqual(set(get_non_system_ks_cf_list(db_node=dummy_node,
                                                        filter_out_table_with_counter=True,
                                                        filter_out_mv=True)), expected_result)


### PR DESCRIPTION
since some of the nemesis assume that any table coming from back
from this function have data in them, this is not always true

Ref: https://trello.com/c/MnwSqgfS

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
