### PR TITLE
fix(create_test_release_jobs): add '-test' suffix to job name

### DIFF
--- a/utils/build_system/create_test_release_jobs.py
+++ b/utils/build_system/create_test_release_jobs.py
@@ -30,6 +30,6 @@ class JenkinsPipelines:
                                        sct_branch_name=self.sct_branch_name,
                                        sct_jenkinsfile=sct_jenkinsfile)
         try:
-            self.jenkins.create_job(f'{self.base_job_dir}/{group_name}/{base_name}', xml_data)
+            self.jenkins.create_job(f'{self.base_job_dir}/{group_name}/{base_name}-test', xml_data)
         except jenkins.JenkinsException as ex:
             print(ex)


### PR DESCRIPTION
Relang team asked for having the job name identical to the
displayname to avoid confusion

Ref: https://github.com/scylladb/scylla-pkg/pull/1338

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
