### PR TITLE
fix(sdcm/cluster.py): Fix to return [] if no packages are there

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -57,13 +57,15 @@ class ArtifactsTest(ClusterTester):
         # Normalize backend name, e.g., `aws' -> `AWS', `gce' -> `GCE', `docker' -> `Docker'.
         backend = self.params.get("cluster_backend")
         backend = {"aws": "AWS", "gce": "GCE", "docker": "Docker"}.get(backend, backend)
-
+        scylla_packages = self.node.scylla_packages_installed
+        if not scylla_packages:
+            scylla_packages = ['No scylla packages are installed. Please check log file.']
         email_data.update({"backend": backend,
                            "region_name": self.params.get("region_name"),
                            "scylla_instance_type": self.params.get('instance_type_db',
                                                                    self.params.get('gce_instance_type_db')),
                            "scylla_node_image": self.node.image,
-                           "scylla_packages_installed": self.node.scylla_packages_installed,
+                           "scylla_packages_installed": scylla_packages,
                            "scylla_repo": self.params.get("scylla_repo"),
                            "scylla_version": self.node.scylla_version, })
 

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2672,7 +2672,10 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             cmd = "rpm -qa 'scylla*'"
         else:
             cmd = "dpkg-query --show 'scylla*'"
-        return self.remoter.run(cmd).stdout.splitlines()
+        result = self.remoter.run(cmd, ignore_status=True)
+        if result.exited == 0:
+            return result.stdout.splitlines()
+        return []
 
     def get_scylla_config_param(self, config_param_name, verbose=True):
         """


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
