### PR TITLE
fix(lwt basic profile): decrease rows amount for data validator views

### DIFF
--- a/data_dir/c-s_lwt_basic.yaml
+++ b/data_dir/c-s_lwt_basic.yaml
@@ -25,9 +25,9 @@ table_definition: |
     AND comment='A table to hold blog posts'
 
 extra_definitions:
-  - create MATERIALIZED VIEW blogposts_update_one_column_lwt_indicator as select domain, lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator < 0 PRIMARY KEY(lwt_indicator, domain, published_date);
+  - create MATERIALIZED VIEW blogposts_update_one_column_lwt_indicator as select domain, lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator >=-150000 and lwt_indicator < 0 PRIMARY KEY(lwt_indicator, domain, published_date);
   - create MATERIALIZED VIEW blogposts_update_one_column_lwt_indicator_after_update as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator = 30000000 PRIMARY KEY(lwt_indicator, domain, published_date);
-  - create MATERIALIZED VIEW blogposts_update_2_columns_lwt_indicator as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator > 0 and lwt_indicator <= 1000000 PRIMARY KEY(lwt_indicator, domain, published_date);
+  - create MATERIALIZED VIEW blogposts_update_2_columns_lwt_indicator as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator > 0 and lwt_indicator <= 150000 PRIMARY KEY(lwt_indicator, domain, published_date);
   - create MATERIALIZED VIEW blogposts_update_2_columns_lwt_indicator_after_update as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator = 20000000 PRIMARY KEY(lwt_indicator, domain, published_date);
   - create MATERIALIZED VIEW blogposts_not_updated_lwt_indicator as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator > 1000000 and lwt_indicator < 20000000 PRIMARY KEY(lwt_indicator, domain, published_date);
 
@@ -72,8 +72,8 @@ queries:
       cql: select * from blogposts where domain = ? LIMIT 1
       fields: samerow
    lwt_update_one_column:
-      cql: update blogposts set lwt_indicator = 30000000 where domain = ? and published_date = ? if lwt_indicator < 0
+      cql: update blogposts set lwt_indicator = 30000000 where domain = ? and published_date = ? if lwt_indicator >=-150000 and lwt_indicator < 0
       fields: samerow
    lwt_update_two_columns:
-      cql: update blogposts set lwt_indicator = 20000000, author = 'text' where domain = ? and published_date = ? if lwt_indicator > 0 and lwt_indicator <= 1000000 and author != 'text'
+      cql: update blogposts set lwt_indicator = 20000000, author = 'text' where domain = ? and published_date = ? if lwt_indicator > 0 and lwt_indicator <= 150000 and author != 'text'
       fields: samerow

--- a/sdcm/utils/data_validator.py
+++ b/sdcm/utils/data_validator.py
@@ -384,10 +384,10 @@ class LongevityDataValidator:
             statement=f"SELECT * FROM {self.view_name_for_not_updated_data}",
             verbose=not during_nemesis)
         if not actual_result:
-            DataValidatorEvent(type='error', name='ImmutableRowsValidator', status=Severity.ERROR,
-                               error=f"Can't validate immutable rows. "
-                                     f"Fetch all rows from {self.view_name_for_not_updated_data} failed. "
-                                     f"See error above in the sct.log")
+            DataValidatorEvent(type='warning', name='ImmutableRowsValidator', status=Severity.WARNING,
+                               message=f"Can't validate immutable rows. "
+                               f"Fetch all rows from {self.view_name_for_not_updated_data} failed. "
+                               f"See error above in the sct.log")
             return
 
         expected_result = self.longevity_self_object.fetch_all_rows(
@@ -395,10 +395,10 @@ class LongevityDataValidator:
             statement=f"SELECT * FROM {self.expected_data_table_name}",
             verbose=not during_nemesis)
         if not expected_result:
