### PR TITLE
fix(sdcm/remote/libssh2_client): Fix gc core

### DIFF
--- a/sdcm/remote/libssh2_client/__init__.py
+++ b/sdcm/remote/libssh2_client/__init__.py
@@ -20,6 +20,7 @@ from io import StringIO
 from warnings import warn
 from socket import socket, AF_INET, SOCK_STREAM, gaierror, error as sock_error
 from threading import Thread, Lock
+from abc import abstractmethod, ABC
 from multiprocessing import Queue, BoundedSemaphore, Event
 from ssh2.channel import Channel  # pylint: disable=no-name-in-module
 from ssh2.exceptions import AuthenticationError  # pylint: disable=no-name-in-module
@@ -41,6 +42,10 @@ class __DEFAULT__:  # pylint: disable=invalid-name, too-few-public-methods
     """ Default value for function attribute when None is not an option """
 
 
+class StreamWatcher(ABC):
+    @abstractmethod
+    def submit_line(self, line: str):
+        pass
 
 
 class SSHReaderThread(Thread):  # pylint: disable=too-many-instance-attributes
@@ -402,7 +407,7 @@ class Client:  # pylint: disable=too-many-instance-attributes
 
     @staticmethod
     def _process_output(  # pylint: disable=too-many-arguments, too-many-branches
-            watchers: List['StreamWatcher'], encoding: str, stdout_stream: StringIO, stderr_stream: StringIO,
+            watchers: List[StreamWatcher], encoding: str, stdout_stream: StringIO, stderr_stream: StringIO,
             reader: SSHReaderThread, timeout: NullableTiming, timeout_read_data_chunk: NullableTiming):
         """Separate different approach for the case when watchers are present, since watchers are slow,
           we can loose data due to the socket buffer limit, if endpoint sending it faster than watchers can read it.

--- a/sdcm/remote/libssh2_client/__init__.py
+++ b/sdcm/remote/libssh2_client/__init__.py
@@ -11,7 +11,6 @@
 #
 # Copyright (c) 2020 ScyllaDB
 
-# pylint: disable=duplicate-code
 from typing import List, Optional, Dict
 from time import perf_counter, sleep
 from os.path import normpath, expanduser, exists
@@ -22,9 +21,11 @@ from socket import socket, AF_INET, SOCK_STREAM, gaierror, error as sock_error
 from threading import Thread, Lock
 from abc import abstractmethod, ABC
 from multiprocessing import Queue, BoundedSemaphore, Event
+
 from ssh2.channel import Channel  # pylint: disable=no-name-in-module
 from ssh2.exceptions import AuthenticationError  # pylint: disable=no-name-in-module
 from ssh2.error_codes import LIBSSH2_ERROR_EAGAIN  # pylint: disable=no-name-in-module
+
 from .exceptions import AuthenticationException, UnknownHostException, ConnectError, PKeyFileError, UnexpectedExit, \
     CommandTimedOut, FailedToReadCommandOutput, ConnectTimeout, FailedToRunCommand, OpenChannelTimeout
 from .result import Result
@@ -621,6 +622,7 @@ class Client:  # pylint: disable=too-many-instance-attributes
             except Exception as exc:  # pylint: disable=broad-except
                 print(f'Failed to close channel due to the following error: {exc}')
             exit_status = channel.get_exit_status()
+            self.session.drop_channel(channel)
             result.exited = exit_status
         if exception:
             raise exception

--- a/sdcm/remote/libssh2_client/exceptions.py
+++ b/sdcm/remote/libssh2_client/exceptions.py
@@ -12,7 +12,9 @@
 # Copyright (c) 2020 ScyllaDB
 
 import traceback
+
 from ssh2.exceptions import SocketRecvError  # pylint: disable=no-name-in-module
+
 from .result import Result
 
 

--- a/sdcm/remote/libssh2_client/session.py
+++ b/sdcm/remote/libssh2_client/session.py
@@ -1,0 +1,59 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2020 ScyllaDB
+
+from select import select
+from threading import Lock
+from ssh2.session import Session as LibSSH2Session, LIBSSH2_SESSION_BLOCK_INBOUND, LIBSSH2_SESSION_BLOCK_OUTBOUND  # pylint: disable=no-name-in-module
+from ssh2.exceptions import SocketRecvError  # pylint: disable=no-name-in-module
+from ssh2.error_codes import LIBSSH2_ERROR_EAGAIN  # pylint: disable=no-name-in-module
+from .timings import NullableTiming
+
+
+class Session(LibSSH2Session):  # pylint: disable=too-few-public-methods
+    """Custom SSH2 Session class with Lock in it, to make it thread safe where it is needed """
+
+    # Libssh2 is currently not thread safe, we have work it around by having separete session for each thread
+    #   but garbage collection part of the issue still not fixed
+    # channels, drop_channel, __del__ and open_session are part of the workaround gc part of the issue.
+
+    def __init__(self):
+        # A lock that is used to make it thread safe
+        self.lock = Lock()
+        super().__init__()
+
+    def simple_select(self, timeout: NullableTiming = None):
+        """Perform single select on ssh2 session socket.
+        It is standalone-function because it is an candidate to be compiled via Cython
+        """
+        try:
+            _socket = self.sock
+            directions = self.block_directions()
+            if directions == 0:
+                return
+            readfds = (_socket,) \
+                if (directions & LIBSSH2_SESSION_BLOCK_INBOUND) else ()
+            writefds = (_socket,) \
+                if (directions & LIBSSH2_SESSION_BLOCK_OUTBOUND) else ()
+            select(readfds, writefds, (), timeout)
+        except (ValueError, SocketRecvError):  # under high load it can throw these errors, on next try it will be ok
+            pass
+
+    def eagain(self, func, args=(), kwargs={},  # pylint: disable=dangerous-default-value
+               timeout: NullableTiming = None) -> int:
+        """Running function followed by simple_select up until it return anything but `LIBSSH2_ERROR_EAGAIN`"""
+        with self.lock:
+            ret = func(*args, **kwargs)
+            while ret == LIBSSH2_ERROR_EAGAIN:
+                self.simple_select(timeout=timeout)
+                ret = func(*args, **kwargs)
+            return ret

--- a/sdcm/remote/libssh2_client/timings.py
+++ b/sdcm/remote/libssh2_client/timings.py
@@ -1,0 +1,44 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2020 ScyllaDB
+
+from typing import Iterable, Optional
+from dataclasses import dataclass, field
+
+
+NullableTiming = Optional[float]
+Timing = float
+Delays = Iterable[float]
+
+
+@dataclass
+class Timings:  # pylint: disable=too-many-instance-attributes
+    """A store for timeouts and delays
+    """
+    keepalive_timeout: Timing = 30
+    keepalive_sending_timeout: Timing = 1
+    socket_timeout: NullableTiming = 10
+    connect_timeout: NullableTiming = 60
+    connect_delays: Delays = field(default_factory=lambda: [0, 0.1, 0.5, 1, 15])
+    interactive_read_data_chunk_timeout: NullableTiming = 0.5
+    read_data_chunk_timeout: NullableTiming = 1
+    read_command_output_timeout: NullableTiming = None
+    check_if_alive_timeout: NullableTiming = 5
+    # Timeout on all basic ssh session operation like authentications, open_session, etc...
+    ssh_session_timeout: NullableTiming = 10
+    ssh_handshake_timeout: NullableTiming = 3
+    auth_timeout: NullableTiming = 10
+    open_channel_timeout: NullableTiming = 15
+    channel_close_timeout: NullableTiming = 0.5
+    close_channel_timeout: NullableTiming = 1
+    # Delays for open_channel, if open_channel failed it sleeps for amount of seconds it got from the list
+    open_channel_delays: Delays = field(default_factory=lambda: [0, 0.1, 0.5, 1, 15])


### PR DESCRIPTION
ssh2-python is not threadsafe, there is possibility to get core when garbage collector clean Session and it's channel at the same time.

This is the fix to close this issue from being meet.
 
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
