### PR TITLE
fix(nemesis): disable network_reject_inter_node_communication namesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1525,7 +1525,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         finally:
             self.target_node.traffic_control(None)
 
-    def disrupt_network_reject_inter_node_communication(self):
+    # Temporary disable due to  https://github.com/scylladb/scylla/issues/6522
+    def _disrupt_network_reject_inter_node_communication(self):
         """
         Generates random firewall rule to drop/reject packets for inter-node communications, port 7000 and 7001
         """
@@ -2462,15 +2463,15 @@ class BlockNetworkMonkey(Nemesis):
     def disrupt(self):
         self.disrupt_network_block()
 
-
-class RejectInterNodeNetworkMonkey(Nemesis):
-    disruptive = True
-    networking = True
-    run_with_gemini = False
-
-    @log_time_elapsed_and_status
-    def disrupt(self):
-        self.disrupt_network_reject_inter_node_communication()
+# Temporary disable due to  https://github.com/scylladb/scylla/issues/6522
+# class RejectInterNodeNetworkMonkey(Nemesis):
+#     disruptive = True
+#     networking = True
+#     run_with_gemini = False
+#
+#     @log_time_elapsed_and_status
+#     def disrupt(self):
+#         self.disrupt_network_reject_inter_node_communication()
 
 
 class RejectNodeExporterNetworkMonkey(Nemesis):


### PR DESCRIPTION
Temporary disable the network_reject_inter_node_communication nemesis
due to https://github.com/scylladb/scylla/issues/6522

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
