### PR TITLE
fix(cluster.py): missing normilize_ipv6_url from

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4384,8 +4384,8 @@ class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-inst
     def add_sct_dashboards_to_grafana(self, node):
 
         def _register_grafana_json(json_filename):
-            # added "[]" / "\\" for IPv6 support
-            url = "'http://\\[{0.external_address}\\]:{1.grafana_port}/api/dashboards/db'".format(node, self)
+            url = "'http://{0}:{1.grafana_port}/api/dashboards/db'".format(normalize_ipv6_url(node.external_address),
+                                                                           self)
             result = LOCALRUNNER.run('curl -XPOST -i %s --data-binary @%s -H "Content-Type: application/json"' %
                                      (url, json_filename))
             return result.exited == 0


### PR DESCRIPTION
_register_grafana_json function.
found it using latest curl version, as it doesn't
accept square brackets.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
