### PR TITLE
fix(sdcm/remote/libssh2_client): Fix memory leaking on reconnect

### DIFF
--- a/sdcm/remote/libssh2_client/session.py
+++ b/sdcm/remote/libssh2_client/session.py
@@ -72,8 +72,18 @@ class Session(LibSSH2Session):  # pylint: disable=too-few-public-methods
     def drop_channel(self, channel: Channel):
         if channel in self.channels:
             self.channels.remove(channel)
+        try:
+            channel.close()
+        except:
+            pass
+        try:
+            channel.wait_closed()
+        except:  # pylint: disable=bare-except
+            pass
+        del channel
 
     def __del__(self):
         if self.channels:
-            self.channels.clear()
+            while self.channels:
+                self.drop_channel(self.channels.pop())
             gc_collect()


### PR DESCRIPTION
Currently libssh2_client leaking memory on reconnect.
It comes from using multiprocessing classes in auxiliary threads.  

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
