### PR TITLE
fix(health_check.py): reducing to error severity

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2563,7 +2563,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         peers_details = self.get_peers_info() or {}
         gossip_info = self.get_gossip_info() or {}
 
-        check_nodes_status(nodes_status, current_node=self)
+        check_nodes_status(nodes_status, current_node=self, removed_nodes_list=self.parent_cluster.removed_nodes)
         check_node_status_in_gossip_and_nodetool_status(gossip_info, nodes_status, current_node=self)
         check_schema_version(gossip_info, peers_details, nodes_status, current_node=self)
         check_nulls_in_peers(gossip_info, peers_details, current_node=self)
@@ -3008,6 +3008,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         self.nemesis_threads = []
         self.nemesis_count = 0
         self._node_cycle = None
+        self.removed_nodes = set()
         super(BaseScyllaCluster, self).__init__(*args, **kwargs)
 
     @staticmethod
@@ -3514,7 +3515,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         if wait_db_up:
             node.wait_db_up(verbose=verbose, timeout=timeout)
             nodes_status = node.get_nodes_status()
-            check_nodes_status(nodes_status=nodes_status, current_node=node)
+            check_nodes_status(nodes_status=nodes_status, current_node=node, removed_nodes_list=self.removed_nodes)
             self.clean_replacement_node_ip(node)
 
     def _scylla_install(self, node):

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2563,7 +2563,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         peers_details = self.get_peers_info() or {}
         gossip_info = self.get_gossip_info() or {}
 
-        check_nodes_status(nodes_status, current_node=self, removed_nodes_list=self.parent_cluster.removed_nodes)
+        check_nodes_status(nodes_status, current_node=self,
+                           removed_nodes_list=self.parent_cluster.dead_nodes_ip_address_list)
         check_node_status_in_gossip_and_nodetool_status(gossip_info, nodes_status, current_node=self)
         check_schema_version(gossip_info, peers_details, nodes_status, current_node=self)
         check_nulls_in_peers(gossip_info, peers_details, current_node=self)
@@ -2757,6 +2758,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
         self.instance_provision = params.get('instance_provision')
         self.params = params
         self.datacenter = region_names or []
+        self.dead_nodes_ip_address_list = set()
 
         if Setup.REUSE_CLUSTER:
             # get_node_ips_param should be defined in child
@@ -2871,6 +2873,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
             node.destroy()
 
     def terminate_node(self, node):
+        self.dead_nodes_ip_address_list.add(node.ip_address)
         self.nodes.remove(node)
         node.destroy()
 
@@ -3008,7 +3011,6 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         self.nemesis_threads = []
         self.nemesis_count = 0
         self._node_cycle = None
-        self.removed_nodes = set()
         super(BaseScyllaCluster, self).__init__(*args, **kwargs)
 
     @staticmethod
@@ -3515,7 +3517,8 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         if wait_db_up:
             node.wait_db_up(verbose=verbose, timeout=timeout)
             nodes_status = node.get_nodes_status()
-            check_nodes_status(nodes_status=nodes_status, current_node=node, removed_nodes_list=self.removed_nodes)
+            check_nodes_status(nodes_status=nodes_status, current_node=node,
+                               removed_nodes_list=self.dead_nodes_ip_address_list)  # pylint: disable=no-member
             self.clean_replacement_node_ip(node)
 
     def _scylla_install(self, node):
@@ -3576,6 +3579,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         :param verbose: Whether to print extra info while watching for init.
         :param timeout: timeout in minutes to wait for init to be finished
         :param wait_db_up: select if wait for db to start up or not
