### PR TITLE
feature(manager): Revamped create_repair_task and create_backup_task

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -221,7 +221,7 @@ class MgmtCliTest(ClusterTester):
         mgr_cluster = manager_tool.add_cluster(name=self.CLUSTER_NAME + '_basic', db_cluster=self.db_cluster,
                                                auth_token=self.monitors.mgmt_auth_token)
         self.generate_load_and_wait_for_results()
-        backup_task = mgr_cluster.create_backup_task({'location': location_list})
+        backup_task = mgr_cluster.create_backup_task(location_list=location_list)
         backup_task.wait_for_status(list_status=[TaskStatus.DONE])
         self.verify_backup_success(mgr_cluster=mgr_cluster, backup_task=backup_task)
         self.log.info('finishing test_basic_backup')
@@ -238,7 +238,7 @@ class MgmtCliTest(ClusterTester):
         self.generate_load_and_wait_for_results()
         self.log.debug(f'tables list = {tables}')
         # TODO: insert data to those tables
-        backup_task = mgr_cluster.create_backup_task({'location': location_list})
+        backup_task = mgr_cluster.create_backup_task(location_list=location_list)
         backup_task.wait_for_status(list_status=[TaskStatus.DONE], timeout=10800)
         self.verify_backup_success(mgr_cluster=mgr_cluster, backup_task=backup_task)
         self.log.info('finishing test_backup_multiple_ks_tables')
@@ -254,7 +254,7 @@ class MgmtCliTest(ClusterTester):
                                                auth_token=self.monitors.mgmt_auth_token)
         self.generate_load_and_wait_for_results()
         try:
-            mgr_cluster.create_backup_task({'location': location_list})
+            mgr_cluster.create_backup_task(location_list=location_list)
         except ScyllaManagerError as error:
             self.log.info(f'Expected to fail - error: {error}')
         self.log.info('finishing test_backup_location_with_path')
@@ -268,9 +268,9 @@ class MgmtCliTest(ClusterTester):
         mgr_cluster = manager_tool.add_cluster(name=self.CLUSTER_NAME + '_rate_limit', db_cluster=self.db_cluster,
                                                auth_token=self.monitors.mgmt_auth_token)
         self.generate_load_and_wait_for_results()
-        rate_limit = ','.join([f'{dc}:{randint(1, 10)}' for dc in self.get_all_dcs_names()])
-        self.log.info(f'rate limit will be {rate_limit}')
-        backup_task = mgr_cluster.create_backup_task({'location': location_list, 'rate-limit': rate_limit})
+        rate_limit_list = [f'{dc}:{randint(1, 10)}' for dc in self.get_all_dcs_names()]
+        self.log.info(f'rate limit will be {rate_limit_list}')
+        backup_task = mgr_cluster.create_backup_task(location_list=location_list, rate_limit_list=rate_limit_list)
         task_status = backup_task.wait_and_get_final_status()
         self.log.info(f'backup task finished with status {task_status}')
         # TODO: verify that the rate limit is as set in the cmd

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1258,7 +1258,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         region = self.cluster.params.get('region_name').split()
         for node in self.cluster.nodes:
             update_config_file(node=node, region=region[0])
-        mgr_task = mgr_cluster.create_backup_task({'location': ['s3:{}'.format(bucket_location_name[0])]})
+        mgr_task = mgr_cluster.create_backup_task(location_list=['s3:{}'.format(bucket_location_name[0])])
 
         succeeded, status = mgr_task.wait_for_task_done_status(timeout=54000)
         if succeeded and status == TaskStatus.DONE:


### PR DESCRIPTION
Revamped the create_repair_task and create_backup_task functions to be able to
use all of the args the manager's 'sctool repair' and 'sctool backup' commands
can accept, accordingly

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
