### PR TITLE
fix(resharding nemesis): Decrease nodetool compactionstats calls from 5sec to 1min to avoid the noise

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2373,7 +2373,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
             return
 
-        resharding_finished = wait.wait_for(func=self._resharding_status, step=5,
+        # Decrease nodetool compactionstats calls from 5sec to 1min to avoid the noise
+        resharding_finished = wait.wait_for(func=self._resharding_status, step=60,
                                             text="Wait for re-sharding to be finished", status='finish')
 
         if not resharding_finished:


### PR DESCRIPTION

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
