### PR TITLE
Extend CDC replication test with option to run with gemini

### DIFF
--- a/jenkins-pipelines/feature-cdc-replication-gemini.jenkinsfile
+++ b/jenkins-pipelines/feature-cdc-replication-gemini.jenkinsfile
@@ -8,8 +8,8 @@ cdcReplicationPipeline(
 
     backend: 'aws',
     aws_region: 'eu-west-1',
-    test_name: 'cdc_replication_test.CDCReplicationTest.test_replication_cs',
-    test_config: 'test-cases/cdc/cdc-15m-replication.yaml',
+    test_name: 'cdc_replication_test.CDCReplicationTest.test_replication_gemini',
+    test_config: 'test-cases/cdc/cdc-15m-replication-gemini.yaml',
 
     timeout: [time: 100, unit: 'MINUTES'],
     email_recipients: 'kbraun@scylladb.com,piotr@scylladb.com,alex.bykov@scylladb.com'

--- a/test-cases/cdc/cdc-15m-replication-gemini.yaml
+++ b/test-cases/cdc/cdc-15m-replication-gemini.yaml
@@ -1,0 +1,29 @@
+test_duration: 60
+
+user_prefix: 'cdc-replication-gemini'
+db_type: mixed_scylla
+
+use_legacy_cluster_init: false
+
+n_db_nodes: 3
+instance_type_db: 'i3.large'
+
+n_test_oracle_db_nodes: 1
+instance_type_db_oracle: 'i3.large'
+
+n_loaders: 1
+instance_type_loader: 'c4.large'
+
+n_monitor_nodes: 0
+# instance_type_monitor: 't3.small'
+
+nemesis_class_name: 'RandomInterruptionNetworkMonkey'
+nemesis_interval: 1
+# Required by the nemesis:
+extra_network_interface: true
+
+gemini_cmd: "gemini -d --duration 15m --warmup 0s -c 5 -m write --non-interactive --cql-features basic --max-mutation-retries 100 --max-mutation-retries-backoff 100ms --replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '3'}\" --table-options \"cdc = {'enabled': true}\""
+
+gemini_version: 'latest'
+# Required by SCT, although not used:
+gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json'

--- a/test-cases/cdc/cdc-15m-replication.yaml
+++ b/test-cases/cdc/cdc-15m-replication.yaml
@@ -1,6 +1,6 @@
 test_duration: 60
 
-user_prefix: 'cdc-replication'
+user_prefix: 'cdc-replication-cs'
 db_type: mixed_scylla
 
 use_legacy_cluster_init: false


### PR DESCRIPTION
PR https://github.com/scylladb/scylla-cluster-tests/pull/2283 introduced a test for CDC which uses the CDC log generated on one cluster to replicate changes to another cluster and then compares them using scylla-migrate.

The workload in the original test is generated using cassandra-stress. It uses a simple fixed schema and a simple UPDATE writing to a small number of partitions.

This PR extends the test with an option to generate workload using gemini.