### PR TITLE
improvement(hydra): always update hydra image on a builder

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -28,13 +28,13 @@ if ! docker --version; then
     exit 1
 fi
 
-
-if [[ ! -z "`docker images ${DOCKER_REPO}:${VERSION} -q`" ]]; then
-    echo "Image up-to-date"
-else
-    echo "Image with version $VERSION not found. Pulling..."
+if [[ ${USER} == "jenkins" || -z "`docker images ${DOCKER_REPO}:${VERSION} -q`" ]]; then
+    echo "Pull version $VERSION from Docker Hub..."
     docker pull ${DOCKER_REPO}:${VERSION}
+else
+    echo "There is ${DOCKER_REPO}:${VERSION} in local cache, use it."
 fi
+
 # Check for SSH keys
 "${SCT_DIR}/get-qa-ssh-keys.sh"
 


### PR DESCRIPTION
This change will help us with PRs which require rebuild of hydra image and test provision. Also it will help if we'll replace some buggy image on Docker Hub with fixed one.

`docker pull` do nothing if hash sum of local image equals to Docker Hub's:

```
$ docker pull scylladb/hydra:v0.68
v0.68: Pulling from scylladb/hydra
Digest: sha256:06e8b127ef5e56f2fd2cac546cd6ac692f17e1f2f17d9739f50676444c06016e
Status: Image is up to date for scylladb/hydra:v0.68
docker.io/scylladb/hydra:v0.68
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
