### PR TITLE
A CDC replication test.

### DIFF
--- a/cdc_replication_test.py
+++ b/cdc_replication_test.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2020 ScyllaDB
+
+import shutil
+import sys
+import os
+import time
+from tempfile import TemporaryDirectory
+from textwrap import dedent
+
+from cassandra import ConsistencyLevel
+from cassandra.query import SimpleStatement
+from cassandra.cluster import Cluster
+
+from sdcm import cluster
+from sdcm.tester import ClusterTester
+
+def print_file_to_stdout(path: str) -> None:
+    with open(path, "r") as f:
+       shutil.copyfileobj(f, sys.stdout)
+
+# Write a CQL select result to a file.
+def write_cql_result(res, path: str):
+    with open(path, 'w') as f:
+        for r in res:
+            f.write(str(r) + '\n')
+        f.flush()
+        os.fsync(f.fileno())
+
+SCYLLA_MIGRATE_URL = "https://kbr-scylla.s3-eu-west-1.amazonaws.com/scylla-migrate"
+REPLICATOR_URL = "https://kbr-scylla.s3-eu-west-1.amazonaws.com/scylla-cdc-replicator-0.0.1-SNAPSHOT-jar-with-dependencies.jar"
+
+class CDCReplicationTest(ClusterTester):
+    KS_NAME = 'ks1'
+    TABLE_NAME = 'table1'
+
+    def collect_data_for_analysis(self,
+            migrate_log_path: str, replicator_log_path: str,
+            master_node: cluster.BaseNode, replica_node: cluster.BaseNode) -> None:
+        self.log.info('scylla-migrate log:')
+        print_file_to_stdout(migrate_log_path)
+        self.log.info('Replicator log:')
+        print_file_to_stdout(replicator_log_path)
+
+        with self.cql_connection_patient(node=master_node) as sess:
+            self.log.info('Fetching master table...')
+            res = sess.execute(SimpleStatement(f'select * from {self.KS_NAME}.{self.TABLE_NAME}',
+                consistency_level=ConsistencyLevel.QUORUM, fetch_size=1000))
+            write_cql_result(res, os.path.join(self.logdir, 'master-table'))
+
+        with self.cql_connection_patient(node=replica_node) as sess:
+            self.log.info('Fetching replica table...')
+            res = sess.execute(SimpleStatement(f'select * from {self.KS_NAME}.{self.TABLE_NAME}',
+                consistency_level=ConsistencyLevel.QUORUM, fetch_size=1000))
+            write_cql_result(res, os.path.join(self.logdir, 'replica-table'))
+
+    def test_replication(self) -> None:
+        self.log.info('Waiting for the latest CDC generation to start...')
+        # 2 * ring_delay (ring_delay = 30s) + leeway
+        time.sleep(70)
+
+        self.log.info('Starting stressor.')
+        stress_thread = self.run_stress_cassandra_thread(stress_cmd=self.params.get('stress_cmd'))
+
+        self.log.info('Let stressor run for a while...')
+        # Wait for C-S to create keyspaces/tables/UTs
+        time.sleep(20)
+
+        self.log.info('Fetching schema definitions from master cluster.')
+        master_node = self.db_cluster.nodes[0]
+        with self.cql_connection_patient(node=master_node) as sess:
+            sess.cluster.refresh_schema_metadata()
+            # For some reason, `refresh_schema_metadata` doesn't refresh immediatelly...
+            time.sleep(10)
+            ks = sess.cluster.metadata.keyspaces[self.KS_NAME]
+            ut_ddls = [t[1].as_cql_query() for t in ks.user_types.items()]
+            table_ddls = []
+            for name, table in ks.tables.items():
+                if name.endswith('_scylla_cdc_log'):
+                    continue
+                # Don't enable CDC on the replica cluster
+                if 'cdc' in table.extensions:
+                    del table.extensions['cdc']
+                table_ddls.append(table.as_cql_query())
+
+        if ut_ddls:
+            self.log.info('User types:\n{}'.format('\n'.join(ut_ddls)))
+        self.log.info('Table definitions:\n{}'.format('\n'.join(table_ddls)))
+
+        self.log.info('Creating schema on replica cluster.')
+        replica_node = self.cs_db_cluster.nodes[0]
+        with self.cql_connection_patient(node=replica_node) as sess:
+            sess.execute(f"create keyspace if not exists {self.KS_NAME}"
+                          " with replication = {'class': 'SimpleStrategy', 'replication_factor': 1}")
+            for stmt in ut_ddls + table_ddls:
+                sess.execute(stmt)
+
+        self.log.info('Starting nemesis.')
+        self.db_cluster.add_nemesis(nemesis=self.get_nemesis_class(), tester_obj=self)
+        self.db_cluster.start_nemesis()
+
+        loader_node = self.loaders.nodes[0]
+
+        self.log.info('Installing tmux on loader node.')
+        res = loader_node.remoter.run(cmd='sudo yum install -y tmux')
+        if res.exit_status != 0:
+            self.fail('Could not install tmux.')
+
+        self.log.info('Getting scylla-migrate on loader node.')
+        res = loader_node.remoter.run(cmd=f'wget {SCYLLA_MIGRATE_URL} -O scylla-migrate && chmod +x scylla-migrate')
+        if res.exit_status != 0:
+            self.fail('Could not obtain scylla-migrate.')
+
+        self.log.info('Getting replicator on loader node.')
+        res = loader_node.remoter.run(cmd=f'wget {REPLICATOR_URL} -O replicator.jar')
+        if res.exit_status != 0:
+            self.fail('Could not obtain CDC replicator.')
+
+        # We run the replicator in a tmux session so that remoter.run returns immediately
+        # (the replicator will run in the background). We redirect the output to a log file for later extraction.
+        replicator_script = dedent("""
+            (cat >runreplicator.sh && chmod +x runreplicator.sh && tmux new-session -d -s 'replicator' ./runreplicator.sh) <<'EOF'
+            #!/bin/bash
+
+            java -cp replicator.jar com.scylladb.scylla.cdc.replicator.Main -k {} -t {} -s {} -d {} -cl {} 2>&1 | tee replicatorlog
+            EOF
+        """.format(self.KS_NAME, self.TABLE_NAME, master_node.external_address, replica_node.external_address, 'one'))
+
+        self.log.info('Replicator script:\n{}'.format(replicator_script))
+
+        self.log.info('Starting replicator.')
+        res = loader_node.remoter.run(cmd=replicator_script)
+        if res.exit_status != 0:
+            self.fail('Could not start CDC replicator.')
+
+        self.log.info('Let stressor run for a while...')
+        time.sleep(30)
+
+        self.log.info('Stopping nemesis before bootstrapping a new node.')
+        self.db_cluster.stop_nemesis(timeout=60)
+
+        self.log.info('Let stressor run for a while...')
+        time.sleep(30)
+
+        self.log.info('Bootstrapping a new node...')
+        new_node = self.db_cluster.add_nodes(count=1, enable_auto_bootstrap=True)[0]
+        self.log.info('Waiting for new node to finish initializing...')
+        self.db_cluster.wait_for_init(node_list=[new_node])
+        self.monitors.reconfigure_scylla_monitoring()
+
+        self.log.info('Bootstrapped, restarting nemesis.')
+        self.db_cluster.start_nemesis()
+
+        self.log.info('Waiting for stressor to finish...')
+        stress_results = stress_thread.get_results()
+        self.log.info('cassandra-stress results: {}'.format([r for r in stress_results]))
+
+        self.log.info('Waiting for replicator to finish (sleeping 60s)...')
+        time.sleep(60)
+
+        self.log.info('Stopping nemesis.')
+        self.db_cluster.stop_nemesis(timeout=60)
+
+        self.log.info('Fetching replicator logs.')
+        replicator_log_path = os.path.join(self.logdir, 'replicator.log')
+        loader_node.remoter.receive_files(src='replicatorlog', dst=replicator_log_path)
+
+        self.log.info('Comparing table contents using scylla-migrate...')
+        res = loader_node.remoter.run(cmd=
+            './scylla-migrate check --master-address {} --replica-address {}'
+            ' --ignore-schema-difference {}.{} 2>&1 | tee migratelog'.format(
+                    master_node.external_address, replica_node.external_address,
+                    self.KS_NAME, self.TABLE_NAME))
+
+        migrate_log_path = os.path.join(self.logdir, 'scylla-migrate.log')
+        loader_node.remoter.receive_files(src='migratelog', dst=migrate_log_path)
+        with open(migrate_log_path) as f:
+            consistency_ok = 'Consistency check OK.\n' in (line for line in f)
+
+        if not consistency_ok:
+            self.log.error('Inconsistency detected.')
+        if res.exit_status != 0:
+            self.log.error('scylla-migrate command returned status', res.exit_status)
+
+        if consistency_ok and res.exit_status == 0:
+            self.log.info('Consistency check successful.')
+        else:
+            self.collect_data_for_analysis(
+                    migrate_log_path, replicator_log_path,
+                    master_node, replica_node)
+            self.fail('Consistency check failed.')
+

