### PR TITLE
fix(sdcm/remote/remote_base.py): fix context generation

### DIFF
--- a/sdcm/remote/remote_base.py
+++ b/sdcm/remote/remote_base.py
@@ -72,6 +72,7 @@ class RemoteCmdRunnerBase(CommandRunner):  # pylint: disable=too-many-instance-a
         if connection is None:
             connection = self._create_connection()
             setattr(self.connection_thread_map, str(id(self)), connection)
+            self._bind_generation_to_connection(connection)
         return connection
 
     @classmethod
@@ -527,11 +528,12 @@ class RemoteCmdRunnerBase(CommandRunner):  # pylint: disable=too-many-instance-a
             with self._create_connection() as connection:
                 result = connection.run(**command_kwargs)
         else:
-            if not self._is_connection_generation_ok(self.connection):
-                self.connection.close()
-                self.connection.open()
-                self._bind_generation_to_connection(self.connection)
-            result = self.connection.run(**command_kwargs)
+            connection = self.connection
+            if not self._is_connection_generation_ok(connection):
+                connection.close()
+                connection.open()
+                self._bind_generation_to_connection(connection)
+            result = connection.run(**command_kwargs)
         result.duration = time.perf_counter() - start_time
         result.exit_status = result.exited
         return result


### PR DESCRIPTION
Change https://github.com/scylladb/scylla-cluster-tests/pull/2482 was done with bug that allows context generation been not trigered.
https://trello.com/c/hthoz2bd/2208-fix-context-generation

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
