### PR TITLE
fix(rollingupgradepipeline): preventing null values for internode_compression

### DIFF
--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -91,7 +91,9 @@ def call(Map pipelineParams) {
                                                         export SCT_AMI_ID_DB_SCYLLA_DESC="\$SCT_AMI_ID_DB_SCYLLA_DESC-\$SCT_SCYLLA_LINUX_DISTRO"
 
                                                         export SCT_WORKAROUND_KERNEL_BUG_FOR_IOTUNE=${pipelineParams.workaround_kernel_bug_for_iotune}
-                                                        export SCT_INTERNODE_COMPRESSION=${pipelineParams.internode_compression}
+                                                        if [[ ${pipelineParams.internode_compression} != null ]] ; then
+                                                            export SCT_INTERNODE_COMPRESSION=${pipelineParams.internode_compression}
+                                                        fi
 
                                                         echo "start test ......."
                                                         ./docker/env/hydra.sh run-test ${pipelineParams.test_name} --backend ${params.backend}  --logdir "`pwd`"


### PR DESCRIPTION
This fix prevents assigning null value to SCT_INTERNODE_COMPRESSION 
previously we where exporting null and that caused some issues with the rolling upgrades because SCT_INTERNODE_COMPRESSION=null is not supported 

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
