### PR TITLE
fix(artifacts-ami): increase timeout of ami-test

### DIFF
--- a/jenkins-pipelines/artifacts-ami.jenkinsfile
+++ b/jenkins-pipelines/artifacts-ami.jenkinsfile
@@ -10,7 +10,7 @@ artifactsPipeline(
     backend: 'aws',
     instance_provision: 'spot_low_price',
 
-    timeout: [time: 30, unit: 'MINUTES'],
+    timeout: [time: 45, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     builds_to_keep: '100'
 )


### PR DESCRIPTION
There is a 1 minute delay/stuck with i3.metal, because locking memory is slower
on the special type of instance.

40 mins should be enough for the AMI-test with i3.metal, let's increase
the general timeout for all ami-tests to 45 mins.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
