### PR TITLE
improvement(gce-instance-types): optimizing GCE instance types

### DIFF
--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -4,11 +4,11 @@ gce_network: 'qa-vpc'
 gce_image: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
 gce_image_username: 'scylla-test'
 
-gce_instance_type_loader: 'n1-standard-2'
+gce_instance_type_loader: 'e2-standard-2'
 gce_root_disk_type_loader: 'pd-standard'
 gce_n_local_ssd_disk_loader: 0
 
-gce_instance_type_monitor: 'n1-standard-1'
+gce_instance_type_monitor: 'e2-medium'
 gce_root_disk_type_monitor: 'pd-standard'
 gce_root_disk_size_monitor: 50
 gce_n_local_ssd_disk_monitor: 0


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5269241/80690558-a2135880-8ad7-11ea-99ca-0b280d57658d.png)
I suggest the following:

Monitor: **e2-medium**  [ n1-standard-1]
Loaders: **e2-standard-2** [ n1-standard-2 / n2-standard-2 ]
DB: **n1-highmem-8** [ n2-highmem-8]