### PR TITLE
fix (refresh nemesis): load sstable files to all db nodes by refresh

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -621,7 +621,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                                 user_agent=creds['user_agent'])
             result = node.remoter.run("sudo ls -t /var/lib/scylla/data/keyspace1/")
             upload_dir = result.stdout.split()[0]
-            node.remoter.run('sudo tar xvfz {} -C /var/lib/scylla/data/keyspace1/{}/upload/'.format(
+            node.remoter.run('sudo -u scylla tar xvfz {} -C /var/lib/scylla/data/keyspace1/{}/upload/'.format(
                 sstable_file, upload_dir))
             # Scylla Enterprise 2019.1 doesn't support to load schema.cql and manifest.json, let's remove them
             node.remoter.run(

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -588,12 +588,24 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             sstable_url = 'https://s3.amazonaws.com/scylla-qa-team/refresh_nemesis/keyspace1.standard1.100M.tar.gz'
             sstable_file = '/tmp/keyspace1.standard1.100M.tar.gz'
             sstable_md5 = '9c5dd19cfc78052323995198b0817270'
-            keys_num = 1000
+            keys_num = 501000
         else:
             sstable_url = 'https://s3.amazonaws.com/scylla-qa-team/refresh_nemesis/keyspace1.standard1.tar.gz'
             sstable_file = "/tmp/keyspace1.standard1.tar.gz"
             sstable_md5 = 'c033a3649a1aec3ba9b81c446c6eecfd'
-            keys_num = 501000
+            keys_num = 1000
+
+        # Use special schema (one column) for refresh before https://github.com/scylladb/scylla/issues/6617 is fixed
+        if big_sstable:
+            sstable_url = 'https://s3.amazonaws.com/scylla-qa-team/refresh_nemesis_c0/keyspace1.standard1.100M.tar.gz'
+            sstable_file = '/tmp/keyspace1.standard1.100M.tar.gz'
+            sstable_md5 = 'e4f6addc2db8e9af3a906953288ef676'
+            keys_num = 1001000
+        else:
+            sstable_url = 'https://s3.amazonaws.com/scylla-qa-team/refresh_nemesis_c0/keyspace1.standard1.tar.gz'
+            sstable_file = "/tmp/keyspace1.standard1.tar.gz"
+            sstable_md5 = 'c4aee10691fa6343a786f52663e7f758'
+            keys_num = 1000
 
         self.log.debug('Prepare keyspace1.standard1 if it does not exist')
         self._prepare_test_table(ks='keyspace1', table='standard1')

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -618,8 +618,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         else:
             # Note: when issue #6617 is fixed, we can try to load snapshot (cols=5) to a table (1 < cols < 5),
             #       expect that refresh will fail (no serious db error).
-            raise UnsupportedNemesis(
-                'Scylla does not support to load snapshot that has more columns than current table, Known issue: scylla/issues#6617')
+            raise UnsupportedNemesis("Schema doesn't match the snapshot, not uploading")
 
         self.log.debug('Prepare keyspace1.standard1 if it does not exist')
         self._prepare_test_table(ks='keyspace1', table='standard1')


### PR DESCRIPTION
When loading the sstable files to cluster, they files have to be loaded
to all db nodes by 'nodetool refresh ..'.

Otherwise, RF should be set to #number of db nodes#, load the sstable to
one node, and execute 'nodetool repair' on that node. We don't want to
change RF of keyspace1.standard1 in this nemesis, different longevity
jobs use different RF, different nodes number.

So let's load sstable files to all db nodes by refresh.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
