### PR TITLE
improvement(paramiko-logging): set paramiko log level to critical in …

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -406,6 +406,8 @@ def show_monitor(test_id, date_time, kill):
 @investigate.command('search-builder', help='Search builder where test run with test-id located')
 @click.argument('test-id')
 def search_builder(test_id):
+    logging.getLogger("paramiko").setLevel(logging.CRITICAL)
+
     results = get_builder_by_test_id(test_id)
     tbl = PrettyTable(['Builder Name', "Public IP", "path"])
     tbl.align = 'l'
@@ -481,6 +483,7 @@ def cloud_usage_report(emails):
 @click.option('--config-file', type=str, help='config test file path')
 def collect_logs(test_id=None, logdir=None, backend='aws', config_file=None):
     from sdcm.logcollector import Collector
+    logging.getLogger("paramiko").setLevel(logging.CRITICAL)
     if not os.environ.get('SCT_CLUSTER_BACKEND', None):
         os.environ['SCT_CLUSTER_BACKEND'] = backend
     if config_file and not os.environ.get('SCT_CONFIG_FILES', None):


### PR DESCRIPTION
…hydra command

Till now, when running  `hydra investigate search-builder` and `hydra collect-logs`
we received tons of log messages like this:
```
08:40:30  Connected (version 2.0, client OpenSSH_7.4)
08:40:30  Authentication (publickey) successful!
08:40:30  Connected (version 2.0, client OpenSSH_7.4)
08:40:30  Connected (version 2.0, client OpenSSH_7.4)
08:40:30  Authentication (publickey) successful!
```
This commit set the log level of paramiko to show critical errors only

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
