### PR TITLE
fix(perf regression): filter job_name was correct

### DIFF
--- a/sdcm/utils/es_queries.py
+++ b/sdcm/utils/es_queries.py
@@ -84,9 +84,9 @@ class PerformanceQueryFilter(QueryFilter):
             filter_query = ""
             if job_name[0] and job_name[0] in job_item['job_folder']:
                 base_job_name = job_name[1]
-                filter_query = r'(test_details.job_name.keyword: {}\/{}\/* OR'.format(job_name[0],
-                                                                                      base_job_name)
-                filter_query += r' test_details.job_name.keyword: {}\/*) '.format(base_job_name)
+                filter_query = r'(test_details.job_name.keyword: {}\/{}* OR'.format(job_name[0],
+                                                                                    base_job_name)
+                filter_query += r' test_details.job_name.keyword: {}*) '.format(base_job_name)
             return filter_query
 
         def get_query_filter_by_job_prefix(job_item):
@@ -95,9 +95,9 @@ class PerformanceQueryFilter(QueryFilter):
                 if not job_name[0].startswith(job_prefix):
                     continue
                 base_job_name = job_name[0]
-                filter_query = r'(test_details.job_name.keyword: {}\/{}\/* OR'.format(job_item['job_folder'],
-                                                                                      base_job_name)
-                filter_query += r' test_details.job_name.keyword: {}\/*) '.format(base_job_name)
+                filter_query = r'(test_details.job_name.keyword: {}\/{}* OR'.format(job_item['job_folder'],
+                                                                                    base_job_name)
+                filter_query += r' test_details.job_name.keyword: {}*) '.format(base_job_name)
                 break
             return filter_query
 


### PR DESCRIPTION
Seem like `build_filter_job_name()` was have extra slash before the
asterix, causing only old jobs to be selected.
was hardly noticed, cause it was getting updated results from the branch-perf-v8

Fixes: #2222

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
