### PR TITLE
fix(sct_events): EventsFilter broke all Events subscribers

### DIFF
--- a/sdcm/sct_events.py
+++ b/sdcm/sct_events.py
@@ -121,7 +121,7 @@ class EventsDevice(Process):
                     # specific node is bigger the time filter was canceled
                     for filter_key, filter_obj in list(filters.items()):
                         if filter_obj.expire_time and filter_obj.expire_time < obj.timestamp:
-                            if (isinstance(obj, DatabaseLogEvent) and filter_obj.node == obj.node) or \
+                            if (isinstance(obj, DatabaseLogEvent) and getattr(filter_obj, 'node', '') == obj.node) or \
                                     isinstance(filter_obj, EventsFilter):
                                 del filters[filter_key]
 


### PR DESCRIPTION
Fixed an issue when DatabaseLogEvent is the event that expires an EventFilter,
and that filter doesn't have a node field.
up until now the filter was only to DatabaseLogEvent, and always had a node field.

Fix: #2115

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
