### PR TITLE
fix(restore_monitor_stack): Increase timeout for uploading dashboard

### DIFF
--- a/sdcm/utils/monitorstack.py
+++ b/sdcm/utils/monitorstack.py
@@ -237,7 +237,7 @@ def run_monitoring_stack_containers(monitoring_stack_dir, monitoring_data_dir, s
         return False
 
 
-@retrying(n=3, sleep_time=3, message='Uploading sct dashboard')
+@retrying(n=3, sleep_time=20, message='Uploading sct dashboard')
 def restore_sct_dashboards(monitoring_dockers_dir, scylla_version):
     sct_dashboard_file_name = "scylla-dash-per-server-nemesis.{}.json".format(scylla_version)
     sct_dashboard_file = os.path.join(monitoring_dockers_dir,
@@ -272,7 +272,7 @@ def restore_sct_dashboards(monitoring_dockers_dir, scylla_version):
         raise
 
 
-@retrying(n=3, sleep_time=3, message='Uploading annotations data')
+@retrying(n=3, sleep_time=20, message='Uploading annotations data')
 def restore_annotations_data(monitoring_stack_dir):
     annotations_file = os.path.join(monitoring_stack_dir,
                                     'sct_monitoring_addons',
@@ -299,14 +299,14 @@ def restore_annotations_data(monitoring_stack_dir):
         raise
 
 
-@retrying(n=3, sleep_time=1, message='Start docker containers')
+@retrying(n=3, sleep_time=5, message='Start docker containers')
 def start_dockers(monitoring_dockers_dir, monitoring_stack_data_dir, scylla_version):  # pylint: disable=unused-argument
     graf_port = GRAFANA_DOCKER_PORT
     alert_port = ALERT_DOCKER_PORT
     prom_port = PROMETHEUS_DOCKER_PORT
     lr = LocalCmdRunner()  # pylint: disable=invalid-name
     lr.run('cd {monitoring_dockers_dir}; ./kill-all.sh -g {graf_port} -m {alert_port} -p {prom_port}'.format(**locals()),
-           ignore_status=True)
+           ignore_status=True, verbose=False)
     cmd = dedent("""cd {monitoring_dockers_dir};
             ./start-all.sh \
             -g {graf_port} -m {alert_port} -p {prom_port} \


### PR DESCRIPTION
For heavy loaded host or not enough fast host during monitoring stack restoring
after docker starts, uploading the grafana dashboard and anotations could failed,
because of grafana is not full initialized in docker.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] ~I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)~
- [ ] ~I didn't leave commented-out/debugging code~
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [x] All new and existing unit tests passed (CI)
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
