### PR TITLE
fix(nemesis.py): Hot reloading of SSL certificates is not supported on cloud

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1925,6 +1925,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if not self.cluster.params.get('server_encrypt', None):
             raise UnsupportedNemesis('Server Encryption is not enabled, hence skipping')
 
+        if self.cluster.params.get('cluster_backend') == 'aws-siren':
+            raise UnsupportedNemesis(
+                'Hot reloading of SSL certificates is not supported on cloud backend with scylla enterprise 2019.x')
+
         @retrying(allowed_exceptions=LogContentNotFound)
         def check_ssl_reload_log(target_node, file_path, since_time):
             msg = target_node.remoter.run(f'journalctl -u scylla-server --since="{since_time}" | '


### PR DESCRIPTION


	current cloud scylla version of 2019.1 does not include
	4.1 feature of hot reload ssl certificate.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
