### PR TITLE
fix(remote_logger): Fix duplicate initialization of RemoteCMDRunner

### DIFF
--- a/sdcm/utils/remote_logger.py
+++ b/sdcm/utils/remote_logger.py
@@ -67,7 +67,6 @@ class SSHLoggerBase(LoggerBase):
 
     @raise_event_on_failure
     def _journal_thread(self):
-        self._remoter = self._remoter_params.pop('__class__')(**self._remoter_params)
         self._remoter = RemoteCmdRunner(**self._remoter_params)
         read_from_timestamp = None
         while not self._termination_event.is_set():


### PR DESCRIPTION
Remove duplication initializtion of RemoteCMDRunner which cause
error:
self._remoter = self._remoter_params.pop('__class__')(**self._remoter_params)
KeyError: '__class__'

and this error don't allow to get db log

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
