### PR TITLE
[BACKPORT] test(manager): test an sctool backup during enospc

### DIFF
--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -357,6 +357,18 @@ class BackupTask(ManagerTask):
         snapshot_tag = snapshot_line[snapshot_index].split(":")[1].strip()
         return snapshot_tag
 
+    def is_task_in_uploading_stage(self):
+        full_progress_string = self.sctool.run("task progress {} -c {}".format(self.id, self.cluster_id),
+                                               parse_table_res=False,
+                                               is_verify_errorless_result=True).stdout.lower()
+        return "upload" in full_progress_string
+
+    def wait_for_uploading_stage(self, timeout=1440, step=10):
+        text = "Waiting until backup task: {} starts to upload snapshots".format(self.id)
+        is_status_reached = wait.wait_for(func=self.is_task_in_uploading_stage, step=step,
+                                          text=text, timeout=timeout)
+        return is_status_reached
+
 
 class ManagerCluster(ScyllaManagerBase):
 


### PR DESCRIPTION
In the test we run a backup on a node, stop it midway, fill its disk to 100% during the backup,
and run another backup afterwards. The second backup should run with no issue running
since the first backup already created snapshots that occupy some of the disk space,
and as such the second backup should go smoothly.

Backport of #2212 

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
