### PR TITLE
fix(run_stress_thread): support to identify cs cmdline starts with JVM_OPTION

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -748,7 +748,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                       keyspace_name=keyspace_name, profile=profile, prefix=prefix, round_robin=round_robin,
                       stats_aggregate_cmds=stats_aggregate_cmds, use_single_loader=use_single_loader)
 
-        if stress_cmd.startswith('cassandra-stress'):
+        if 'cassandra-stress' in stress_cmd:  # cs cmdline might started with JVM_OPTION
             return self.run_stress_cassandra_thread(**params)
         elif stress_cmd.startswith('scylla-bench'):
             return self.run_stress_thread_bench(**params)


### PR DESCRIPTION
The cassandra-stress cmdline might be started with JVM_OPTION. It's adapted in
https://github.com/scylladb/scylla-cluster-tests/commit/f9fffc66c .
But https://github.com/scylladb/scylla-cluster-tests/commit/40203728e changed
this back.

In large-collection longevity, JVM_OPTION is used to increase memory.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
