### PR TITLE
fix(remote): logging levels

### DIFF
--- a/sdcm/remote/base.py
+++ b/sdcm/remote/base.py
@@ -102,9 +102,9 @@ class CommandRunner(metaclass=ABCMeta):
         """When verbose=True and ignore_status=True that means nothing will be printed in any case"""
         if verbose and not result.failed:
             if result.stderr:
-                self.log.info('STDERR: %s', result.stderr)
+                self.log.debug('STDERR: %s', result.stderr)
 
-            self.log.info('Command "%s" finished with status %s', result.command, result.exited)
+            self.log.debug('Command "%s" finished with status %s', result.command, result.exited)
             return
 
         if verbose and result.failed and not ignore_status:

--- a/sdcm/remote/remote_base.py
+++ b/sdcm/remote/remote_base.py
@@ -185,7 +185,7 @@ class RemoteCmdRunnerBase(CommandRunner):  # pylint: disable=too-many-instance-a
                 rsync = self._make_rsync_cmd([remote_source], local_dest,
                                              delete_dst, preserve_symlinks, timeout)
                 result = LocalCmdRunner().run(rsync, timeout=timeout)
-                self.log.info(result.exited)
+                self.log.debug(result.exited)
                 try_scp = False
             except (self.exception_failure, self.exception_unexpected) as ex:
                 self.log.warning("Trying scp, rsync failed: %s", ex)
@@ -211,12 +211,12 @@ class RemoteCmdRunnerBase(CommandRunner):  # pylint: disable=too-many-instance-a
                     if self._is_error_retryable(ex.result.stderr):
                         raise RetryableNetworkException(ex.result.stderr, original=ex)
                     raise
-                self.log.info("Command %s with status %s", result.command, result.exited)
+                self.log.debug("Command %s with status %s", result.command, result.exited)
                 if result.exited:
                     files_received = False
                 # Avoid "already printed" message without real error
                 if result.stderr:
-                    self.log.info("Stderr: %s", result.stderr)
+                    self.log.deubg("Stderr: %s", result.stderr)
                     files_received = False
 
         if not preserve_perm:
@@ -324,7 +324,7 @@ class RemoteCmdRunnerBase(CommandRunner):  # pylint: disable=too-many-instance-a
                     if self._is_error_retryable(ex.result.stderr):
                         raise RetryableNetworkException(ex.result.stderr, original=ex)
                     raise
-                self.log.info('Command %s with status %s', result.command, result.exited)
+                self.log.debug('Command %s with status %s', result.command, result.exited)
                 if result.exited:
                     files_sent = False
         return files_sent


### PR DESCRIPTION
too many places in remoter code were printing with `log.info`
cause the output.log to become huge, and might cause issues
for jenkins, and makes it impossible to track a job in jenkins.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
