### PR TITLE
fix(parse_toppartition): Search pattern in output instead of match

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1495,7 +1495,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             toppartitions = {}
             for out in output.strip().split('\n\n'):
                 partition = OrderedDict()
-                sampler_data = re.match(pattern1, out, re.MULTILINE)
+                sampler_data = re.search(pattern1, out, re.MULTILINE)
                 assert sampler_data, f"Pattern:{pattern1} are not matched on string:\n {out}"
                 sampler_data = sampler_data.groupdict()
                 partitions = re.findall(pattern2, out, re.MULTILINE)


### PR DESCRIPTION
Search pattern1 in string instead of match, to avoid additional line
in nodetool toppartition output

On master nodetool command returns `Using /etc/scylla/scylla.yaml as the config file` as first line. This line breaks parsing toppartitions output. Switch from match method to search.
```
(DisruptionEvent Severity.ERROR): type=end name=ShowTopPartitions node=Node gemini-with-nemesis-3h-normal-maste-db-node-e8675da8-2 [13.53.83.194 | 10.0.1.8] (seed: False) duration=17 error=Pattern:(?P<sampler>[A-Z]+)\sSampler:\W+Cardinality:\s~(?P<cardinality>[0-9]+)\s\((?P<capacity>[0-9]+)\scapacity\)\W+Top\s(?P<toppartitions>[0-9]+)\spartitions: are not matched on string:
02:59:03  Using /etc/scylla/scylla.yaml as the config file
02:59:03  WRITES Sampler:
02:59:03  Cardinality: ~0 (601 capacity)
02:59:03  Top 11 partitions:
02:59:03  Nothing recorded during sampling period...
02:59:03  Traceback (most recent call last):
02:59:03  File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 2114, in wrapper
02:59:03  result = method(*args, **kwargs)
02:59:03  File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 2770, in disrupt
02:59:03  self.call_random_disrupt_method(disrupt_methods=self.disrupt_methods_list)
02:59:03  File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 734, in call_random_disrupt_method
02:59:03  disrupt_method()
02:59:03  File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 1539, in disrupt_show_toppartitions
02:59:03  toppartition_result = _parse_toppartitions_output(result.stdout)
02:59:03  File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 1497, in _parse_toppartitions_output
02:59:03  assert sampler_data, f"Pattern:{pattern1} are not matched on string:\n {out}"
02:59:03  AssertionError: Pattern:(?P<sampler>[A-Z]+)\sSampler:\W+Cardinality:\s~(?P<cardinality>[0-9]+)\s\((?P<capacity>[0-9]+)\scapacity\)\W+Top\s(?P<toppartitions>[0-9]+)\spartitions: are not matched on string:
02:59:03  Using /etc/scylla/scylla.yaml as the config file
02:59:03  WRITES Sampler:
02:59:03  Cardinality: ~0 (601 capacity)
02:59:03  Top 11 partitions:
02:59:03  Nothing recorded during sampling period...
```

Additional fix #2445 

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
