### PR TITLE
fix(./upgrade_test.py): rename search_system_log to search_database_log

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -676,7 +676,7 @@ class UpgradeTest(FillDatabaseData):
     def count_log_errors(self, search_pattern, step, search_for_idx_token_error=True):
         schema_load_error_num = 0
         for node in self.db_cluster.nodes:
-            errors = node.search_system_log(search_pattern=search_pattern,
+            errors = node.search_database_log(search_pattern=search_pattern,
                                             start_from_beginning=True,
                                             publish_events=False)
             schema_load_error_num += len(errors)


### PR DESCRIPTION
Fixes search_system_log to search_database_log

Jenkins job that failed:
https://jenkins.scylladb.com/job/enterprise-2020.1/job/rolling-upgrade/job/rolling-upgrade-ubuntu18.04-test/14/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
