### PR TITLE
fix(wait_init): Fix passing arguments in wrapper to node_setup

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1650,7 +1650,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
     def patch_scylla_yaml(self, yaml_file=SCYLLA_YAML_PATH, **kwargs):
         """
-        A user can send a dictionary of values ​​(just like the function "config_setup") and thus only change the
+        A user can send a dictionary of values (just like the function "config_setup") and thus only change the
         values he has chosen. If one of the keys contains a "None" value, the same value will be removed from the Yaml
         file.
         """
@@ -2936,7 +2936,8 @@ def wait_for_init_wrap(method):
         LOGGER.debug('Method kwargs: %s', kwargs)
         node_list = kwargs.get('node_list', None) or cl_inst.nodes
         timeout = kwargs.get('timeout', None)
-        setup_kwargs = {k: kwargs[k] for k in kwargs if k != 'node_list'}
+        # remove all arguments which is not supported by BaseScyllaCluster.node_setup method
+        setup_kwargs = {k: kwargs[k] for k in kwargs if k not in ["node_list", "check_node_health"]}
 
         _queue = queue.Queue()
 


### PR DESCRIPTION
Build arguments in wait_for_init_wrapper for node_setup based
on node_setup method signature

Fix for issue #2386 
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
