### PR TITLE
fix(sdcm/): Make event cycles been stopped gracefully, not loosing any event which is in progress.

### DIFF
--- a/sdcm/prometheus.py
+++ b/sdcm/prometheus.py
@@ -286,3 +286,7 @@ class PrometheusDumper(threading.Thread):
 
     def terminate(self):
         self.stop_event.set()
+
+    def stop(self, timeout: float = None):
+        self.stop_event.set()
+        self.join(timeout)

--- a/sdcm/sct_events_analyzer.py
+++ b/sdcm/sct_events_analyzer.py
@@ -22,8 +22,7 @@ class EventsAnalyzer(threading.Thread):
 
     @raise_event_on_failure
     def run(self):
-        for event_class, message_data in EVENTS_PROCESSES['MainDevice'].subscribe_events(
-                stop_event=self.stop_event):
+        for event_class, message_data in EVENTS_PROCESSES['MainDevice'].subscribe_events(stop_event=self.stop_event):
             try:
                 if event_class == 'TestResultEvent':
                     # don't send kill test cause of those event, test is already done when those are sent out
@@ -44,6 +43,10 @@ class EventsAnalyzer(threading.Thread):
 
     def terminate(self):
         self.stop_event.set()
+
+    def stop(self, timeout: float = None):
+        self.stop_event.set()
+        self.join(timeout)
 
     def kill_test(self, backtrace_with_reason):
         if not Setup.tester_obj():


### PR DESCRIPTION
Will fix problem with some flaky tests and loosing events on teardown.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
