### PR TITLE
feature(nemesis.py): added to _add_and_init_new_cluster_node new feature

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -930,7 +930,7 @@ class CassandraAWSCluster(ScyllaAWSCluster):
                                                                  dc_idx=dc_idx)
         return added_nodes
 
-    def node_setup(self, node, verbose=False, timeout=3600):
+    def node_setup(self, node, verbose=False, timeout=3600, wait_db_up=True):
         node.wait_ssh_up(verbose=verbose)
         node.wait_db_up(verbose=verbose)
 
@@ -945,7 +945,7 @@ class CassandraAWSCluster(ScyllaAWSCluster):
         node.remoter.run('sudo apt-get install -y openjdk-6-jdk')
 
     @cluster.wait_for_init_wrap
-    def wait_for_init(self, node_list=None, verbose=False, timeout=None):
+    def wait_for_init(self, node_list=None, verbose=False, timeout=None, wait_db_up=True):
         self.get_seed_nodes()
 
 

--- a/sdcm/cluster_baremetal.py
+++ b/sdcm/cluster_baremetal.py
@@ -111,7 +111,7 @@ class ScyllaPhysicalCluster(cluster.BaseScyllaCluster, PhysicalMachineCluster):
         ))
         super(ScyllaPhysicalCluster, self).__init__(**kwargs)
 
-    def node_setup(self, node, verbose=False, timeout=3600):
+    def node_setup(self, node, verbose=False, timeout=3600, wait_db_up=True):
         """
         Configure scylla.yaml on cluster nodes.
         We have to modify scylla.yaml on our own because we are not on AWS,

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -222,7 +222,7 @@ class ScyllaDockerCluster(cluster.BaseScyllaCluster, DockerCluster):  # pylint: 
                          n_nodes=n_nodes,
                          params=params)
 
-    def node_setup(self, node, verbose=False, timeout=3600):
+    def node_setup(self, node, verbose=False, timeout=3600, wait_db_up=True):
         endpoint_snitch = self.params.get('endpoint_snitch')
         seed_address = ','.join(self.seed_nodes_ips)
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -429,14 +429,26 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.monitoring_set.reconfigure_scylla_monitoring()
         self.set_current_running_nemesis(node=new_node)  # prevent to run nemesis on new node when running in parallel
         new_node.replacement_node_ip = old_node_ip
+        disable_autocompaction = random.choice([True, False])
+        keyspaces = self.cluster.get_test_keyspaces()
         try:
-            self.cluster.wait_for_init(node_list=[new_node], timeout=timeout)
+            self.cluster.wait_for_init(node_list=[new_node], timeout=timeout, wait_db_up=False)
+            if disable_autocompaction:
+                self.log.info(f'During bootstrap, autocompaction will be disabled for keyspaces {keyspaces}')
+                for keyspace in keyspaces:
+                    new_node.run_nodetool(sub_cmd='disableautocompaction', args=keyspace, ignore_status=True)
+            new_node.wait_db_up(timeout=timeout)
+            self.cluster.clean_replacement_node_ip(new_node)
         except (NodeSetupFailed, NodeSetupTimeout):
             self.log.warning("Setup of the '%s' failed, removing it from list of nodes" % new_node)
             self.cluster.nodes.remove(new_node)
             self.log.warning("Node will not be terminated. Please terminate manually!!!")
             raise
         self.cluster.wait_for_nodes_up_and_normal(nodes=[new_node])
+        if disable_autocompaction:
+            self.log.info(f'Bootstrap is finished and will enable autocompaction for keyspaces {keyspaces}')
+            for keyspace in keyspaces:
+                new_node.run_nodetool(sub_cmd='enableautocompaction', args=keyspace)
         return new_node
 
     def _terminate_cluster_node(self, node):


### PR DESCRIPTION
function a random call to new Scylla feature
(disable/enable autocompaction), so during the bootstrap
phase, if calling the command, the autocompaction
will be disabled. Per dev explanation, it is a feature
to be used during DR, and we want just to be sure this
feature isn't broken at any point.
At the end of bootstrap, we enable autocompaction to
have the cluster running regularly.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
