### PR TITLE
4.1 Backport: fix (refresh nemesis): load sstable files to all db nodes by refresh #2266

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -524,13 +524,13 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self._set_current_disruption('MajorCompaction %s' % self.target_node)
         self.target_node.run_nodetool("compact")
 
-    def disrupt_nodetool_refresh(self, big_sstable=True, skip_download=False):
+    def disrupt_nodetool_refresh(self, big_sstable=True, skip_download=False):  # pylint: disable=too-many-statements
         self._set_current_disruption('Refresh keyspace1.standard1 on {}'.format(self.target_node.name))
 
         # Checking the columns number of keyspace1.standard1
         query_cmd = "SELECT * FROM keyspace1.standard1 LIMIT 1"
         result = self.target_node.run_cqlsh(query_cmd)
-        col_num = len(re.findall("(\| C\d+)", result.stdout))
+        col_num = len(re.findall(r"(\| C\d+)", result.stdout))
 
         if col_num == 1:
             # Use special schema (one column) for refresh before https://github.com/scylladb/scylla/issues/6617 is fixed

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -526,44 +526,90 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def disrupt_nodetool_refresh(self, big_sstable=True, skip_download=False):
         self._set_current_disruption('Refresh keyspace1.standard1 on {}'.format(self.target_node.name))
-        if big_sstable:
-            # 100G, the big file will be saved to GCE image
-            # Fixme: It's very slow and unstable to download 100G files from S3 to GCE instances,
-            #        currently we actually uploaded a small file (3.6 K) to S3.
-            #        We had a solution to save the file in GCE image, it requires bigger boot disk.
-            #        In my old test, the instance init is easy to fail. We can try to use a
-            #        split shared disk to save the 100GB file.
-            # 100M (500000 rows)
-            sstable_url = 'https://s3.amazonaws.com/scylla-qa-team/refresh_nemesis/keyspace1.standard1.100M.tar.gz'
-            sstable_file = '/tmp/keyspace1.standard1.100M.tar.gz'
-            sstable_md5 = '9c5dd19cfc78052323995198b0817270'
+
+        # Checking the columns number of keyspace1.standard1
+        query_cmd = "SELECT * FROM keyspace1.standard1 LIMIT 1"
+        result = self.target_node.run_cqlsh(query_cmd)
+        col_num = len(re.findall("(\| C\d+)", result.stdout))
+
+        if col_num == 1:
+            # Use special schema (one column) for refresh before https://github.com/scylladb/scylla/issues/6617 is fixed
+            if big_sstable:
+                sstable_url = 'https://s3.amazonaws.com/scylla-qa-team/refresh_nemesis_c0/keyspace1.standard1.100M.tar.gz'
+                sstable_file = '/tmp/keyspace1.standard1.100M.tar.gz'
+                sstable_md5 = 'e4f6addc2db8e9af3a906953288ef676'
+                keys_num = 1001000
+            else:
+                sstable_url = 'https://s3.amazonaws.com/scylla-qa-team/refresh_nemesis_c0/keyspace1.standard1.tar.gz'
+                sstable_file = "/tmp/keyspace1.standard1.tar.gz"
+                sstable_md5 = 'c4aee10691fa6343a786f52663e7f758'
+                keys_num = 1000
+        elif col_num >= 5:
+            # The snapshot has 5 columns, the snapshot (col=5) can be loaded to table (col > 5).
+            # they rest columns will be filled to 'null'.
+            if big_sstable:
+                # 100G, the big file will be saved to GCE image
+                # Fixme: It's very slow and unstable to download 100G files from S3 to GCE instances,
+                #        currently we actually uploaded a small file (3.6 K) to S3.
+                #        We had a solution to save the file in GCE image, it requires bigger boot disk.
+                #        In my old test, the instance init is easy to fail. We can try to use a
+                #        split shared disk to save the 100GB file.
+                # 100M (500000 rows)
+                sstable_url = 'https://s3.amazonaws.com/scylla-qa-team/refresh_nemesis/keyspace1.standard1.100M.tar.gz'
+                sstable_file = '/tmp/keyspace1.standard1.100M.tar.gz'
+                sstable_md5 = '9c5dd19cfc78052323995198b0817270'
+                keys_num = 501000
+            else:
+                sstable_url = 'https://s3.amazonaws.com/scylla-qa-team/refresh_nemesis/keyspace1.standard1.tar.gz'
+                sstable_file = "/tmp/keyspace1.standard1.tar.gz"
+                sstable_md5 = 'c033a3649a1aec3ba9b81c446c6eecfd'
+                keys_num = 1000
         else:
