### PR TITLE
fix(increase monitor disk): job multi-ks-60h reached

### DIFF
--- a/test-cases/longevity/longevity-multi-keyspaces.yaml
+++ b/test-cases/longevity/longevity-multi-keyspaces.yaml
@@ -19,7 +19,7 @@ n_monitor_nodes: 1
 
 instance_type_db: 'i3.8xlarge'
 instance_type_loader: 'c5.4xlarge'
-aws_root_disk_size_monitor: 40
+aws_root_disk_size_monitor: 100
 
 user_prefix: 'longevity-1000-keyspaces'
 


### PR DESCRIPTION
scylla-cluster-tests/test-cases/longevity/longevity-multi-keyspaces.yaml
monitor full disk usage. Increasing the disk size
as this job has potential to write lot of  data.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
