### PR TITLE
fix(get_latest_gemini_version): Fix get latest version of gemini

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -52,6 +52,7 @@ import libcloud.storage.types
 import yaml
 from libcloud.compute.providers import get_driver
 from libcloud.compute.types import Provider
+from packaging.version import Version
 
 from sdcm.utils.ssh_agent import SSHAgent
 from sdcm.utils.decorators import retrying
@@ -245,11 +246,10 @@ def get_latest_gemini_version():
     bucket_name = 'downloads.scylladb.com'
 
     results = S3Storage(bucket_name).search_by_path(path='gemini')
-    versions = set()
-    for result_file in results:
-        versions.add(result_file.split('/')[1])
+    versions = {Version(result_file.split('/')[1]) for result_file in results}
+    latest_version = max(versions)
 
-    return str(sorted(versions)[-1])
+    return latest_version.public
 
 
 def list_logs_by_test_id(test_id):


### PR DESCRIPTION
Once gemini 1.6.10 was release, the sorting of gemini version work incorrectly
and return wrong latest gemini version

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
