### PR TITLE
feature(lightweight transaction): decrease threads amount to get lower load

### DIFF
--- a/test-cases/longevity/longevity-lwt-1loader-3h.yaml
+++ b/test-cases/longevity/longevity-lwt-1loader-3h.yaml
@@ -1,7 +1,7 @@
 test_duration: 180
 prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml n=10000000 ops'(insert=1)' cl=QUORUM -mode native cql3 -rate threads=80" ]
-stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=QUORUM duration=160m -mode native cql3 -rate threads=50" ]
-stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(select=1)' cl=SERIAL duration=160m -mode native cql3 -rate threads=50" ]
+stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=QUORUM duration=160m -mode native cql3 -rate threads=20" ]
+stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(select=1)' cl=SERIAL duration=160m -mode native cql3 -rate threads=20" ]
 
 n_db_nodes: 4
 n_loaders: 1

--- a/test-cases/longevity/longevity-lwt-basic-24h.yaml
+++ b/test-cases/longevity/longevity-lwt-basic-24h.yaml
@@ -1,9 +1,9 @@
 test_duration: 1500
-prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml n=10000000 ops'(insert=1)' cl=QUORUM -mode native cql3 -rate threads=50" ]
-stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=QUORUM duration=1440m -mode native cql3 -rate threads=30",
-             "cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=QUORUM duration=1440m -mode native cql3 -rate threads=30"
+prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml n=10000000 ops'(insert=1)' cl=QUORUM -mode native cql3 -rate threads=30" ]
+stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=QUORUM duration=1440m -mode native cql3 -rate threads=20",
+             "cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=QUORUM duration=1440m -mode native cql3 -rate threads=20"
             ]
-stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(select=1)' cl=SERIAL duration=1440m -mode native cql3 -rate threads=30" ]
+stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(select=1)' cl=SERIAL duration=1440m -mode native cql3 -rate threads=20" ]
 
 n_db_nodes: 4
 n_loaders: 3

--- a/test-cases/longevity/longevity-lwt-basic-3h.yaml
+++ b/test-cases/longevity/longevity-lwt-basic-3h.yaml
@@ -1,9 +1,9 @@
 test_duration: 180
-prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml n=10000000 ops'(insert=1)' cl=QUORUM -mode native cql3 -rate threads=50"]
-stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=QUORUM duration=160m -mode native cql3 -rate threads=30",
-             "cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=QUORUM duration=160m -mode native cql3 -rate threads=30"
+prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml n=10000000 ops'(insert=1)' cl=QUORUM -mode native cql3 -rate threads=30"]
+stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=QUORUM duration=160m -mode native cql3 -rate threads=20",
+             "cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=QUORUM duration=160m -mode native cql3 -rate threads=20"
             ]
-stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(select=1)' cl=SERIAL duration=160m -mode native cql3 -rate threads=30" ]
+stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(select=1)' cl=SERIAL duration=160m -mode native cql3 -rate threads=20" ]
 
 n_db_nodes: 4
 n_loaders: 3


### PR DESCRIPTION
Decrease load to prevent cluster overload and mutation_write errors
(issue https://github.com/scylladb/scylla/issues/6155)

Even with this low amount of threads we can catch this message during nemesis

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
