### PR TITLE
fix(sdcm/remote/remote_base.py): fix it for case when ~ is present

### DIFF
--- a/sdcm/remote/remote_base.py
+++ b/sdcm/remote/remote_base.py
@@ -284,7 +284,7 @@ class RemoteCmdRunnerBase(CommandRunner):  # pylint: disable=too-many-instance-a
         files_sent = True
         if self.use_rsync():
             try:
-                local_sources = [quote(path) for path in src]
+                local_sources = [quote(os.path.expanduser(path)) for path in src]
                 rsync = self._make_rsync_cmd(local_sources, remote_dest,
                                              delete_dst, preserve_symlinks)
                 LocalCmdRunner().run(rsync)
@@ -481,7 +481,7 @@ class RemoteCmdRunnerBase(CommandRunner):  # pylint: disable=too-many-instance-a
             set_file_privs(dest)
 
     def _make_rsync_cmd(  # pylint: disable=too-many-arguments
-            self, src: str, dst: str, delete_dst: bool, preserve_symlinks: bool, timeout: int = 300) -> str:
+            self, src: list, dst: str, delete_dst: bool, preserve_symlinks: bool, timeout: int = 300) -> str:
         """
         Given a list of source paths and a destination path, produces the
         appropriate rsync command for copying them. Remote paths must be


### PR DESCRIPTION
Fixing error:

```
< t:2020-08-06 09:06:46,751 f:remote_base.py  l:274  c:RemoteCmdRunner      p:DEBUG > Send files (src) ~/.ssh/scylla-qa-ec2 -> (dst) /tmp/scylla-test
< t:2020-08-06 09:06:46,758 f:local_cmd_runner.py l:58   c:LocalCmdRunner       p:DEBUG > Running command "rsync -L  --timeout=300 --rsh='/usr/bin/ssh  -a -x  -o StrictHostKeyChecking=no -o UserKnownHostsFile=/tmp/tmpevhm3j6e -o BatchMode=yes -o ConnectTimeout=300 -o ServerAliveInterval=300 -l centos -p 22 -i /home/ubuntu/.ssh/scylla-qa-ec2' -az '~/.ssh/scylla-qa-ec2' centos@[10.0.3.32]:"/tmp/scylla-test""...
< t:2020-08-06 09:06:46,759 f:config.py       l:273  c:fabric               p:DEBUG > File not found, skipping
< t:2020-08-06 09:06:46,760 f:config.py       l:271  c:fabric               p:DEBUG > Loaded 2 new ssh_config rules from '/etc/ssh/ssh_config'
< t:2020-08-06 09:06:47,061 f:base.py         l:187  c:LocalCmdRunner       p:DEBUG > rsync: change_dir "/home/ubuntu/scylla-cluster-tests//~/.ssh" failed: No such file or directory (2)
< t:2020-08-06 09:06:47,163 f:base.py         l:187  c:LocalCmdRunner       p:DEBUG > rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1207) [sender=3.1.3]
< t:2020-08-06 09:06:47,170 f:base.py         l:111  c:LocalCmdRunner       p:ERROR > Error executing command: "rsync -L  --timeout=300 --rsh='/usr/bin/ssh  -a -x  -o StrictHostKeyChecking=no -o UserKnownHostsFile=/tmp/tmpevhm3j6e -o BatchMode=yes -o ConnectTimeout=300 -o ServerAliveInterval=300 -l centos -p 22 -i /home/ubuntu/.ssh/scylla-qa-ec2' -az '~/.ssh/scylla-qa-ec2' centos@[10.0.3.32]:"/tmp/scylla-test""; Exit status: 23
< t:2020-08-06 09:06:47,170 f:base.py         l:115  c:LocalCmdRunner       p:DEBUG > STDERR: rsync: change_dir "/home/ubuntu/scylla-cluster-tests//~/.ssh" failed: No such file or directory (2)
< t:2020-08-06 09:06:47,170 f:base.py         l:115  c:LocalCmdRunner       p:DEBUG > rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1207) [sender=3.1.3]
< t:2020-08-06 09:06:47,171 f:remote_base.py  l:293  c:RemoteCmdRunner      p:WARNING > Trying scp, rsync failed: Encountered a bad command exit code!
< t:2020-08-06 09:06:47,171 f:remote_base.py  l:293  c:RemoteCmdRunner      p:WARNING > 
< t:2020-08-06 09:06:47,171 f:remote_base.py  l:293  c:RemoteCmdRunner      p:WARNING > Command: 'rsync -L  --timeout=300 --rsh=\'/usr/bin/ssh  -a -x  -o StrictHostKeyChecking=no -o UserKnownHostsFile=/tmp/tmpevhm3j6e -o BatchMode=yes -o ConnectTimeout=300 -o ServerAliveInterval=300 -l centos -p 22 -i /home/ubuntu/.ssh/scylla-qa-ec2\' -az \'~/.ssh/scylla-qa-ec2\' centos@[10.0.3.32]:"/tmp/scylla-test"'
< t:2020-08-06 09:06:47,171 f:remote_base.py  l:293  c:RemoteCmdRunner      p:WARNING > 
< t:2020-08-06 09:06:47,171 f:remote_base.py  l:293  c:RemoteCmdRunner      p:WARNING > Exit code: 23
< t:2020-08-06 09:06:47,171 f:remote_base.py  l:293  c:RemoteCmdRunner      p:WARNING > 
< t:2020-08-06 09:06:47,171 f:remote_base.py  l:293  c:RemoteCmdRunner      p:WARNING > Stdout:
< t:2020-08-06 09:06:47,171 f:remote_base.py  l:293  c:RemoteCmdRunner      p:WARNING > 
< t:2020-08-06 09:06:47,171 f:remote_base.py  l:293  c:RemoteCmdRunner      p:WARNING > 
< t:2020-08-06 09:06:47,171 f:remote_base.py  l:293  c:RemoteCmdRunner      p:WARNING > 
< t:2020-08-06 09:06:47,171 f:remote_base.py  l:293  c:RemoteCmdRunner      p:WARNING > Stderr:
< t:2020-08-06 09:06:47,171 f:remote_base.py  l:293  c:RemoteCmdRunner      p:WARNING > 
< t:2020-08-06 09:06:47,171 f:remote_base.py  l:293  c:RemoteCmdRunner      p:WARNING > rsync: change_dir "/home/ubuntu/scylla-cluster-tests//~/.ssh" failed: No such file or directory (2)
< t:2020-08-06 09:06:47,171 f:remote_base.py  l:293  c:RemoteCmdRunner      p:WARNING > rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1207) [sender=3.1.3]
< t:2020-08-06 09:06:47,171 f:remote_base.py  l:293  c:RemoteCmdRunner      p:WARNING > 
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
