### PR TITLE
fix(aborting on shard): add new database log event for aborting on shard

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -396,6 +396,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             DatabaseLogEvent(type='FILESYSTEM_ERROR', regex='filesystem_error'),
             DatabaseLogEvent(type='STACKTRACE', regex='stacktrace'),
             DatabaseLogEvent(type='BACKTRACE', regex='backtrace', severity=Severity.ERROR),
+            DatabaseLogEvent(type='ABORTING_ON_SHARD', regex='Aborting on shard'),
             DatabaseLogEvent(type='SEGMENTATION', regex='segmentation'),
             DatabaseLogEvent(type='INTEGRITY_CHECK', regex='integrity check failed'),
             DatabaseLogEvent(type='REACTOR_STALLED', regex='Reactor stalled', severity=Severity.WARNING),


### PR DESCRIPTION
As 'Aborting on shard' is severe event, it should be helpfull to
add new database log event for it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
