### PR TITLE
fix(refresh nemesis): recreate snapshot without COMPACT STORAGE

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -513,7 +513,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self._set_current_disruption('MajorCompaction %s' % self.target_node)
         self.target_node.run_nodetool("compact")
 
-    def _disable_disrupt_nodetool_refresh(self, big_sstable=True, skip_download=False):
+    def disrupt_nodetool_refresh(self, big_sstable=True, skip_download=False):
         self._set_current_disruption('Refresh keyspace1.standard1 on {}'.format(self.target_node.name))
         if big_sstable:
             # 100G, the big file will be saved to GCE image
@@ -522,14 +522,14 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             #        We had a solution to save the file in GCE image, it requires bigger boot disk.
             #        In my old test, the instance init is easy to fail. We can try to use a
             #        split shared disk to save the 100GB file.
-            sstable_url = 'https://s3.amazonaws.com/scylla-qa-team/keyspace1.standard1.tar.gz'
-            sstable_file = "/tmp/keyspace1.standard1.tar.gz"
-            sstable_md5 = '76cca3135e175d859c0efb67c6a7b233'
-        else:
-            # 100M (300000 rows)
-            sstable_url = 'https://s3.amazonaws.com/scylla-qa-team/keyspace1.standard1.100M.tar.gz'
+            # 100M (500000 rows)
+            sstable_url = 'https://s3.amazonaws.com/scylla-qa-team/refresh_nemesis/keyspace1.standard1.100M.tar.gz'
             sstable_file = '/tmp/keyspace1.standard1.100M.tar.gz'
-            sstable_md5 = 'f641f561067dd612ff95f2b89bd12530'
+            sstable_md5 = '9c5dd19cfc78052323995198b0817270'
+        else:
+            sstable_url = 'https://s3.amazonaws.com/scylla-qa-team/refresh_nemesis/keyspace1.standard1.tar.gz'
+            sstable_file = "/tmp/keyspace1.standard1.tar.gz"
+            sstable_md5 = 'c033a3649a1aec3ba9b81c446c6eecfd'
         if not skip_download:
             key_store = KeyStore()
             creds = key_store.get_scylladb_upload_credentials()
@@ -546,8 +546,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.target_node.remoter.run('sudo tar xvfz {} -C /var/lib/scylla/data/keyspace1/{}/upload/'.format(
                 sstable_file, upload_dir))
             self.target_node.run_nodetool(sub_cmd="refresh", args="-- keyspace1 standard1")
-            cmd = "select * from keyspace1.standard1 where key=0x314e344b4d504d4b4b30"
-            self.target_node.run_cqlsh(cmd)
+            cmd = "select * from keyspace1.standard1 where key=0x32373131364f334f3830"
+            result = self.target_node.run_cqlsh(cmd)
+            assert '(1 rows)' in result.stdout, 'The key is not loaded by `nodetool refresh`'
 
     def disrupt_nodetool_enospc(self, sleep_time=30, all_nodes=False):
         if all_nodes:
@@ -2129,22 +2130,22 @@ class MajorCompactionMonkey(Nemesis):
         self.disrupt_major_compaction()
 
 
-# class RefreshMonkey(Nemesis):
-#     disruptive = False
-#     run_with_gemini = False
-#
-#     @log_time_elapsed_and_status
-#     def disrupt(self):
-#         self.disrupt_nodetool_refresh()
+class RefreshMonkey(Nemesis):
+    disruptive = False
+    run_with_gemini = False
+
+    @log_time_elapsed_and_status
+    def disrupt(self):
+        self.disrupt_nodetool_refresh()
 
 
-# class RefreshBigMonkey(Nemesis):
-#     disruptive = False
-#     run_with_gemini = False
-#
-#     @log_time_elapsed_and_status
-#     def disrupt(self):
-#         self.disrupt_nodetool_refresh(big_sstable=True, skip_download=True)
+class RefreshBigMonkey(Nemesis):
+    disruptive = False
+    run_with_gemini = False
+
+    @log_time_elapsed_and_status
+    def disrupt(self):
+        self.disrupt_nodetool_refresh(big_sstable=True, skip_download=False)
 
 
 class EnospcMonkey(Nemesis):


### PR DESCRIPTION
The default created schema of CS doesn't have COMPACT STORAGE, it caused
the Refresh nemesis failed, I had recreated the snapshot and uploaded to
s3.

1. Created keyspace1 and standard1 by:
 # cassandra-stress write no-warmup n=0

2. Prepare data for small snapshot
 # cassandra-stress write no-warmup n=1000 -pop seq=2000000000..2000001000

2. Additional data for 100M snapshot
 # cassandra-stress write no-warmup n=500000 -pop seq=3000000000..3000500000

$ du -sh *
99M	keyspace1.standard1.100M.tar.gz
204K	keyspace1.standard1.tar.gz

$ md5sum /tmp/new/*
9c5dd19cfc78052323995198b0817270  /tmp/new/keyspace1.standard1.100M.tar.gz
c033a3649a1aec3ba9b81c446c6eecfd  /tmp/new/keyspace1.standard1.tar.gz

 # Schema of keyspace1.standard1
CREATE KEYSPACE keyspace1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}  AND durable_writes = true;

CREATE TABLE keyspace1.standard1 (
    key blob PRIMARY KEY,
    "C0" blob,
    "C1" blob,
    "C2" blob,
    "C3" blob,
    "C4" blob
) WITH bloom_filter_fp_chance = 0.01
    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
    AND comment = ''
    AND compaction = {'class': 'SizeTieredCompactionStrategy'}
    AND compression = {}
    AND crc_check_chance = 1.0
    AND dclocal_read_repair_chance = 0.1
    AND default_time_to_live = 0
    AND gc_grace_seconds = 864000
    AND max_index_interval = 2048
    AND memtable_flush_period_in_ms = 0
    AND min_index_interval = 128
    AND read_repair_chance = 0.0
    AND COMPACT STORAGE
    AND speculative_retry = '99.0PERCENTILE';

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
