### PR TITLE
fix(sdcm/stress_thread.py): don't add skip-unsupported-columns if it is not supported

### DIFF
--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -129,7 +129,8 @@ class CassandraStressThread():  # pylint: disable=too-many-instance-attributes
                           3]  # make sure each loader is targeting on datacenter/region
             first_node = first_node[0] if first_node else self.node_list[0]
             stress_cmd += " -node {}".format(first_node.ip_address)
-        stress_cmd = self._add_errors_option(stress_cmd, ['skip-unsupported-columns'])
+        if 'skip-unsupported-columns' in self._get_available_suboptions(node, '-errors'):
+            stress_cmd = self._add_errors_option(stress_cmd, ['skip-unsupported-columns'])
         return stress_cmd
 
     @staticmethod
@@ -138,6 +139,16 @@ class CassandraStressThread():  # pylint: disable=too-many-instance-attributes
         if ' -errors' not in stress_cmd:
             return stress_cmd + ' -errors ' + to_add
         return re.sub('-errors([ ]+[^-][a-zA-Z0-9-]+)+([ ]* -[a-z]+|[ ]*)', '-errors\\1 ' + to_add + '\\2', stress_cmd)
+
+    def _get_available_suboptions(self, node, option):
+        try:
+            result = node.remoter.run(
+                cmd=f'cassandra-stress help {option} | grep "^Usage:"',
+                timeout=self.timeout,
+                ignore_status=True).stdout
+        except Exception:  # pylint: disable=broad-except
+            return []
+        return re.findall(r' *\[([\w-]+?)[=?]*\] *', result)
 
     def _run_stress(self, node, loader_idx, cpu_idx, keyspace_idx):  # pylint: disable=too-many-locals
         stress_cmd = self.create_stress_cmd(node, loader_idx, keyspace_idx)


### PR DESCRIPTION
https://trello.com/c/aH8E4OAG/1972-only-add-skip-unsupported-columns-parameter-when-the-current-c-s-supports-it?menu=filter&filter=member:dmitrykropachev

skip-unsupported-columns parameter is a new iterm for -errors option of cassandra-stress.

It's added by scylladb/scylla-tools-java: d3e5bbe on Mar 25.The commit had been backported scylla-tool-java 4.1.
But in Upgrade test of 4.1, we installed scylla-tool-java 4.0 packages on the loader. The new parameter doesn't exist, it caused the test failed.Hi Dmitry,
We should only add skip-unsupported-columns parameter when the current c-s supports it.
test job: https://jenkins.scylladb.com/view/scylla-4.1/job/scylla-4.1/job/rolling-upgrade/job/rolling-upgrade-centos7-test/9/console

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
