### PR TITLE
fix(repositories): stop using private repo url

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -3,8 +3,8 @@ db_type: "scylla"
 ip_ssh_connections: 'private'
 
 mgmt_port: 10090
-scylla_repo_m: 'http://repositories.scylladb.com/scylla/repo/qa-test/centos/scylladb-2019.1.repo'
-scylla_mgmt_repo: 'https://repositories.scylladb.com/scylla/repo/qa-test/centos/scylladb-manager-2.0.repo'
+scylla_repo_m: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-2019.1.repo'
+scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-2.0.repo'
 mgmt_segments_per_repair: 10
 
 experimental: true


### PR DESCRIPTION
since all the issues we having lately,
we are moving to download directly from s3

```
file: file:///etc/yum.repos.d/scylla-manager.repo, line: 1
'{errorMessage=RequestId: ed45ba07-46e7-42fa-a626-a5cef8d87fe8
Process exited before completing request}'
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
