### PR TITLE
fix(setup): Changed the time between nodes setup

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2894,7 +2894,7 @@ def wait_for_init_wrap(method):
                                             args=(node,))
             setup_thread.daemon = True
             setup_thread.start()
-            time.sleep(30)
+            setup_thread.join(timeout=300)
 
         results = []
         while len(results) != len(node_list):


### PR DESCRIPTION
Due to issue #6354, I lengthened the time between the setup of each non-seed node
from 30 to the maximum of 300 seconds

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
