### PR TITLE
fix(sdcm/): Make paramiko remoter threadsafe

### DIFF
--- a/sdcm/remote/remote_cmd_runner.py
+++ b/sdcm/remote/remote_cmd_runner.py
@@ -30,6 +30,7 @@ from .remote_base import RemoteCmdRunnerBase
 
 
 class RemoteCmdRunner(RemoteCmdRunnerBase, ssh_transport='fabric', default=True):  # pylint: disable=too-many-instance-attributes
+    connection: Connection
     ssh_config: Config = None
     ssh_is_up: threading.Event = None
     ssh_up_thread: Optional[threading.Thread] = None

--- a/sdcm/remote/remote_libssh_cmd_runner.py
+++ b/sdcm/remote/remote_libssh_cmd_runner.py
@@ -37,7 +37,7 @@ class RemoteLibSSH2CmdRunner(RemoteCmdRunnerBase, ssh_transport='libssh2'):  # p
     Whenever remoter read self.connection, we return value from _connection_thread_map associated with current thread,
       And if it is not there, we create it.
     """
-    connection_thread_map = threading.local()
+    connection: LibSSH2Client
     exception_unexpected = UnexpectedExit
     exception_failure = Failure
     exception_retryable = (
@@ -45,18 +45,6 @@ class RemoteLibSSH2CmdRunner(RemoteCmdRunnerBase, ssh_transport='libssh2'):  # p
         AuthenticationException, UnknownHostException, ConnectError, FailedToReadCommandOutput,
         CommandTimedOut, FailedToRunCommand, OpenChannelTimeout, SocketRecvError, socket.timeout
     )
-
-    @property
-    def connection(self) -> LibSSH2Client:
-        """
-        Map connection to current thread.
-        If there is no such thread, create it.
-        """
-        connection = getattr(self.connection_thread_map, str(id(self)), None)
-        if connection is None:
-            connection = self._create_connection()
-            setattr(self.connection_thread_map, str(id(self)), connection)
-        return connection
 
     def _create_connection(self) -> LibSSH2Client:
         return LibSSH2Client(


### PR DESCRIPTION
Addresses issue https://github.com/scylladb/scylla-cluster-tests/issues/2187
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
