### PR TITLE
fix(in memory cs): InMemoryCompactionStrategy is missed in the compaction strategy enum

### DIFF
--- a/test_lib/compaction.py
+++ b/test_lib/compaction.py
@@ -12,6 +12,7 @@ class CompactionStrategy(Enum):
     SIZE_TIERED = "SizeTieredCompactionStrategy"
     TIME_WINDOW = "TimeWindowCompactionStrategy"
     INCREMENTAL = "IncrementalCompactionStrategy"
+    IN_MEMORY = "InMemoryCompactionStrategy"
 
     @classmethod
     def from_str(cls, output_str):


### PR DESCRIPTION
Test longevity-in-memory-36gb-1d-test failed in the branch-2020.1 with error:
ValueError: 'InMemoryCompactionStrategy' is not a valid CompactionStrategy
during the nemesis ToggleTableICS due to InMemoryCompactionStrategy is missed
in the compaction strategy enum.
Add this cs to enum

I need this commit is merged urgent because of the  longevity-in-memory-36gb-1d-test can'r be competed in branch-2020.1

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
