### PR TITLE
fix(rolling upgrade): remove subtest and correct schema_load_error_num

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -21,6 +21,7 @@ import random
 import time
 from collections import OrderedDict
 from uuid import UUID
+from distutils.version import LooseVersion
 
 from cassandra import InvalidRequest
 from cassandra.util import sortedset, SortedSet  # pylint: disable=no-name-in-module
@@ -39,6 +40,9 @@ class FillDatabaseData(ClusterTester):
     Fill scylla with many types of records, tables and data types (taken from dtest) originally by Andrei.
 
     """
+    NON_FROZEN_SUPPORT_OS_MIN_VERSION = '4.1'  # open source version with non-frozen user_types support
+    NON_FROZEN_SUPPORT_ENTERPRISE_MIN_VERSION = '2020'  # enterprise version with non-frozen user_types support
+
     # List of dictionaries for all items tables and their data
     all_verification_items = [
         # order_by_with_in_test: Check that order-by works with IN
@@ -2641,6 +2645,7 @@ class FillDatabaseData(ClusterTester):
                         "[[OrderedMapSerializedKey([('home', home_address(street='...', city='SF', zip_code=94102, phones=SortedSet(['123456'])))])]]"],
             'min_version': '',
             'max_version': '',
+            'skip_condition': 'self.version_non_frozen_udt_support()',
             'skip': ''},
         # more_user_types_test
         {
@@ -2930,12 +2935,20 @@ class FillDatabaseData(ClusterTester):
     def cql_create_tables(self, session):
         truncates = []
         # Run through the list of items and create all tables
-        for item in self.all_verification_items:
+        for i, item in enumerate(self.all_verification_items):
+            # Check if current cluster version supports non-frozed UDT
+            if 'skip_condition' in item and 'non_frozen_udt' in item['skip_condition'] \
+                    and not eval(item['skip_condition']):
+                item['skip'] = 'skip'
+                self.all_verification_items[i]['skip'] = 'skip'
+                self.log.debug(f"Version doesn't support the item, skip it: {item['create_tables']}.")
+
             if not item['skip'] and ('skip_condition' not in item or eval(str(item['skip_condition']))):
                 for create_table in item['create_tables']:
                     # wait a while before creating index, there is a delay of create table for waiting the schema agreement
                     if 'CREATE INDEX' in create_table.upper():
                         time.sleep(15)
+                    self.log.debug(f"create table: {create_table}")
                     session.execute(create_table)
                     if 'CREATE TYPE' in create_table.upper():
                         time.sleep(15)
@@ -2946,6 +2959,26 @@ class FillDatabaseData(ClusterTester):
         time.sleep(30)
         for truncate in truncates:
             session.execute(truncate)
+
+    def version_non_frozen_udt_support(self):
+        """
+        Check if current version supports non-frozen user type
+        Issue: https://github.com/scylladb/scylla/pull/4934
+        """
+        node = self.db_cluster.nodes[0]
+        if not node.scylla_version:
+            node.get_scylla_version()
+
+        scylla_version = node.scylla_version
+        if node.is_enterprise:
+            version_with_support = self.NON_FROZEN_SUPPORT_ENTERPRISE_MIN_VERSION
+        else:
+            version_with_support = self.NON_FROZEN_SUPPORT_OS_MIN_VERSION
+
+        if LooseVersion(scylla_version) < LooseVersion(version_with_support):
+            return False  # current version doesn't support non-frozen UDT
+        else:
+            return True  # current version supports non-frozen UDT
 
     @retrying(n=3, sleep_time=20, allowed_exceptions=ProtocolException)
     def truncate_table(self, session, truncate):  # pylint: disable=no-self-use
@@ -3027,6 +3060,7 @@ class FillDatabaseData(ClusterTester):
         and after upgrade of every node to check the consistency of data
         """
         node = self.db_cluster.nodes[0]
+
         with self.cql_connection_patient(node) as session:
             # pylint: disable=no-member
             # override driver consistency level
