### PR TITLE
improvement(cluster): filter out unknown args from append_scylla_args

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -63,6 +63,8 @@ from sdcm.utils.auto_ssh import AutoSshContainerMixin
 from sdcm.utils.rsyslog import RSYSLOG_SSH_TUNNEL_LOCAL_PORT
 from sdcm.logcollector import GrafanaSnapshot, GrafanaScreenShot, PrometheusSnapshots, MonitoringStack
 from sdcm.utils.remote_logger import get_system_logging_thread
+from sdcm.utils.scylla_args import ScyllaArgParser
+
 
 CREDENTIALS = []
 DEFAULT_USER_PREFIX = getpass.getuser()
@@ -1827,6 +1829,11 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         self.remoter.run('sudo mv /tmp/scylla.yaml {}'.format(yaml_file))
 
         if append_scylla_args:
+            scylla_help = self.remoter.run("scylla --help", ignore_status=True).stdout
+            scylla_arg_parser = ScyllaArgParser.from_scylla_help(scylla_help)
+            append_scylla_args = scylla_arg_parser.filter_args(append_scylla_args)
+            self.log.debug("Append following args to scylla: `%s'", append_scylla_args)
+
             if self.is_rhel_like():
                 result = self.remoter.run("sudo grep '\\%s' /etc/sysconfig/scylla-server" %
                                           append_scylla_args, ignore_status=True)

--- a/sdcm/utils/scylla_args.py
+++ b/sdcm/utils/scylla_args.py
@@ -1,0 +1,63 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2020 ScyllaDB
+
+import re
+import logging
+import argparse
+from typing import Text, NoReturn
+
+
+# Regexp for parsing arguments from the output of `scylla --help' command:
+# $ scylla --help
+# ...
+#   -h [ --help ]                         show help message
+#   --version                             print version number and exit
+#   --options-file arg                    configuration file (i.e.
+# ...
+#   -W [ --workdir ] arg                  The directory in which Scylla will put
+# ...
+SCYLLA_ARG = \
+    re.compile(r"^  (?:(?:(?P<short_arg>-\w) \[ (?P<long_arg>--[\w-]+) \])|(?P<arg>--[\w-]+))(?P<val> arg)?", re.M)
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ScyllaArgError(Exception):
+    pass
+
+
+class ScyllaArgParser(argparse.ArgumentParser):
+    def __init__(self, prog: str) -> None:
+        super().__init__(prog=prog, argument_default=argparse.SUPPRESS, add_help=False)
+
+    def error(self, message: Text) -> NoReturn:
+        LOGGER.error(message)
+        raise ScyllaArgError(message)
+
+    @classmethod
+    def from_scylla_help(cls, help: Text) -> "ScyllaArgParser":
+        parser = cls(prog="scylla")
+        for *args, val in SCYLLA_ARG.findall(help):
+            parser.add_argument(*filter(bool, args), action="store" if val else "store_false")
+        return parser
+
+    def filter_args(self, args: str) -> str:
+        parsed_args, unknown_args = self.parse_known_args(args.split())
+        if unknown_args:
+            LOGGER.warning("Following arguments are filtered out: %s", unknown_args)
+        filtered_args = []
+        for arg, val in vars(parsed_args).items():
+            filtered_args.append(f"--{arg.replace('_', '-')}")
+            if val:
+                filtered_args.append(val)
+        return " ".join(filtered_args)

--- a/unit_tests/test_utils_scylla_args.py
+++ b/unit_tests/test_utils_scylla_args.py
@@ -1,0 +1,48 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2020 ScyllaDB
+
+import unittest
+
+from sdcm.utils.scylla_args import ScyllaArgParser, ScyllaArgError
+
+
+SCYLLA_HELP_EXAMPLE = """\
+Scylla version 4.0.0-0.20200505.d95aa77b62 with build-id c9cf14d33523aca01a1ba502a91eb9d400de9c34 starting ...
+command used: "/usr/bin/scylla --help"
+parsed command line options: [help]
+Scylla options:
+  -h [ --help ]                         show help message
+  --version                             print version number and exit
+  --options-file arg                    configuration file (i.e.
+                                        <SCYLLA_HOME>/conf/scylla.yaml)
+  -W [ --workdir ] arg                  The directory in which Scylla will put
+                                        all its subdirectories. The location of
+                                        individual subdirs can be overriden by
+                                        the respective *_directory options.
+"""
+
+
+class TestScyllaArgParser(unittest.TestCase):
+    def setUp(self):
+        self.parser = ScyllaArgParser.from_scylla_help(SCYLLA_HELP_EXAMPLE)
+
+    def test_filter_args(self):
+        self.assertEqual(self.parser.filter_args("--arg1 arg --version -W arg --arg2 -h --options-file arg"),
+                         "--version --workdir arg --help --options-file arg")
+
+    def test_filter_args_unchanged(self):
+        args = "--version --workdir arg --help --options-file arg"
+        self.assertEqual(self.parser.filter_args(args), args)
+
+    def test_wrong_known_arg(self):
+        self.assertRaises(ScyllaArgError, self.parser.filter_args, "-W --arg arg --arg2")


### PR DESCRIPTION
Trello: https://trello.com/c/Ac6Z78GO/1740-support-scylla-flags-with-backward-compatbility

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
