### PR TITLE
fix(data validator): fix c-s_lwt_basic.yaml profile and add DataValidatorEvent

### DIFF
--- a/data_dir/c-s_lwt_basic.yaml
+++ b/data_dir/c-s_lwt_basic.yaml
@@ -26,9 +26,9 @@ table_definition: |
 
 extra_definitions:
   - create MATERIALIZED VIEW blogposts_update_one_column_lwt_indicator as select domain, lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator < 0 PRIMARY KEY(lwt_indicator, domain, published_date);
-  - create MATERIALIZED VIEW blogposts_update_one_column_lwt_indicator_upd as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator = 30000000 PRIMARY KEY(lwt_indicator, domain, published_date);
-  - create MATERIALIZED VIEW blogposts_update_two_columns_lwt_indicator as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator > 0 and lwt_indicator <= 1000000 PRIMARY KEY(lwt_indicator, domain, published_date);
-  - create MATERIALIZED VIEW blogposts_update_two_columns_lwt_indicator_upd as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator = 20000000 PRIMARY KEY(lwt_indicator, domain, published_date);
+  - create MATERIALIZED VIEW blogposts_update_one_column_lwt_indicator_after_update as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator = 30000000 PRIMARY KEY(lwt_indicator, domain, published_date);
+  - create MATERIALIZED VIEW blogposts_update_2_columns_lwt_indicator as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator > 0 and lwt_indicator <= 1000000 PRIMARY KEY(lwt_indicator, domain, published_date);
+  - create MATERIALIZED VIEW blogposts_update_2_columns_lwt_indicator_after_update as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator = 20000000 PRIMARY KEY(lwt_indicator, domain, published_date);
   - create MATERIALIZED VIEW blogposts_not_updated_lwt_indicator as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator > 1000000 and lwt_indicator < 20000000 PRIMARY KEY(lwt_indicator, domain, published_date);
 
 ### Column Distribution Specifications ###

--- a/data_dir/scylla-dash-per-server-nemesis.4.0.json
+++ b/data_dir/scylla-dash-per-server-nemesis.4.0.json
@@ -5526,9 +5526,14 @@
                         "selected": false,
                         "text": "ClusterHealthValidatorEvent",
                         "value": "ClusterHealthValidatorEvent"
+                      },
+                      {
+                        "selected": false,
+                        "text": "DataValidatorEvent",
+                        "value": "DataValidatorEvent"
                       }
                     ],
-                    "query": "InfoEvent, CassandraStressEvent, ScyllaBenchEvent, DatabaseLogEvent, DisruptionEvent, CoreDumpEvent, SpotTerminationEvent, ClusterHealthValidatorEvent",
+                    "query": "InfoEvent, CassandraStressEvent, ScyllaBenchEvent, DatabaseLogEvent, DisruptionEvent, CoreDumpEvent, SpotTerminationEvent, ClusterHealthValidatorEvent, DataValidatorEvent",
                     "skipUrlSync": false,
                     "type": "custom"
                   }

--- a/data_dir/scylla-dash-per-server-nemesis.master.json
+++ b/data_dir/scylla-dash-per-server-nemesis.master.json
@@ -5532,9 +5532,14 @@
                         "selected": false,
                         "text": "ClusterHealthValidatorEvent",
                         "value": "ClusterHealthValidatorEvent"
+                      },
+                      {
+                        "selected": false,
+                        "text": "DataValidatorEvent",
+                        "value": "DataValidatorEvent"
                       }
                     ],
-                    "query": "InfoEvent, CassandraStressEvent, ScyllaBenchEvent, DatabaseLogEvent, DisruptionEvent, CoreDumpEvent, SpotTerminationEvent, ClusterHealthValidatorEvent",
+                    "query": "InfoEvent, CassandraStressEvent, ScyllaBenchEvent, DatabaseLogEvent, DisruptionEvent, CoreDumpEvent, SpotTerminationEvent, ClusterHealthValidatorEvent, DataValidatorEvent",
                     "skipUrlSync": false,
                     "type": "custom"
                   }

--- a/sdcm/sct_events.py
+++ b/sdcm/sct_events.py
@@ -549,6 +549,29 @@ class ClusterHealthValidatorEvent(SctEvent):
             return super(ClusterHealthValidatorEvent, self).__str__()
 
 
+class DataValidatorEvent(SctEvent):
+    def __init__(self, type, name, status=Severity.ERROR, message=None, error=None, **kwargs):  # pylint: disable=redefined-builtin,too-many-arguments
+        super(DataValidatorEvent, self).__init__()
+        self.name = name
+        self.type = type
+        self.severity = status
+        self.error = error if error else ''
+        self.message = message if message else ''
+
+        self.__dict__.update(kwargs)
+        self.publish()
+
+    def __str__(self):
+        if self.severity in (Severity.NORMAL, Severity.WARNING):
+            return "{0}: type={1.type} name={1.name} message={1.message}".format(
+                super(DataValidatorEvent, self).__str__(), self)
+        elif self.severity in (Severity.CRITICAL, Severity.ERROR):
+            return "{0}: type={1.type} name={1.name} error={1.error}".format(
+                super(DataValidatorEvent, self).__str__(), self)
+        else:
+            return super(DataValidatorEvent, self).__str__()
+
+
 class FullScanEvent(SctEvent):
     def __init__(self, type, ks_cf, db_node_ip, severity=Severity.NORMAL, message=None):   # pylint: disable=redefined-builtin,too-many-arguments
         super(FullScanEvent, self).__init__()


### PR DESCRIPTION
Few changes are present in this commit:
1. Urgent fix - change view names in the data_dir/c-s_lwt_basic.yaml user profile according to data validator naming convention. Now longevity-lwt-3h doesn't perform data validation because of the view names are not as expected
2. add DataValidatorEvent
3. in case the data validation view is not found, let WARNING and don't try to collect the data

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
