### PR TITLE
fix(manager): changed the debian monitor root disk name

### DIFF
--- a/configurations/manager/debian9.yaml
+++ b/configurations/manager/debian9.yaml
@@ -1,4 +1,4 @@
-aws_root_disk_name_monitor: "/dev/xvda"
+aws_root_disk_name_monitor: "xvda"
 ami_id_monitor: 'ami-0cfac3931b2a799d1'  # Debian stretch image
 ami_monitor_user: 'admin'
 


### PR DESCRIPTION
changed aws_root_disk_name_monitor for the debian9 manager sanity to xvda

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
