### PR TITLE
feature(nemesis.py): Nemesis to run hot SSL reload

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -36,7 +36,8 @@ from cassandra import ConsistencyLevel  # pylint: disable=ungrouped-imports
 from sdcm.cluster_aws import ScyllaAWSCluster
 from sdcm.cluster import SCYLLA_YAML_PATH, NodeSetupTimeout, NodeSetupFailed, Setup
 from sdcm.mgmt import TaskStatus, update_config_file
-from sdcm.utils.common import remote_get_file, get_non_system_ks_cf_list, get_db_tables, generate_random_string
+from sdcm.utils.common import remote_get_file, get_non_system_ks_cf_list, get_db_tables, generate_random_string, \
+    update_certificates
 from sdcm.utils.decorators import retrying
 from sdcm.log import SDCMAdapter
 from sdcm.keystore import KeyStore
@@ -58,6 +59,10 @@ class NoKeyspaceFound(Exception):
 
 
 class FilesNotCorrupted(Exception):
+    pass
+
+
+class LogContentNotFound(Exception):
     pass
 
 
@@ -1877,6 +1882,45 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         self.log.info("Finish cluster shrink. Current number of nodes %s", len(self.cluster.nodes))
 
+    def disrupt_hot_reloading_internode_certificate(self):
+        '''
+        https://github.com/scylladb/scylla/issues/6067
+        Scylla has the ability to hot reload SSL certificates.
+        This test will create and reload new certificates for the inter node communication.
+        '''
+        self._set_current_disruption('HotReloadInternodeCertificate')
+        if not self.cluster.params.get('server_encrypt', None):
+            raise UnsupportedNemesis('Server Encryption is not enabled, hence skipping')
+
+        @retrying(allowed_exceptions=LogContentNotFound)
+        def check_ssl_reload_log(target_node, file_path, since_time):
+            msg = target_node.remoter.run(f'journalctl -u scylla-server --since="{since_time}" | '
+                                          f'grep Reload | grep {file_path}', ignore_status=True)
+            if not msg.stdout:
+                raise LogContentNotFound('Reload SSL message not found in node log')
+            return msg.stdout
+
+        ssl_files_location = '/etc/scylla/ssl_conf'
+        in_place_crt = self.target_node.remoter.run(f"cat {os.path.join(ssl_files_location, 'db.crt')}",
+                                                    ignore_status=True).stdout
+        update_certificates()
+        time_now = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+        for node in self.cluster.nodes:
+            node.remoter.send_files(src='data_dir/ssl_conf/db.crt', dst='/tmp')
+        for node in self.cluster.nodes:
+            node.remoter.run(f"sudo cp -f /tmp/db.crt {ssl_files_location}")
+        for node in self.cluster.nodes:
+            new_crt = node.remoter.run(f"cat {os.path.join(ssl_files_location, 'db.crt')}").stdout
+            if in_place_crt == new_crt:
+                raise Exception('The CRT file was not replaced with the new one')
+            reload = check_ssl_reload_log(target_node=node, file_path=os.path.join(ssl_files_location, 'db.crt'),
+                                          since_time=time_now)
+
+            if not reload:
+                raise Exception('SSL auto Reload did not happen')
+
+        self.log.info('hot reloading internode ssl nemesis finished')
+
 
 class NotSpotNemesis(Nemesis):
     def set_target_node(self):
@@ -1980,6 +2024,14 @@ def log_time_elapsed_and_status(method):  # pylint: disable=too-many-statements
         return result
 
     return wrapper
+
+
+class SslHotReloadingNemesis(Nemesis):
+    disruptive = False
+
+    @log_time_elapsed_and_status
+    def disrupt(self):
+        self.disrupt_hot_reloading_internode_certificate()
 
 
 class NoOpMonkey(Nemesis):

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1284,17 +1284,21 @@ def wait_ami_available(client, ami_id):
                 )
 
 
-def update_certificates():
+def update_certificates(db_csr='data_dir/ssl_conf/example/db.csr', cadb_pem='data_dir/ssl_conf/cadb.pem',
+                        cadb_key='data_dir/ssl_conf/example/cadb.key', db_crt='data_dir/ssl_conf/db.crt'):
     """
     Update the certificate of server encryption, which might be expired.
     """
     try:
         from sdcm.remote import LocalCmdRunner
         localrunner = LocalCmdRunner()
-        localrunner.run('openssl x509 -req -in data_dir/ssl_conf/example/db.csr -CA data_dir/ssl_conf/cadb.pem -CAkey data_dir/ssl_conf/example/cadb.key -CAcreateserial -out data_dir/ssl_conf/db.crt -days 365')
-        localrunner.run('openssl x509 -enddate -noout -in data_dir/ssl_conf/db.crt')
+        localrunner.run(f'openssl x509 -req -in {db_csr} -CA {cadb_pem} -CAkey {cadb_key} -CAcreateserial '
+                        f'-out {db_crt} -days 365')
+        localrunner.run(f'openssl x509 -enddate -noout -in {db_crt}')
+        new_crt = localrunner.run(f'cat {db_crt}').stdout
     except Exception as ex:
         raise Exception('Failed to update certificates by openssl: %s' % ex)
+    return new_crt
 
 
 def s3_download_dir(bucket, path, target):


### PR DESCRIPTION
following a new feature (commit scylladb/scylla#6061)
this nemesis will create a new CRT ssl file, and
upload it to all nodes, and add it to the directory
Scylla is listening to.
The test also is supposed to confirm in the log that
the listener found the new files and reloaded the
new CRT file.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
~~- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)~~
~~- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
~~- [ ] All new and existing unit tests passed (CI)~~
~~- [ ] I have updated the Readme/doc folder accordingly (if needed)~~
