### PR TITLE
fix(remoter): reduce log level of the new remoter code

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -118,7 +118,7 @@ pipeline {
             steps {
                 script {
                     try {
-                        sh './docker/env/hydra.sh bash -c "cd \"`pwd`\"; pre-commit run -a"'
+                        sh './docker/env/hydra.sh bash -c "cd \"`pwd`\"; sudo apt-get update; sudo apt-get install -y --no-install-recommends build-essential cmake libssl-dev zlib1g-dev ; pre-commit run -a"'
                         // also check the commit-messge for the rules we want
                         sh 'git show -s --format=%B  > commit-msg'
                         sh './docker/env/hydra.sh bash -c "cd \"`pwd`\"; pre-commit run --hook-stage commit-msg --commit-msg-filename commit-msg"'

--- a/sdcm/remote/base.py
+++ b/sdcm/remote/base.py
@@ -184,13 +184,13 @@ class OutputWatcher(StreamWatcher):  # pylint: disable=too-few-public-methods
 
         while '\n' in stream_buffer:
             out_buf, rest_buf = stream_buffer.split('\n', 1)
-            self.log.info(out_buf)
+            self.log.debug(out_buf)
             stream_buffer = rest_buf
         self.len = len(stream) - len(stream_buffer)
         return []
 
     def submit_line(self, line: str):
-        self.log.info(line.rstrip('\n'))
+        self.log.debug(line.rstrip('\n'))
 
 
 class LogWriteWatcher(StreamWatcher):  # pylint: disable=too-few-public-methods


### PR DESCRIPTION
2b7b807838487d1c81caf22fcf4c97a494d8ef97 introduced few new `log.info` calls that fill up
output.log with all the command being executed, like c-s command
install command, we prefer those to be going into sct.log
and not hogging jenkins by handling those

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
