### PR TITLE
fix(validate_hh_short_downtime): don't run ValidateHintedHandoffShortDowntime nemesis if hinted_handoff is disabled

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1342,6 +1342,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             during short stop of one of the nodes in cluster
         """
         self._set_current_disruption("ValidateHintedHandoffShortDowntime")
+        if self.cluster.params.get('hinted_handoff', 'enabled') == 'disabled':
+            raise UnsupportedNemesis('For this nemesis to work, `hinted_handoff` needs to be set to `enabled`')
+
         start_time = time.time()
         self.target_node.stop_scylla()
         time.sleep(10)


### PR DESCRIPTION

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
