### PR TITLE
improvement(sct_investigate): New subcommand to monitor runnnig jobs …

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1526,7 +1526,8 @@ def get_builder_by_test_id(test_id):
                                                                                             test_id=test_id),
                              ignore_status=True, verbose=False)
 
-        if not result.exited and not result.stderr:
+        if not result.exited and result.stdout:
+            builder["remoter"] = remoter
             path = result.stdout.strip()
             LOGGER.info("Builder name %s, ip %s, folder %s", builder['name'], builder['public_ip'], path)
             return {


### PR DESCRIPTION
…by testid

command investigate added new sub command monitor-job, which
allow to get content, follow changes, download file events_log/events.log
for running jenkins job by test-id

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
