### PR TITLE
improvement(test_rolling_upgrade.py): Creating upgrade rolling for Alternator

### DIFF
--- a/jenkins-pipelines/rolling-upgrade-ubuntu18.04.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-ubuntu18.04.jenkinsfile
@@ -7,7 +7,7 @@ rollingUpgradePipeline(
     params: params,
 
     backend: 'gce',
-    base_versions: ['4.1'],
+    base_versions: ['4.1', '2019.1'],
     linux_distro: 'ubuntu-bionic',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-1804-lts',
 

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -12,9 +12,9 @@ import getpass
 import pathlib
 
 from distutils.util import strtobool  # pylint: disable=import-error,no-name-in-module
-
 import anyconfig
 
+from sdcm.utils import alternator
 from sdcm.utils.common import get_s3_scylla_repos_mapping, get_scylla_ami_versions, get_branched_ami, get_ami_tags, \
     ami_built_by_scylla
 from sdcm.utils.version_utils import get_branch_version, get_branch_version_for_multiple_repositories
@@ -369,8 +369,9 @@ class SCTConfiguration(dict):
         dict(name="alternator_port", env="SCT_ALTERNATOR_PORT", type=int,
              help="Port to configure for alternator in scylla.yaml"),
         dict(name="dynamodb_primarykey_type", env="SCT_DYNAMODB_PRIMARYKEY_TYPE", type=str,
-             help="Type of dynamodb table to create with range key or not, can be HASH or HASH_AND_RANGE",
-             choices=['HASH', 'HASH_AND_RANGE']),
+             help=f"Type of dynamodb table to create with range key or not, can be:\n"
+                  f"{','.join([schema.value for schema in alternator.enums.YCSVSchemaTypes])}",
+             choices=[schema.value for schema in alternator.enums.YCSVSchemaTypes]),
         dict(name="alternator_write_isolation", env="SCT_ALTERNATOR_WRITE_ISOLATION", type=str,
              help="Set the write isolation for the alternator table, see https://github.com/scylladb/scylla/blob"
                   "/master/docs/alternator/alternator.md#write-isolation-policies for more details"),
@@ -979,6 +980,49 @@ class SCTConfiguration(dict):
 
         dict(name="use_legacy_cluster_init", env="SCT_USE_LEGACY_CLUSTER_INIT", type=bool,
              help="""Use legacy cluster initialization with autobootsrap disabled and parallel node setup"""),
