### PR TITLE
fix(sdcm/): Get rid of search_system_log

### DIFF
--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -81,31 +81,18 @@ class TestBaseNode(unittest.TestCase):
         self.node.system_log = os.path.join(os.path.dirname(__file__), 'test_data', 'system.log')
 
     def test_search_system_log(self):
-        critical_errors = self.node.search_system_log()
-        self.assertEqual(len(critical_errors), 34)
-
-        for _, line in critical_errors:
-            print(line)
-
-    def test_search_system_log_teardown(self):  # pylint: disable=invalid-name
-        critical_errors = self.node.search_system_log(start_from_beginning=True, publish_events=False)
-        self.assertEqual(len(critical_errors), 36)
-
-        for _, line in critical_errors:
-            print(line)
+        critical_errors = list(self.node.follow_system_log(start_from_beginning=True))
+        self.assertEqual(36, len(critical_errors))
 
     def test_search_system_log_specific_log(self):  # pylint: disable=invalid-name
-        errors = self.node.search_system_log(
-            search_pattern='Failed to load schema version', start_from_beginning=True, publish_events=False)
+        errors = list(self.node.follow_system_log(
+            patterns=['Failed to load schema version'], start_from_beginning=True))
         self.assertEqual(len(errors), 2)
-
-        for line_number, line in errors:
-            print(line_number, line)
 
     def test_search_system_interlace_reactor_stall(self):  # pylint: disable=invalid-name
         self.node.system_log = os.path.join(os.path.dirname(__file__), 'test_data', 'system_interlace_stall.log')
 
-        _ = self.node.search_system_log()
+        self.node._read_system_log_and_publish_events()
 
         events_file = open(EVENTS_PROCESSES['MainDevice'].raw_events_filename, 'r')
         events = []
@@ -126,7 +113,7 @@ class TestBaseNode(unittest.TestCase):
         self.node.system_log = os.path.join(os.path.dirname(
             __file__), 'test_data', 'system_suppressed_messages.log')
 
-        _ = self.node.search_system_log(start_from_beginning=True)
+        self.node._read_system_log_and_publish_events(start_from_beginning=True)
 
         events_file = open(EVENTS_PROCESSES['MainDevice'].raw_events_filename, 'r')
 

--- a/unit_tests/test_decode_backtrace.py
+++ b/unit_tests/test_decode_backtrace.py
@@ -58,7 +58,7 @@ class TestDecodeBactraces(unittest.TestCase):
         Setup.BACKTRACE_DECODING = False
 
         self.monitor_node.start_decode_on_monitor_node_thread()
-        _ = self.node.search_system_log()
+        self.node._read_system_log_and_publish_events()
         self.monitor_node.termination_event.set()
         self.monitor_node.stop_task_threads()
 
@@ -78,7 +78,7 @@ class TestDecodeBactraces(unittest.TestCase):
         Setup.DECODING_QUEUE = queue.Queue()
 
         self.monitor_node.start_decode_on_monitor_node_thread()
-        _ = self.node.search_system_log()
+        self.node._read_system_log_and_publish_events()
 
         self.monitor_node.termination_event.set()
         self.monitor_node.stop_task_threads()
@@ -102,7 +102,7 @@ class TestDecodeBactraces(unittest.TestCase):
         self.monitor_node.start_decode_on_monitor_node_thread()
         self.node.system_log = os.path.join(os.path.dirname(__file__), 'test_data', 'system_interlace_stall.log')
 
-        _ = self.node.search_system_log()
+        self.node._read_system_log_and_publish_events()
 
         self.monitor_node.termination_event.set()
         self.monitor_node.stop_task_threads()
@@ -125,7 +125,7 @@ class TestDecodeBactraces(unittest.TestCase):
         self.monitor_node.start_decode_on_monitor_node_thread()
         self.node.system_log = os.path.join(os.path.dirname(__file__), 'test_data', 'system_core.log')
 
-        _ = self.node.search_system_log()
+        self.node._read_system_log_and_publish_events()
 
         self.monitor_node.termination_event.set()
         self.monitor_node.stop_task_threads()

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -426,9 +426,7 @@ class UpgradeTest(FillDatabaseData):
     # @staticmethod
     def search_for_idx_token_error_after_upgrade(self, node, step):
         self.log.debug('Search for idx_token error. Step {}'.format(step))
-        idx_token_error = node.search_system_log(
-            search_pattern='idx_token',
-            start_from_beginning=True)
+        idx_token_error = list(node.follow_system_log(patterns=['idx_token'], start_from_beginning=True))
         if idx_token_error:
             IndexSpecialColumnErrorEvent('Node: %s. Step: %s. '
                                          'Found error: index special column "idx_token" is not recognized' %
@@ -670,9 +668,7 @@ class UpgradeTest(FillDatabaseData):
     def count_log_errors(self, search_pattern, step, search_for_idx_token_error=True):
         schema_load_error_num = 0
         for node in self.db_cluster.nodes:
-            errors = node.search_system_log(search_pattern=search_pattern,
-                                            start_from_beginning=True,
-                                            publish_events=False)
+            errors = list(node.follow_system_log(patterns=[search_pattern], start_from_beginning=True))
             schema_load_error_num += len(errors)
             if search_for_idx_token_error:
                 self.search_for_idx_token_error_after_upgrade(node=node, step=step)


### PR DESCRIPTION
https://trello.com/c/6r7p9dLh/2129-dont-use-searchsystemlog-function-with-startfrombeginningfalse-in-the-nemesises-or-other-function-except-of-events

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
