### PR TITLE
feature(data validation): add data validation to LWT longevity. 500Gb LWT longevity test

### DIFF
--- a/data_dir/c-s_lwt_big_data.yaml
+++ b/data_dir/c-s_lwt_big_data.yaml
@@ -1,0 +1,126 @@
+# LWT test: create and update data using LWT.
+### DML ###
+
+# Keyspace Name
+keyspace: cqlstress_lwt_example
+
+# The CQL for creating a keyspace (optional if it already exists)
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS cqlstress_lwt_example WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};
+
+# Table name
+table: blogposts
+
+# The CQL for creating a table you wish to stress (optional if it already exists)
+table_definition: |
+  CREATE TABLE IF NOT EXISTS blogposts (
+        domain int,
+        published_date int,
+        lwt_indicator int,
+        url blob,
+        url1 blob,
+        url2 blob,
+        url3 blob,
+        url4 blob,
+        author text,
+        title text,
+        c ascii,
+        d varchar,
+        e boolean,
+        f inet,
+        g int,
+        h bigint,
+        char ascii,
+        vchar varchar,
+        finished boolean,
+        osirisjson blob,
+        ip inet,
+        size int,
+        imagebase bigint,
+        small_num smallint,
+        tiny_num tinyint,
+        vint varint,
+        decimal_num decimal,
+        double_num double,
+        float_num float,
+        start_date date,
+        start_time time,
+        check_date timestamp,
+        pass_date timestamp,
+        upload_time timeuuid,
+        user_uid uuid,
+        name_set set<text>,
+        name_list list<text>,
+        PRIMARY KEY(domain, published_date)
+  ) WITH compaction = { 'class':'LeveledCompactionStrategy' }
+    AND comment='A table to hold blog posts'
+
+extra_definitions:
+  - create MATERIALIZED VIEW blogposts_update_one_column_lwt_indicator as select domain, lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator >=-2000 and lwt_indicator < 0 PRIMARY KEY(lwt_indicator, domain, published_date);
+  - create MATERIALIZED VIEW blogposts_update_one_column_lwt_indicator_after_update as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator = 30000000 PRIMARY KEY(lwt_indicator, domain, published_date);
+  - create MATERIALIZED VIEW blogposts_update_2_columns_lwt_indicator as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator > 0 and lwt_indicator <= 2000 PRIMARY KEY(lwt_indicator, domain, published_date);
+  - create MATERIALIZED VIEW blogposts_update_2_columns_lwt_indicator_after_update as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator = 20000000 PRIMARY KEY(lwt_indicator, domain, published_date);
+  - create MATERIALIZED VIEW blogposts_not_updated_lwt_indicator as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator > 1000000 and lwt_indicator < 20000000 PRIMARY KEY(lwt_indicator, domain, published_date);
+  - create MATERIALIZED VIEW blogposts_deletions as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator > 10000 and lwt_indicator < 100000 PRIMARY KEY(lwt_indicator, domain, published_date);
+
+### Column Distribution Specifications ###
+
+columnspec:
+  - name: domain
+    population: seq(1..500000000)  #500M possible domains to pick from
+
+  - name: published_date
+    cluster: uniform(1..2000)         #under each domain we will have max 2000 posts
+
+  - name: lwt_indicator
+    population: seq(1..1001000)
+
+  - name: url
+    size: fixed(200)
+
+  - name: url1
+    size: fixed(200)
+
+  - name: url2
+    size: fixed(200)
+
+  - name: url3
+    size: fixed(200)
+
+  - name: url4
+    size: fixed(200)
+
+  - name: title                  #titles shouldn't go beyond 20 chars
+    size: gaussian(10..20)
+
+  - name: author
+    size: uniform(5..20)         #author names should be short
+
+### Batch Ratio Distribution Specifications ###
+
+insert:
+  partitions: fixed(1)            # Our partition key is the domain so only insert one per batch
+
+  select:    fixed(1)/2000        # We have 2000 posts per domain so 1/2000 will allow 1 post per batch
+
+  batchtype: UNLOGGED             # Unlogged batches
+
+  condition: IF title = NULL       # LWT: Do not override
+
+
+#
+# A list of queries you wish to run against the schema
+#
+queries:
+   select:
+      cql: select * from blogposts where domain = ? LIMIT 1
+      fields: samerow
+   lwt_update_one_column:
+      cql: update blogposts set lwt_indicator = 30000000 where domain = ? and published_date = ? if lwt_indicator >=-2000 and lwt_indicator < 0
+      fields: samerow
+   lwt_update_two_columns:
+      cql: update blogposts set lwt_indicator = 20000000, author = 'text' where domain = ? and published_date = ? if lwt_indicator > 0 and lwt_indicator <= 2000 and author != 'text'
+      fields: samerow
+   lwt_deletes:
+     cql: delete from blogposts where domain = ? and published_date = ? if lwt_indicator > 10000 and lwt_indicator < 100000
+     fields: samerow

--- a/jenkins-pipelines/longevity-lwt-500G-3d.jenkinsfile
+++ b/jenkins-pipelines/longevity-lwt-500G-3d.jenkinsfile
@@ -1,0 +1,15 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    params: params,
+
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_lwt_test.LWTLongevityTest.test_lwt_longevity',
+    test_config: 'test-cases/longevity/longevity-lwt-500G-3d.yaml',
+
+    timeout: [time: 5000, unit: 'MINUTES']
+)

--- a/longevity_lwt_test.py
+++ b/longevity_lwt_test.py
@@ -1,207 +1,48 @@
 #
-# This is stress longevity test that runs light weight transactions in parallel with differnt node operations:
+# This is stress longevity test that runs light weight transactions in parallel with different node operations:
 # disruptive and not disruptive
 #
-# Schema definition yaml: data_dir/c-s_lwt_basic.yaml
-#
 # After the test is finished will be performed the data validation.
-#
-# 2 kinds of LWT updated will be run:
-#
-# update one column:
-#    set lwt_indicator=30000000,
-#    condition: for all rows where if lwt_indicator < 0
-#
-# update two columns:
-#    set lwt_indicator=20000000 and author='text',
-#    condition: for all rows where if lwt_indicator > 0 and lwt_indicator <= 1000000 and author != 'text'
-#
-# Additional expected that all rows where lwt_indicator > 1000000 and lwt_indicator < 20000000 won't be updated
-#
-# Based on this 3 types of validation will be performed:
-#
-# - Rows which are expected to stay intact, are not updated
-# - Rows for a certain row range, lwt_indicator is changed to 30000000
-# - Rows for another row range lwt_indicator is changed to 20000000
-#
-#
-# ***Validation implementation***
-#
-# 1. Rows which are expected to stay intact.
-#    To be able to validate that, I added a MV called blogposts_not_updated_lwt_indicator
-#
-#     - create MATERIALIZED VIEW blogposts_not_updated_lwt_indicator as select lwt_indicator, author from blogposts
-#       where domain is not null and published_date is not null and lwt_indicator > 1000000 and lwt_indicator < 20000000
-#       PRIMARY KEY(lwt_indicator, domain, published_date);
-#     This MV hold all rows that shouldn't be updated.
-#
-#     Once the prepare_write_cmd part will be completed, all data from the view
-#     blogposts_not_updated_lwt_indicator will be copied to a side table called
-#     blogposts_not_updated_lwt_indicator_expect (created by test). This table uses as the expected data for this
-#     validation.
-#
-#     When test is finished, the test checks that data in the blogposts_not_updated_lwt_indicator and
-#     blogposts_not_updated_lwt_indicator_expect will be same.
-#
-# 2. For the rows where lwt_indicator was changed to "30000000", the data validation behaves as follow:
-#
-#     Two more Materialized View are added.
-#     First one holds rows that candidates for this update (before the update):
-#
-#     create MATERIALIZED VIEW blogposts_update_one_column_lwt_indicator as select domain, lwt_indicator, author
-#     from blogposts where domain is not null and published_date is not null and lwt_indicator < 0
-#     PRIMARY KEY(lwt_indicator, domain, published_date);
-#     Second one holds rows with lwt_indicator=30000000 (means - after update):
-#
-#     create MATERIALIZED VIEW blogposts_update_one_column_lwt_indicator_upd as select lwt_indicator, author
-#     from blogposts where domain is not null and published_date is not null and lwt_indicator = 30000000
-#     PRIMARY KEY(lwt_indicator, domain, published_date);
-#     Ideally, The view blogposts_update_one_column_lwt_indicator should be empty after the update and the view
-#     blogposts_update_one_column_lwt_indicator_upd will hold same amount of data as
-#     blogposts_update_one_column_lwt_indicator had before the update.
-#
-#     However, due to the fact we cannot control the c-s workload to go over all the rows (should visit all the rows
-#     with lwt_indicator negative value), for now it's just validated that blogposts_update_one_column_lwt_indicator_upd
-#     has some records.
-#     (It's unreasonable that the workload won't visit any row with negative value)
-#
-# 3. For the rows where lwt_indicator is changed to "20000000", the data validation the data validation behaves as
-#    follow:
-#
-#     Two more Materialized View are added.
-#     First one holds rows that are candidates for this update (before update):
-#
-#      create MATERIALIZED VIEW blogposts_update_two_columns_lwt_indicator as select lwt_indicator, author
-#      from blogposts where domain is not null and published_date is not null and lwt_indicator > 0 and
-#      lwt_indicator <= 1000000 PRIMARY KEY(lwt_indicator, domain, published_date);
-#     Second one holds rows with lwt_indicator=20000000 (means - after the update):
-#
-#     create MATERIALIZED VIEW blogposts_update_two_columns_lwt_indicator_upd as select lwt_indicator, author
-#     from blogposts where domain is not null and published_date is not null and lwt_indicator = 20000000
-#     PRIMARY KEY(lwt_indicator, domain, published_date);
-
-#     Ideally, the view blogposts_update_two_columns_lwt_indicator should be empty after the update and the view
-#     blogposts_update_two_columns_lwt_indicator_upd will hold the same amount of data that as the view
-#     blogposts_update_two_columns_lwt_indicator had before the update.
-#
-#     However, due to the same reason as above, the current validation is just that
-#     blogposts_update_two_columns_lwt_indicator_upd has some records.
-#
-
-import re
-
 import time
