### PR TITLE
refactor(sct_events.py): Crating object for group common DB events

### DIFF
--- a/cdc_replication_test.py
+++ b/cdc_replication_test.py
@@ -94,13 +94,13 @@ class CDCReplicationTest(ClusterTester):
         self.log.info('Starting stressor.')
         if is_gemini_test:
             stress_thread = GeminiStressThread(
-                    test_cluster=self.db_cluster,
-                    oracle_cluster=None,
-                    loaders=self.loaders,
-                    gemini_cmd=self.params.get('gemini_cmd'),
-                    timeout=self.get_duration(None),
-                    outputdir=self.loaders.logdir,
-                    params=self.params).run()
+                test_cluster=self.db_cluster,
+                oracle_cluster=None,
+                loaders=self.loaders,
+                gemini_cmd=self.params.get('gemini_cmd'),
+                timeout=self.get_duration(None),
+                outputdir=self.loaders.logdir,
+                params=self.params).run()
         else:
             stress_thread = self.run_stress_cassandra_thread(stress_cmd=self.params.get('stress_cmd'))
 

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -19,6 +19,7 @@ from random import randint
 from invoke import exceptions
 
 from sdcm import mgmt
+from sdcm.group_common_events import ignore_no_space_errors
 from sdcm.mgmt import HostStatus, HostSsl, HostRestStatus, TaskStatus, ScyllaManagerError, ScyllaManagerTool
 from sdcm.nemesis import MgmtRepair, DbEventsFilter
 from sdcm.utils.common import reach_enospc_on_node, clean_enospc_on_node
@@ -495,10 +496,7 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
 
         self.generate_load_and_wait_for_results()
         has_enospc_been_reached = False
-        with DbEventsFilter(type='NO_SPACE_ERROR', node=target_node),\
-                DbEventsFilter(type='BACKTRACE', line='No space left on device', node=target_node), \
-                DbEventsFilter(type='DATABASE_ERROR', line='No space left on device', node=target_node), \
-                DbEventsFilter(type='FILESYSTEM_ERROR', line='No space left on device', node=target_node):
+        with ignore_no_space_errors(node=target_node):
             try:
                 backup_task = mgr_cluster.create_backup_task(location_list=location_list)
                 backup_task.wait_for_uploading_stage()

--- a/performance_regression_alternator_test.py
+++ b/performance_regression_alternator_test.py
@@ -14,8 +14,8 @@
 import contextlib
 
 from performance_regression_test import PerformanceRegressionTest
+from sdcm.group_common_events import ignore_operation_errors, ignore_alternator_client_errors
 from sdcm.utils import alternator
-from sdcm.sct_events import Severity, EventsSeverityChangerFilter, DatabaseLogEvent
 
 
 class PerformanceRegressionAlternatorTest(PerformanceRegressionTest):
@@ -24,11 +24,8 @@ class PerformanceRegressionAlternatorTest(PerformanceRegressionTest):
 
         # suppress YCSB client error and timeout to warnings for all the test in this class
         self.stack = contextlib.ExitStack()
-        self.stack.enter_context(alternator.api.ignore_alternator_client_errors())
-        self.stack.enter_context(EventsSeverityChangerFilter(event_class=DatabaseLogEvent, regex=r".*Operation timed out.*",
-                                                             severity=Severity.WARNING, extra_time_to_expiration=30))
-        self.stack.enter_context(EventsSeverityChangerFilter(event_class=DatabaseLogEvent, regex=r'.*Operation failed for system.paxos.*',
-                                                             severity=Severity.WARNING, extra_time_to_expiration=30))
+        self.stack.enter_context(ignore_alternator_client_errors())
+        self.stack.enter_context(ignore_operation_errors())
 
     def _workload(self, stress_cmd, stress_num, test_name=None, sub_type=None, keyspace_num=1, prefix='', debug_message='',  # pylint: disable=too-many-arguments,arguments-differ
                   save_stats=True, is_alternator=True):

--- a/performance_regression_lwt_test.py
+++ b/performance_regression_lwt_test.py
@@ -2,8 +2,8 @@ import pprint
 
 from invoke.exceptions import UnexpectedExit, Failure
 from performance_regression_test import PerformanceRegressionTest
+from sdcm.group_common_events import ignore_operation_errors
 from sdcm.utils.decorators import log_run_info, retrying
-from sdcm.sct_events import apply_log_filters, EVENT_FILTER_TIMEOUT
 
 PP = pprint.PrettyPrinter(indent=2)
 
@@ -108,7 +108,7 @@ class PerformanceRegressionLWTTest(PerformanceRegressionTest):
         return self._test_id
 
     def test_latency(self):
-        with apply_log_filters(*EVENT_FILTER_TIMEOUT()):
+        with ignore_operation_errors():
             self.preload_data()
             self.run_compaction_on_all_nodes()
             for subtest in self.lwt_subtests:
