### PR TITLE
fix(in memory test): shorten longevity-in-memory-36GB-4days test to 24h

### DIFF
--- a/jenkins-pipelines/longevity-in-memory-36gb-4d.jenkinsfile
+++ b/jenkins-pipelines/longevity-in-memory-36gb-4d.jenkinsfile
@@ -11,5 +11,5 @@ longevityPipeline(
     test_name: 'longevity_in_memory_test.InMemoryLongevityTest.test_in_mem_longevity',
     test_config: 'test-cases/longevity/longevity-in-memory-36GB-4days.yaml',
 
-    timeout: [time: 6610, unit: 'MINUTES']
+    timeout: [time: 1560, unit: 'MINUTES']
 )

--- a/test-cases/longevity/longevity-in-memory-36GB-4days.yaml
+++ b/test-cases/longevity/longevity-in-memory-36GB-4days.yaml
@@ -1,8 +1,8 @@
-test_duration: 6550
+test_duration: 1500
 prepare_write_cmd:  ["cassandra-stress write                         cl=QUORUM n=21000000     -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=500 -pop seq=1..21000000 -col 'size=FIXED(200) n=FIXED(5)' -log interval=10"]
 prepare_verify_cmd: ["cassandra-stress read                          cl=QUORUM n=21000000     -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=500 -pop seq=1..21000000 -col 'size=FIXED(200) n=FIXED(5)' -log interval=10"]
-stress_cmd:         ["cassandra-stress mixed 'ratio(write=1,read=8)' cl=QUORUM duration=5760m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -pop seq=1..21000000 -col 'size=FIXED(200) n=FIXED(5)' -log interval=10"]
-stress_read_cmd:    ["cassandra-stress read                          cl=QUORUM duration=5760m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=1..21000000 -col 'size=FIXED(200) n=FIXED(5)' -log interval=10"]
+stress_cmd:         ["cassandra-stress mixed 'ratio(write=1,read=8)' cl=QUORUM duration=1400m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -pop seq=1..21000000 -col 'size=FIXED(200) n=FIXED(5)' -log interval=10"]
+stress_read_cmd:    ["cassandra-stress read                          cl=QUORUM duration=1400m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=1..21000000 -col 'size=FIXED(200) n=FIXED(5)' -log interval=10"]
 
 run_fullscan: 'random, 30' # 'ks.cf|random, interval(min)''
 


### PR DESCRIPTION
Shorten longevity-in-memory-36GB-4days test to 24h by Roy's request

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
