### PR TITLE
fix(run_user_stress_in_batches): start nemesis thread after stress

### DIFF
--- a/longevity_test.py
+++ b/longevity_test.py
@@ -312,8 +312,6 @@ class LongevityTest(ClusterTester):
                 self.monitors.reconfigure_scylla_monitoring()
                 self.db_cluster.wait_for_init(node_list=new_nodes)
 
-        self.db_cluster.start_nemesis()
-
         stress_params_list = list()
 
         customer_profiles = self.params.get('cs_user_profiles', default=[])
@@ -331,11 +329,18 @@ class LongevityTest(ClusterTester):
                 for _ in range(user_profile_table_count):
                     stress_params_list += self.create_templated_user_stress_params(next(templated_table_counter),
                                                                                    cs_profile)
-
+            stress_queue = list()
             self._run_user_stress_in_batches(batch_size=batch_size,
-                                             stress_params_list=stress_params_list)
+                                             stress_params_list=stress_params_list,
+                                             stress_queue=stress_queue)
 
-    def _run_user_stress_in_batches(self, batch_size, stress_params_list):
+            # Start nemesis thread after stress
+            self.db_cluster.start_nemesis()
+
+            for stress in stress_queue:
+                self.verify_stress_thread(cs_thread_pool=stress)
+
+    def _run_user_stress_in_batches(self, batch_size, stress_params_list, stress_queue):
         """
         run user profile in batches, while adding 4 stress-commands which are not with precreated tables
         and wait for them to finish
@@ -351,7 +356,6 @@ class LongevityTest(ClusterTester):
 
         for batch, _, _, extra_tables_idx in list(chunks(stress_params_list, batch_size)):
 
-            stress_queue = list()
             batch_params = dict(round_robin=True, stress_cmd=[])
 
             # add few stress threads with tables that weren't pre-created
@@ -368,8 +372,6 @@ class LongevityTest(ClusterTester):
                 batch_params['stress_cmd'] += [params['stress_cmd']]
 
             self._run_all_stress_cmds(stress_queue, params=batch_params)
-            for stress in stress_queue:
-                self.verify_stress_thread(cs_thread_pool=stress)
 
     def _run_stress_in_batches(self, total_stress, batch_size, stress_cmd):
         stress_queue = list()


### PR DESCRIPTION
5000 tables test uses this function. Nemesis should start after stress threads


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
