### PR TITLE
fix(hints_sending_in_progress): is failing with "No results from Prom…

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1712,7 +1712,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
     @retrying(n=3, sleep_time=15, allowed_exceptions=(AssertionError,))
     def hints_sending_in_progress(self):
-        query = "sum(rate(scylla_hints_manager_sent{}[15s]))"
+        query = "sum(rate(scylla_hints_manager_sent{}[1m]))"
         now = time.time()
         # check status of sending hints during last minute range
         results = self.prometheus_db.query(query=query, start=now - 60, end=now)
@@ -1731,8 +1731,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         assert self.hints_sending_in_progress() is False, "Waiting until Prometheus hints counter will not change"
 
     def verify_no_drops_and_errors(self, starting_from):
-        q_dropped = "sum(rate(scylla_hints_manager_dropped{}[15s]))"
-        q_errors = "sum(rate(scylla_hints_manager_errors{}[15s]))"
+        q_dropped = "sum(rate(scylla_hints_manager_dropped{}[1m]))"
+        q_errors = "sum(rate(scylla_hints_manager_errors{}[1m]))"
         queries_to_check = [q_dropped, q_errors]
         for query in queries_to_check:
             results = self.prometheus_db.query(query=query, start=starting_from, end=time.time())


### PR DESCRIPTION
…etheus"

Seem like the scrape_interval was set to 20s in:
scylladb/scylla-monitoring@6acafea

Since our query was with 15s, it returned without data we should make our
range a bit bigger then the step (we are using scrape_interval for the step)
in the api call

Fixes: #2123

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
