### PR TITLE
feature(hydra-prepare-region): add ability to pre-configure region in…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,9 +126,14 @@ To configure a region: create VPC and all related environment elements (Subnet, 
     hydra prepare-aws-region --region <region_name>
 
 SCT can run locally and on remote Runner instance.
-To run SCT using runner create an image using::
+First of all we before creating a Runner instance we need to  create an image using::
 
     hydra create-runner-image --region <region_name>
+
+Then create a Runner instance::
+
+    hydra create-runner-instance -r <region_name> -z <az> -t <test-id> -d <run_duration>
+
 
 Run a test
 ----------
@@ -138,6 +143,10 @@ Example running test using Hydra using `test-cases/PR-provision-test.yaml` confi
 on AWS::
 
     hydra "run-test longevity_test.LongevityTest.test_custom_time --backend aws --config test-cases/PR-provision-test.yaml"
+
+on AWS using SCT Runner::
+
+    hydra --execute-on-runner <runner-ip|`cat sct_runner_ip> "run-test longevity_test.LongevityTest.test_custom_time --backend aws --config test-cases/PR-provision-test.yaml"
 
 on GCE::
 

--- a/README.rst
+++ b/README.rst
@@ -125,6 +125,11 @@ To configure a region: create VPC and all related environment elements (Subnet, 
 
     hydra prepare-aws-region --region <region_name>
 
+SCT can run locally and on remote Runner instance.
+To run SCT using runner create an image using::
+
+    hydra create-runner-image --region <region_name>
+
 Run a test
 ----------
 

--- a/README.rst
+++ b/README.rst
@@ -117,6 +117,14 @@ To run SCT tests locally run following::
     pyenv activate sct38
     pip install -r requirements-python.txt
 
+Preparing AWS Cloud environment
+-------------------------------
+
+To run tests in different regions SCT needs pre-configured environment.
+To configure a region: create VPC and all related environment elements (Subnet, Security Group, etc.) use::
+
+    hydra prepare-aws-region --region <region_name>
+
 Run a test
 ----------
 

--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -14,10 +14,10 @@ regions_data:
     ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
     backup_bucket_location: 'manager-backup-tests-eu-west-1'
   eu-west-2:
-    ami_id_loader: 'ami-05f5e60a958ed70d6' # Loader dedicated AMI v10 with golang 1.13
+    ami_id_loader: 'ami-05f5e60a958ed70d6' # Loader dedicated AMI v11
     ami_id_monitor: 'ami-0eab3a90fc693af19' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
   eu-north-1:
-    ami_id_loader: 'ami-047a96eb9be325519' # Loader dedicated AMI v10 with golang 1.13
+    ami_id_loader: 'ami-03389f1ec374f22d3' # Loader dedicated AMI v10 with golang 1.13
     ami_id_monitor: 'ami-5ee66f20' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
   us-west-2:
     ami_id_loader: 'ami-0de1ee51de25ac133' # Loader dedicated AMI v11

--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -16,6 +16,9 @@ regions_data:
   eu-west-2:
     ami_id_loader: 'ami-05f5e60a958ed70d6' # Loader dedicated AMI v10 with golang 1.13
     ami_id_monitor: 'ami-0eab3a90fc693af19' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
+  eu-north-1:
+    ami_id_loader: 'ami-047a96eb9be325519' # Loader dedicated AMI v10 with golang 1.13
+    ami_id_monitor: 'ami-5ee66f20' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
   us-west-2:
     ami_id_loader: 'ami-0de1ee51de25ac133' # Loader dedicated AMI v11
     ami_id_monitor: 'ami-01ed306a12b7d1c96' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01

--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -17,8 +17,11 @@ regions_data:
     ami_id_loader: 'ami-05f5e60a958ed70d6' # Loader dedicated AMI v11
     ami_id_monitor: 'ami-0eab3a90fc693af19' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
   eu-north-1:
-    ami_id_loader: 'ami-03389f1ec374f22d3' # Loader dedicated AMI v10 with golang 1.13
+    ami_id_loader: 'ami-03389f1ec374f22d3' # Loader dedicated AMI v11
     ami_id_monitor: 'ami-5ee66f20' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
+  eu-central-1:
+    ami_id_loader: 'ami-05ffe040de90c0a53' # Loader dedicated AMI v11
+    ami_id_monitor: 'ami-04cf43aca3e6f3de3' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
   us-west-2:
     ami_id_loader: 'ami-0de1ee51de25ac133' # Loader dedicated AMI v11
     ami_id_monitor: 'ami-01ed306a12b7d1c96' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01

--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -6,25 +6,22 @@ instance_type_loader: 'c5.xlarge'
 instance_type_monitor: 't3.large'
 regions_data:
   us-east-1:
-    security_group_ids: 'sg-c5e1f7a0'
-    subnet_id: 'subnet-ec4a72c4'
     ami_id_loader: 'ami-03c856a491257cb7f' # Loader dedicated AMI v11
     ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
     backup_bucket_location: 'manager-backup-tests-us-east-1'
   eu-west-1:
-    security_group_ids: 'sg-059a7f66a947d4b5c'
-    subnet_id: 'subnet-088fddaf520e4c7a8'
     ami_id_loader: 'ami-0ac1d5f2066dfc9b4' # Loader dedicated AMI v11
     ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
     backup_bucket_location: 'manager-backup-tests-eu-west-1'
+  eu-west-2:
+    ami_id_loader: 'ami-05f5e60a958ed70d6' # Loader dedicated AMI v10 with golang 1.13
+    ami_id_monitor: 'ami-0eab3a90fc693af19' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
   us-west-2:
-    security_group_ids: 'sg-81703ae4'
-    subnet_id: 'subnet-5207ee37'
     ami_id_loader: 'ami-0de1ee51de25ac133' # Loader dedicated AMI v11
     ami_id_monitor: 'ami-01ed306a12b7d1c96' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
     backup_bucket_location: 'manager-backup-tests-eu-west-2'
 
-
+availability_zone: 'a'
 aws_root_disk_size_monitor: 50  # GB, remove this field if default disk size should be used
 aws_root_disk_size_db: 15
 aws_root_disk_size_loader: 30  # GB, Increase loader disk in order to have extra space for a larger swap

--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -9,7 +9,9 @@ SCT_DIR=$(dirname "${SCT_DIR}")
 VERSION=v$(cat "${DOCKER_ENV_DIR}/version")
 WORK_DIR=/sct
 HOST_NAME=SCT-CONTAINER
-
+RUN_BY_USER=$(python3 "${SCT_DIR}/sdcm/utils/get_username.py")
+USER_ID=$(id -u "${USER}")
+HOME_DIR=${HOME}
 
 export SCT_TEST_ID=${SCT_TEST_ID:-$(uuidgen)}
 export GIT_USER_EMAIL=$(git config --get user.email)
@@ -43,12 +45,6 @@ echo "Making sure the ownerships of results directories are of the user"
 sudo chown -R `whoami`:`whoami` ~/sct-results &> /dev/null || true
 sudo chown -R `whoami`:`whoami` "${SCT_DIR}/sct-results" &> /dev/null || true
 
-subcommand="$1"
-if [[ ${subcommand} == 'bash'* ]] || [[ ${subcommand} == 'python'* ]]; then
-    echo "running  ${subcommand}"
-else
-    CMD="./sct.py $@"
-fi
 
 # export all SCT_* env vars into the docker run
 SCT_OPTIONS=$(env | grep SCT_ | cut -d "=" -f 1 | xargs -i echo "--env {}")
@@ -67,33 +63,91 @@ for gid in $(id -G); do
     group_args+=(--group-add "$gid")
 done
 
-docker run --rm ${TTY_STDIN} --privileged \
-    -h ${HOST_NAME} \
-    -l "TestId=${SCT_TEST_ID}" \
-    -l "RunByUser=$(python3 "${SCT_DIR}/sdcm/utils/get_username.py")" \
-    -v /var/run:/run \
-    -v "${SCT_DIR}:${SCT_DIR}" \
-    -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
-    -v /tmp:/tmp \
-    -v /var/tmp:/var/tmp \
-    -v "${HOME}:${HOME}" \
-    -v /etc/passwd:/etc/passwd:ro \
-    -v /etc/group:/etc/group:ro \
-    -v /etc/sudoers:/etc/sudoers:ro \
-    -v /etc/sudoers.d/:/etc/sudoers.d:ro \
-    -v /etc/shadow:/etc/shadow:ro \
-    -w "${SCT_DIR}" \
-    -e JOB_NAME="${JOB_NAME}" \
-    -e BUILD_URL="${BUILD_URL}" \
-    -e _SCT_BASE_DIR="${SCT_DIR}" \
-    -e GIT_USER_EMAIL \
-    -u $(id -u "${USER}") \
-    ${group_args[@]} \
-    ${SCT_OPTIONS} \
-    ${BUILD_OPTIONS} \
-    ${JENKINS_OPTIONS} \
-    ${AWS_OPTIONS} \
-    --net=host \
-    --name=${SCT_TEST_ID} \
-    ${DOCKER_REPO}:${VERSION} \
-    /bin/bash -c "sudo ln -s '${SCT_DIR}' '${WORK_DIR}'; ${TERM_SET_SIZE} eval '${CMD}'"
+./get-qa-ssh-keys.sh >/dev/null 2>&1
+
+function run_in_docker () {
+    CMD_TO_RUN=$1
+    REMOTE_DOCKER_HOST=$2
+    echo "Going to run '${CMD_TO_RUN}'..."
+    docker ${REMOTE_DOCKER_HOST} run --rm ${TTY_STDIN} --privileged \
+        -h ${HOST_NAME} \
+        -l "TestId=${SCT_TEST_ID}" \
+        -l "RunByUser=${RUN_BY_USER}" \
+        -v /var/run:/run \
+        -v "${SCT_DIR}:${SCT_DIR}" \
+        -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+        -v /tmp:/tmp \
+        -v /var/tmp:/var/tmp \
+        -v "${HOME_DIR}:${HOME_DIR}" \
+        -v /etc/passwd:/etc/passwd:ro \
+        -v /etc/group:/etc/group:ro \
+        -v /etc/sudoers:/etc/sudoers:ro \
+        -v /etc/sudoers.d/:/etc/sudoers.d:ro \
+        -v /etc/shadow:/etc/shadow:ro \
+        -w "${SCT_DIR}" \
+        -e JOB_NAME="${JOB_NAME}" \
+        -e BUILD_URL="${BUILD_URL}" \
+        -e _SCT_BASE_DIR="${SCT_DIR}" \
+        -e GIT_USER_EMAIL \
+        -u ${USER_ID} \
+        ${group_args[@]} \
+        ${SCT_OPTIONS} \
+        ${BUILD_OPTIONS} \
+        ${JENKINS_OPTIONS} \
+        ${AWS_OPTIONS} \
+        --net=host \
+        --name="${SCT_TEST_ID}_$(date +%s)" \
+        ${DOCKER_REPO}:${VERSION} \
+        /bin/bash -c "sudo ln -s '${SCT_DIR}' '${WORK_DIR}'; /sct/get-qa-ssh-keys.sh; ${TERM_SET_SIZE} eval '${CMD_TO_RUN}'"
+}
+
+
+subcommand="$1"
+if [[ ${subcommand} == "--execute-on-runner" ]]; then
+    SCT_RUNNER_IP="$2"
+    echo "SCT Runner IP: $SCT_RUNNER_IP"
+    if [[ -n $SCT_RUNNER_IP ]] && [[ $SCT_RUNNER_IP =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        eval $(ssh-agent)
+        function clean_ssh_agent {
+            echo "Cleaning SSH agent"
+            eval $(ssh-agent -k)
+        }
+        trap clean_ssh_agent EXIT
+        ssh-add ~/.ssh/scylla-qa-ec2
+        echo "Going to run a Hydra commands on SCT runner '$SCT_RUNNER_IP'..."
+        HOME_DIR="/home/ubuntu"
+        echo "Syncing ${SCT_DIR} to the SCT runner instance..."
+        rsync -ar -e "ssh -o StrictHostKeyChecking=no" --delete ${SCT_DIR} ubuntu@${SCT_RUNNER_IP}:/home/ubuntu/
+        if [[ -z "$AWS_OPTIONS" ]]; then
+          echo "AWS credentials were not passed using AWS_* environment variables!"
+          echo "Checking if ~/.aws/credentials exists..."
+          if [ -f ~/.aws/credentials ]; then
+              echo "AWS credentials file found. Syncing to SCT Runner..."
+              rsync -ar -e "ssh -o StrictHostKeyChecking=no" --delete ~/.aws ubuntu@${SCT_RUNNER_IP}:/home/ubuntu/
+          else
+              echo "Can't run SCT without AWS credentials!"
+              exit 1
+          fi
+        else
+            echo "AWS_* environment variables found and will passed to Hydra container."
+        fi
+        SCT_DIR="/home/ubuntu/scylla-cluster-tests"
+        USER_ID=1000
+        DOCKER_HOST="-H ssh://ubuntu@${SCT_RUNNER_IP}"
+        CMD=${@:3}
+        subcommand=$CMD
+    else
+      echo "=========================================================================================================="
+      echo "Invalid IP provided for '--execute-on-runner'. Run 'hydra create-runner-instance' or check ./sct_runner_ip"
+      echo "=========================================================================================================="
+      exit 2
+    fi
+
+fi
+if [[ ${subcommand} == *'bash'* ]] || [[ ${subcommand} == *'python'* ]]; then
+    CMD=${subcommand}
+else
+    CMD="./sct.py ${CMD}"
+fi
+
+run_in_docker "${CMD}" "${DOCKER_HOST}"

--- a/sct.py
+++ b/sct.py
@@ -22,7 +22,7 @@ from sdcm.utils.common import (list_instances_aws, list_instances_gce, list_reso
                                all_aws_regions, get_scylla_ami_versions, get_s3_scylla_repos_mapping,
                                list_logs_by_test_id, get_branched_ami, gce_meta_to_dict,
                                aws_tags_to_dict, list_elastic_ips_aws, get_builder_by_test_id,
-                               clean_resources_according_post_behavior,
+                               clean_resources_according_post_behavior, clean_sct_runners,
                                search_test_id_in_latest, get_testrun_dir, format_timestamp)
 from sdcm.utils.monitorstack import (restore_monitoring_stack, get_monitoring_stack_services,
                                      kill_running_monitoring_stack_services)
@@ -750,6 +750,12 @@ def create_runner_instance(cloud_provider, region, availability_zone, test_id, d
     else:
         LOGGER.error(f"Unable to SSH to {instance.public_ip_address}! Exiting...")
         sys.exit(1)
+
+
+@cli.command("clean-runner-instances", help="Clean all unused SCT runner instances")
+def clean_runner_instances():
+    add_file_logger()
+    clean_sct_runners()
 
 
 if __name__ == '__main__':

--- a/sct.py
+++ b/sct.py
@@ -26,6 +26,7 @@ from sdcm.utils.monitorstack import (restore_monitoring_stack, get_monitoring_st
                                      kill_running_monitoring_stack_services)
 from sdcm.cluster import Setup
 from sdcm.utils.log import setup_stdout_logger
+from sdcm.utils.prepare_region import AwsRegion
 from utils.build_system.create_test_release_jobs import JenkinsPipelines
 
 LOGGER = setup_stdout_logger()
@@ -698,6 +699,14 @@ def create_test_release_jobs_enterprise(branch, username, password, sct_branch, 
 
     server.create_pipeline_job(
         f'{server.base_sct_dir}/jenkins-pipelines/longevity-in-memory-36gb-1d.jenkinsfile', 'SCT_Enterprise_Features')
+
+
+@cli.command("prepare-aws-region", help="Create and configure VPC in selected AWS region")
+@click.option("-r", "--region", required=True, type=str, help="Name of the region")
+def prepare_aws_region(region):
+    add_file_logger()
+    aws_region = AwsRegion(region_name=region)
+    aws_region.configure()
 
 
 if __name__ == '__main__':

--- a/sdcm/keystore.py
+++ b/sdcm/keystore.py
@@ -1,24 +1,29 @@
 import json
+from collections import namedtuple
 
 import boto3
 from mypy_boto3_s3.service_resource import S3ServiceResource
 
 KEYSTORE_S3_BUCKET = "scylla-qa-keystore"
 
+SSHKey = namedtuple("SSHKey", ["name", "public_key", "private_key"])
+
 
 class KeyStore:
     def __init__(self):
         self.s3: S3ServiceResource = boto3.resource("s3")
 
+    def get_file_contents(self, file_name):
+        obj = self.s3.Object(KEYSTORE_S3_BUCKET, file_name)
+        return obj.get()["Body"].read()
+
     def get_json(self, json_file):
-        obj = self.s3.Object(KEYSTORE_S3_BUCKET, json_file)
         # deepcode ignore replace~read~decode~json.loads: is done automatically
-        return json.loads(obj.get()["Body"].read())
+        return json.loads(self.get_file_contents(json_file))
 
     def download_file(self, filename, dest_filename):
-        obj = self.s3.Object(KEYSTORE_S3_BUCKET, filename)
         with open(dest_filename, 'w') as file_obj:
-            file_obj.write(obj.get()["Body"].read().decode())
+            file_obj.write(self.get_file_contents(filename).decode())
 
     def get_email_credentials(self):
         return self.get_json("email_config.json")
@@ -35,9 +40,22 @@ class KeyStore:
     def get_qa_users(self):
         return self.get_json("qa_users.json")
 
+    def get_ssh_key_pair(self, name):
+        return SSHKey(name=name,
+                      public_key=self.get_file_contents(file_name=f"{name}.pub"),
+                      private_key=self.get_file_contents(file_name=name))
+
+    def get_ec2_ssh_key_pair(self):
+        return self.get_ssh_key_pair(name="scylla-qa-ec2")
+
+    def get_gce_ssh_key_pair(self):
+        return self.get_ssh_key_pair(name="scylla-test")
+
     def get_qa_ssh_keys(self):
-        # TODO
-        pass
+        return [
+            self.get_ec2_ssh_key_pair(),
+            self.get_gce_ssh_key_pair(),
+        ]
 
     def get_housekeeping_db_credentials(self):
         return self.get_json("housekeeping-db.json")

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -979,6 +979,9 @@ class SCTConfiguration(dict):
 
         dict(name="use_legacy_cluster_init", env="SCT_USE_LEGACY_CLUSTER_INIT", type=bool,
              help="""Use legacy cluster initialization with autobootsrap disabled and parallel node setup"""),
+        dict(name="availability_zone", env="SCT_AVAILABILITY_ZONE",
+             type=str,
+             help="Availability zone to use. Same for multi-region scenario."),
     ]
 
     required_params = ['cluster_backend', 'test_duration', 'n_db_nodes', 'n_loaders', 'use_preinstalled_scylla',
@@ -987,8 +990,9 @@ class SCTConfiguration(dict):
     # those can be added to a json scheme to validate / or write the validation code for it to be a bit clearer output
     backend_required_params = {
         'aws': ['user_prefix', "instance_type_loader", "instance_type_monitor", "instance_type_db",
-                "region_name", "security_group_ids", "subnet_id", "ami_id_db_scylla", "ami_id_loader",
-                "ami_id_monitor", "aws_root_disk_size_monitor", "ami_db_scylla_user", "ami_monitor_user"],
+                "region_name", "ami_id_db_scylla", "ami_id_loader",
+                "ami_id_monitor", "aws_root_disk_size_monitor", "aws_root_disk_name_monitor", "ami_db_scylla_user",
+                "ami_monitor_user"],
 
         'gce': ['user_prefix', 'gce_network', 'gce_image', 'gce_image_username', 'gce_instance_type_db',
                 'gce_root_disk_type_db', 'gce_root_disk_size_db', 'gce_n_local_ssd_disk_db',
@@ -1023,7 +1027,7 @@ class SCTConfiguration(dict):
     }
 
     multi_region_params = [
-        'region_name', 'n_db_nodes', 'security_group_ids', 'subnet_id', 'ami_id_db_scylla', 'ami_id_loader'
+        'region_name', 'n_db_nodes', 'ami_id_db_scylla', 'ami_id_loader'
     ]
 
     def __init__(self):

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -1,0 +1,264 @@
+import logging
+import random
+import sys
+import tempfile
+from enum import Enum
+from functools import lru_cache
+from math import ceil
+from textwrap import dedent
+
+import boto3
+
+from sdcm.keystore import KeyStore
+from sdcm.remote import RemoteCmdRunnerBase
+from sdcm.utils.common import ec2_instance_wait_public_ip
+from sdcm.utils.get_username import get_username
+from sdcm.utils.prepare_region import AwsRegion
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ImageType(Enum):
+    source = "source"
+    general = "general"
+
+
+class SctRunner:
+    """Provisions and configures the SCT runner"""
+    VERSION = 1.1  # Version of the Image
+    IMAGE_NAME = f"sct-runner-{VERSION}"
+    RUNNER_NAME = "SCT-Runner"
+    BASE_IMAGE_ID = "ami-0ffac660dd0cb2973"  # ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200609
+    SOURCE_IMAGE_REGION = "eu-west-2"  # where the source Runner image will be created and copied to other regions
+    LOGIN_USER = "ubuntu"
+    IMAGE_DESCRIPTION = "SCT runner image"
+
+    def __init__(self, region_name: str):
+        self.region_name = region_name
+        self.ec2_client = boto3.client("ec2", region_name=region_name)
+        self.ec2_client_source = boto3.client("ec2", region_name=self.SOURCE_IMAGE_REGION)
+        self.ec2_resource = boto3.resource("ec2", region_name=region_name)
+        self.ec2_resource_source = boto3.resource("ec2", region_name=self.SOURCE_IMAGE_REGION)
+        self._ssh_pkey_file = None
+
+    @staticmethod
+    def instance_type(test_duration):
+        if test_duration > 7 * 60:
+            return "m5.large"
+        return "t3.large"  # has 7h 12m CPU burst
+
+    @staticmethod
+    @lru_cache(maxsize=None)
+    def key_pair():
+        ks = KeyStore()
+        return ks.get_ec2_ssh_key_pair()
+
+    def get_remoter(self, host):
+        self._ssh_pkey_file = tempfile.NamedTemporaryFile(mode="w", delete=False)
+        self._ssh_pkey_file.write(self.key_pair().private_key.decode())
+        self._ssh_pkey_file.flush()
+        return RemoteCmdRunnerBase.create_remoter(hostname=host, user=self.LOGIN_USER, key_file=self._ssh_pkey_file.name)
+
+    def install_prereqs(self, public_ip):
+        LOGGER.info("Installing required packages...")
+        prereqs_script = dedent(f"""
+            echo "fs.aio-max-nr = 65536" >> /etc/sysctl.conf
+            mkdir -p -m 777 /home/ubuntu/sct-results
+            chown ubuntu:ubuntu /home/ubuntu/sct-results
+            echo "cd ~/sct-results" >> /home/ubuntu/.bashrc
+            apt clean
+            apt update
+            apt install -y python3-pip htop screen tree
+            pip3 install awscli
+            # docker
+            apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common
+            curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+            apt-key fingerprint 0EBFCD88
+            add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+            apt update
+            apt install -y docker-ce docker-ce-cli containerd.io
+            usermod -aG docker {self.LOGIN_USER}
+            # configure Jenkins user
+            apt install -y openjdk-14-jre-headless
+            adduser --disabled-password --gecos "" jenkins
+            usermod -aG docker jenkins
+            mkdir -p /home/jenkins/.ssh
+            echo "{self.key_pair().public_key.decode()}" > /home/jenkins/.ssh/authorized_keys
+            chmod 600 /home/jenkins/.ssh/authorized_keys
+            chown -R jenkins:jenkins /home/jenkins
+            echo "jenkins ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/jenkins
+            # Jenkins pipelines run /bin/sh for some reason
+            unlink /bin/sh
+            ln -s /bin/bash /bin/sh
+        """)
+        remoter = self.get_remoter(host=public_ip)
+        result = remoter.run(f"sudo bash -cxe '{prereqs_script}'", ignore_status=True)
+
+        remoter.stop()
+        if result.exit_status == 0:
+            LOGGER.info("All packages successfully installed.")
+        else:
+            raise Exception("Unable to install required packages:\n%s" % (result.stdout + result.stderr))
+
+    def _image(self, image_type=ImageType.source):
+        if image_type == ImageType.source:
+            client = self.ec2_client_source
+        elif image_type == ImageType.general:
+            client = self.ec2_client
+        else:
+            raise ValueError("Unknown Image type")
+        amis = client.describe_images(Owners=["self"],
+                                      Filters=[{"Name": "tag:Name", "Values": [self.IMAGE_NAME]},
+                                               {"Name": "tag:Version", "Values": [str(self.VERSION)]}])
+        LOGGER.debug(f"Found SCT Runner AMIs: {amis}")
+        existing_amis = amis.get("Images", [])
+        if len(existing_amis) == 0:
+            return None
+        assert len(existing_amis) == 1, \
+            f"More than 1 SCT Runner AMI with {self.IMAGE_NAME}:{self.VERSION} " \
+            f"found in {self.region_name}: {existing_amis}"
+        return self.ec2_resource.Image(existing_amis[0]["ImageId"])  # pylint: disable=no-member
+
+    @property
+    def source_image(self):
+        return self._image(image_type=ImageType.source)
+
+    @property
+    def image(self):
+        return self._image(image_type=ImageType.general)
+
+    def _create_instance(self, instance_type, image_id, tags_list, region_az=""):
+        region = region_az[:-1]
+        aws_region = AwsRegion(region_name=region)
+        region_az = region_az if region_az else random.choice(aws_region.availability_zones)
+        subnet = aws_region.sct_subnet(region_az=region_az)
+        assert subnet, f"No SCT subnet found in the source region. " \
+                       f"Use hydra prepare-region --region-name '{self.region_name}' to create cloud env!"
+        LOGGER.info("Creating instance...")
+        ec2_resource = boto3.resource("ec2", region_name=region)
+        result = ec2_resource.create_instances(
+            ImageId=image_id,
+            InstanceType=instance_type,
+            MinCount=1,
+            MaxCount=1,
+            KeyName=aws_region.KEY_PAIR_NAME,
+            NetworkInterfaces=[{
+                "DeviceIndex": 0,
+                "AssociatePublicIpAddress": True,
+                "SubnetId": subnet.subnet_id,
+                "Groups": [aws_region.sct_security_group.group_id],
+                "DeleteOnTermination": True,
+            }],
+            TagSpecifications=[{"ResourceType": "instance", "Tags": tags_list}],
+        )
+        instance = result[0]
+        LOGGER.info("Instance created. Waiting until it becomes running... ")
+        instance.wait_until_running()
+        LOGGER.info("Instance '%s' is running. Waiting for public IP...", instance.instance_id)
+        ec2_instance_wait_public_ip(instance=instance)
+        LOGGER.info("Got public IP: %s", instance.public_ip_address)
+        return instance
+
+    def tag_image(self, image_id, image_type):
+        if image_type == ImageType.source:
+            ec2_resource = self.ec2_resource_source
+        elif image_type == ImageType.general:
+            ec2_resource = self.ec2_resource
+        image_tags = [
+            {"Key": "Name", "Value": self.IMAGE_NAME},
+            {"Key": "Version", "Value": str(self.VERSION)},
+        ]
+        runer_image = ec2_resource.Image(image_id)
+        runer_image.wait_until_exists()
+        LOGGER.info("Image '%s' exists and ready. Tagging...", image_id)
+        runer_image.create_tags(Tags=image_tags)
+        LOGGER.info("Tagging completed.")
+        LOGGER.info("SCT Runner image created in '%s'. Id [%s].", self.region_name, image_id)
+
+    def create_image(self):
+        """
+            Create an Image for SCT Runner in specified region. If the Image exists in SOURCE_REGION
+            it will be copied to the destination region.
+            Warning: this can't run in parallel!
+        """
+        LOGGER.info(f"Looking for source SCT Runner Image in {self.SOURCE_IMAGE_REGION}...")
+        source_image = self.source_image
+        if not source_image:
+            LOGGER.info(f"Source SCT Runner Image not found. Creating...")
+            instance = self._create_instance(
+                instance_type="t3.small",
+                image_id=self.BASE_IMAGE_ID,
+                tags_list=[{"Key": "Name", "Value": "sct-image-builder"},
+                           {"Key": "keep", "Value": "1"},
+                           {"Key": "keep_action", "Value": "terminate"},
+                           {"Key": "Version", "Value": str(self.VERSION)},
+                           ],
+                region_az=self.SOURCE_IMAGE_REGION + "a"
+            )
+            self.install_prereqs(public_ip=instance.public_ip_address)
+            LOGGER.info("Stopping the SCT Image Builder instance...")
+            instance.stop()
+            instance.wait_until_stopped()
+            LOGGER.info("SCT Image Builder instance stopped.\nCreating image...")
+            result = self.ec2_client_source.create_image(
+                Description=self.IMAGE_DESCRIPTION,
+                InstanceId=instance.instance_id,
+                Name=self.IMAGE_NAME,
+                NoReboot=False
+            )
+            self.tag_image(image_id=result["ImageId"], image_type=ImageType.source)
+            try:
+                LOGGER.info("Terminating image builder instance '%s'...", instance.instance_id)
+                instance.terminate()
+            except Exception as ex:  # pylint: disable=broad-except
+                LOGGER.warning(f"Was not able to terminate '{instance.instance_id}': {ex}\n"
+                               "Please terminate manually!!!")
+
+        else:
+            LOGGER.info(f"SCT Runner image exists in the source region '{self.SOURCE_IMAGE_REGION}'! "
+                        f"ID: {source_image.image_id}")
+
+        if self.region_name != self.SOURCE_IMAGE_REGION and self.image is None:
+            LOGGER.info(f"Copying {self.IMAGE_NAME} to {self.region_name}...\nNote: It can take 5-15 minutes.")
+            result = self.ec2_client.copy_image(  # pylint: disable=no-member
+                Description=self.IMAGE_DESCRIPTION,
+                Name=self.IMAGE_NAME,
+                SourceImageId=self.source_image.image_id,
+                SourceRegion=self.SOURCE_IMAGE_REGION
+            )
+            LOGGER.info("Image copied, id: '%s'.", result["ImageId"])
+            self.tag_image(image_id=result["ImageId"], image_type=ImageType.general)
+            LOGGER.info("Done.")
+        else:
+            LOGGER.info("No need to copy SCT Runner image since it  already exists in '%s'.", self.region_name)
+
+    def create_instance(self, test_id: str, test_duration: int, region_az: str):
+        """
+            :param test_duration: used to set keep-alive flags, measured in MINUTES
+        """
+        LOGGER.info("Creating SCT Runner instance...")
+        image = self.image
+        if not image:
+            LOGGER.error(f"SCT Runner image was not found in {self.region_name}! "
+                         f"Use hydra create-runner-image --cloud-privider aws --region {self.region_name}")
+            sys.exit(1)
+        return self._create_instance(
+            instance_type=self.instance_type(test_duration=test_duration),
+            image_id=self.image.image_id,
+            tags_list=[
+                {"Key": "Name", "Value": self.RUNNER_NAME},
+                {"Key": "TestId", "Value": test_id},
+                {"Key": "RunByUser", "Value": get_username()},
+                {"Key": "keep", "Value": str(ceil(test_duration / 60))},
+                {"Key": "keep_action", "Value": "stop"},
+            ],
+            region_az=region_az,
+        )
+
+
+if __name__ == "__main__":
+    TEST_REGION = "eu-west-2"
+    SCT_RUNNER = SctRunner(region_name=TEST_REGION)
+    SCT_RUNNER.create_image()
+    SCT_RUNNER.create_instance(test_id="byakabuka", test_duration=60, region_az=TEST_REGION)

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -28,6 +28,7 @@ class SctRunner:
     """Provisions and configures the SCT runner"""
     VERSION = 1.1  # Version of the Image
     IMAGE_NAME = f"sct-runner-{VERSION}"
+    NODE_TYPE = "sct-runner"
     RUNNER_NAME = "SCT-Runner"
     BASE_IMAGE_ID = "ami-0ffac660dd0cb2973"  # ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200609
     SOURCE_IMAGE_REGION = "eu-west-2"  # where the source Runner image will be created and copied to other regions
@@ -249,9 +250,10 @@ class SctRunner:
             tags_list=[
                 {"Key": "Name", "Value": self.RUNNER_NAME},
                 {"Key": "TestId", "Value": test_id},
+                {"Key": "NodeType", "Value": self.NODE_TYPE},
                 {"Key": "RunByUser", "Value": get_username()},
-                {"Key": "keep", "Value": str(ceil(test_duration / 60))},
-                {"Key": "keep_action", "Value": "stop"},
+                {"Key": "keep", "Value": str(ceil(test_duration / 60) + 6)},
+                {"Key": "keep_action", "Value": "terminate"},
             ],
             region_az=region_az,
         )

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1877,3 +1877,16 @@ def clean_enospc_on_node(target_node, sleep_time):
     time.sleep(sleep_time / 2)
     target_node.remoter.run('sudo systemctl restart scylla-server.service')
     target_node.wait_db_up()
+
+
+class PublicIpNotReady(Exception):
+    pass
+
+
+@retrying(n=7, sleep_time=10, allowed_exceptions=(PublicIpNotReady,),
+          message="Waiting for instance to get public ip")
+def ec2_instance_wait_public_ip(instance):
+    instance.reload()
+    if instance.public_ip_address is None:
+        raise PublicIpNotReady(instance)
+    LOGGER.debug(f"[{instance}] Got public ip: {instance.public_ip_address}")

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -671,7 +671,11 @@ def clean_instances_aws(tags_dict):
         for instance in instance_list:
             tags = aws_tags_to_dict(instance.get('Tags'))
             name = tags.get("Name", "N/A")
+            node_type = tags.get("NodeType")
             instance_id = instance['InstanceId']
+            if node_type and node_type == "sct-runner":
+                LOGGER.info(f"Skipping Sct Runner instance '{instance_id}'")
+                continue
             LOGGER.info("Going to delete '{instance_id}' [name={name}] ".format(instance_id=instance_id, name=name))
             response = client.terminate_instances(InstanceIds=[instance_id])
             LOGGER.debug("Done. Result: %s\n", response['TerminatingInstances'])

--- a/sdcm/utils/get_username.py
+++ b/sdcm/utils/get_username.py
@@ -24,7 +24,7 @@ def get_email_user(email_addr: str) -> str:
     return email_addr.strip().split("@")[0]
 
 
-def get_username() -> str:
+def get_username() -> str:  # pylint: disable=too-many-return-statements
     # First check that we running on Jenkins try to get user email
     email = os.environ.get('BUILD_USER_EMAIL')
     if is_email_in_scylladb_domain(email):
@@ -37,6 +37,8 @@ def get_username() -> str:
     current_linux_user = getpass.getuser()
     if current_linux_user == "jenkins":
         return current_linux_user
+    if current_linux_user == "ubuntu":
+        return "sct-runner"
 
     # We are not on Jenkins and running in Hydra, try to get email from Git
     # when running in Hydra there are env issues so we pass it using SCT_GIT_USER_EMAIL variable before docker run

--- a/sdcm/utils/log.py
+++ b/sdcm/utils/log.py
@@ -5,9 +5,9 @@ import logging.config
 LOGGER = logging.getLogger(__name__)
 
 
-def setup_stdout_logger():
+def setup_stdout_logger(log_level=logging.INFO):
     root_logger = logging.getLogger()
-    root_logger.setLevel(logging.INFO)
+    root_logger.setLevel(log_level)
     root_logger.addHandler(logging.StreamHandler(sys.stdout))
     return root_logger
 

--- a/sdcm/utils/prepare_region.py
+++ b/sdcm/utils/prepare_region.py
@@ -1,0 +1,364 @@
+import logging
+from ipaddress import ip_network
+from functools import cached_property
+
+import boto3
+import botocore
+from mypy_boto3_ec2 import EC2Client, EC2ServiceResource
+
+from sdcm.keystore import KeyStore
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class AwsRegion:
+    VPC_NAME = "SCT-vpc"
+    VPC_CIDR = ip_network("10.0.0.0/16")
+    SECURITY_GROUP_NAME = "SCT-sg"
+    SUBNET_NAME = "SCT-subnet-{availability_zone}"
+    INTERNET_GATEWAY_NAME = "SCT-igw"
+    ROUTE_TABLE_NAME = "SCT-rt"
+    KEY_PAIR_NAME = "scylla-qa-ec2"  # TODO: change legacy name to sct-keypair-aws
+
+    def __init__(self, region_name):
+        self.region_name = region_name
+        self.client: EC2Client = boto3.client("ec2", region_name=region_name)
+        self.resource: EC2ServiceResource = boto3.resource("ec2", region_name=region_name)
+
+    @property
+    def sct_vpc(self) -> EC2ServiceResource.Vpc:
+        vpcs = self.client.describe_vpcs(Filters=[{"Name": "tag:Name", "Values": [self.VPC_NAME]}])
+        LOGGER.debug(f"Found VPCs: {vpcs}")
+        existing_vpcs = vpcs.get("Vpcs", [])
+        if len(existing_vpcs) == 0:
+            return None
+        assert len(existing_vpcs) == 1, \
+            f"More than 1 VPC with {self.VPC_NAME} found in {self.region_name}: {existing_vpcs}"
+        return self.resource.Vpc(existing_vpcs[0]["VpcId"])  # pylint: disable=no-member
+
+    def create_vpc(self):
+        LOGGER.info("Going to create VPC...")
+        if self.sct_vpc:
+            LOGGER.warning(f"VPC '{self.VPC_NAME}' already exists!  Id: '{self.sct_vpc.vpc_id}'.")
+            return self.sct_vpc.vpc_id
+        else:
+            result = self.client.create_vpc(CidrBlock=str(self.VPC_CIDR), AmazonProvidedIpv6CidrBlock=True)
+            vpc_id = result["Vpc"]["VpcId"]
+            vpc = self.resource.Vpc(vpc_id)  # pylint: disable=no-member
+            vpc.create_tags(Tags=[{"Key": "Name", "Value": self.VPC_NAME}])
+            LOGGER.info("'%s' with id '%s' created. Waiting until it becomes available...", self.VPC_NAME, vpc_id)
+            vpc.wait_until_available()
+            return vpc_id
+
+    @cached_property
+    def availability_zones(self):
+        response = self.client.describe_availability_zones()
+        return [zone["ZoneName"]for zone in response['AvailabilityZones'] if zone["State"] == "available"]
+
+    @cached_property
+    def vpc_ipv6_cidr(self):
+        return ip_network(self.sct_vpc.ipv6_cidr_block_association_set[0]["Ipv6CidrBlock"])
+
+    def az_subnet_name(self, region_az):
+        return self.SUBNET_NAME.format(availability_zone=region_az)
+
+    def sct_subnet(self, region_az) -> EC2ServiceResource.Subnet:
+        subnet_name = self.az_subnet_name(region_az)
+        subnets = self.client.describe_subnets(Filters=[{"Name": "tag:Name", "Values": [subnet_name]}])
+        LOGGER.debug(f"Found Subnets: {subnets}")
+        existing_subnets = subnets.get("Subnets", [])
+        if len(existing_subnets) == 0:
+            return None
+        assert len(existing_subnets) == 1, \
+            f"More than 1 Subnet with {subnet_name} found in {self.region_name}: {existing_subnets}!"
+        return self.resource.Subnet(existing_subnets[0]["SubnetId"])  # pylint: disable=no-member
+
+    def create_subnet(self, region_az, ipv4_cidr, ipv6_cidr):
+        LOGGER.info(f"Creating subnet for {region_az}...")
+        subnet_name = self.az_subnet_name(region_az)
+        if self.sct_subnet(region_az):
+            subnet_id = self.sct_subnet(region_az).subnet_id
+            LOGGER.warning(f"Subnet '{subnet_name}' already exists!  Id: '{subnet_id}'.")
+        else:
+
+            result = self.client.create_subnet(CidrBlock=str(ipv4_cidr), Ipv6CidrBlock=str(ipv6_cidr),
+                                               VpcId=self.sct_vpc.vpc_id, AvailabilityZone=region_az)
+            subnet_id = result["Subnet"]["SubnetId"]
+            subnet = self.resource.Subnet(subnet_id)  # pylint: disable=no-member
+            subnet.create_tags(Tags=[{"Key": "Name", "Value": subnet_name}])
+            LOGGER.info("Configuring to automatically assign public IPv4 and IPv6 addresses...")
+            self.client.modify_subnet_attribute(
+                MapPublicIpOnLaunch={"Value": True},
+                SubnetId=subnet_id
+            )
+            # for some reason boto3 throws error when both AssignIpv6AddressOnCreation and MapPublicIpOnLaunch are used
+            self.client.modify_subnet_attribute(
+                AssignIpv6AddressOnCreation={"Value": True},
+                SubnetId=subnet_id
+            )
+            LOGGER.info("'%s' with id '%s' created.", subnet_name, subnet_id)
+
+    def create_subnets(self):
+        num_subnets = len(self.availability_zones)
+        ipv4_cidrs = list(self.VPC_CIDR.subnets(6))[:num_subnets]
+        ipv6_cidrs = list(self.vpc_ipv6_cidr.subnets(8))[:num_subnets]
+        for i, az_name in enumerate(self.availability_zones):
+            self.create_subnet(region_az=az_name, ipv4_cidr=ipv4_cidrs[i], ipv6_cidr=ipv6_cidrs[i])
+
+    @property
+    def sct_internet_gateway(self) -> EC2ServiceResource.InternetGateway:
+        igws = self.client.describe_internet_gateways(Filters=[{"Name": "tag:Name",
+                                                                "Values": [self.INTERNET_GATEWAY_NAME]}])
+        LOGGER.debug(f"Found Internet gateways: {igws}")
+        existing_igws = igws.get("InternetGateways", [])
+        if len(existing_igws) == 0:
+            return None
+        assert len(existing_igws) == 1, \
+            f"More than 1 Internet Gateway with {self.INTERNET_GATEWAY_NAME} found " \
+            f"in {self.region_name}: {existing_igws}!"
+        return self.resource.InternetGateway(existing_igws[0]["InternetGatewayId"])  # pylint: disable=no-member
+
+    def create_internet_gateway(self):
+        LOGGER.info("Creating Internet Gateway..")
+        if self.sct_internet_gateway:
+            LOGGER.warning(f"Internet Gateway '{self.INTERNET_GATEWAY_NAME}' already exists! "
+                           f"Id: '{self.sct_internet_gateway.internet_gateway_id}'.")
+        else:
+            result = self.client.create_internet_gateway()
+            igw_id = result["InternetGateway"]["InternetGatewayId"]
+            igw = self.resource.InternetGateway(igw_id)  # pylint: disable=no-member
+            igw.create_tags(Tags=[{"Key": "Name", "Value": self.INTERNET_GATEWAY_NAME}])
+            LOGGER.info("'%s' with id '%s' created. Attaching to '%s'",
+                        self.INTERNET_GATEWAY_NAME, igw_id, self.sct_vpc.vpc_id)
+            igw.attach_to_vpc(VpcId=self.sct_vpc.vpc_id)
+
+    @cached_property
+    def sct_route_table(self) -> EC2ServiceResource.RouteTable:
+        route_tables = self.client.describe_route_tables(Filters=[{"Name": "tag:Name",
+                                                                   "Values": [self.ROUTE_TABLE_NAME]}])
+        LOGGER.debug(f"Found Route Tables: {route_tables}")
+        existing_rts = route_tables.get("RouteTables", [])
+        if len(existing_rts) == 0:
+            return None
+        assert len(existing_rts) == 1, \
+            f"More than 1 Route Table with {self.ROUTE_TABLE_NAME} found " \
+            f"in {self.region_name}: {existing_rts}!"
+        return self.resource.RouteTable(existing_rts[0]["RouteTableId"])  # pylint: disable=no-member
+
+    def configure_route_table(self):
+        # add route to Internet: 0.0.0.0/0 -> igw
+        LOGGER.info("Configuring main Route Table...")
+        if self.sct_route_table:
+            LOGGER.warning(f"Route Table '{self.ROUTE_TABLE_NAME}' already exists! "
+                           f"Id: '{self.sct_route_table.route_table_id}'.")
+        else:
+            route_tables = list(self.sct_vpc.route_tables.all())
+            assert len(route_tables) == 1, f"Only one main route table should exist for {self.VPC_NAME}. " \
+                                           f"Found {len(route_tables)}!"
+            route_table: EC2ServiceResource.RouteTable = route_tables[0]
+            route_table.create_tags(Tags=[{"Key": "Name", "Value": self.ROUTE_TABLE_NAME}])
+            LOGGER.info("Setting routing of all outbound traffic via Internet Gateway...")
+            route_table.create_route(DestinationCidrBlock="0.0.0.0/0",
+                                     GatewayId=self.sct_internet_gateway.internet_gateway_id)
+            route_table.create_route(DestinationIpv6CidrBlock="::/0",
+                                     GatewayId=self.sct_internet_gateway.internet_gateway_id)
+            LOGGER.info("Going to associate all Subnets with the Route Table...")
+            for az_name in self.availability_zones:
+                subnet_id = self.sct_subnet(az_name).subnet_id
+                LOGGER.info("Associating Route Table with '%s' [%s]...", self.az_subnet_name(az_name), subnet_id)
+                route_table.associate_with_subnet(SubnetId=subnet_id)
+
+    @property
+    def sct_security_group(self) -> EC2ServiceResource.SecurityGroup:
+        security_groups = self.client.describe_security_groups(Filters=[{"Name": "tag:Name",
+                                                                         "Values": [self.SECURITY_GROUP_NAME]}])
+        LOGGER.debug(f"Found Security Groups: {security_groups}")
+        existing_sgs = security_groups.get("SecurityGroups", [])
+        if len(existing_sgs) == 0:
+            return None
+        assert len(existing_sgs) == 1, \
+            f"More than 1 Security group with {self.SECURITY_GROUP_NAME} found " \
+            f"in {self.region_name}: {existing_sgs}!"
+        return self.resource.SecurityGroup(existing_sgs[0]["GroupId"])  # pylint: disable=no-member
+
+    def create_security_group(self):
+        """
+
+        Custom TCP	TCP	9093	0.0.0.0/0	Allow alert manager for all
+        Custom TCP	TCP	9093	::/0	Allow alert manager for all
+
+        """
+        LOGGER.info("Creating Security Group...")
+        if self.sct_security_group:
+            LOGGER.warning(f"Security Group '{self.SECURITY_GROUP_NAME}' already exists! "
+                           f"Id: '{self.sct_internet_gateway.internet_gateway_id}'.")
+        else:
+            result = self.client.create_security_group(Description='Security group that is used by SCT',
+                                                       GroupName=self.SECURITY_GROUP_NAME,
+                                                       VpcId=self.sct_vpc.vpc_id)
+            sg_id = result["GroupId"]
+            security_group = self.resource.SecurityGroup(sg_id)  # pylint: disable=no-member
+            security_group.create_tags(Tags=[{"Key": "Name", "Value": self.SECURITY_GROUP_NAME}])
+            LOGGER.info("'%s' with id '%s' created. ", self.SECURITY_GROUP_NAME, self.sct_security_group.group_id)
+            LOGGER.info("Creating common ingress rules...")
+            security_group.authorize_ingress(
+                IpPermissions=[
+                    {
+                        "IpProtocol": "-1",
+                        "UserIdGroupPairs": [
+                            {
+                                "Description": "Allow ALL traffic inside the Security group",
+                                "GroupId": sg_id,
+                                "UserId": security_group.owner_id
+                            }
+                        ]
+                    },
+                    {
+                        "FromPort": 22,
+                        "ToPort": 22,
+                        "IpProtocol": "tcp",
+                        "IpRanges": [{'CidrIp': '0.0.0.0/0', 'Description': 'SSH connectivity to the instances'}],
+                        "Ipv6Ranges": [{'CidrIpv6': '::/0', 'Description': 'SSH connectivity to the instances'}]
+                    },
+                    {
+                        "FromPort": 3000,
+                        "ToPort": 3000,
+                        "IpProtocol": "tcp",
+                        "IpRanges": [{'CidrIp': '0.0.0.0/0', 'Description': 'Allow Grafana for ALL'}],
+                        "Ipv6Ranges": [{'CidrIpv6': '::/0', 'Description': 'Allow Grafana for ALL'}]
+                    },
+                    {
+                        "FromPort": 9042,
+                        "ToPort": 9042,
+                        "IpProtocol": "tcp",
+                        "IpRanges": [{'CidrIp': '0.0.0.0/0', 'Description': 'Allow CQL for ALL'}],
+                        "Ipv6Ranges": [{'CidrIpv6': '::/0', 'Description': 'Allow CQL for ALL'}]
+                    },
+                    {
+                        "FromPort": 9142,
+                        "ToPort": 9142,
+                        "IpProtocol": "tcp",
+                        "IpRanges": [{'CidrIp': '0.0.0.0/0', 'Description': 'Allow SSL CQL for ALL'}],
+                        "Ipv6Ranges": [{'CidrIpv6': '::/0', 'Description': 'Allow SSL CQL for ALL'}]
+                    },
+                    {
+                        "FromPort": 9100,
+                        "ToPort": 9100,
+                        "IpProtocol": "tcp",
+                        "IpRanges": [{'CidrIp': '0.0.0.0/0', 'Description': 'Allow node_exporter on Db nodes for ALL'}],
+                        "Ipv6Ranges": [{'CidrIpv6': '::/0', 'Description': 'Allow node_exporter on Db nodes for ALL'}]
+                    },
+                    {
+                        "FromPort": 8080,
+                        "ToPort": 8080,
+                        "IpProtocol": "tcp",
+                        "IpRanges": [{'CidrIp': '0.0.0.0/0', 'Description': 'Allow Alternator for ALL'}],
+                        "Ipv6Ranges": [{'CidrIpv6': '::/0', 'Description': 'Allow Alternator for ALL'}]
+                    },
+                    {
+                        "FromPort": 9090,
+                        "ToPort": 9090,
+                        "IpProtocol": "tcp",
+                        "IpRanges": [{'CidrIp': '0.0.0.0/0', 'Description': 'Allow Prometheus for ALL'}],
+                        "Ipv6Ranges": [{'CidrIpv6': '::/0', 'Description': 'Allow  Prometheus for ALL'}]
+                    },
+                    {
+                        "FromPort": 9180,
+                        "ToPort": 9180,
+                        "IpProtocol": "tcp",
+                        "IpRanges": [{'CidrIp': '0.0.0.0/0', 'Description': 'Allow Prometheus API for ALL'}],
+                        "Ipv6Ranges": [{'CidrIpv6': '::/0', 'Description': 'Allow Prometheus API for ALL'}]
+                    },
+                    {
+                        "FromPort": 7000,
+                        "ToPort": 7000,
+                        "IpProtocol": "tcp",
+                        "IpRanges": [{'CidrIp': '0.0.0.0/0',
+                                      'Description': 'Allow Inter-node communication (RPC) for ALL'}],
+                        "Ipv6Ranges": [{'CidrIpv6': '::/0',
+                                        'Description': 'Allow Inter-node communication (RPC) for ALL'}]
+                    },
+                    {
+                        "FromPort": 7001,
+                        "ToPort": 7001,
+                        "IpProtocol": "tcp",
+                        "IpRanges": [{'CidrIp': '0.0.0.0/0',
+                                      'Description': 'Allow SSL inter-node communication (RPC) for ALL'}],
+                        "Ipv6Ranges": [{'CidrIpv6': '::/0',
+                                        'Description': 'Allow SSL inter-node communication (RPC) for ALL'}]
+                    },
+                    {
+                        "FromPort": 7199,
+                        "ToPort": 7199,
+                        "IpProtocol": "tcp",
+                        "IpRanges": [{'CidrIp': '0.0.0.0/0', 'Description': 'Allow JMX management for ALL'}],
+                        "Ipv6Ranges": [{'CidrIpv6': '::/0', 'Description': 'Allow JMX management for ALL'}]
+                    },
+                    {
+                        "FromPort": 10001,
+                        "ToPort": 10001,
+                        "IpProtocol": "tcp",
+                        "IpRanges": [{'CidrIp': '0.0.0.0/0',
+                                      'Description': 'Allow Scylla Manager Agent REST API  for ALL'}],
+                        "Ipv6Ranges": [{'CidrIpv6': '::/0',
+                                        'Description': 'Allow Scylla Manager Agent REST API for ALL'}]
+                    },
+                    {
+                        "FromPort": 56090,
+                        "ToPort": 56090,
+                        "IpProtocol": "tcp",
+                        "IpRanges": [{'CidrIp': '0.0.0.0/0',
+                                      'Description': 'Allow Scylla Manager Agent Prometheus API for ALL'}],
+                        "Ipv6Ranges": [{'CidrIpv6': '::/0',
+                                        'Description': 'Allow Scylla Manager Agent Prometheus API for ALL'}]
+                    },
+                    {
+                        "IpProtocol": "-1",
+                        "IpRanges": [{'CidrIp': '172.0.0.0/11',
+                                      'Description': 'Allow traffic from Scylla Cloud lab while VPC peering for ALL'}],
+                    }
+                ]
+            )
+
+    @property
+    def sct_keypair(self):
+        try:
+            key_pairs = self.client.describe_key_pairs(KeyNames=[self.KEY_PAIR_NAME])
+        except botocore.exceptions.ClientError as ex:
+            if "InvalidKeyPair.NotFound" in str(ex):
+                return None
+            else:
+                raise
+        LOGGER.debug(f"Found key pairs: {key_pairs}")
+        existing_key_pairs = key_pairs.get("KeyPairs", [])
+        assert len(existing_key_pairs) == 1, \
+            f"More than 1 Key Pair with {self.KEY_PAIR_NAME} found " \
+            f"in {self.region_name}: {existing_key_pairs}!"
+        return self.resource.KeyPair(existing_key_pairs[0]["KeyName"])  # pylint: disable=no-member
+
+    def create_key_pair(self):
+        LOGGER.info("Creating SCT Key Pair...")
+        if self.sct_keypair:
+            LOGGER.warning(f"SCT Key Pair already exists in {self.region_name}!")
+        else:
+            ks = KeyStore()
+            sct_key_pair = ks.get_ec2_ssh_key_pair()
+            self.resource.import_key_pair(KeyName=self.KEY_PAIR_NAME,  # pylint: disable=no-member
+                                          PublicKeyMaterial=sct_key_pair.public_key)
+            LOGGER.info("SCT Key Pair created.")
+
+    def configure(self):
+        LOGGER.info(f"Configuring '{self.region_name}' region...")
+        self.create_vpc()
+        self.create_subnets()
+        self.create_internet_gateway()
+        self.configure_route_table()
+        self.create_security_group()
+        self.create_key_pair()
+        LOGGER.info("Region configured successfully.")
+
+
+if __name__ == "__main__":
+    AWS_REGION = AwsRegion(region_name="eu-west-2")
+    AWS_REGION.configure()

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -53,12 +53,13 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         os.environ['SCT_N_DB_NODES'] = '2 2'
         os.environ['SCT_INSTANCE_TYPE_DB'] = 'i3.large'
         os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-06f919eb ami-eae4f795'
+        os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/minimal_test_case.yaml'
 
         conf = SCTConfiguration()
         conf.verify_configuration()
         conf.dump_config()
 
-        self.assertEqual(conf.get('security_group_ids'), 'sg-059a7f66a947d4b5c sg-c5e1f7a0')
+        self.assertEqual(conf.get('ami_id_db_scylla'), 'ami-06f919eb ami-eae4f795')
 
     def test_05_docker(self):
         os.environ['SCT_CLUSTER_BACKEND'] = 'docker'
@@ -284,16 +285,27 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
 
         self.assertEqual(conf['store_results_in_elasticsearch'], False)
 
-    def test_14_(self):
-        os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
+    def test_14_aws_siren_from_env(self):
+        os.environ['SCT_CLUSTER_BACKEND'] = 'aws-siren'
         os.environ['SCT_REGION_NAME'] = 'us-east-1'
         os.environ['SCT_N_DB_NODES'] = '2'
         os.environ['SCT_INSTANCE_TYPE_DB'] = 'i3.large'
         os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-eae4f795'
+        os.environ['SCT_AUTHENTICATOR_USER'] = "user"
+        os.environ['SCT_AUTHENTICATOR_PASSWORD'] = "pass"
+        os.environ['SCT_CLOUD_CLUSTER_ID'] = "193712947904378"
+        os.environ['SCT_SECURITY_GROUP_IDS'] = "sg-89fi3rkl"
+        os.environ['SCT_SUBNET_ID'] = "sub-d32f09sdf"
+
+        os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/multi_region_dc_test_case.yaml'
 
         conf = SCTConfiguration()
         conf.verify_configuration()
-        self.assertEqual(conf.get('security_group_ids'), 'sg-c5e1f7a0')
+        self.assertEqual(conf.get('cloud_cluster_id'), 193712947904378)
+        assert conf["authenticator_user"] == "user"
+        assert conf["authenticator_password"] == "pass"
+        assert conf["security_group_ids"] == ["sg-89fi3rkl"]
+        assert conf["subnet_id"] == ["sub-d32f09sdf"]
 
     def test_15_new_scylla_repo(self):
         centos_repo = 'https://s3.amazonaws.com/downloads.scylladb.com/enterprise/rpm/unstable/centos/' \

--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -1,10 +1,12 @@
 #! groovy
 
 def call(Map pipelineParams) {
+    def builder = getJenkinsLabels(params.backend, params.get('region_name', 'eu-west-1'))
+
     pipeline {
         agent {
             label {
-                label getJenkinsLabels(params.backend, params.get('region_name', 'eu-west-1'))
+                label builder.label
             }
         }
         environment {
@@ -65,7 +67,7 @@ def call(Map pipelineParams) {
                         params.instance_type.split(' ').each {
                             def instance_type = it
                             tasks["${instance_type}"] = {
-                                node(getJenkinsLabels(params.backend, params.get('region_name', 'eu-west-1'))) {
+                                node(builder.label) {
                                     withEnv(["AWS_ACCESS_KEY_ID=${env.AWS_ACCESS_KEY_ID}",
                                              "AWS_SECRET_ACCESS_KEY=${env.AWS_SECRET_ACCESS_KEY}",]) {
                                         stage("Checkout (${instance_type})") {

--- a/vars/byoLongevityPipeline.groovy
+++ b/vars/byoLongevityPipeline.groovy
@@ -1,5 +1,6 @@
 #!groovy
 
+
 def call() {
 
     def builder = getJenkinsLabels(params.backend, params.aws_region)
@@ -38,18 +39,28 @@ def call() {
                description: 'aws|gce',
                name: 'backend')
             string(defaultValue: "eu-west-1",
-               description: 'Supported: us-east-1|eu-west-1|eu-west-2|random (randomly select region)',
+               description: 'Supported: us-east-1|eu-west-1|eu-west-2|eu-north-1|random (randomly select region)',
                name: 'aws_region')
             string(defaultValue: "a",
                description: 'Availability zone',
                name: 'availability_zone')
+
             string(defaultValue: '', description: '', name: 'loader_ami_id')
             string(defaultValue: '', description: '', name: 'scylla_ami_id')
             string(defaultValue: '', description: '', name: 'scylla_version')
             string(defaultValue: '', description: '', name: 'scylla_repo')
+
+            string(defaultValue: '',
+                   description: 'If empty - the default manager version will be taken',
+                   name: 'scylla_mgmt_repo')
+
             string(defaultValue: "spot_low_price",
                    description: 'spot_low_price|on_demand|spot_fleet|spot_low_price|spot_duration',
                    name: 'provision_type')
+
+            string(defaultValue: "private",
+                   description: 'private|public|ipv6',
+                   name: 'ip_ssh_connections')
 
             string(defaultValue: "keep-on-failure",
                    description: 'keep|keep-on-failure|destroy',
@@ -70,7 +81,9 @@ def call() {
             string(defaultValue: '',
                    description: 'cloud path for RPMs, s3:// or gs://',
                    name: 'update_db_packages')
-
+            string(defaultValue: "false",
+                   description: 'true|false',
+                   name: 'tag_ami_with_result')
             string(defaultValue: "qa@scylladb.com",
                    description: 'email recipients of email report',
                    name: 'email_recipients')
@@ -103,16 +116,9 @@ def call() {
                         script {
                             wrap([$class: 'BuildUser']) {
                                 dir('scylla-cluster-tests') {
-                                    def cloud_provider = params.backend.trim().toLowerCase()
-                                    println("AWS region: " + builder.region)
-                                    sh """
-                                    if [[ "$cloud_provider" == "aws" ]]; then
-                                        rm -fv sct_runner_ip
-                                        ./docker/env/hydra.sh create-runner-instance --cloud-provider ${cloud_provider} --region ${builder.region} --availability-zone ${params.availability_zone} --test-id \${SCT_TEST_ID} --duration ${params.timeout}
-                                    else
-                                        echo "Currently, <$cloud_provider> not supported to. Will run on regular builder."
-                                    fi
-                                    """
+                                    println(params)
+                                    println(builder)
+                                    createSctRunner(params, params.timeout.toInteger(), builder.region)
                                 }
                             }
                         }
@@ -125,61 +131,7 @@ def call() {
                         script {
                             wrap([$class: 'BuildUser']) {
                                 dir('scylla-cluster-tests') {
-
-                                    // handle params which can be a json list
-                                    def aws_region = initAwsRegionParam(params.aws_region, builder.region)
-                                    def test_config = groovy.json.JsonOutput.toJson(params.test_config)
-                                    def cloud_provider = params.backend.trim().toLowerCase()
-
-                                    sh """
-                                    #!/bin/bash
-                                    set -xe
-                                    env
-
-                                    rm -fv ./latest
-
-                                    export SCT_CLUSTER_BACKEND="${params.backend}"
-                                    export SCT_REGION_NAME=${aws_region}
-                                    export SCT_CONFIG_FILES=${test_config}
-
-                                    if [[ ! -z "${params.loader_ami_id}" ]] ; then
-                                        export SCT_AMI_ID_LOADER="${params.loader_ami_id}"
-                                    fi
-
-                                    if [[ ! -z "${params.scylla_ami_id}" ]] ; then
-                                        export SCT_AMI_ID_DB_SCYLLA="${params.scylla_ami_id}"
-                                    elif [[ ! -z "${params.scylla_version}" ]] ; then
-                                        export SCT_SCYLLA_VERSION="${params.scylla_version}"
-                                    elif [[ ! -z "${params.scylla_repo}" ]] ; then
-                                        export SCT_SCYLLA_REPO="${params.scylla_repo}"
-                                    else
-                                        echo "need to choose one of SCT_AMI_ID_DB_SCYLLA | SCT_SCYLLA_VERSION | SCT_SCYLLA_REPO"
-                                        exit 1
-                                    fi
-                                    if [[ ! -z "${params.update_db_packages}" ]]; then
-                                        export SCT_UPDATE_DB_PACKAGES="${params.update_db_packages}"
-                                    fi
-                                    export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
-                                    export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
-                                    export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"
-                                    export SCT_INSTANCE_PROVISION="${params.provision_type}"
-                                    export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$GIT_BRANCH | sed -E 's+(origin/|origin/branch-)++')
-                                    export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$SCT_AMI_ID_DB_SCYLLA_DESC | tr ._ - | cut -c1-8 )
-
-                                    echo "start test ......."
-                                    if [[ "$cloud_provider" == "aws" ]]; then
-                                        SCT_RUNNER_IP=\$(cat sct_runner_ip||echo "")
-                                        if [[ ! -z "\${SCT_RUNNER_IP}" ]] ; then
-                                            ./docker/env/hydra.sh --execute-on-runner \${SCT_RUNNER_IP} run-test ${params.test_name} --backend ${params.backend}
-                                        else
-                                            echo "SCT runner IP file is empty. Probably SCT Runner was not created."
-                                            exit 1
-                                        fi
-                                    else
-                                        ./docker/env/hydra.sh run-test ${params.test_name} --backend ${params.backend}  --logdir "`pwd`"
-                                    fi
-                                    echo "end test ....."
-                                    """
+                                    runSctTest(params, builder.region)
                                 }
                             }
                         }
@@ -192,34 +144,7 @@ def call() {
                         script {
                             wrap([$class: 'BuildUser']) {
                                 dir('scylla-cluster-tests') {
-                                    def aws_region = initAwsRegionParam(params.aws_region, builder.region)
-                                    def test_config = groovy.json.JsonOutput.toJson(params.test_config)
-                                    def cloud_provider = params.backend.trim().toLowerCase()
-
-                                    sh """
-                                    #!/bin/bash
-
-                                    set -xe
-                                    env
-
-                                    export SCT_CLUSTER_BACKEND="${params.backend}"
-                                    export SCT_REGION_NAME=${aws_region}
-                                    export SCT_CONFIG_FILES=${test_config}
-
-                                    echo "start collect logs ..."
-                                    if [[ "$cloud_provider" == "aws" ]]; then
-                                        SCT_RUNNER_IP=\$(cat sct_runner_ip||echo "")
-                                        if [[ ! -z "\${SCT_RUNNER_IP}" ]] ; then
-                                            ./docker/env/hydra.sh --execute-on-runner \${SCT_RUNNER_IP} collect-logs
-                                        else
-                                            echo "SCT runner IP file is empty. Probably SCT Runner was not created."
-                                            exit 1
-                                        fi
-                                    else
-                                        ./docker/env/hydra.sh collect-logs --logdir "`pwd`"
-                                    fi
-                                    echo "end collect logs"
-                                    """
+                                    runCollectLogs(params, builder.region)
                                 }
                             }
                         }
@@ -232,37 +157,7 @@ def call() {
                         script {
                             wrap([$class: 'BuildUser']) {
                                 dir('scylla-cluster-tests') {
-                                    def aws_region = initAwsRegionParam(params.aws_region, builder.region)
-                                    def test_config = groovy.json.JsonOutput.toJson(params.test_config)
-                                    def cloud_provider = params.backend.trim().toLowerCase()
-
-                                    sh """
-                                    #!/bin/bash
-
-                                    set -xe
-                                    env
-                                    export SCT_CONFIG_FILES=${test_config}
-                                    export SCT_CLUSTER_BACKEND="${params.backend}"
-                                    export SCT_REGION_NAME=${aws_region}
-                                    export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
-                                    export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
-                                    export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"
-
-                                    echo "Starting to clean resources ..."
-                                    if [[ "$cloud_provider" == "aws" ]]; then
-                                        SCT_RUNNER_IP=\$(cat sct_runner_ip||echo "")
-                                        if [[ ! -z "\${SCT_RUNNER_IP}" ]] ; then
-                                            ./docker/env/hydra.sh --execute-on-runner \${SCT_RUNNER_IP} clean-resources --test-id \$SCT_TEST_ID
-                                        else
-                                            echo "SCT runner IP file is empty. Probably SCT Runner was not created."
-                                            exit 1
-                                        fi
-                                    else
-                                        ./docker/env/hydra.sh clean-resources --logdir "`pwd`"
-                                    fi
-                                    ./docker/env/hydra.sh clean-runner-instances
-                                    echo "Finished cleaning resources."
-                                    """
+                                    runCleanupResource(params, builder.region)
                                 }
                             }
                         }
@@ -275,29 +170,7 @@ def call() {
                         script {
                             wrap([$class: 'BuildUser']) {
                                 dir('scylla-cluster-tests') {
-                                    def email_recipients = groovy.json.JsonOutput.toJson(params.email_recipients)
-                                    def cloud_provider = params.backend.trim().toLowerCase()
-                                    def start_time = currentBuild.startTimeInMillis.intdiv(1000)
-                                    def test_status = currentBuild.currentResult
-                                    sh """
-                                    #!/bin/bash
-
-                                    set -xe
-                                    env
-
-                                    echo "Sending email..."
-                                    if [[ "$cloud_provider" == "aws" ]]; then
-                                        SCT_RUNNER_IP=\$(cat sct_runner_ip||echo "")
-                                        if [[ ! -z "\${SCT_RUNNER_IP}" ]] ; then
-                                            ./docker/env/hydra.sh --execute-on-runner \${SCT_RUNNER_IP} send-email --email-recipients "${email_recipients}"
-                                            exit \$?
-                                        else
-                                            echo "SCT runner IP file is empty. Probably SCT Runner was not created."
-                                        fi
-                                    fi
-                                    ./docker/env/hydra.sh send-email --test-status ${test_status} --start-time ${start_time} --logdir "`pwd`" --email-recipients "${email_recipients}"
-                                    echo "Email sent."
-                                    """
+                                    runSendEmail(params, currentBuild)
                                 }
                             }
                         }

--- a/vars/byoLongevityPipeline.groovy
+++ b/vars/byoLongevityPipeline.groovy
@@ -255,6 +255,7 @@ def call() {
                                     else
                                         ./docker/env/hydra.sh clean-resources --logdir "`pwd`"
                                     fi
+                                    ./docker/env/hydra.sh clean-runner-instances
                                     echo "Finished cleaning resources."
                                     """
                                 }

--- a/vars/cdcReplicationPipeline.groovy
+++ b/vars/cdcReplicationPipeline.groovy
@@ -202,7 +202,6 @@ def call(Map pipelineParams) {
         }
         post {
             always {
-                archiveArtifacts artifacts: 'scylla-cluster-tests/latest/**'
                 script {
                     def collect_logs = completed_stages['collect_logs']
                     def clean_resources = completed_stages['clean_resources']

--- a/vars/createSctRunner.groovy
+++ b/vars/createSctRunner.groovy
@@ -1,0 +1,19 @@
+#!groovy
+
+def call(Map params, Integer test_duration, String region) {
+
+    def cloud_provider = params.backend.trim().toLowerCase()
+    println(params)
+    sh """
+    #!/bin/bash
+    set -xe
+    env
+
+    if [[ "$cloud_provider" == "aws" ]]; then
+        rm -fv sct_runner_ip
+        ./docker/env/hydra.sh create-runner-instance --cloud-provider ${cloud_provider} --region ${region} --availability-zone ${params.availability_zone} --test-id \${SCT_TEST_ID} --duration ${test_duration}
+    else
+        echo "Currently, <$cloud_provider> not supported to. Will run on regular builder."
+    fi
+    """
+}

--- a/vars/getJenkinsLabels.groovy
+++ b/vars/getJenkinsLabels.groovy
@@ -11,6 +11,7 @@ def call(String backend, String aws_region=null) {
 
 
     def jenkins_labels = ['aws-eu-west-1': 'aws-sct-builders-eu-west-1',
+                          'aws-eu-west-2': 'aws-sct-builders-eu-west-2',
                           'aws-us-east-1' : 'aws-sct-builders-us-east-1',
                           'gce': 'gce-sct-builders',
                           'docker': 'sct-builders']

--- a/vars/getJenkinsLabels.groovy
+++ b/vars/getJenkinsLabels.groovy
@@ -9,19 +9,26 @@ def call(String backend, String aws_region=null) {
 
     }
 
-
     def jenkins_labels = ['aws-eu-west-1': 'aws-sct-builders-eu-west-1',
                           'aws-eu-west-2': 'aws-sct-builders-eu-west-2',
+                          'aws-eu-north-1': 'aws-sct-builders-eu-north-1',
                           'aws-us-east-1' : 'aws-sct-builders-us-east-1',
                           'gce': 'gce-sct-builders',
                           'docker': 'sct-builders']
-
+    println("Finding builder for region: " + aws_region)
     if (backend == 'aws' && aws_region)
     {
-        return jenkins_labels["${backend}-${aws_region}"]
+        if (aws_region == "random"){
+            def aws_supported_regions = ["eu-west-2", "eu-north-1"]
+            Collections.shuffle(aws_supported_regions)
+            aws_region = aws_supported_regions[0]
+        }
+
+        return [ "label": jenkins_labels["${backend}-${aws_region}"], "region": aws_region ]
+
     }
     else
     {
-        return jenkins_labels[backend]
+        return [ "label": jenkins_labels[backend] ]
     }
 }

--- a/vars/getJenkinsLabels.groovy
+++ b/vars/getJenkinsLabels.groovy
@@ -12,6 +12,7 @@ def call(String backend, String aws_region=null) {
     def jenkins_labels = ['aws-eu-west-1': 'aws-sct-builders-eu-west-1',
                           'aws-eu-west-2': 'aws-sct-builders-eu-west-2',
                           'aws-eu-north-1': 'aws-sct-builders-eu-north-1',
+                          'aws-eu-central-1': 'aws-sct-builders-eu-central-1',
                           'aws-us-east-1' : 'aws-sct-builders-us-east-1',
                           'gce': 'gce-sct-builders',
                           'docker': 'sct-builders']
@@ -19,7 +20,7 @@ def call(String backend, String aws_region=null) {
     if (backend == 'aws' && aws_region)
     {
         if (aws_region == "random"){
-            def aws_supported_regions = ["eu-west-2", "eu-north-1"]
+            def aws_supported_regions = ["eu-west-2", "eu-north-1", "eu-central-1"]
             Collections.shuffle(aws_supported_regions)
             aws_region = aws_supported_regions[0]
         }

--- a/vars/getJenkinsLabels.groovy
+++ b/vars/getJenkinsLabels.groovy
@@ -24,7 +24,13 @@ def call(String backend, String aws_region=null) {
             aws_region = aws_supported_regions[0]
         }
 
-        return [ "label": jenkins_labels["${backend}-${aws_region}"], "region": aws_region ]
+        label = jenkins_labels.get("${backend}-${aws_region}", null)
+        if (label != null){
+            return [ "label": label, "region": aws_region ]
+        }
+        else{
+            throw new Exception("=================== AWS region ${aws_region} not supported ! ===================")
+        }
 
     }
     else

--- a/vars/initAwsRegionParam.groovy
+++ b/vars/initAwsRegionParam.groovy
@@ -1,6 +1,6 @@
 #!groovy
 
-def String initAwsRegionParam(String regionStr, String builder_region){
+def call(String regionStr, String builder_region){
     if (regionStr == "random"){
         return builder_region
     }

--- a/vars/initAwsRegionParam.groovy
+++ b/vars/initAwsRegionParam.groovy
@@ -1,0 +1,10 @@
+#!groovy
+
+def String initAwsRegionParam(String regionStr, String builder_region){
+    if (regionStr == "random"){
+        return builder_region
+    }
+    else{
+        return groovy.json.JsonOutput.toJson(regionStr)
+    }
+}

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -164,7 +164,6 @@ def call(Map pipelineParams) {
         }
         post {
             always {
-                archiveArtifacts artifacts: 'scylla-cluster-tests/latest/**'
                 script {
                     def collect_logs = completed_stages['collect_logs']
                     def clean_resources = completed_stages['clean_resources']

--- a/vars/runCleanupResource.groovy
+++ b/vars/runCleanupResource.groovy
@@ -1,0 +1,36 @@
+#!groovy
+
+def call(Map params, String region){
+    def aws_region = initAwsRegionParam(params.aws_region, region)
+    def test_config = groovy.json.JsonOutput.toJson(params.test_config)
+    def cloud_provider = params.backend.trim().toLowerCase()
+
+    sh """
+    #!/bin/bash
+
+    set -xe
+    env
+
+    export SCT_CONFIG_FILES=${test_config}
+    export SCT_CLUSTER_BACKEND="${params.backend}"
+    export SCT_REGION_NAME=${aws_region}
+    export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
+    export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
+    export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"
+
+    echo "Starting to clean resources ..."
+    if [[ "$cloud_provider" == "aws" ]]; then
+        SCT_RUNNER_IP=\$(cat sct_runner_ip||echo "")
+        if [[ ! -z "\${SCT_RUNNER_IP}" ]] ; then
+            ./docker/env/hydra.sh --execute-on-runner \${SCT_RUNNER_IP} clean-resources --test-id \$SCT_TEST_ID
+        else
+            echo "SCT runner IP file is empty. Probably SCT Runner was not created."
+            exit 1
+        fi
+    else
+        ./docker/env/hydra.sh clean-resources --logdir "`pwd`"
+    fi
+    ./docker/env/hydra.sh clean-runner-instances
+    echo "Finished cleaning resources."
+    """
+}

--- a/vars/runCollectLogs.groovy
+++ b/vars/runCollectLogs.groovy
@@ -1,0 +1,33 @@
+#! groovy
+
+
+def call(Map params, String region){
+    def aws_region = initAwsRegionParam(params.aws_region, region)
+    def test_config = groovy.json.JsonOutput.toJson(params.test_config)
+    def cloud_provider = params.backend.trim().toLowerCase()
+    sh """
+    #!/bin/bash
+
+    set -xe
+    env
+
+    echo "${params.test_config}"
+    export SCT_CLUSTER_BACKEND="${params.backend}"
+    export SCT_REGION_NAME=${aws_region}
+    export SCT_CONFIG_FILES=${test_config}
+
+    echo "start collect logs ..."
+    if [[ "$cloud_provider" == "aws" ]]; then
+        SCT_RUNNER_IP=\$(cat sct_runner_ip||echo "")
+        if [[ ! -z "\${SCT_RUNNER_IP}" ]] ; then
+            ./docker/env/hydra.sh --execute-on-runner \${SCT_RUNNER_IP} collect-logs
+        else
+            echo "SCT runner IP file is empty. Probably SCT Runner was not created."
+            exit 1
+        fi
+    else
+        ./docker/env/hydra.sh collect-logs --logdir "`pwd`"
+    fi
+    echo "end collect logs"
+    """
+}

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -1,0 +1,60 @@
+#!groovy
+
+def call(Map params, String region){
+    // handle params which can be a json list
+    def aws_region = initAwsRegionParam(params.aws_region, region)
+    def test_config = groovy.json.JsonOutput.toJson(params.test_config)
+    def cloud_provider = params.backend.trim().toLowerCase()
+
+    sh """
+    #!/bin/bash
+    set -xe
+    env
+
+    rm -fv ./latest
+
+    export SCT_CLUSTER_BACKEND="${params.backend}"
+    export SCT_REGION_NAME=${aws_region}
+    export SCT_CONFIG_FILES=${test_config}
+    export SCT_COLLECT_LOGS=false
+
+    if [[ ! -z "${params.scylla_ami_id}" ]] ; then
+        export SCT_AMI_ID_DB_SCYLLA="${params.scylla_ami_id}"
+    elif [[ ! -z "${params.scylla_version}" ]] ; then
+        export SCT_SCYLLA_VERSION="${params.scylla_version}"
+    elif [[ ! -z "${params.scylla_repo}" ]] ; then
+        export SCT_SCYLLA_REPO="${params.scylla_repo}"
+    else
+        echo "need to choose one of SCT_AMI_ID_DB_SCYLLA | SCT_SCYLLA_VERSION | SCT_SCYLLA_REPO"
+        exit 1
+    fi
+
+    export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
+    export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
+    export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"
+    export SCT_INSTANCE_PROVISION="${params.get('provision_type', '')}"
+    export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$GIT_BRANCH | sed -E 's+(origin/|origin/branch-)++')
+    export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$SCT_AMI_ID_DB_SCYLLA_DESC | tr ._ - | cut -c1-8 )
+
+    export SCT_TAG_AMI_WITH_RESULT="${params.tag_ami_with_result}"
+    export SCT_IP_SSH_CONNECTIONS="${params.ip_ssh_connections}"
+
+    if [[ ! -z "${params.scylla_mgmt_repo}" ]] ; then
+        export SCT_SCYLLA_MGMT_REPO="${params.scylla_mgmt_repo}"
+    fi
+
+    echo "start test ......."
+    if [[ "$cloud_provider" == "aws" ]]; then
+        SCT_RUNNER_IP=\$(cat sct_runner_ip||echo "")
+        if [[ ! -z "\${SCT_RUNNER_IP}" ]] ; then
+            ./docker/env/hydra.sh --execute-on-runner \${SCT_RUNNER_IP} run-test ${params.test_name} --backend ${params.backend}
+        else
+            echo "SCT runner IP file is empty. Probably SCT Runner was not created."
+            exit 1
+        fi
+    else
+        ./docker/env/hydra.sh run-test ${params.test_name} --backend ${params.backend}  --logdir "`pwd`"
+    fi
+    echo "end test ....."
+    """
+}

--- a/vars/runSendEmail.groovy
+++ b/vars/runSendEmail.groovy
@@ -1,0 +1,37 @@
+#!groovy
+
+import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
+
+def call(Map params, RunWrapper currentBuild){
+    def start_time = currentBuild.startTimeInMillis.intdiv(1000)
+    def test_status = currentBuild.currentResult
+    if (test_status) {
+        test_status = "--test-status " + test_status
+    }
+    if (start_time) {
+        start_time = "--start-time " + start_time
+    }
+
+    def email_recipients = groovy.json.JsonOutput.toJson(params.email_recipients)
+    def cloud_provider = params.backend.trim().toLowerCase()
+
+    sh """
+    #!/bin/bash
+    set -xe
+    env
+    echo "Start send email ..."
+    if [[ "$cloud_provider" == "aws" ]]; then
+        SCT_RUNNER_IP=\$(cat sct_runner_ip||echo "")
+        if [[ ! -z "\${SCT_RUNNER_IP}" ]] ; then
+            ./docker/env/hydra.sh --execute-on-runner \${SCT_RUNNER_IP} send-email ${test_status} ${start_time} --email-recipients "${email_recipients}"
+        else
+            echo "SCT runner IP file is empty. Probably SCT Runner was not created."
+            ./docker/env/hydra.sh send-email ${test_status} ${start_time} --logdir "`pwd`" --email-recipients "${email_recipients}"
+            exit 1
+        fi
+    else
+        ./docker/env/hydra.sh send-email ${test_status} ${start_time} --logdir "`pwd`" --email-recipients "${email_recipients}"
+    fi
+    echo "Email sent."
+    """
+}


### PR DESCRIPTION
… AWS

the feature allowes automatically creating all the resources needed
for SCT test run environment. This includes configuraiton of VPC,
subnet, SG and other resources.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