+
+        dict(name="alternator_write_stress_during_entire_test", env="SCT_ALTERNATOR_WRITE_STRESS_DURING_ENTIRE_TEST",
+             type=str,
+             help="""YCSB-stress commands.
+                    You can specify everything but the -node parameter, which is going to
+                    be provided by the test suite infrastructure.
+                    multiple commands can passed as a list"""),
+
+        dict(name="alternator_verify_stress_after_cluster_upgrade",
+             env="SCT_ALTERNATOR_VERIFY_STRESS_AFTER_CLUSTER_UPGRADE",
+             type=str,
+             help="""YCSB-stress commands.
+                You can specify everything but the -node parameter, which is going to
+                be provided by the test suite infrastructure.
+                multiple commands can passed as a list"""),
+
+        dict(name="alternator_prepare_write_stress", env="SCT_ALTERNATOR_PREPARE_WRITE_STRESS",
+             type=str,
+             help="""YCSB-stress commands.
+                You can specify everything but the -node parameter, which is going to
+                be provided by the test suite infrastructure.
+                multiple commands can passed as a list"""),
+
+        dict(name="alternator_stress_cmd_read_cl_quorum", env="SCT_ALTERNATOR_STRESS_CMD_READ_CL_QUORUM",
+             type=str,
+             help="""YCSB-stress commands.
+                    You can specify everything but the -node parameter, which is going to
+                    be provided by the test suite infrastructure.
+                    multiple commands can passed as a list"""),
+
+        dict(name="alternator_stress_cmd_read_10m", env="SCT_ALTERNATOR_STRESS_CMD_READ_10_M",
+             type=str,
+             help="""YCSB-stress commands.
+                    You can specify everything but the -node parameter, which is going to
+                    be provided by the test suite infrastructure.
+                    multiple commands can passed as a list"""),
+
+        dict(name="alternator_stress_cmd_read_60m", env="SCT_ALTERNATOR_STRESS_CMD_READ_60_M",
+             type=str,
+             help="""YCSB-stress commands.
+                You can specify everything but the -node parameter, which is going to
+                be provided by the test suite infrastructure.
+                multiple commands can passed as a list"""),
     ]
 
     required_params = ['cluster_backend', 'test_duration', 'n_db_nodes', 'n_loaders', 'use_preinstalled_scylla',
@@ -1259,7 +1303,10 @@ class SCTConfiguration(dict):
                            'stress_cmd_read_cl_quorum', 'verify_stress_after_cluster_upgrade',
                            'stress_cmd_complex_verify_delete', 'stress_cmd_lwt_mixed', 'stress_cmd_lwt_de',
                            'stress_cmd_lwt_dc', 'stress_cmd_lwt_ue', 'stress_cmd_lwt_uc', 'stress_cmd_lwt_ine',
-                           'stress_cmd_lwt_d', 'stress_cmd_lwt_u', 'stress_cmd_lwt_i']:
+                           'stress_cmd_lwt_d', 'stress_cmd_lwt_u', 'stress_cmd_lwt_i',
+                           'alternator_write_stress_during_entire_test', 'alternator_prepare_write_stress',
+                           'alternator_verify_stress_after_cluster_upgrade', 'alternator_stress_cmd_read_cl_quorum',
+                           'alternator_stress_cmd_read_10m', 'alternator_stress_cmd_read_60m']:
             stress_cmds = self.get(param_name, default=None)
             if stress_cmds is None:
                 continue

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -303,7 +303,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         if self.params.get("logs_transport") == 'rsyslog':
             Setup.configure_rsyslog(self.localhost, enable_ngrok=False)
 
-        self.alternator = alternator.api.Alternator(sct_params=self.params)
+        self.alternator: alternator.api.Alternator = alternator.api.Alternator(sct_params=self.params)
         start_events_device(self.logdir)
         time.sleep(0.5)
         InfoEvent('TEST_START test_id=%s' % Setup.test_id())

--- a/sdcm/utils/alternator/api.py
+++ b/sdcm/utils/alternator/api.py
@@ -120,9 +120,9 @@ class Alternator:
                     batch.delete_item({key: item[key] for key in table_keys})
         return table
 
-    def compare_table_data(self, node, table_data, table_name=consts.TABLE_NAME) -> bool:
+    def compare_table_data(self, node, table_data, table_name=consts.TABLE_NAME) -> set:
         data = self.scan_table(node=node, table_name=table_name)
-        return set(hash(tuple(str(xxx))) for xxx in table_data) == set(hash(tuple(str(xxx))) for xxx in data)
+        return set(hash(str(xxx)) for xxx in table_data) - set(hash(str(xxx)) for xxx in data)
 
     def is_table_exists(self, node, table_name: consts.TABLE_NAME, endpoint_url=None):
         dynamodb_api = self.get_dynamodb_api(node=node)

--- a/test-cases/upgrades/rolling-upgrade.yaml
+++ b/test-cases/upgrades/rolling-upgrade.yaml
@@ -14,11 +14,45 @@ stress_cmd_complex_verify_read: cassandra-stress user no-warmup profile=/tmp/com
 stress_cmd_complex_verify_more: cassandra-stress user no-warmup profile=/tmp/complex_schema.yaml  ops'(read1=1,read2=1,update_static=1,update_ttl=1,update_diff1_ts=1,update_diff2_ts=1,update_same1_ts=1,update_same2_ts=1)' cl=ALL n=5000000 -mode cql3 native -rate threads=200 -pop seq=1..5000000
 stress_cmd_complex_verify_delete: cassandra-stress user no-warmup profile=/tmp/complex_schema.yaml  ops'(delete_row=1)' cl=ALL n=500000 -mode cql3 native -rate threads=200 -pop seq=1..500000
 
