### PR TITLE
fix(manager): fixed test_client_encryption by using fail-fast option

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -283,7 +283,7 @@ class MgmtCliTest(ClusterTester):
         mgr_cluster = manager_tool.add_cluster(name=self.CLUSTER_NAME+"_encryption", db_cluster=self.db_cluster,
                                                auth_token=self.monitors.mgmt_auth_token)
         self.generate_load_and_wait_for_results()
-        repair_task = mgr_cluster.create_repair_task()
+        repair_task = mgr_cluster.create_repair_task(fail_fast=True)
         dict_host_health = mgr_cluster.get_hosts_health()
         for host_health in dict_host_health.values():
             assert host_health.ssl == HostSsl.OFF, "Not all hosts ssl is 'OFF'"

--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -372,8 +372,10 @@ class ManagerCluster(ScyllaManagerBase):
         LOGGER.debug("Created task id is: {}".format(task_id))
         return BackupTask(task_id=task_id, cluster_id=self.id, scylla_manager=self.manager_node)
 
-    def create_repair_task(self):
+    def create_repair_task(self, fail_fast=False):
         cmd = "repair -c {}".format(self.id)
+        if fail_fast:
+            cmd += " --fail-fast"
         res = self.sctool.run(cmd=cmd, parse_table_res=False)
         if not res:
             raise ScyllaManagerError("Unknown failure for sctool {} command".format(cmd))


### PR DESCRIPTION
Due to changes in the scylla manager code, a repair task does not fail immediately
when the target cluster enables its encryption, like it is expected to do in
test_client_encryption. To cause the repair task the test creates to fail as expected,
I've added the --fail-fast option to the command that creates it

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
