### PR TITLE
fix(gce-node): disable sshguard on gce ubuntu bionic/xenial

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -731,6 +731,7 @@ class Nemesis(object):  # pylint: disable=too-many-instance-attributes,too-many-
         """
             Alters a non-system table compaction strategy from ICS to any-other and vise versa.
         """
+        # pylint: disable=too-many-locals
         list_additional_params = get_compaction_random_additional_params()
         all_ks_cfs = get_non_system_ks_cf_list(db_node=self.target_node)
         non_mview_ks_cfs = get_non_system_ks_cf_list(db_node=self.target_node, filter_out_mv=True)

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -984,7 +984,7 @@ def tag_ami(ami_id, tags_dict, region_name):
     LOGGER.info("tagged %s with %s", ami_id, tags)
 
 
-def get_non_system_ks_cf_list(loader_node, db_node, request_timeout=300, filter_out_table_with_counter=False,
+def get_non_system_ks_cf_list(loader_node=None, db_node=None, request_timeout=300, filter_out_table_with_counter=False,
                               filter_out_mv=False):
     """Get all not system keyspace.tables pairs
 


### PR DESCRIPTION
(cherry picked from commit a7a3d5345b6a9ce051608aa101cb85f9cebb1df1)

(manually backport part of commit 657d8ddf14c0e499bb2c880e8ec3892d79e3429e)
Added extra_meta parameter for gce_create_metadata function.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
