### PR TITLE
fix(docker): increase Docker API call timeout

### DIFF
--- a/sdcm/utils/docker_utils.py
+++ b/sdcm/utils/docker_utils.py
@@ -29,6 +29,8 @@ from sdcm.utils.common import deprecation
 from sdcm.utils.decorators import retrying, Retry
 
 
+DOCKER_API_CALL_TIMEOUT = 180  # seconds
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -49,7 +51,7 @@ class DockerClient(docker.DockerClient):
         return res
 
 
-_docker = DockerClient.from_env()  # pylint: disable=invalid-name
+_docker = DockerClient.from_env(timeout=DOCKER_API_CALL_TIMEOUT)  # pylint: disable=invalid-name
 
 
 class _Name(SimpleNamespace):

--- a/sdcm/utils/remotewebbrowser.py
+++ b/sdcm/utils/remotewebbrowser.py
@@ -18,7 +18,7 @@ from typing import Optional
 from docker import DockerClient  # pylint: disable=wrong-import-order
 from selenium.webdriver import Remote, ChromeOptions
 
-from sdcm.utils.docker_utils import ContainerManager
+from sdcm.utils.docker_utils import ContainerManager, DOCKER_API_CALL_TIMEOUT
 from sdcm.utils.common import get_free_port, wait_for_port
 from sdcm.utils.ssh_agent import SSHAgent
 from sdcm.utils.decorators import cached_property
@@ -44,7 +44,8 @@ class WebDriverContainerMixin:
         if not self.ssh_login_info:
             return None
         SSHAgent.add_keys((self.ssh_login_info["key_file"], ))
-        return DockerClient(base_url=f"ssh://{self.ssh_login_info['user']}@{self.ssh_login_info['hostname']}")
+        return DockerClient(base_url=f"ssh://{self.ssh_login_info['user']}@{self.ssh_login_info['hostname']}",
+                            timeout=DOCKER_API_CALL_TIMEOUT)
 
 
 class RemoteBrowser:


### PR DESCRIPTION
Trello: https://trello.com/c/kozvtNsd/2011-unixhttpconnectionpool-readtimeout-occurred-at-the-beginning-of-test-2235

It looks like a problem in slow environment so, I increased Docker API call timeout from default 60 seconds to 180 seconds.

Fixes #2235 


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
