### PR TITLE
improvement(new loader ami): change default loaders

### DIFF
--- a/data_dir/c-s_lwt_basic.yaml
+++ b/data_dir/c-s_lwt_basic.yaml
@@ -61,13 +61,14 @@ insert:
 
   batchtype: UNLOGGED             # Unlogged batches
 
-  condition: IF title = NULL       # LWT: Do not override
-
 
 #
 # A list of queries you wish to run against the schema
 #
 queries:
+   insert_query:
+      cql: insert into blogposts (domain, published_date, lwt_indicator, url, author, title) values (?,?,?,?,?,?) if not exists
+      fields: samerow
    select:
       cql: select * from blogposts where domain = ? LIMIT 1
       fields: samerow

--- a/data_dir/c-s_lwt_big_data.yaml
+++ b/data_dir/c-s_lwt_big_data.yaml
@@ -105,13 +105,14 @@ insert:
 
   batchtype: UNLOGGED             # Unlogged batches
 
-  condition: IF title = NULL       # LWT: Do not override
-
 
 #
 # A list of queries you wish to run against the schema
 #
 queries:
+   insert_query:
+      cql: insert into blogposts(domain, published_date, lwt_indicator,  url, url1, url2, url3, url4, author, title, c, d, e, f, g, h, char, vchar, finished, osirisjson, ip, size, imagebase, small_num, tiny_num, vint, decimal_num, double_num, float_num, start_date, start_time, check_date, pass_date, upload_time, user_uid, name_set, name_list) values (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?) if not exists
+      fields: samerow
    select:
       cql: select * from blogposts where domain = ? LIMIT 1
       fields: samerow

--- a/data_dir/c-s_lwt_big_data_multidc.yaml
+++ b/data_dir/c-s_lwt_big_data_multidc.yaml
@@ -105,13 +105,14 @@ insert:
 
   batchtype: UNLOGGED             # Unlogged batches
 
-  condition: IF title = NULL       # LWT: Do not override
-
 
 #
 # A list of queries you wish to run against the schema
 #
 queries:
+   insert_query:
+      cql: insert into blogposts(domain, published_date, lwt_indicator,  url, url1, url2, url3, url4, author, title, c, d, e, f, g, h, char, vchar, finished, osirisjson, ip, size, imagebase, small_num, tiny_num, vint, decimal_num, double_num, float_num, start_date, start_time, check_date, pass_date, upload_time, user_uid, name_set, name_list) values (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?) if not exists
+      fields: samerow
    select:
       cql: select * from blogposts where domain = ? LIMIT 1
       fields: samerow

--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -8,19 +8,19 @@ regions_data:
   us-east-1:
     security_group_ids: 'sg-c5e1f7a0'
     subnet_id: 'subnet-ec4a72c4'
-    ami_id_loader: 'ami-0fd5b310a58d39dcc' # Loader dedicated AMI v10 with golang 1.13
+    ami_id_loader: 'ami-03c856a491257cb7f' # Loader dedicated AMI v11
     ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
     backup_bucket_location: 'manager-backup-tests-us-east-1'
   eu-west-1:
     security_group_ids: 'sg-059a7f66a947d4b5c'
     subnet_id: 'subnet-088fddaf520e4c7a8'
-    ami_id_loader: 'ami-0ce9dc296997751b7' # Loader dedicated AMI v10 with golang 1.13
+    ami_id_loader: 'ami-0ac1d5f2066dfc9b4' # Loader dedicated AMI v11
     ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
     backup_bucket_location: 'manager-backup-tests-eu-west-1'
   us-west-2:
     security_group_ids: 'sg-81703ae4'
     subnet_id: 'subnet-5207ee37'
-    ami_id_loader: 'ami-0ec72c85a0b3b105b' # Loader dedicated AMI v10 with golang 1.13
+    ami_id_loader: 'ami-0de1ee51de25ac133' # Loader dedicated AMI v11
     ami_id_monitor: 'ami-01ed306a12b7d1c96' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
     backup_bucket_location: 'manager-backup-tests-eu-west-2'
 

--- a/test-cases/longevity/longevity-lwt-1loader-3h.yaml
+++ b/test-cases/longevity/longevity-lwt-1loader-3h.yaml
@@ -1,5 +1,5 @@
 test_duration: 180
-prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml n=10000000 ops'(insert=1)' cl=QUORUM -mode native cql3 -rate threads=80" ]
+prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml n=10000000 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=80" ]
 stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=QUORUM duration=160m -mode native cql3 -rate threads=20" ]
 stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(select=1)' cl=SERIAL duration=160m -mode native cql3 -rate threads=20" ]
 
@@ -8,18 +8,6 @@ n_loaders: 1
 n_monitor_nodes: 1
 
 instance_type_db: 'i3.2xlarge'
-
-# loader AMI with c-s ver. 4 and few fixes:
-#  - fix NoSuchElementException
-#  - enable control over both consistency levels: regular and serial
-#  - bring shard awareness
-regions_data:
-  us-east-1:
-    ami_id_loader: 'ami-0b94f0e897d884b1b'
-  eu-west-1:
-    ami_id_loader: 'ami-0bf19545bc7bc9e1f'
-  us-west-2:
-    ami_id_loader: 'ami-063a97bde47353690'
 
 nemesis_class_name: 'ChaosMonkey'
 nemesis_interval: 5

--- a/test-cases/longevity/longevity-lwt-24h-multidc.yaml
+++ b/test-cases/longevity/longevity-lwt-24h-multidc.yaml
@@ -1,5 +1,5 @@
 test_duration: 1560
-prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data_multidc.yaml n=10000000 ops'(insert=1)' cl=QUORUM -mode native cql3 -rate threads=1000" ]
+prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data_multidc.yaml n=10000000 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=1000" ]
 stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data_multidc.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1,lwt_deletes=1)' cl=QUORUM duration=1440m -mode native cql3 -rate threads=30" ]
 stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data_multidc.yaml ops'(select=1)' cl=SERIAL duration=1440m -mode native cql3 -rate threads=30" ]
 
@@ -8,18 +8,6 @@ n_loaders: 3
 n_monitor_nodes: 1
 
 instance_type_db: 'i3.xlarge'
-
-# loader AMI with c-s ver. 4 and few fixes:
-#  - fix NoSuchElementException
-#  - enable control over both consistency levels: regular and serial
-#  - bring shard awareness
-regions_data:
-  us-east-1:
-    ami_id_loader: 'ami-0b94f0e897d884b1b'
-  eu-west-1:
-    ami_id_loader: 'ami-0bf19545bc7bc9e1f'
-  us-west-2:
-    ami_id_loader: 'ami-063a97bde47353690'
 
 nemesis_class_name: 'ChaosMonkey'
 nemesis_interval: 5

--- a/test-cases/longevity/longevity-lwt-500G-3d.yaml
+++ b/test-cases/longevity/longevity-lwt-500G-3d.yaml
@@ -1,6 +1,6 @@
 # Test duration 25 hours temporary. Should be 3 days. Will be changed later
 test_duration: 1500
-prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml n=400000000 ops'(insert=1)' cl=QUORUM -mode native cql3 -rate threads=1000" ]
+prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml n=400000000 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=1000" ]
 stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1,lwt_deletes=1)' cl=QUORUM duration=900m -mode native cql3 -rate threads=10" ,
              "cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1,lwt_deletes=1)' cl=QUORUM duration=900m -mode native cql3 -rate threads=10"
             ]
@@ -13,18 +13,6 @@ round_robin: true
 
 instance_type_db: 'i3.4xlarge'
 instance_type_loader: 'c5.2xlarge'
-
-# loader AMI with c-s ver. 4 and few fixes:
-#  - fix NoSuchElementException
-#  - enable control over both consistency levels: regular and serial
-#  - bring shard awareness
-regions_data:
-  us-east-1:
-    ami_id_loader: 'ami-0b94f0e897d884b1b'
-  eu-west-1:
-    ami_id_loader: 'ami-0bf19545bc7bc9e1f'
-  us-west-2:
-    ami_id_loader: 'ami-063a97bde47353690'
 
 nemesis_class_name: 'ChaosMonkey'
 nemesis_interval: 5

