### PR TITLE
fix(streaming_err nemesis): only interrupt streaming task by reboot

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1772,21 +1772,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.log.debug('wait for random between 10s to 10m')
         time.sleep(random.randint(10, 600))
 
-        self.log.info('Interrupt the task (%s) to trigger streaming error' % task)
-        if random.randint(0, 1) == 0:
-            self.log.debug('Interrupt the task by pkill')
-            self.target_node.remoter.run('sudo pkill -9 -f %s' % task, ignore_status=True)
-            self.log.debug("Stop background repair task by storage_service/force_terminate_repair API")
-            with DbEventsFilter(type='DATABASE_ERROR', line="repair's stream failed: streaming::stream_exception",
-                                node=self.target_node), \
-                    DbEventsFilter(type='RUNTIME_ERROR', line='Can not find stream_manager', node=self.target_node), \
-                    DbEventsFilter(type='RUNTIME_ERROR', line='is aborted', node=self.target_node), \
-                    DbEventsFilter(type='RUNTIME_ERROR', line='Failed to repair', node=self.target_node):
-                self.target_node.remoter.run(
-                    'curl -X POST --header "Content-Type: application/json" --header "Accept: application/json" "http://127.0.0.1:10000/storage_service/force_terminate_repair"')
-        else:
-            self.log.debug('Interrupt the task by hard reboot')
-            self.target_node.reboot(hard=True, verify_ssh=True)
+        self.log.debug('Interrupt the task by hard reboot')
+        self.target_node.reboot(hard=True, verify_ssh=True)
         streaming_thread.join(60)
 
         new_node = decommission_post_action()


### PR DESCRIPTION
In streaming err nemesis, the rebuild task might still execute in the
background after nodetool process is killed. This causes the next
rebuild task fails.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