@@ -3047,6 +3081,7 @@ class FillDatabaseData(ClusterTester):
         """
         # Prepare connection and keyspace
         node = self.db_cluster.nodes[0]
+
         with self.cql_connection_patient(node) as session:
             # override driver consistency level
             session.default_consistency_level = ConsistencyLevel.QUORUM

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -448,20 +448,23 @@ class UpgradeTest(FillDatabaseData):
                 not is_enterprise(target_upgrade_version):
             self.truncate_entries_flag = True
 
-        with self.subTest('pre-test - prepare test keyspaces and tables'):
-            # prepare test keyspaces and tables before upgrade to avoid schema change during mixed cluster.
-            self.prepare_keyspaces_and_tables()
-            self.fill_and_verify_db_data('BEFORE UPGRADE', pre_fill=True)
+        self.log.info('pre-test - prepare test keyspaces and tables')
+        # prepare test keyspaces and tables before upgrade to avoid schema change during mixed cluster.
+        self.prepare_keyspaces_and_tables()
+        self.fill_and_verify_db_data('BEFORE UPGRADE', pre_fill=True)
 
-            # write workload during entire test
-            self.log.info('Starting c-s write workload during entire test')
-            write_stress_during_entire_test = self.params.get('write_stress_during_entire_test')
-            entire_write_cs_thread_pool = self.run_stress_thread(stress_cmd=write_stress_during_entire_test)
+        # write workload during entire test
+        self.log.info('Starting c-s write workload during entire test')
+        write_stress_during_entire_test = self.params.get('write_stress_during_entire_test')
+        entire_write_cs_thread_pool = self.run_stress_thread(stress_cmd=write_stress_during_entire_test)
 
-            # Prepare keyspace and tables for truncate test
-            if self.truncate_entries_flag:
-                self.insert_rows = 10
-                self.fill_db_data_for_truncate_test(insert_rows=self.insert_rows)
+        # Let to write_stress_during_entire_test complete the schema changes
+        time.sleep(300)
+
+        # Prepare keyspace and tables for truncate test
+        if self.truncate_entries_flag:
+            self.insert_rows = 10
+            self.fill_db_data_for_truncate_test(insert_rows=self.insert_rows)
 
         # generate random order to upgrade
         nodes_num = len(self.db_cluster.nodes)
@@ -470,22 +473,22 @@ class UpgradeTest(FillDatabaseData):
         # shuffle it so we will upgrade the nodes in a random order
         random.shuffle(indexes)
 
-        with self.subTest('pre-test - Run stress workload before upgrade'):
-            # complex workload: prepare write
-            self.log.info('Starting c-s complex workload (5M) to prepare data')
-            stress_cmd_complex_prepare = self.params.get('stress_cmd_complex_prepare')
-            complex_cs_thread_pool = self.run_stress_thread(
-                stress_cmd=stress_cmd_complex_prepare, profile='data_dir/complex_schema.yaml')
+        self.log.info('pre-test - Run stress workload before upgrade')
+        # complex workload: prepare write
+        self.log.info('Starting c-s complex workload (5M) to prepare data')
+        stress_cmd_complex_prepare = self.params.get('stress_cmd_complex_prepare')
+        complex_cs_thread_pool = self.run_stress_thread(
+            stress_cmd=stress_cmd_complex_prepare, profile='data_dir/complex_schema.yaml')
 
-            # wait for the complex workload to finish
-            self.verify_stress_thread(complex_cs_thread_pool)
+        # wait for the complex workload to finish
+        self.verify_stress_thread(complex_cs_thread_pool)
 
-            # prepare write workload
-            self.log.info('Starting c-s prepare write workload (n=10000000)')
-            prepare_write_stress = self.params.get('prepare_write_stress')
-            prepare_write_cs_thread_pool = self.run_stress_thread(stress_cmd=prepare_write_stress)
-            self.log.info('Sleeping for 60s to let cassandra-stress start before the upgrade...')
-            time.sleep(60)
+        # prepare write workload
+        self.log.info('Starting c-s prepare write workload (n=10000000)')
+        prepare_write_stress = self.params.get('prepare_write_stress')
+        prepare_write_cs_thread_pool = self.run_stress_thread(stress_cmd=prepare_write_stress)
+        self.log.info('Sleeping for 60s to let cassandra-stress start before the upgrade...')
+        time.sleep(60)
 
         with DbEventsFilter(type='DATABASE_ERROR', line='Failed to load schema'), \
                 DbEventsFilter(type='SCHEMA_FAILURE', line='Failed to load schema'), \
@@ -493,71 +496,71 @@ class UpgradeTest(FillDatabaseData):
                 DbEventsFilter(type='RUNTIME_ERROR', line='Failed to load schema'):
 
             step = 'Step1 - Upgrade First Node '
-            with self.subTest(step):
-                # upgrade first node
-                self.db_cluster.node_to_upgrade = self.db_cluster.nodes[indexes[0]]
-                self.log.info('Upgrade Node %s begin', self.db_cluster.node_to_upgrade.name)
-                self.upgrade_node(self.db_cluster.node_to_upgrade)
-                self.log.info('Upgrade Node %s ended', self.db_cluster.node_to_upgrade.name)
-                self.db_cluster.node_to_upgrade.check_node_health()
+            self.log.info(step)
+            # upgrade first node
+            self.db_cluster.node_to_upgrade = self.db_cluster.nodes[indexes[0]]
+            self.log.info('Upgrade Node %s begin', self.db_cluster.node_to_upgrade.name)
+            self.upgrade_node(self.db_cluster.node_to_upgrade)
+            self.log.info('Upgrade Node %s ended', self.db_cluster.node_to_upgrade.name)
+            self.db_cluster.node_to_upgrade.check_node_health()
 
-                # wait for the prepare write workload to finish
-                self.verify_stress_thread(prepare_write_cs_thread_pool)
+            # wait for the prepare write workload to finish
+            self.verify_stress_thread(prepare_write_cs_thread_pool)
 
-                # read workload (cl=QUORUM)
-                self.log.info('Starting c-s read workload (cl=QUORUM n=10000000)')
-                stress_cmd_read_cl_quorum = self.params.get('stress_cmd_read_cl_quorum')
-                read_stress_queue = self.run_stress_thread(stress_cmd=stress_cmd_read_cl_quorum)
-                # wait for the read workload to finish
-                self.verify_stress_thread(read_stress_queue)
-                self.fill_and_verify_db_data('after upgraded one node')
-                self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
-                                                              step=step+' - after upgraded one node')
+            # read workload (cl=QUORUM)
+            self.log.info('Starting c-s read workload (cl=QUORUM n=10000000)')
+            stress_cmd_read_cl_quorum = self.params.get('stress_cmd_read_cl_quorum')
+            read_stress_queue = self.run_stress_thread(stress_cmd=stress_cmd_read_cl_quorum)
+            # wait for the read workload to finish
+            self.verify_stress_thread(read_stress_queue)
+            self.fill_and_verify_db_data('after upgraded one node')
+            self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
+                                                          step=step+' - after upgraded one node')
 
-                # read workload
-                self.log.info('Starting c-s read workload for 10m')
-                stress_cmd_read_10m = self.params.get('stress_cmd_read_10m')
-                read_10m_cs_thread_pool = self.run_stress_thread(stress_cmd=stress_cmd_read_10m)
+            # read workload
+            self.log.info('Starting c-s read workload for 10m')
+            stress_cmd_read_10m = self.params.get('stress_cmd_read_10m')
+            read_10m_cs_thread_pool = self.run_stress_thread(stress_cmd=stress_cmd_read_10m)
 
-                self.log.info('Sleeping for 60s to let cassandra-stress start before the upgrade...')
-                time.sleep(60)
+            self.log.info('Sleeping for 60s to let cassandra-stress start before the upgrade...')
+            time.sleep(60)
 
             step = 'Step2 - Upgrade Second Node '
-            with self.subTest(step):
-                # upgrade second node
-                self.db_cluster.node_to_upgrade = self.db_cluster.nodes[indexes[1]]
-                self.log.info('Upgrade Node %s begin', self.db_cluster.node_to_upgrade.name)
-                self.upgrade_node(self.db_cluster.node_to_upgrade)
-                self.log.info('Upgrade Node %s ended', self.db_cluster.node_to_upgrade.name)
-                self.db_cluster.node_to_upgrade.check_node_health()
+            self.log.info(step)
+            # upgrade second node
+            self.db_cluster.node_to_upgrade = self.db_cluster.nodes[indexes[1]]
+            self.log.info('Upgrade Node %s begin', self.db_cluster.node_to_upgrade.name)
+            self.upgrade_node(self.db_cluster.node_to_upgrade)
+            self.log.info('Upgrade Node %s ended', self.db_cluster.node_to_upgrade.name)
+            self.db_cluster.node_to_upgrade.check_node_health()
 
-                # wait for the 10m read workload to finish
-                self.verify_stress_thread(read_10m_cs_thread_pool)
-                self.fill_and_verify_db_data('after upgraded two nodes')
-                self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
-                                                              step=step+' - after upgraded two nodes')
+            # wait for the 10m read workload to finish
+            self.verify_stress_thread(read_10m_cs_thread_pool)
+            self.fill_and_verify_db_data('after upgraded two nodes')
+            self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
+                                                          step=step+' - after upgraded two nodes')
 
-                # read workload (60m)
-                self.log.info('Starting c-s read workload for 60m')
-                stress_cmd_read_60m = self.params.get('stress_cmd_read_60m')
-                read_60m_cs_thread_pool = self.run_stress_thread(stress_cmd=stress_cmd_read_60m)
-                self.log.info('Sleeping for 60s to let cassandra-stress start before the rollback...')
-                time.sleep(60)
+            # read workload (60m)
+            self.log.info('Starting c-s read workload for 60m')
+            stress_cmd_read_60m = self.params.get('stress_cmd_read_60m')
+            read_60m_cs_thread_pool = self.run_stress_thread(stress_cmd=stress_cmd_read_60m)
+            self.log.info('Sleeping for 60s to let cassandra-stress start before the rollback...')
+            time.sleep(60)
 
-            with self.subTest('Step3 - Rollback Second Node '):
-                # rollback second node
-                self.log.info('Rollback Node %s begin', self.db_cluster.nodes[indexes[1]].name)
-                self.rollback_node(self.db_cluster.nodes[indexes[1]])
-                self.log.info('Rollback Node %s ended', self.db_cluster.nodes[indexes[1]].name)
-                self.db_cluster.nodes[indexes[1]].check_node_health()
+            self.log.info('Step3 - Rollback Second Node ')
+            # rollback second node
+            self.log.info('Rollback Node %s begin', self.db_cluster.nodes[indexes[1]].name)
+            self.rollback_node(self.db_cluster.nodes[indexes[1]])
+            self.log.info('Rollback Node %s ended', self.db_cluster.nodes[indexes[1]].name)
+            self.db_cluster.nodes[indexes[1]].check_node_health()
 
         step = 'Step4 - Verify data during mixed cluster mode '
-        with self.subTest(step):
-            self.fill_and_verify_db_data('after rollback the second node')
-            self.log.info('Repair the first upgraded Node')
-            self.db_cluster.nodes[indexes[0]].run_nodetool(sub_cmd='repair')
-            self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
-                                                          step=step)
+        self.log.info(step)
+        self.fill_and_verify_db_data('after rollback the second node')
+        self.log.info('Repair the first upgraded Node')
+        self.db_cluster.nodes[indexes[0]].run_nodetool(sub_cmd='repair')
+        self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
+                                                      step=step)
 
         with DbEventsFilter(type='DATABASE_ERROR', line='Failed to load schema'), \
                 DbEventsFilter(type='SCHEMA_FAILURE', line='Failed to load schema'), \
@@ -565,105 +568,121 @@ class UpgradeTest(FillDatabaseData):
                 DbEventsFilter(type='RUNTIME_ERROR', line='Failed to load schema'):
 
             step = 'Step5 - Upgrade rest of the Nodes '
-            with self.subTest(step):
-                for i in indexes[1:]:
-                    self.db_cluster.node_to_upgrade = self.db_cluster.nodes[i]
-                    self.log.info('Upgrade Node %s begin', self.db_cluster.node_to_upgrade.name)
-                    self.upgrade_node(self.db_cluster.node_to_upgrade)
-                    self.log.info('Upgrade Node %s ended', self.db_cluster.node_to_upgrade.name)
-                    self.db_cluster.node_to_upgrade.check_node_health()
-                    self.fill_and_verify_db_data('after upgraded %s' % self.db_cluster.node_to_upgrade.name)
-                    self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
-                                                                  step=step)
+            self.log.info(step)
+            for i in indexes[1:]:
+                self.db_cluster.node_to_upgrade = self.db_cluster.nodes[i]
+                self.log.info('Upgrade Node %s begin', self.db_cluster.node_to_upgrade.name)
+                self.upgrade_node(self.db_cluster.node_to_upgrade)
+                self.log.info('Upgrade Node %s ended', self.db_cluster.node_to_upgrade.name)
+                self.db_cluster.node_to_upgrade.check_node_health()
+                self.fill_and_verify_db_data('after upgraded %s' % self.db_cluster.node_to_upgrade.name)
+                self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
+                                                              step=step)
 
-        with self.subTest('Step6 - Verify stress results after upgrade '):
-            self.log.info('Waiting for stress threads to complete after upgrade')
-            # wait for the 60m read workload to finish
-            self.verify_stress_thread(read_60m_cs_thread_pool)
+        self.log.info('Step6 - Verify stress results after upgrade ')
+        self.log.info('Waiting for stress threads to complete after upgrade')
+        # wait for the 60m read workload to finish
+        self.verify_stress_thread(read_60m_cs_thread_pool)
 
-            self.verify_stress_thread(entire_write_cs_thread_pool)
+        self.verify_stress_thread(entire_write_cs_thread_pool)
 
-        with self.subTest('Step7 - Upgrade sstables to latest supported version '):
-            # figure out what is the last supported sstable version
-            self.expected_sstable_format_version = self.get_highest_supported_sstable_version()
+        self.log.info('Step7 - Upgrade sstables to latest supported version ')
+        # figure out what is the last supported sstable version
+        self.expected_sstable_format_version = self.get_highest_supported_sstable_version()
 
-            # run 'nodetool upgradesstables' on all nodes and check/wait for all file to be upgraded
-            upgradesstables = self.db_cluster.run_func_parallel(func=self.upgradesstables_if_command_available)
+        # run 'nodetool upgradesstables' on all nodes and check/wait for all file to be upgraded
+        upgradesstables = self.db_cluster.run_func_parallel(func=self.upgradesstables_if_command_available)
 
-            # only check sstable format version if all nodes had 'nodetool upgradesstables' available
-            if all(upgradesstables):
-                self.log.info('Upgrading sstables if new version is available')
-                tables_upgraded = self.db_cluster.run_func_parallel(func=self.wait_for_sstable_upgrade)
-                assert all(tables_upgraded), "Failed to upgrade the sstable format {}".format(tables_upgraded)
+        # only check sstable format version if all nodes had 'nodetool upgradesstables' available
+        if all(upgradesstables):
+            self.log.info('Upgrading sstables if new version is available')
+            tables_upgraded = self.db_cluster.run_func_parallel(func=self.wait_for_sstable_upgrade)
+            assert all(tables_upgraded), "Failed to upgrade the sstable format {}".format(tables_upgraded)
 
-            # Verify sstabledump
-            self.log.info('Starting sstabledump to verify correctness of sstables')
-            self.db_cluster.nodes[0].remoter.run(
-                'for i in `sudo find /var/lib/scylla/data/keyspace_complex/ -type f |grep -v manifest.json |'
-                'grep -v snapshots |head -n 1`; do echo $i; sudo sstabledump $i 1>/tmp/sstabledump.output || '
-                'exit 1; done', verbose=True)
+        # Verify sstabledump
+        self.log.info('Starting sstabledump to verify correctness of sstables')
+        self.db_cluster.nodes[0].remoter.run(
+            'for i in `sudo find /var/lib/scylla/data/keyspace_complex/ -type f |grep -v manifest.json |'
+            'grep -v snapshots |head -n 1`; do echo $i; sudo sstabledump $i 1>/tmp/sstabledump.output || '
+            'exit 1; done', verbose=True)
 
-        with self.subTest('Step8 - Run stress and verify after upgrading entire cluster '):
-            self.log.info('Starting verify_stress_after_cluster_upgrade')
-            verify_stress_after_cluster_upgrade = self.params.get(  # pylint: disable=invalid-name
-                'verify_stress_after_cluster_upgrade')
-            verify_stress_cs_thread_pool = self.run_stress_thread(stress_cmd=verify_stress_after_cluster_upgrade)
-            self.verify_stress_thread(verify_stress_cs_thread_pool)
+        self.log.info('Step8 - Run stress and verify after upgrading entire cluster ')
+        self.log.info('Starting verify_stress_after_cluster_upgrade')
+        verify_stress_after_cluster_upgrade = self.params.get(  # pylint: disable=invalid-name
+            'verify_stress_after_cluster_upgrade')
+        verify_stress_cs_thread_pool = self.run_stress_thread(stress_cmd=verify_stress_after_cluster_upgrade)
+        self.verify_stress_thread(verify_stress_cs_thread_pool)
 
-            # complex workload: verify data by simple read cl=ALL
-            self.log.info('Starting c-s complex workload to verify data by simple read')
-            stress_cmd_complex_verify_read = self.params.get('stress_cmd_complex_verify_read')
-            complex_cs_thread_pool = self.run_stress_thread(
-                stress_cmd=stress_cmd_complex_verify_read, profile='data_dir/complex_schema.yaml')
-            # wait for the read complex workload to finish
-            self.verify_stress_thread(complex_cs_thread_pool)
+        # complex workload: verify data by simple read cl=ALL
+        self.log.info('Starting c-s complex workload to verify data by simple read')
+        stress_cmd_complex_verify_read = self.params.get('stress_cmd_complex_verify_read')
+        complex_cs_thread_pool = self.run_stress_thread(
+            stress_cmd=stress_cmd_complex_verify_read, profile='data_dir/complex_schema.yaml')
+        # wait for the read complex workload to finish
+        self.verify_stress_thread(complex_cs_thread_pool)
 
-            # After adjusted the workloads, there is a entire write workload, and it uses a fixed duration for catching
-            # the data lose.
-            # But the execute time of workloads are not exact, so let only use basic prepare write & read verify for
-            # complex workloads,and comment two complex workloads.
-            #
-            # TODO: retest commented workloads and decide to enable or delete them.
-            #
-            # complex workload: verify data by multiple ops
-            # self.log.info('Starting c-s complex workload to verify data by multiple ops')
-            # stress_cmd_complex_verify_more = self.params.get('stress_cmd_complex_verify_more')
-            # complex_cs_thread_pool = self.run_stress_thread(stress_cmd=stress_cmd_complex_verify_more,
-            #                                                profile='data_dir/complex_schema.yaml')
+        # After adjusted the workloads, there is a entire write workload, and it uses a fixed duration for catching
+        # the data lose.
+        # But the execute time of workloads are not exact, so let only use basic prepare write & read verify for
+        # complex workloads,and comment two complex workloads.
+        #
+        # TODO: retest commented workloads and decide to enable or delete them.
+        #
+        # complex workload: verify data by multiple ops
+        # self.log.info('Starting c-s complex workload to verify data by multiple ops')
+        # stress_cmd_complex_verify_more = self.params.get('stress_cmd_complex_verify_more')
+        # complex_cs_thread_pool = self.run_stress_thread(stress_cmd=stress_cmd_complex_verify_more,
+        #                                                profile='data_dir/complex_schema.yaml')
 
-            # wait for the complex workload to finish
-            # self.verify_stress_thread(complex_cs_thread_pool)
+        # wait for the complex workload to finish
+        # self.verify_stress_thread(complex_cs_thread_pool)
 
-            # complex workload: verify data by delete 1/10 data
-            # self.log.info('Starting c-s complex workload to verify data by delete')
-            # stress_cmd_complex_verify_delete = self.params.get('stress_cmd_complex_verify_delete')
-            # complex_cs_thread_pool = self.run_stress_thread(stress_cmd=stress_cmd_complex_verify_delete,
-            #                                                profile='data_dir/complex_schema.yaml')
-            # wait for the complex workload to finish
-            # self.verify_stress_thread(complex_cs_thread_pool)
+        # complex workload: verify data by delete 1/10 data
+        # self.log.info('Starting c-s complex workload to verify data by delete')
+        # stress_cmd_complex_verify_delete = self.params.get('stress_cmd_complex_verify_delete')
+        # complex_cs_thread_pool = self.run_stress_thread(stress_cmd=stress_cmd_complex_verify_delete,
+        #                                                profile='data_dir/complex_schema.yaml')
+        # wait for the complex workload to finish
+        # self.verify_stress_thread(complex_cs_thread_pool)
 
         # During the test we filter and ignore some specific errors, but we want to allow only certain amount of them
         step = 'Step9 - Search for errors that we filter during the test '
-        with self.subTest(step):
-            self.log.info('Checking how many failed_to_load_schem errors happened during the test')
-            error_factor = 3
-            schema_load_error_num = 0
+        self.log.info(step)
+        self.log.info('Checking how many failed_to_load_schem errors happened during the test')
+        error_factor = 3
+        schema_load_error_num = self.count_log_errors(search_pattern='Failed to load schema version',
+                                                      step=step)
+        # Warning example:
+        # workload prioritization - update_service_levels_from_distributed_data: an error occurred while retrieving
+        # configuration (exceptions::read_failure_exception (Operation failed for system_distributed.service_levels
+        # - received 0 responses and 1 failures from 1 CL=ONE.))
+        workload_prioritization_error_num = self.count_log_errors(search_pattern='workload prioritization.*read_failure_exception',
+                                                                  step=step, search_for_idx_token_error=False)
 
-            for node in self.db_cluster.nodes:
-                errors = node.search_system_log(search_pattern='Failed to load schema version',
-                                                start_from_beginning=True,
-                                                publish_events=False)
-                schema_load_error_num += len(errors)
-                self.search_for_idx_token_error_after_upgrade(node=node,
-                                                              step=step)
+        self.log.info(f'schema_load_error_num: {schema_load_error_num}; '
+                      f'workload_prioritization_error_num: {workload_prioritization_error_num}')
 
-            self.log.info('schema_load_error_num: %d', schema_load_error_num)
-            assert schema_load_error_num <= error_factor * 8 * \
-                len(self.db_cluster.nodes), 'Only allowing shards_num * %d schema load errors per host during the ' \
-                                            'entire test, actual: %d' % (
-                    error_factor, schema_load_error_num)
+        # Issue #https://github.com/scylladb/scylla-enterprise/issues/1391
+        # By Eliran's comment: For 'Failed to load schema version' error which is expected and non offensive is
+        # to count the 'workload prioritization' warning and subtract that amount from the amount of overall errors.
+        load_error_num = schema_load_error_num-workload_prioritization_error_num
+        assert load_error_num <= error_factor * 8 * \
+            len(self.db_cluster.nodes), 'Only allowing shards_num * %d schema load errors per host during the ' \
+                                        'entire test, actual: %d' % (
+                error_factor, schema_load_error_num)
 
-            self.log.info('all nodes were upgraded, and last workaround is verified.')
+        self.log.info('all nodes were upgraded, and last workaround is verified.')
+
+    def count_log_errors(self, search_pattern, step, search_for_idx_token_error=True):
+        schema_load_error_num = 0
+        for node in self.db_cluster.nodes:
+            errors = node.search_system_log(search_pattern=search_pattern,
+                                            start_from_beginning=True,
+                                            publish_events=False)
+            schema_load_error_num += len(errors)
+            if search_for_idx_token_error:
+                self.search_for_idx_token_error_after_upgrade(node=node, step=step)
+        return schema_load_error_num
 
     def get_email_data(self):
         self.log.info('Prepare data for email')


### PR DESCRIPTION
Few fixes for rolling upgrade:
1. remove using subTest
2. Issue https://github.com/scylladb/scylla-enterprise/issues/1391.
By Eliran's comment: For 'Failed to load schema version' error which is expected and non offensive
is to count the 'workload prioritization' warning and subtract that amount from the amount of
overall errors.
3. using non-frozen user type for cluster key is not supported in some versions
(https://github.com/scylladb/scylla/pull/4934). If Scylla base version doesn't support it,
ignore CQL for testing this

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