--- a/test-cases/longevity/longevity-lwt-basic-24h-1dis-2nondis.yaml
+++ b/test-cases/longevity/longevity-lwt-basic-24h-1dis-2nondis.yaml
@@ -1,5 +1,5 @@
 test_duration: 1500
-prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml n=10000000 ops'(insert=1)' cl=QUORUM -mode native cql3 -rate threads=50" ]
+prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml n=10000000 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=50" ]
 stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=QUORUM duration=1440m -mode native cql3 -rate threads=30" ]
 stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(select=1)' cl=SERIAL duration=1440m -mode native cql3 -rate threads=30" ]
 
@@ -8,18 +8,6 @@ n_loaders: 3
 n_monitor_nodes: 1
 
 instance_type_db: 'i3.2xlarge'
-
-# loader AMI with c-s ver. 4 and few fixes:
-#  - fix NoSuchElementException
-#  - enable control over both consistency levels: regular and serial
-#  - bring shard awareness
-regions_data:
-  us-east-1:
-    ami_id_loader: 'ami-0b94f0e897d884b1b'
-  eu-west-1:
-    ami_id_loader: 'ami-0bf19545bc7bc9e1f'
-  us-west-2:
-    ami_id_loader: 'ami-063a97bde47353690'
 
 nemesis_class_name: 'DisruptiveMonkey:1 NonDisruptiveMonkey:2'
 nemesis_interval: 5

--- a/test-cases/longevity/longevity-lwt-basic-24h.yaml
+++ b/test-cases/longevity/longevity-lwt-basic-24h.yaml
@@ -1,5 +1,5 @@
 test_duration: 1500
-prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml n=10000000 ops'(insert=1)' cl=QUORUM -mode native cql3 -rate threads=30" ]
+prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml n=10000000 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=30" ]
 stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=QUORUM duration=1440m -mode native cql3 -rate threads=20",
              "cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=QUORUM duration=1440m -mode native cql3 -rate threads=20"
             ]
@@ -11,18 +11,6 @@ n_monitor_nodes: 1
 round_robin: true
 
 instance_type_db: 'i3.2xlarge'
-
-# loader AMI with c-s ver. 4 and few fixes:
-#  - fix NoSuchElementException
-#  - enable control over both consistency levels: regular and serial
-#  - bring shard awareness
-regions_data:
-  us-east-1:
-    ami_id_loader: 'ami-0b94f0e897d884b1b'
-  eu-west-1:
-    ami_id_loader: 'ami-0bf19545bc7bc9e1f'
-  us-west-2:
-    ami_id_loader: 'ami-063a97bde47353690'
 
 nemesis_class_name: 'ChaosMonkey'
 nemesis_interval: 5

--- a/test-cases/longevity/longevity-lwt-basic-3h.yaml
+++ b/test-cases/longevity/longevity-lwt-basic-3h.yaml
@@ -1,5 +1,5 @@
 test_duration: 180
-prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml n=10000000 ops'(insert=1)' cl=QUORUM -mode native cql3 -rate threads=30"]
+prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml n=10000000 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=30"]
 stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=QUORUM duration=160m -mode native cql3 -rate threads=20",
              "cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=QUORUM duration=160m -mode native cql3 -rate threads=20"
             ]
@@ -11,19 +11,6 @@ n_monitor_nodes: 1
 round_robin: true
 
 instance_type_db: 'i3.2xlarge'
-
-# loader AMI with c-s ver. 4 and few fixes:
-#  - fix NoSuchElementException
-#  - enable control over both consistency levels: regular and serial
-#  - bring shard awareness
-regions_data:
-  us-east-1:
-    ami_id_loader: 'ami-0b94f0e897d884b1b'
-  eu-west-1:
-    ami_id_loader: 'ami-0bf19545bc7bc9e1f'
-  us-west-2:
-    ami_id_loader: 'ami-063a97bde47353690'
-
 
 nemesis_class_name: 'ChaosMonkey'
 nemesis_interval: 5


### PR DESCRIPTION
Now we have 2 kinds of loader ami:
1. default, that uses in most of tests
2. with support of LWT
3. with ISC support

New ami of loader, that support all features, was created and copied to regions that
we use to run the tests there.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
