### PR TITLE
fix(full scan): set warning event if full scan failed with timeout

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -900,7 +900,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             # 'unpack requires a string argument of length 4' error is received when cassandra.connection return
             # "Error decoding response from Cassandra":
             # failure like: Operation failed for keyspace1.standard1 - received 0 responses and 1 failures from 1 CL=ONE
-            if 'timed out' in str(details) or 'unpack requires' in str(details) or db_node.running_nemesis:
+            if 'timed out' in str(details) or 'unpack requires' in str(details) or 'timeout' in str(details)\
+                    or db_node.running_nemesis:
                 severity = Severity.WARNING
             else:
                 severity = Severity.ERROR


### PR DESCRIPTION
If Full Scan stopped because of 'Client request timeout.', set WARNING event
instead of ERROR

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
