### PR TITLE
fix(livesnapshot): Change xpath for get livesnapshot

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -471,9 +471,8 @@ class GrafanaSnapshot(GrafanaEntity):
 
     snapshot_locators_sequence = [
         (By.XPATH, """//button[contains(@class, "navbar-button--share")]"""),
-        (By.LINK_TEXT, """Snapshot"""),
-        (By.XPATH, """//a[contains(text(), "Snapshot") and contains(@class, "gf-tabs-link")]"""),
-        (By.XPATH, """//button[contains(text(), "Publish to snapshot.raintank.io") and contains(@class, "gf-form-btn")]"""),
+        (By.XPATH, """//ul/li[contains(text(), "Snapshot")]"""),
+        (By.XPATH, """//button//span[contains(text(), "Publish to snapshot.raintank.io")]"""),
         (By.XPATH, """//a[contains(@href, "https://snapshot.raintank.io")]""")
     ]
 


### PR DESCRIPTION
with monitoring stack branch 3.4 Grafana UI and xpath changed,
this cause error during getting livesnapshot

Trello: https://trello.com/c/MIbv9CIO

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
