### PR TITLE
fix(toppartition_nemesis): Fix incorrect output splitting for toppartition command

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1434,11 +1434,13 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             pattern1 = r"(?P<sampler>[A-Z]+)\sSampler:\W+Cardinality:\s~(?P<cardinality>[0-9]+)\s\((?P<capacity>[0-9]+)\scapacity\)\W+Top\s(?P<toppartitions>[0-9]+)\spartitions:"
             pattern2 = r"(?P<partition>[\w:]+)\s+(?P<count>[\d]+)\s+(?P<margin>[\d]+)"
             toppartitions = {}
-            for out in output.split('\n\n'):
+            for out in output.strip().split('\n\n'):
                 partition = OrderedDict()
                 sampler_data = re.match(pattern1, out, re.MULTILINE)
+                assert sampler_data, f"Pattern:{pattern1} are not matched on string:\n {out}"
                 sampler_data = sampler_data.groupdict()
                 partitions = re.findall(pattern2, out, re.MULTILINE)
+                self.log.debug(f"Next list of top partitions are found {partitions}")
                 for val in partitions:
                     partition.update({val[0]: {'count': val[1], 'margin': val[2]}})
                 sampler_data.update({'partitions': partition})


### PR DESCRIPTION
if the result of command toppartition output contains \n\n at the
end, splitting by sampler could cause error in matching regexp
on empty string.

issue was detected by job [scylla-master longevity-200gb-48h/53](https://jenkins.scylladb.com/view/master/job/scylla-master/view/master-test/job/longevity/job/longevity-200gb-48h/53)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