-from longevity_test import LongevityTest
 
-from sdcm.utils.common import get_profile_content
+from longevity_test import LongevityTest
+from sdcm.sct_events import EventsSeverityChangerFilter, DatabaseLogEvent, Severity
+from sdcm.utils.data_validator import LongevityDataValidator
 
 
 class LWTLongevityTest(LongevityTest):
+    BASE_TABLE_PARTITION_KEYS = ['domain', 'published_date']
+
     def __init__(self, *args):
         super(LWTLongevityTest, self).__init__(*args)
-        self._keyspace_name = None
-        self._mv_for_not_updated_data = None
-        self._expected_data_table = None
-        self._validate_not_updated_data = True
-
-    @property
-    def keyspace_name(self):
-        if not self._keyspace_name:
-            prepare_write_cmd = self.params.get('prepare_write_cmd', default=[])
-            profiles = [cmd for cmd in prepare_write_cmd if 'c-s_lwt' in cmd]
-            if not profiles:
-                self._validate_not_updated_data = False
-                self.log.warning('Keyspace is not recognized. '
-                                 'Data validation of not updated rows won\' be performed')
-                return self._keyspace_name
-            cs_profile = profiles[0]
-            _, profile = get_profile_content(cs_profile)
-            self._keyspace_name = profile['keyspace']
-
-        return self._keyspace_name
-
-    @property
-    def mv_for_not_updated_data(self):
-        """
-        Get MV name that holds rows which are expected to stay intact
-        """
-        if not self._mv_for_not_updated_data:
-            name_substr = '_not_updated'
-            self._mv_for_not_updated_data = self.get_mv_name_from_profile(name_substr)
-            return self._mv_for_not_updated_data
-
-        return self._mv_for_not_updated_data
-
-    @property
-    def expected_data_table_name(self):
-        """
-        Table name for expected data (needs for validate rows which are expected to stay intact - implemented in
-         validate_range_not_expected_to_change function)
-        """
-        if not self._expected_data_table:
-            self._expected_data_table = '%s_expect' % self.mv_for_not_updated_data
-        return self._expected_data_table
-
-    def get_mv_name_from_profile(self, name_substr, cs_profile=None):
-        mv_name = None
-
-        if not cs_profile:
-            prepare_write_cmd = self.params.get('prepare_write_cmd', default=[])
-            cs_profile = [cmd for cmd in prepare_write_cmd if 'c-s_lwt' in cmd]
-
-        if not cs_profile:
-            return mv_name
-
-        if not isinstance(cs_profile, list):
-            cs_profile = [cs_profile]
-
-        for profile in cs_profile:
-            _, profile_content = get_profile_content(profile)
-            mv_create_cmd = self.get_mv_cmd_from_profile(profile_content, name_substr)
-            if mv_create_cmd:
-                mv_name = self.get_mv_name_from_stress_cmd(mv_create_cmd, name_substr)
-                break
-
-        return mv_name
-
-    @staticmethod
-    def get_mv_cmd_from_profile(profile_content, name_substr):
-        all_mvs = profile_content['extra_definitions']
-        mv_cmd = [cmd for cmd in all_mvs if name_substr in cmd]
-
-        mv_cmd = mv_cmd[0] if mv_cmd else ''
-        return mv_cmd
-
-    @staticmethod
-    def get_mv_name_from_stress_cmd(mv_create_cmd, name_substr):
-        find_mv_name = re.search(r'materialized view (.*%s.*) as' % name_substr, mv_create_cmd, re.I)
-        return find_mv_name.group(1)
-
-    def copy_expected_data(self):
-        if self._validate_not_updated_data:
-            if not self.copy_view(src_keyspace=self.keyspace_name, src_view=self.mv_for_not_updated_data,
-                                  dest_keyspace=self.keyspace_name, dest_table=self.expected_data_table_name,
-                                  copy_data=True):
-                self._validate_not_updated_data = False
-                self.log.warning('Problem during copying expected data. '
-                                 'Data validation of not updated rows won\' be performed')
+        self.data_validator = None
 
     def run_prepare_write_cmd(self):
-        super(LWTLongevityTest, self).run_prepare_write_cmd()
+        # mutation_write_ warning is thrown when system is overloaded and got timeout on operations on system.paxos
+        # table. Decrease severity of this event during prepare. Shouldn't impact on test result
+        with EventsSeverityChangerFilter(event_class=DatabaseLogEvent, regex=r".*mutation_write_*",
+                                         severity=Severity.WARNING, extra_time_to_expiration=30), \
+            EventsSeverityChangerFilter(event_class=DatabaseLogEvent, regex=r'.*Operation failed for system.paxos.*',
+                                        severity=Severity.WARNING, extra_time_to_expiration=30), \
+            EventsSeverityChangerFilter(event_class=DatabaseLogEvent, regex=r'.*Operation timed out for system.paxos.*',
+                                        severity=Severity.WARNING, extra_time_to_expiration=30):
+            super(LWTLongevityTest, self).run_prepare_write_cmd()
 
-        # TODO: Temporary print. Will be removed later
-        self.log.debug('Get rows count in {} MV before sleep'.format(self.mv_for_not_updated_data))
-        self.get_rows_count(self.db_cluster.nodes[0],
-                            keyspace_name='cqlstress_lwt_example',
-                            table_name='blogposts_not_updated_lwt_indicator')
+        # Stop nemesis. Prefer all nodes will be run before collect data for validation
+        # Increase timeout to wait for nemesis finish
+        if self.db_cluster.nemesis_threads:
+            self.db_cluster.stop_nemesis(timeout=300)
 
         # Wait for MVs data will be fully inserted (running on background)
         time.sleep(300)
 
-        # Run repair on all nodes. We need it to fix the case, when part of data wasn't inserted because of timeouts
-        self.stop_nemesis_and_repair_cluster()
+        self.data_validator = LongevityDataValidator(longevity_self_object=self,
+                                                     user_profile_name='c-s_lwt',
+                                                     base_table_partition_keys=self.BASE_TABLE_PARTITION_KEYS)
 
-        self.copy_expected_data()
+        self.data_validator.copy_immutable_expected_data()
+        self.data_validator.copy_updated_expected_data()
+        self.data_validator.save_count_rows_for_deletion()
 
         # Run nemesis during stress as it was stopped before copy expected data
         if self.params.get('nemesis_during_prepare'):
@@ -211,104 +52,18 @@ class LWTLongevityTest(LongevityTest):
         self.db_cluster.termination_event.clear()
         self.db_cluster.start_nemesis()
 
-    def stop_nemesis_and_repair_cluster(self):
-        # Stop nemesis. Repair on all nodes will be run before data validation, so all nodes should be up
-        # and also prevent case to run repair from nemesis in parallel
-        if self.db_cluster.nemesis_threads:
-            self.db_cluster.stop_nemesis()
-
-        # TODO: Temporary print. Will be removed later
-        self.log.debug('Get rows count in {} MV after sleep and before repair'.format(self.mv_for_not_updated_data))
-        self.get_rows_count(self.db_cluster.nodes[0],
-                            keyspace_name='cqlstress_lwt_example',
-                            table_name='blogposts_not_updated_lwt_indicator')
-
-        for node in self.db_cluster.nodes:
-            self.log.debug('Start nodetool repair on {} node'.format(node.name))
-            node.run_nodetool("repair")
-
-        # TODO: Temporary print. Will be removed later
-        self.log.debug('Get rows count in {} MV after repair'.format(self.mv_for_not_updated_data))
-        self.get_rows_count(self.db_cluster.nodes[0],
-                            keyspace_name='cqlstress_lwt_example',
-                            table_name='blogposts_not_updated_lwt_indicator')
-
     def test_lwt_longevity(self):
         self.test_custom_time()
 
-        # Run repair on all nodes. We need it to fix the case, when part of data wasn't inserted because of timeouts
-        self.stop_nemesis_and_repair_cluster()
+        # Stop nemesis. Prefer all nodes will be run before collect data for validation
+        # Increase timeout to wait for nemesis finish
+        if self.db_cluster.nemesis_threads:
+            self.db_cluster.stop_nemesis(timeout=300)
         self.validate_data()
 
     def validate_data(self):
         node = self.db_cluster.nodes[0]
