### PR TITLE
Hydra SCT runner gid fix

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -133,6 +133,11 @@ if [[ ${subcommand} == "--execute-on-runner" ]]; then
         fi
         SCT_DIR="/home/ubuntu/scylla-cluster-tests"
         USER_ID=1000
+        group_args=()
+        for gid in $(ssh -o StrictHostKeyChecking=no ubuntu@${SCT_RUNNER_IP} id -G); do
+           group_args+=(--group-add "$gid")
+        done
+
         DOCKER_HOST="-H ssh://ubuntu@${SCT_RUNNER_IP}"
         CMD=${@:3}
         subcommand=$CMD

--- a/sct.py
+++ b/sct.py
@@ -742,7 +742,7 @@ def create_runner_instance(cloud_provider, region, availability_zone, test_id, d
     instance = sct_runner.create_instance(test_id=test_id, test_duration=duration, region_az=region + availability_zone)
     LOGGER.info("Verifying SSH connectivity...")
     remoter = sct_runner.get_remoter(host=instance.public_ip_address)
-    result = remoter.run("true", timeout=60, verbose=False, ignore_status=True)
+    result = remoter.run("true", timeout=100, verbose=False, ignore_status=True)
     if result.exit_status == 0:
         LOGGER.info(f"Successfully connected the SCT Runner. Public IP:  {instance.public_ip_address}")
         with sct_runner_ip_path.open("w") as sct_runner_ip_file:


### PR DESCRIPTION
When running on SCT  Runner the Group ids that is passed to Hydra container should be the same as in the SCT Runner
## PR pre-checks (self revew)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
