### PR TITLE
feature(monitor-3.3): Switch using monitor-3.3 branch

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -19,7 +19,7 @@ scylla_linux_distro_loader: 'centos'
 
 system_auth_rf: 3
 
-monitor_branch: 'branch-3.2'
+monitor_branch: 'branch-3.3'
 store_results_in_elasticsearch: true
 
 space_node_threshold: 0


### PR DESCRIPTION
Switching to a new branch of monitor-3.3 with new dashboards for LWT.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
