### PR TITLE
fix(terminate then replace nemesis): Replaced node to serve writes during bootstrap

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2630,6 +2630,24 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             cmd = "dpkg-query --show 'scylla*'"
         return self.remoter.run(cmd).stdout.splitlines()
 
+    def get_scylla_config_param(self, config_param_name, verbose=True):
+        """
+        Get Scylla configuration parameter that not exists in the scylla.yaml
+        """
+        try:
+            request_out = self.remoter.run(
+                f'sudo curl --request GET http://localhost:10000/v2/config/{config_param_name}')
+            if "No such config entry" in request_out.stdout:
+                self.log.error(
+                    f'Failed to retreive value of {config_param_name} parameter. Error: {request_out.stdout}')
+                return None
+            if verbose:
+                self.log.debug(f'{config_param_name} parameter value: {request_out.stdout}')
+            return request_out.stdout
+        except Exception as e:  # pylint: disable=broad-except
+            self.log.error(f'Failed to retreive value of {config_param_name} parameter. Error: {e}')
+            return None
+
 
 class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-public-methods
     """

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -468,8 +468,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         old_node_ip = self.target_node.ip_address
         self._terminate_cluster_node(self.target_node)
         new_node = self._add_and_init_new_cluster_node(old_node_ip)
+
         try:
-            self.repair_nodetool_repair(new_node)
+            if new_node.get_scylla_config_param("enable_repair_based_node_ops") == 'false':
+                self.repair_nodetool_repair(new_node)
         finally:
             new_node.running_nemesis = None
 


### PR DESCRIPTION
[Task](https://trello.com/c/LbgumxO6/1949-replaced-node-to-serve-writes-during-bootstrap)

When replacing a node, the new node will now serve writes while data is streamed into it, no need
to repair after replace when combined with repair base operations.
In SCT we run repair after replace node (terminate and replace nemesis).
If "enable_repair_based_node_ops" parameter is "true", repair_based on replace will be start
and "nodetool repair" won't be run. Otherwise run "nodetool repair"

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
