### PR TITLE
Improve timeout handling

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -366,14 +366,15 @@ def list_repos(dist_type, dist_version):
 
 
 @cli.command(help="Check test configuration file")
-@click.argument('config_file', type=click.Path(exists=True))
+@click.argument('config_file', type=str, default='')
 @click.option('-b', '--backend', type=click.Choice(SCTConfiguration.available_backends), default='aws')
 def conf(config_file, backend):
     add_file_logger()
 
     if backend:
         os.environ['SCT_CLUSTER_BACKEND'] = backend
-    os.environ['SCT_CONFIG_FILES'] = config_file
+    if config_file:
+        os.environ['SCT_CONFIG_FILES'] = config_file
     config = SCTConfiguration()
     try:
         config.verify_configuration()

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -99,8 +99,8 @@ class SCTConfiguration(dict):
 
         dict(name="test_duration", env="SCT_TEST_DURATION", type=int,
              help="""
-                  Test duration (min). Parameter used to keep instances produced by tests that are
-                  supposed to run longer than 24 hours from being killed
+                  Test duration (min). Parameter used to keep instances produced by tests
+                  and for jenkins pipeline timeout and TimoutThread.
              """),
 
         dict(name="n_db_nodes", env="SCT_N_DB_NODES", type=int_or_list,
@@ -1187,13 +1187,15 @@ class SCTConfiguration(dict):
         new_scylla_repo = self.get('new_scylla_repo', None)
         if new_scylla_repo and 'target_upgrade_version' not in self:
             self['target_upgrade_version'] = get_branch_version(new_scylla_repo)
-        self.log.info(self.dump_config())
 
         # 9) instance_provision MIXED is not supported
         if self.get('instance_provision') == 'mixed':
             self.log.warning('Selected instance_provision type "MIXED" is not supported!')
 
         self._update_environment_variables()
+
+    def log_config(self):
+        self.log.info(self.dump_config())
 
     @classmethod
     def get_config_option(cls, name):

--- a/sdcm/sct_events.py
+++ b/sdcm/sct_events.py
@@ -959,7 +959,7 @@ class EventsFileLogger(multiprocessing.Process):  # pylint: disable=too-many-ins
 EVENTS_PROCESSES = dict()
 
 
-def start_events_device(log_dir, timeout=5):  # pylint: disable=redefined-outer-name
+def start_events_device(log_dir):
     from sdcm.utils.grafana import GrafanaEventAggragator, GrafanaAnnotator
     from sdcm.sct_events_analyzer import EventsAnalyzer
 

--- a/sdcm/sct_events_analyzer.py
+++ b/sdcm/sct_events_analyzer.py
@@ -1,7 +1,5 @@
-import os
 import sys
 import threading
-import signal
 import logging
 
 from sdcm.sct_events import EVENTS_PROCESSES, Severity, raise_event_on_failure
@@ -49,10 +47,8 @@ class EventsAnalyzer(threading.Thread):
         self.join(timeout)
 
     def kill_test(self, backtrace_with_reason):
+        self.terminate()
         if not Setup.tester_obj():
             LOGGER.error("no test was register using 'Setup.set_tester_obj()', not killing")
             return
-        test_pid = os.getpid()
-        Setup.tester_obj().result.addFailure(Setup.tester_obj(), backtrace_with_reason)
-        os.kill(test_pid, signal.SIGUSR2)
-        self.terminate()
+        Setup.tester_obj().kill_test(backtrace_with_reason)

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -203,6 +203,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         self.result = None
         self._results = []
         self.status = "RUNNING"
+        self.start_time = time.time()
         self._init_params()
         reuse_cluster_id = self.params.get('reuse_cluster', default=False)
         if reuse_cluster_id:
@@ -258,10 +259,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         self.scylla_dir = SCYLLA_DIR
         self.scylla_hints_dir = os.path.join(self.scylla_dir, "hints")
         self._logs = {}
+        self.timeout_thread = self._init_test_timeout_thread()
         self.email_reporter = build_reporter(self.__class__.__name__,
                                              self.params.get('email_recipients', default=()),
                                              self.logdir)
-        self.start_time = time.time()
 
         self.localhost = self._init_localhost()
         if self.params.get("logs_transport") == 'rsyslog':
@@ -272,11 +273,26 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         time.sleep(0.5)
         InfoEvent('TEST_START test_id=%s' % Setup.test_id())
 
+    def _init_test_timeout_thread(self) -> threading.Timer:
+        start_time = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(self.start_time))
+
+        def kill_the_test():
+            try:
+                raise RuntimeError(
+                    f"Test started at {start_time} has reached timeout ({self.test_duration} minutes)"
+                )
+            except:  # pylint: disable=bare-except
+                self.kill_test(sys.exc_info())
+        th = threading.Timer(60 * int(self.test_duration), kill_the_test)
+        th.start()
+        return th
+
     def _init_localhost(self):
         return LocalHost(user_prefix=self.params.get("user_prefix", None), test_id=Setup.test_id())
 
     def _init_params(self):
         self.params = SCTConfiguration()
