### PR TITLE
fix(cluster.py): Added a mandatory write-isolation param for running scylla with Alternator

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -44,6 +44,7 @@ from sdcm.prometheus import start_metrics_server, PrometheusAlertManagerListener
 from sdcm.log import SDCMAdapter
 from sdcm.remote import RemoteCmdRunner, LOCALRUNNER, NETWORK_EXCEPTIONS
 from sdcm import wait
+from sdcm.utils.alternator import WriteIsolation
 from sdcm.utils.common import deprecation, get_data_dir_path, verify_scylla_repo_file, S3Storage, get_my_ip, \
     get_latest_gemini_version, makedirs, normalize_ipv6_url, download_dir_from_cloud, generate_random_string
 from sdcm.utils.distro import Distro
@@ -1713,6 +1714,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
         if alternator_port:
             scylla_yml['alternator_port'] = alternator_port
+            scylla_yml['alternator_write_isolation'] = WriteIsolation.ALWAYS_USE_LWT.value
 
         if alternator_enforce_authorization:
             scylla_yml['alternator_enforce_authorization'] = True

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -73,7 +73,7 @@ from sdcm.cdclog_reader_thread import CDCLogReaderThread
 from sdcm.logcollector import SCTLogCollector, ScyllaLogCollector, MonitorLogCollector, LoaderLogCollector
 from sdcm.send_email import build_reporter, read_email_data_from_file, get_running_instances_for_email_report, \
     save_email_data_to_file
-from sdcm.utils.alternator import create_table as alternator_create_table
+from sdcm.utils.alternator import create_table as alternator_create_table, WriteIsolation
 
 try:
     import cluster_cloud
@@ -415,7 +415,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                           self.params.get('alternator_secret_access_key')))
 
             alternator_create_table(endpoint_url, self.params)
-            params = dict(self.params, alternator_write_isolation='forbid')
+            params = dict(self.params, alternator_write_isolation=WriteIsolation.FORBID_RMW)
             alternator_create_table(endpoint_url, test_params=params, table_name='usertable_no_lwt')
 
     def get_nemesis_class(self):


### PR DESCRIPTION

        fix https://github.com/scylladb/scylla/commit/c3da9f2bd4a767b53c58e09dbfc2642fa82a581e
	in order to start scylla with alternator, a value for write-isolation must be set in
	 yaml (or cmd-line).

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
