### PR TITLE
feature(defaults/aws_config): increase root disk size of aws instance

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -26,7 +26,7 @@ regions_data:
 
 
 aws_root_disk_size_monitor: 50  # GB, remove this field if default disk size should be used
-aws_root_disk_size_db: 15
+aws_root_disk_size_db: 30  # GB, increase root disk for larger swap (maximum: 16G)
 aws_root_disk_size_loader: 30  # GB, Increase loader disk in order to have extra space for a larger swap
 loader_swap_size: 10240  #10GB SWAP space
 ami_db_scylla_user: 'centos'


### PR DESCRIPTION
Scylla_setup added support of swap setup, the maximum swap is 16G.
Current default root disk isn't enough.

The default disk size of GCE is 50G, and we don't use large GCE instance
in our test. So current value is fine.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
