### PR TITLE
fix(sdcm/nemesis.py): Enable add drop column nemesis for c-s tables

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -110,8 +110,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self._add_drop_column_tables_to_ignore = {
             'scylla_bench': '*',  # Ignore scylla-bench tables
             'alternator_usertable': '*',  # Ignore alternator tables
-            'mview': 'users',  # Ignore MV user-profile tables
-            'sec_index': 'users',  # Ignore SI user-profile tables
             'ks_truncate': 'counter1',  # Ignore counter table
             'keyspace1': 'counter1',  # Ignore counter table
             # TODO: issue https://github.com/scylladb/scylla/issues/6074. Waiting for dev conclusions

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -129,6 +129,8 @@ class CassandraStressThread():  # pylint: disable=too-many-instance-attributes
             first_node = first_node[0] if first_node else self.node_list[0]
             stress_cmd += " -node {}".format(first_node.ip_address)
 
+        stress_cmd += ' -errors skip-unsupported-columns'
+
         return stress_cmd
 
     def _run_stress(self, node, loader_idx, cpu_idx, keyspace_idx):


### PR DESCRIPTION
https://trello.com/c/8TycZWE5/1929-enable-add-drop-column-nemesis
After https://github.com/scylladb/scylla-cluster-tests/pull/2138, issue that was causing https://github.com/scylladb/scylla-cluster-tests/pull/1858 become fixed and now we can roll it back.

Test run:
https://jenkins.scylladb.com/view/master/job/scylla-master/job/longevity/job/longevity-mv-si-4days-test-test/
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
