### PR TITLE
fix(ear cert place): cert on /tmp is bad as isn't persisted

### DIFF
--- a/configurations/hytrust-kmip-ear.yaml
+++ b/configurations/hytrust-kmip-ear.yaml
@@ -7,7 +7,7 @@ append_scylla_yaml: |
   system_info_encryption:
       enabled: True  # system_info_encryption
       key_provider: LocalFileSystemKeyProviderFactory  # system_info_encryption
-      secret_key_file: '/tmp/system_info_encryption_keyfile'
+      secret_key_file: '/etc/scylla/encrypt_conf/system_info_encryption_keyfile'
 
   kmip_hosts:
        kmip_test:

--- a/configurations/kmip-ear.yaml
+++ b/configurations/kmip-ear.yaml
@@ -7,7 +7,7 @@ append_scylla_yaml: |
   system_info_encryption:
       enabled: True  # system_info_encryption
       key_provider: LocalFileSystemKeyProviderFactory  # system_info_encryption
-      secret_key_file: '/tmp/system_info_encryption_keyfile'
+      secret_key_file: '/etc/scylla/encrypt_conf/system_info_encryption_keyfile'
 
   kmip_hosts:
        kmip_test:

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1788,6 +1788,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         if append_scylla_yaml and ('system_key_directory' in append_scylla_yaml or 'system_info_encryption' in append_scylla_yaml or 'kmip_hosts:' in append_scylla_yaml):
             self.remoter.send_files(src='./data_dir/encrypt_conf',  # pylint: disable=not-callable
                                     dst='/tmp/')
+            self.remoter.run('sudo mkdir -p /etc/scylla/encrypt_conf')
+            self.remoter.run('sudo chown -R scylla:scylla /etc/scylla/')
             self.remoter.run('sudo rm -rf /etc/encrypt_conf')
             self.remoter.run('sudo mv -f /tmp/encrypt_conf /etc/')
             self.remoter.run('sudo mkdir /etc/encrypt_conf/system_key_dir/')

--- a/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
+++ b/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
@@ -28,7 +28,7 @@ authenticator_password: cassandra
 authorizer: 'CassandraAuthorizer'
 
 pre_create_schema: True
-scylla_encryption_options: "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'LocalFileSystemKeyProviderFactory', 'secret_key_file': '/tmp/secret_key'}"
+scylla_encryption_options: "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'LocalFileSystemKeyProviderFactory', 'secret_key_file': '/etc/scylla/encrypt_conf/secret_key'}"
 
 # enable system_info_encryption, config kmip_hosts
 append_scylla_yaml: |
@@ -36,7 +36,7 @@ append_scylla_yaml: |
   system_info_encryption:
       enabled: True  # system_info_encryption
       key_provider: LocalFileSystemKeyProviderFactory  # system_info_encryption
-      secret_key_file: '/tmp/system_info_encryption_keyfile'
+      secret_key_file: '/etc/scylla/encrypt_conf/system_info_encryption_keyfile'
 
   kmip_hosts:
        kmip_test:


### PR DESCRIPTION
one of the nodes failed after reboot, as the directory /tmp
is cleaned during boot.
Moving the cert file to /etc/scylla/ssl_conf/ (with all
other scylla certification files).

this is related to scylladb/scylla-enterprise#1415

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
