### PR TITLE
fix(longevity-in-memory): fix "Multiple definition for property 'compaction' " error

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1439,7 +1439,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             # will default to lz4 compression
             query += ' AND compression = {}'
 
-        if compaction is not None or sstable_size:
+        if not in_memory and (compaction is not None or sstable_size):
             compaction = compaction or self.params.get('compaction_strategy')
             prefix = ' AND compaction={'
             postfix = '}'
@@ -2086,7 +2086,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         assert res, "No results from Prometheus"
         used = int(res[0]["values"][0][1]) / (2 ** 10)
         assert used >= size, f"Waiting for Scylla data dir to reach '{size}', " \
-                             f"current size is: '{used}'"
+            f"current size is: '{used}'"
 
     def check_regression(self):
         results_analyzer = PerformanceResultsAnalyzer(es_index=self._test_index, es_doc_type=self._es_doc_type,


### PR DESCRIPTION
longevity-in-memory test failed with error "Multiple definition for property 'compaction'".
The issue is that there is a default value for compaction_strategy parameter.
So when the table is created, this default compaction_strategy will be defined for the table.
In case of in-memory test 'InMemoryCompactionStrategy' compaction strategy will be additionally defined.
It fails the test.

It's urgent commit as I can't run in-memory test with 2020.1

Tested in the staging, on 2 jobs:
[longevity-in-memory-36gb-1d-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/yulia/job/longevity-in-memory-36gb-1d-test/1/)
[longevity-100gb-4h-test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/yulia/job/longevity-100gb-4h-test/1/)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
