### PR TITLE
fix(large-collections-12h timeout): increase timeout

### DIFF
--- a/jenkins-pipelines/longevity-large-collections-12h.jekinsfile
+++ b/jenkins-pipelines/longevity-large-collections-12h.jekinsfile
@@ -11,5 +11,5 @@ longevityPipeline(
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-large-collections-12h.yaml',
 
-    timeout: [time: 780, unit: 'MINUTES']
+    timeout: [time: 870, unit: 'MINUTES']
 )

--- a/test-cases/longevity/longevity-large-collections-12h.yaml
+++ b/test-cases/longevity/longevity-large-collections-12h.yaml
@@ -1,4 +1,4 @@
-test_duration: 780
+test_duration: 840
 stress_cmd: [
 "JVM_OPTION='-Xms8033M -Xmx8033M -Xmn400M' cassandra-stress user profile=/tmp/large_collections.yaml ops'(insert=3,read1=1,update1=1)' cl=QUORUM duration=720m -port jmx=6868 -mode cql3 native -rate threads=20"
              ]


### PR DESCRIPTION
to allow post test stages to finish after stress
timeout.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
