### PR TITLE
fix(scylla install): drop external openjdk installation

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1937,8 +1937,6 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5e08fbd8b5d6ec9c
                     add-apt-repository -y ppa:scylladb/ppa
                     apt-get update
-                    apt-get install -y openjdk-8-jre-headless
-                    update-java-alternatives --jre-headless -s java-1.8.0-openjdk-amd64
                 """)
                 self.remoter.run('sudo bash -cxe "%s"' % install_prereqs)
             elif self.is_debian8():


### PR DESCRIPTION
    We already have strict dependency version in scylla-tools-java spec file, and
    openjd-11 is already supported in (jmx, etc). So we don't need external openjdk
    installation and update-java-alternatives.
    
    This patch only changed supported distros.
    
    On Ubuntu16.04, openjdk-8 and open-jdk-9 are available. On Ubuntu18.04,
    openjdk-8 and open-jdk-11 are available. In scylla-tools-java spec file,
    openjdk-8 has high priority, so it will be installed by default.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