-        with self.cql_connection_patient(node, keyspace='cqlstress_lwt_example') as session:
-            self.validate_range_not_expected_to_change(session=session)
-            self.validate_updated_data(session=session)
-
-    def validate_range_not_expected_to_change(self, session):
-        """
-        Part of data in the user profile table shouldn't be updated using LWT.
-        This data will be saved in the materialized view with "not_updated" substring in the name
-        After prepare write all data from this materialized view will be saved in the separate table as expected result.
-        During stress (after prepare) LWT update statements will be run for a few hours.
-        When updates will be finished this function verifies that data in "not_updated" MV and expected result table
-        is same
-        """
-        if self._validate_not_updated_data and self.mv_for_not_updated_data and self.expected_data_table_name:
-            self.log.debug('Verify not updated rows')
-            # Get all rows, not use pagination
-            session.default_fetch_size = 0
-
-            actual_result = self.rows_to_list(session.execute("SELECT * FROM %s" % self.mv_for_not_updated_data))
-            expected_result = self.rows_to_list(session.execute("SELECT * FROM %s" % self.expected_data_table_name))
-
-            # Issue https://github.com/scylladb/scylla/issues/6181
-            # Not fail the test if unexpected additional rows where found in actual result table
-            if len(actual_result) > len(expected_result):
-                self.log.warning('Actual dataset length {} more '
-                                 'then expected dataset length: {}. '
-                                 'Issue #6181'.format(len(actual_result),
-                                                      len(expected_result)))
-            else:
-
-                self.assertEqual(len(actual_result), len(expected_result),
-                                 'One or more rows are not as expected, suspected LWT wrong update. '
-                                 'Actual dataset length: {}, Expected dataset length: {}'.format(len(actual_result),
-                                                                                                 len(expected_result)))
-
-                self.assertEqual(actual_result, expected_result,
-                                 'One or more rows are not as expected, suspected LWT wrong update')
-
-    def validate_updated_data(self, session):
-        """
-        In user profile 'data_dir/c-s_lwt_basic.yaml' LWT updates the lwt_indicator and author columns with hard coded
-        values. Validate, that we can find these values
-        Two more materialized views are added. The first one holds rows that are candidates for the update
-        (i.e. all rows before the update).
-        The second one holds rows with lwt_indicator=30000000 (i.e. only the updated rows)
-        """
-        stress_cmd = self.params.get('stress_cmd', default=[])
-        stress_read_cmd = self.params.get('stress_read_cmd', default=[])
-
-        one_column_run_update = [cmd for cmd in stress_cmd+stress_read_cmd if 'lwt_update_one_column' in cmd]
-        two_columns_run_update = [cmd for cmd in stress_cmd+stress_read_cmd if 'lwt_update_two_columns' in cmd]
-
-        if one_column_run_update or two_columns_run_update:
-            self.log.info('Verify that rows were updated')
-
-            if one_column_run_update:
-                expected_data_mv_name = self.get_mv_name_from_profile(name_substr='one_column_lwt_indicator_upd',
-                                                                      cs_profile=one_column_run_update)
-                result = session.execute('SELECT * from {name}'.format(name=expected_data_mv_name))
-
-                self.assertTrue(result, 'Data in the column "lwt_indicator" was not updated by light weight '
-                                        'transaction')
-
-            if two_columns_run_update:
-                expected_data_mv_name = self.get_mv_name_from_profile(name_substr='two_columns_lwt_indicator_upd',
-                                                                      cs_profile=two_columns_run_update)
-                result = session.execute('SELECT * from {name}'.format(name=expected_data_mv_name))
-
-                self.assertTrue(result, 'Data in the columns "lwt_indicator" and "author" were not updated by light '
-                                'weight transaction')
+        with self.cql_connection_patient(node, keyspace=self.data_validator.keyspace_name) as session:
+            self.data_validator.validate_range_not_expected_to_change(session=session)
+            self.data_validator.validate_range_expected_to_change(session=session)
+            self.data_validator.validate_deleted_rows(session=session)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -506,6 +506,13 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         return 'true' in result.stdout.lower()
 
     @property
+    def cpu_cores(self):
+        result = self.remoter.run("nproc", ignore_status=True)
+        cores = result.stdout.lower()
+        cores = int(cores) if cores else None
+        return cores
+
+    @property
     def is_server_encrypt(self):
         result = self.remoter.run("grep '^server_encryption_options:' /etc/scylla/scylla.yaml", ignore_status=True)
         return 'server_encryption_options' in result.stdout.lower()

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1925,17 +1925,15 @@ def log_time_elapsed_and_status(method):  # pylint: disable=too-many-statements
     :return: Wrapped method.
     """
 
-    # TODO: Temporary function. Will be removed later
     def data_validation_prints(args):
-        view_count = args[0].tester.get_rows_count(args[0].cluster.nodes[0],
-                                                   keyspace_name='cqlstress_lwt_example',
-                                                   table_name='blogposts_not_updated_lwt_indicator')
-        table_count = args[0].tester.get_rows_count(args[0].cluster.nodes[0],
-                                                    keyspace_name='cqlstress_lwt_example',
-                                                    table_name='blogposts_not_updated_lwt_indicator_expect')
-        if view_count and table_count and view_count != table_count:
-            args[0].log.error('One or more rows are not as expected, suspected LWT wrong update. '
-                              'Actual dataset length: {}, Expected dataset length: {}'.format(view_count, table_count))
+        try:
+            if hasattr(args[0].tester, 'data_validator') and args[0].tester.data_validator:
+                with args[0].tester.cql_connection_patient(args[0].cluster.nodes[0], keyspace=args[0].tester.data_validator.keyspace_name) as session:
+                    args[0].tester.data_validator.validate_range_not_expected_to_change(session, during_nemesis=True)
+                    args[0].tester.data_validator.validate_range_expected_to_change(session, during_nemesis=True)
+                    args[0].tester.data_validator.validate_deleted_rows(session, during_nemesis=True)
+        except Exception as err:  # pylint: disable=broad-except
+            args[0].log.debug(f'Data validator error: {err}')
 
     def wrapper(*args, **kwargs):  # pylint: disable=too-many-statements
         # pylint: disable=too-many-locals

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -25,12 +25,15 @@ from uuid import uuid4
 from functools import wraps
 import traceback
 import signal
+import sys
 
 import boto3.session
+
 from libcloud.compute.providers import get_driver
 from libcloud.compute.types import Provider
 from invoke.exceptions import UnexpectedExit, Failure
 
+from cassandra.concurrent import execute_concurrent_with_args
 from cassandra import ConsistencyLevel
 from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
 from cassandra.auth import PlainTextAuthProvider
@@ -52,7 +55,7 @@ from sdcm.cluster_aws import LoaderSetAWS
 from sdcm.cluster_aws import MonitorSetAWS
 from sdcm.utils.common import ScyllaCQLSession, get_non_system_ks_cf_list, makedirs, format_timestamp, \
     wait_ami_available, tag_ami, update_certificates, download_dir_from_cloud, get_post_behavior_actions, \
-    get_testrun_status, download_encrypt_keys, get_username
+    get_testrun_status, download_encrypt_keys, get_username, PageFetcher, rows_to_list
 from sdcm.utils.decorators import log_run_info, retrying
 from sdcm.utils.log import configure_logging
 from sdcm.db_stats import PrometheusDBStats
@@ -1017,17 +1020,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                     port=port, ssl_opts=ssl_opts, node_ips=[node.external_address],
                                     connect_timeout=connect_timeout, verbose=verbose)
 
-    # TODO: Temporary function. Will be removed
-    def get_rows_count(self, node, keyspace_name, table_name):
-        try:
-            with self.cql_connection_patient(node, keyspace=keyspace_name) as session:
-                session.default_consistency_level = ConsistencyLevel.QUORUM
-                result = session.execute('select count(*) as cnt from %s' % table_name)
-                self.log.debug("Rows in {}: {}".format(table_name, result[0].cnt))
-                return result[0].cnt
-        except:  # pylint: disable=bare-except
-            return None
-
     @retrying(n=8, sleep_time=15, allowed_exceptions=(NoHostAvailable,))
     def cql_connection_patient(self, node, keyspace=None,  # pylint: disable=too-many-arguments
                                user=None, password=None,
@@ -1258,57 +1250,91 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     def rows_to_list(rows):
         return [list(row) for row in rows]
 
-    def copy_table(self, src_keyspace, src_table, dest_keyspace, dest_table, copy_data=False):  # pylint: disable=too-many-arguments
+    def copy_table(self, node, src_keyspace, src_table, dest_keyspace, dest_table, columns_list=None, copy_data=False):  # pylint: disable=too-many-arguments
         """
         Create table with same structure as <src_keyspace>.<src_table>.
+        If columns_list is supplied, the table with create with the columns that in the columns_list
         Copy data from <src_keyspace>.<src_view> to <dest_keyspace>.<dest_table> if copy_data is True
         """
         result = True
         create_statement = "SELECT * FROM system_schema.table where table_name = '%s' " \
                            "and keyspace_name = '%s'" % (src_table, src_keyspace)
-        self.create_table_as(src_keyspace, src_table, dest_keyspace, dest_table, create_statement)
+        if not self.create_table_as(node, src_keyspace, src_table, dest_keyspace,
+                                    dest_table, create_statement, columns_list):
+            return False
 
         if copy_data:
-            result = self.copy_data_between_tables(src_keyspace, src_table, dest_keyspace, dest_table)
+            try:
+                result = self.copy_data_between_tables(node, src_keyspace, src_table,
+                                                       dest_keyspace, dest_table, columns_list)
+            except Exception as error:  # pylint: disable=broad-except
+                self.log. error(f'Copying data from {src_table} to {dest_table} failed with error: {error}')
+                return False
 
         return result
 
-    def copy_view(self, src_keyspace, src_view, dest_keyspace, dest_table, copy_data=False):  # pylint: disable=too-many-arguments
+    def copy_view(self, node, src_keyspace, src_view, dest_keyspace, dest_table, columns_list=None, copy_data=False):  # pylint: disable=too-many-arguments
         """
         Create table with same structure as <src_keyspace>.<src_view>.
