### PR TITLE
fix(sdcm/stress_thread.py): Fix logic of adding errors option

### DIFF
--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -128,10 +128,15 @@ class CassandraStressThread():  # pylint: disable=too-many-instance-attributes
                           3]  # make sure each loader is targeting on datacenter/region
             first_node = first_node[0] if first_node else self.node_list[0]
             stress_cmd += " -node {}".format(first_node.ip_address)
-
-        stress_cmd += ' -errors skip-unsupported-columns'
-
+        stress_cmd = self._add_errors_option(stress_cmd, ['skip-unsupported-columns'])
         return stress_cmd
+
+    @staticmethod
+    def _add_errors_option(stress_cmd: str, to_add: list):
+        to_add = (' '.join(to_add))
+        if ' -errors' not in stress_cmd:
+            return stress_cmd + ' -errors ' + to_add
+        return re.sub('-errors([ ]+[^-][a-zA-Z0-9-]+)+([ ]* -[a-z]+|[ ]*)', '-errors\\1 ' + to_add + '\\2', stress_cmd)
 
     def _run_stress(self, node, loader_idx, cpu_idx, keyspace_idx):
         stress_cmd = self.create_stress_cmd(node, loader_idx, keyspace_idx)


### PR DESCRIPTION
https://trello.com/c/h05Y8SxI/1965-fix-c-s-thread-in-case-when-errors-is-provided

Currently we add -errors to c-s command line no matter what, this logic fails when -errors is provided in yaml file.

For example if stress commnad is defined as 
cassandra-stress user profile=/tmp/cs_profile_background_reads_overload.yaml ops'(insert=100)' no-warmup cl=ONE duration=10m -port jmx=6868 -mode cql3 native -rate threads=1500 -errors ignore -node 10.0.110.171

Than we endup with:
cassandra-stress user profile=/tmp/cs_profile_background_reads_overload.yaml ops'(insert=100)' no-warmup cl=ONE duration=10m -port jmx=6868 -mode cql3 native -rate threads=1500 -errors ignore -node 10.0.110.171 -errors skip-unsupported-columns

Which is resulted in synatx error.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
