### PR TITLE
fix(detect_disks): Fix regexp pattern for matching the nvme disk name

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2102,7 +2102,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         :param nvme: NVMe(True) or SCSI(False) disk
         :return: list of disk names
         """
-        patt = (r'nvme*n*', r'nvme*n\w+') if nvme else (r'sd[b-z]', r'sd\w+')
+        patt = (r'nvme*n*', r'nvme\d+n\d+') if nvme else (r'sd[b-z]', r'sd\w+')
         result = self.remoter.run('ls /dev/{}'.format(patt[0]))
         disks = re.findall(r'/dev/{}'.format(patt[1]), result.stdout)
         assert disks, 'Failed to find disks!'


### PR DESCRIPTION
Fixing pattern to match nvme disk names for regular expression

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
