### PR TITLE
fix(cluster_init): Add recommended cluster initialization with bootst…

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -77,3 +77,4 @@ region_aware_loader: false
 stop_test_on_stress_failure: true
 
 stress_cdc_log_reader_batching_enable: true
+use_legacy_cluster_init: true

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -197,3 +197,5 @@
 | **<a name="use_preinstalled_scylla">use_preinstalled_scylla</a>**  | Don't install/update ScyllaDB on DB nodes | False | SCT_USE_PREINSTALLED_SCYLLA
 | **<a name="stress_cdclog_reader_cmd">stress_cdclog_reader_cmd</a>**  | cdc-stressor command to read cdc_log table.<br>You can specify everything but the -node , -keyspace, -table, parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CDCLOG_READER_CMD
 | **<a name="store_cdclog_reader_stats_in_es">store_cdclog_reader_stats_in_es</a>**  | Add cdclog reader stats to ES for future performance result calculating | N/A | SCT_STORE_CDCLOG_READER_STATS_IN_ES
+| **<a name="use_legacy_cluster_init">use_legacy_cluster_init</a>**  | Use legacy cluster initialization with autobootsrap disabled and parallel node setup | True | SCT_USE_LEGACY_CLUSTER_INIT
+

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -930,6 +930,9 @@ class SCTConfiguration(dict):
         dict(name="stress_cdc_log_reader_batching_enable", env="SCT_STRESS_CDC_LOG_READER_BATCHING_ENABLE",
              type=boolean,
              help="""retrieving data from multiple streams in one poll"""),
+
+        dict(name="use_legacy_cluster_init", env="SCT_USE_LEGACY_CLUSTER_INIT", type=bool,
+             help="""Use legacy cluster initialization with autobootsrap disabled and parallel node setup"""),
     ]
 
     required_params = ['cluster_backend', 'test_duration', 'n_db_nodes', 'n_loaders', 'use_preinstalled_scylla',

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -279,6 +279,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         Setup.set_intra_node_comm_public(self.params.get(
             'intra_node_comm_public') or Setup.MULTI_REGION)
 
+        Setup.USE_LEGACY_CLUSTER_INIT = self.params.get('use_legacy_cluster_init')
+        if Setup.USE_LEGACY_CLUSTER_INIT:
+            Setup.AUTO_BOOTSTRAP = False
+
         # for saving test details in DB
         self.create_stats = self.params.get(key='store_results_in_elasticsearch', default=True)
         self.scylla_dir = SCYLLA_DIR
@@ -338,7 +342,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         return duration * 60 + 600
 
     @staticmethod
-    def init_nodes(db_cluster):
+    def legacy_init_nodes(db_cluster):
         db_cluster.set_seeds()
 
         # Init seed nodes
@@ -347,6 +351,15 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         # Init non-seed nodes
         if db_cluster.non_seed_nodes:
             db_cluster.wait_for_init(node_list=db_cluster.non_seed_nodes)
+
+    @staticmethod
+    def init_nodes(db_cluster):
+        db_cluster.set_seeds(first_only=True)
+        db_cluster.wait_for_init(node_list=db_cluster.nodes)
+        db_cluster.set_seeds()
+
+        for node in db_cluster.nodes:
+            node.patch_scylla_yaml_with_seeds(",".join(db_cluster.seed_nodes_ips))
 
     @staticmethod
     def update_certificates():
@@ -385,10 +398,15 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         append_scylla_yaml = self.params.get('append_scylla_yaml')
         if append_scylla_yaml and ('system_key_directory' in append_scylla_yaml or 'system_info_encryption' in append_scylla_yaml or 'kmip_hosts:' in append_scylla_yaml):
             download_encrypt_keys()
+
         self.init_resources()
 
         if self.db_cluster and self.db_cluster.nodes:
-            self.init_nodes(db_cluster=self.db_cluster)
+            if Setup.USE_LEGACY_CLUSTER_INIT:
+                self.legacy_init_nodes(db_cluster=self.db_cluster)
+            else:
+                self.init_nodes(db_cluster=self.db_cluster)
+
             self.set_system_auth_rf()
 
             db_node_address = self.db_cluster.nodes[0].ip_address


### PR DESCRIPTION
…rap enabled

According to scylla doc next schema of cluster initializtion should be used:
1. choose one node as seed.
2. update scylla.yaml on all other node with seed ip(only one)
3. start scylla on node as seed with auto bootstrap enabled
4. start next node with autobootstrap enabled.
5. wait node is UN
6. Repeat 4, 5 for all other node.
7. update scylla.yaml with required number of seeds ips. Reboot not required

docs:
https://docs.scylladb.com/operating-scylla/procedures/cluster-management/create_cluster/

Trello: https://trello.com/c/PUmcD1bV

fix #2247 

Support: https://github.com/scylladb/scylla-docs/issues/2647

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
