### PR TITLE
fix(sdcm/send_email.py): Add reporter for SlaPerUserTest

### DIFF
--- a/sdcm/send_email.py
+++ b/sdcm/send_email.py
@@ -423,7 +423,7 @@ def build_reporter(name: str,
     #  pylint: disable=too-many-return-statements
     if "Gemini" in name:
         return GeminiEmailReporter(email_recipients=email_recipients, logdir=logdir)
-    elif "Longevity" in name:
+    elif "Longevity" in name or 'SlaPerUser' in name:
         return LongevityEmailReporter(email_recipients=email_recipients, logdir=logdir)
     elif "Upgrade" in name:
         return UpgradeEmailReporter(email_recipients=email_recipients, logdir=logdir)


### PR DESCRIPTION
Will enable reporting for SlaPerUserTest tests

Example for job:
https://jenkins.scylladb.com/view/enterprise-2020.1/job/enterprise-2020.1/job/SCT_Enterprise_Features/job/Workload_Prioritization/job/features-sla-read-throughput-vs-latency-cache-and-disk-test/2/console

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
