### PR TITLE
fix(verify_no_drops_and_errors): fix error message

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1959,7 +1959,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         queries_to_check = [q_dropped, q_errors]
         for query in queries_to_check:
             results = self.prometheus_db.query(query=query, start=starting_from, end=time.time())
-            err_msg = "There were hint manager %s detected during the test!" % "drops" if "dropped" in query else "errors"
+            err_msg = "There were hint manager %s detected during the test!" % (
+                "drops" if "dropped" in query else "errors")
             assert any([float(v[1]) for v in results[0]["values"]]) is False, err_msg
 
     def get_data_set_size(self, cs_cmd):


### PR DESCRIPTION
Error that was returned: 'AssertionError: errors'
Seems in python 3 it works on other way

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
