### PR TITLE
fix(sdcm/tester.py): don't configure db node device mapping for cloud cluster

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -618,7 +618,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             db_info['type'] = self.params.get('instance_type_db')
         if db_info['disk_size'] is None:
             db_info['disk_size'] = self.params.get('aws_root_disk_size_db', default=None)
-        if db_info['device_mappings'] is None:
+        if db_info['device_mappings'] is None and self.params.get('ami_id_db_scylla'):
             if db_info['disk_size']:
                 db_info['device_mappings'] = [{
                     "DeviceName": get_root_device_name(self.params.get('ami_id_db_scylla').split()[0]),


### PR DESCRIPTION

	in case of a cloud cluster, db node device mapping can be skipped

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
