### PR TITLE
fix(common function): Add retrying decorator to get_non_system_ks_cf_list function

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1132,7 +1132,9 @@ def get_db_tables(session, ks, with_compact_storage=True):
             output.append(table)
     return output
 
-
+# Add @retrying to prevent situation when nemesis failed on connection timeout when try to receive the
+# keyspace and table for the test
+@retrying(n=5, sleep_time=5)
 def get_non_system_ks_cf_list(db_node, request_timeout=300, filter_out_table_with_counter=False,  # pylint: disable=too-many-arguments
                               filter_out_mv=False, filter_empty_tables=True):
     """Get all not system keyspace.tables pairs


### PR DESCRIPTION
Add @retrying to prevent situation when nemesis failed
on connection timeout when try to receive the keyspace and table for the test

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