+        If columns_list is supplied, the table with create with the columns that in the columns_list
         Copy data from <src_keyspace>.<src_view> to <dest_keyspace>.<dest_table> if copy_data is True
         """
         result = True
         create_statement = "SELECT * FROM system_schema.views where view_name = '%s' " \
                            "and keyspace_name = '%s'" % (src_view, src_keyspace)
         self.log.debug('Start create table with statement: {}'.format(create_statement))
-        self.create_table_as(src_keyspace, src_view, dest_keyspace, dest_table, create_statement)
+        if not self.create_table_as(node, src_keyspace, src_view, dest_keyspace,
+                                    dest_table, create_statement, columns_list):
+            return False
         self.log.debug('Finish create table')
         if copy_data:
-            result = self.copy_data_between_tables(src_keyspace, src_view, dest_keyspace, dest_table)
+            try:
+                result = self.copy_data_between_tables(node, src_keyspace, src_view,
+                                                       dest_keyspace, dest_table, columns_list)
+            except Exception as error:  # pylint: disable=broad-except
+                self.log. error(f'Copying data from {src_view} to {dest_table} failed with error {error}')
+                return False
 
         return result
 
-    def create_table_as(self, src_keyspace, src_table, dest_keyspace, dest_table, create_statement):  # pylint: disable=too-many-arguments
-        """ Create table with same structure as another table or view """
-        with self.cql_connection_patient(self.db_cluster.nodes[0]) as session:
+    def create_table_as(self, node, src_keyspace, src_table, dest_keyspace, dest_table, create_statement,  # pylint: disable=too-many-arguments,too-many-locals,inconsistent-return-statements
+                        columns_list=None):
+        """ Create table with same structure as another table or view
+            If columns_list is supplied, the table with create with the columns that in the columns_list
+        """
+        with self.cql_connection_patient(node) as session:
 
-            result = self.rows_to_list(session.execute(create_statement))
+            result = rows_to_list(session.execute(create_statement))
             if result:
                 result = session.execute("SELECT * FROM {keyspace}.{table} LIMIT 1".format(keyspace=src_keyspace,
                                                                                            table=src_table))
 
+                primary_keys = []
                 # Create table with table/view structure
                 columns = list(zip(result.column_names, [typelist.typename for typelist in result.column_types]))
 
-                primary_keys = []
-                for column in result.column_names:
+                # if columns list was supplied, create the table with those columns only
+                if columns_list:
+                    column_types = []
+                    for column in columns_list:
+                        column_types.extend(column_type for column_type in columns if column == column_type[0])
+                    columns = column_types
+
+                if not columns:
+                    self.log.error(f'Wrong supplied columns list: {columns}. '
+                                   f'The columns do not exist in the {src_keyspace}.{src_table} table')
+                    return False
+
+                for column in columns_list or result.column_names:
                     column_kind = session.execute("select kind from system_schema.columns where keyspace_name='{ks}' "
                                                   "and table_name='{name}' and column_name='{column}'".format(ks=src_keyspace,
                                                                                                               name=src_table,
                                                                                                               column=column))
                     if column_kind.current_rows[0].kind in ['partition_key', 'clustering']:
                         primary_keys.append(column)
+
+                if not primary_keys:
+                    primary_keys.append(columns[0][0])
 
                 create_cql = 'create table {keyspace}.{name} ({columns}, PRIMARY KEY ({pk}))' \
                     .format(keyspace=dest_keyspace,
@@ -1317,47 +1343,81 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                             pk=', '.join(primary_keys))
                 self.log.debug('Create new table with cql: {}'.format(create_cql))
                 session.execute(create_cql)
+                return True
 
-    def copy_data_between_tables(self, src_keyspace, src_table, dest_keyspace, dest_table):
+    @retrying(n=4, sleep_time=5, message='Fetch all rows', raise_on_exceeded=False)
+    def fetch_all_rows(self, session, default_fetch_size, statement, verbose=True):
+        """
+        ******* Caution *******
+        All data from table will be read to the memory
+        BE SURE that the builder has enough memory and your dataset will be less then 2Gb.
+        """
+        if verbose:
+            self.log.debug(f"Fetch all rows by statement: {statement}")
+        session.default_fetch_size = default_fetch_size
+        session.default_consistency_level = ConsistencyLevel.QUORUM
+        result = session.execute_async(statement)
+        fetcher = PageFetcher(result).request_all()
+        current_rows = fetcher.all_data()
+        if verbose and current_rows:
+            dataset_size = sum(sys.getsizeof(e) for e in current_rows[0])*len(current_rows)
+            self.log.debug(f"Size of fetched rows: {dataset_size} bytes")
+        return current_rows
+
+    def copy_data_between_tables(self, node, src_keyspace, src_table, dest_keyspace,  # pylint: disable=too-many-arguments,too-many-locals
+                                 dest_table, columns_list=None):
         """ Copy all data from one table/view to another table
             Structure of the tables has to be same
         """
         self.log.debug('Start copying data')
-        # TODO: Temporary print. Will be removed
-        count = self.get_rows_count(self.db_cluster.nodes[0], keyspace_name=src_keyspace,
-                                    table_name=src_table)
-        self.log.debug('Count rows in the {} MV before saving: {}'.format(src_table, count))
-
-        with self.cql_connection_patient(self.db_cluster.nodes[0]) as session:
+        with self.cql_connection_patient(node, verbose=False) as session:
             # Copy data from source to the destination table
-            session.default_fetch_size = 0
-            result = session.execute("SELECT * FROM {keyspace}.{table}".format(keyspace=src_keyspace,
-                                                                               table=src_table))
-            # TODO: Temporary function. Will be removed
-            self.log.debug('Rows in the {} MV before saving: {}'.format(src_table, len(result.current_rows)))
-            columns = list(zip(result.column_names, [typelist.typename for typelist in result.column_types]))
-            insert_statement = session.prepare(
-                'insert into {keyspace}.{name} ({columns}) values ({values})'.format(keyspace=dest_keyspace,
-                                                                                     name=dest_table,
-                                                                                     columns=', '.join(
-                                                                                         [c[0] for c in columns]),
-                                                                                     values=', '.join(['?' for _ in columns])))
+            statement = "SELECT {columns} FROM {keyspace}.{table}".format(keyspace=src_keyspace,
+                                                                          table=src_table,
+                                                                          columns=','.join(
+                                                                              columns_list) if columns_list else '*')
+            # Get table columns list
+            result = session.execute(statement + ' LIMIT 1')
+            columns = result.column_names
 
-            for row in result.current_rows:
-                session.execute(insert_statement, row)
-            source_rows_count = len(result.current_rows)
-
-            result = session.execute("SELECT * FROM {keyspace}.{name}".format(keyspace=dest_keyspace, name=dest_table))
-            if len(result.current_rows) != source_rows_count:
-                self. log.warning('Problem during copying data. '
-                                  'Rows in source table: {source}; '
-                                  'Rows in destination table: {destination}.'.format(source=source_rows_count,
-                                                                                     destination=len(result.current_rows))
-                                  )
+            # Fetch all rows from view / table
+            source_table_rows = self.fetch_all_rows(session=session, default_fetch_size=5000, statement=statement)
+            if not source_table_rows:
+                self.log.error(f"Can't copy data from {src_table}. Fetch all rows failed, see error above")
                 return False
-            self.log.debug('All rows have been copied from {from_name} to {to_name}'.format(from_name=src_table,
-                                                                                            to_name=dest_table))
-        self.log.debug('Finish copying data')
+
+            # TODO: Temporary function. Will be removed
+            self.log.debug('Rows in the {} MV before saving: {}'.format(src_table, len(source_table_rows)))
+
+            insert_statement = session.prepare(
+                'insert into {keyspace}.{name} ({columns}) '
+                'values ({values})'.format(keyspace=dest_keyspace,
+                                           name=dest_table,
+                                           columns=', '.join(columns),
+                                           values=', '.join(['?' for _ in columns])))
+
+            # Save all rows
+            # Workers = Parallel queries = (nodes in cluster) ✕ (cores in node) ✕ 3
+            # (from https://www.scylladb.com/2017/02/13/efficient-full-table-scans-with-scylla-1-6/)
+            cores = self.db_cluster.nodes[0].cpu_cores
+            if not cores:
+                # If CPU core didn't find, put 8 as default
+                cores = 8
+            max_workers = len(self.db_cluster.nodes) * cores * 3
+
+            session.default_consistency_level = ConsistencyLevel.QUORUM
+
+            execute_concurrent_with_args(session=session, statement=insert_statement, parameters=source_table_rows,
+                                         concurrency=max_workers)
+
+            result = session.execute(f"SELECT count(*) FROM {dest_keyspace}.{dest_table}")
+            if result:
+                if result.current_rows[0].count != len(source_table_rows):
+                    self. log.warning(f'Problem during copying data. '
+                                      f'Rows in source table: {len(source_table_rows)}; '
+                                      f'Rows in destination table: {len(result.current_rows)}.')
+                    return False
+        self.log.debug(f'All rows have been copied from {src_table} to {dest_table}')
         return True
 
     def collect_partitions_info(self, table_name, primary_key_column, save_into_file_name):

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1628,3 +1628,174 @@ def get_username():
         return get_email_user(res.stdout)
     # we didn't find email, fallback to current user with unknown email user identifier
     return "linux_user={}".format(current_linux_user)
+
+
+def rows_to_list(rows):
+    return [list(row) for row in rows]
+
+
+# Copied from dtest
+class Page:  # pylint: disable=too-few-public-methods
+    data = None
+
+    def __init__(self):
+        self.data = []
+
+    def add_row(self, row):
+        self.data.append(row)
+
+
+# Copied from dtest
+class PageFetcher:
+    """
+    Requests pages, handles their receipt,
+    and provides paged data for testing.
+
+    The first page is automatically retrieved, so an initial
+    call to request_one is actually getting the *second* page!
+    """
+    pages = None
+    error = None
+    future = None
+    requested_pages = None
+    retrieved_pages = None
+    retrieved_empty_pages = None
+
+    def __init__(self, future):
+        self.pages = []
+
+        # the first page is automagically returned (eventually)
+        # so we'll count this as a request, but the retrieved count
+        # won't be incremented until it actually arrives
+        self.requested_pages = 1
+        self.retrieved_pages = 0
+        self.retrieved_empty_pages = 0
+
+        self.future = future
+        self.future.add_callbacks(
+            callback=self.handle_page,
+            errback=self.handle_error
+        )
+
+        # wait for the first page to arrive, otherwise we may call
+        # future.has_more_pages too early, since it should only be
+        # called after the first page is returned
+        self.wait(seconds=30)
+
+    def handle_page(self, rows):
+        # occasionally get a final blank page that is useless
+        if rows == []:
+            self.retrieved_empty_pages += 1
+            return
+
+        page = Page()
+        self.pages.append(page)
+
+        for row in rows:
+            page.add_row(row)
+
+        self.retrieved_pages += 1
+
+    def handle_error(self, exc):
+        self.error = exc
+        raise exc
+
+    def request_one(self):
+        """
+        Requests the next page if there is one.
+
+        If the future is exhausted, this is a no-op.
+        """
+        if self.future.has_more_pages:
+            self.future.start_fetching_next_page()
+            self.requested_pages += 1
+            self.wait()
+
+        return self
+
+    def request_all(self):
+        """
+        Requests any remaining pages.
+
+        If the future is exhausted, this is a no-op.
+        """
+        while self.future.has_more_pages:
+            self.future.start_fetching_next_page()
+            self.requested_pages += 1
+            self.wait()
+
+        return self
+
+    def wait(self, seconds=10):
+        """
+        Blocks until all *requested* pages have been returned.
+
+        Requests are made by calling request_one and/or request_all.
+
+        Raises RuntimeError if seconds is exceeded.
+        """
+        def error_message(msg):
+            return "{}. Requested: {}; retrieved: {}; empty retrieved {}".format(
+                msg, self.requested_pages, self.retrieved_pages, self.retrieved_empty_pages)
+
+        def missing_pages():
+            pages = self.requested_pages - (self.retrieved_pages + self.retrieved_empty_pages)
+            assert pages >= 0, error_message('Retrieved too many pages')
+            return pages
+
+        missing = missing_pages()
+        if missing <= 0:
+            return self
+        expiry = time.time() + seconds * missing
+
+        while time.time() < expiry:
+            if missing_pages() <= 0:
+                return self
+            # small wait so we don't need excess cpu to keep checking
+            time.sleep(0.1)
+
+        raise RuntimeError(error_message('Requested pages were not delivered before timeout'))
+
+    def pagecount(self):
+        """
+        Returns count of *retrieved* pages which were not empty.
+
+        Pages are retrieved by requesting them with request_one and/or request_all.
+        """
+        return len(self.pages)
+
+    def num_results(self, page_num):
+        """
+        Returns the number of results found at page_num
+        """
+        return len(self.pages[page_num - 1].data)
+
+    def num_results_all(self):
+        return [len(page.data) for page in self.pages]
+
+    def page_data(self, page_num):
+        """
+        Returns retreived data found at pagenum.
+
+        The page should have already been requested with request_one and/or request_all.
+        """
+        return self.pages[page_num - 1].data
+
+    def all_data(self):
+        """
+        Returns all retrieved data flattened into a single list (instead of separated into Page objects).
+
+        The page(s) should have already been requested with request_one and/or request_all.
+        """
+        all_pages_combined = []
+        for page in self.pages:
+            all_pages_combined.extend(page.data[:])
+
+        return all_pages_combined
+
+    @property  # make property to match python driver api
+    def has_more_pages(self):
+        """
+        Returns bool indicating if there are any pages not retrieved.
+        """
+        return self.future.has_more_pages

--- a/sdcm/utils/data_validator.py
+++ b/sdcm/utils/data_validator.py
@@ -1,0 +1,519 @@
+# Data validation module may be used with cassandra-stress user profile only
+#
+# **************** Caution **************************************************************
+# BE AWARE: During data validation all materialized views/expected table rows will be read into the memory
+#           Be sure your dataset will be less then 2Gb.
+# ****************************************************************************************
+#
+# Here is described Data validation module and requirements for user profile.
+# Please, read the explanation and requirements
+#
+#
+# 2 kinds of updates may be tested:
+#
+# 1. update rows
+#   Example:
+#   update one column:
+#       set lwt_indicator=30000000,
+#       condition: for all rows where if lwt_indicator < 0
+#
+#   update two columns:
+#       set lwt_indicator=20000000 and author='text',
+#       condition: for all rows where if lwt_indicator > 0 and lwt_indicator <= 1000000 and author != 'text'
+#
+# 2. delete rows
+#   Example:
+#   deletes:
+#       delete from blogposts where
+#       condition: lwt_indicator > 10000 and lwt_indicator < 100000
+#
+#
+# And additional expected that all rows in the certain rand won't be updated
+# Example:
+#   where lwt_indicator > 1000000 and lwt_indicator < 20000000
+#
+# Based on this 3 types of validation will be performed:
+#
+# - Rows which are expected to stay intact, are not updated
+#   REQUIREMENTS:
+#     1. create view with substring "_not_updated" in the name. Example: blogposts_not_updated_lwt_indicator
+#     2. view name length have to be less then 40 characters
+# - Rows for a certain row range, that were updated
+#   REQUIREMENTS:
+#     1. create 2 views:
+#            1 - first one holds rows that candidates for this update. View name length have to be less then 27
+#                characters. Example: blogposts_update_one_column_lwt_indicator
+#            2 - Second one holds rows after update.
+#               The name of this view have to be as: <name of first view>+<_after_update>
+#               Example: blogposts_update_one_column_lwt_indicator_after_update
+#
+# - Rows for another row range that part of them were deleted
+#   REQUIREMENT:
+#       with substring "_deletions" in the name should be created (example, blogposts_deletions)
+#
+#
+# ***Validation implementation***
+#
+# 1. Rows which are expected to stay intact.
+#    To be able to validate that, the MV with substring "_not_updated" in the name should be created (example,
+#       blogposts_not_updated_lwt_indicator)
+#
+#    Example:
+#     - create MATERIALIZED VIEW blogposts_not_updated_lwt_indicator as select lwt_indicator, author from blogposts
+#       where domain is not null and published_date is not null and lwt_indicator > 1000000 and lwt_indicator < 20000000
+#       PRIMARY KEY(lwt_indicator, domain, published_date);
+#     This MV hold all rows that shouldn't be updated.
+#
+#     Once the prepare_write_cmd part will be completed, all data from the view
+#     blogposts_not_updated_lwt_indicator will be copied to a side table called
+#     blogposts_not_updated_lwt_indicator_expect (created by test). This table uses as the expected data for this
+#     validation.
+#
+#     When test is finished, the test checks that data in the blogposts_not_updated_lwt_indicator and
+#     blogposts_not_updated_lwt_indicator_expect will be same.
+#
+# 2. For the rows one or more columns were updated, the data validation behaves as follow:
+#
+#     Two more Materialized View have to be added added:
+#       1 - First one holds rows that candidates for this update (before the update):
+#           ****IMPORTANT: name of this view have no to be longer then 27 characters****
+#       Example:
+#           create MATERIALIZED VIEW blogposts_update_one_column_lwt_indicator as select domain, lwt_indicator, author
+#           from blogposts where domain is not null and published_date is not null and lwt_indicator < 0
+#           PRIMARY KEY(lwt_indicator, domain, published_date);
+#
+#       2 - Second one holds rows after update.
+#           The name of this view have to be as: <name of first view>+<_after_update>
+#       Example:
+#           create MATERIALIZED VIEW blogposts_update_one_column_lwt_indicator_after_update as
+#           select lwt_indicator, author from blogposts
+#           where domain is not null and published_date is not null and
+#           lwt_indicator = 30000000 PRIMARY KEY(lwt_indicator, domain, published_date);
+#
+#     Once the prepare_write_cmd part will be completed, all primary key data from the first view
+#     will be copied to a side table called <view name>+<_expect> (example, blogposts_not_updated_lwt_indicator_expect)
+#     that created by test. This table uses as the expected data for this validation.
+#
+#     Ideally, The view blogposts_update_one_column_lwt_indicator should be empty after the update and
+#     the view blogposts_update_one_column_lwt_indicator_after_update will hold same amount of data as
+#     blogposts_update_one_column_lwt_indicator had before the update.
+#
+#     However, due to the fact we cannot control the c-s workload to go over all the rows (should visit all the rows
+#     with appropriate value), it's validated that first and second views together has same primary keys that in
+#     expected data table
+#
+#
+# 3. Rows which are deleted.
+#    To be able to validate that, the MV with substring "_deletions" in the name should be created (example,
+#       blogposts_deletions)
+#
+#   Example:
+#     - create MATERIALIZED VIEW blogposts_deletions as select lwt_indicator, author from blogposts
+#       where domain is not null and published_date is not null and lwt_indicator > 10000 and lwt_indicator < 100000
+#       PRIMARY KEY(lwt_indicator, domain, published_date);
+#     This MV hold all rows that may be updated.
+#
+#     Once the prepare_write_cmd part will be completed, rows in the view will be counted and saved.
+#
+#     When test is finished, rows will be counted in the view and validate that this count less then count before
+#     running stress.
+#
+
+import logging
+import re
+
+from sdcm.utils.common import get_profile_content
+
+LOGGER = logging.getLogger(__name__)
+
+
+# pylint: disable=too-many-instance-attributes
+class LongevityDataValidator:
+    SUFFIX_FOR_VIEW_AFTER_UPDATE = '_after_update'
+    SUFFIX_EXPECTED_DATA_TABLE = '_expect'
+    SUBSTRING_NOT_UPDATED = '_not_updated'
+    SUBSTRING_DELETION = '_deletions'
+    DEFAULT_FETCH_SIZE = 5000
+
+    def __init__(self, longevity_self_object, user_profile_name, base_table_partition_keys,
+                 stress_cmds_part='prepare_write_cmd'):
+        """
+
+        :param longevity_self_object: "self" object of longevity test that inherited from ClusterTester
+        :param user_profile_name: name of user profile with appropriate defined views
+        :param stress_cmds_part: name of stress part from test yaml
+        :param base_table_partition_keys: used for test of updated rows. List of all primary keys of base table
+                                          For example: ['domain', 'published_date']
+        """
+        self.longevity_self_object = longevity_self_object
+        self.user_profile_name = user_profile_name
+        self.stress_cmds_part = stress_cmds_part
+        self.base_table_partition_keys = base_table_partition_keys
+
+        self._validate_not_updated_data = True
+        self._validate_updated_data = True
+        self._keyspace_name = None
+        self._mv_for_not_updated_data = None
+        self._mvs_for_updated_data = None
+        self._mvs_after_updated_data = None
+        self._expected_data_table = None
+        self._validate_not_updated_data = True
+        self._validate_updated_data = True
+        self._validate_updated_per_view = []
+        self._mv_for_deletions = None
+        self.rows_before_deletion = None
+
+    @property
+    def keyspace_name(self):
+        if not self._keyspace_name:
+            prepare_write_cmd = self.longevity_self_object.params.get(self.stress_cmds_part, default=[])
+            profiles = [cmd for cmd in prepare_write_cmd if self.user_profile_name in cmd]
+            if not profiles:
+                self._validate_not_updated_data = False
+                self._validate_updated_data = False
+
+                LOGGER.warning('Keyspace is not recognized. '
+                               'Data validation can\'t be performed')
+                return self._keyspace_name
+
+            cs_profile = profiles[0]
+            _, profile = get_profile_content(cs_profile)
+            self._keyspace_name = profile['keyspace']
+
+        return self._keyspace_name
+
+    @property
+    def view_names_for_updated_data(self):
+        """
+        Get MV name that holds rows which are expected to be updated
+        """
+        if not self._mvs_for_updated_data:
+            mvs_names = self.get_view_name_from_profile(self.SUFFIX_FOR_VIEW_AFTER_UPDATE, all_entries=True)
+            self._mvs_for_updated_data = [view_name.replace(self.SUFFIX_FOR_VIEW_AFTER_UPDATE, '')
+                                          for view_name in mvs_names]
+            return self._mvs_for_updated_data
+
+        return self._mvs_for_updated_data
+
+    @property
+    def view_names_after_updated_data(self):
+        """
+        Get MV name that holds rows which were updated
+        """
+        if not self._mvs_after_updated_data:
+            self._mvs_after_updated_data = self.get_view_name_from_profile(self.SUFFIX_FOR_VIEW_AFTER_UPDATE,
+                                                                           all_entries=True)
+            return self._mvs_after_updated_data
+
+        return self._mvs_after_updated_data
+
+    @property
+    def view_name_for_not_updated_data(self):
+        """
+        Get MV name that holds rows which are expected to stay intact
+        """
+        if not self._mv_for_not_updated_data:
+            mv_for_not_updated_data = self.get_view_name_from_profile(self.SUBSTRING_NOT_UPDATED)
+
+            self._mv_for_not_updated_data = mv_for_not_updated_data[0] if mv_for_not_updated_data else None
+            return self._mv_for_not_updated_data
+
+        return self._mv_for_not_updated_data
+
+    @property
+    def view_name_for_deletion_data(self):
+        """
+        Get MV name that holds rows which may be deleted
+        """
+        if not self._mv_for_deletions:
+            mv_for_deletions = self.get_view_name_from_profile(self.SUBSTRING_DELETION)
+
+            self._mv_for_deletions = mv_for_deletions[0] if mv_for_deletions else None
+            return self._mv_for_deletions
+
+        return self._mv_for_deletions
+
+    @property
+    def expected_data_table_name(self):
+        """
+        Table name for expected data (needs for validate rows which are expected to stay intact - implemented in
+         validate_range_not_expected_to_change function)
+        """
+        if not self._expected_data_table:
+            self._expected_data_table = self.set_expected_data_table_name(self.view_name_for_not_updated_data)
+        return self._expected_data_table
+
+    def set_expected_data_table_name(self, view_name):
+        return view_name + self.SUFFIX_EXPECTED_DATA_TABLE
+
+    def get_view_name_from_profile(self, name_substr, cs_profile=None, all_entries=False):
+        mv_names = []
+
+        if not cs_profile:
+            stress_cmd = self.longevity_self_object.params.get(self.stress_cmds_part, default=[])
+            cs_profile = [cmd for cmd in stress_cmd if self.user_profile_name in cmd]
+
+        if not cs_profile:
+            return mv_names
+
+        if not isinstance(cs_profile, list):
+            cs_profile = [cs_profile]
+
+        for profile in cs_profile:
+            _, profile_content = get_profile_content(profile)
+            mv_create_cmd = self.get_view_cmd_from_profile(profile_content, name_substr, all_entries)
+            LOGGER.debug(f'Create commands: {mv_create_cmd}')
+            for cmd in mv_create_cmd:
+                view_name = self.get_view_name_from_stress_cmd(cmd, name_substr)
+                if view_name:
+                    mv_names.append(view_name)
+                    if not all_entries:
+                        break
+
+        return mv_names
+
+    @staticmethod
+    def get_view_cmd_from_profile(profile_content, name_substr, all_entries=False):
+        all_mvs = profile_content['extra_definitions']
+        mv_cmd = [cmd for cmd in all_mvs if name_substr in cmd]
+
+        mv_cmd = [mv_cmd[0]] if not all_entries and mv_cmd else mv_cmd
+        return mv_cmd
+
+    @staticmethod
+    def get_view_name_from_stress_cmd(mv_create_cmd, name_substr):
+        find_mv_name = re.search(r'materialized view (.*%s.*) as' % name_substr, mv_create_cmd, re.I)
+        return find_mv_name.group(1) if find_mv_name else None
+
+    def copy_immutable_expected_data(self):
+        # Create expected data for immutable rows
+        if self._validate_not_updated_data:
+            LOGGER.debug(
+                f'Copy expected data for immutable rows: {self.view_name_for_not_updated_data} -> {self.expected_data_table_name}')
+            if not self.longevity_self_object.copy_view(node=self.longevity_self_object.db_cluster.nodes[0],
+                                                        src_keyspace=self.keyspace_name, src_view=self.view_name_for_not_updated_data,
+                                                        dest_keyspace=self.keyspace_name, dest_table=self.expected_data_table_name,
+                                                        copy_data=True):
+                self._validate_not_updated_data = False
+                LOGGER.warning(f'Problem during copying expected data from {self.view_name_for_not_updated_data} '
+                               f'to {self.expected_data_table_name}. '
+                               f'Data validation of not updated rows won\' be performed')
+
+    def copy_updated_expected_data(self):
+        # Create expected data for updated rows
+        if self._validate_updated_data:
+            LOGGER.debug(f'Copy expected data for updated rows. {self.view_names_for_updated_data}')
+            for src_view in self.view_names_for_updated_data:
+                expected_data_table_name = self.set_expected_data_table_name(src_view)
+                LOGGER.debug(f'Expected data table name {expected_data_table_name}')
+                if not self.longevity_self_object.copy_view(node=self.longevity_self_object.db_cluster.nodes[0],
+                                                            src_keyspace=self.keyspace_name, src_view=src_view,
+                                                            dest_keyspace=self.keyspace_name,
+                                                            dest_table=expected_data_table_name,
+                                                            columns_list=self.base_table_partition_keys,
+                                                            copy_data=True):
+                    self._validate_updated_per_view.append(False)
+                    LOGGER.warning(f'Problem during copying expected data from {src_view} '
+                                   f'to {expected_data_table_name}. '
+                                   f'Data validation of updated rows won\' be performed')
+                self._validate_updated_per_view.append(True)
+
+    def save_count_rows_for_deletion(self):
+        LOGGER.debug(f'Get rows count in {self.view_name_for_deletion_data} MV before stress')
+        pk_name = self.base_table_partition_keys[0]
+        with self.longevity_self_object.cql_connection_patient(self.longevity_self_object.db_cluster.nodes[0],
+                                                               keyspace=self.keyspace_name) as session:
+            rows_before_deletion = self.longevity_self_object.fetch_all_rows(session=session, default_fetch_size=self.DEFAULT_FETCH_SIZE,
+                                                                             statement=f"SELECT {pk_name} FROM {self.view_name_for_deletion_data}")
+            if rows_before_deletion:
+                self.rows_before_deletion = len(rows_before_deletion)
+                LOGGER.debug(f"{self.rows_before_deletion} rows for deletion")
+
+    def validate_range_not_expected_to_change(self, session, during_nemesis=False):
+        """
+        Part of data in the user profile table shouldn't be updated using LWT.
+        This data will be saved in the materialized view with "not_updated" substring in the name
+        After prepare write all data from this materialized view will be saved in the separate table as expected result.
+        During stress (after prepare) LWT update statements will be run for a few hours.
+        When updates will be finished this function verifies that data in "not_updated" MV and expected result table
+        is same
+        """
+
+        if not (self._validate_not_updated_data and self.view_name_for_not_updated_data
+                and self.expected_data_table_name):
+            LOGGER.debug('Verify immutable rows can\'t be performed as expected data has not been saved. '
+                         'See error above')
+            return
+
+        if not during_nemesis:
+            LOGGER.debug('Verify immutable rows')
+
+        actual_result = self.longevity_self_object.fetch_all_rows(
+            session=session, default_fetch_size=self.DEFAULT_FETCH_SIZE,
+            statement=f"SELECT * FROM {self.view_name_for_not_updated_data}",
+            verbose=not during_nemesis)
+        if not actual_result:
+            LOGGER.error(f"Can't validate immutable rows. "
+                         f"Fetch all rows from {self.view_name_for_not_updated_data} failed. See error above")
+            return
+
+        expected_result = self.longevity_self_object.fetch_all_rows(
+            session=session, default_fetch_size=self.DEFAULT_FETCH_SIZE,
+            statement=f"SELECT * FROM {self.expected_data_table_name}",
+            verbose=not during_nemesis)
+        if not expected_result:
+            LOGGER.error(f"Can't validate immutable rows. "
+                         f"Fetch all rows from {self.expected_data_table_name} failed. See error above")
+            return
+
+        # Issue https://github.com/scylladb/scylla/issues/6181
+        # Not fail the test if unexpected additional rows where found in actual result table
+        if len(actual_result) > len(expected_result):
+            LOGGER.warning(f'Actual dataset length {len(actual_result)} more '
+                           f'then expected dataset length: {len(expected_result)}. Issue #6181')
+        else:
+            if not during_nemesis:
+                assert len(actual_result) == len(expected_result), \
+                    'One or more rows are not as expected, suspected LWT wrong update. ' \
+                    'Actual dataset length: {}, Expected dataset length: {}'.format(len(actual_result),
+                                                                                    len(expected_result))
+
+                assert (actual_result, expected_result,
+                        'One or more rows are not as expected, suspected LWT wrong update')
+                LOGGER.info('Validation immutable rows finished successfully')
+            else:
+                if len(actual_result) < len(expected_result):
+                    LOGGER.error(
+                        f'Verify immutable rows. One or more rows didn\'t find as expected, suspected LWT wrong update. '
+                        f'Actual dataset length: {len(actual_result)}, Expected dataset length: {len(expected_result)}')
+                else:
+                    LOGGER.debug(
+                        f'Verify immutable rows. '
+                        f'Actual dataset length: {len(actual_result)}, Expected dataset length: {len(expected_result)}')
+
+    def validate_range_expected_to_change(self, session, during_nemesis=False):
+        """
+        In user profile 'data_dir/c-s_lwt_basic.yaml' LWT updates the lwt_indicator and author columns with hard coded
+        values.
+
+        Two more materialized views are added. The first one holds rows that are candidates for the update
+        (i.e. all rows before the update).
+        The second one holds rows with lwt_indicator=30000000 (i.e. only the updated rows)
+
+        After prepare all primay keys from first materialized view will be saved in the separate table as
+        expected result.
+
+        After the updates will be finished, 2 type of validation:
+        1. All primary key values that saved in the expected result table, should be found in the both views
+        2. Also validate row counts in the both veiws agains
+        """
+        if not (self._validate_updated_data and self.view_names_for_updated_data):
+            LOGGER.debug('Verify updated rows can\'t be performed as expected data has not been saved. See error above')
+            return
+
+        if not during_nemesis:
+            LOGGER.debug('Verify updated rows')
+
+        partition_keys = ', '.join(self.base_table_partition_keys)
+
+        # List of tuples of correlated  view names for validation: before update, after update, expected data
+        views_list = list(zip(self.view_names_for_updated_data,
+                              self.view_names_after_updated_data,
+                              [self.set_expected_data_table_name(view) for view in
+                               self.view_names_for_updated_data],
+                              self._validate_updated_per_view, ))
+        for views_set in views_list:
+            # views_set[0] - view name with rows before update
+            # views_set[1] - view name with rows after update
+            # views_set[2] - view name with all expected partition keys
+            # views_set[3] - do perform validation for the view or not
+            if not during_nemesis:
+                LOGGER.debug(f'Verify updated row. View {views_set[0]}')
+            if not views_set[3]:
+                LOGGER.error(f"Can't start validation for {views_set[0]}. "
+                             f"Copying expected data failed. See error above")
+                return
+
+            before_update_rows = self.longevity_self_object.fetch_all_rows(
+                session=session, default_fetch_size=self.DEFAULT_FETCH_SIZE,
+                statement=f"SELECT {partition_keys} FROM {views_set[0]}",
+                verbose=not during_nemesis)
+            if not before_update_rows:
+                LOGGER.error(f"Can't validate updated rows. "
+                             f"Fetch all rows from {views_set[0]} failed. See error above")
+                return
+
+            after_update_rows = self.longevity_self_object.fetch_all_rows(
+                session=session, default_fetch_size=self.DEFAULT_FETCH_SIZE,
+                statement=f"SELECT {partition_keys} FROM {views_set[1]}",
+                verbose=not during_nemesis)
+            if not after_update_rows:
+                LOGGER.error(f"Can't validate updated rows. "
+                             f"Fetch all rows from {views_set[1]} failed. See error above")
+                return
+
+            expected_rows = self.longevity_self_object.fetch_all_rows(
+                session=session, default_fetch_size=self.DEFAULT_FETCH_SIZE,
+                statement=f"SELECT {partition_keys} FROM {views_set[2]}",
+                verbose=not during_nemesis)
+            if not expected_rows:
+                LOGGER.error(f"Can't validate updated row. "
+                             f"Fetch all rows from {views_set[2]} failed. See error above")
+                return
+
+            # Issue https://github.com/scylladb/scylla/issues/6181
+            # Not fail the test if unexpected additional rows where found in actual result table
+            if len(before_update_rows) + len(after_update_rows) > len(expected_rows):
+                LOGGER.warning(f'View {views_set[0]}. '
+                               f'Actual dataset length {len(before_update_rows) + len(after_update_rows)} more '
+                               f'then expected dataset length: { len(expected_rows)}. Issue #6181')
+            else:
+                actual_data = sorted(before_update_rows+after_update_rows)
+                expected_data = sorted(expected_rows)
+                if not during_nemesis:
+                    assert actual_data == expected_data,\
+                        'One or more rows are not as expected, suspected LWT wrong update'
+
+                    assert len(before_update_rows) + len(after_update_rows) == len(expected_rows), \
+                        'One or more rows are not as expected, suspected LWT wrong update. '\
+                        f'Actual dataset length: {len(before_update_rows) + len(after_update_rows)}, ' \
+                        f'Expected dataset length: {len(expected_rows)}'
+
+                    LOGGER.info(f'Validation updated rows finished successfully. View {views_set[0]}')
+                else:
+                    LOGGER.debug(f'Validation updated rows.  View {views_set[0]}. '
+                                 f'Actual dataset length {len(before_update_rows) + len(after_update_rows)}, '
+                                 f'Expected dataset length: {len(expected_rows)}.')
+
+    def validate_deleted_rows(self, session, during_nemesis=False):
+        """
+        Part of data in the user profile table will be deleted using LWT.
+        This data will be saved in the materialized view with "_deletions" substring in the name
+        After prepare write rows count in this materialized view will be saved self.rows_before_deletion variable as
+        expected result.
+        During stress (after prepare) LWT delete statements will be run for a few hours.
+        When stress will be finished this function verifies that rows count in "_deletions" MV will be less then it
+        was saved in self.rows_before_deletion
+        """
+        if not self.rows_before_deletion:
+            LOGGER.debug('Verify deleted rows can\'t be performed as expected rows count was had not been saved')
+            return
+
+        pk_name = self.base_table_partition_keys[0]
+        if not during_nemesis:
+            LOGGER.debug('Verify deleted rows')
+
+        actual_result = self.longevity_self_object.fetch_all_rows(session=session, default_fetch_size=self.DEFAULT_FETCH_SIZE,
+                                                                  statement=f"SELECT {pk_name} FROM {self.view_name_for_deletion_data}",
+                                                                  verbose=not during_nemesis)
+        if not actual_result:
+            LOGGER.error(f"Can't validate deleted rows. "
+                         f"Fetch all rows from {self.view_name_for_deletion_data} failed. See error above")
+            return
+
+        if len(actual_result) < self.rows_before_deletion:
+            LOGGER.info('Validation deleted rows finished successfully')
+        else:
+            LOGGER.warning('Deleted row were not found. May be issue #6181. '
+                           'Actual dataset length: {}, Expected dataset length: {}'.format(len(actual_result),
+                                                                                           self.rows_before_deletion))

--- a/sdcm/utils/decorators.py
+++ b/sdcm/utils/decorators.py
@@ -93,7 +93,7 @@ class retrying:  # pylint: disable=invalid-name,too-few-public-methods
     """
 
     def __init__(self, n=3, sleep_time=1,  # pylint: disable=too-many-arguments
-                 allowed_exceptions=(Exception,), message="", timeout=0):  # pylint: disable=redefined-outer-name
+                 allowed_exceptions=(Exception,), message="", timeout=0, raise_on_exceeded=True):  # pylint: disable=redefined-outer-name
         if n:
             self.n = n  # number of times to retry  # pylint: disable=invalid-name
         else:
