### PR TITLE
fix(create_spot_instances): fix duration calculate in python 3

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -132,7 +132,7 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
                            aws_instance_profile=self.params.get('aws_instance_profile_name'))
         if self.instance_provision == INSTANCE_PROVISION_SPOT_DURATION:
             # duration value must be a multiple of 60
-            spot_params.update({'duration': cluster.TEST_DURATION / 60 * 60 + 60})
+            spot_params.update({'duration': round(cluster.TEST_DURATION / 60) * 60 + 60})
 
         limit = SPOT_FLEET_LIMIT if self.instance_provision == INSTANCE_PROVISION_SPOT_FLEET else SPOT_CNT_LIMIT
         request_cnt = 1


### PR DESCRIPTION
Spot duration value must be a multiple of 60. In python 3 when integer devided by integer
the result may be float. As result the duraion is not multiplyed of 60 and spot creation of "spot_duration" type fails.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
