### PR TITLE
fix(perf-regression-latency): Increase scylla-release-perf-regression…

### DIFF
--- a/jenkins-pipelines/perf-regression-latency-1TB.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-1TB.jenkinsfile
@@ -12,5 +12,5 @@ perfRegressionParallelPipeline(
     test_config: "test-cases/performance/perf-regression-latency-1TB.yaml",
     sub_tests: ["test_latency"],
 
-    timeout: [time: 400, unit: "MINUTES"]
+    timeout: [time: 500, unit: "MINUTES"]
 )


### PR DESCRIPTION
…-aws-test-latency timeout

The test itself taking 6:40 not leaving enough time to collect logs.
