### PR TITLE
fix(manager-installation): using correct paramter for GCE region

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3404,7 +3404,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                           murmur3_partitioner_ignore_msb_bits=murmur3_partitioner_ignore_msb_bits,
                           alternator_enforce_authorization=self.params.get('alternator_enforce_authorization'))
 
-    def node_setup(self, node, verbose=False, timeout=3600):
+    def node_setup(self, node, verbose=False, timeout=3600):  # pylint: disable=too-many-branches
         node.wait_ssh_up(verbose=verbose, timeout=timeout)
 
         install_scylla = True
@@ -3437,7 +3437,6 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             node.remoter.run('sudo cat /etc/scylla.d/io.conf')
 
             if self.params.get('use_mgmt', None):
-                region = self.params.get('region_name').split()
                 pkgs_url = self.params.get('scylla_mgmt_pkg', None)
                 pkg_path = None
                 if pkgs_url:
@@ -3445,7 +3444,12 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                     node.remoter.run('mkdir -p {}'.format(pkg_path))
                     node.remoter.send_files(src='{}*.rpm'.format(pkg_path), dst=pkg_path)
                 node.install_manager_agent(package_path=pkg_path)
-                update_config_file(node=node, region=region[0])
+                cluster_backend = self.params.get("cluster_backend")
+                if cluster_backend == "aws":
+                    region = self.params.get('region_name').split()
+                    update_config_file(node=node, region=region[0])
+                else:
+                    self.log.warning("Backend '%s' not support. Won't configure manager backups!", cluster_backend)
         else:
             self._reuse_cluster_setup(node)
 


### PR DESCRIPTION
Fixes exception:    region = self.params.get('region_name').split()
AttributeError: 'NoneType' object has no attribute 'split'

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