@@ -103,6 +103,8 @@ class retrying:  # pylint: disable=invalid-name,too-few-public-methods
         self.message = message  # string that will be printed between retries
         self.timeout = timeout  # if timeout is defined it will raise error
         #   if it is reached even when maximum retries not reached yet
+        self.raise_on_exceeded = raise_on_exceeded  # if True - raise exception when number of retries exceeded,
+        # otherwise - return None
 
     def __call__(self, func):
         @wraps(func)
@@ -124,7 +126,9 @@ class retrying:  # pylint: disable=invalid-name,too-few-public-methods
                     time.sleep(self.sleep_time)
                     if i == self.n - 1 or (end_time and time.time() > end_time):
                         LOGGER.error(f"'{func.__name__}': Number of retries exceeded!")
-                        raise
+                        if self.raise_on_exceeded:
+                            raise
+                        return None
 
         return inner
 

--- a/test-cases/longevity/longevity-lwt-500G-3d.yaml
+++ b/test-cases/longevity/longevity-lwt-500G-3d.yaml
@@ -1,0 +1,34 @@
+# Test duration 25 hours temporary. Should be 3 days. Will be changed later
+test_duration: 1500
+prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml n=400000000 ops'(insert=1)' cl=QUORUM -mode native cql3 -rate threads=1000" ]
+stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1,lwt_deletes=1)' cl=QUORUM duration=900m -mode native cql3 -rate threads=10" ,
+             "cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1,lwt_deletes=1)' cl=QUORUM duration=900m -mode native cql3 -rate threads=10"
+            ]
+stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml ops'(select=1)' cl=SERIAL duration=900m -mode native cql3 -rate threads=10" ]
+
+n_db_nodes: 4
+n_loaders: 3
+n_monitor_nodes: 1
+round_robin: true
+
+instance_type_db: 'i3.4xlarge'
+instance_type_loader: 'c5.2xlarge'
+
+# loader AMI with c-s ver. 4 and few fixes:
+#  - fix NoSuchElementException
+#  - enable control over both consistency levels: regular and serial
+#  - bring shard awareness
+regions_data:
+  us-east-1:
+    ami_id_loader: 'ami-0b94f0e897d884b1b'
+  eu-west-1:
+    ami_id_loader: 'ami-0ea704a8c9ec08e57'
+  us-west-2:
+    ami_id_loader: 'ami-063a97bde47353690'
+
+nemesis_class_name: 'ChaosMonkey'
+nemesis_interval: 5
+nemesis_during_prepare: false
+space_node_threshold: 64424
+
+user_prefix: 'longevity-lwt-500G-3d'


