### PR TITLE
fix(abort_repair nemesis): fix pattern of active_repair API result

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1308,7 +1308,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             active_repair_cmd = 'curl -s -X GET --header "Content-Type: application/json" --header ' \
                                 '"Accept: application/json" "http://127.0.0.1:10000/storage_service/active_repair/"'
             result = self.target_node.remoter.run(active_repair_cmd)
-            active_repairs = re.match(r".*\[(\d)\].*", result.stdout)
+            active_repairs = re.match(r".*\[(\d)+\].*", result.stdout)
             if active_repairs:
                 self.log.debug("Found '%s' active repairs", active_repairs.group(1))
                 return True


### PR DESCRIPTION
active_repair API returns a list of repair task number, currently pattern can
only match one number. When the repair number is larger than 9,
repair_streaming_exists() can't identify the tasks.

Signed-off-by: Amos Kong <amos@scylladb.com>

Fixes https://github.com/scylladb/scylla-cluster-tests/issues/885

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)

-------
Known issue: 
```
Trim Trailing Whitespace.................................................Passed
Fix End of Files.........................................................Passed
Check Yaml...............................................................Passed
Check for added large files..............................................Passed
Check JSON...............................................................Passed
Detect AWS Credentials...................................................Passed
Detect Private Key.......................................................Passed
autopep8.................................................................Passed
pylint...................................................................Failed
hookid: pylint

************* Module unit_tests.test_utils_version
unit_tests/test_utils_version.py:1:0: R0801: Similar lines in 2 files
==sdcm.tester:2244
==unit_tests.test_events:75
    def store_test_result(  # pylint: disable=too-many-arguments
            self,
            source,
            message='',
            exception: Exception = '',
            trace='',
            severity=Severity.ERROR):
        if exception:
            exception = repr(exception)
            if exception[0] != '\n' and message[-1] != '\n':
                message += '\n'
            message += repr(exception)
        if trace:
            if message[0] != '\n':
                message += '\n'
            message += ('Traceback (most recent call last):\n' + ''.join(traceback.format_stack(trace)))
        results = getattr(self, '_results', None)
        if results is None:
            results = []
            setattr(self, '_results', results)
        results.append({
            'source': source,
            'message': message,
            'severity': severity,
        })

    def get_test_results(self, source, severity=None):
        output = []
        for result in getattr(self, '_results', []):
            if result.get('source', None) != source:
                continue
            if severity is not None and severity != result['severity']:
                continue
            output.append(result['message'])
        return output (duplicate-code)

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, -0.00)
```