### PR TITLE
fix(getjenkinslabels): on master, moved to use new builders

### DIFF
--- a/vars/getJenkinsLabels.groovy
+++ b/vars/getJenkinsLabels.groovy
@@ -9,11 +9,11 @@ def call(String backend, String aws_region=null) {
 
     }
 
-    def jenkins_labels = ['aws-eu-west-1': 'aws-sct-builders-eu-west-1',
+    def jenkins_labels = ['aws-eu-west-1': 'aws-sct-builders-eu-west-1-new',
                           'aws-eu-west-2': 'aws-sct-builders-eu-west-2',
                           'aws-eu-north-1': 'aws-sct-builders-eu-north-1',
                           'aws-eu-central-1': 'aws-sct-builders-eu-central-1',
-                          'aws-us-east-1' : 'aws-sct-builders-us-east-1',
+                          'aws-us-east-1' : 'aws-sct-builders-us-east-1-new',
                           'gce': 'gce-sct-builders',
                           'docker': 'sct-builders']
 


### PR DESCRIPTION
as old builders are in a different VPC, and there is no
way to move the VPC of an existing instance, 2 new builders
were created on us-east-1 and eu-west-1 to suply to master
jobs a builder in the new VPC, but leave the old builders
as they are, to continue to run all other branches on those
regions, without the need to merge the new builder and runner
code.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
