### PR TITLE
fix(toppartitions): skip nemesis if toppartitions isn't supported

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1438,6 +1438,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             }
 
         self._set_current_disruption("ShowTopPartitions")
+        result = self.target_node.run_nodetool(sub_cmd='help', args='toppartitions')
+        if 'Unknown command toppartitions' in result.stdout:
+            raise UnsupportedNemesis("nodetool doesn't support toppartitions")
+
         # workaround for issue #4519
         self.target_node.run_nodetool('cfstats')
 


### PR DESCRIPTION
Since in some case we are running with older versions,
like in scylla-cloud which now running 2019.1.8

We want to skip this nemesis and not fail on it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
