### PR TITLE
Latest changes for cdc stressor: enable batching

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -72,7 +72,9 @@ dynamodb_primarykey_type: 'HASH'
 
 
 store_cdclog_reader_stats_in_es: false
-
 region_aware_loader: false
 
 stop_test_on_stress_failure: true
+
+stress_cdc_log_reader_batching_enable: true
+

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -77,4 +77,3 @@ region_aware_loader: false
 stop_test_on_stress_failure: true
 
 stress_cdc_log_reader_batching_enable: true
-

--- a/jenkins-pipelines/perf-regression-cdc-mixed-throughput-60min.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-cdc-mixed-throughput-60min.jenkinsfile
@@ -1,0 +1,16 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    params: params,
+
+    backend: "aws",
+    aws_region: "us-east-1",
+    test_name: "performance_regression_cdc_test.PerformanceRegressionCDCTest",
+    test_config: "test-cases/performance/perf-regression-throughput-cdc-mixed-poll-batching.yaml",
+    sub_tests: ["test_mixed_throughput"],
+
+    timeout: [time: 550, unit: "MINUTES"]
+)

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -779,6 +779,8 @@ class LoaderLogCollector(LogCollector):
         FileLog(name='*gemini-l*.log',
                 search_locally=True),
         FileLog(name='gemini_result*.log',
+                search_locally=True),
+        FileLog(name='cdclogreader*.log',
                 search_locally=True)
     ]
 

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -922,13 +922,14 @@ class SCTConfiguration(dict):
         dict(name="store_cdclog_reader_stats_in_es", env="SCT_STORE_CDCLOG_READER_STATS_IN_ES",
              type=boolean,
              help="""Add cdclog reader stats to ES for future performance result calculating"""),
-
         dict(name="stop_test_on_stress_failure", env="SCT_STOP_TEST_ON_STRESS_FAILURE",
              type=boolean,
              help="""If set to True the test will be stopped immediately when stress command failed.
                      When set to False the test will continue to run even when there are errors in the
                      stress process"""),
-
+        dict(name="stress_cdc_log_reader_batching_enable", env="SCT_STRESS_CDC_LOG_READER_BATCHING_ENABLE",
+             type=boolean,
+             help="""retrieving data from multiple streams in one poll"""),
     ]
 
     required_params = ['cluster_backend', 'test_duration', 'n_db_nodes', 'n_loaders', 'use_preinstalled_scylla',

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -964,7 +964,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                    round_robin=round_robin, params=self.params).run()
 
     def run_cdclog_reader_thread(self, stress_cmd, duration=None, stress_num=1, prefix='',  # pylint: disable=too-many-arguments
-                                 round_robin=False, stats_aggregate_cmds=True,
+                                 round_robin=False, stats_aggregate_cmds=True, enable_batching=True,
                                  keyspace_name=None, base_table_name=None):   # pylint: disable=unused-argument
         timeout = self.get_duration(duration)
 
@@ -977,6 +977,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                   node_list=self.db_cluster.nodes,
                                   keyspace_name=keyspace_name,
                                   base_table_name=base_table_name,
+                                  enable_batching=enable_batching,
                                   round_robin=round_robin, params=self.params).run()
 
     def run_gemini(self, cmd, duration=None):

--- a/test-cases/performance/perf-regression-throughput-cdc-mixed-poll-batching.yaml
+++ b/test-cases/performance/perf-regression-throughput-cdc-mixed-poll-batching.yaml
@@ -1,0 +1,33 @@
+# test runs 4 subtest with duration 60 min
+# and time for clear table between subtest
+test_duration: 500
+
+stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=60m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=1..30000000"
+stress_cdclog_reader_cmd: "cdc-stressor -duration 70m -stream-query-round-duration 30s"
+store_cdclog_reader_stats_in_es: false
+stress_cdc_log_reader_batching_enable: true
+
+
+n_db_nodes: 3
+n_loaders: 4
+n_monitor_nodes: 1
+
+instance_type_loader: 'c4.2xlarge'
+instance_type_monitor: 't3.small'
+instance_type_db: 'i3.2xlarge'
+
+user_prefix: 'perf-cdc-mixed'
+space_node_threshold: 644245094
+
+
+store_perf_results: true
+append_scylla_args: '--blocked-reactor-notify-ms 50'
+
+
+append_scylla_yaml: |
+  experimental_features:
+    - cdc
+
+send_email: true
+email_recipients: ['qa@scylladb.com']
+backtrace_decoding: false


### PR DESCRIPTION
cdc stressor tool was updated with new command parameter and flow of execution.
Added appropriate changes to sct

Cdc stressor now support batching: Read changes from several streams in a batch.
Added collecting log file of cdc stressor tool

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