### PR DESCRIPTION
**This commit presents:**
1. New 500G LWT longevity test
2. Data validation module

Jenkins jobs:
1. https://jenkins.scylladb.com/view/master/job/scylla-master/job/longevity/job/longevity-lwt-500G-3d/
2. https://jenkins.scylladb.com/view/scylla-4.0/job/scylla-4.0/job/longevity/job/longevity-lwt-500G-3d/

**Data validation module explanation**

Data validation module may be used with cassandra-stress user profile only

Here is described Data validation module and requirements for user profile.
Please, read the explanation and requirements

2 kinds of updates may be tested:

1. update rows
  Examples:
  update one column:
      set lwt_indicator=30000000,
      condition for MV example: for all rows where if lwt_indicator < 0

  update two columns:
      set lwt_indicator=20000000 and author='text',
      condition for MV example: for all rows where if lwt_indicator > 0 and lwt_indicator
<= 1000000 and author != 'text'

2. delete rows
  Example:
  deletes:
      delete from blogposts where
      condition for MV example: lwt_indicator > 10000 and lwt_indicator < 100000

And additional expected that all rows in the certain rand won't be updated
Condition for MV example:
  where lwt_indicator > 1000000 and lwt_indicator < 20000000

Based on this 3 types of validation will be performed:

