### PR TITLE
fix(sdcm/nemesis): fix refreshmonkeys failure if there is no target table

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -579,6 +579,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self._set_current_disruption('Refresh keyspace1.standard1 on {}'.format(self.target_node.name))
 
         # Checking the columns number of keyspace1.standard1
+        self.log.debug('Prepare keyspace1.standard1 if it does not exist')
+        self._prepare_test_table(ks='keyspace1', table='standard1')
         query_cmd = "SELECT * FROM keyspace1.standard1 LIMIT 1"
         result = self.target_node.run_cqlsh(query_cmd)
         col_num = len(re.findall("(\| C\d+)", result.stdout))
@@ -620,8 +622,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             #       expect that refresh will fail (no serious db error).
             raise UnsupportedNemesis("Schema doesn't match the snapshot, not uploading")
 
-        self.log.debug('Prepare keyspace1.standard1 if it does not exist')
-        self._prepare_test_table(ks='keyspace1', table='standard1')
         result = self.target_node.run_nodetool(sub_cmd="cfstats", args="keyspace1.standard1")
 
         def do_refresh(node):


### PR DESCRIPTION
https://trello.com/c/enAEIZQc/2201-fix-refreshmonkey-and-refreshbigmonkey

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
