### PR TITLE
fix(sdcm/cluster.py): Make reboot more stable

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1120,7 +1120,12 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             self.hard_reboot()
         else:
             self.log.debug('Softly rebooting node')
-            self.remoter.run('sudo reboot', ignore_status=True)
+            if not self.remoter.is_up(60):
+                raise RuntimeError('Target host is down')
+            try:
+                self.remoter.run('sudo reboot', ignore_status=True, retry=0)
+            except Exception:  # pylint: disable=broad-except
+                pass
 
         # wait until the reboot is executed
         wait.wait_for(func=uptime_changed, step=10, timeout=500, throw_exc=True)


### PR DESCRIPTION
  Soft reboot tends to have failures when endpoint drops ssh before "reboot" command is completed
  This is a fix to address this issue

https://trello.com/c/oc4ZILkM/2198-several-sudo-reboot-command-during-softreboot-nemesis-due-to-retrying-decorator-on-run-method-for-baseremoter

https://github.com/scylladb/scylla-cluster-tests/issues/2462

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
