### PR TITLE
fix(nemesis.py): remove reboot nemesis from toggle ics Monkey

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2425,8 +2425,7 @@ class ToggleTableIcsMonkey(Nemesis):
 
     @log_time_elapsed_and_status
     def disrupt(self):
-        self.call_random_disrupt_method(
-            disrupt_methods=['disrupt_toggle_table_ics', 'disrupt_hard_reboot_node'])
+        self.disrupt_toggle_table_ics()
 
 
 class MgmtBackup(Nemesis):


### PR DESCRIPTION
	toggle ICS nemesis should not include reboot nemesis as
	an additional nemesis of the same disruption.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
