### PR TITLE
improvement(sct_events.py): Creating one place for  all SCT events

### DIFF
--- a/cdc_replication_test.py
+++ b/cdc_replication_test.py
@@ -94,13 +94,13 @@ class CDCReplicationTest(ClusterTester):
         self.log.info('Starting stressor.')
         if is_gemini_test:
             stress_thread = GeminiStressThread(
-                    test_cluster=self.db_cluster,
-                    oracle_cluster=None,
-                    loaders=self.loaders,
-                    gemini_cmd=self.params.get('gemini_cmd'),
-                    timeout=self.get_duration(None),
-                    outputdir=self.loaders.logdir,
-                    params=self.params).run()
+                test_cluster=self.db_cluster,
+                oracle_cluster=None,
+                loaders=self.loaders,
+                gemini_cmd=self.params.get('gemini_cmd'),
+                timeout=self.get_duration(None),
+                outputdir=self.loaders.logdir,
+                params=self.params).run()
         else:
             stress_thread = self.run_stress_cassandra_thread(stress_cmd=self.params.get('stress_cmd'))
 

--- a/performance_regression_alternator_test.py
+++ b/performance_regression_alternator_test.py
@@ -15,7 +15,7 @@ import contextlib
 
 from performance_regression_test import PerformanceRegressionTest
 from sdcm.utils import alternator
-from sdcm.sct_events import Severity, EventsSeverityChangerFilter, DatabaseLogEvent
+from sdcm.sct_events import ReduceToWarningEvents, EventsFilter
 
 
 class PerformanceRegressionAlternatorTest(PerformanceRegressionTest):
@@ -25,10 +25,11 @@ class PerformanceRegressionAlternatorTest(PerformanceRegressionTest):
         # suppress YCSB client error and timeout to warnings for all the test in this class
         self.stack = contextlib.ExitStack()
         self.stack.enter_context(alternator.api.ignore_alternator_client_errors())
-        self.stack.enter_context(EventsSeverityChangerFilter(event_class=DatabaseLogEvent, regex=r".*Operation timed out.*",
-                                                             severity=Severity.WARNING, extra_time_to_expiration=30))
-        self.stack.enter_context(EventsSeverityChangerFilter(event_class=DatabaseLogEvent, regex=r'.*Operation failed for system.paxos.*',
-                                                             severity=Severity.WARNING, extra_time_to_expiration=30))
+
+        self.stack.enter_context(EventsFilter(
+            ReduceToWarningEvents.OPERATION_TIMED_OUT, extra_time_to_expiration=30, is_reduce_event=True))
+        self.stack.enter_context(EventsFilter(
+            ReduceToWarningEvents.PAXOS_OPERATION_FAILED, extra_time_to_expiration=30, is_reduce_event=True))
 
     def _workload(self, stress_cmd, stress_num, test_name=None, sub_type=None, keyspace_num=1, prefix='', debug_message='',  # pylint: disable=too-many-arguments,arguments-differ
                   save_stats=True, is_alternator=True):

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -24,7 +24,7 @@ from sdcm import ec2_client
 from sdcm.cluster import INSTANCE_PROVISION_ON_DEMAND
 from sdcm.utils.common import list_instances_aws, get_ami_tags, ec2_instance_wait_public_ip
 from sdcm.utils.decorators import retrying
-from sdcm.sct_events import SpotTerminationEvent, DbEventsFilter
+from sdcm.sct_events import SpotTerminationEvent, DbEventsFilter, DbEvents
 from sdcm import wait
 from sdcm.remote import LocalCmdRunner, NETWORK_EXCEPTIONS
 
@@ -586,11 +586,11 @@ class AWSNode(cluster.BaseNode):
         event_filters = ()
         if any(ss in self._instance.instance_type for ss in ['i3', 'i2']):
             # since there's no disk yet in those type, lots of the errors here are acceptable, and we'll ignore them
