### PR TITLE
fix(manager): Moved the backup configuration to node setup

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -38,7 +38,7 @@ from paramiko.ssh_exception import NoValidConnectionsError
 
 
 from sdcm.collectd import ScyllaCollectdSetup
-from sdcm.mgmt import ScyllaManagerError, get_scylla_manager_tool
+from sdcm.mgmt import ScyllaManagerError, get_scylla_manager_tool, update_config_file
 from sdcm.prometheus import start_metrics_server, PrometheusAlertManagerListener, AlertSilencer
 from sdcm.log import SDCMAdapter
 from sdcm.remote import RemoteCmdRunner, LOCALRUNNER, NETWORK_EXCEPTIONS
@@ -335,6 +335,7 @@ class UserRemoteCredentials():
 
 class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disable=too-many-instance-attributes,too-many-public-methods
     CQL_PORT = 9042
+    MANAGER_AGENT_PORT = 10001
 
     log = LOGGER
 
@@ -1318,6 +1319,19 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             self._report_housekeeping_uuid()
         except Exception as details:  # pylint: disable=broad-except
             self.log.error('Failed to report housekeeping uuid. Error details: %s', details)
+
+    def manager_agent_up(self):
+        if self.is_port_used(port=self.MANAGER_AGENT_PORT, service_name="scylla-manager-agent"):
+            # When the agent is IP, it should answer an http request of https://NODE_IP:10001/ping with status code 204
+            response = requests.get(f"https://{self.ip_address}:10001/ping", verify=False)
+            return response.status_code == 204
+        return False
+
+    def wait_manager_agent_up(self, verbose=True, timeout=180):
+        text = None
+        if verbose:
+            text = '%s: Waiting for manager agent to be up' % self
+        wait.wait_for(func=self.manager_agent_up, step=10, text=text, timeout=timeout, throw_exc=True)
 
     # Configuration node-exporter.service when use IPv6
     def set_web_listen_address(self):
@@ -3403,6 +3417,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             node.remoter.run('sudo cat /etc/scylla.d/io.conf')
 
             if self.params.get('use_mgmt', None):
+                region = self.params.get('region_name').split()
                 pkgs_url = self.params.get('scylla_mgmt_pkg', None)
                 pkg_path = None
                 if pkgs_url:
@@ -3410,6 +3425,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                     node.remoter.run('mkdir -p {}'.format(pkg_path))
                     node.remoter.send_files(src='{}*.rpm'.format(pkg_path), dst=pkg_path)
                 node.install_manager_agent(package_path=pkg_path)
+                update_config_file(node=node, region=region[0])
         else:
             self._reuse_cluster_setup(node)
 

--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -113,6 +113,7 @@ def update_config_file(node, region, config_file='/etc/scylla-manager-agent/scyl
     new_configuration = yaml.dump(configuration, default_flow_style=False)
     node.remoter.run(f'sudo echo -e \"{new_configuration}\" > {config_file}')
     node.remoter.run('sudo systemctl restart scylla-manager-agent')
+    node.wait_manager_agent_up()
 
 
 class ScyllaManagerBase():  # pylint: disable=too-few-public-methods

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -35,7 +35,7 @@ from cassandra import ConsistencyLevel  # pylint: disable=ungrouped-imports
 
 from sdcm.cluster_aws import ScyllaAWSCluster
 from sdcm.cluster import SCYLLA_YAML_PATH, NodeSetupTimeout, NodeSetupFailed, Setup
-from sdcm.mgmt import TaskStatus, update_config_file
+from sdcm.mgmt import TaskStatus
 from sdcm.utils.common import remote_get_file, get_non_system_ks_cf_list, get_db_tables, generate_random_string, \
     update_certificates
 from sdcm.utils.decorators import retrying
@@ -1227,9 +1227,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             mgr_cluster = manager_tool.add_cluster(name=cluster_name, host=targets[0][1], disable_automatic_repair=True,
                                                    auth_token=self.monitoring_set.mgmt_auth_token)
         bucket_location_name = self.cluster.params.get('backup_bucket_location').split()
-        region = self.cluster.params.get('region_name').split()
-        for node in self.cluster.nodes:
-            update_config_file(node=node, region=region[0])
         mgr_task = mgr_cluster.create_backup_task(location_list=['s3:{}'.format(bucket_location_name[0])])
 
         succeeded, status = mgr_task.wait_for_task_done_status(timeout=54000)
@@ -1492,7 +1489,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if not self.cluster.extra_network_interface:
             raise UnsupportedNemesis("for this nemesis to work, you need to set `extra_network_interface: True`")
 
-        rate_limit : Optional[str] = self.get_rate_limit_for_network_disruption()
+        rate_limit: Optional[str] = self.get_rate_limit_for_network_disruption()
         if not rate_limit:
             self.log.warn("NetworkRandomInterruption won't limit network bandwith due to lack of monitoring nodes.")
 


### PR DESCRIPTION
Due to issues with the backup nemesis, I moved the updating of the agent configuration from
the backup nemesis to the node setup. In addition, I added a function that waits until the
agent is up before continuing.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
