### PR TITLE
fix(sdcm/tester.py): don't log final event if test failed

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1801,7 +1801,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self.log.info(str(final_event))
             return
         self._remove_errors_from_unittest_results(self._outcome)
-        self.log.error(str(final_event))
         self._outcome.errors.append((self, (TestResultEvent, final_event, None)))
 
     @silence()


### PR DESCRIPTION
Don't log it, since unittest is printing it.
 
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
