### PR TITLE
feature(nemesis): introducing Nemesis.add_disrupt_method

### DIFF
--- a/unit_tests/test_nemesis.py
+++ b/unit_tests/test_nemesis.py
@@ -1,0 +1,24 @@
+from collections import namedtuple
+import sdcm.utils.cloud_monitor  # pylint: disable=unused-import # import only to avoid cyclic dependency
+from sdcm.nemesis import Nemesis, ChaosMonkey
+
+
+PARAMS = dict(nemesis_interval=1, nemesis_filter_seeds=False)
+Cluster = namedtuple("Cluster", ['params'])
+FakeTester = namedtuple("FakeTester", ['params', 'loaders', 'monitors', 'db_cluster'],
+                        defaults=[PARAMS, {}, {}, Cluster(params=PARAMS)])
+
+
+class AddRemoveDCMonkey(Nemesis):
+    @Nemesis.add_disrupt_method
+    def disrupt_add_remove_dc(self):  # pylint: disable=no-self-use
+        return 'Worked'
+
+    def disrupt(self):
+        self.disrupt_add_remove_dc()
+
+
+def test_list_nemesis_of_added_disrupt_methods():
+    nemesis = ChaosMonkey(FakeTester(), None)
+    assert 'disrupt_add_remove_dc' in nemesis.get_list_of_disrupt_methods_for_nemesis_subclasses(disruptive=False)
+    assert nemesis.call_random_disrupt_method(disrupt_methods=['disrupt_add_remove_dc']) is None


### PR DESCRIPTION
adding this decorator, can help implementing Nemsis classes in other files
or packages, and also would help us to break Nemsis class apart, without introducing
more complex plugin system (at last not now)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