-            event_filters = DbEventsFilter(type="DATABASE_ERROR", node=self), \
-                DbEventsFilter(type="SCHEMA_FAILURE", node=self), \
-                DbEventsFilter(type="NO_SPACE_ERROR", node=self), \
-                DbEventsFilter(type="FILESYSTEM_ERROR", node=self), \
-                DbEventsFilter(type="RUNTIME_ERROR", node=self)
+            event_filters = DbEventsFilter(DbEvents.DATABASE_ERRORS, node=self), \
+                DbEventsFilter(DbEvents.SCHEMA_FAILURES, node=self), \
+                DbEventsFilter(DbEvents.NO_SPACE_ERRORS, node=self), \
+                DbEventsFilter(DbEvents.FILESYSTEM_ERRORS, node=self), \
+                DbEventsFilter(DbEvents.RUNTIME_ERRORS, node=self)
 
             clean_script = dedent("""
                 sudo sed -e '/.*scylla/s/^/#/g' -i /etc/fstab

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -378,4 +378,4 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main(verbosity=2)

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -24,7 +24,7 @@ from pkg_resources import parse_version
 from sdcm.fill_db_data import FillDatabaseData
 from sdcm import wait
 from sdcm.utils.version_utils import is_enterprise
-from sdcm.sct_events import DbEventsFilter, IndexSpecialColumnErrorEvent
+from sdcm.sct_events import DbEventsFilter, IndexSpecialColumnErrorEvent, DbEvents
 
 
 def truncate_entries(func):
@@ -490,10 +490,10 @@ class UpgradeTest(FillDatabaseData):
         self.log.info('Sleeping for 60s to let cassandra-stress start before the upgrade...')
         time.sleep(60)
 
-        with DbEventsFilter(type='DATABASE_ERROR', line='Failed to load schema'), \
-                DbEventsFilter(type='SCHEMA_FAILURE', line='Failed to load schema'), \
-                DbEventsFilter(type='DATABASE_ERROR', line='Failed to pull schema'), \
-                DbEventsFilter(type='RUNTIME_ERROR', line='Failed to load schema'):
+        with DbEventsFilter(DbEvents.DATABASE_ERROR__LOAD_SCHEMA_FAILED), \
+                DbEventsFilter(DbEvents.SCHEMA_FAILURE__LOAD_SCHEMA_FAILED), \
+                DbEventsFilter(DbEvents.DATABASE_ERROR__LOAD_SCHEMA_FAILED), \
+                DbEventsFilter(DbEvents.RUNTIME_ERROR__LOAD_SCHEMA_FAILED):
 
             step = 'Step1 - Upgrade First Node '
             self.log.info(step)
@@ -562,10 +562,10 @@ class UpgradeTest(FillDatabaseData):
         self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
                                                       step=step)
 
-        with DbEventsFilter(type='DATABASE_ERROR', line='Failed to load schema'), \
-                DbEventsFilter(type='SCHEMA_FAILURE', line='Failed to load schema'), \
-                DbEventsFilter(type='DATABASE_ERROR', line='Failed to pull schema'), \
-                DbEventsFilter(type='RUNTIME_ERROR', line='Failed to load schema'):
+        with DbEventsFilter(DbEvents.DATABASE_ERROR__LOAD_SCHEMA_FAILED), \
+                DbEventsFilter(DbEvents.SCHEMA_FAILURE__LOAD_SCHEMA_FAILED), \
+                DbEventsFilter(DbEvents.DATABASE_ERROR__LOAD_SCHEMA_FAILED), \
+                DbEventsFilter(DbEvents.RUNTIME_ERROR__LOAD_SCHEMA_FAILED):
 
             step = 'Step5 - Upgrade rest of the Nodes '
             self.log.info(step)


### PR DESCRIPTION
* Trello - https://trello.com/c/V3Ca21uD
   Trello description:
   Same filterd events are used for common actions.
   Need to find a way to group them in one file under the same Object
   Example:
   ```
     with DbEventsFilter(type='DATABASE_ERROR', line="repair's stream failed: streaming::stream_exception",
                    node=self.target_node), \
        DbEventsFilter(type='RUNTIME_ERROR', line='Can not find stream_manager', node=self.target_node), \
        DbEventsFilter(type='RUNTIME_ERROR', line='is aborted', node=self.target_node), \
        DbEventsFilter(type='RUNTIME_ERROR', line='Failed to repair', node=self.target_node):
   ```
* BasicSeverityEvent - Create DummyEvent namedtuple for tests
* SeverityEvent - Create SeverityEvent namedtuple for events with severity
* DbEventType - Create one place with all Database events type
* DbEvent - Create enum for each Cassandra event
* DbEventsFilter - Improvement DbEventsFilter class to support all events
* DummyEventsFilter - Create enum for each dummy event (event_class and regex) for tests
* SeverityEvents - Create enum for each severity (include Alternator) events
* EventsFilter - Improvement EventsFilter class to supported all Scylla events. Create 3 events types.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