+        :param check_node_health: select if run node health check or not
         :return:
         """
         node_list = node_list or self.nodes

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -946,7 +946,7 @@ class CassandraAWSCluster(ScyllaAWSCluster):
         node.remoter.run('sudo apt-get install -y openjdk-6-jdk')
 
     @cluster.wait_for_init_wrap
-    def wait_for_init(self, node_list=None, verbose=False, timeout=None, wait_db_up=True):  # pylint: disable=arguments-differ
+    def wait_for_init(self, node_list=None, verbose=False, timeout=None, wait_db_up=True, check_node_health=True):  # pylint: disable=too-many-arguments
         self.get_seed_nodes()
 
 

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -244,7 +244,8 @@ class ScyllaDockerCluster(cluster.BaseScyllaCluster, DockerCluster):  # pylint: 
 
         node.wait_db_up(verbose=verbose, timeout=timeout)
         nodes_status = node.get_nodes_status()
-        check_nodes_status(nodes_status=nodes_status, current_node=node)
+        check_nodes_status(nodes_status=nodes_status, current_node=node,
+                           removed_nodes_list=self.dead_nodes_ip_address_list)
         self.clean_replacement_node_ip(node)
 
     @staticmethod

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -495,6 +495,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def disrupt_nodetool_decommission(self, add_node=True, disruption_name=None):
         self._set_current_disruption(f"{disruption_name or 'Decommission'} {self.target_node}")
         self.cluster.decommission(self.target_node)
+        self.cluster.removed_nodes.add(self.target_node)
         if add_node:
             # When adding node after decommission the node is declared as up only after it completed bootstrapping,
             # increasing the timeout for now
@@ -539,6 +540,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self._set_current_disruption('TerminateAndReplaceNode %s' % self.target_node)
         old_node_ip = self.target_node.ip_address
         self._terminate_cluster_node(self.target_node)
+        self.cluster.removed_nodes.add(self.target_node)
         new_node = self._add_and_init_new_cluster_node(old_node_ip)
 
         try:
@@ -1767,6 +1769,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 self.log.error(
                     'The target node is decommission unexpectedly, decommission might complete before stopping it. Re-add a new node')
                 self._terminate_cluster_node(self.target_node)
+                self.cluster.removed_nodes.add(self.target_node)
                 new_node = self._add_and_init_new_cluster_node()
                 new_node.running_nemesis = None
                 return new_node
@@ -1910,6 +1913,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.metrics_srv.event_start('del_node')
             try:
                 self.cluster.decommission(self.target_node)
+                self.cluster.removed_nodes.add(self.target_node)
             finally:
                 self.metrics_srv.event_stop('del_node')
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -495,7 +495,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def disrupt_nodetool_decommission(self, add_node=True, disruption_name=None):
         self._set_current_disruption(f"{disruption_name or 'Decommission'} {self.target_node}")
         self.cluster.decommission(self.target_node)
-        self.cluster.removed_nodes.add(self.target_node)
         if add_node:
             # When adding node after decommission the node is declared as up only after it completed bootstrapping,
             # increasing the timeout for now
@@ -540,7 +539,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self._set_current_disruption('TerminateAndReplaceNode %s' % self.target_node)
         old_node_ip = self.target_node.ip_address
         self._terminate_cluster_node(self.target_node)
-        self.cluster.removed_nodes.add(self.target_node)
         new_node = self._add_and_init_new_cluster_node(old_node_ip)
 
         try:
@@ -1769,7 +1767,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 self.log.error(
                     'The target node is decommission unexpectedly, decommission might complete before stopping it. Re-add a new node')
                 self._terminate_cluster_node(self.target_node)
-                self.cluster.removed_nodes.add(self.target_node)
                 new_node = self._add_and_init_new_cluster_node()
                 new_node.running_nemesis = None
                 return new_node
@@ -1913,7 +1910,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.metrics_srv.event_start('del_node')
             try:
                 self.cluster.decommission(self.target_node)
-                self.cluster.removed_nodes.add(self.target_node)
             finally:
                 self.metrics_srv.event_stop('del_node')
 

--- a/sdcm/utils/health_checker.py
+++ b/sdcm/utils/health_checker.py
@@ -16,8 +16,8 @@ def check_nodes_status(nodes_status, current_node, removed_nodes_list=None):
     for node_ip, node_properties in nodes_status.items():
         if node_properties['status'] != "UN":
             is_target = current_node.print_node_running_nemesis(node_ip)
-            LOGGER.info(f'REMOVED NODES LIST = {[node.ip_address for node in removed_nodes_list]}')
-            if node_ip in [node.ip_address for node in removed_nodes_list]:
+            LOGGER.debug(f'REMOVED NODES LIST = {removed_nodes_list}')
+            if node_ip in removed_nodes_list:
                 severity = Severity.ERROR
             else:
                 severity = Severity.CRITICAL


### PR DESCRIPTION
because of issue scylladb/scylla-enterprise#1419.
It must be reverted once issue is fixed.
For now, when check_node_status fails, it will raise
an error event, and not a critical event, so the
execution will continue, and not halt because of the
critical event.


