### PR TITLE
fix(wait_for_init): add parameter that allow either run node.check_node_health or not

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3567,7 +3567,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         return True
 
     @wait_for_init_wrap
-    def wait_for_init(self, node_list=None, verbose=False, timeout=None, wait_db_up=True):  # pylint: disable=unused-argument
+    def wait_for_init(self, node_list=None, verbose=False, timeout=None, wait_db_up=True, check_node_health=True):  # pylint: disable=unused-argument, too-many-arguments
         """
         Scylla cluster setup.
         :param node_list: List of nodes to watch for init.
@@ -3585,7 +3585,12 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                       text="wait for db logs", step=20, timeout=300, throw_exc=True)
 
         self.log.info("{} nodes configured and stated.".format(node_list))
-        node_list[0].check_node_health()
+
+        # If wait_for_init is called during cluster initialization we may want this validation will be performed,
+        # but if it was called from nemesis, we don't need it in the middle of nemesis. It may cause to not relevant
+        # failures
+        if check_node_health:
+            node_list[0].check_node_health()
 
     def restart_scylla(self, nodes=None):
         if nodes:

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -465,7 +465,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             disable_autocompaction = random.choice([True, False])
         keyspaces = self.cluster.get_test_keyspaces()
         try:
-            self.cluster.wait_for_init(node_list=[new_node], timeout=timeout, wait_db_up=False)
+            self.cluster.wait_for_init(node_list=[new_node], timeout=timeout, wait_db_up=False, check_node_health=False)
             if disable_autocompaction:
                 self.log.info(f'During bootstrap, autocompaction will be disabled for keyspaces {keyspaces}')
                 for keyspace in keyspaces:


### PR DESCRIPTION
If wait_for_init function is called during cluster initialization we may want node.check_node_health validation will be performed,
but if it was called from nemesis, we don't need it in the middle of nemesis.
It may cause to not relevant failures.

For example:
Terminate and replace nemesis. If the new node is not joined yet and has status "UJ" in time the node.check_node_health runs, or terminated node still didn't leave the cluster (has status "DN"), it will cause the CRITICAL error and fails the test.
It's better to wait when the nemesis will finish and let to ClusterHealthValidator run and check the status.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
