### PR TITLE
feature(scylla setup): enable swap setup for GCE instances

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2158,14 +2158,14 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 The kernel bug doesn't occur all the time, so we can get some succeed gce instance.
                 the config files are copied from a succeed GCE instance (same instance type, same test
             """.format(self.kernel_version)))
-            self.remoter.run('sudo /usr/lib/scylla/scylla_setup --nic {} --disks {} --no-io-setup {}'
+            self.remoter.run('sudo /usr/lib/scylla/scylla_setup --nic {} --disks {} --no-io-setup {} --swap-directory /'
                              .format(devname, ','.join(disks), extra_setup_args))
             for conf in ['io.conf', 'io_properties.yaml']:
                 self.remoter.send_files(src=os.path.join('./configurations/', conf),  # pylint: disable=not-callable
                                         dst='/tmp/')
                 self.remoter.run('sudo mv /tmp/{0} /etc/scylla.d/{0}'.format(conf))
         else:
-            self.remoter.run('sudo /usr/lib/scylla/scylla_setup --nic {} --disks {} {}'
+            self.remoter.run('sudo /usr/lib/scylla/scylla_setup --nic {} --disks {} {} --swap-directory /'
                              .format(devname, ','.join(disks), extra_setup_args))
 
         result = self.remoter.run('cat /proc/mounts')


### PR DESCRIPTION
This patch enabled swap setup for GCE instances, swap file will be
created in root directory.

Scylla swap setup requires 1/3 total memroy for swap, the minimum swap
is 16G.

Currently the default instance has enough free space in root directory
for swap. If larger instance is used, the root disk size can be increased
by gce_root_disk_size_db parameter.

Note: the AWS support will be added in scylla-machine-image.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
