### PR TITLE
fix(sdcm/tester.py): Make it show very last exception point

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -208,8 +208,6 @@ class silence:  # pylint: disable=invalid-name
 
     @staticmethod
     def _store_test_result(parent, exc_val, exc_tb, name):
-        if exc_tb.tb_next:
-            exc_tb = exc_tb.tb_next
         TestFrameworkEvent(
             source=parent.__class__.__name__,
             source_method=name,


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
