### PR TITLE
fix(sct_config): aws-siren wasn't working since sct-runner changes

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1004,9 +1004,8 @@ class SCTConfiguration(dict):
 
         'baremetal': ['db_nodes_private_ip', 'db_nodes_public_ip', 'user_credentials_path'],
 
-        'aws-siren': ["user_prefix", "instance_type_loader", "region_name", "security_group_ids", "subnet_id",
-                      "cloud_credentials_path", "authenticator_user", "authenticator_password", "cloud_cluster_id",
-                      "nemesis_filter_seeds"],
+        'aws-siren': ["user_prefix", "instance_type_loader", "region_name", "cloud_credentials_path",
+                      "authenticator_user", "authenticator_password", "cloud_cluster_id", "nemesis_filter_seeds"],
 
         'k8s-gce-minikube': ['gce_image_minikube', 'gce_instance_type_minikube', 'gce_root_disk_type_minikube',
                              'gce_root_disk_size_minikube', 'user_credentials_path', 'scylla_version',

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -698,7 +698,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         ec2_security_group_ids = []
         ec2_subnet_ids = []
         cluster_backend = self.params.get('cluster_backend')
-        if cluster_backend == "aws":
+        if "aws" in cluster_backend:
             availability_zone = self.params.get("availability_zone")
             for region in regions:
                 aws_region = AwsRegion(region_name=region)


### PR DESCRIPTION
some configuration were removed, and need to be removed also
from `aws-siren` backend

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
