### PR TITLE
fix(scylla_cloud_nemesis.yaml): Disable server encrypt for cloud longevity

### DIFF
--- a/configurations/scylla_cloud_nemesis.yaml
+++ b/configurations/scylla_cloud_nemesis.yaml
@@ -2,3 +2,4 @@ nemesis_class_name: ChaosMonkey
 nemesis_interval: 15
 nemesis_during_prepare: false
 cluster_health_check: false
+server_encrypt: false


### PR DESCRIPTION

	server encryption related nemesis are not relevant to cloud cluster.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
