### PR TITLE
improvement(test_rolling_upgrade.py): Creating upgrade rolling for Al…

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -303,7 +303,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         if self.params.get("logs_transport") == 'rsyslog':
             Setup.configure_rsyslog(self.localhost, enable_ngrok=False)
 
-        self.alternator = alternator.api.Alternator(sct_params=self.params)
+        self.alternator: alternator.api.Alternator = alternator.api.Alternator(sct_params=self.params)
         start_events_device(self.logdir)
         time.sleep(0.5)
         InfoEvent('TEST_START test_id=%s' % Setup.test_id())

--- a/sdcm/utils/alternator/enums.py
+++ b/sdcm/utils/alternator/enums.py
@@ -27,6 +27,6 @@ class GeneratorType(Enum):
     STR_BINARY = auto()
 
 
-class YCSVSchemaTypes(Enum):
+class YCSBSchemaTypes(Enum):
     HASH_SCHEMA = "HASH"
     HASH_AND_RANGE = "HASH_AND_RANGE"

--- a/sdcm/utils/alternator/schemas.py
+++ b/sdcm/utils/alternator/schemas.py
@@ -19,6 +19,6 @@ HASH_AND_STR_RANGE_SCHEMA = dict(
     ])
 
 ALTERNATOR_SCHEMAS = {
-    enums.YCSVSchemaTypes.HASH_SCHEMA.value: HASH_SCHEMA,
-    enums.YCSVSchemaTypes.HASH_AND_RANGE.value: HASH_AND_STR_RANGE_SCHEMA,
+    enums.YCSBSchemaTypes.HASH_SCHEMA.value: HASH_SCHEMA,
+    enums.YCSBSchemaTypes.HASH_AND_RANGE.value: HASH_AND_STR_RANGE_SCHEMA,
 }

--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -123,19 +123,19 @@ class YcsbStressThread(DockerBasedStressThread):  # pylint: disable=too-many-ins
                        self.params.get('alternator_port')))
 
             dynamodb_primarykey_type = self.params.get('dynamodb_primarykey_type')
-            if isinstance(dynamodb_primarykey_type, alternator.enums.YCSVSchemaTypes):
+            if isinstance(dynamodb_primarykey_type, alternator.enums.YCSBSchemaTypes):
                 dynamodb_primarykey_type = dynamodb_primarykey_type.value
 
-            if dynamodb_primarykey_type == alternator.enums.YCSVSchemaTypes.HASH_AND_RANGE.value:
+            if dynamodb_primarykey_type == alternator.enums.YCSBSchemaTypes.HASH_AND_RANGE.value:
                 dynamodb_teample += dedent(f'''
                     dynamodb.primaryKey = {alternator.consts.HASH_KEY_NAME}
                     dynamodb.hashKeyName = {alternator.consts.RANGE_KEY_NAME}
-                    dynamodb.primaryKeyType = {alternator.enums.YCSVSchemaTypes.HASH_AND_RANGE.value}
+                    dynamodb.primaryKeyType = {alternator.enums.YCSBSchemaTypes.HASH_AND_RANGE.value}
                 ''')
