### PR TITLE
fix(sdcm/cluster_docker.py): fix monitoring node on docker backend

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -72,7 +72,7 @@ docker run --rm ${TTY_STDIN} --privileged \
     -l "TestId=${SCT_TEST_ID}" \
     -l "RunByUser=$(python3 "${SCT_DIR}/sdcm/utils/get_username.py")" \
     -v /var/run:/run \
-    -v "${SCT_DIR}:${WORK_DIR}" \
+    -v "${SCT_DIR}:${SCT_DIR}" \
     -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
     -v /tmp:/tmp \
     -v /var/tmp:/var/tmp \
@@ -80,8 +80,9 @@ docker run --rm ${TTY_STDIN} --privileged \
     -v /etc/passwd:/etc/passwd:ro \
     -v /etc/group:/etc/group:ro \
     -v /etc/sudoers:/etc/sudoers:ro \
+    -v /etc/sudoers.d/:/etc/sudoers.d:ro \
     -v /etc/shadow:/etc/shadow:ro \
-    -w "${WORK_DIR}" \
+    -w "${SCT_DIR}" \
     -e JOB_NAME="${JOB_NAME}" \
     -e BUILD_URL="${BUILD_URL}" \
     -e _SCT_BASE_DIR="${SCT_DIR}" \
@@ -95,4 +96,4 @@ docker run --rm ${TTY_STDIN} --privileged \
     --net=host \
     --name=${SCT_TEST_ID} \
     ${DOCKER_REPO}:${VERSION} \
-    /bin/bash -c "${TERM_SET_SIZE} eval '${CMD}'"
+    /bin/bash -c "sudo ln -s '${SCT_DIR}' '${WORK_DIR}'; ${TERM_SET_SIZE} eval '${CMD}'"

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4114,6 +4114,7 @@ class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-inst
 
     def download_scylla_monitoring(self, node):
         install_script = dedent("""
+            sudo rm -rf {0.monitor_install_path_base}
             mkdir -p {0.monitor_install_path_base}
             cd {0.monitor_install_path_base}
             wget https://github.com/scylladb/scylla-monitoring/archive/{0.monitor_branch}.zip

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -17,7 +17,6 @@
 import os
 import re
 import logging
-import pathlib
 from typing import Optional, Union, Dict
 
 from sdcm import cluster
@@ -374,13 +373,6 @@ class MonitorSetDocker(cluster.BaseMonitorSet, DockerCluster):  # pylint: disabl
     @staticmethod
     def install_scylla_monitoring_prereqs(node):  # pylint: disable=invalid-name
         pass  # since running local, don't install anything, just the monitor
-
-    @staticmethod
-    def get_monitor_install_path_base(node):
-        base_dir = os.environ.get("_SCT_BASE_DIR", None)
-        logdir = pathlib.Path(node.logdir)
-        logdir = pathlib.Path(base_dir).joinpath(*logdir.parts[2:]) if base_dir else logdir
-        return str(logdir)
 
     def get_backtraces(self):
         pass


### PR DESCRIPTION
https://trello.com/c/72lAXfcU/1980-fix-docker-monitoring-node
After https://github.com/scylladb/scylla-cluster-tests/pull/2008, docker monitoring is using working directory, problem that we are not mounting it, so it does not work.
This fix changes it to use /sct/{date}/sct-monitoring for it.

It fails with:
< t:2020-05-27 10:49:36,066 f:cluster.py      l:2811 c:sdcm.cluster         p:ERROR > invoke.exceptions.UnexpectedExit: Encountered a bad command exit code!
< t:2020-05-27 10:49:36,066 f:cluster.py      l:2811 c:sdcm.cluster         p:ERROR > 
< t:2020-05-27 10:49:36,066 f:cluster.py      l:2811 c:sdcm.cluster         p:ERROR > Command: "bash -ce '\nmkdir -p /usr/src/scylladb/scylla-cluster-tests/dkropachev3/20200527-104931-524122/PR-provision-docker-dkropachev-monitor-set-c79f55b6/PR-provision-docker-dkropachev-monitor-node-c79f55b6-0\ncd /usr/src/scylladb/scylla-cluster-tests/dkropachev3/20200527-104931-524122/PR-provision-docker-dkropachev-monitor-set-c79f55b6/PR-provision-docker-dkropachev-monitor-node-c79f55b6-0\nwget https://github.com/scylladb/scylla-monitoring/archive/master.zip\nrm -rf ./tmp /usr/src/scylladb/scylla-cluster-tests/dkropachev3/20200527-104931-524122/PR-provision-docker-dkropachev-monitor-set-c79f55b6/PR-provision-docker-dkropachev-monitor-node-c79f55b6-0/scylla-monitoring-src 2>/dev/null\nunzip master.zip -d ./tmp\nmv ./tmp/scylla-monitoring-master/ /usr/src/scylladb/scylla-cluster-tests/dkropachev3/20200527-104931-524122/PR-provision-docker-dkropachev-monitor-set-c79f55b6/PR-provision-docker-dkropachev-monitor-node-c79f55b6-0/scylla-monitoring-src\nrm -rf ./tmp 2>/dev/null\n'"
< t:2020-05-27 10:49:36,066 f:cluster.py      l:2811 c:sdcm.cluster         p:ERROR > 
< t:2020-05-27 10:49:36,066 f:cluster.py      l:2811 c:sdcm.cluster         p:ERROR > Exit code: 1
< t:2020-05-27 10:49:36,066 f:cluster.py      l:2811 c:sdcm.cluster         p:ERROR > 
< t:2020-05-27 10:49:36,066 f:cluster.py      l:2811 c:sdcm.cluster         p:ERROR > Stdout:
< t:2020-05-27 10:49:36,066 f:cluster.py      l:2811 c:sdcm.cluster         p:ERROR > 
< t:2020-05-27 10:49:36,066 f:cluster.py      l:2811 c:sdcm.cluster         p:ERROR > 
< t:2020-05-27 10:49:36,066 f:cluster.py      l:2811 c:sdcm.cluster         p:ERROR > 
< t:2020-05-27 10:49:36,066 f:cluster.py      l:2811 c:sdcm.cluster         p:ERROR > Stderr:
< t:2020-05-27 10:49:36,066 f:cluster.py      l:2811 c:sdcm.cluster         p:ERROR > 
< t:2020-05-27 10:49:36,066 f:cluster.py      l:2811 c:sdcm.cluster         p:ERROR > mkdir: cannot create directory ‘/usr/src/scylladb’: Permission denied
< t:2020-05-27 10:49:36,066 f:cluster.py      l:2811 c:sdcm.cluster         p:ERROR > 

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
