### PR TITLE
fix(upgrade_test): generate random order before complex workload

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -463,6 +463,13 @@ class UpgradeTest(FillDatabaseData):
                 self.insert_rows = 10
                 self.fill_db_data_for_truncate_test(insert_rows=self.insert_rows)
 
+        # generate random order to upgrade
+        nodes_num = len(self.db_cluster.nodes)
+        # prepare an array containing the indexes
+        indexes = list(range(nodes_num))
+        # shuffle it so we will upgrade the nodes in a random order
+        random.shuffle(indexes)
+
         with self.subTest('pre-test - Run stress workload before upgrade'):
             # complex workload: prepare write
             self.log.info('Starting c-s complex workload (5M) to prepare data')
@@ -472,14 +479,6 @@ class UpgradeTest(FillDatabaseData):
 
             # wait for the complex workload to finish
             self.verify_stress_thread(complex_cs_thread_pool)
-
-            # generate random order to upgrade
-            nodes_num = len(self.db_cluster.nodes)
-            # prepare an array containing the indexes
-            indexes = list(range(nodes_num))
-            # shuffle it so we will upgrade the nodes in a
-            # random order
-            random.shuffle(indexes)
 
             # prepare write workload
             self.log.info('Starting c-s prepare write workload (n=10000000)')


### PR DESCRIPTION
Currently the random order is generated after complex workload finishes,
if the workload fails, rest sub-steps might fail for UnboundLocalError
(local variable 'indexes' referenced before assignment).

This moved the random order generate before this sub-test.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
