### PR TITLE
improvement(manager install): change default prometheus

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1772,6 +1772,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
     def install_manager_agent(self, package_path=None):
         auth_token = Setup.test_id()
+        manager_prometheus_port = self.parent_cluster.params.get("manager_prometheus_port", 5090)
         if package_path:
             package_name = '{}scylla-manager-agent*'.format(package_path)
         else:
@@ -1785,9 +1786,10 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             scyllamgr_ssl_cert_gen
             sed -i 's/#tls_cert_file/tls_cert_file/' /etc/scylla-manager-agent/scylla-manager-agent.yaml
             sed -i 's/#tls_key_file/tls_key_file/' /etc/scylla-manager-agent/scylla-manager-agent.yaml
+            sed -i 's/#prometheus: .*/prometheus: :{}/' /etc/scylla-manager-agent/scylla-manager-agent.yaml
             systemctl restart scylla-manager-agent
             systemctl enable scylla-manager-agent
-        """.format(package_name, auth_token))
+        """.format(package_name, auth_token, manager_prometheus_port))
         self.remoter.run('sudo bash -cxe "%s"' % install_and_config_agent_command)
         version = self.remoter.run('scylla-manager-agent --version').stdout
         self.log.info(f'node {self.name} has scylla-manager-agent version {version}')
@@ -2112,13 +2114,15 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             self.remoter.run('sudo systemctl restart scylla-manager.service')
             res = self.remoter.run('sudo systemctl status scylla-manager.service')
 
+        manager_prometheus_port = self.parent_cluster.params.get("manager_prometheus_port", 5090)
         if self.is_rhel_like():  # TODO: Add debian and ubuntu support
             configuring_manager_command = dedent("""
             scyllamgr_ssl_cert_gen
             sed -i 's/#tls_cert_file/tls_cert_file/' /etc/scylla-manager/scylla-manager.yaml
             sed -i 's/#tls_key_file/tls_key_file/' /etc/scylla-manager/scylla-manager.yaml
+            sed -i 's/#prometheus: .*/prometheus: :{}/' /etc/scylla-manager/scylla-manager.yaml
             systemctl restart scylla-manager
-            """.format(auth_token))  # pylint: disable=too-many-format-args
+            """.format(manager_prometheus_port))  # pylint: disable=too-many-format-args
             self.remoter.run('sudo bash -cxe "%s"' % configuring_manager_command)
 
         if not res or "Active: failed" in res.stdout:

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -207,6 +207,9 @@ class SCTConfiguration(dict):
         dict(name="mgmt_segments_per_repair", env="MGMT_SEGMENTS_PER_REPAIR", type=int,
              help="the number of segments per repair used for the manager's repair"),
 
+        dict(name="manager_prometheus_port", env="SCT_MANAGER_PROMETHEUS_PORT", type=int,
+             help="Port to be used by the manager to contact Prometheus"),
+
         dict(name="update_db_packages", env="SCT_UPDATE_DB_PACKAGES", type=str,
              help="""A local directory of rpms to install a custom version on top of
                      the scylla installed (or from repo or from ami)"""),


### PR DESCRIPTION
port manager uses. It is a workaround for mermaid issue
https://github.com/scylladb/mermaid/issues/1895

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
