### PR TITLE
fix(manager): changed get_cluster to accept empty cluster list table

### DIFF
--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -665,11 +665,11 @@ class ScyllaManagerTool(ScyllaManagerBase):
         # ╰──────────────────────────────────────┴──────────╯
         try:
             cluster_list = self.cluster_list
-            column_names = cluster_list[0]
-            if "ID" in column_names:
-                column_to_search = "ID"
-            else:
-                column_to_search = "cluster id"
+            column_to_search = "ID"
+            if cluster_list:
+                column_names = cluster_list[0]
+                if "cluster id" in column_names:
+                    column_to_search = "cluster id"
             cluster_id = self.sctool.get_table_value(parsed_table=cluster_list, column_name=column_to_search,
                                                      identifier=cluster_name)
         except ScyllaManagerError as ex:


### PR DESCRIPTION
Fixed a situation where the ScyllaManagerTool.get_cluster recieved an empty output
from the ScyllaManagerTool.cluster_list property, which happened whenever there were
no clusters connected to the scylla manager.
Previously, ScyllaManagerTool.get_cluster tried to index the empty list recieved from
ScyllaManagerTool.cluster_list, but now the function checks the list length beforehand

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
