### PR TITLE
improvement(cluster.py): Added support for cloud manager

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -46,6 +46,7 @@ post_behavior_loader_nodes: "destroy"
 post_behavior_monitor_nodes: "keep-on-failure"
 
 cloud_credentials_path: '~/.ssh/support'
+use_cloud_manager: false
 
 backtrace_decoding: true
 

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -26,6 +26,7 @@
 | **<a name="scylla_mgmt_repo">scylla_mgmt_repo</a>**  | Url to the repo of scylla manager version to install for management tests | https://repositories.scylladb.com/scylla/repo/qa-test/centos/scylladb-manager-2.0.repo | SCT_SCYLLA_MGMT_REPO
 | **<a name="scylla_mgmt_agent_repo">scylla_mgmt_agent_repo</a>**  | Url to the repo of scylla manager agent version to install for management tests | N/A | SCT_SCYLLA_MGMT_AGENT_REPO
 | **<a name="scylla_mgmt_pkg">scylla_mgmt_pkg</a>**  | Url to the scylla manager packages to install for management tests | N/A | SCT_SCYLLA_MGMT_PKG
+| **<a name="use_cloud_manager">use_cloud_manager</a>**  | When define true, will install scylla cloud manager | N/A | SCT_USE_CLOUD_MANAGER
 | **<a name="use_mgmt">use_mgmt</a>**  | When define true, will install scylla management | N/A | SCT_USE_MGMT
 | **<a name="mgmt_port">mgmt_port</a>**  | The port of scylla management | 10090 | SCT_MGMT_PORT
 | **<a name="mgmt_segments_per_repair">mgmt_segments_per_repair</a>**  | the number of segments per repair used for the manager's repair | 10 | MGMT_SEGMENTS_PER_REPAIR

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -42,7 +42,7 @@ from sdcm.mgmt import ScyllaManagerError, get_scylla_manager_tool, update_config
 from sdcm.prometheus import start_metrics_server, PrometheusAlertManagerListener, AlertSilencer
 from sdcm.log import SDCMAdapter
 from sdcm.remote import RemoteCmdRunner, LOCALRUNNER, NETWORK_EXCEPTIONS
-from sdcm import wait
+from sdcm import wait, mgmt
 from sdcm.utils.alternator import WriteIsolation
 from sdcm.utils.common import deprecation, get_data_dir_path, verify_scylla_repo_file, S3Storage, get_my_ip, \
     get_latest_gemini_version, makedirs, normalize_ipv6_url, download_dir_from_cloud, generate_random_string
@@ -3618,6 +3618,21 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         LOGGER.info('Decommission %s PASS', node)
         self.terminate_node(node)  # pylint: disable=no-member
         Setup.tester_obj().monitors.reconfigure_scylla_monitoring()
+
+    def get_cluster_manager(self):
+        if not self.params.get('use_mgmt', default=None):
+            raise ScyllaManagerError('Scylla-manager configuration is not defined!')
+        manager_node = Setup.tester_obj().monitors.nodes[0]
+        manager_tool = mgmt.get_scylla_manager_tool(manager_node=manager_node)
+        LOGGER.debug("sctool version is : {}".format(manager_tool.version))
+        cluster_name = self.name  # pylint: disable=no-member
+        mgr_cluster = manager_tool.get_cluster(cluster_name)
+        if not mgr_cluster:
+            self.log.debug("Could not find cluster : {} on Manager. Adding it to Manager".format(cluster_name))
+            targets = [[n, n.ip_address] for n in self.nodes]
+            mgr_cluster = manager_tool.add_cluster(name=cluster_name, host=targets[0], disable_automatic_repair=True,
+                                                   auth_token=Setup.tester_obj().monitors.mgmt_auth_token)
+        return mgr_cluster
 
 
 class BaseLoaderSet():

