### PR TITLE
fix(db_stats.py): Add 'sudo' to collected stats

### DIFF
--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -645,11 +645,11 @@ class TestStatsMixin(Stats):
 
         if self.db_cluster and scylla_conf and 'scylla_args' not in self._stats['setup_details'].keys():
             node = self.db_cluster.nodes[0]
-            res = node.remoter.run('grep ^SCYLLA_ARGS /etc/sysconfig/scylla-server', verbose=True)
+            res = node.remoter.run('sudo grep ^SCYLLA_ARGS /etc/sysconfig/scylla-server', verbose=True)
             self._stats['setup_details']['scylla_args'] = res.stdout.strip()
-            res = node.remoter.run('cat /etc/scylla.d/io.conf', verbose=True)
+            res = node.remoter.run('sudo cat /etc/scylla.d/io.conf', verbose=True)
             self._stats['setup_details']['io_conf'] = remove_comments(res.stdout.strip())
-            res = node.remoter.run('cat /etc/scylla.d/cpuset.conf', verbose=True)
+            res = node.remoter.run('sudo cat /etc/scylla.d/cpuset.conf', verbose=True)
             self._stats['setup_details']['cpuset_conf'] = remove_comments(res.stdout.strip())
 
         self._stats['status'] = self.status

--- a/sdcm/results_analyze/__init__.py
+++ b/sdcm/results_analyze/__init__.py
@@ -310,7 +310,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
     @staticmethod
     def _get_setup_details(test_doc, is_gce):
         setup_details = {'cluster_backend': test_doc['_source']['setup_details'].get('cluster_backend')}
-        if "aws" in setup_details['cluster_backend']:
+        if setup_details['cluster_backend'] == "aws":
             setup_details['ami_id_db_scylla'] = test_doc['_source']['setup_details']['ami_id_db_scylla']
         for setup_param in QueryFilter(test_doc, is_gce).setup_instance_params():
             setup_details.update(


### PR DESCRIPTION
	Running with siren backend requires sudo permission for db nodes directories

This issues caused an error on running performance regression with cloud -
```
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  >   File "/home/jenkins/slave/workspace/scylla-staging/Longevity_yaron/cloud_performance_throughput_write_test/scylla-cluster-tests/sdcm/db_stats.py", line 648, in update_test_details
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  >     res = node.remoter.run('grep ^SCYLLA_ARGS /etc/sysconfig/scylla-server', verbose=True)
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  >   File "/home/jenkins/slave/workspace/scylla-staging/Longevity_yaron/cloud_performance_throughput_write_test/scylla-cluster-tests/sdcm/utils/decorators.py", line 61, in inner
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  >     return func(*args, **kwargs)
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  >   File "/home/jenkins/slave/workspace/scylla-staging/Longevity_yaron/cloud_performance_throughput_write_test/scylla-cluster-tests/sdcm/remote.py", line 373, in run
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  >     result = _run()
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  >   File "/home/jenkins/slave/workspace/scylla-staging/Longevity_yaron/cloud_performance_throughput_write_test/scylla-cluster-tests/sdcm/utils/decorators.py", line 56, in inner
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  >     return func(*args, **kwargs)
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  >   File "/home/jenkins/slave/workspace/scylla-staging/Longevity_yaron/cloud_performance_throughput_write_test/scylla-cluster-tests/sdcm/remote.py", line 358, in _run
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  >     result = self.connection.run(**command_kwargs)
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  >   File "<decorator-gen-3>", line 2, in run
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  >   File "/usr/local/lib/python3.8/site-packages/fabric/connection.py", line 30, in opens
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  >     return method(self, *args, **kwargs)
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  >   File "/usr/local/lib/python3.8/site-packages/fabric/connection.py", line 721, in run
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  >     return self._run(self._remote_runner(), command, **kwargs)
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  >   File "/usr/local/lib/python3.8/site-packages/invoke/context.py", line 101, in _run
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  >     return runner.run(command, **kwargs)
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  >   File "/usr/local/lib/python3.8/site-packages/invoke/runners.py", line 291, in run
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  >     return self._run_body(command, **kwargs)
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  >   File "/usr/local/lib/python3.8/site-packages/invoke/runners.py", line 442, in _run_body
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  >     raise UnexpectedExit(result)
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  > invoke.exceptions.UnexpectedExit: Encountered a bad command exit code!
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  > 
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  > Command: 'grep ^SCYLLA_ARGS /etc/sysconfig/scylla-server'
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  > 
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  > Exit code: 2
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  > 
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  > Stdout:
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  > 
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  > 
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  > 
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  > Stderr:
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  > 
22:51:29  < t:2020-07-12 19:51:29,322 f:sct_events.py   l:907  c:sdcm.sct_events      p:INFO  > grep: /etc/sysconfig/scylla-server: Permission denied
```
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
