### PR TITLE
fix(manager): fixed the name of the root disk in the debian sanity

### DIFF
--- a/jenkins-pipelines/manager/debian9-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/debian9-manager-sanity.jenkinsfile
@@ -13,6 +13,7 @@ managerPipeline(
     test_config: 'test-cases/manager/manager-regression-multiDC-set-distro.yaml',
     ami_id_monitor: 'ami-0cfac3931b2a799d1', // Debian stretch image
     ami_monitor_user: 'admin',
+    aws_root_disk_name_monitor: '/dev/xvda',
     scylla_repo_m: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/debian/scylla-2019.1-stretch.list',
 
     timeout: [time: 500, unit: 'MINUTES'],

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -158,6 +158,10 @@ def call(Map pipelineParams) {
                                         export SCT_SCYLLA_MGMT_PKG="${params.scylla_mgmt_pkg}"
                                     fi
 
+                                    if [[ ! -z "${params.aws_root_disk_name_monitor}" ]] ; then
+                                        export SCT_AWS_ROOT_DISK_NAME_MONITOR="${params.aws_root_disk_name_monitor}"
+                                    fi
+
                                     echo "start test ......."
                                     ./docker/env/hydra.sh run-test ${pipelineParams.test_name} --backend ${params.backend}  --logdir /sct
                                     echo "end test ....."


### PR DESCRIPTION
Since debian machines require a different root disk name, I changed the
device name in the manager's debian sanity to '/dev/xvda'

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
