### PR TITLE
improvement(nemesis.py): calculate latency for perf

### DIFF
--- a/jenkins-pipelines/perf-regression-latency-250gb-with-nemesis.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-250gb-with-nemesis.jenkinsfile
@@ -5,7 +5,6 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: "test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml",
     sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"],

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -16,7 +16,6 @@
 
 import os
 import time
-
 import yaml
 
 from sdcm.tester import ClusterTester
@@ -237,9 +236,10 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
             self.db_cluster.add_nemesis(nemesis=self.get_nemesis_class(), tester_obj=self)
             self.db_cluster.start_nemesis(interval=interval)
         results = self.get_stress_results(queue=stress_queue)
-        self.update_test_details()
+        self.update_test_details(scrap_metrics_step=60)
         self.display_results(results, test_name='test_latency' if not nemesis else 'test_latency_with_nemesis')
-        self.check_regression()
+        check_latency = self.check_regression if not nemesis else self.check_latency_during_ops
+        check_latency()
 
     def prepare_mv(self, on_populated=False):
         with self.db_cluster.cql_connection_patient_exclusive(self.db_cluster.nodes[0]) as session:

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2881,6 +2881,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
             raise ValueError('Unsupported type: {}'.format(type(n_nodes)))
         self.coredumps = dict()
         self.ldap_configured = False
+        self.latency_results = dict()
         super(BaseCluster, self).__init__()
 
     @cached_property

--- a/sdcm/report_templates/results_latency_during_ops.html
+++ b/sdcm/report_templates/results_latency_during_ops.html
@@ -1,0 +1,94 @@
+{% extends 'results_base_custom.html' %}
+{% block body %}
+    {% block title %}
+    <h3>Test: {{ test_name }}</h3>
+    {% endblock %}
+    <h3>
+        <span>Test start time: </span>
+        <span class="blue">{{ test_start_time }}</span>
+        <br>
+        <span>Test test id: </span>
+        <span class="blue">{{ test_id }}</span>
+    </h3>
+    <h3>
+        <span>Version: </span>
+        <span class="blue">{{ test_version.version }} </span>
+    </h3>
+    <div>
+        <span> Setup Details: </span>
+        <ul>
+        {% for key, val in setup_details.items()|sort %}
+            <li>
+                {{ key }}: <span class="blue"> {{ val }} </span>
+            </li>
+        {% endfor %}
+        </ul>
+    </div>
+
+    {% for workload_type, operations in stats.items() %}
+        <h1>Test {{ workload_type }}</h1>
+        <div>
+            {% for operation, results in operations.items() %}
+                {% if operation != 'Steady State' %}
+                    <h2>{{ operation }}</h2>
+                    <table id="results_table">
+                        <th>Latency Type</th>
+                        {% for cycle in results['cycles'] %}
+                            <th>Cycle #{{ loop.index }}</th>
+                        {% endfor %}
+                        <th>Cycles Average</th>
+                        <th>Steady State</th>
+                        <th>Relative to Steady</th>
+                        {% set lat_type_list = [] %}
+                        {% for cycle in results['cycles'] %}
+                            {% for key, value in cycle.items() %}
+                                {% if key not in lat_type_list %}
+                                    {% do lat_type_list.append(key) %}
+                                {% endif %}
+                            {% endfor %}
+                        {% endfor %}
+
+                        {% for lat_type in lat_type_list|sort %}
+                            <tr>
+                                <td>{{ lat_type }}</td>
+                                {% for cycle in results['cycles'] %}
+                                    <td>{{ cycle[lat_type] }}</td>
+                                {% endfor %}
+                                <td>{{ results['Cycles Average'][lat_type] }}</td>
+                                <td>{{ operations['Steady State'][lat_type] }}</td>
+                                <td>{{ results['Relative to Steady'][lat_type] }}</td>
+                            </tr>
+                        {% endfor %}
+                    </table>
+                {% endif %}
+            {% endfor %}
+        </div>
+    {% endfor %}
+
+    <h3>Links:</h3>
+    <ul>
+        <li><a href="{{ job_url }}">Jenkins job</a></li>
+        {% if grafana_screenshots %}
+            {% if grafana_screenshots[0] %}
+                <li><a href={{ grafana_screenshots[0] }}>Download "Per server metrics nemesis" Grafana Screenshot</a></li>
+            {% endif %}
+            {% if grafana_snapshots[1] %}
+                <li><a href={{ grafana_screenshots[1] }}>Download "Overview metrics" Grafana Screenshot</a></li>
+            {% endif %}
+        {% endif %}
+        {% if grafana_snapshots %}
+            {% if grafana_snapshots[0] %}
+                <li><a href={{ grafana_snapshots[0] }}>Shared "Per server metrics nemesis" Grafana Snapshot</a></li>
+            {% endif %}
+            {% if grafana_snapshots[1] %}
+                <li><a href={{ grafana_snapshots[1] }}>Shared "Overview metrics" Grafana Snapshot</a></li>
+            {% endif %}
+        {% endif %}
+    </ul>
+    {% if grafana_screenshots %}
+        <h3>Grafana Screenshot:</h3>
+        {% for screenshot in grafana_screenshots %}
+            <img src="{{ screenshot }}"  height="50%" width="50%">
+        {% endfor %}
+    {% endif %}
+{% endblock %}

