### PR TITLE
Manager 2.1 tests p2

### DIFF
--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -356,6 +356,18 @@ class BackupTask(ManagerTask):
         snapshot_tag = snapshot_line[snapshot_index].split(":")[1].strip()
         return snapshot_tag
 
+    def is_task_in_uploading_stage(self):
+        full_progress_string = self.sctool.run("task progress {} -c {}".format(self.id, self.cluster_id),
+                                               parse_table_res=False,
+                                               is_verify_errorless_result=True).stdout.lower()
+        return "upload" in full_progress_string
+
+    def wait_for_uploading_stage(self, timeout=1440, step=10):
+        text = "Waiting until backup task: {} starts to upload snapshots".format(self.id)
+        is_status_reached = wait.wait_for(func=self.is_task_in_uploading_stage, step=step,
+                                          text=text, timeout=timeout)
+        return is_status_reached
+
 
 class ManagerCluster(ScyllaManagerBase):
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -37,7 +37,7 @@ from sdcm.cluster_aws import ScyllaAWSCluster
 from sdcm.cluster import SCYLLA_YAML_PATH, NodeSetupTimeout, NodeSetupFailed, Setup
 from sdcm.mgmt import TaskStatus, update_config_file
 from sdcm.utils.common import remote_get_file, get_non_system_ks_cf_list, get_db_tables, generate_random_string, \
-    update_certificates
+    update_certificates, reach_enospc_on_node, clean_enospc_on_node
 from sdcm.utils.decorators import retrying
 from sdcm.log import SDCMAdapter
 from sdcm.keystore import KeyStore
@@ -538,57 +538,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                     self.log.error("Scylla doesn't use an individual storage, skip enospc test")
                     continue
 
-                self.reach_enospc_on_node(target_node=node, log_object=self.log)
-
-                self.clean_enospc_on_node(target_node=node, log_object=self.log, sleep_time=sleep_time)
-
-    @staticmethod
-    def reach_enospc_on_node(target_node, log_object):
-        def search_database_enospc(node):
-            """
-            Search system log by executing cmd inside node, use shell tool to
-            avoid return and process huge data.
-            """
-            cmd = "sudo journalctl --no-tail --no-pager -u scylla-server.service|grep 'No space left on device'|wc -l"
-            result = node.remoter.run(cmd, verbose=True)
-            return int(result.stdout)
-
-        def approach_enospc(node, orig_errors):
-            # get the size of free space (default unit: KB)
-            result = node.remoter.run("df -l|grep '/var/lib/scylla'")
-            free_space_size = result.stdout.split()[3]
-
-            occupy_space_size = int(int(free_space_size) * 90 / 100)
-            occupy_space_cmd = 'sudo fallocate -l {}K /var/lib/scylla/occupy_90percent.{}'.format(
-                occupy_space_size, datetime.datetime.now().strftime('%s'))
-            log_object.debug('Cost 90% free space on /var/lib/scylla/ by {}'.format(occupy_space_cmd))
-            try:
-                node.remoter.run(occupy_space_cmd, verbose=True)
-            except Exception as details:  # pylint: disable=broad-except
-                log_object.error(str(details))
-            return search_database_enospc(node) > orig_errors
-
-        # check original ENOSPC error
-        orig_errors = search_database_enospc(target_node)
-        wait.wait_for(func=approach_enospc,
-                      timeout=300,
-                      step=5,
-                      text='Wait for new ENOSPC error occurs in database',
-                      node=target_node,
-                      orig_errors=orig_errors)
-
-    @staticmethod
-    def clean_enospc_on_node(target_node, log_object, sleep_time):
-        log_object.debug('Sleep {} seconds before releasing space to scylla'.format(sleep_time))
-        time.sleep(sleep_time)
-
-        log_object.debug('Delete occupy_90percent file to release space to scylla-server')
-        target_node.remoter.run('sudo rm -rf /var/lib/scylla/occupy_90percent.*')
-
-        log_object.debug('Sleep a while before restart scylla-server')
-        time.sleep(sleep_time / 2)
-        target_node.remoter.run('sudo systemctl restart scylla-server.service')
-        target_node.wait_db_up()
+                try:
+                    reach_enospc_on_node(target_node=node)
+                finally:
+                    clean_enospc_on_node(target_node=node, sleep_time=sleep_time)
 
     def _deprecated_disrupt_stop_start(self):
         # TODO: We don't support fully stopping the AMI instance anymore
@@ -1501,7 +1454,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if not self.cluster.extra_network_interface:
             raise UnsupportedNemesis("for this nemesis to work, you need to set `extra_network_interface: True`")
 
-        rate_limit : Optional[str] = self.get_rate_limit_for_network_disruption()
+        rate_limit: Optional[str] = self.get_rate_limit_for_network_disruption()
         if not rate_limit:
             self.log.warn("NetworkRandomInterruption won't limit network bandwith due to lack of monitoring nodes.")
 


### PR DESCRIPTION
Includes 2 tests:

    test(manager): test an sctool backup during enospc
    
    In the test we run a backup on a node, stop it midway, fill its disk to 100% during the backup,
    and run another backup afterwards. The second backup should run with no issue running
    since the first backup already created snapshots that occupy some of the disk space,
    and as such the second backup should go smoothly.


    test(manager): attempting a purge on a large data set
    
    The added test does as follow: A large dataset is inserted into the cluster,
    the test run a backup task and when it's finished the test deletes te dataset.
    Afterwards, the backup task is ran a few more times, so that a purge will occur,
    and the test passes if there was no issue in the next runs and the purge went accordingly


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)


### **Do Note! Relies on #2163 , please merge it before this pr**