### PR TITLE
fix(test_cases_lint): assort fixes for the test_case linting

### DIFF
--- a/grow_cluster_test.py
+++ b/grow_cluster_test.py
@@ -31,8 +31,8 @@ class GrowClusterTest(ClusterTester):
 
     def __init__(self, *args, **kwargs):
         super(GrowClusterTest, self).__init__(*args, **kwargs)
-        self._cluster_starting_size = self.params.get('n_db_nodes', default=3)
-        self._cluster_target_size = self.params.get('cluster_target_size', default=5)
+        self._cluster_starting_size = self.params.get('n_db_nodes')
+        self._cluster_target_size = self.params.get('cluster_target_size')
         self.metrics_srv = prometheus.nemesis_metrics_obj()
 
     def get_stress_cmd_profile(self):

--- a/jenkins-pipelines/ics-longevity-toggle-strategy-large-partitions-24h.jenkinsfile
+++ b/jenkins-pipelines/ics-longevity-toggle-strategy-large-partitions-24h.jenkinsfile
@@ -9,6 +9,6 @@ longevityPipeline(
     backend: 'aws',
     aws_region: 'eu-west-1',
     test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
-    test_config: '''["test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml", "test-cases/longevity/longevity-ics-toggle-strategy-large-partitions-24h.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml", "test-cases/enterprise-features/ics/longevity/ics-longevity-toggle-strategy-large-partitions-24h.yaml"]''',
     timeout: [time: 6540, unit: 'MINUTES'],
 )

--- a/sct.py
+++ b/sct.py
@@ -356,6 +356,7 @@ def conf(config_file, backend):
         config.verify_configuration()
         config.check_required_files()
     except Exception as ex:  # pylint: disable=broad-except
+        logging.exception(str(ex))
         click.secho(str(ex), fg='red')
         sys.exit(1)
     else:

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1187,7 +1187,7 @@ class SCTConfiguration(dict):
     def check_required_files(self):
         # pylint: disable=too-many-nested-blocks
         for param_name in ['stress_cmd', 'stress_read_cmd', 'stress_cmd_w', 'stress_cmd_r', 'stress_cmd_m',
-                           'prepare_write_cmd', 'stress_cmd_no_mv', 'stress_cmd_no_mv_profile', 'stress_cmd_mv',
+                           'prepare_write_cmd', 'stress_cmd_no_mv', 'stress_cmd_no_mv_profile',
                            'prepare_stress_cmd', 'stress_cmd_1', 'stress_cmd_complex_prepare', 'prepare_write_stress',
                            'stress_cmd_read_10m', 'stress_cmd_read_cl_one', 'stress_cmd_read_80m',
                            'stress_cmd_complex_verify_read', 'stress_cmd_complex_verify_more',

--- a/test-cases/enterprise-features/ics/longevity/ics-longevity-toggle-strategy-large-partitions-24h.yaml
+++ b/test-cases/enterprise-features/ics/longevity/ics-longevity-toggle-strategy-large-partitions-24h.yaml
@@ -1,4 +1,4 @@
 compaction_strategy: 'IncrementalCompactionStrategy'
 nemesis_class_name: 'ToggleTableIcsMonkey'
 nemesis_interval: 30
-user_prefix: 'longevity-ics-toggle-strategy-large-partitions-1d'
+user_prefix: 'ics-longevity-toggle-strategy-large-partitions-1d'

--- a/test-cases/features/scale-cluster.yaml
+++ b/test-cases/features/scale-cluster.yaml
@@ -3,11 +3,13 @@ cassandra_stress_population_size: 10000000
 space_node_threshold: 100
 
 add_node_cnt: 1
-seeds_num: 5
+seeds_num: 3
 seeds_selector: 'first'
 
+n_db_nodes: 3
 n_loaders: 1
 n_monitor_nodes: 1
+cluster_target_size: 5
 
 instance_type_db: 'i3.large'
 

--- a/utils/lint_test_cases.sh
+++ b/utils/lint_test_cases.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-for f in `find ./test-cases/ \\( -iname "*.yaml" ! -iname "*multi-dc.yaml" ! -iname *multiDC*.yaml ! -iname *multiple-dc*.yaml ! -iname *rolling* \\)` ; do
+for f in `find ./test-cases/ \\( -iname "*.yaml" ! -iname "*multi-dc.yaml" ! -iname *multiDC*.yaml ! -iname *multiple-dc*.yaml ! -iname *rolling* ! -iregex .*docker.* ! -iregex .*artifacts.* !  -iregex .*private-repo.* ! -iregex .*ics/long.* \\)` ; do
     echo "---- linting: $f -----"
     RES=$( script --flush --quiet --return /tmp/test-case.txt --command "SCT_SCYLLA_VERSION=4.0.0 python3 ./sct.py conf $f" )
     if [[ "$?" == "1" ]]; then
@@ -9,9 +9,9 @@ for f in `find ./test-cases/ \\( -iname "*.yaml" ! -iname "*multi-dc.yaml" ! -in
     fi
 done
 
-for f in `find ./test-cases/ \\( -iname *multi-dc.yaml -or -iname *multiDC*.yaml -or -iname *multiple-dc*.yaml -or -iname *rolling* \\)`; do
+for f in `find ./test-cases/ \\( -iname *multi-dc.yaml -or -iname *multiDC*.yaml -or -iname *multiple-dc*.yaml -or -iname *rolling* -or -iregex .*artifacts.*yaml -or -iregex .*private-repo.*\.yaml \\) ! -name docker.yaml`; do
     echo "---- linting: $f -----"
-    RES=$( script --flush --quiet --return /tmp/test-case.txt --command "SCT_SCYLLA_REPO=abc python3 ./sct.py conf --backend gce $f" )
+    RES=$( script --flush --quiet --return /tmp/test-case.txt --command "SCT_SCYLLA_REPO=http://repositories.scylladb.com/scylla/repo/qa-test/centos/scylladb-2019.1.repo python3 ./sct.py conf --backend gce $f" )
     if [[ "$?" == "1" ]]; then
         cat /tmp/test-case.txt
         exit 1;


### PR DESCRIPTION
Seems like this is broken for some time now, and recent change to
how we run the linting, is exposing them

* few wrong configuration files, missing parameters
* need to skip some files which are partial configurations,
  used only to mask specific params in other yamls
* removed some params default from code (`grow_cluster_test.py`)
* printing the exceptions from the `hydra conf` command, so it would
  be clear where the failure is originating

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
