### PR TITLE
fix(local_cmd_runner): added missing timeout

### DIFF
--- a/sdcm/remote.py
+++ b/sdcm/remote.py
@@ -216,15 +216,15 @@ class LocalCmdRunner(CommandRunner):  # pylint: disable=too-few-public-methods
 
     @retrying(n=3, sleep_time=5, allowed_exceptions=(RetriableNetworkException, ))
     def receive_files(self, src, dst, delete_dst=False,  # pylint: disable=too-many-arguments,unused-argument
-                      preserve_perm=True, preserve_symlinks=False):  # pylint: disable=too-many-arguments,unused-argument
+                      preserve_perm=True, preserve_symlinks=False, timeout=300):  # pylint: disable=too-many-arguments,unused-argument
         if src != dst:
-            self.run(f'cp {src} {dst}')
+            self.run(f'cp {src} {dst}', timeout=timeout)
 
     @retrying(n=3, sleep_time=5, allowed_exceptions=(RetriableNetworkException, ))
     def send_files(self, src, dst, delete_dst=False,  # pylint: disable=too-many-arguments,unused-argument
-                   preserve_symlinks=False, verbose=False):  # pylint: disable=unused-argument
+                   preserve_symlinks=False, verbose=False, timeout=300):  # pylint: disable=unused-argument
         if src != dst:
-            self.run(f'cp {src} {dst}')
+            self.run(f'cp {src} {dst}', timeout=timeout)
 
 
 LOCALRUNNER = LocalCmdRunner()


### PR DESCRIPTION
fixes:

```
13:33:30  Error occured during collecting on host: monitor-node-ae67be29-cc40-4686-8f81-e4d0403038ec-0
13:33:30  receive_files() got an unexpected keyword argument 'timeout'
13:33:30  LocalCmdRunner [jenkins@aws-scylla-qa-builder]: /home/jenkins
13:33:30  LocalCmdRunner [jenkins@aws-scylla-qa-builder]: Command "echo $HOME" finished with status 0
```
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