--- a/sdcm/results_analyze/__init__.py
+++ b/sdcm/results_analyze/__init__.py
@@ -397,7 +397,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
                        'hits.hits._source.results.throughput',
                        'hits.hits._source.versions']
         tests_filtered = self._es.search(index=self._es_index, q=query, filter_path=filter_path,  # pylint: disable=unexpected-keyword-arg
-                                         size=self._limit)
+                                         size=self._limit, request_timeout=30)
 
         if not tests_filtered:
             self.log.info('Cannot find tests with the same parameters as {}'.format(test_id))

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -423,6 +423,9 @@ class SCTConfiguration(dict):
         dict(name="nemesis_interval", env="SCT_NEMESIS_INTERVAL", type=int,
              help="""Nemesis sleep interval to use if None provided specifically in the test"""),
 
+        dict(name="nemesis_sequence_sleep_between_ops", env="SCT_NEMESIS_SEQUENCE_SLEEP_BETWEEN_OPS", type=int,
+             help="""Sleep interval between nemesis operations for use in unique_sequence nemesis kind of tests"""),
+
         dict(name="nemesis_during_prepare", env="SCT_NEMESIS_DURING_PREPARE", type=boolean,
              help="""Run nemesis during prepare stage of the test"""),
 

--- a/sdcm/utils/es_queries.py
+++ b/sdcm/utils/es_queries.py
@@ -110,8 +110,10 @@ class PerformanceQueryFilter(QueryFilter):
                 break
 
         if not job_filter_query:
-            job_filter_query = r'test_details.job_name.keyword: {} '.format(
-                self.test_doc['_source']['test_details']['job_name'])
+            full_job_name = self.test_doc['_source']['test_details']['job_name']
+            if '/' in full_job_name:
+                full_job_name = f'"{full_job_name}"'
+            job_filter_query = r'test_details.job_name.keyword: {} '.format(full_job_name)
 
         return job_filter_query
 