- Rows which are expected to stay intact, are not updated
  REQUIREMENTS:
    1. create view with substring "_not_updated" in the name.
    Example: blogposts_not_updated_lwt_indicator
    2. view name length have to be less then 40 characters

- Rows for a certain row range, that were updated
  REQUIREMENTS:
    1. create 2 views:
           1 - first one holds rows that candidates for this update.
               View name length have to be less then 27 characters.
              Example: blogposts_update_one_column_lwt_indicator
           2 - Second one holds rows after update.
              The name of this view have to be as: <name of first view>+<_after_update>
              Example: blogposts_update_one_column_lwt_indicator_after_update

- Rows for another row range that part of them were deleted
  REQUIREMENT:
     materialized view with substring "_deletions" in the name should be created (example, blogposts_deletions)

***Validation implementation***

1. Rows which are expected to stay intact.
   To be able to validate that, the MV with substring _not_updated in the name should be created
      (example, blogposts_not_updated_lwt_indicator)

   Example:
    - create MATERIALIZED VIEW blogposts_not_updated_lwt_indicator as
      select lwt_indicator, author from blogposts
      where domain is not null and published_date is not null and lwt_indicator > 1000000
      and lwt_indicator < 20000000
      PRIMARY KEY(lwt_indicator, domain, published_date);
    This MV hold all rows that shouldn't be updated.

    Once the prepare_write_cmd part will be completed, all data from the view
    blogposts_not_updated_lwt_indicator will be copied to a side table called
    blogposts_not_updated_lwt_indicator_expect (created by test).
    This table uses as the expected data for this validation.

    When test is finished, the test checks that data in the blogposts_not_updated_lwt_indicator and
    blogposts_not_updated_lwt_indicator_expect will be same.

