### PR TITLE
fix(cluster): host parameter of add_cluster() should be an IP address

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3682,8 +3682,8 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         mgr_cluster = manager_tool.get_cluster(cluster_name)
         if not mgr_cluster:
             self.log.debug("Could not find cluster : {} on Manager. Adding it to Manager".format(cluster_name))
-            targets = [[n, n.ip_address] for n in self.nodes]
-            mgr_cluster = manager_tool.add_cluster(name=cluster_name, host=targets[0], disable_automatic_repair=True,
+            target = self.nodes[0].ip_address
+            mgr_cluster = manager_tool.add_cluster(name=cluster_name, host=target, disable_automatic_repair=True,
                                                    auth_token=Setup.tester_obj().monitors.mgmt_auth_token)
         return mgr_cluster
 


### PR DESCRIPTION
Fix for an issue introduced by #2323 

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x]  All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
