### PR TITLE
fix(lwt loader ami): replace terminated ami with new one (branch-2020.1)

### DIFF
--- a/test-cases/longevity/longevity-lwt-1loader-3h.yaml
+++ b/test-cases/longevity/longevity-lwt-1loader-3h.yaml
@@ -17,7 +17,7 @@ regions_data:
   us-east-1:
     ami_id_loader: 'ami-0b94f0e897d884b1b'
   eu-west-1:
-    ami_id_loader: 'ami-0ea704a8c9ec08e57'
+    ami_id_loader: 'ami-0bf19545bc7bc9e1f'
   us-west-2:
     ami_id_loader: 'ami-063a97bde47353690'
 

--- a/test-cases/longevity/longevity-lwt-24h-multidc.yaml
+++ b/test-cases/longevity/longevity-lwt-24h-multidc.yaml
@@ -17,7 +17,7 @@ regions_data:
   us-east-1:
     ami_id_loader: 'ami-0b94f0e897d884b1b'
   eu-west-1:
-    ami_id_loader: 'ami-0ea704a8c9ec08e57'
+    ami_id_loader: 'ami-0bf19545bc7bc9e1f'
   us-west-2:
     ami_id_loader: 'ami-063a97bde47353690'
 

--- a/test-cases/longevity/longevity-lwt-500G-3d.yaml
+++ b/test-cases/longevity/longevity-lwt-500G-3d.yaml
@@ -22,7 +22,7 @@ regions_data:
   us-east-1:
     ami_id_loader: 'ami-0b94f0e897d884b1b'
   eu-west-1:
-    ami_id_loader: 'ami-0ea704a8c9ec08e57'
+    ami_id_loader: 'ami-0bf19545bc7bc9e1f'
   us-west-2:
     ami_id_loader: 'ami-063a97bde47353690'
 

--- a/test-cases/longevity/longevity-lwt-basic-24h-1dis-2nondis.yaml
+++ b/test-cases/longevity/longevity-lwt-basic-24h-1dis-2nondis.yaml
@@ -17,7 +17,7 @@ regions_data:
   us-east-1:
     ami_id_loader: 'ami-0b94f0e897d884b1b'
   eu-west-1:
-    ami_id_loader: 'ami-0ea704a8c9ec08e57'
+    ami_id_loader: 'ami-0bf19545bc7bc9e1f'
   us-west-2:
     ami_id_loader: 'ami-063a97bde47353690'
 

--- a/test-cases/longevity/longevity-lwt-basic-24h.yaml
+++ b/test-cases/longevity/longevity-lwt-basic-24h.yaml
@@ -20,7 +20,7 @@ regions_data:
   us-east-1:
     ami_id_loader: 'ami-0b94f0e897d884b1b'
   eu-west-1:
-    ami_id_loader: 'ami-0ea704a8c9ec08e57'
+    ami_id_loader: 'ami-0bf19545bc7bc9e1f'
   us-west-2:
     ami_id_loader: 'ami-063a97bde47353690'
 

--- a/test-cases/longevity/longevity-lwt-basic-3h.yaml
+++ b/test-cases/longevity/longevity-lwt-basic-3h.yaml
@@ -20,7 +20,7 @@ regions_data:
   us-east-1:
     ami_id_loader: 'ami-0b94f0e897d884b1b'
   eu-west-1:
-    ami_id_loader: 'ami-0ea704a8c9ec08e57'
+    ami_id_loader: 'ami-0bf19545bc7bc9e1f'
   us-west-2:
     ami_id_loader: 'ami-063a97bde47353690'
 


### PR DESCRIPTION
LWT loader ami on eu-west-1 was terminated mistakenly.
Replace it with new ami

It's urgent, because LWT test failed because of this problem

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
