### PR TITLE
fix(create session): add 'verbose' parameter to ScyllaCQLSession

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -952,7 +952,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
     def _create_session(self, node, keyspace, user, password, compression,  # pylint: disable=too-many-arguments, too-many-locals
                         protocol_version, load_balancing_policy=None,
-                        port=None, ssl_opts=None, node_ips=None, connect_timeout=None):
+                        port=None, ssl_opts=None, node_ips=None, connect_timeout=None,
+                        verbose=True):
         if not port:
             port = node.CQL_PORT
 
@@ -992,29 +993,29 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         # override driver default consistency level of LOCAL_QUORUM
         session.default_consistency_level = ConsistencyLevel.ONE
 
-        return ScyllaCQLSession(session, cluster_driver)
+        return ScyllaCQLSession(session, cluster_driver, verbose)
 
     def cql_connection(self, node, keyspace=None, user=None,  # pylint: disable=too-many-arguments
                        password=None, compression=True, protocol_version=None,
-                       port=None, ssl_opts=None, connect_timeout=100):
+                       port=None, ssl_opts=None, connect_timeout=100, verbose=True):
         # TODO: ask Bentsi why it was reverted (PR #1236)
         node_ips = self.db_cluster.get_node_external_ips()
         wlrr = WhiteListRoundRobinPolicy(node_ips)
         return self._create_session(node, keyspace, user, password,
                                     compression, protocol_version, wlrr,
                                     port=port, ssl_opts=ssl_opts, node_ips=node_ips,
-                                    connect_timeout=connect_timeout)
+                                    connect_timeout=connect_timeout, verbose=verbose)
 
     def cql_connection_exclusive(self, node, keyspace=None, user=None,  # pylint: disable=too-many-arguments
                                  password=None, compression=True,
                                  protocol_version=None, port=None,
-                                 ssl_opts=None, connect_timeout=100):
+                                 ssl_opts=None, connect_timeout=100, verbose=True):
 
         wlrr = WhiteListRoundRobinPolicy([node.external_address])
         return self._create_session(node, keyspace, user, password,
                                     compression, protocol_version, wlrr,
                                     port=port, ssl_opts=ssl_opts, node_ips=[node.external_address],
-                                    connect_timeout=connect_timeout)
+                                    connect_timeout=connect_timeout, verbose=verbose)
 
     # TODO: Temporary function. Will be removed
     def get_rows_count(self, node, keyspace_name, table_name):
@@ -1031,7 +1032,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     def cql_connection_patient(self, node, keyspace=None,  # pylint: disable=too-many-arguments
                                user=None, password=None,
                                compression=True, protocol_version=None,
-                               port=None, ssl_opts=None, connect_timeout=100):
+                               port=None, ssl_opts=None, connect_timeout=100, verbose=True):
         """
         Returns a connection after it stops throwing NoHostAvailables.
 
@@ -1047,7 +1048,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                          user=None, password=None, timeout=30,
                                          compression=True,
                                          protocol_version=None,
-                                         port=None, ssl_opts=None, connect_timeout=100):
+                                         port=None, ssl_opts=None, connect_timeout=100, verbose=True):
         """
         Returns a connection after it stops throwing NoHostAvailables.
 

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -952,9 +952,10 @@ class FileFollowerThread():
 
 
 class ScyllaCQLSession:
-    def __init__(self, session, cluster):
+    def __init__(self, session, cluster, verbose=True):
         self.session = session
         self.cluster = cluster
+        self.verbose = verbose
 
     def __enter__(self):
         execute_orig = self.session.execute
@@ -967,7 +968,8 @@ class ScyllaCQLSession:
             LOGGER.debug(f"Executing CQL '{query}'...")
             return execute_orig(*args, **kwargs)
 
-        self.session.execute = execute_verbose
+        if self.verbose:
+            self.session.execute = execute_verbose
         return self.session
 
     def __exit__(self, exc_type, exc_val, exc_tb):


### PR DESCRIPTION
Add ability don't print executed query if not need

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
