### PR TITLE
fix(lwt test): fix issue when lwt longevities consume all memory

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1717,8 +1717,19 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
             session.default_consistency_level = ConsistencyLevel.QUORUM
 
-            execute_concurrent_with_args(session=session, statement=insert_statement, parameters=source_table_rows,
-                                         concurrency=max_workers)
+            results = execute_concurrent_with_args(session=session, statement=insert_statement, parameters=source_table_rows,
+                                                   concurrency=max_workers, results_generator=True)
+
+            try:
+                succeeded_rows = sum(1 for (success, result) in results if success)
+                if succeeded_rows != len(source_table_rows):
+                    self. log.warning(f'Problem during copying data. Not all rows were inserted.'
+                                      f'Rows expected to be inserted: {len(source_table_rows)}; '
+                                      f'Actually inserted rows: {succeeded_rows}.')
+                    return False
+            except Exception as exc:
+                self.log.warning(f'Problem during copying data: {exc}')
+                return False
 
             result = session.execute(f"SELECT count(*) FROM {dest_keyspace}.{dest_table}")
             if result:


### PR DESCRIPTION
Sometimes longevities eats all memory available and hungs.
Source of problem is using execute_concurrent_with_args.
For each row it creates, beside response it self,  structure that
holds ResponseFuture, that holds whole bunch of information, multiplying
memory consumption.
To prevent it return execution result as generator and not as full
recordset.

[Task](https://trello.com/c/HR8gwZah/2116-investigate-and-fix-issue-when-lwt-longevities-consume-all-memory)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
