### PR TITLE
fix(get_profile_content): support user profiles not in data_dir

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -91,12 +91,19 @@ def remote_get_file(remoter, src, dst, hash_expected=None, retries=1, user_agent
 
 
 def get_profile_content(stress_cmd):
+    """
+    Looking profile yaml in data_dir or the path as is to get the user profile
+    and loading it's yaml
+
+    :return: (profile_filename, dict with yaml)
+    """
+
     cs_profile = re.search(r'profile=(.*\.yaml)', stress_cmd).group(1)
     sct_cs_profile = os.path.join(os.path.dirname(__file__), '../../', 'data_dir', os.path.basename(cs_profile))
-    if not os.path.exists(sct_cs_profile):
-        raise FileNotFoundError('User profile file {} not found'.format(sct_cs_profile))
-
-    cs_profile = sct_cs_profile
+    if os.path.exists(sct_cs_profile):
+        cs_profile = sct_cs_profile
+    elif not os.path.exists(cs_profile):
+        raise FileNotFoundError('User profile file {} not found'.format(cs_profile))
 
     with open(cs_profile, 'r') as yaml_stream:
         profile = yaml.safe_load(yaml_stream)


### PR DESCRIPTION
recent changes broke the support of generated user profile files
and files that doesn't come from sct `data_dir`

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
