### PR TITLE
fix(sdcm/tester.py): Fail test is critical or error event spotted

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -356,7 +356,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         try:
             self.init_resources()
 
-            if self.db_cluster.nodes:
+            if self.db_cluster and self.db_cluster.nodes:
                 self.init_nodes(db_cluster=self.db_cluster)
                 self.set_system_auth_rf()
 
@@ -372,15 +372,17 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 # sync test_start_time with ES
                 self.start_time = self.get_test_start_time()
 
-            self.monitors.wait_for_init()
+            if self.monitors:
+                self.monitors.wait_for_init()
 
             # cancel reuse cluster - for new nodes added during the test
             Setup.reuse_cluster(False)
-            if self.monitors.nodes:
+            if self.monitors and self.monitors.nodes:
                 self.prometheus_db = PrometheusDBStats(host=self.monitors.nodes[0].public_ip_address)
             self.start_time = time.time()
 
-            self.db_cluster.validate_seeds_on_all_nodes()
+            if self.db_cluster:
+                self.db_cluster.validate_seeds_on_all_nodes()
         except Exception:
             TestFrameworkEvent(
                 source=self.__class__.__name__,
@@ -1739,24 +1741,33 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         self.stop_resources()
         self.get_test_failing_events()
         self.get_test_failures()
-        self.save_email_data()
         if self.params.get('collect_logs'):
             self.collect_logs()
         self.clean_resources()
         if self.create_stats:
             self.update_test_with_errors()
-        self.publish_final_event()
-        self.stop_event_device()
-        self.destroy_localhost()
-        self.send_email()
         self.tag_ami_with_result()
+        self.destroy_localhost()
+        self.publish_final_event()
+        time.sleep(1)  # Sleep is needed to let final event being saved into files
+        self.save_email_data()
+        self.send_email()
+        self.stop_event_device()
         if self.params.get('collect_logs'):
             self.collect_sct_logs()
-        framework_errors = self.get_test_results('framework')
-        if framework_errors:
-            framework_errors = "\n".join(framework_errors)
-            self.log.error('%s\nFRAMEWORK ERRORS:\n%s\n%s', (">" * 70), framework_errors, (">" * 70))
+        self.finalize_teardown()
         self.log.info('Test ID: {}'.format(Setup.test_id()))
+
+    def finalize_teardown(self):
+        for _ in range(len(self._outcome.errors) - 1):
+            self._outcome.errors.pop()
+        self._outcome.errors.append((self, (
+            TestResultEvent,
+            TestResultEvent(
+                test_errors=self.get_test_results('test'),
+                framework_errors=self.get_test_results('framework')
+            ),
+            None)))
 
     @silence()
     def destroy_localhost(self):
@@ -1793,8 +1804,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     @silence()
     def publish_final_event(self):
         test_result_event = TestResultEvent(
-            test_name=self.id(),
-            errors=self.get_test_results('test'))
+            test_errors=self.get_test_results('test'),
+            framework_errors=self.get_test_results('framework')
+        )
         test_result_event.publish()
 
     def populate_data_parallel(self, size_in_gb, blocking=True, read=False):

--- a/unit_tests/test_events.py
+++ b/unit_tests/test_events.py
@@ -495,7 +495,10 @@ class TesterFailure(BaseEventsTest):
     def tearDown(self) -> None:
         ClusterTester.get_test_failures(self)
         test_errors = ClusterTester.get_test_results(self, source='test')
-        tre = TestResultEvent(test_name=self.id(), errors=test_errors)
+        tre = TestResultEvent(
+            test_errors=test_errors,
+            framework_errors=ClusterTester.get_test_results(self, source='framework')
+        )
         assert tre.severity == Severity.ERROR
         tre.publish(guaranteed=True)
         print(str(tre))
@@ -514,7 +517,10 @@ class TesterNoErrors(BaseEventsTest):
     def tearDown(self) -> None:
         ClusterTester.get_test_failures(self)
         test_errors = ClusterTester.get_test_results(self, source='test')
-        tre = TestResultEvent(test_name=self.id(), errors=test_errors)
+        tre = TestResultEvent(
+            test_errors=test_errors,
+            framework_errors=ClusterTester.get_test_results(self, source='framework')
+        )
         assert tre.severity == Severity.NORMAL
         tre.publish(guaranteed=True)
         print(str(tre))
@@ -535,7 +541,10 @@ class TesterErrorDuringSetUp(BaseEventsTest):
         ClusterTester.get_test_failures(self)
         test_errors = ClusterTester.get_test_results(self, source='test')
         assert test_errors is not None
-        tre = TestResultEvent(test_name=self.id(), errors=test_errors)
+        tre = TestResultEvent(
+            test_errors=test_errors,
+            framework_errors=ClusterTester.get_test_results(self, source='framework')
+        )
         assert tre.severity == Severity.ERROR
 
 
@@ -559,7 +568,10 @@ class TesterMultiSubTest(unittest.TestCase):
         test_errors = ClusterTester.get_test_results(self, source='test')
         assert "test3" in test_errors
         assert "test2" in test_errors
-        tre = TestResultEvent(test_name=self.id(), errors=test_errors)
+        tre = TestResultEvent(
+            test_errors=test_errors,
+            framework_errors=ClusterTester.get_test_results(self, source='framework')
+        )
         assert tre.severity == Severity.CRITICAL
         self._outcome.errors = []  # we don't want to fail test
 


### PR DESCRIPTION
https://trello.com/c/PaKvQMxV/2056-test-failed-but-jenkins-job-status-is-passed-blue

This PR will change following:
1. Include framework errors to TestResultEvent 
2. Stop logging TestResultEvent to avoid showing it twice, by unittest and as log message.
3. Publish TestResultEvent and feed it to the unittest framework as an legit error at the end of the test teardown.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
