### PR TITLE
fix(sdcm/sct_events.py): Fix wrong message test when source_method is not provided

### DIFF
--- a/sdcm/sct_events.py
+++ b/sdcm/sct_events.py
@@ -268,7 +268,8 @@ class TestFrameworkEvent(SctEvent):  # pylint: disable=too-many-instance-attribu
         args = f' args={self.args}' if self.args else ''
         kwargs = f' kwargs={self.kwargs}' if self.kwargs else ''
         params = ','.join([args, kwargs]) if kwargs or args else ''
-        return f"{super().__str__()}, source={self.source}.{self.source_method}({params}) {message}"
+        source_method = f'.{self.source_method}({params})' if self.source_method else ''
+        return f"{super().__str__()}, source={self.source}{source_method} {message}"
 
 
 class TestResultEvent(SctEvent):


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
