### PR TITLE
test(manager-upgrade): Separate repository for agent + deb tests

### DIFF
--- a/jenkins-pipelines/manager/debian9-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian9-manager-upgrade.jenkinsfile
@@ -11,10 +11,10 @@ managerPipeline(
 
     target_scylla_mgmt_server_repo: '',
     target_scylla_mgmt_agent_repo: '',
-    scylla_mgmt_repo: 'https://repositories.scylladb.com/scylla/repo/qa-test/centos/scylladb-manager-2.0.repo',
+    scylla_mgmt_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/debian/scylladb-manager-2.0-stretch.list',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
-    test_config: 'test-cases/upgrades/manager-upgrade.yaml',
+    test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/debian9.yaml"]''',
 
     timeout: [time: 360, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/manager/ubuntu16-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu16-manager-upgrade.jenkinsfile
@@ -11,10 +11,10 @@ managerPipeline(
 
     target_scylla_mgmt_server_repo: '',
     target_scylla_mgmt_agent_repo: '',
-    scylla_mgmt_repo: 'https://repositories.scylladb.com/scylla/repo/qa-test/centos/scylladb-manager-2.0.repo',
+    scylla_mgmt_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.0-xenial.list',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
-    test_config: 'test-cases/upgrades/manager-upgrade.yaml',
+    test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/ubuntu16.yaml"]''',
 
     timeout: [time: 360, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/manager/ubuntu18-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu18-manager-upgrade.jenkinsfile
@@ -11,10 +11,10 @@ managerPipeline(
 
     target_scylla_mgmt_server_repo: '',
     target_scylla_mgmt_agent_repo: '',
-    scylla_mgmt_repo: 'https://repositories.scylladb.com/scylla/repo/qa-test/centos/scylladb-manager-2.0.repo',
+    scylla_mgmt_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.0-bionic.list',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
-    test_config: 'test-cases/upgrades/manager-upgrade.yaml',
+    test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/ubuntu18.yaml"]''',
 
     timeout: [time: 360, unit: 'MINUTES']
 )

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1849,7 +1849,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             self.remoter.run('sudo yum update scylla-manager-agent -y')
         else:
             self.remoter.run(cmd="sudo apt-get update", ignore_status=True)
-            self.remoter.run('sudo apt-get --only-upgrade install -y scylla-manager-agent')
+            self.remoter.run('sudo apt-get install -y scylla-manager-agent')
         self.remoter.run("sudo scyllamgr_agent_setup -y")
         if start_agent_after_upgrade:
             if self.is_docker():
@@ -2111,7 +2111,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             # 1) scylla-manager
             # 2) scylla-manager-client
             # 3) scylla-manager-server
-            self.remoter.run('sudo apt-get --only-upgrade install -y scylla-manager*')
+            self.remoter.run('sudo apt-get dist-upgrade scylla-manager-server scylla-manager-client -y -o '
+                             'Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --force-yes'
+                             ' --allow-unauthenticated')
         time.sleep(3)
         if start_manager_after_upgrade:
             if self.is_docker():

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -254,8 +254,11 @@ class SCTConfiguration(dict):
         dict(name="manager_prometheus_port", env="SCT_MANAGER_PROMETHEUS_PORT", type=int,
              help="Port to be used by the manager to contact Prometheus"),
 
-        dict(name="target_scylla_mgmt_repo", env="SCT_TARGET_SCYLLA_MGMT_REPO", type=str,
-             help="Url to the repo of scylla manager version used to upgrade the manager and agents"),
+        dict(name="target_scylla_mgmt_server_repo", env="SCT_TARGET_SCYLLA_MGMT_SERVER_REPO", type=str,
+             help="Url to the repo of scylla manager version used to upgrade the manager server"),
+
+        dict(name="target_scylla_mgmt_agent_repo", env="SCT_TARGET_SCYLLA_MGMT_AGENT_REPO", type=str,
+             help="Url to the repo of scylla manager version used to upgrade the manager agents"),
 
         dict(name="update_db_packages", env="SCT_UPDATE_DB_PACKAGES", type=str,
              help="""A local directory of rpms to install a custom version on top of

--- a/test-cases/upgrades/manager-upgrade.yaml
+++ b/test-cases/upgrades/manager-upgrade.yaml
@@ -7,7 +7,6 @@ region_name: 'us-east-1'
 n_db_nodes: '3'
 n_loaders: 1
 n_monitor_nodes: 1
-scylla_mgmt_repo: "https://repositories.scylladb.com/scylla/repo/qa-test/centos/scylladb-manager-2.0.repo"
 
 post_behavior_db_nodes: "destroy"
 post_behavior_loader_nodes: "destroy"
@@ -19,5 +18,6 @@ ip_ssh_connections: 'private'
 
 use_mgmt: true
 mgmt_port: 10090
+scylla_mgmt_agent_repo: "https://repositories.scylladb.com/scylla/repo/qa-test/centos/scylladb-manager-2.0.repo"
 
 aws_instance_profile_name: 'qa-scylla-manager-backup-instance-profile'

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -51,17 +51,21 @@ def call(Map pipelineParams) {
                    description: 'If empty - the default manager version will be taken',
                    name: 'scylla_mgmt_repo')
 
+            string(defaultValue: "${pipelineParams.get('scylla_mgmt_agent_repo', '')}",
+                   description: 'manager agent repo',
+                   name: 'scylla_mgmt_agent_repo')
+
             string(defaultValue: '',
-                   description: 'Link to the repository of the manager that will be used as a target of the manager upgrade test',
-                   name: 'target_scylla_mgmt_repo')
+                   description: 'Link to the repository of the manager that will be used as a target of the manager server in the manager upgrade test',
+                   name: 'target_scylla_mgmt_server_repo')
+
+            string(defaultValue: '',
+                   description: 'Link to the repository of the manager that will be used as a target of the manager agents in the manager upgrade test',
+                   name: 'target_scylla_mgmt_agent_repo')
 
             string(defaultValue: "${pipelineParams.get('email_recipients', 'qa@scylladb.com')}",
                    description: 'email recipients of email report',
                    name: 'email_recipients')
-
-            string(defaultValue: "${pipelineParams.get('scylla_mgmt_agent_repo', '')}",
-                   description: 'manager agent repo',
-                   name: 'scylla_mgmt_agent_repo')
 
             string(defaultValue: "${pipelineParams.get('scylla_mgmt_pkg', '')}",
                    description: 'Url to the scylla manager packages',
@@ -134,8 +138,12 @@ def call(Map pipelineParams) {
                                         export SCT_SCYLLA_MGMT_REPO="${params.scylla_mgmt_repo}"
                                     fi
 
-                                    if [[ ! -z "${params.target_scylla_mgmt_repo}" ]] ; then
-                                        export SCT_TARGET_SCYLLA_MGMT_REPO="${params.target_scylla_mgmt_repo}"
+                                    if [[ ! -z "${params.target_scylla_mgmt_server_repo}" ]] ; then
+                                        export SCT_TARGET_SCYLLA_MGMT_SERVER_REPO="${params.target_scylla_mgmt_server_repo}"
+                                    fi
+
+                                    if [[ ! -z "${params.target_scylla_mgmt_agent_repo}" ]] ; then
+                                        export SCT_TARGET_SCYLLA_MGMT_AGENT_REPO="${params.target_scylla_mgmt_agent_repo}"
                                     fi
 
                                     if [[ ! -z "${params.scylla_mgmt_agent_repo}" ]] ; then


### PR DESCRIPTION
Added a variable to the manager pipeline that supplies a repo for the upgrade of the manager agents,
separated from the manager client repo.
Added pipelines for manager upgrade test for ubuntu 18, ubuntu 16 and debian 9.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
