### PR TITLE
fix(manager): Fixed the call of mutliple yaml config files

### DIFF
--- a/jenkins-pipelines/manager/debian9-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/debian9-manager-sanity.jenkinsfile
@@ -10,7 +10,7 @@ managerPipeline(
     ip_ssh_connections: 'public',
     aws_region: '''["us-east-1", "us-west-2"]''',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
-    test_config: ['test-cases/manager/manager-regression-multiDC-set-distro.yaml', 'configurations/manager/debian9.yaml'],
+    test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/debian9.yaml"]''',
 
     timeout: [time: 500, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',

--- a/jenkins-pipelines/manager/ubuntu16-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu16-manager-sanity.jenkinsfile
@@ -10,7 +10,7 @@ managerPipeline(
     ip_ssh_connections: 'public',
     aws_region: '''["us-east-1", "us-west-2"]''',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
-    test_config: ['test-cases/manager/manager-regression-multiDC-set-distro.yaml', 'configurations/manager/ubuntu16.yaml'],
+    test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/ubuntu16.yaml"]''',
 
     timeout: [time: 500, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',

--- a/jenkins-pipelines/manager/ubuntu18-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu18-manager-sanity.jenkinsfile
@@ -10,7 +10,7 @@ managerPipeline(
     ip_ssh_connections: 'public',
     aws_region: '''["us-east-1", "us-west-2"]''',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
-    test_config: ['test-cases/manager/manager-regression-multiDC-set-distro.yaml', 'configurations/manager/ubuntu18.yaml'],
+    test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/ubuntu18.yaml"]''',
 
     timeout: [time: 500, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',


### PR DESCRIPTION
Fixed the usage of the test_config parameter in the jenkins files of the manager sanities

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
