### PR TITLE
improvement(ipv6 workaround): remove ipv6 workaround

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -270,7 +270,7 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
                 ec2_user_data += ' --bootstrap false '
         return ec2_user_data
 
-    # This is workaround for issue #5179: IPv6 - routing in scylla AMI isn't configured properly
+    # This is workaround for issue #5179: IPv6 - routing in scylla AMI isn't configured properly (when not Amazon Linux)
     @staticmethod
     def network_config_ipv6_workaround_script():  # pylint: disable=invalid-name
         return dedent("""
@@ -278,7 +278,7 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
             MAC=`curl -s ${BASE_EC2_NETWORK_URL}`
             IPv6_CIDR=`curl -s ${BASE_EC2_NETWORK_URL}${MAC}/subnet-ipv6-cidr-blocks`
 
-            sudo ip route add $IPv6_CIDR dev eth0
+            grep -qi "amazon linux" /etc/os-release || sudo ip route add $IPv6_CIDR dev eth0
         """)
 
     @staticmethod
@@ -355,7 +355,7 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
                        enumerate(instances, start=self._node_index + 1)]
         for node in added_nodes:
             node.enable_auto_bootstrap = enable_auto_bootstrap
-            if self.params.get('ip_ssh_connections') == 'ipv6':
+            if self.params.get('ip_ssh_connections') == 'ipv6' and not node.distro.is_amazon2:
                 node.config_ipv6_as_persistent()
         self._node_index += len(added_nodes)
         self.nodes += added_nodes


### PR DESCRIPTION
Amazon Linux 2 has a fix for the IPv6 persistency, hence it
doesn't need the workaround. Other AMIs still need it, so
the code is checking if not Amazon Linux 2 to run the IPv6
persistency (as it was until today).

related to #2284 

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