2. For the rows one or more columns were updated, the data validation behaves as follow:

    Two more Materialized View have to be added added:
      1 - First one holds rows that candidates for this update (before the update):
          ****IMPORTANT: name of this view have no to be longer then 27 characters****
      Example:
          create MATERIALIZED VIEW blogposts_update_one_column_lwt_indicator as
          select domain, lwt_indicator, author
          from blogposts where domain is not null and published_date is not null
          and lwt_indicator >=-2000 and lwt_indicator < 0
          PRIMARY KEY(lwt_indicator, domain, published_date);
          
         The rows from this MV may be updated by stress command (example):
         update blogposts set lwt_indicator = **30000000** where domain = ? and published_date = ? if lwt_indicator >=-2000 and lwt_indicator < 0

      2 - Second one holds rows after update.
          The name of this view have to be as: <name of first view>+<_after_update>
      Example:
          create MATERIALIZED VIEW blogposts_update_one_column_lwt_indicator_after_update as
          select lwt_indicator, author from blogposts
          where domain is not null and published_date is not null and
          lwt_indicator = **30000000** PRIMARY KEY(lwt_indicator, domain, published_date);

    Once the prepare_write_cmd part will be completed, all primary key data from the first view
    will be copied to a side table called <view name>+<_expect>
    (example, blogposts_not_updated_lwt_indicator_expect)
    that created by test. This table uses as the expected data for this validation.

    Ideally, The view blogposts_update_one_column_lwt_indicator should be empty after the update
    and the view blogposts_update_one_column_lwt_indicator_after_update will hold same amount
    of data as blogposts_update_one_column_lwt_indicator had before the update.

    However, due to the fact we cannot control the c-s workload to go over all the rows
   (should visit all the rows with appropriate value), it's validated that first and second
   views together has same primary keys that in expected data table

3. Rows which are deleted.
   To be able to validate that, the MV with substring _deletions in the name should be created
      (example, blogposts_deletions)

  Example:
    - create MATERIALIZED VIEW blogposts_deletions as select lwt_indicator, author from blogposts
      where domain is not null and published_date is not null and lwt_indicator > 10000
      and lwt_indicator < 100000
      PRIMARY KEY(lwt_indicator, domain, published_date);
    This MV hold all rows that may be updated.

    Once the prepare_write_cmd part will be completed, rows in the view will be counted and saved.

    When test is finished, rows will be counted in the view and validate that this count less then
    count before running stress.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
