### PR TITLE
fix(longevity config): update the loader AMI to latest

### DIFF
--- a/test-cases/longevity/longevity-5000-tables.yaml
+++ b/test-cases/longevity/longevity-5000-tables.yaml
@@ -24,7 +24,7 @@ regions_data:
   us-east-1:
     ami_id_loader: 'ami-0b94f0e897d884b1b'
   eu-west-1:
-    ami_id_loader: 'ami-0ea704a8c9ec08e57'
+    ami_id_loader: 'ami-0bf19545bc7bc9e1f'
   us-west-2:
     ami_id_loader: 'ami-063a97bde47353690'
 

--- a/test-cases/longevity/longevity-multi-keyspaces.yaml
+++ b/test-cases/longevity/longevity-multi-keyspaces.yaml
@@ -31,7 +31,7 @@ regions_data:
   us-east-1:
     ami_id_loader: 'ami-0b94f0e897d884b1b'
   eu-west-1:
-    ami_id_loader: 'ami-0ea704a8c9ec08e57'
+    ami_id_loader: 'ami-0bf19545bc7bc9e1f'
   us-west-2:
     ami_id_loader: 'ami-063a97bde47353690'
 


### PR DESCRIPTION
The current AMI had been deleted, this patch updated the two config file
to use the latest AMI.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
