### PR TITLE
fix(run_stress_thread_bench): local variable 'result' referenced before assignment

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3838,6 +3838,7 @@ class BaseLoaderSet():
             # Select first seed node to send the scylla-bench cmds
             ips = node_list[0].private_ip_address
 
+            result = None
             try:
                 result = node.remoter.run(
                     cmd="/$HOME/go/bin/{name} -nodes {ips}".format(name=stress_cmd.strip(), ips=ips),
@@ -3851,7 +3852,8 @@ class BaseLoaderSet():
 
             ScyllaBenchEvent(type='finish', node=str(node), stress_cmd=stress_cmd, log_file_name=log_file_name)
 
-            _queue[RES_QUEUE].put((node, result))
+            if result is not None:
+                _queue[RES_QUEUE].put((node, result))
             _queue[TASK_QUEUE].task_done()
 
         if round_robin:


### PR DESCRIPTION
[Task](https://trello.com/c/1M6UtZ7R/1964-sdcm-clusterpy-runstressthreadbench-has-reference-before-assigment?menu=filter&filter=member:juliayakovlev1)

If scylla-bench thread finish with exception, local variable result is not defined

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
