### PR TITLE
fix(refresh nemesis): remove unsupported file from snapshot

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -602,6 +602,11 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             upload_dir = result.stdout.split()[0]
             self.target_node.remoter.run('sudo tar xvfz {} -C /var/lib/scylla/data/keyspace1/{}/upload/'.format(
                 sstable_file, upload_dir))
+            # Scylla Enterprise 2019.1 doesn't support to load schema.cql and manifest.json, let's remove them
+            self.target_node.remoter.run(
+                'sudo rm -f /var/lib/scylla/data/keyspace1/{}/upload/schema.cql'.format(upload_dir))
+            self.target_node.remoter.run(
+                'sudo rm -f /var/lib/scylla/data/keyspace1/{}/upload/manifest.json'.format(upload_dir))
             self.target_node.run_nodetool(sub_cmd="refresh", args="-- keyspace1 standard1")
             cmd = "select * from keyspace1.standard1 where key=0x32373131364f334f3830"
             result = self.target_node.run_cqlsh(cmd)


### PR DESCRIPTION
	Scylla Enterprise 2019.1 doesn't support to load schema.cql and manifest.json,
	let's remove them from the snapshot.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