-            elif dynamodb_primarykey_type == alternator.enums.YCSVSchemaTypes.HASH_SCHEMA.value:
+            elif dynamodb_primarykey_type == alternator.enums.YCSBSchemaTypes.HASH_SCHEMA.value:
                 dynamodb_teample += dedent(f'''
                     dynamodb.primaryKey = {alternator.consts.HASH_KEY_NAME}
-                    dynamodb.primaryKeyType = {alternator.enums.YCSVSchemaTypes.HASH_SCHEMA.value}
+                    dynamodb.primaryKeyType = {alternator.enums.YCSBSchemaTypes.HASH_SCHEMA.value}
                 ''')
 
             aws_empty_file = dedent(f""""

--- a/test-cases/upgrades/rolling-upgrade.yaml
+++ b/test-cases/upgrades/rolling-upgrade.yaml
@@ -14,11 +14,45 @@ stress_cmd_complex_verify_read: cassandra-stress user no-warmup profile=/tmp/com
 stress_cmd_complex_verify_more: cassandra-stress user no-warmup profile=/tmp/complex_schema.yaml  ops'(read1=1,read2=1,update_static=1,update_ttl=1,update_diff1_ts=1,update_diff2_ts=1,update_same1_ts=1,update_same2_ts=1)' cl=ALL n=5000000 -mode cql3 native -rate threads=200 -pop seq=1..5000000
 stress_cmd_complex_verify_delete: cassandra-stress user no-warmup profile=/tmp/complex_schema.yaml  ops'(delete_row=1)' cl=ALL n=500000 -mode cql3 native -rate threads=200 -pop seq=1..500000
 
+# Alternator stress
+alternator_write_stress_during_entire_test: >-2
+  bin/ycsb run dynamodb -P workloads/workloada -threads 100 -p recordcount=2010020
+  -p readproportion=0 -p updateproportion=1 -p scanproportion=0 -p insertproportion=0 -p requestdistribution=uniform
+  -p fieldcount=10 -p fieldlength=512 -p operationcount=2010020 -p table=alternator_entire_test
+alternator_verify_stress_after_cluster_upgrade: >-2
+  bin/ycsb run dynamodb -P workloads/workloada -threads 100 -p recordcount=2010020
+  -p readproportion=1 -p updateproportion=0 -p scanproportion=0 -p insertproportion=0 -p requestdistribution=uniform
+  -p fieldcount=10 -p fieldlength=512 -p operationcount=2010020 -p table=alternator_entire_test
+alternator_prepare_write_stress: >-2
+  bin/ycsb run dynamodb -P workloads/workloada -threads 100 -p recordcount=1010020
+  -p readproportion=0 -p updateproportion=1 -p scanproportion=0 -p insertproportion=0 -p requestdistribution=uniform
+  -p fieldcount=10 -p fieldlength=512 -p operationcount=1010020 -p table=usertable
+alternator_prepare_read_stress: >-2
+  bin/ycsb run dynamodb -P workloads/workloada -threads 100 -p recordcount=1010020
+  -p readproportion=1 -p updateproportion=0 -p scanproportion=0 -p insertproportion=0 -p requestdistribution=uniform
+  -p fieldcount=10 -p fieldlength=512 -p operationcount=1010020 -p table=usertable
+alternator_stress_cmd_read_10m: >-2
+  bin/ycsb run dynamodb -P workloads/workloada -threads 100 -p recordcount=1010020
+  -p readproportion=1 -p updateproportion=0 -p scanproportion=0 -p insertproportion=0 -p requestdistribution=uniform
+  -p fieldcount=10 -p fieldlength=512 -p operationcount=1010020 - maxexecutiontime=600 -p table=usertable
+alternator_stress_cmd_read_60m: >-2
+  bin/ycsb run dynamodb -P workloads/workloada -threads 100 -p recordcount=1010020
+  -p readproportion=1 -p updateproportion=0 -p scanproportion=0 -p insertproportion=0 -p requestdistribution=uniform
+  -p fieldcount=10 -p fieldlength=512 -p operationcount=1010020 - maxexecutiontime=3600 -p table=usertable
+
 n_db_nodes: 4
 n_loaders: 1
 n_monitor_nodes: 1
 
 user_prefix: 'rolling-upgrade'
+
+alternator_port: 8080
+alternator_use_dns_routing: true
+
+dynamodb_primarykey_type: HASH_AND_RANGE
+alternator_enforce_authorization: true
+alternator_access_key_id: 'alternator'
+alternator_secret_access_key: 'password'
 
 server_encrypt: true
 authenticator: 'PasswordAuthenticator'

--- a/unit_tests/test_ycsb_thread.py
+++ b/unit_tests/test_ycsb_thread.py
@@ -189,4 +189,4 @@ def test_04_insert_new_data(docker_scylla):
     ALTERNATOR.batch_write_actions(node=docker_scylla, new_items=new_items,
                                    schema=alternator.schemas.HASH_AND_STR_RANGE_SCHEMA)
     diff = ALTERNATOR.compare_table_data(node=docker_scylla, table_data=new_items)
-    assert diff
+    assert not diff

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -17,12 +17,15 @@ import random
 import time
 import re
 import os
+from pprint import pformat
+from string import ascii_letters
 from functools import wraps
 
 from pkg_resources import parse_version
 
 from sdcm.fill_db_data import FillDatabaseData
 from sdcm import wait
+from sdcm.utils import alternator
 from sdcm.group_common_events import ignore_upgrade_schema_errors
 from sdcm.utils.version_utils import is_enterprise
 from sdcm.sct_events import IndexSpecialColumnErrorEvent
@@ -421,6 +424,39 @@ class UpgradeTest(FillDatabaseData):
             self.log.info('Re-Populate DB with many types of tables and data')
             self.fill_db_data()
 
+    def fill_and_verify_alternator_db_data(self, node, note, table_name, schema, pre_fill=False, rewrite_data=True):
+        items, items2 = [], []
+        schema_keys = [key_details["AttributeName"]
+                       for key_details in alternator.schemas.ALTERNATOR_SCHEMAS[schema]["KeySchema"]]
+        key_format = "test_{}"
+        items_size = 10
+
+        number_of_existing_items = len(self.alternator.scan_table(node=node, table_name=table_name))
+        for idx in range(items_size):
+            item_value = "".join(random.choices(population=ascii_letters, k=10))
+            item_value2 = "".join(random.choices(population=ascii_letters, k=10))
+            items.append({schema_keys[0]:  key_format.format(number_of_existing_items + idx),
+                          schema_keys[1]: item_value})
+            items2.append({schema_keys[0]:  key_format.format(number_of_existing_items + items_size + idx),
+                           schema_keys[1]: item_value2})
+
+        if pre_fill:
+            self.log.info(f"Adding new items to Alternator '{table_name}' table")
+            self.alternator.batch_write_actions(node=node, table_name=table_name, schema=schema, new_items=items)
+        items += self.alternator.scan_table(node=node, table_name=table_name)
+        self.log.info('Run some Queries to verify data %s', note)
+        diff = self.alternator.compare_table_data(node=node, table_data=items, table_name=table_name)
+        assert not diff, f"The new data entered in the table is not the same as the one inside the table. The diff " \
+                         f"'{pformat(diff)}'"
+
+        if rewrite_data:
+            self.log.info(f"Ending exist items of Alternator '{table_name}' table with new values")
+            self.alternator.batch_write_actions(
+                node=node, table_name=table_name, schema=schema, new_items=items2)
+            diff = self.alternator.compare_table_data(node=node, table_data=items + items2, table_name=table_name)
+            assert not diff, f"The new data entered in the table is not the same as the one inside the table. The " \
+                             f"diff '{pformat(diff)}'"
+
     # Added to cover the issue #5621: upgrade from 3.1 to 3.2 fails on std::logic_error (Column idx_token doesn't exist
     # in base and this view is not backing a secondary index)
     # @staticmethod
@@ -434,16 +470,30 @@ class UpgradeTest(FillDatabaseData):
                                          'Found error: index special column "idx_token" is not recognized' %
                                          (node.name, step))
 
-    def test_rolling_upgrade(self):  # pylint: disable=too-many-locals,too-many-statements
+    def test_rolling_upgrade(self):  # pylint: disable=too-many-locals,too-many-statements,too-many-branches
         """
         Upgrade half of nodes in the cluster, and start special read workload
         during the stage. Checksum method is changed to xxhash from Scylla 2.2,
         we want to use this case to verify the read (cl=ALL) workload works
         well, upgrade all nodes to new version in the end.
         """
+        alternator_prepare_write_thread_pool = None
+        alternator_entire_write_thread_pool = None
+        alternator_verify_stress_thread_pool = None
+        alternator_table_name = "alternator_fill_db_data"
+        alternator_table_schema = alternator.enums.YCSBSchemaTypes.HASH_AND_RANGE.value
+        alternator_table_names = [alternator_table_name, "usertable", "alternator_entire_test"]
+
         # In case the target version >= 3.1 we need to perform test for truncate entries
         target_upgrade_version = self.params.get('target_upgrade_version', default='')
+        current_version = self.params.get("scylla_version", default="")
+
         self.truncate_entries_flag = False
+        if is_enterprise(version=current_version):
+            is_alternator_supported = parse_version(current_version) > parse_version("2020.0")
+        else:
+            is_alternator_supported = parse_version(current_version) > parse_version("4.0")
+
         if target_upgrade_version and parse_version(target_upgrade_version) >= parse_version('3.1') and \
                 not is_enterprise(target_upgrade_version):
             self.truncate_entries_flag = True
@@ -451,12 +501,30 @@ class UpgradeTest(FillDatabaseData):
         self.log.info('pre-test - prepare test keyspaces and tables')
         # prepare test keyspaces and tables before upgrade to avoid schema change during mixed cluster.
         self.prepare_keyspaces_and_tables()
+        if is_alternator_supported:
+            self.db_cluster.node_to_upgrade = self.db_cluster.nodes[0]
+            if self.params.get('alternator_enforce_authorization'):
+                with self.cql_connection_patient(node=self.db_cluster.node_to_upgrade) as session:
+                    session.execute("""
+                                   INSERT INTO system_auth.roles (role, salted_hash) VALUES (%s, %s)
+                               """, (self.params.get('alternator_access_key_id'),
+                                     self.params.get('alternator_secret_access_key')))
+            for table_name in alternator_table_names:
+                self.alternator.create_table(
+                    node=self.db_cluster.node_to_upgrade, schema=alternator_table_schema, table_name=table_name)
+            self.fill_and_verify_alternator_db_data(
+                node=self.db_cluster.node_to_upgrade, note="ALTERNATOR BEFORE UPGRADE",
+                table_name=alternator_table_name, schema=alternator_table_schema, pre_fill=True)
         self.fill_and_verify_db_data('BEFORE UPGRADE', pre_fill=True)
 
         # write workload during entire test
         self.log.info('Starting c-s write workload during entire test')
         write_stress_during_entire_test = self.params.get('write_stress_during_entire_test')
         entire_write_cs_thread_pool = self.run_stress_thread(stress_cmd=write_stress_during_entire_test)
+        if is_alternator_supported:
+            self.log.info('Starting YCSB write workload during entire test')
+            alternator_entire_write_thread_pool = self.run_stress_thread(stress_cmd=self.params.get(
+                "alternator_write_stress_during_entire_test"))
 
         # Let to write_stress_during_entire_test complete the schema changes
         time.sleep(300)
@@ -487,6 +555,10 @@ class UpgradeTest(FillDatabaseData):
         self.log.info('Starting c-s prepare write workload (n=10000000)')
         prepare_write_stress = self.params.get('prepare_write_stress')
         prepare_write_cs_thread_pool = self.run_stress_thread(stress_cmd=prepare_write_stress)
+        if is_alternator_supported:
+            alternator_prepare_write_stress = self.params.get('alternator_prepare_write_stress')
+            alternator_prepare_write_thread_pool = self.run_stress_thread(
+                stress_cmd=alternator_prepare_write_stress)
         self.log.info('Sleeping for 60s to let cassandra-stress start before the upgrade...')
         time.sleep(60)
 
@@ -502,15 +574,31 @@ class UpgradeTest(FillDatabaseData):
             self.db_cluster.node_to_upgrade.check_node_health()
 
             # wait for the prepare write workload to finish
+            self.log.info("Waiting until c-s prepare write is finished")
             self.verify_stress_thread(prepare_write_cs_thread_pool)
+            if is_alternator_supported:
+                self.log.info("Waiting until Alternator prepare write is finished")
+                self.verify_stress_thread(alternator_prepare_write_thread_pool)
 
             # read workload (cl=QUORUM)
             self.log.info('Starting c-s read workload (cl=QUORUM n=10000000)')
             stress_cmd_read_cl_quorum = self.params.get('stress_cmd_read_cl_quorum')
             read_stress_queue = self.run_stress_thread(stress_cmd=stress_cmd_read_cl_quorum)
+            if is_alternator_supported:
+                alternator_prepare_read_stress = self.params.get('alternator_prepare_read_stress')
+                self.log.info(f"Starting Alternator read workload ('{alternator_prepare_read_stress}')")
+                alternator_read_stress_queue = self.run_stress_thread(
+                    stress_cmd=alternator_prepare_read_stress)
+
             # wait for the read workload to finish
             self.verify_stress_thread(read_stress_queue)
             self.fill_and_verify_db_data('after upgraded one node')
+            if is_alternator_supported:
+                self.verify_stress_thread(alternator_read_stress_queue)
+                self.fill_and_verify_alternator_db_data(
+                    node=self.db_cluster.node_to_upgrade, note='Alternator after upgraded one node',
+                    table_name=alternator_table_name, schema=alternator_table_schema)
+
             self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
                                                           step=step+' - after upgraded one node')
 
@@ -518,6 +606,10 @@ class UpgradeTest(FillDatabaseData):
             self.log.info('Starting c-s read workload for 10m')
             stress_cmd_read_10m = self.params.get('stress_cmd_read_10m')
             read_10m_cs_thread_pool = self.run_stress_thread(stress_cmd=stress_cmd_read_10m)
+            if is_alternator_supported:
+                self.log.info('Starting Alternator read workload for 10m')
+                alternator_stress_cmd_read_10m = self.params.get('alternator_stress_cmd_read_10m')
+                alternator_read_10m_thread_pool = self.run_stress_thread(stress_cmd=alternator_stress_cmd_read_10m)
 
             self.log.info('Sleeping for 60s to let cassandra-stress start before the upgrade...')
             time.sleep(60)
@@ -533,7 +625,15 @@ class UpgradeTest(FillDatabaseData):
 
             # wait for the 10m read workload to finish
             self.verify_stress_thread(read_10m_cs_thread_pool)
+            if is_alternator_supported:
+                self.verify_stress_thread(alternator_read_10m_thread_pool)
+
             self.fill_and_verify_db_data('after upgraded two nodes')
+            if is_alternator_supported:
+                self.fill_and_verify_alternator_db_data(
+                    node=self.db_cluster.node_to_upgrade, note='Alternator after upgraded two nodes',
+                    table_name=alternator_table_name, schema=alternator_table_schema)
+
             self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
                                                           step=step+' - after upgraded two nodes')
 
@@ -541,6 +641,10 @@ class UpgradeTest(FillDatabaseData):
             self.log.info('Starting c-s read workload for 60m')
             stress_cmd_read_60m = self.params.get('stress_cmd_read_60m')
             read_60m_cs_thread_pool = self.run_stress_thread(stress_cmd=stress_cmd_read_60m)
+            if is_alternator_supported:
+                self.log.info('Starting Alternator read workload for 60m')
+                alternator_stress_cmd_read_60m = self.params.get('alternator_stress_cmd_read_60m')
+                alternator_read_60m_thread_pool = self.run_stress_thread(stress_cmd=alternator_stress_cmd_read_60m)
             self.log.info('Sleeping for 60s to let cassandra-stress start before the rollback...')
             time.sleep(60)
 
@@ -554,6 +658,10 @@ class UpgradeTest(FillDatabaseData):
         step = 'Step4 - Verify data during mixed cluster mode '
         self.log.info(step)
         self.fill_and_verify_db_data('after rollback the second node')
+        if is_alternator_supported:
+            self.fill_and_verify_alternator_db_data(
+                node=self.db_cluster.node_to_upgrade, note='Alternator after rollback the second node',
+                table_name=alternator_table_name, schema=alternator_table_schema)
         self.log.info('Repair the first upgraded Node')
         self.db_cluster.nodes[indexes[0]].run_nodetool(sub_cmd='repair')
         self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
@@ -570,6 +678,11 @@ class UpgradeTest(FillDatabaseData):
                 self.log.info('Upgrade Node %s ended', self.db_cluster.node_to_upgrade.name)
                 self.db_cluster.node_to_upgrade.check_node_health()
                 self.fill_and_verify_db_data('after upgraded %s' % self.db_cluster.node_to_upgrade.name)
+                if is_alternator_supported:
+                    self.fill_and_verify_alternator_db_data(
+                        node=self.db_cluster.node_to_upgrade,
+                        note=f"Alternator after upgraded '{self.db_cluster.node_to_upgrade.name}'",
+                        table_name=alternator_table_name, schema=alternator_table_schema)
                 self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
                                                               step=step)
 
@@ -577,8 +690,12 @@ class UpgradeTest(FillDatabaseData):
         self.log.info('Waiting for stress threads to complete after upgrade')
         # wait for the 60m read workload to finish
         self.verify_stress_thread(read_60m_cs_thread_pool)
-
         self.verify_stress_thread(entire_write_cs_thread_pool)
+        if is_alternator_supported:
+            self.log.info('Waiting for Alternator stress threads to complete after upgrade')
+            # wait for the 60m read workload to finish
+            self.verify_stress_thread(alternator_read_60m_thread_pool)
+            self.verify_stress_thread(alternator_entire_write_thread_pool)
 
         self.log.info('Step7 - Upgrade sstables to latest supported version ')
         # figure out what is the last supported sstable version
@@ -605,7 +722,15 @@ class UpgradeTest(FillDatabaseData):
         verify_stress_after_cluster_upgrade = self.params.get(  # pylint: disable=invalid-name
             'verify_stress_after_cluster_upgrade')
         verify_stress_cs_thread_pool = self.run_stress_thread(stress_cmd=verify_stress_after_cluster_upgrade)
+        if is_alternator_supported:
+            self.log.info("Verifying Alternator data after cluster upgraded")
+            alternator_verify_stress_after_cluster_upgrade = self.params.get(  # pylint: disable=invalid-name
+                'alternator_verify_stress_after_cluster_upgrade')
+            alternator_verify_stress_thread_pool = \
+                self.run_stress_thread(stress_cmd=alternator_verify_stress_after_cluster_upgrade)
         self.verify_stress_thread(verify_stress_cs_thread_pool)
+        if is_alternator_supported:
+            self.verify_stress_thread(alternator_verify_stress_thread_pool)
 
         # complex workload: verify data by simple read cl=ALL
         self.log.info('Starting c-s complex workload to verify data by simple read')

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -54,7 +54,7 @@ def call(Map pipelineParams) {
                     script {
                         def tasks = [:]
 
-                        for (version in supportedUpgradeFromVersions(env.GIT_BRANCH, pipelineParams.base_versions)) {
+                        for (version in pipelineParams.base_versions) {
                             def base_version = version
                             tasks["${base_version}"] = {
                                 node(builder.label) {


### PR DESCRIPTION
…ternator

* rolloing-upgrade.yaml - Adding new stress commands for Alternator
* upgrade_test.py:
  * fill_and_verify_alternator_db_data - The function add data and veryfy it
  * test_rolling_upgrade - Add steps to check Alternator
* Adding new SCT config variables:
  * alternator_write_stress_during_entire_test
  * alternator_verify_stress_after_cluster_upgrade
  * alternator_prepare_write_stress
  * alternator_stress_cmd_read_cl_quorum
  * alternator_stress_cmd_read_10m
  * alternator_stress_cmd_read_60m

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
