### PR TITLE
fix(cluster): add --jre-headless parameter to update-java-alternatives

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1894,7 +1894,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 self.remoter.run('sudo add-apt-repository -y ppa:scylladb/ppa')
                 self.remoter.run('sudo apt-get update')
                 self.remoter.run('sudo apt-get install -y openjdk-8-jre-headless')
-                self.remoter.run('sudo update-java-alternatives -s java-1.8.0-openjdk-amd64')
+                self.remoter.run('sudo update-java-alternatives --jre-headless -s java-1.8.0-openjdk-amd64')
             elif self.is_ubuntu18() or self.is_ubuntu16():
                 install_prereqs = dedent("""
                     export DEBIAN_FRONTEND=noninteractive
@@ -1905,7 +1905,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                     add-apt-repository -y ppa:scylladb/ppa
                     apt-get update
                     apt-get install -y openjdk-8-jre-headless
-                    update-java-alternatives -s java-1.8.0-openjdk-amd64
+                    update-java-alternatives --jre-headless -s java-1.8.0-openjdk-amd64
                 """)
                 self.remoter.run('sudo bash -cxe "%s"' % install_prereqs)
             elif self.is_debian8():
@@ -1925,7 +1925,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                     'echo "deb http://download.opensuse.org/repositories/home:/scylladb:/scylla-3rdparty-jessie/Debian_8.0/ /" |sudo tee /etc/apt/sources.list.d/scylla-3rdparty.list')
                 self.remoter.run('sudo apt-get update')
                 self.remoter.run('sudo apt-get install -y openjdk-8-jre-headless -t jessie-backports')
-                self.remoter.run('sudo update-java-alternatives -s java-1.8.0-openjdk-amd64')
+                self.remoter.run('sudo update-java-alternatives --jre-headless -s java-1.8.0-openjdk-amd64')
             elif self.is_debian9():
                 force = ''
                 install_debian_9_prereqs = dedent("""
@@ -3621,7 +3621,7 @@ class BaseLoaderSet():
                 add-apt-repository -y ppa:scylladb/ppa
                 apt-get update
                 apt-get install -y openjdk-8-jre-headless
-                update-java-alternatives -s java-1.8.0-openjdk-amd64
+                update-java-alternatives --jre-headless -s java-1.8.0-openjdk-amd64
             """)
             node.remoter.run('sudo bash -cxe "%s"' % install_java_script)
 
@@ -3638,7 +3638,7 @@ class BaseLoaderSet():
                 echo 'deb http://download.opensuse.org/repositories/home:/scylladb:/scylla-3rdparty-jessie/Debian_8.0/ /' |sudo tee /etc/apt/sources.list.d/scylla-3rdparty.list
                 apt-get update
                 apt-get install -y openjdk-8-jre-headless -t jessie-backports
-                update-java-alternatives -s java-1.8.0-openjdk-amd64
+                update-java-alternatives --jre-headless -s java-1.8.0-openjdk-amd64
             """)
             node.remoter.run('sudo bash -cxe "%s"' % install_java_script)
 


### PR DESCRIPTION
Trello: https://trello.com/c/a6iMc56I/1989-ubuntu-deb-installations-fails-to-install-java-alternatives-but-still-succeed

We install headless JRE, but try to update alternatives for whole JDK.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