-            sstable_url = 'https://s3.amazonaws.com/scylla-qa-team/refresh_nemesis/keyspace1.standard1.tar.gz'
-            sstable_file = "/tmp/keyspace1.standard1.tar.gz"
-            sstable_md5 = 'c033a3649a1aec3ba9b81c446c6eecfd'
-        if not skip_download:
-            key_store = KeyStore()
-            creds = key_store.get_scylladb_upload_credentials()
-            remote_get_file(self.target_node.remoter, sstable_url, sstable_file,
-                            hash_expected=sstable_md5, retries=2,
-                            user_agent=creds['user_agent'])
+            # Note: when issue #6617 is fixed, we can try to load snapshot (cols=5) to a table (1 < cols < 5),
+            #       expect that refresh will fail (no serious db error).
+            raise UnsupportedNemesis("Schema doesn't match the snapshot, not uploading")
 
         self.log.debug('Prepare keyspace1.standard1 if it does not exist')
-        self._prepare_test_table(ks='keyspace1')
+        self._prepare_test_table(ks='keyspace1', table='standard1')
         result = self.target_node.run_nodetool(sub_cmd="cfstats", args="keyspace1.standard1")
-        if result is not None and result.exit_status == 0:
-            result = self.target_node.remoter.run("sudo ls -t /var/lib/scylla/data/keyspace1/")
+
+        def do_refresh(node):
+            if not skip_download:
+                key_store = KeyStore()
+                creds = key_store.get_scylladb_upload_credentials()
+                # Download the sstable files from S3
+                remote_get_file(node.remoter, sstable_url, sstable_file,
+                                hash_expected=sstable_md5, retries=2,
+                                user_agent=creds['user_agent'])
+            result = node.remoter.run("sudo ls -t /var/lib/scylla/data/keyspace1/")
             upload_dir = result.stdout.split()[0]
