### PR TITLE
fix(remote): fix a typo in key_file arg

### DIFF
--- a/sdcm/remote/remote_base.py
+++ b/sdcm/remote/remote_base.py
@@ -68,7 +68,7 @@ class RemoteCmdRunnerBase(CommandRunner):  # pylint: disable=too-many-instance-a
         Return instance parameters required to rebuild instance
         """
         return {'hostname': self.hostname, 'user': self.user, 'password': self.password, 'port': self.port,
-                'connect_timeout': self.connect_timeout, 'keyfile': self.key_file,
+                'connect_timeout': self.connect_timeout, 'key_file': self.key_file,
                 'extra_ssh_options': self.extra_ssh_options, 'auth_sleep_time': self.auth_sleep_time}
 
     def __init_subclass__(cls, ssh_transport: str = None, default: bool = False):


### PR DESCRIPTION
Fixes: #2413 

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
