### PR TITLE
fix(grow_shrink_nemesis): Fix GrowShrinkClusterNemesis for parallel run

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1882,6 +1882,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def disrupt_grow_shrink_cluster(self):
         add_nodes_number = self.tester.params.get('nemesis_add_node_cnt')
+        self.target_node.running_nemesis = None
 
         self._set_current_disruption("GrowCluster")
         self.log.info("Start grow cluster on %s nodes", add_nodes_number)


### PR DESCRIPTION
Fix for issue https://github.com/scylladb/scylla-cluster-tests/issues/2118

when cluster is shrinking, the targe node is changed, and this cause
that base target node, From which nemesis was started, stay with enabled
running_nemesis property. In parallel run, this become a reason, why no
free nodes left for nemesis

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
