### PR TITLE
fix(#2217): adding timeout to docker restart command

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4201,8 +4201,7 @@ class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-inst
             node.reboot(hard=False)
         else:
             node.remoter.reconnect()
-        node.remoter.run(cmd='sudo systemctl restart docker')
-        node.remoter.run(cmd='docker run hello-world', ignore_status=True)
+        node.remoter.run(cmd='sudo systemctl restart docker', timeout=60)
 
     def download_scylla_monitoring(self, node):
         install_script = dedent("""


### PR DESCRIPTION
also removed unnecessary `docker run hello-world` command

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
