### PR TITLE
fix(epel install): enable amazon2-extras repo of epel

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1995,11 +1995,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         force = '--force-yes '
         if self.is_rhel_like():
             # `screen' package is missed in CentOS/RHEL 8. Should be installed from EPEL repository.
-            if self.distro.is_centos8:
-                self.remoter.run("sudo yum install -y epel-release")
-            elif self.distro.is_rhel8:
-                self.remoter.run(
-                    "sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm")
+            if self.distro.is_centos8 or self.distro.is_rhel8:
+                self.install_epel()
             self.remoter.run('sudo yum install -y rsync tcpdump screen wget net-tools')
             self.download_scylla_repo(scylla_repo)
             # hack cause of broken caused by EPEL
@@ -2220,7 +2217,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         if not (self.is_rhel_like() or self.is_debian() or self.is_ubuntu()):
             raise ValueError('Unsupported Distribution type: {}'.format(str(self.distro)))
         if self.is_rhel_like():
-            self.remoter.run('sudo yum install -y epel-release', retry=3)
+            self.install_epel()
             self.remoter.run('sudo yum install python36-PyYAML -y', retry=3)
         else:
             self.remoter.run('sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B2BFD3660EF3F5B', retry=3)
@@ -2751,6 +2748,26 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         except Exception as e:  # pylint: disable=broad-except
             self.log.error(f'Failed to retreive value of {config_param_name} parameter. Error: {e}')
             return None
+
+    def install_epel(self):
+        """
+        Standard repositories might not provide all the packages that can be installed on CentOS, RHEL,
+        or Amazon Linux-based distributions. Enabling the EPEL repository provides additional options for
+        package installation.
+        """
+        if not self.distro.is_rhel_like:
+            raise Exception('EPEL can only be installed for RHEL like distros')
+
+        if self.distro.is_amazon2:
+            # Enable amazon2-extras repo for installing epel
+            # Reference: https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
+            self.remoter.run('sudo amazon-linux-extras install epel')
+
+        if self.distro.is_rhel8:
+            self.remoter.run(
+                "sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm")
+        else:
+            self.remoter.run('sudo yum install -y epel-release', retry=3)
 
 
 class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-public-methods
@@ -4335,7 +4352,7 @@ class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-inst
     @staticmethod
     def install_scylla_monitoring_prereqs(node):  # pylint: disable=invalid-name
         if node.is_rhel_like():
-            node.remoter.run("sudo yum install -y epel-release")
+            node.install_epel()
             node.update_repo_cache()
             prereqs_script = dedent("""
                 yum install -y unzip wget

--- a/sdcm/collectd.py
+++ b/sdcm/collectd.py
@@ -469,7 +469,7 @@ WantedBy=multi-user.target
         self.node = node
 
         if self.node.is_rhel_like():
-            self.node.remoter.run('sudo yum install -y epel-release', retry=3)
+            node.install_epel()
             self.node.remoter.run('sudo yum upgrade ca-certificates -y '
                                   '--disablerepo=epel',
                                   ignore_status=True,

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2038,7 +2038,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         we don't monitor swap usage in /proc/$scylla_pid/status, just make sure
         no coredump, serious db error occur during the heavy load of memory.
         """
-        self.target_node.remoter.run('sudo yum install -y epel-release', retry=3)
+        self.target_node.install_epel()
         self.target_node.remoter.run('sudo yum install -y stress-ng')
 
         self.log.info('Try to allocate 120% available memory, the allocated memory will be swaped out')


### PR DESCRIPTION
In Amazon2 Linux, epel package can't be installed directly.
The amazon2-extras repo of epel should be enabled first before install
epel by yum.

Reference: https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras

This patch introduced a helper function for BaseNode to install epel.

Signed-off-by: Amos Kong <amos@scylladb.com>

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/2490

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
