### PR TITLE
fix(sdcm/group_common_events.py): fix ExitStack usage

### DIFF
--- a/sdcm/group_common_events.py
+++ b/sdcm/group_common_events.py
@@ -36,7 +36,7 @@ def ignore_operation_errors():
 
 @contextmanager
 def ignore_upgrade_schema_errors():
-    with ExitStack as stack:
+    with ExitStack() as stack:
         stack.enter_context(DbEventsFilter(type='DATABASE_ERROR', line='Failed to load schema'))
         stack.enter_context(DbEventsFilter(type='SCHEMA_FAILURE', line='Failed to load schema'))
         stack.enter_context(DbEventsFilter(type='DATABASE_ERROR', line='Failed to pull schema'))


### PR DESCRIPTION
Fix test failure:

```
2020-08-11 10:02:47.008: (TestFrameworkEvent Severity.ERROR), source=UpgradeTest.test_rolling_upgrade (upgrade_test.UpgradeTest)() message=Traceback (most recent call last):
File "/jenkins/slave/workspace/scylla-master/rolling-upgrade/rolling-upgrade-debian10-test/scylla-cluster-tests/upgrade_test.py", line 493, in test_rolling_upgrade
with ignore_upgrade_schema_errors():
File "/usr/local/lib/python3.8/contextlib.py", line 113, in __enter__
return next(self.gen)
File "/jenkins/slave/workspace/scylla-master/rolling-upgrade/rolling-upgrade-debian10-test/scylla-cluster-tests/sdcm/group_common_events.py", line 39, in ignore_upgrade_schema_errors
with ExitStack as stack:
AttributeError: __enter__
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
