### PR TITLE
fix(fill_db_data): sleep before creating index

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -2897,6 +2897,9 @@ class FillDatabaseData(ClusterTester):
         for item in self.all_verification_items:
             if not item['skip'] and ('skip_condition' not in item or eval(str(item['skip_condition']))):
                 for create_table in item['create_tables']:
+                    # wait a while before creating index, there is a delay of create table for waiting the schema agreement
+                    if 'CREATE INDEX' in create_table.upper():
+                        time.sleep(10)
                     session.execute(create_table)
                 for truncate in item['truncates']:
                     truncates.append(truncate)


### PR DESCRIPTION
Wait a while before creating index, there is a delay of create table for
waiting the schema agreement.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
