### PR TITLE
fix(sdcm/tester.py): Fix teardown order to avoid distracting report by events happened during teardown

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1731,10 +1731,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             InfoEvent('TEST_END')
         self.log.info('TearDown is starting...')
         self.stop_event_analyzer()
+        self.stop_resources()
         self.get_test_failing_events()
         self.get_test_failures()
-        self.tag_ami_with_result()
-        self.stop_resources()
         self.save_email_data()
         if self.params.get('collect_logs'):
             self.collect_logs()
@@ -1745,12 +1744,13 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         self.stop_event_device()
         self.destroy_localhost()
         self.send_email()
+        self.tag_ami_with_result()
         if self.params.get('collect_logs'):
             self.collect_sct_logs()
         framework_errors = self.get_test_results('framework')
         if framework_errors:
             framework_errors = "\n".join(framework_errors)
-            self.log.info('%s\nFRAMEWORK ERRORS:\n%s\n%s', (">" * 70), framework_errors, (">" * 70))
+            self.log.error('%s\nFRAMEWORK ERRORS:\n%s\n%s', (">" * 70), framework_errors, (">" * 70))
         self.log.info('Test ID: {}'.format(Setup.test_id()))
 
     @silence()


### PR DESCRIPTION
https://trello.com/c/sBR2IGwQ/1996-test-marked-success-when-there-were-errors-found

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