-            DataValidatorEvent(type='error', name='ImmutableRowsValidator', status=Severity.ERROR,
-                               error=f"Can't validate immutable rows. "
-                                     f"Fetch all rows from {self.expected_data_table_name} failed. "
-                                     f"See error above in the sct.log")
+            DataValidatorEvent(type='warning', name='ImmutableRowsValidator', status=Severity.WARNING,
+                               message=f"Can't validate immutable rows. "
+                               f"Fetch all rows from {self.expected_data_table_name} failed. "
+                               f"See error above in the sct.log")
             return
 
         # Issue https://github.com/scylladb/scylla/issues/6181
@@ -472,9 +472,9 @@ class LongevityDataValidator:
             if not during_nemesis:
                 LOGGER.debug(f'Verify updated row. View {views_set[0]}')
             if not views_set[3]:
-                DataValidatorEvent(type='error', name='UpdatedRowsValidator', status=Severity.ERROR,
-                                   error=f"Can't start validation for {views_set[0]}. "
-                                         f"Copying expected data failed. See error above in the sct.log")
+                DataValidatorEvent(type='warning', name='UpdatedRowsValidator', status=Severity.WARNING,
+                                   message=f"Can't start validation for {views_set[0]}. "
+                                   f"Copying expected data failed. See error above in the sct.log")
                 return
 
             before_update_rows = self.longevity_self_object.fetch_all_rows(
@@ -482,9 +482,9 @@ class LongevityDataValidator:
                 statement=f"SELECT {partition_keys} FROM {views_set[0]}",
                 verbose=not during_nemesis)
             if not before_update_rows:
-                DataValidatorEvent(type='error', name='UpdatedRowsValidator', status=Severity.ERROR,
-                                   error=f"Can't validate updated rows. "
-                                         f"Fetch all rows from {views_set[0]} failed. See error above in the sct.log")
+                DataValidatorEvent(type='warning', name='UpdatedRowsValidator', status=Severity.WARNING,
+                                   message=f"Can't validate updated rows. "
+                                   f"Fetch all rows from {views_set[0]} failed. See error above in the sct.log")
                 return
 
             after_update_rows = self.longevity_self_object.fetch_all_rows(
@@ -492,9 +492,9 @@ class LongevityDataValidator:
                 statement=f"SELECT {partition_keys} FROM {views_set[1]}",
                 verbose=not during_nemesis)
             if not after_update_rows:
-                DataValidatorEvent(type='error', name='UpdatedRowsValidator', status=Severity.ERROR,
-                                   error=f"Can't validate updated rows. "
-                                         f"Fetch all rows from {views_set[1]} failed. See error above in the sct.log")
+                DataValidatorEvent(type='warning', name='UpdatedRowsValidator', status=Severity.WARNING,
+                                   message=f"Can't validate updated rows. "
+                                   f"Fetch all rows from {views_set[1]} failed. See error above in the sct.log")
                 return
 
             expected_rows = self.longevity_self_object.fetch_all_rows(
@@ -502,9 +502,9 @@ class LongevityDataValidator:
                 statement=f"SELECT {partition_keys} FROM {views_set[2]}",
                 verbose=not during_nemesis)
             if not expected_rows:
-                DataValidatorEvent(type='error', name='UpdatedRowsValidator', status=Severity.ERROR,
-                                   error=f"Can't validate updated row. "
-                                         f"Fetch all rows from {views_set[2]} failed. See error above in the sct.log")
+                DataValidatorEvent(type='warning', name='UpdatedRowsValidator', status=Severity.WARNING,
+                                   message=f"Can't validate updated row. "
+                                   f"Fetch all rows from {views_set[2]} failed. See error above in the sct.log")
                 return
 
             # Issue https://github.com/scylladb/scylla/issues/6181
@@ -545,7 +545,7 @@ class LongevityDataValidator:
         was saved in self.rows_before_deletion
         """
         if not self.rows_before_deletion:
-            LOGGER.debug('Verify deleted rows can\'t be performed as expected rows count was had not been saved')
+            LOGGER.debug('Verify deleted rows can\'t be performed as expected rows count had not been saved')
             return
 
         pk_name = self.base_table_partition_keys[0]


### PR DESCRIPTION
Big rows amount in the views that created for data validator cause exceeding memory limit.

Change ERROR to the WARNING because this problem should not fail the test

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
