### PR TITLE
fix(scylla_setup): support multiple nvme devices

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2102,7 +2102,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         :param nvme: NVMe(True) or SCSI(False) disk
         :return: list of disk names
         """
-        patt = (r'nvme0n*', r'nvme0n\w+') if nvme else (r'sd[b-z]', r'sd\w+')
+        patt = (r'nvme*n*', r'nvme*n\w+') if nvme else (r'sd[b-z]', r'sd\w+')
         result = self.remoter.run('ls /dev/{}'.format(patt[0]))
         disks = re.findall(r'/dev/{}'.format(patt[1]), result.stdout)
         assert disks, 'Failed to find disks!'


### PR DESCRIPTION
In debain-like distros, there is a redundant /dev/nvme0, our additional
data disks use /dev/nvme1. This causes scylla_setup failed.
The problem might be caused by recent kernel update.

| scylla-test@rolling-upgrade-upgrade--ubuntu-bio-db-node-2d7c3e44-0-2:~$ file /dev/nvme*
| /dev/nvme0:   character special (243/0)
| /dev/nvme1:   character special (243/1)
| /dev/nvme1n1: block special (259/0)
| /dev/nvme1n2: block special (259/1)
| /dev/nvme1n3: block special (259/2)
|
| SCT Error:
| ls: cannot access '/dev/nvme0n*': No such file or directory

This patch workaround the problem by changing the device pattern,
removed the hardcode number.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
