### PR TITLE
fix(sdcm/sct_events.py): Add log message on error while reading events file

### DIFF
--- a/sdcm/sct_events.py
+++ b/sdcm/sct_events.py
@@ -919,9 +919,10 @@ class EventsFileLogger(Process):  # pylint: disable=too-many-instance-attributes
                         if limit and len(events_bucket) >= limit:
                             events_bucket.pop(0)
                         events_bucket.append(event)
-            except Exception:  # pylint: disable=broad-except
+            except Exception as exc:  # pylint: disable=broad-except
+                LOGGER.info("failed to read %s file, due to the %s", events_file_path, str(exc))
                 if not output.get(severity.name, None):
-                    output[severity.name] = []
+                    output[severity.name] = [f"failed to read {events_file_path} file, due to the {str(exc)}"]
         return output
 
 


### PR DESCRIPTION
https://trello.com/c/Tpy6l70b/1973-longevities-could-show-no-critical-events-when-event-limit-is-reached-for-the-report

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
