### PR TITLE
fix(cql_connection): connect to cluster which node is belong to

### DIFF
--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -215,7 +215,7 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
         self.check_regression()
 
     def prepare_mv(self, on_populated=False):
-        with self.cql_connection_patient_exclusive(self.db_cluster.nodes[0], timeout=60) as session:
+        with self.cql_connection_patient_exclusive(self.db_cluster.nodes[0]) as session:
 
             ks_name = 'keyspace1'
             base_table_name = 'standard1'
@@ -526,7 +526,7 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
             query = 'drop materialized view {}'.format(mv_name)
 
             try:
-                with self.cql_connection_patient_exclusive(self.db_cluster.nodes[0], timeout=60) as session:
+                with self.cql_connection_patient_exclusive(self.db_cluster.nodes[0]) as session:
                     self.log.debug('Run query: {}'.format(query))
                     session.execute(query)
             except Exception as ex:

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1149,8 +1149,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     def cql_connection(self, node, keyspace=None, user=None,  # pylint: disable=too-many-arguments
                        password=None, compression=True, protocol_version=None,
                        port=None, ssl_opts=None, connect_timeout=100, verbose=True):
-        # TODO: ask Bentsi why it was reverted (PR #1236)
-        node_ips = self.db_cluster.get_node_external_ips()
+        node_ips = node.parent_cluster.get_node_external_ips()
         wlrr = WhiteListRoundRobinPolicy(node_ips)
         return self._create_session(node, keyspace, user, password,
                                     compression, protocol_version, wlrr,
@@ -1185,7 +1184,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
     @retrying(n=8, sleep_time=15, allowed_exceptions=(NoHostAvailable,))
     def cql_connection_patient_exclusive(self, node, keyspace=None,  # pylint: disable=invalid-name,too-many-arguments,unused-argument
-                                         user=None, password=None, timeout=30,
+                                         user=None, password=None,
                                          compression=True,
                                          protocol_version=None,
                                          port=None, ssl_opts=None, connect_timeout=100, verbose=True):

--- a/snitch_test.py
+++ b/snitch_test.py
@@ -28,7 +28,7 @@ class SnitchTest(ClusterTester):
         result = self.db_cluster.nodes[0].run_nodetool("describecluster")
         assert 'GoogleCloudSnitch' in result.stdout, "Cluster doesn't use GoogleCloudSnitch"
 
-        with self.cql_connection_patient_exclusive(self.db_cluster.nodes[0], timeout=60) as session:
+        with self.cql_connection_patient_exclusive(self.db_cluster.nodes[0]) as session:
             # pylint: disable=no-member
             result = list(session.execute('select * from system.peers'))
             self.log.debug(result)


### PR DESCRIPTION
ClusterTester.cql_connection method should use node.parent_cluster
to collect all node ips from cluster

- issue fix #2248
- issue fix #2249

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
