### PR TITLE
fix(scylla_setup): fix typo in device pattern

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2102,7 +2102,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         :param nvme: NVMe(True) or SCSI(False) disk
         :return: list of disk names
         """
-        patt = (r'nvme*n*', r'nvme*n\w+') if nvme else (r'sd[b-z]', r'sd\w+')
+        patt = (r'nvme*n*', r'nvme\d+n\w+') if nvme else (r'sd[b-z]', r'sd\w+')
         result = self.remoter.run('ls /dev/{}'.format(patt[0]))
         disks = re.findall(r'/dev/{}'.format(patt[1]), result.stdout)
         assert disks, 'Failed to find disks!'


### PR DESCRIPTION
Can't successfully match devices by r'nvme*n\w+',
r'nvme\d+n\w+' works well.

https://github.com/scylladb/scylla-cluster-tests/pull/2363 didn't solve the problem.
This PR fixed the pattern, The new patch was tested by https://jenkins.scylladb.com/job/enterprise-2019.1/job/rolling-upgrade/job/rolling-upgrade-ubuntu18.04/21/


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
