### PR TITLE
fix(manager): changed the timeout of the manager sanities to 2 hours

### DIFF
--- a/jenkins-pipelines/manager/centos-manager-sanity-ipv6.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-sanity-ipv6.jenkinsfile
@@ -12,7 +12,7 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: 'test-cases/manager/manager-regression-ipv6.yaml',
 
-    timeout: [time: 500, unit: 'MINUTES'],
+    timeout: [time: 120, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'keep-on-failure'

--- a/jenkins-pipelines/manager/centos-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-sanity.jenkinsfile
@@ -13,7 +13,7 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: 'test-cases/manager/manager-regression-multiDC-set-distro.yaml',
 
-    timeout: [time: 500, unit: 'MINUTES'],
+    timeout: [time: 120, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'keep-on-failure'

--- a/jenkins-pipelines/manager/debian9-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/debian9-manager-sanity.jenkinsfile
@@ -12,7 +12,7 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/debian9.yaml"]''',
 
-    timeout: [time: 500, unit: 'MINUTES'],
+    timeout: [time: 120, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'keep-on-failure'

--- a/jenkins-pipelines/manager/ubuntu16-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu16-manager-sanity.jenkinsfile
@@ -12,7 +12,7 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/ubuntu16.yaml"]''',
 
-    timeout: [time: 500, unit: 'MINUTES'],
+    timeout: [time: 120, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'keep-on-failure'

--- a/jenkins-pipelines/manager/ubuntu18-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu18-manager-sanity.jenkinsfile
@@ -12,7 +12,7 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/ubuntu18.yaml"]''',
 
-    timeout: [time: 500, unit: 'MINUTES'],
+    timeout: [time: 120, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'keep-on-failure'


### PR DESCRIPTION
The current timeout, 500 minutes, is too long for the test that takes 90 minutes at most.
As such, I lowered the timeout in all of the sanities to 120 minutes

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
