### PR TITLE
fix(manager): changed the column name the get_cluster searches for

### DIFF
--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -633,14 +633,20 @@ class ScyllaManagerTool(ScyllaManagerBase):
         """
         Returns Manager Cluster object by a given name if exist, else returns none.
         """
-        # ╭──────────────────────────────────────┬──────────┬─────────────┬────────────────╮
-        # │ cluster id                           │ name     │ host        │ ssh user       │
-        # ├──────────────────────────────────────┼──────────┼─────────────┼────────────────┤
-        # │ 1de39a6b-ce64-41be-a671-a7c621035c0f │ Dev_Test │ 10.142.0.25 │ scylla-manager │
-        # │ bf6571ef-21d9-4cf1-9f67-9d05bc07b32e │ Prod     │ 10.142.0.26 │ scylla-manager │
-        # ╰──────────────────────────────────────┴──────────┴─────────────┴────────────────╯
+        # ╭──────────────────────────────────────┬──────────╮
+        # │ cluster id                           │ name     │
+        # ├──────────────────────────────────────┼──────────┤
+        # │ 1de39a6b-ce64-41be-a671-a7c621035c0f │ Dev_Test │
+        # │ bf6571ef-21d9-4cf1-9f67-9d05bc07b32e │ Prod     │
+        # ╰──────────────────────────────────────┴──────────╯
         try:
-            cluster_id = self.sctool.get_table_value(parsed_table=self.cluster_list, column_name="cluster id",
+            cluster_list = self.cluster_list
+            column_names = cluster_list[0]
+            if "ID" in column_names:
+                column_to_search = "ID"
+            else:
+                column_to_search = "cluster id"
+            cluster_id = self.sctool.get_table_value(parsed_table=cluster_list, column_name=column_to_search,
                                                      identifier=cluster_name)
         except ScyllaManagerError as ex:
             LOGGER.warning("Cluster name not found in Scylla-Manager: {}".format(ex))


### PR DESCRIPTION
Due to changes in manager 2.0.2, the name of the column that houses
the cluster id's in the output of the 'sctool cluster list' command
changed from 'ID' to 'cluster id'.
In order to support all versions of manager 2.0.X, I've modified the
get_cluster function to support both column names, or in other words,
all 2.0.X manager versions.


### for manager2.1 branch, clone of #2105

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
