### PR TITLE
fix(unit_tests/test_events.py): Fix pylint issue

### DIFF
--- a/unit_tests/test_events.py
+++ b/unit_tests/test_events.py
@@ -73,13 +73,22 @@ class BaseEventsTest(unittest.TestCase):
             process.join()
         stop_events_device()
 
+    def get_test_results(self, source, severity=None):
+        # It is a copy of the routing from ClusterTester
+        # It has been done in such way because it is impossible to reuse ClusterTester for testing purpose
+        output = []
+        for result in getattr(self, '_results', []):
+            if result.get('source', None) != source:
+                continue
+            if severity is not None and severity != result['severity']:
+                continue
+            output.append(result['message'])
+        return output
+
     def store_test_result(  # pylint: disable=too-many-arguments
-            self,
-            source,
-            message='',
-            exception: Exception = '',
-            trace='',
-            severity=Severity.ERROR):
+            self, source, message='', exception: Exception = '', trace='', severity=Severity.ERROR):
+        # It is a copy of the routing from ClusterTester
+        # It has been done in such way because it is impossible to reuse ClusterTester for testing purpose
         if exception:
             exception = repr(exception)
             if exception[0] != '\n' and message[-1] != '\n':
@@ -98,16 +107,6 @@ class BaseEventsTest(unittest.TestCase):
             'message': message,
             'severity': severity,
         })
-
-    def get_test_results(self, source, severity=None):
-        output = []
-        for result in getattr(self, '_results', []):
-            if result.get('source', None) != source:
-                continue
-            if severity is not None and severity != result['severity']:
-                continue
-            output.append(result['message'])
-        return output
 
 
 class SctEventsTests(BaseEventsTest):  # pylint: disable=too-many-public-methods


### PR DESCRIPTION
Addressing pylint duplicate code issue.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
