### PR TITLE
fix(sdcm/sct_events.py): Fix TestResultEvent in case when errors are present

### DIFF
--- a/sdcm/sct_events.py
+++ b/sdcm/sct_events.py
@@ -279,7 +279,7 @@ class TestResultEvent(SctEvent):
         self.test_name = test_name
         self.errors = errors
         self.ok = not errors
-        self.severity = Severity.NORMAL if self.ok else Severity.CRITICAL
+        self.severity = Severity.NORMAL if self.ok else Severity.ERROR
 
     def __str__(self):
         header = dedent(f"""

--- a/unit_tests/test_events.py
+++ b/unit_tests/test_events.py
@@ -497,7 +497,7 @@ class TesterFailure(BaseEventsTest):
         ClusterTester.get_test_failures(self)
         test_errors = ClusterTester.get_test_results(self, source='test')
         tre = TestResultEvent(test_name=self.id(), errors=test_errors)
-        assert tre.severity == Severity.CRITICAL
+        assert tre.severity == Severity.ERROR
         tre.publish(guaranteed=True)
         print(str(tre))
         assert test_errors
@@ -537,7 +537,7 @@ class TesterErrorDuringSetUp(BaseEventsTest):
         test_errors = ClusterTester.get_test_results(self, source='test')
         assert test_errors is not None
         tre = TestResultEvent(test_name=self.id(), errors=test_errors)
-        assert tre.severity == Severity.CRITICAL
+        assert tre.severity == Severity.ERROR
 
 
 class TesterMultiSubTest(unittest.TestCase):


### PR DESCRIPTION
https://trello.com/c/ITMokRfV/1998-test-reported-failed-but-there-were-no-critical-error-events
Post action was acted as if there was critical error becasue TestResultEvent had CRITICAL severity.
So even when no critical erros were found in the test it self, we were TestResultEvent with critical severity at the end of the test, which where triggering further wrongfull actions.


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
