### PR TITLE
fix(wait for schema agreement): wait for schema agreement on all nodes after schema change

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -52,7 +52,7 @@ from sdcm.utils.distro import Distro
 from sdcm.utils.docker_utils import ContainerManager, NotFound
 
 from sdcm.utils.health_checker import check_nodes_status, check_node_status_in_gossip_and_nodetool_status, \
-    check_schema_version, check_nulls_in_peers
+    check_schema_version, check_nulls_in_peers, check_schema_agreement_in_gossip_and_peers
 from sdcm.utils.decorators import retrying, log_run_info
 from sdcm.utils.get_username import get_username
 from sdcm.utils.remotewebbrowser import WebDriverContainerMixin
@@ -3362,6 +3362,14 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                             for node in nodes_running_nemesis)
         ClusterHealthValidatorEvent(type='warning', name='NodesNemesis', status=Severity.WARNING,
                                     message=f"There are more then expected nodes running nemesis: {message}")
+
+    @retrying(n=6, sleep_time=10, allowed_exceptions=(AssertionError,))
+    def wait_for_schema_agreement(self):
+
+        for node in self.nodes:
+            assert check_schema_agreement_in_gossip_and_peers(node), 'Schema agreement is not reached'
+        self.log.debug('Schema agreement is reached')
+        return True
 
     def check_nodes_up_and_normal(self, nodes=None, verification_node=None):
         """Checks via nodetool that node joined the cluster and reached 'UN' state"""

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1192,6 +1192,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 raise UnsupportedNemesis("for this nemesis to work, you need ICS supported scylla version.")
             raise unexpected_exit
 
+        self.cluster.wait_for_schema_agreement()
+
     def modify_table_compaction(self):
         """
             The compaction property defines the compaction strategy class for this table.

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1038,6 +1038,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             # Configure encryption at-rest for all test tables, sleep a while to wait the workload starts and test tables are created
             time.sleep(60)
             self.alter_test_tables_encryption(scylla_encryption_options=scylla_encryption_options)
+            self.db_cluster.wait_for_schema_agreement()
         return cs_thread
 
     def run_stress_thread_bench(self, stress_cmd, duration=None, stress_num=1, keyspace_num=1, profile=None, prefix='',  # pylint: disable=too-many-arguments,unused-argument


### PR DESCRIPTION
Nemesis toggle_table_ics runs alter table and finishes immediately. So the schema merge started
after the nemesis is finished and as result health checker fails on NodeSchemaVersion validation
because of schema change is running.

Another case - encription-at-rest longevity - test table is altered with scylla_encryption_options
and we need to wait for schema agreement completed

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
