### PR TITLE
fix(rsyslog-logdir): fix log path when using rsyslog logs transport

### DIFF
--- a/sdcm/utils/rsyslog.py
+++ b/sdcm/utils/rsyslog.py
@@ -27,7 +27,7 @@ LOGGER = logging.getLogger(__name__)
 class RSyslogContainerMixin:  # pylint: disable=too-few-public-methods
     def rsyslog_container_run_args(self, logdir: str) -> dict:
         basedir, logdir = os.path.split(logdir)
-        logdir = os.path.abspath(os.path.join(os.environ.get("_SCT_BASE_DIR", basedir), logdir))
+        logdir = os.path.abspath(os.path.join(os.environ.get("_SCT_LOGDIR", basedir), logdir))
         os.makedirs(logdir, exist_ok=True)
         LOGGER.info("rsyslog will store logs at %s", logdir)
 


### PR DESCRIPTION
when no logdir provided to run-test the default path for logging
is ~/sct-results. Rsyslog used _SCT_BASE_DIR instead of _SCT_LOGDIR
hence ryslog transported logs were saved in SCT dir instead of the log dir

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
