### PR TITLE
fix(network_random_interruptions): query time range too narrow

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1466,10 +1466,11 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         # get the last 10min avg network bandwidth used, and limit  30% to 70% of it
         prometheus_stats = PrometheusDBStats(host=self.monitoring_set.nodes[0].external_address)
-        query = 'avg(irate(node_network_receive_bytes_total{instance=~".*?%s.*?", device="eth0"}[30s]))' % \
+        query = 'avg(irate(node_network_receive_bytes_total{instance=~".*?%s.*?", device="eth0"}[60s]))' % \
                 self.target_node.ip_address
         now = time.time()
         results = prometheus_stats.query(query=query, start=now - 600, end=now)
+        assert results, "no results for node_network_receive_bytes_total metric in Prometheus "
         avg_bitrate_per_node = max([float(avg_rate) for _, avg_rate in results[0]["values"]])
         avg_mpbs_per_node = avg_bitrate_per_node / 1024 / 1024
 


### PR DESCRIPTION
fixes:
```
2020-06-03 12:05:29.070: (DisruptionEvent Severity.ERROR): type=end name=NetworkRandomInterruption node=Node longevity-200gb-48h-network-master-db-node-dfcb7b74-5 [35.169.161.9 | 172.30.0.244] (seed: False) duration=0 error=list index out of range

Traceback (most recent call last):

  File "/sct/sdcm/nemesis.py", line 1987, in wrapper

    result = method(*args, **kwargs)

  File "/sct/sdcm/nemesis.py", line 2615, in disrupt

    self.call_random_disrupt_method(disrupt_methods=self.disrupt_methods_list)

  File "/sct/sdcm/nemesis.py", line 627, in call_random_disrupt_method

    disrupt_method()

  File "/sct/sdcm/nemesis.py", line 1473, in disrupt_network_random_interruptions

    avg_bitrate_per_node = max([float(avg_rate) for _, avg_rate in results[0]["values"]])

IndexError: list index out of range
```
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
