### PR TITLE
fix(nemesis.py): don't use disableautocompaction if not supported

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -429,7 +429,11 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.monitoring_set.reconfigure_scylla_monitoring()
         self.set_current_running_nemesis(node=new_node)  # prevent to run nemesis on new node when running in parallel
         new_node.replacement_node_ip = old_node_ip
-        disable_autocompaction = random.choice([True, False])
+        result = new_node.run_nodetool(sub_cmd='help', args='enableautocompaction')
+        if 'Unknown command enableautocompaction' in result.stdout:
+            disable_autocompaction = False
+        else:
+            disable_autocompaction = random.choice([True, False])
         keyspaces = self.cluster.get_test_keyspaces()
         try:
             self.cluster.wait_for_init(node_list=[new_node], timeout=timeout, wait_db_up=False)


### PR DESCRIPTION
	check if scylla version of nodetool supports disableautocompaction,
	and only run it if so, otherwise skip.

https://trello.com/c/sp2Driir

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
