### PR TITLE
fix(artifacts test): remove workaround for Amazon Linux 2

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -15,7 +15,8 @@ from distutils.util import strtobool  # pylint: disable=import-error,no-name-in-
 
 import anyconfig
 
-from sdcm.utils.common import get_s3_scylla_repos_mapping, get_scylla_ami_versions, get_branched_ami, get_ami_tags
+from sdcm.utils.common import get_s3_scylla_repos_mapping, get_scylla_ami_versions, get_branched_ami, get_ami_tags, \
+    ami_built_by_scylla
 from sdcm.utils.version_utils import get_branch_version
 
 logging.getLogger("anyconfig").setLevel(logging.ERROR)
@@ -1314,6 +1315,8 @@ class SCTConfiguration(dict):
         for ami_list in [ami_id_db_scylla, ami_id_db_oracle]:
             if ami_list:
                 for ami_id, region_name in zip(ami_list, region_names):
+                    if not ami_built_by_scylla(ami_id, region_name):
+                        continue
                     tags = get_ami_tags(ami_id, region_name)
                     assert 'user_data_format_version' in tags.keys(), \
                         f"\n\t'user_data_format_version' tag missing from [{ami_id}] on {region_name}\n\texisting tags: {tags}"

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -61,6 +61,7 @@ from sdcm.utils.decorators import retrying
 LOGGER = logging.getLogger('utils')
 DEFAULT_AWS_REGION = "eu-west-1"
 DOCKER_CGROUP_RE = re.compile("/docker/([0-9a-f]+)")
+SCYLLA_AMI_OWNER_ID = "797456418907"
 
 
 def deprecation(message):
@@ -1114,6 +1115,12 @@ def get_branched_ami(ami_version, region_name):
         return amis
     else:
         return amis[:1]
+
+
+def ami_built_by_scylla(ami_id: str, region_name: str) -> bool:
+    ec2_resource = boto3.resource("ec2", region_name=region_name)
+    image = ec2_resource.Image(ami_id)
+    return image.owner_id == SCYLLA_AMI_OWNER_ID
 
 
 def get_ami_tags(ami_id, region_name):

--- a/test-cases/artifacts/amazon2.yaml
+++ b/test-cases/artifacts/amazon2.yaml
@@ -1,6 +1,5 @@
 ami_db_scylla_user: 'ec2-user'
 ami_id_db_scylla: 'ami-099a8245f5daa82bf'
-append_scylla_setup_args: '--no-cpuscaling-setup'
 aws_root_disk_name_db: '/dev/xvda'
 aws_root_disk_size_db: 50
 backtrace_decoding: false


### PR DESCRIPTION
Trello: https://trello.com/c/DVgtnYUv/1728-keep-eyes-on-scylladb-scylla5977

https://github.com/scylladb/scylla/issues/5977 fixed by https://github.com/scylladb/scylla/pull/6621, so we can remove workaround

**NB**: This is not about using Amazon Linux 2 as a base image for our AMI, it's about using Amazon Linux 2 as a bare Linux distribution for installing our .rpms.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
