### PR TITLE
fix(replicated-ear): config system_key

### DIFF
--- a/configurations/replicated-ear.yaml
+++ b/configurations/replicated-ear.yaml
@@ -1,2 +1,6 @@
 
 scylla_encryption_options: "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'key_provider': 'ReplicatedKeyProviderFactory'}"
+
+# set system_key_directory
+append_scylla_yaml: |
+  system_key_directory: /etc/encrypt_conf/


### PR DESCRIPTION
Currently system_key_directory isn't assigned in config, then system_key
won't be pre-created, but it's required in enabling replicated-ear.

Signed-off-by: Amos Kong <amos@scylladb.com>

Fixed https://github.com/scylladb/scylla-cluster-tests/issues/2391

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
