### PR TITLE
fix(system.peers): print all columns from system.peers table

### DIFF
--- a/sdcm/utils/health_checker.py
+++ b/sdcm/utils/health_checker.py
@@ -46,6 +46,10 @@ def check_nulls_in_peers(gossip_info, peers_details, current_node):
             f"node {ip}{is_target} with status {gossip_info[ip]['status']} : " \
             f"{peers_details[ip]}"
 
+        # By Asias request: https://github.com/scylladb/scylla/issues/6397#issuecomment-666893877
+        LOGGER.debug(f'Print all columns from system.peers for peer {ip}')
+        current_node.run_cqlsh(f"select * from system.peers where peer = '{ip}'", split=True, verbose=True)
+
         if ip in gossip_info and gossip_info[ip]['status'] not in current_node.GOSSIP_STATUSES_FILTER_OUT:
             ClusterHealthValidatorEvent(type='error', name='NodePeersNulls', status=Severity.ERROR,
                                         node=current_node.name,


### PR DESCRIPTION
Print all columns from system.peers table when hit issue 'Node properties are null in system.peers'.
Added by Asias request https://github.com/scylladb/scylla/issues/6397#issuecomment-666893877:
```
Columns for node 8 in system.peers was not fully shown here. e.g., tokens. I think you only selected part of the columns in the sct. We need to know all the columns. Can you please modify the sct test so that when we hit it again we know the full info in system.peers? 
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
