### PR TITLE
feature(sdcm/fill_db_data.py): add non-frozen UDT test

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -2605,6 +2605,43 @@ class FillDatabaseData(ClusterTester):
             'min_version': '',
             'max_version': '',
             'skip': ''},
+        # non-frozen user_types_test
+        # only tests normal non-frozen UDT. Non-frozen UDT isn't supported inside collection.
+        {
+            'create_tables': ["""
+              CREATE TYPE address (
+              street text,
+              city text,
+              zip_code int,
+              phones set<text>
+              )
+           """, """
+              CREATE TYPE non_frozen_fullname (
+               firstname text,
+               lastname text
+              )
+           """, """
+              CREATE TABLE non_frozen_user_types_test (
+               id uuid PRIMARY KEY,
+               name non_frozen_fullname,
+               addresses map<text, frozen<address>>
+              )
+           """],
+            'truncates': ["TRUNCATE non_frozen_user_types_test"],
+            'inserts': [
+                "INSERT INTO non_frozen_user_types_test (id, name) VALUES (ea0b7cc8-dee9-437e-896c-c14ed34ce9cd, ('Paul', 'smith'))"],
+            'queries': [
+                "SELECT name.firstname FROM non_frozen_user_types_test WHERE id = ea0b7cc8-dee9-437e-896c-c14ed34ce9cd",
+                "SELECT name.lastname FROM non_frozen_user_types_test WHERE id = ea0b7cc8-dee9-437e-896c-c14ed34ce9cd",
+                "UPDATE non_frozen_user_types_test SET addresses = addresses + { 'home': ( '...', 'SF',  94102, {'123456'} ) } WHERE id=ea0b7cc8-dee9-437e-896c-c14ed34ce9cd",
+                "#STR SELECT addresses FROM non_frozen_user_types_test WHERE id = ea0b7cc8-dee9-437e-896c-c14ed34ce9cd"],
+            'results': [[['Paul']],
+                        [['smith']],
+                        [],
+                        "[[OrderedMapSerializedKey([('home', address(street='...', city='SF', zip_code=94102, phones=SortedSet(['123456'])))])]]"],
+            'min_version': '',
+            'max_version': '',
+            'skip': ''},
         # more_user_types_test
         {
             'create_tables': ["""


### PR DESCRIPTION
Scylla 3.0 did not mark user-defined types in "mc" format sstables as frozen.
When Scylla 3.1 introduced non-frozen user-defined types, sstables from Scylla
3.0 became invalid, so upgrades from nodes with such sstables became
impossible. We now detect such sstables and load them correctly.

Releated commit:
https://github.com/scylladb/scylla/commit/3d811e2f957f4614d6b8dda293eeb7f485a63c68

This patch added a new subtest to fill_db_data test.

Note: only tests normal non-frozen UDT. Non-frozen UDT isn't supported inside collection.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
