### PR TITLE
fix(cluster.py): during backport variable name changed

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3439,7 +3439,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         node.wait_db_up(verbose=verbose, timeout=timeout)
         nodes_status = node.get_nodes_status()
         check_nodes_status(nodes_status=nodes_status, current_node=node,
-                           removed_nodes_list=self.removed_nodes)  # pylint: disable=no-member
+                           removed_nodes_list=self.dead_nodes_ip_address_list)  # pylint: disable=no-member
 
         self.clean_replacement_node_ip(node)
 


### PR DESCRIPTION
and while sending this old name to the function,
it wasn't found, and made the test to fail with
Python exception.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
