### PR TITLE
fix(create_test_release_jobs): sct_base_dir wasn't configured correctly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -386,7 +386,7 @@ Creating pipeline jobs for new branch
 
 Once a new branch is create, we could build all the need job for this branch with the following script ::
 
-    JENKINS_USER=[jenkins username] JENKINS_PASS=[token from jenkins] hydra create-test-release-jobs scylla-4.0 --sct_branch branch-4.0
+    JENKINS_USERNAME=[jenkins username] JENKINS_PASSWORD=[token from jenkins] hydra create-test-release-jobs scylla-4.0 --sct_branch branch-4.0
 
 FAQ
 ====

--- a/utils/build_system/create_test_release_jobs.py
+++ b/utils/build_system/create_test_release_jobs.py
@@ -8,7 +8,7 @@ JOB_TEMPLATE = open(Path(__file__).parent / 'template.xml').read()
 class JenkinsPipelines:
     def __init__(self, username, password, base_job_dir, sct_branch_name, sct_repo):  # pylint: disable=too-many-arguments
         self.jenkins = jenkins.Jenkins('https://jenkins.scylladb.com', username=username, password=password)
-        self.base_sct_dir = Path(__file__).parent.parent
+        self.base_sct_dir = Path(__file__).parent.parent.parent
         self.base_job_dir = base_job_dir
         self.sct_branch_name = sct_branch_name
         self.sct_repo = sct_repo


### PR DESCRIPTION
seem like the refactoring of the directories broke it,
also the README wasn't accurate enough, to copy paste the command

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
