### PR TITLE
fix(spot fleet): spot fleet couldn't be built

### DIFF
--- a/sdcm/ec2_client.py
+++ b/sdcm/ec2_client.py
@@ -104,9 +104,8 @@ class EC2ClientWarpper():
         return request_ids
 
     def _request_spot_fleet(self, instance_type, image_id, region_name, network_if, key_pair='', user_data='', count=3,  # pylint: disable=too-many-arguments
-                            block_device_mappings=None, tags_list=None, aws_instance_profile=None):
+                            block_device_mappings=None, aws_instance_profile=None):
 
-        tags_list = tags_list if tags_list else []
         spot_price = self._get_spot_price(instance_type)
         fleet_config = {'LaunchSpecifications':
                         [
@@ -114,12 +113,6 @@ class EC2ClientWarpper():
                              'InstanceType': instance_type,
                              'NetworkInterfaces': network_if,
                              'Placement': {'AvailabilityZone': region_name},
-                             'TagSpecifications': [
-                                 {
-                                     'ResourceType': 'instance',
-                                     'Tags': tags_list
-                                 }
-                             ]
                              },
                         ],
                         'IamFleetRole': 'arn:aws:iam::797456418907:role/aws-ec2-spot-fleet-role',
@@ -297,7 +290,7 @@ class EC2ClientWarpper():
         self._client.create_tags(Resources=[instance_id], Tags=tags)
 
     def create_spot_instances(self, instance_type, image_id, region_name, network_if, key_pair='', user_data='',  # pylint: disable=too-many-arguments
-                              count=1, duration=0, block_device_mappings=None, tags_list=None, aws_instance_profile=None):
+                              count=1, duration=0, block_device_mappings=None, aws_instance_profile=None):
         """
         Create spot instances
 
@@ -309,14 +302,13 @@ class EC2ClientWarpper():
         :param user_data: user data to be passed to instances
         :param count: number of instances to launch
         :param duration: (optional) instance life time in minutes(multiple of 60)
-        :param tags_list: list of tags to assign to fleet instances
+        :param aws_instance_profile: instance profile granting access to S3 objects
 
         :return: list of instance id-s
         """
 
         # pylint: disable=too-many-locals
 
-        tags_list = tags_list if tags_list else []
         spot_price = self._get_spot_price(instance_type)
 
         request_ids = self._request_spot_instance(instance_type, image_id, region_name, network_if, spot_price['desired'],
@@ -338,7 +330,7 @@ class EC2ClientWarpper():
         return instances
 
     def create_spot_fleet(self, instance_type, image_id, region_name, network_if, key_pair='', user_data='', count=3,  # pylint: disable=too-many-arguments
-                          block_device_mappings=None, tags_list=None, aws_instance_profile=None):
+                          block_device_mappings=None, aws_instance_profile=None):
         """
         Create spot fleet
         :param instance_type: instance type
@@ -349,16 +341,15 @@ class EC2ClientWarpper():
         :param user_data: user data to be passed to instances
         :param count: number of instances to launch
         :param block_device_mappings:
-        :param tags_list: list of tags to assign to fleet instances
+        :param aws_instance_profile: instance profile granting access to S3 objects
+
         :return: list of instance id-s
         """
         # pylint: disable=too-many-locals
 
-        tags_list = tags_list if tags_list else []
-
         request_id = self._request_spot_fleet(instance_type, image_id, region_name, network_if, key_pair,
                                               user_data, count, block_device_mappings=block_device_mappings,
-                                              tags_list=tags_list, aws_instance_profile=aws_instance_profile)
+                                              aws_instance_profile=aws_instance_profile)
         instance_ids, resp = self._wait_for_fleet_request_done(request_id)
         if not instance_ids:
             err_code = MAX_SPOT_EXCEEDED_ERROR if resp == FLEET_LIMIT_EXCEEDED_ERROR else STATUS_ERROR


### PR DESCRIPTION
it happened because of a tag being passed empty, but
AWS requested to have something in it when passing
this parameter.
Spot instances don't send this parameter, hence removing
it from spot fleet instances too.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
