### PR TITLE
fix(rsyslog): support the case of possible IP change in AWS

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -617,7 +617,8 @@ class AWSNode(cluster.BaseNode):
         self._wait_public_ip()
         self.log.debug('Got new public IP %s',
                        self._instance.public_ip_address)
-        self.remoter.hostname = self.external_address
+
+        self.refresh_ip_address()
         self.wait_ssh_up()
 
         if any(ss in self._instance.instance_type for ss in ['i3', 'i2']):


### PR DESCRIPTION
Since external IP addresses can change in multi-dc setup
we failed to restart the tunneling docker of autossh:rsyslogd in those cases

create a new function `BaseNode.refresh_ip_address` to handle those.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
