### PR TITLE
Extend CDC replication test with pre/post-image modes.

### DIFF
--- a/jenkins-pipelines/feature-cdc-replication-gemini-postimage.jenkinsfile
+++ b/jenkins-pipelines/feature-cdc-replication-gemini-postimage.jenkinsfile
@@ -8,8 +8,8 @@ cdcReplicationPipeline(
 
     backend: 'aws',
     aws_region: 'eu-west-1',
-    test_name: 'cdc_replication_test.CDCReplicationTest.test_replication_gemini_delta',
-    test_config: 'test-cases/cdc/cdc-15m-replication-gemini.yaml',
+    test_name: 'cdc_replication_test.CDCReplicationTest.test_replication_gemini_postimage',
+    test_config: 'test-cases/cdc/cdc-15m-replication-postimage.yaml',
 
     timeout: [time: 100, unit: 'MINUTES'],
     email_recipients: 'kbraun@scylladb.com,piotr@scylladb.com,alex.bykov@scylladb.com'

--- a/jenkins-pipelines/feature-cdc-replication-gemini-preimage.jenkinsfile
+++ b/jenkins-pipelines/feature-cdc-replication-gemini-preimage.jenkinsfile
@@ -8,8 +8,8 @@ cdcReplicationPipeline(
 
     backend: 'aws',
     aws_region: 'eu-west-1',
-    test_name: 'cdc_replication_test.CDCReplicationTest.test_replication_gemini_delta',
-    test_config: 'test-cases/cdc/cdc-15m-replication-gemini.yaml',
+    test_name: 'cdc_replication_test.CDCReplicationTest.test_replication_gemini_preimage',
+    test_config: 'test-cases/cdc/cdc-15m-replication-preimage.yaml',
 
     timeout: [time: 100, unit: 'MINUTES'],
     email_recipients: 'kbraun@scylladb.com,piotr@scylladb.com,alex.bykov@scylladb.com'

--- a/test-cases/cdc/cdc-15m-replication-postimage.yaml
+++ b/test-cases/cdc/cdc-15m-replication-postimage.yaml
@@ -1,0 +1,31 @@
+test_duration: 60
+
+user_prefix: 'cdc-replication-gemini'
+db_type: mixed_scylla
+
+use_legacy_cluster_init: false
+
+n_db_nodes: 3
+instance_type_db: 'i3.large'
+
+n_test_oracle_db_nodes: 1
+instance_type_db_oracle: 'i3.large'
+
+n_loaders: 1
+instance_type_loader: 'c4.large'
+
+n_monitor_nodes: 0
+# instance_type_monitor: 't3.small'
+
+nemesis_class_name: 'RandomInterruptionNetworkMonkey'
+nemesis_interval: 1
+# Required by the nemesis:
+extra_network_interface: true
+
+# Note: for preimage and postimage we use 1 thread because there is no sensible way
+# to test pre/post-images with concurrent writes happening to a single row.
+gemini_cmd: "gemini -d --duration 15m --warmup 0s -c 1 -m write --non-interactive --cql-features basic --max-mutation-retries 100 --max-mutation-retries-backoff 100ms --replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '3'}\" --table-options \"cdc = {'enabled': true, 'postimage': true}\""
+
+gemini_version: 'latest'
+# Required by SCT, although not used:
+gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json'

--- a/test-cases/cdc/cdc-15m-replication-preimage.yaml
+++ b/test-cases/cdc/cdc-15m-replication-preimage.yaml
@@ -1,0 +1,31 @@
+test_duration: 60
+
+user_prefix: 'cdc-replication-gemini'
+db_type: mixed_scylla
+
+use_legacy_cluster_init: false
+
+n_db_nodes: 3
+instance_type_db: 'i3.large'
+
+n_test_oracle_db_nodes: 1
+instance_type_db_oracle: 'i3.large'
+
+n_loaders: 1
+instance_type_loader: 'c4.large'
+
+n_monitor_nodes: 0
+# instance_type_monitor: 't3.small'
+
+nemesis_class_name: 'RandomInterruptionNetworkMonkey'
+nemesis_interval: 1
+# Required by the nemesis:
+extra_network_interface: true
+
+# Note: for preimage and postimage we use 1 thread because there is no sensible way
+# to test pre/post-images with concurrent writes happening to a single row.
+gemini_cmd: "gemini -d --duration 15m --warmup 0s -c 1 -m write --non-interactive --cql-features basic --max-mutation-retries 100 --max-mutation-retries-backoff 100ms --replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '3'}\" --table-options \"cdc = {'enabled': true, 'preimage': 'full'}\""
+
+gemini_version: 'latest'
+# Required by SCT, although not used:
+gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json'


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)

The original test uses delta entries in the CDC log to replicate changes to another cluster.
This PR adds an option to use preimages or postimages.

With postimages it's pretty much the same as with deltas, except that we don't compare timestamps of cells in the master and replica cluster. They might change when we overwrite an entire row.

With preimages it's trickier. The test will work as follows: instead of checking consistency with scylla-migrate, we will use the replicator itself. As before, the replicator will use CDC log's delta entry to write to the replica cluster. However, before it performs the write, it will query the replica cluster, and compare the results with the CDC log's preimage.

In preimage and postimage modes we use gemini with a single thread to perform the writes. Because pre/post-images are generated by querying the database, concurrent changes to the same row might result in them not making much sense.