--- a/data_dir/cdc_replication_profile.yaml
+++ b/data_dir/cdc_replication_profile.yaml
@@ -1,0 +1,30 @@
+keyspace: ks1
+
+keyspace_definition: |
+
+  CREATE KEYSPACE IF NOT EXISTS ks1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'} AND durable_writes = true;
+
+table: table1
+
+table_definition: |
+
+  CREATE TABLE ks1.table1 (
+    pk int,
+    ck int,
+    v text,
+    primary key (pk, ck)) WITH cdc = {'enabled': true}
+
+columnspec:
+  - name: pk
+    population: uniform(1..1k)
+
+  - name: ck
+    population: uniform(1..1k)
+
+  - name: v
+    size: exp(1..5)
+
+queries:
+  update:
+    cql: update ks1.table1 set v = ? where pk = ? and ck = ?
+    fields: samerow

--- a/jenkins-pipelines/cdcReplicationPipeline.jenkinsfile
+++ b/jenkins-pipelines/cdcReplicationPipeline.jenkinsfile
@@ -1,0 +1,180 @@
+#!groovy
+
+// Import shared libraries
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+pipeline {
+    parameters {
+        string(defaultValue: "eu-west-1",
+           description: 'us-east-1|eu-west-1',
+           name: 'aws_region')
+
+        string(defaultValue: 'master:latest', description: '', name: 'master_scylla_version')
+        string(defaultValue: 'master:latest', description: '', name: 'oracle_scylla_version')
+
+        string(defaultValue: "spot_low_price",
+               description: 'spot_low_price|on_demand|spot_fleet|spot_duration',
+               name: 'provision_type')
+
+        string(defaultValue: "private",
+               description: 'private|public|ipv6',
+               name: 'ip_ssh_connections')
+
+        string(defaultValue: "qa@scylladb.com",
+               description: 'email recipients of email report',
+               name: 'email_recipients')
+    }
+    agent {
+        label getJenkinsLabels('aws', params.aws_region)
+    }
+    options {
+        timestamps()
+        disableConcurrentBuilds()
+        timeout(time: 60, unit: 'MINUTES')
+        buildDiscarder(logRotator(numToKeepStr: '10'))
+    }
+    environment {
+        AWS_ACCESS_KEY_ID     = credentials('qa-aws-secret-key-id')
+        AWS_SECRET_ACCESS_KEY = credentials('qa-aws-secret-access-key')
+
+        SCT_LOGS_TRANSPORT="ssh"
+        SCT_CLUSTER_BACKEND="aws"
+        SCT_REGION_NAME="${params.aws_region}"
+        SCT_CONFIG_FILES="test-cases/cdc/cdc-15m-replication.yaml"
+    }
+    stages {
+        stage('Checkout') {
+            steps {
+                dir('scylla-cluster-tests') {
+                    checkout scm
+
+                    dir("scylla-qa-internal") {
+                        git(url: 'git@github.com:scylladb/scylla-qa-internal.git',
+                            credentialsId:'b8a774da-0e46-4c91-9f74-09caebaea261',
+                            branch: 'master')
+                    }
+                }
+            }
+        }
+
+        stage('Run SCT Test') {
+            environment  {
+                // Logs are collected in another stage.
+                SCT_COLLECT_LOGS=false
+                SCT_SCYLLA_VERSION="${params.master_scylla_version}"
+                SCT_ORACLE_SCYLLA_VERSION="${params.oracle_scylla_version}"
+                SCT_INSTANCE_PROVISION="${params.provision_type}"
+                SCT_IP_SSH_CONNECTIONS="${params.ip_ssh_connections}"
+                SCT_STORE_RESULTS_IN_ELASTICSEARCH="false"
+            }
+            steps {
+                catchError(stageResult: 'FAILURE') {
+                    wrap([$class: 'BuildUser']) {
+                        dir('scylla-cluster-tests') {
+                            sh """
+                            #!/bin/bash
+                            set -xe
+                            env
+
+                            rm -fv ./latest
+
+                            echo "start test ......."
+                            ./docker/env/hydra.sh run-test cdc_replication_test.CDCReplicationTest.test_replication --backend aws  --logdir "`pwd`"
+                            echo "end test ....."
+                            """
+                        }
+                    }
+                }
+            }
+        }
+
+        stage("Collect log data") {
+            steps {
+                catchError(stageResult: 'FAILURE') {
+                    wrap([$class: 'BuildUser']) {
+                        dir('scylla-cluster-tests') {
+                            sh """
+                            #!/bin/bash
+
+                            set -xe
+                            env
+
+                            echo "start collect logs ..."
+                            ./docker/env/hydra.sh collect-logs --logdir "`pwd`"
+                            echo "end collect logs"
+                            """
+                        }
+                    }
+                }
+            }
+        }
+    }
+    post {
+        always {
+            archiveArtifacts artifacts: 'scylla-cluster-tests/latest/**'
+        }
+        failure {
+            echo "Sending email with results..."
+            wrap([$class: 'BuildUser']) {
+                dir('scylla-cluster-tests') {
+                    script {
+                        def test_status = currentBuild.currentResult
+                        if (test_status) {
+                            test_status = "--test-status " + test_status
+                        }
+
+                        def start_time = currentBuild.startTimeInMillis.intdiv(1000)
+                        if (start_time) {
+                            start_time = "--start-time " + start_time
+                        }
+
+
+                        def email_recipients = groovy.json.JsonOutput.toJson(params.email_recipients)
+
+                        sh """
+                        #!/bin/bash
+                        set -xe
+                        env
+                        echo "Start send email ..."
+                        ./docker/env/hydra.sh send-email ${test_status} ${start_time} --logdir "`pwd`" --email-recipients "${email_recipients}"
+                        echo "Email sent"
+                        """
+                    }
+                }
+            }
+        }
+        cleanup {
+            wrap([$class: 'BuildUser']) {
+                dir('scylla-cluster-tests') {
+                    // Keep the cluster running if and only if the build has failed
+                    // (due to any reason: a framework error, the test itself failing, or failure of log collection).
+                    // I'm not using SCT_POST_BEHAVIOR_DB_NODES=keep-on-failure since it decides basing only on critical
+                    // (framework) errors. I want the cluster running if any part of the test fails.
+                    script {
+                        if (currentBuild.currentResult != 'SUCCESS') {
+                            echo "Build failed, leaving cluster intact."
+                            return
+                        }
+
+                        echo "Build succeeded, cleaning resources..."
+
+                        sh """
+                        #!/bin/bash
+
+                        set -xe
+                        env
+
+                        export SCT_POST_BEHAVIOR_DB_NODES="destroy"
+                        export SCT_POST_BEHAVIOR_LOADER_NODES="destroy"
+                        export SCT_POST_BEHAVIOR_MONITOR_NODES="destroy"
+
+                        echo "start clean resources ..."
+                        ./docker/env/hydra.sh clean-resources --logdir "`pwd`"
+                        echo "end clean resources"
+                        """
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test-cases/cdc/cdc-15m-replication.yaml
+++ b/test-cases/cdc/cdc-15m-replication.yaml
@@ -1,0 +1,25 @@
+test_duration: 60
+
+user_prefix: 'cdc-replication'
+db_type: mixed_scylla
+
+use_legacy_cluster_init: false
+
+n_db_nodes: 3
+instance_type_db: 'i3.large'
+
+n_test_oracle_db_nodes: 1
+instance_type_db_oracle: 'i3.large'
+
+n_loaders: 1
+instance_type_loader: 'c4.large'
+
+n_monitor_nodes: 0
+# instance_type_monitor: 't3.small'
+
+nemesis_class_name: 'RandomInterruptionNetworkMonkey'
+nemesis_interval: 1
+# Required by the nemesis:
+extra_network_interface: true
+
+stress_cmd: "cassandra-stress user no-warmup profile=/tmp/cdc_replication_profile.yaml 'ops(update=1)' cl=QUORUM duration=15m -port jmx=6868 -mode cql3 native -rate threads=10 -log interval=5 -errors retries=999"


### PR DESCRIPTION
This test sets up two clusters, runs a workload on one of them (the "master"), and runs an application ("replicator") which uses CDC to copy data from the master to the other cluster (the "replica") as it appears on the master.

It uses two external tools:
1. A variant of [scylla-migrate](https://github.com/scylladb/scylla-migrate/pull/15),
2. @haaawk's [CDC replicator](https://github.com/haaawk/scylla-cdc-java).

I host a version of each tool in an AWS bucket.

The PR also adds a jenkinsfile containing a Jenkins pipeline to run the test.