--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -213,7 +213,7 @@ class ManagerTask(ScyllaManagerBase):
         Gets the task's status
         """
         cmd = "task list -c {}".format(self.cluster_id)
-        res = self.sctool.run(cmd=cmd, is_verify_errorless_result=True)
+        res = self.sctool.run(cmd=cmd)
         str_status = self.get_property(parsed_table=res, column_name='status')
         str_accurate_status = str_status.split()[0]
         # The manager will sometimes retry a task a few times if it's defined this way, and so in the case of

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1233,6 +1233,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def disrupt_mgmt_backup(self):
         self._set_current_disruption('ManagementBackup')
+        if not self.cluster.params.get('use_mgmt', default=None) and not self.cluster.params.get('use_cloud_manager',
+                                                                                                 default=None):
+            raise UnsupportedNemesis('Scylla-manager configuration is not defined!')
         if not self.cluster.params.get('backup_bucket_location'):
             raise UnsupportedNemesis('backup bucket location configuration is not defined!')
 
@@ -1252,6 +1255,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def disrupt_mgmt_repair_cli(self):
         self._set_current_disruption('ManagementRepair')
+        if not self.cluster.params.get('use_mgmt', default=None) and not self.cluster.params.get('use_cloud_manager',
+                                                                                                 default=None):
+            raise UnsupportedNemesis('Scylla-manager configuration is not defined!')
         mgr_cluster = self.cluster.get_cluster_manager()
         mgr_task = mgr_cluster.create_repair_task()
         task_final_status = mgr_task.wait_and_get_final_status(timeout=86400)  # timeout is 24 hours

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1233,8 +1233,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def disrupt_mgmt_backup(self):
         self._set_current_disruption('ManagementBackup')
-        if not self.cluster.params.get('use_mgmt', default=None) and not self.cluster.params.get('use_cloud_manager',
-                                                                                                 default=None):
+        # TODO: When cloud backup is supported - add this to the belowq 'if' statement:
+        #  and not self.cluster.params.get('use_cloud_manager', default=None)
+        if not self.cluster.params.get('use_mgmt', default=None):
             raise UnsupportedNemesis('Scylla-manager configuration is not defined!')
         if not self.cluster.params.get('backup_bucket_location'):
             raise UnsupportedNemesis('backup bucket location configuration is not defined!')

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -34,7 +34,7 @@ from invoke import UnexpectedExit
 from cassandra import ConsistencyLevel  # pylint: disable=ungrouped-imports
 
 from sdcm.cluster_aws import ScyllaAWSCluster
-from sdcm.cluster import SCYLLA_YAML_PATH, NodeSetupTimeout, NodeSetupFailed, Setup
+from sdcm.cluster import SCYLLA_YAML_PATH, NodeSetupTimeout, NodeSetupFailed
 from sdcm.mgmt import TaskStatus
 from sdcm.utils.common import remote_get_file, get_non_system_ks_cf_list, get_db_tables, generate_random_string, \
     update_certificates
@@ -42,7 +42,7 @@ from sdcm.utils.decorators import retrying
 from sdcm.log import SDCMAdapter
 from sdcm.keystore import KeyStore
 from sdcm.prometheus import nemesis_metrics_obj
-from sdcm import mgmt, wait
+from sdcm import wait
 from sdcm.sct_events import DisruptionEvent, DbEventsFilter, Severity
 from sdcm.db_stats import PrometheusDBStats
 from sdcm.utils.alternator import ignore_alternator_client_errors
@@ -1233,22 +1233,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def disrupt_mgmt_backup(self):
         self._set_current_disruption('ManagementBackup')
-        if not self.cluster.params.get('use_mgmt', default=None):
-            raise UnsupportedNemesis('Scylla-manager configuration is not defined!')
         if not self.cluster.params.get('backup_bucket_location'):
             raise UnsupportedNemesis('backup bucket location configuration is not defined!')
 
-        manager_node = self.monitoring_set.nodes[0]
-        manager_tool = mgmt.get_scylla_manager_tool(manager_node=manager_node)
-        self.log.debug("sctool version is : {}".format(manager_tool.version))
-
-        cluster_name = self.cluster.name
-        mgr_cluster = manager_tool.get_cluster(cluster_name)
-        if not mgr_cluster:
-            self.log.debug("Could not find cluster : {} on Manager. Adding it to Manager".format(cluster_name))
-            targets = [[n, n.ip_address] for n in self.cluster.nodes]
-            mgr_cluster = manager_tool.add_cluster(name=cluster_name, host=targets[0][1], disable_automatic_repair=True,
-                                                   auth_token=self.monitoring_set.mgmt_auth_token)
+        mgr_cluster = self.cluster.get_cluster_manager()
         bucket_location_name = self.cluster.params.get('backup_bucket_location').split()
         mgr_task = mgr_cluster.create_backup_task(location_list=['s3:{}'.format(bucket_location_name[0])])
 
@@ -1264,28 +1252,12 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def disrupt_mgmt_repair_cli(self):
         self._set_current_disruption('ManagementRepair')
-        if not self.cluster.params.get('use_mgmt', default=None):
-            raise UnsupportedNemesis('Scylla-manager configuration is not defined!')
-
-        manager_node = self.monitoring_set.nodes[0]
-        manager_tool = mgmt.get_scylla_manager_tool(manager_node=manager_node)
-
-        cluster_name = self.cluster.name
-        mgr_cluster = manager_tool.get_cluster(cluster_name)
-        if not mgr_cluster:
-            self.log.debug("Could not find cluster : {} on Manager. Adding it to Manager".format(cluster_name))
-            ip_addr_attr = 'public_ip_address' if self.cluster.params.get('cluster_backend') != 'gce' and \
-                Setup.INTRA_NODE_COMM_PUBLIC else 'private_ip_address'
-            targets = [getattr(n, ip_addr_attr) for n in self.cluster.nodes]
-            mgr_cluster = manager_tool.add_cluster(name=cluster_name, host=targets[0], disable_automatic_repair=True,
-                                                   auth_token=self.monitoring_set.mgmt_auth_token)
+        mgr_cluster = self.cluster.get_cluster_manager()
         mgr_task = mgr_cluster.create_repair_task()
         task_final_status = mgr_task.wait_and_get_final_status(timeout=86400)  # timeout is 24 hours
         assert task_final_status == TaskStatus.DONE, 'Task: {} final status is: {}.'.format(
             mgr_task.id, str(mgr_task.status))
         self.log.info('Task: {} is done.'.format(mgr_task.id))
-
-        self.log.debug("sctool version is : {}".format(manager_tool.version))
 
     def disrupt_abort_repair(self):
         """

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -242,6 +242,9 @@ class SCTConfiguration(dict):
              type=str,
              help="Stress command for LWT performance test for mixed lwt load baseline"),
 
+        dict(name="use_cloud_manager", env="SCT_USE_CLOUD_MANAGER", type=boolean,
+             help="When define true, will install scylla cloud manager"),
+
         dict(name="use_mgmt", env="SCT_USE_MGMT", type=boolean,
              help="When define true, will install scylla management"),
 


### PR DESCRIPTION
	in order to test both SCT standard manager and cloud manager,
	a new function called 'get_cluster_manager' was added,
	to both cluster.py and cloud_cluster.py

the completing PR of this enhancement is: https://github.com/scylladb/siren-tests/pull/193

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
