### PR TITLE
fix(break_streaming_task_and_rebuild): added wait_db_up after reboot

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1820,8 +1820,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 'Streaming is not used. In latest Scylla, it is optional to use streaming for rebuild and decommission, and repair will not use streaming.')
         self.log.info('Recover the target node by a final rebuild')
         if new_node:
+            new_node.wait_db_up(verbose=True, timeout=300)
             new_node.run_nodetool('rebuild')
         else:
+            self.target_node.wait_db_up(verbose=True, timeout=300)
             self.target_node.run_nodetool('rebuild')
 
     def disrupt_decommission_streaming_err(self):


### PR DESCRIPTION
The RepairStreamingErr nemesis had incidents where the 'nodetool reboot'
command at the end of the test were executed before the target node's scylla service
was completely up, so I added calls to wait_db_up before the executions
of the command

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
