### PR TITLE
fix(repo test): remove deleted repo from unittest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,7 +145,7 @@ pipeline {
             steps {
                 script {
                     try {
-                        sh ''' ./utils/lint_test_cases.sh '''
+                        sh ''' ./docker/env/hydra.sh bash ./utils/lint_test_cases.sh '''
                         pullRequestSetResult('success', 'jenkins/lint_test_cases', 'All test cases are passed')
                     } catch(Exception ex) {
                         pullRequestSetResult('failure', 'jenkins/lint_test_cases', 'Some test cases failed')

--- a/unit_tests/test_version_utils.py
+++ b/unit_tests/test_version_utils.py
@@ -15,8 +15,6 @@ RPM_URL = \
     f'f592edaf15e028faf3b7f695f39ebc1-525a0255f73d454f8f97f32b8bdd71c8dec35d3d-a6b2b2355c666b1893f702a587287da' \
     f'978aeec22/71/scylla.repo'
 
-ISSUE_5288_RPM_URL = 'http://scratch.scylladb.com/amos/yum_repos/master/piotrj_issue5288_v3/scylla.repo'
-
 BROKEN_URL = 'https://www.google.com'
 
 
@@ -35,7 +33,7 @@ class TestVersionUtils(unittest.TestCase):
         self.assertEqual(get_branch_version(DEB_URL), '2019.1.1')
 
     def test_02_get_branch_version_from_repo(self):
-        self.check_multiple_urls(urls=[(RPM_URL, "2019.1.1"), (ISSUE_5288_RPM_URL, "666.development")])
+        self.check_multiple_urls(urls=[(RPM_URL, "2019.1.1")])
 
     def test_03_get_branch_version(self):
         self.check_multiple_urls(urls=[(RPM_URL, "2019.1.1"), (DEB_URL, "2019.1.1")])

--- a/utils/lint_test_cases.sh
+++ b/utils/lint_test_cases.sh
@@ -2,7 +2,7 @@
 
 for f in `find ./test-cases/ \\( -iname "*.yaml" ! -iname "*multi-dc.yaml" ! -iname *multiDC*.yaml ! -iname *multiple-dc*.yaml ! -iname *rolling* \\)` ; do
     echo "---- linting: $f -----"
-    RES=$( script --flush --quiet --return /tmp/test-case.txt --command "SCT_AMI_ID_DB_SCYLLA=abc ./docker/env/hydra.sh conf $f" )
+    RES=$( script --flush --quiet --return /tmp/test-case.txt --command "SCT_SCYLLA_VERSION=4.0.0 python3 ./sct.py conf $f" )
     if [[ "$?" == "1" ]]; then
         cat /tmp/test-case.txt
         exit 1;
@@ -11,7 +11,7 @@ done
 
 for f in `find ./test-cases/ \\( -iname *multi-dc.yaml -or -iname *multiDC*.yaml -or -iname *multiple-dc*.yaml -or -iname *rolling* \\)`; do
     echo "---- linting: $f -----"
-    RES=$( script --flush --quiet --return /tmp/test-case.txt --command "SCT_SCYLLA_REPO=abc ./docker/env/hydra.sh conf --backend gce $f" )
+    RES=$( script --flush --quiet --return /tmp/test-case.txt --command "SCT_SCYLLA_REPO=abc python3 ./sct.py conf --backend gce $f" )
     if [[ "$?" == "1" ]]; then
         cat /tmp/test-case.txt
         exit 1;


### PR DESCRIPTION
some repo that we were using in the unittest seem to be delete.
we can live without this repo

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
