### PR TITLE
fix(sdcm/remote): Privatize reconnect

### DIFF
--- a/sdcm/cluster_k8s.py
+++ b/sdcm/cluster_k8s.py
@@ -189,7 +189,7 @@ class GceMinikubeCluster(MinikubeCluster, cluster_gce.GCECluster):
     @cluster.wait_for_init_wrap
     def wait_for_init(self):
         for node in self.nodes:
-            node.remoter.reconnect()  # Reconnect to update user groups in main thread too.
+            node.remoter._reconnect()  # Reconnect to update user groups in main thread too.
 
     def get_node_ips_param(self, public_ip=True):
         raise NotImplementedError("Not implemented yet.")  # TODO: add implementation of this method

--- a/sdcm/remote/remote_base.py
+++ b/sdcm/remote/remote_base.py
@@ -136,10 +136,11 @@ class RemoteCmdRunnerBase(CommandRunner):  # pylint: disable=too-many-instance-a
         self.stop()
 
     @retrying(n=5, sleep_time=1, allowed_exceptions=(Exception,), message="Reconnecting")
-    def reconnect(self):
+    def _reconnect(self):
         """
-            Use with caution!!! This method forcefully disconnects the SSH session so the commands may stay
-            running on the remote
+            Close and reopen connection to the remote endpoint.
+            It is done only for connection specific for given thread.
+            Connections for other threads are not affected.
         """
         self.log.debug("Reconnecting to '%s'", self.hostname)
         self._close_connection()

--- a/sdcm/report_templates/results_aborted.html
+++ b/sdcm/report_templates/results_aborted.html
@@ -2,4 +2,3 @@
 
 {% block events_summary %}
 {% endblock %}
-

--- a/unit_tests/test_remoter.py
+++ b/unit_tests/test_remoter.py
@@ -43,7 +43,7 @@ class TestRemoteCmdRunners(unittest.TestCase):
         except Exception as exc:  # pylint: disable=broad-except
             result = exc
         paramiko_thread_results.append(result)
-        remoter.reconnect()
+        remoter._reconnect()
         try:
             result = remoter.run(stmt, **kwargs)
         except Exception as exc:  # pylint: disable=broad-except
@@ -58,7 +58,7 @@ class TestRemoteCmdRunners(unittest.TestCase):
         except Exception as exc:  # pylint: disable=broad-except
             result = exc
         paramiko_thread_results.append(result)
-        remoter.reconnect()
+        remoter._reconnect()
         try:
             result = remoter.run(stmt, **kwargs)
         except Exception as exc:  # pylint: disable=broad-except
@@ -138,7 +138,7 @@ class TestRemoteCmdRunners(unittest.TestCase):
             paramiko_result = remoter.run(stmt, **kwargs)
         except Exception as exc:  # pylint: disable=broad-except
             paramiko_result = exc
-        remoter.reconnect()
+        remoter._reconnect()
         try:
             paramiko_result2 = remoter.run(stmt, **kwargs)
         except Exception as exc:  # pylint: disable=broad-except
@@ -151,7 +151,7 @@ class TestRemoteCmdRunners(unittest.TestCase):
             lib2ssh_result = remoter.run(stmt, **kwargs)
         except Exception as exc:  # pylint: disable=broad-except
             lib2ssh_result = exc
-        remoter.reconnect()
+        remoter._reconnect()
         try:
             lib2ssh_result2 = remoter.run(stmt, **kwargs)
         except Exception as exc:  # pylint: disable=broad-except


### PR DESCRIPTION
  Reconnect is not intended for common use,
    it is supposed that remoter handle connection issues within itself.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
