### PR TITLE
fix(traffic_control): Install traffic control on AMAZON2 image

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -693,6 +693,13 @@ class AWSNode(cluster.BaseNode):
             tc_command = LOCAL_CMD_RUNNER.run("tcset eth1 {} --tc-command".format(tcconfig_params)).stdout
             self.remoter.run('sudo bash -cxe "%s"' % tc_command)
 
+    def install_traffic_control(self):
+        if self.distro.is_amazon2:
+            self.log.debug("Installing iproute-tc package for AMAZON2")
+            self.remoter.run("sudo yum install -y iproute-tc", ignore_status=True)
+
+        return self.remoter.run("/sbin/tc -h", ignore_status=True).ok
+
     @property
     def image(self):
         return self._instance.image_id

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1582,6 +1582,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if not self.cluster.extra_network_interface:
             raise UnsupportedNemesis("for this nemesis to work, you need to set `extra_network_interface: True`")
 
+        if not self.target_node.install_traffic_control():
+            raise UnsupportedNemesis("Traffic control package not installed on system")
+
         rate_limit: Optional[str] = self.get_rate_limit_for_network_disruption()
         if not rate_limit:
             self.log.warn("NetworkRandomInterruption won't limit network bandwith due to lack of monitoring nodes.")
@@ -1622,6 +1625,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self._set_current_disruption('BlockNetwork')
         if not self.cluster.extra_network_interface:
             raise UnsupportedNemesis("for this nemesis to work, you need to set `extra_network_interface: True`")
+
+        if not self.target_node.install_traffic_control():
+            raise UnsupportedNemesis("Traffic control package not installed on system")
 
         selected_option = "--loss 100%"
         list_of_timeout_options = [10, 60, 120, 300, 500]


### PR DESCRIPTION
AMAZON2 image doesn't have traffic control package installed.
Check and install package if needed

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