--- a/sdcm/utils/latency.py
+++ b/sdcm/utils/latency.py
@@ -1,0 +1,117 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2020 ScyllaDB
+
+from sdcm.db_stats import PrometheusDBStats
+
+
+def avg(values):
+    if values:
+        return float(format(sum([float(val) for val in values])/len(values), '.1f'))
+    else:
+        return None
+
+
+def collect_latency(monitor_node, start, end, load_type, cluster, nodes_list):
+    res = dict()
+    prometheus = PrometheusDBStats(host=monitor_node.ip_address)
+    duration = int(end - start)
+    cassandra_stress_precision = ['99', '95']  # in the future should include also 'max'
+    scylla_precision = ['99']  # in the future should include also '95', '5'
+
+    for precision in cassandra_stress_precision:
+        metric = f'c-s {precision}' if precision == 'max' else f'c-s P{precision}'
+        if not precision == 'max':
+            precision = f'perc_{precision}'
+        query = f'collectd_cassandra_stress_{load_type}_gauge{{type="lat_{precision}"}}'
+        query_res = prometheus.query(query, start, end)
+        latency_values_lst = list()
+        for entry in query_res:
+            lat_value = None
+            if not entry['values']:
+                continue
+            sequence = [val[-1] for val in entry['values'] if not val[-1].lower() == 'nan']
+            if all([val == sequence[0] for val in sequence]):
+                continue
+            if precision == 'max':
+                if sequence:
+                    lat_value = max([float(val) for val in sequence])
+            else:
+                lat_value = avg(sequence)
+            latency_values_lst.append(lat_value)
+        if latency_values_lst:
+            res[metric] = format(float(max([float(val) for val in latency_values_lst])), '.2f') if precision == 'max' \
+                else format(float(avg(latency_values_lst)), '.2f')
+
+    for precision in scylla_precision:
+        query = f'histogram_quantile(0.{precision},sum(rate(scylla_storage_proxy_coordinator_{load_type}_' \
+                f'latency_bucket{{}}[{duration}s])) by (instance, le))'
+        query_res = prometheus.query(query, start, end)
+        for entry in query_res:
+            node_ip = entry['metric']['instance'].replace('[', '').replace(']', '')
+            node = cluster.get_node_by_ip(node_ip)
+            if not node:
+                for db_node in nodes_list:
+                    if db_node.ip_address == node_ip:
+                        node = db_node
+            if node:
+                node_idx = node.name.split('-')[-1]
+            else:
+                continue
+            node_name = f'node-{node_idx}'
+            metric = f"Scylla P{precision} - {node_name}"
+            if not entry['values']:
+                continue
+            sequence = [val[-1] for val in entry['values'] if not val[-1].lower() == 'nan']
+            if sequence:
+                res[metric] = format(float(avg(sequence) / 1000), '.2f')
+
+    return res
+
+
+def calculate_latency(latency_results):
+    result_dict = dict()
+    for workload in latency_results.keys():
+        if workload not in result_dict:
+            result_dict[workload] = dict()
+        all_keys = list(latency_results[workload].keys())
+        steady_key = ''
+        if all_keys:
+            steady_key = [key for key in all_keys if 'steady' in key.lower()]
+        if not steady_key or not all_keys:
+            result_dict[workload] = latency_results[workload]
+            continue
+        else:
+            steady_key = all_keys.pop(all_keys.index(steady_key[0]))
+        result_dict[workload][steady_key] = latency_results[workload][steady_key].copy()
+        for key in all_keys:
+            result_dict[workload][key] = latency_results[workload][key].copy()
+            temp_dict = dict()
+            for cycle in latency_results[workload][key]['cycles']:
+                for metric, value in cycle.items():
+                    if metric not in temp_dict:
+                        temp_dict[metric] = list()
+                    temp_dict[metric].append(value)
+            for temp_key, temp_val in temp_dict.items():
+                if 'Cycles Average' not in result_dict[workload][key]:
+                    result_dict[workload][key]['Cycles Average'] = dict()
+                average = format(float(avg(temp_val)), '.2f')
+                result_dict[workload][key]['Cycles Average'][temp_key] = float(f'{average}')
+                if 'Relative to Steady' not in result_dict[workload][key]:
+                    result_dict[workload][key]['Relative to Steady'] = dict()
+                if temp_key in latency_results[workload][steady_key]:
+                    steady_val = float(latency_results[workload][steady_key][temp_key])
+                    if steady_val != 0:
+                        result_dict[workload][key]['Relative to Steady'][temp_key] = \
+                            format((float(average) - steady_val), '.2f')
+
+    return result_dict

--- a/test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml
+++ b/test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml
@@ -1,24 +1,25 @@
-test_duration: 1400
+test_duration: 580
 prepare_write_cmd: ["cassandra-stress write no-warmup cl=ALL n=62500000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..62500000",
                     "cassandra-stress write no-warmup cl=ALL n=62500000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=62500001..125000000",
                     "cassandra-stress write no-warmup cl=ALL n=62500000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=125000001..187500000",
                     "cassandra-stress write no-warmup cl=ALL n=62500000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=187500001..250000000"]
 
-stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=700m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=50 throttle=5000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..250000000,125000000,12500000)' "
-stress_cmd_r: "cassandra-stress read no-warmup  cl=QUORUM duration=700m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=50 throttle=4000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..250000000,125000000,12500000)' "
-stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=700m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=50 throttle=3500/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..250000000,125000000,12500000)' "
+stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=250m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=50 throttle=5000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..250000000,125000000,12500000)' "
+stress_cmd_r: "cassandra-stress read no-warmup  cl=QUORUM duration=250m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=50 throttle=4000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..250000000,125000000,12500000)' "
+stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=250m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=50 throttle=3500/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..250000000,125000000,12500000)' "
 
 n_db_nodes: 3
 nemesis_add_node_cnt: 3
 n_loaders: 4
 n_monitor_nodes: 1
 
-instance_type_loader: 'c4.2xlarge'
+instance_type_loader: 'c5.2xlarge'
 instance_type_monitor: 't3.large'
 instance_type_db: 'i3.2xlarge'
 
 nemesis_class_name: 'NemesisSequence'
 nemesis_interval: 30
+nemesis_sequence_sleep_between_ops: 10
 
 user_prefix: 'perf-latency-nemesis'
 space_node_threshold: 644245094
@@ -32,4 +33,4 @@ use_mgmt: true
 
 store_perf_results: true
 send_email: true
-email_recipients: ['scylla-perf-results@scylladb.com']
+email_recipients: ["scylla-perf-results@scylladb.com"]


### PR DESCRIPTION
Added a function that will calculate all the performance
latency we want to show.
Created a decorator, and added it to the parts of the
nemesis we want to measure the latencies.
Few of those parts were added to local functions
created inside their own nemesis functions.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