-            self.target_node.remoter.run('sudo tar xvfz {} -C /var/lib/scylla/data/keyspace1/{}/upload/'.format(
+            node.remoter.run('sudo -u scylla tar xvfz {} -C /var/lib/scylla/data/keyspace1/{}/upload/'.format(
                 sstable_file, upload_dir))
             # Scylla Enterprise 2019.1 doesn't support to load schema.cql and manifest.json, let's remove them
-            self.target_node.remoter.run(
+            node.remoter.run(
                 'sudo rm -f /var/lib/scylla/data/keyspace1/{}/upload/schema.cql'.format(upload_dir))
-            self.target_node.remoter.run(
+            node.remoter.run(
                 'sudo rm -f /var/lib/scylla/data/keyspace1/{}/upload/manifest.json'.format(upload_dir))
-            self.target_node.run_nodetool(sub_cmd="refresh", args="-- keyspace1 standard1")
-            cmd = "select * from keyspace1.standard1 where key=0x32373131364f334f3830"
-            result = self.target_node.run_cqlsh(cmd)
+            self.log.debug(f'Loading {keys_num} keys to {node.name} by refresh')
+            node.run_nodetool(sub_cmd="refresh", args="-- keyspace1 standard1")
+
+        if result is not None and result.exit_status == 0:
+            # Check one special key before refresh, we will verify refresh by query in the end
+            # Note: we can't DELETE the key before refresh, otherwise the old sstable won't be loaded
+            #       TRUNCATE can be used the clean the table, but we can't do it for keyspace1.standard1
+            query_verify = "SELECT * FROM keyspace1.standard1 WHERE key=0x32373131364f334f3830"
+            result = self.target_node.run_cqlsh(query_verify)
+            if '(0 rows)' in result.stdout:
+                self.log.debug('Key 0x32373131364f334f3830 does not exist before refresh')
+            else:
+                self.log.debug('Key 0x32373131364f334f3830 already exists before refresh')
+
+            # Executing rolling refresh one by one
+            for node in self.cluster.nodes:
+                do_refresh(node)
+
+            # Verify that the special key is loaded by SELECT query
+            result = self.target_node.run_cqlsh(query_verify)
             assert '(1 rows)' in result.stdout, 'The key is not loaded by `nodetool refresh`'
 
     def disrupt_nodetool_enospc(self, sleep_time=30, all_nodes=False):
@@ -698,12 +744,13 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             for keyspace in test_keyspaces:
                 node.run_nodetool(sub_cmd="cleanup", args=keyspace)
 
-    def _prepare_test_table(self, ks='keyspace1'):
-        # get the count of the truncate table
-        test_keyspaces = self.cluster.get_test_keyspaces()
+    def _prepare_test_table(self, ks='keyspace1', table=None):
+        ks_cfs = get_non_system_ks_cf_list(db_node=self.target_node)
+        table_exist = f'{ks}.{table}' in ks_cfs if table else True
 
-        # if keyspace doesn't exist, create it by cassandra-stress
-        if ks not in test_keyspaces:
+        test_keyspaces = self.cluster.get_test_keyspaces()
+        # if keyspace or table doesn't exist, create it by cassandra-stress
+        if ks not in test_keyspaces or not table_exist:
             stress_cmd = "cassandra-stress write n=400000 cl=QUORUM -port jmx=6868 -mode native cql3 -schema 'replication(factor=3)' -log interval=5"
             cs_thread = self.tester.run_stress_thread(
                 stress_cmd=stress_cmd, keyspace_name=ks, stop_test_on_failure=False)

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -556,6 +556,11 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             upload_dir = result.stdout.split()[0]
             self.target_node.remoter.run('sudo tar xvfz {} -C /var/lib/scylla/data/keyspace1/{}/upload/'.format(
                 sstable_file, upload_dir))
+            # Scylla Enterprise 2019.1 doesn't support to load schema.cql and manifest.json, let's remove them
+            self.target_node.remoter.run(
+                'sudo rm -f /var/lib/scylla/data/keyspace1/{}/upload/schema.cql'.format(upload_dir))
+            self.target_node.remoter.run(
+                'sudo rm -f /var/lib/scylla/data/keyspace1/{}/upload/manifest.json'.format(upload_dir))
             self.target_node.run_nodetool(sub_cmd="refresh", args="-- keyspace1 standard1")
             cmd = "select * from keyspace1.standard1 where key=0x32373131364f334f3830"
             result = self.target_node.run_cqlsh(cmd)

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1557,7 +1557,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                       f'Rows expected to be inserted: {len(source_table_rows)}; '
                                       f'Actually inserted rows: {succeeded_rows}.')
                     return False
-            except Exception as exc:
+            except Exception as exc:  # pylint: disable=broad-except
                 self.log.warning(f'Problem during copying data: {exc}')
                 return False
 

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -677,8 +677,8 @@ class UpgradeTest(FillDatabaseData):
         schema_load_error_num = 0
         for node in self.db_cluster.nodes:
             errors = node.search_database_log(search_pattern=search_pattern,
-                                            start_from_beginning=True,
-                                            publish_events=False)
+                                              start_from_beginning=True,
+                                              publish_events=False)
             schema_load_error_num += len(errors)
             if search_for_idx_token_error:
                 self.search_for_idx_token_error_after_upgrade(node=node, step=step)


### PR DESCRIPTION
This PR backported PR #2266 to branch-4.1, two additional PR was backported together for solving the conflicts.

- https://github.com/scylladb/scylla-cluster-tests/pull/2181
- https://github.com/scylladb/scylla-cluster-tests/pull/2415

TODO: need to update backport lables of 3 PRs later

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
