### PR TITLE
fix(cluster): ignore absent scylla data files

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1914,7 +1914,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         ]
         self.log.debug("Clean all files from scylla data dirs")
         for cmd in clean_commands_list:
-            self.remoter.run(cmd)
+            self.remoter.run(cmd, ignore_status=True)
 
     def clean_scylla(self):
         """


### PR DESCRIPTION
Fix for an issue introduced by #2326

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
