### PR TITLE
fix(cdc_repl_test): Use oracle cluster for cql connection

### DIFF
--- a/cdc_replication_test.py
+++ b/cdc_replication_test.py
@@ -69,7 +69,7 @@ class CDCReplicationTest(ClusterTester):
                                                consistency_level=ConsistencyLevel.QUORUM, fetch_size=1000))
             write_cql_result(res, os.path.join(self.logdir, 'master-table'))
 
-        with self.db_cluster.cql_connection_patient(node=replica_node) as sess:
+        with self.cs_db_cluster.cql_connection_patient(node=replica_node) as sess:
             self.log.info('Fetching replica table...')
             res = sess.execute(SimpleStatement(f'select * from {self.KS_NAME}.{self.TABLE_NAME}',
                                                consistency_level=ConsistencyLevel.QUORUM, fetch_size=1000))
@@ -131,7 +131,7 @@ class CDCReplicationTest(ClusterTester):
 
         self.log.info('Creating schema on replica cluster.')
         replica_node = self.cs_db_cluster.nodes[0]
-        with self.db_cluster.cql_connection_patient(node=replica_node) as sess:
+        with self.cs_db_cluster.cql_connection_patient(node=replica_node) as sess:
             sess.execute(f"create keyspace if not exists {self.KS_NAME}"
                          " with replication = {'class': 'SimpleStrategy', 'replication_factor': 1}")
             for stmt in ut_ddls + table_ddls:


### PR DESCRIPTION
Create schema on oracle cluster should use cs_db_cluster object
for connection management

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
