### PR TITLE
fix(nemesis): disable unstable streaming err nemesises

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2618,31 +2618,33 @@ class GeminiNonDisruptiveChaosMonkey(Nemesis):
         self.call_random_disrupt_method(disrupt_methods=self.disrupt_methods_list)
 
 
-class DecommissionStreamingErrMonkey(Nemesis):
-
-    disruptive = True
-
-    @log_time_elapsed_and_status
-    def disrupt(self):
-        self.disrupt_decommission_streaming_err()
-
-
-class RebuildStreamingErrMonkey(Nemesis):
-
-    disruptive = True
-
-    @log_time_elapsed_and_status
-    def disrupt(self):
-        self.disrupt_rebuild_streaming_err()
-
-
-class RepairStreamingErrMonkey(Nemesis):
-
-    disruptive = True
-
-    @log_time_elapsed_and_status
-    def disrupt(self):
-        self.disrupt_repair_streaming_err()
+# Disable unstable streaming err nemesises
+#
+# class DecommissionStreamingErrMonkey(Nemesis):
+#
+#     disruptive = True
+#
+#     @log_time_elapsed_and_status
+#     def disrupt(self):
+#         self.disrupt_decommission_streaming_err()
+#
+#
+# class RebuildStreamingErrMonkey(Nemesis):
+#
+#     disruptive = True
+#
+#     @log_time_elapsed_and_status
+#     def disrupt(self):
+#         self.disrupt_rebuild_streaming_err()
+#
+#
+# class RepairStreamingErrMonkey(Nemesis):
+#
+#     disruptive = True
+#
+#     @log_time_elapsed_and_status
+#     def disrupt(self):
+#         self.disrupt_repair_streaming_err()
 
 
 RELATIVE_NEMESIS_SUBCLASS_LIST = [NotSpotNemesis]

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1785,7 +1785,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             repair_logs = self.target_node.search_database_log(
                 'repair - Repair 1 out of', start_from_beginning=False, publish_events=False, severity=Severity.NORMAL)
             self.log.debug(repair_logs)
-            return len(streaming_logs) > 0 and len(repair_logs) > 0
+            return len(streaming_logs) > 0 or len(repair_logs) > 0
 
         wait.wait_for(func=is_streaming_started, timeout=200, step=1,
                       text='Wait for streaming starts', throw_exc=False)


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
