### PR TITLE
Fix(sdcm/*): TearDown did not cleanup resources

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1693,14 +1693,14 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         actions_per_cluster_type = get_post_behavior_actions(self.params)
         critical_events = self.get_test_results(source='test')
         if self.db_cluster is not None:
-            self.log.info("Action for db nodes is %s", actions_per_cluster_type['db_nodes'])
-            if (actions_per_cluster_type['db_nodes'] == 'destroy') or \
-               (actions_per_cluster_type['db_nodes'] == 'keep-on-failure' and not critical_events):
+            action = actions_per_cluster_type['db_nodes']['action']
+            self.log.info("Action for db nodes is %s", action)
+            if (action == 'destroy') or (action == 'keep-on-failure' and not critical_events):
                 self.destroy_cluster(self.db_cluster)
                 self.db_cluster = None
                 if self.cs_db_cluster:
                     self.destroy_cluster(self.cs_db_cluster)
-            elif actions_per_cluster_type['db_nodes'] == 'keep-on-failure' and critical_events:
+            elif action == 'keep-on-failure' and critical_events:
                 self.log.info('Critical errors found. Set keep flag for db nodes')
                 Setup.keep_cluster(node_type='db_nodes', val='keep')
                 self.set_keep_alive_on_failure(self.db_cluster)
@@ -1708,23 +1708,23 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                     self.set_keep_alive_on_failure(self.cs_db_cluster)
 
         if self.loaders is not None:
-            self.log.info("Action for loader nodes is %s", actions_per_cluster_type['loader_nodes'])
-            if (actions_per_cluster_type['loader_nodes'] == 'destroy') or \
-               (actions_per_cluster_type['loader_nodes'] == 'keep-on-failure' and not critical_events):
+            action = actions_per_cluster_type['loader_nodes']['action']
+            self.log.info("Action for loader nodes is %s", action)
+            if (action == 'destroy') or (action == 'keep-on-failure' and not critical_events):
                 self.destroy_cluster(self.loaders)
                 self.loaders = None
-            elif actions_per_cluster_type['loader_nodes'] == 'keep-on-failure' and critical_events:
+            elif action == 'keep-on-failure' and critical_events:
                 self.log.info('Critical errors found. Set keep flag for loader nodes')
                 Setup.keep_cluster(node_type='loader_nodes', val='keep')
                 self.set_keep_alive_on_failure(self.loaders)
 
         if self.monitors is not None:
-            self.log.info("Action for monitor nodes is %s", actions_per_cluster_type['monitor_nodes'])
-            if (actions_per_cluster_type['monitor_nodes'] == 'destroy') or \
-               (actions_per_cluster_type['monitor_nodes'] == 'keep-on-failure' and not critical_events):
+            action = actions_per_cluster_type['monitor_nodes']['action']
+            self.log.info("Action for monitor nodes is %s", action)
+            if (action == 'destroy') or (action == 'keep-on-failure' and not critical_events):
                 self.destroy_cluster(self.monitors)
                 self.monitors = None
-            elif actions_per_cluster_type['monitor_nodes'] == 'keep-on-failure' and critical_events:
+            elif action == 'keep-on-failure' and critical_events:
                 self.log.info('Critical errors found. Set keep flag for monitor nodes')
                 Setup.keep_cluster(node_type='monitor_nodes', val='keep')
                 self.set_keep_alive_on_failure(self.monitors)


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylla-cluster-tests/issues/2244
Broken after https://github.com/scylladb/scylla-cluster-tests/commit/a094ee1bb8b9db176912f13728b313535eb38373

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
