### PR TITLE
fix(longevity-5000-tables): use larger db instance

### DIFF
--- a/test-cases/longevity/longevity-5000-tables.yaml
+++ b/test-cases/longevity/longevity-5000-tables.yaml
@@ -12,7 +12,7 @@ n_monitor_nodes: 1
 n_db_nodes: 1
 add_node_cnt: 5
 
-instance_type_db: 'i3.4xlarge'
+instance_type_db: 'i3.8xlarge'
 instance_type_loader: 'c5.2xlarge'
 user_prefix: 'longevity-5000-tables'
 


### PR DESCRIPTION
The latest longevity-5000-tables failed for heavy load, the c-s crashed.
Let's try with larger db instance.

Requested by @roydahan 

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