@@ -119,7 +119,7 @@ class PerformanceRegressionLWTTest(PerformanceRegressionTest):
             )
 
     def test_throughput(self):
-        with apply_log_filters(*EVENT_FILTER_TIMEOUT()):
+        with ignore_operation_errors():
             self.preload_data()
             self.run_compaction_on_all_nodes()
             for subtest in self.lwt_subtests:

--- a/sdcm/group_common_events.py
+++ b/sdcm/group_common_events.py
@@ -1,0 +1,53 @@
+from contextlib import contextmanager, ExitStack
+
+from sdcm.sct_events import DbEventsFilter, Severity, DatabaseLogEvent, EventsSeverityChangerFilter, YcsbStressEvent, \
+    PrometheusAlertManagerEvent
+
+
+@contextmanager
+def ignore_alternator_client_errors():
+    with ExitStack() as stack:
+        stack.enter_context(EventsSeverityChangerFilter(
+            event_class=PrometheusAlertManagerEvent, regex=".*YCSBTooManyErrors.*", severity=Severity.WARNING,
+            extra_time_to_expiration=60))
+        stack.enter_context(EventsSeverityChangerFilter(
+            event_class=PrometheusAlertManagerEvent, regex=".*YCSBTooManyVerifyErrors.*", severity=Severity.WARNING,
+            extra_time_to_expiration=60))
+        stack.enter_context(EventsSeverityChangerFilter(
+            event_class=YcsbStressEvent, regex=r".*Cannot achieve consistency level.*", severity=Severity.WARNING,
+            extra_time_to_expiration=30))
+        stack.enter_context(EventsSeverityChangerFilter(
+            event_class=YcsbStressEvent, regex=r".*Operation timed out.*", severity=Severity.WARNING,
+            extra_time_to_expiration=30))
+        yield
+
+
+@contextmanager
+def ignore_operation_errors():
+    with ExitStack() as stack:
+        stack.enter_context(EventsSeverityChangerFilter(
+            event_class=DatabaseLogEvent, regex=r".*Operation timed out.*", severity=Severity.WARNING,
+            extra_time_to_expiration=30))
+        stack.enter_context(EventsSeverityChangerFilter(
+            event_class=DatabaseLogEvent, regex=r'.*Operation failed for system.paxos.*', severity=Severity.WARNING,
+            extra_time_to_expiration=30))
+        yield
+
+
+@contextmanager
+def ignore_upgrade_schema_errors():
+    with ExitStack as stack:
+        stack.enter_context(DbEventsFilter(type='DATABASE_ERROR', line='Failed to load schema'))
+        stack.enter_context(DbEventsFilter(type='SCHEMA_FAILURE', line='Failed to load schema'))
+        stack.enter_context(DbEventsFilter(type='DATABASE_ERROR', line='Failed to pull schema'))
+        stack.enter_context(DbEventsFilter(type='RUNTIME_ERROR', line='Failed to load schema'))
+        yield
+
+
+@contextmanager
+def ignore_no_space_errors(node):
+    with DbEventsFilter(type='NO_SPACE_ERROR', node=node), \
+         DbEventsFilter(type='BACKTRACE', line='No space left on device', node=node), \
+         DbEventsFilter(type='DATABASE_ERROR', line='No space left on device', node=node), \
+         DbEventsFilter(type='FILESYSTEM_ERROR', line='No space left on device', node=node):
+        yield

--- a/sdcm/sct_events.py
+++ b/sdcm/sct_events.py
@@ -1031,15 +1031,6 @@ def apply_log_filters(*event_filters_list: List[BaseFilter]):
         yield
 
 
-def EVENT_FILTER_TIMEOUT():  # pylint: disable=invalid-name
-    return [
-        EventsSeverityChangerFilter(event_class=DatabaseLogEvent, regex=r".*Operation timed out.*",
-                                    severity=Severity.WARNING, extra_time_to_expiration=30),
-        EventsSeverityChangerFilter(event_class=DatabaseLogEvent, regex=r'.*Operation failed for system.paxos.*',
-                                    severity=Severity.WARNING, extra_time_to_expiration=30)
-    ]
-
-
 atexit.register(stop_events_device)
 
 


### PR DESCRIPTION
* Trello - https://trello.com/c/V3Ca21uD
   Trello description:
    Same filtered events are used for common actions.
    Need to find a way to group them in one file under the same Object
    Example:
    ```
      with DbEventsFilter(type='DATABASE_ERROR', line="repair's stream failed: streaming::stream_exception",
                     node=self.target_node), \
         DbEventsFilter(type='RUNTIME_ERROR', line='Can not find stream_manager', node=self.target_node), \
         DbEventsFilter(type='RUNTIME_ERROR', line='is aborted', node=self.target_node), \
         DbEventsFilter(type='RUNTIME_ERROR', line='Failed to repair', node=self.target_node):
    ```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
