### PR TITLE
fix(upgrade_test): don't revert system.paxos change in rollback

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -271,7 +271,7 @@ class UpgradeTest(FillDatabaseData):
 
             node.remoter.run('sudo systemctl daemon-reload')
 
-        result = node.remoter.run('sudo find /var/lib/scylla/data/system')
+        result = node.remoter.run('sudo find /var/lib/scylla/data/system |grep -v paxos')
         snapshot_name = re.findall(r"system/peers-[a-z0-9]+/snapshots/(\d+)\n", result.stdout)
         # cmd = r"DIR='/var/lib/scylla/data/system'; for i in `sudo ls $DIR`;do sudo test -e $DIR/$i/snapshots/%s && sudo find $DIR/$i/snapshots/%s -type f -exec sudo /bin/cp {} $DIR/$i/ \;; done" % (snapshot_name[0], snapshot_name[0])
         # recover the system tables


### PR DESCRIPTION
We don't want to revert writes to system.paxos table, whose state is needed to
provide the linearizability guarantee for tables using LWT.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
