### PR TITLE
fix(eip_allocation_id): try to release_address while still in use

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -649,12 +649,17 @@ class AWSNode(cluster.BaseNode):
     def hard_reboot(self):
         self._instance_wait_safe(self._instance.reboot)
 
+    def release_address(self):
+        self._instance.wait_until_terminated()
+
+        client: EC2Client = boto3.client('ec2', region_name=self.parent_cluster.region_names[self.dc_idx])
+        client.release_address(AllocationId=self.eip_allocation_id)
+
     def destroy(self):
         self.stop_task_threads()
         self._instance.terminate()
         if self.eip_allocation_id:
-            client: EC2Client = boto3.client('ec2', region_name=self.parent_cluster.region_names[self.dc_idx])
-            client.release_address(AllocationId=self.eip_allocation_id)
+            self.release_address()
         super().destroy()
 
     def get_console_output(self):


### PR DESCRIPTION
In some case the termination of node it happening too quickly, and
this code that should cleanup is happing too quickly, and this error
is happening, stopping all the cleanup process
```
"ClientError('An error occurred (InvalidIPAddress.InUse) when calling
the ReleaseAddress operation: Address 63.34.195.214 is in use.')"
```

Fixes: #2295

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
