### PR TITLE
fix(docker): filter out current container from the list of containers

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -59,6 +59,7 @@ from sdcm.utils.decorators import retrying
 
 LOGGER = logging.getLogger('utils')
 DEFAULT_AWS_REGION = "eu-west-1"
+DOCKER_CGROUP_RE = re.compile("/docker/([0-9a-f]+)")
 
 
 def deprecation(message):
@@ -454,6 +455,15 @@ def clean_cloud_resources(tags_dict):
     return True
 
 
+def docker_current_container_id() -> Optional[str]:
+    with open("/proc/1/cgroup") as cgroup:
+        for line in cgroup:
+            match = DOCKER_CGROUP_RE.search(line)
+            if match:
+                return match.group(1)
+    return None
+
+
 def list_clients_docker(builder_name: Optional[str] = None, verbose: bool = False) -> Dict[str, docker.DockerClient]:
     log = LOGGER if verbose else Mock()
     docker_clients = {}
@@ -499,6 +509,8 @@ def list_resources_docker(tags_dict: Optional[dict] = None,
     log = LOGGER if verbose else Mock()
     filters = {}
 
+    current_container_id = docker_current_container_id()
+
     if tags_dict:
         filters["label"] = [f"{key}={value}" for key, value in tags_dict.items()]
 
@@ -508,6 +520,8 @@ def list_resources_docker(tags_dict: Optional[dict] = None,
     def get_containers(builder_name: str, docker_client: docker.DockerClient) -> None:
         log.info("%s: scan for Docker containers", builder_name)
         containers_list = docker_client.containers.list(filters=filters, sparse=True)
+        if current_container_id:
+            containers_list = [container for container in containers_list if container.id != current_container_id]
         if running:
             containers_list = [container for container in containers_list if container.status == "running"]
         else:


### PR DESCRIPTION
Do not shoot own leg: in case of trying to clean resources for yourself it will try to kill hydra which run `clean-resources` command.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
