### PR TITLE
fix(cluster_baremetal): pass along node_type

### DIFF
--- a/sdcm/cluster_baremetal.py
+++ b/sdcm/cluster_baremetal.py
@@ -83,7 +83,8 @@ class PhysicalMachineCluster(cluster.BaseCluster):  # pylint: disable=abstract-m
             raise NodeIpsNotConfiguredError('Physical hosts IPs are not configured!')
         super(PhysicalMachineCluster, self).__init__(node_prefix=kwargs.get('node_prefix'),
                                                      n_nodes=n_nodes,
-                                                     params=params)
+                                                     params=params,
+                                                     node_type=kwargs.get('node_type'))
 
     def _create_node(self, name, public_ip, private_ip):
         node = PhysicalMachineNode(name,
@@ -110,6 +111,7 @@ class ScyllaPhysicalCluster(cluster.BaseScyllaCluster, PhysicalMachineCluster):
         self._user_prefix = kwargs.get('user_prefix', cluster.DEFAULT_USER_PREFIX)
         self._node_prefix = '%s-%s' % (self._user_prefix, BASE_NAME)
         super(ScyllaPhysicalCluster, self).__init__(node_prefix=kwargs.get('node_prefix', self._node_prefix),
+                                                    node_type='scylla-db',
                                                     **kwargs)
 
     def node_setup(self, node, verbose=False, timeout=3600):
@@ -125,7 +127,7 @@ class LoaderSetPhysical(PhysicalMachineCluster, cluster.BaseLoaderSet):  # pylin
 
     def __init__(self, **kwargs):
         self._node_prefix = '%s-%s' % (kwargs.get('user_prefix', cluster.DEFAULT_USER_PREFIX), LOADER_NAME)
-        super(LoaderSetPhysical, self).__init__(node_prefix=self._node_prefix, **kwargs)
+        super(LoaderSetPhysical, self).__init__(node_prefix=self._node_prefix, node_type='loader', **kwargs)
 
     @classmethod
     def _get_node_ips_param(cls, ip_type='public'):
@@ -139,4 +141,4 @@ class MonitorSetPhysical(cluster.BaseMonitorSet, PhysicalMachineCluster):
         cluster.BaseMonitorSet.__init__(self,
                                         targets=kwargs["targets"],
                                         params=kwargs["params"])
-        PhysicalMachineCluster.__init__(self, node_prefix=self._node_prefix, **kwargs)
+        PhysicalMachineCluster.__init__(self, node_prefix=self._node_prefix, node_type='monitor', **kwargs)


### PR DESCRIPTION
since recent tags refactoring node_type is a mandatory parameter on
cluster object, `PhysicalMachineCluster` wasn't passing it down

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
