### PR TITLE
fix(vars/longevityPipeline.groovy): Add unlink of ./latest just before test start

### DIFF
--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -72,6 +72,8 @@ def call(Map pipelineParams) {
                                         }
                                         stage("Run SCT Test (${instance_type})") {
                                             sctScript """
+                                                rm -fv ./latest
+
                                                 export SCT_COLLECT_LOGS=false
                                                 export SCT_CONFIG_FILES=${params.test_config}
 

--- a/vars/byoLongevityPipeline.groovy
+++ b/vars/byoLongevityPipeline.groovy
@@ -105,6 +105,8 @@ def call() {
                                     set -xe
                                     env
 
+                                    rm -fv ./latest
+
                                     export SCT_CLUSTER_BACKEND="${params.backend}"
                                     export SCT_REGION_NAME=${aws_region}
                                     export SCT_CONFIG_FILES=${test_config}

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -13,6 +13,8 @@ def runSctTest(Map params){
     set -xe
     env
 
+    rm -fv ./latest
+
     export SCT_CLUSTER_BACKEND="${params.backend}"
     export SCT_REGION_NAME=${aws_region}
     export SCT_CONFIG_FILES=${test_config}

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -95,6 +95,7 @@ def call(Map pipelineParams) {
                                     #!/bin/bash
                                     set -xe
                                     env
+                                    rm -fv ./latest
 
                                     export SCT_CLUSTER_BACKEND="${params.backend}"
                                     export SCT_REGION_NAME=${aws_region}

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -89,6 +89,8 @@ def call(Map pipelineParams) {
                                                         set -xe
                                                         env
 
+                                                        rm -fv ./latest
+
                                                         export SCT_CLUSTER_BACKEND=${params.backend}
                                                         export SCT_REGION_NAME=${pipelineParams.aws_region}
                                                         export SCT_CONFIG_FILES=${pipelineParams.test_config}

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -66,6 +66,9 @@ def call(Map pipelineParams) {
                                                         #!/bin/bash
                                                         set -xe
                                                         env
+
+                                                        rm -fv ./latest
+
                                                         export SCT_CLUSTER_BACKEND=gce
 
                                                         export SCT_CONFIG_FILES=${pipelineParams.test_config}


### PR DESCRIPTION
https://trello.com/c/I5mjx0Al/1656-improve-identification-of-the-current-run-in-the-send-email-stage

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