+# Alternator stress
+alternator_write_stress_during_entire_test: >-2
+  bin/ycsb run dynamodb -P workloads/workloada -threads 100 -p recordcount=1010020
+  -p readproportion=0 -p updateproportion=1 -p scanproportion=0 -p insertproportion=0 -p requestdistribution=uniform
+  -p fieldcount=10 -p fieldlength=512 -p operationcount=1010020 -p table=usertable
+alternator_verify_stress_after_cluster_upgrade: >-2
+  bin/ycsb run dynamodb -P workloads/workloada -threads 100 -p recordcount=1010020
+  -p readproportion=1 -p updateproportion=0 -p scanproportion=0 -p insertproportion=0 -p requestdistribution=uniform
+  -p fieldcount=10 -p fieldlength=512 -p operationcount=1010020 -p table=usertable
+alternator_prepare_write_stress: >-2
+  bin/ycsb run dynamodb -P workloads/workloada -threads 100 -p recordcount=1010020
+  -p readproportion=0 -p updateproportion=1 -p scanproportion=0 -p insertproportion=0 -p requestdistribution=uniform
+  -p fieldcount=10 -p fieldlength=512 -p operationcount=1010020 -p table=usertable
+alternator_stress_cmd_read_cl_quorum: >-2
+  bin/ycsb run dynamodb -P workloads/workloada -threads 100 -p recordcount=1010020
+  -p readproportion=1 -p updateproportion=0 -p scanproportion=0 -p insertproportion=0 -p requestdistribution=uniform
+  -p fieldcount=10 -p fieldlength=512 -p operationcount=1010020 -p table=usertable
+alternator_stress_cmd_read_10m: >-2
+  bin/ycsb run dynamodb -P workloads/workloada -threads 100 -p recordcount=1010020
+  -p readproportion=1 -p updateproportion=0 -p scanproportion=0 -p insertproportion=0 -p requestdistribution=uniform
+  -p fieldcount=10 -p fieldlength=512 -p operationcount=1010020 - maxexecutiontime=600 -p table=usertable
+alternator_stress_cmd_read_60m: >-2
+  bin/ycsb run dynamodb -P workloads/workloada -threads 100 -p recordcount=1010020
+  -p readproportion=1 -p updateproportion=0 -p scanproportion=0 -p insertproportion=0 -p requestdistribution=uniform
+  -p fieldcount=10 -p fieldlength=512 -p operationcount=1010020 - maxexecutiontime=3600 -p table=usertable
+
 n_db_nodes: 4
 n_loaders: 1
 n_monitor_nodes: 1
 
 user_prefix: 'rolling-upgrade'
+
+alternator_port: 8080
+alternator_use_dns_routing: true
+
+dynamodb_primarykey_type: HASH_AND_RANGE
+alternator_enforce_authorization: true
+alternator_access_key_id: 'alternator'
+alternator_secret_access_key: 'password'
 
 authenticator: 'PasswordAuthenticator'
 authenticator_user: 'cassandra'

--- a/unit_tests/test_ycsb_thread.py
+++ b/unit_tests/test_ycsb_thread.py
@@ -189,4 +189,4 @@ def test_04_insert_new_data(docker_scylla):
     ALTERNATOR.batch_write_actions(node=docker_scylla, new_items=new_items,
                                    schema=alternator.schemas.HASH_AND_STR_RANGE_SCHEMA)
     diff = ALTERNATOR.compare_table_data(node=docker_scylla, table_data=new_items)
-    assert diff
+    assert not diff


### PR DESCRIPTION
* rolloing-upgrade.yaml - Adding new stress commands for Alternator
* upgrade_test.py:
  * fill_and_verify_alternator_db_data - The function add data and veryfy it
  * test_rolling_upgrade - Add steps to check Alternator
* Adding new SCT config variables:
  * alternator_write_stress_during_entire_test
  * alternator_verify_stress_after_cluster_upgrade
  * alternator_prepare_write_stress
  * alternator_stress_cmd_read_cl_quorum
  * alternator_stress_cmd_read_10m
  * alternator_stress_cmd_read_60m

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
