### PR TITLE
fix(get_nodetool_status): function can't parse line when load is '?'

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3186,7 +3186,14 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                     if line.startswith('--'):  # ignore the title line in result
                         continue
                     try:
-                        state, ip, load, load_unit, tokens, owns, host_id, rack = line.split()
+                        splitted_line = line.split()
+                        # Regulary nodetool status returns node load as "21.71 GB"
+                        # Example: "UN  10.0.59.34    21.71 GB   256          ?       e5bcb094-e4de-43aa-8dc9-b1bf74b3b346  1a"
+                        # But it may be the "?" instead and has no load_unit. Add empty string to prevent the failure
+                        # Example: "UN  10.0.198.153  ?          256          ?       fba174cd-917a-40f6-ab62-cc58efaaf301  1a"
+                        if len(splitted_line) == 7 and splitted_line[3].isdigit():
+                            splitted_line.insert(3, '')
+                        state, ip, load, load_unit, tokens, owns, host_id, rack = splitted_line
                         node_info = {'state': state,
                                      'load': '%s%s' % (load, load_unit),
                                      'tokens': tokens,


### PR DESCRIPTION
When nodetool status return node load as ?, get_nodetool_status function fails to parse such line

What it causes:
cluster checker send ERROR, that the node doesn't exist in the nodetool status despite it exists. And fail test

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
