### PR TITLE
fix(get_non_system_ks_cf_list): Return list instead of set

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3104,7 +3104,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
         return self.cql_connection_exclusive(**kwargs)
 
     def get_non_system_ks_cf_list(self, db_node,  # pylint: disable=too-many-arguments
-                                  filter_out_table_with_counter=False, filter_out_mv=False, filter_empty_tables=True):
+                                  filter_out_table_with_counter=False, filter_out_mv=False, filter_empty_tables=True) -> List[str]:
         regular_column_names = ["keyspace_name", "table_name"]
         materialized_view_column_names = ["keyspace_name", "view_name"]
         regular_table_names, materialized_view_table_names = set(), set()
@@ -3143,7 +3143,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
         if not regular_table_names:
             return []
 
-        return regular_table_names - materialized_view_table_names
+        return list(regular_table_names - materialized_view_table_names)
 
 
 class NodeSetupFailed(Exception):


### PR DESCRIPTION
get_non_system_ks_cf_list should return list, but returns the set.
this cause the issue for call random.choice:
- TypeError: 'set' object is not subscriptable

https://trello.com/c/MJDMC2e1/2213-choosefilefordestroy-typeerror-set-object-is-not-subscriptable

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (CI)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
