### PR TITLE
fix(alternator_api): Add configured region to getting resource

### DIFF
--- a/sdcm/utils/alternator/api.py
+++ b/sdcm/utils/alternator/api.py
@@ -32,7 +32,8 @@ class Alternator:
         endpoint_url = self.create_endpoint_url(node=node)
         if endpoint_url not in self.alternator_apis:
             aws_params = dict(endpoint_url=endpoint_url, aws_access_key_id=self.params.get("alternator_access_key_id"),
-                              aws_secret_access_key=self.params.get("alternator_secret_access_key"))
+                              aws_secret_access_key=self.params.get("alternator_secret_access_key"),
+                              region_name=self.params.get("region_name").split()[0])
             resource: DynamoDBServiceResource = boto3.resource('dynamodb', **aws_params)
             client: DynamoDBClient = boto3.client('dynamodb', **aws_params)
             self.alternator_apis[endpoint_url] = AlternatorApi(resource=resource, client=client)


### PR DESCRIPTION
Alternator Jobs failed
Failed jobs:
https://jenkins.scylladb.com/view/scylla-4.2/job/scylla-4.2/job/longevity/job/longevity-alternator-3h-test/31/ (scylla-4.2, sct:master)
https://jenkins.scylladb.com/view/scylla-4.2/job/scylla-4.2/job/longevity/job/longevity-alternator-3h-test/30/ (scylla-4.2, sct:master)

with error:
14:05:08  < t:2020-08-08 07:05:07,447 f:sct_events.py   l:906  c:sdcm.sct_events      p:INFO  >     result = self._endpoint_for_partition(
14:05:08  < t:2020-08-08 07:05:07,447 f:sct_events.py   l:906  c:sdcm.sct_events      p:INFO  >   File "/usr/local/lib/python3.8/site-packages/botocore/regions.py", line 148, in _endpoint_for_partition

It seems happened, because on sct-runner default region for aws is not configured niether for ubuntu user nor for hydra docker
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
