### PR TITLE
Handle branched AMIs for the oracle cluster

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1083,6 +1083,11 @@ class SCTConfiguration(dict):
             if 'ami_id_db_oracle' not in self and self.get('cluster_backend') == 'aws':
                 ami_list = []
                 for region in self.get('region_name').split():
+                    if ':' in oracle_scylla_version:
+                        amis = get_branched_ami(oracle_scylla_version, region_name=region)
+                        ami_list.append(amis[0].id)
+                        continue
+
                     amis = get_scylla_ami_versions(region)
                     for ami in amis:
                         if oracle_scylla_version in ami['Name']:


### PR DESCRIPTION
When specifying which Scylla version we want to use for the base cluster, we can provide a branch from which the AMI is built:
```
SCT_SCYLLA_VERSION=master:latest
```
However, if we did the same for the oracle cluster:
```
SCT_ORACLE_SCYLLA_VERSION=master:latest
```
It wouldn't work. This commit fixes that.

This is a copy-paste from the corresponding base cluster code.