+        self.params.log_config()
         self.params.verify_configuration()
         self.params.check_required_files()
 
@@ -309,7 +325,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     def test_duration(self):
         return self._duration
 
-    def get_duration(self, duration):
+    def get_duration(self, duration: int):
         """Calculate duration based on test_duration
 
         Calculate duration for stress threads
@@ -359,6 +375,11 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         if summary.get('ERROR', 0) or summary.get('CRITICAL', 0):
             return 'FAILED'
         return 'SUCCESS'
+
+    def kill_test(self, backtrace_with_reason):
+        test_pid = os.getpid()
+        self.result.addFailure(Setup.tester_obj(), backtrace_with_reason)
+        os.kill(test_pid, signal.SIGUSR2)
 
     @teardown_on_exception
     @log_run_info
@@ -1777,6 +1798,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         with silence(parent=self, name='Sending test end event'):
             InfoEvent('TEST_END')
         self.log.info('TearDown is starting...')
+        self.stop_timeout_thread()
         self.stop_event_analyzer()
         self.stop_resources()
         self.get_test_failures()
@@ -1826,6 +1848,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     @silence()
     def stop_event_analyzer(self):  # pylint: disable=no-self-use
         stop_events_analyzer()
+
+    @silence()
+    def stop_timeout_thread(self):
+        self.timeout_thread.cancel()
 
     @silence()
     def collect_sct_logs(self):

--- a/test-cases/PR-provision-test-docker.yaml
+++ b/test-cases/PR-provision-test-docker.yaml
@@ -1,4 +1,4 @@
-test_duration: 15
+test_duration: 60
 stress_cmd: ["cassandra-stress write cl=ONE duration=1m -schema 'replication(factor=1) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..10000000 -log interval=5",
              "cassandra-stress counter_write cl=ONE duration=1m -schema 'replication(factor=1) compaction(strategy=DateTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=5 -pop seq=1..10000000"
              ]

--- a/test-cases/PR-provision-test.yaml
+++ b/test-cases/PR-provision-test.yaml
@@ -1,4 +1,4 @@
-test_duration: 10
+test_duration: 60
 max_partitions_in_test_table: 10
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=1m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5",
              "cassandra-stress counter_write cl=QUORUM duration=1m -schema 'replication(factor=3) compaction(strategy=DateTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=5 -pop seq=1..10000000"

--- a/test-cases/load/admission_control_overload_test.yaml
+++ b/test-cases/load/admission_control_overload_test.yaml
@@ -1,4 +1,4 @@
-test_duration: 25
+test_duration: 50
 
 prepare_write_cmd: "cassandra-stress user profile=/tmp/cs_profile_background_reads_overload.yaml ops'(insert=10)' no-warmup cl=ONE -port jmx=6868 -mode cql3 native -rate threads=1000 -errors ignore"
 stress_cmd_r: "cassandra-stress user profile=/tmp/cs_profile_background_reads_overload.yaml ops'(simple1=100)' no-warmup cl=ONE duration=10m -port jmx=6868 -mode cql3 native -rate threads=1000 -errors ignore"

--- a/test-cases/longevity/longevity-10gb-3h.yaml
+++ b/test-cases/longevity/longevity-10gb-3h.yaml
@@ -1,4 +1,4 @@
-test_duration: 180
+test_duration: 210
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5"
              ]
 

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -65,7 +65,7 @@ class TestBaseNode(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.temp_dir = tempfile.mkdtemp()
-        start_events_device(cls.temp_dir, timeout=5)
+        start_events_device(cls.temp_dir)
 
         cls.node = DummyNode(name='test_node', parent_cluster=None,
                              base_logdir=cls.temp_dir, ssh_login_info=dict(key_file='~/.ssh/scylla-test'))

--- a/unit_tests/test_decode_backtrace.py
+++ b/unit_tests/test_decode_backtrace.py
@@ -35,7 +35,7 @@ class TestDecodeBactraces(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.temp_dir = tempfile.mkdtemp()
-        start_events_device(cls.temp_dir, timeout=5)
+        start_events_device(cls.temp_dir)
 
         cls.node = DecodeDummyNode(name='test_node', parent_cluster=None,
                                    base_logdir=cls.temp_dir, ssh_login_info=dict(key_file='~/.ssh/scylla-test'))

--- a/unit_tests/test_events.py
+++ b/unit_tests/test_events.py
@@ -55,7 +55,7 @@ class BaseEventsTest(unittest.TestCase):
     def setUpClass(cls):
         cls.temp_dir = tempfile.mkdtemp()
         start_metrics_server()
-        start_events_device(cls.temp_dir, timeout=5)
+        start_events_device(cls.temp_dir)
         cls.killed = Event()
         time.sleep(5)
 

--- a/vars/getJobTimeouts.groovy
+++ b/vars/getJobTimeouts.groovy
@@ -1,0 +1,25 @@
+#!groovy
+
+List<Integer> call(Map params, String region){
+    // handle params which can be a json list
+    def test_config = groovy.json.JsonOutput.toJson(params.test_config)
+    def cmd = """
+    #!/bin/bash
+    export SCT_CLUSTER_BACKEND="${params.backend}"
+    export SCT_CONFIG_FILES=${test_config}
+    ./docker/env/hydra.sh conf -b "${params.backend}" 2>/dev/null | grep test_duration | awk '{print \$2}'
+    """
+    def testDuration = sh(script: cmd, returnStdout: true).trim()
+    println("Test duration: $testDuration")
+    testDuration = testDuration.toInteger()
+    println("Test duration: $testDuration")
+    Integer testRunTimeout = testDuration + Math.max( (int) (testDuration * 0.1), (int) 20)
+    println("Test run timeout: $testRunTimeout")
+    Integer runnerTimeout = (int) (testRunTimeout * 1.2)
+    println("Runner timeout: $runnerTimeout")
+    Integer collectLogsTimeout = Math.max( (int) (testDuration * 0.2), (int) 20)
+    println("Collect logs timeout: $collectLogsTimeout")
+    Integer resourceCleanupTimeout = Math.max( (int) (testDuration * 0.2), (int) 20)
+    println("Resource cleanup timeout: $resourceCleanupTimeout")
+    return [testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCleanupTimeout]
+}


### PR DESCRIPTION
https://trello.com/c/kSXVTnzl/2070-stop-the-test-gracefully-when-the-jenkins-job-stopped-by-timeout

1. Make event analyzer fail test by timeout
2. Fix test duration for some tests
4. Fix pipeline to get steps timeout from test yaml

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
