### PR TITLE
fix(wait_for_init): increase wait time between setup non-seeds nodes

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2885,7 +2885,7 @@ def wait_for_init_wrap(method):
                                             args=(node,))
             setup_thread.daemon = True
             setup_thread.start()
-            time.sleep(30)
+            time.sleep(120)
 
         results = []
         while len(results) != len(node_list):


### PR DESCRIPTION
Currently we setup seeds nodes firstly, the setup non-seeds nodes in
parallel. There is a 30 seconds delay between the nodes, but it's not
enough to wait the node to be ready(UP).

This patch increased the delay time to 2 mins, it's helpful to avoid
https://github.com/scylladb/scylla/issues/6354

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
