### PR TITLE
fix(sct.py): Fix falsly sending empty emails

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -6,6 +6,7 @@ import logging
 import glob
 import time
 import subprocess
+import traceback
 
 import pytest
 import click
@@ -563,21 +564,22 @@ def send_email(test_id=None, test_status=None, start_time=None, email_recipients
     if not logdir:
         logdir = os.path.expanduser('~/sct-results')
     test_results = None
-    testrun_dir = None
     if start_time is None:
         start_time = format_timestamp(time.time())
     else:
         start_time = format_timestamp(int(start_time))
-    if not test_status:
-        testrun_dir = get_testrun_dir(test_id=test_id, base_dir=logdir)
-        if testrun_dir:
-            email_results_file = os.path.join(testrun_dir, "email_data.json")
-            test_results = read_email_data_from_file(email_results_file)
+    testrun_dir = get_testrun_dir(test_id=test_id, base_dir=logdir)
+    if testrun_dir:
+        email_results_file = os.path.join(testrun_dir, "email_data.json")
+        test_results = read_email_data_from_file(email_results_file)
+    else:
+        LOGGER.warning("Failed to find test directory for %s", test_id)
 
     if test_results:
         reporter = test_results.get("reporter", "")
         test_results['nodes'] = get_running_instances_for_email_report(test_results['test_id'])
     else:
+        LOGGER.warning("Failed to read test results for %s", test_id)
         reporter = "TestAborted"
         if not test_status:
             test_status = 'FAILED'
@@ -593,6 +595,7 @@ def send_email(test_id=None, test_status=None, start_time=None, email_recipients
     try:
         reporter.send_report(test_results)
     except Exception:  # pylint: disable=broad-except
+        LOGGER.error("Failed to create email due to the following error:\n%s", traceback.format_exc())
         build_reporter("TestAborted", email_recipients, testrun_dir).send_report({
             "build_url": os.environ.get("BUILD_URL"),
             "subject": f"FAILED: {os.environ.get('JOB_NAME')}: {start_time}",


### PR DESCRIPTION
https://trello.com/c/W1C5i2ky/1985-test-result-email-doesnt-include-information-and-sent-twice
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
