### PR TITLE
fix(ycsb_thread): remove exception logging on uninit metrics

### DIFF
--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -92,7 +92,6 @@ class YcsbStatsPublisher(FileFollowerThread):
                                     try:
                                         value = float(value) / 1000.0
                                     except ValueError:
-                                        LOGGER.exception("value isn't a number, default to 0")
                                         value = float(0)
                                 self.set_metric(operation, key, float(value))
 


### PR DESCRIPTION
seem like a bug in YCSB print some of the metrics as null or something
like that:

lot of the metric cause to lot of those exceptions
```
Traceback (most recent call last):
  File "/sct/sdcm/ycsb_thread.py", line 93, in run
    value = float(value) / 1000.0
ValueError: could not convert string to float: '�'
value isn't a number, default to 0
```

this commit is remove this log line, we are fine without see this
at the stdout

Ref: https://trello.com/c/6ryqzL2q

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
