### PR TITLE
fix(hydra_send_email): Set return status 1 on error to fail send_email stage

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -52,24 +52,24 @@ def cli():
     pass
 
 
-'''
-Work in progress
+# '''
+# Work in progress
 
-from sdcm.tester import ClusterTester
+# from sdcm.tester import ClusterTester
 
-@cli.command()
-@click.option('--scylla-version', type=str, default='3.0.3')
-@sct_option('--db-nodes', 'n_db_nodes')
-@sct_option('--loader-nodes', 'n_loaders')
-@sct_option('--monitor-nodes', 'n_monitor_nodes')
-def provision(**kwargs):
-    logging.basicConfig(level=logging.INFO)
-    # click.secho('Going to install scylla cluster version={}'.format(kwargs['scylla_version']), reverse=True, fg='bright_yellow')
-    # TODO: find a better way for ctrl+c to kill this process
-    test = ClusterTester(methodName='setUp')
-    test._setup_environment_variables()
-    test.setUp()
-'''  # pylint: disable=pointless-string-statement
+# @cli.command()
+# @click.option('--scylla-version', type=str, default='3.0.3')
+# @sct_option('--db-nodes', 'n_db_nodes')
+# @sct_option('--loader-nodes', 'n_loaders')
+# @sct_option('--monitor-nodes', 'n_monitor_nodes')
+# def provision(**kwargs):
+#     logging.basicConfig(level=logging.INFO)
+#     # click.secho('Going to install scylla cluster version={}'.format(kwargs['scylla_version']), reverse=True, fg='bright_yellow')
+#     # TODO: find a better way for ctrl+c to kill this process
+#     test = ClusterTester(methodName='setUp')
+#     test._setup_environment_variables()
+#     test.setUp()
+# '''  # pylint: disable=pointless-string-statement
 
 
 @cli.command('clean-resources', help='clean tagged instances in both clouds (AWS/GCE)')
@@ -518,7 +518,7 @@ def send_email(test_id=None, email_recipients=None, logdir=None):
     test_results = read_email_data_from_file(email_results_file)
     if not test_results:
         LOGGER.warning("File with email results data not found")
-        return
+        sys.exit(1)
 
     email_recipients = email_recipients.split(',')
     reporter = build_reporter(test_results.get("reporter", ""), email_recipients, testrun_dir)
@@ -527,6 +527,7 @@ def send_email(test_id=None, email_recipients=None, logdir=None):
         reporter.send_report(test_results)
     else:
         LOGGER.warning("No reporter found")
+        sys.exit(1)
 
 
 @cli.command('create-test-release-jobs', help="Create pipeline jobs for a new branch")


### PR DESCRIPTION
Email stage on jenkins job always passed, even if hydra send-email
command don't find email_data.json file for sending report
Return with exit code 1 if error happened during send email

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (CI)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
