### PR TITLE
fix(artifacts_test.py): make no raise if .node is not available on save_email_data

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -20,6 +20,8 @@ STRESS_CMD: str = "/usr/bin/cassandra-stress"
 class ArtifactsTest(ClusterTester):
     @property
     def node(self):
+        if self.db_cluster is None or not self.db_cluster.nodes:
+            raise ValueError('DB cluster has not been initiated')
         return self.db_cluster.nodes[0]
 
     def run_cassandra_stress(self, args: str):
@@ -57,16 +59,23 @@ class ArtifactsTest(ClusterTester):
         # Normalize backend name, e.g., `aws' -> `AWS', `gce' -> `GCE', `docker' -> `Docker'.
         backend = self.params.get("cluster_backend")
         backend = {"aws": "AWS", "gce": "GCE", "docker": "Docker"}.get(backend, backend)
-        scylla_packages = self.node.scylla_packages_installed
+        try:
+            node = self.node
+        except:  # pylint: disable=bare-except
+            node = None
+        if node:
+            scylla_packages = node.scylla_packages_installed
+        else:
+            scylla_packages = None
         if not scylla_packages:
-            scylla_packages = ['No scylla packages are installed. Please check log file.']
+            scylla_packages = ['No scylla packages are installed. Please check log files.']
         email_data.update({"backend": backend,
                            "region_name": self.params.get("region_name"),
                            "scylla_instance_type": self.params.get('instance_type_db',
                                                                    self.params.get('gce_instance_type_db')),
-                           "scylla_node_image": self.node.image,
+                           "scylla_node_image": node.image if node else 'Node has not been initialized',
                            "scylla_packages_installed": scylla_packages,
                            "scylla_repo": self.params.get("scylla_repo"),
-                           "scylla_version": self.node.scylla_version, })
+                           "scylla_version": node.scylla_version if node else 'Node has not been initialized', })
 
         return email_data


### PR DESCRIPTION
https://trello.com/c/PJbMT5tl/2118-unable-to-save-email-data

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
