### PR TITLE
feature(stop_test_on_failure): don't fail the test if slave cassandra-stress thread failed

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -688,7 +688,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         # if keyspace doesn't exist, create it by cassandra-stress
         if ks not in test_keyspaces:
             stress_cmd = "cassandra-stress write n=400000 cl=QUORUM -port jmx=6868 -mode native cql3 -schema 'replication(factor=3)' -log interval=5"
-            cs_thread = self.tester.run_stress_thread(stress_cmd=stress_cmd, keyspace_name=ks)
+            cs_thread = self.tester.run_stress_thread(
+                stress_cmd=stress_cmd, keyspace_name=ks, stop_test_on_failure=False)
             cs_thread.verify_results()
 
     def disrupt_truncate(self):

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -77,7 +77,7 @@ class CassandraStressEventsPublisher(FileFollowerThread):
 
 class CassandraStressThread():  # pylint: disable=too-many-instance-attributes
     def __init__(self, loader_set, stress_cmd, timeout, stress_num=1, keyspace_num=1, keyspace_name='',  # pylint: disable=too-many-arguments
-                 profile=None, node_list=None, round_robin=False, client_encrypt=False):
+                 profile=None, node_list=None, round_robin=False, client_encrypt=False, stop_test_on_failure=True):
         if not node_list:
             node_list = []
         self.loader_set = loader_set
@@ -90,6 +90,7 @@ class CassandraStressThread():  # pylint: disable=too-many-instance-attributes
         self.node_list = node_list
         self.round_robin = round_robin
         self.client_encrypt = client_encrypt
+        self.stop_test_on_failure = stop_test_on_failure
 
         self.executor = None
         self.results_futures = []
@@ -138,7 +139,7 @@ class CassandraStressThread():  # pylint: disable=too-many-instance-attributes
             return stress_cmd + ' -errors ' + to_add
         return re.sub('-errors([ ]+[^-][a-zA-Z0-9-]+)+([ ]* -[a-z]+|[ ]*)', '-errors\\1 ' + to_add + '\\2', stress_cmd)
 
-    def _run_stress(self, node, loader_idx, cpu_idx, keyspace_idx):
+    def _run_stress(self, node, loader_idx, cpu_idx, keyspace_idx):  # pylint: disable=too-many-locals
         stress_cmd = self.create_stress_cmd(node, loader_idx, keyspace_idx)
 
         if self.profile:
@@ -183,8 +184,12 @@ class CassandraStressThread():  # pylint: disable=too-many-instance-attributes
                                           log_file=log_file_name)
             except Exception as exc:  # pylint: disable=broad-except
                 errors_str = format_stress_cmd_error(exc)
-                CassandraStressEvent(type='failure', node=str(node), stress_cmd=stress_cmd,
-                                     log_file_name=log_file_name, severity=Severity.CRITICAL,
+
+                event_type = 'failure' if self.stop_test_on_failure else 'error'
+                event_severity = Severity.CRITICAL if self.stop_test_on_failure else Severity.ERROR
+
+                CassandraStressEvent(type=event_type, node=str(node), stress_cmd=stress_cmd,
+                                     log_file_name=log_file_name, severity=event_severity,
                                      errors=[errors_str])
 
         CassandraStressEvent(type='finish', node=str(node), stress_cmd=stress_cmd, log_file_name=log_file_name)


### PR DESCRIPTION
Add possibility to decide if fail or not the test in case the cassandra-stress load failed:
- If it's main c-s thread -send CRITICAL event and fail the test
- If it's c-s thread from nemesis - send ERROR event and don't
fail the test

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
