### PR TITLE
fix(sdcm/cluster.py): stop using new_session

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -846,7 +846,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         """
         try:
             backtrace_cmd = f'sudo coredumpctl info --no-pager --no-legend {pid}'
-            return self.remoter.run(backtrace_cmd, verbose=False, ignore_status=True, new_session=True)
+            return self.remoter.run(backtrace_cmd, verbose=False, ignore_status=True)
         except NETWORK_EXCEPTIONS:  # pylint: disable=try-except-raise
             raise
         except Exception as details:  # pylint: disable=broad-except
@@ -990,8 +990,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
     @retrying(n=10, sleep_time=20, allowed_exceptions=NETWORK_EXCEPTIONS, message="Retrying on getting pid of cores")
     def _get_core_pids(self):
-        result = self.remoter.run('sudo coredumpctl --no-pager --no-legend 2>&1',
-                                  verbose=False, ignore_status=True, new_session=True)
+        result = self.remoter.run('sudo coredumpctl --no-pager --no-legend 2>&1', verbose=False, ignore_status=True)
         if "No coredumps found" in result.stdout or result.exit_status == 127:  # exit_status 127: coredumpctl command not found
             return None
         pids_list = []


### PR DESCRIPTION
  After https://github.com/scylladb/scylla-cluster-tests/pull/2422
  new_session parameter is not needed, since every thread has it's own connection instance

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
