### PR TITLE
fix(logcollector): Dont fail logcollector if final archive was not cr…

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -682,6 +682,8 @@ class LogCollector:
             return None
 
         final_archive = self.archive_dir_with_zip64(self.local_dir)
+        if not final_archive:
+            return None
         s3_link = self.upload_logs(final_archive, "{0.test_id}/{0.current_run}".format(self))
         remove_files(self.local_dir)
         remove_files(final_archive)
@@ -725,7 +727,7 @@ class LogCollector:
                         arch.write(full_path, full_path.replace(logdir, ""))
                 os.chdir(cur_dir)
         except Exception as details:  # pylint: disable=broad-except
-            LOGGER.error("Error durint creating archive. Error details: \n%s", details)
+            LOGGER.error("Error during creating archive. Error details: \n%s", details)
             archive_full_name = None
         return archive_full_name
 


### PR DESCRIPTION
…eated

if final archive was not created, logcollector could fail
09:48:18      file_name = os.path.basename(os.path.normpath(file_path))
09:48:18    File "/usr/lib64/python3.6/posixpath.py", line 340, in normpath
09:48:18      path = os.fspath(path)
09:48:18  TypeError: expected str, bytes or os.PathLike object, not NoneType

Fix this issue and typo

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
