### PR TITLE
fix(rolling-upgrade): Removed the use of rows_only from the test

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -897,7 +897,6 @@ class FillDatabaseData(ClusterTester):
                              AND compaction = { 'class' : 'SizeTieredCompactionStrategy',
                                                 'min_sstable_size' : 42 }
                              AND compression = { 'sstable_compression' : 'SnappyCompressor' }
-                             AND caching = 'rows_only'
                         """],
             'results': [[]],
             'min_version': '',


### PR DESCRIPTION
Due to issues with the use of the caching = 'rows_only' in the test,
https://github.com/scylladb/scylla/issues/6470, it was decided to remove it
completely from the test

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
