### PR TITLE
Don't pass `timeout` to cql_connection_patient_exclusive.

### DIFF
--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -215,7 +215,7 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
         self.check_regression()
 
     def prepare_mv(self, on_populated=False):
-        with self.cql_connection_patient_exclusive(self.db_cluster.nodes[0], timeout=60) as session:
+        with self.cql_connection_patient_exclusive(self.db_cluster.nodes[0]) as session:
 
             ks_name = 'keyspace1'
             base_table_name = 'standard1'
@@ -526,7 +526,7 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
             query = 'drop materialized view {}'.format(mv_name)
 
             try:
-                with self.cql_connection_patient_exclusive(self.db_cluster.nodes[0], timeout=60) as session:
+                with self.cql_connection_patient_exclusive(self.db_cluster.nodes[0]) as session:
                     self.log.debug('Run query: {}'.format(query))
                     session.execute(query)
             except Exception as ex:

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1185,7 +1185,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
     @retrying(n=8, sleep_time=15, allowed_exceptions=(NoHostAvailable,))
     def cql_connection_patient_exclusive(self, node, keyspace=None,  # pylint: disable=invalid-name,too-many-arguments,unused-argument
-                                         user=None, password=None, timeout=30,
+                                         user=None, password=None,
                                          compression=True,
                                          protocol_version=None,
                                          port=None, ssl_opts=None, connect_timeout=100, verbose=True):

--- a/snitch_test.py
+++ b/snitch_test.py
@@ -28,7 +28,7 @@ class SnitchTest(ClusterTester):
         result = self.db_cluster.nodes[0].run_nodetool("describecluster")
         assert 'GoogleCloudSnitch' in result.stdout, "Cluster doesn't use GoogleCloudSnitch"
 
-        with self.cql_connection_patient_exclusive(self.db_cluster.nodes[0], timeout=60) as session:
+        with self.cql_connection_patient_exclusive(self.db_cluster.nodes[0]) as session:
             # pylint: disable=no-member
             result = list(session.execute('select * from system.peers'))
             self.log.debug(result)


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylla-cluster-tests/issues/2249.
