### PR TITLE
improvement(artifacts): rename instance_provision jobs parameter to provision_type

### DIFF
--- a/jenkins-pipelines/artifacts-amazon2.jenkinsfile
+++ b/jenkins-pipelines/artifacts-amazon2.jenkinsfile
@@ -9,7 +9,7 @@ artifactsPipeline(
     test_config: 'test-cases/artifacts/amazon2.yaml',
     backend: 'aws',
     region_name: 'eu-west-1',
-    instance_provision: 'spot_low_price',
+    provision_type: 'spot_low_price',
     scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
 
     timeout: [time: 60, unit: 'MINUTES'],

--- a/jenkins-pipelines/artifacts-ami.jenkinsfile
+++ b/jenkins-pipelines/artifacts-ami.jenkinsfile
@@ -8,7 +8,7 @@ artifactsPipeline(
 
     test_config: 'test-cases/artifacts/ami.yaml',
     backend: 'aws',
-    instance_provision: 'spot_low_price',
+    provision_type: 'spot_low_price',
 
     timeout: [time: 45, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',

--- a/jenkins-pipelines/artifacts-centos7.jenkinsfile
+++ b/jenkins-pipelines/artifacts-centos7.jenkinsfile
@@ -8,7 +8,7 @@ artifactsPipeline(
 
     test_config: 'test-cases/artifacts/centos7.yaml',
     backend: 'gce',
-    instance_provision: 'spot',
+    provision_type: 'spot',
     scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
 
     timeout: [time: 30, unit: 'MINUTES'],

--- a/jenkins-pipelines/artifacts-centos8.jenkinsfile
+++ b/jenkins-pipelines/artifacts-centos8.jenkinsfile
@@ -8,7 +8,7 @@ artifactsPipeline(
 
     test_config: 'test-cases/artifacts/centos8.yaml',
     backend: 'gce',
-    instance_provision: 'spot',
+    provision_type: 'spot',
     scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
 
     timeout: [time: 30, unit: 'MINUTES'],

--- a/jenkins-pipelines/artifacts-debian10.jenkinsfile
+++ b/jenkins-pipelines/artifacts-debian10.jenkinsfile
@@ -8,7 +8,7 @@ artifactsPipeline(
 
     test_config: 'test-cases/artifacts/debian10.yaml',
     backend: 'gce',
-    instance_provision: 'spot',
+    provision_type: 'spot',
     scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/buster/master/latest/scylladb-manager-master/scylla-manager.list',
 
     timeout: [time: 30, unit: 'MINUTES'],

--- a/jenkins-pipelines/artifacts-debian9.jenkinsfile
+++ b/jenkins-pipelines/artifacts-debian9.jenkinsfile
@@ -8,7 +8,7 @@ artifactsPipeline(
 
     test_config: 'test-cases/artifacts/debian9.yaml',
     backend: 'gce',
-    instance_provision: 'spot',
+    provision_type: 'spot',
     scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/stretch/master/latest/scylladb-manager-master/scylla-manager.list',
 
     timeout: [time: 30, unit: 'MINUTES'],

--- a/jenkins-pipelines/artifacts-oel76.jenkinsfile
+++ b/jenkins-pipelines/artifacts-oel76.jenkinsfile
@@ -9,7 +9,7 @@ artifactsPipeline(
     test_config: 'test-cases/artifacts/oel76.yaml',
     backend: 'aws',
     region_name: 'eu-west-1',
-    instance_provision: 'spot_low_price',
+    provision_type: 'spot_low_price',
     scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
 
     timeout: [time: 60, unit: 'MINUTES'],

--- a/jenkins-pipelines/artifacts-ubuntu1604.jenkinsfile
+++ b/jenkins-pipelines/artifacts-ubuntu1604.jenkinsfile
@@ -8,7 +8,7 @@ artifactsPipeline(
 
     test_config: 'test-cases/artifacts/ubuntu1604.yaml',
     backend: 'gce',
-    instance_provision: 'spot',
+    provision_type: 'spot',
     scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/xenial/master/latest/scylla-manager-master/scylla-manager.list',
 
     timeout: [time: 30, unit: 'MINUTES'],

--- a/jenkins-pipelines/artifacts-ubuntu1804.jenkinsfile
+++ b/jenkins-pipelines/artifacts-ubuntu1804.jenkinsfile
@@ -8,7 +8,7 @@ artifactsPipeline(
 
     test_config: 'test-cases/artifacts/ubuntu1804.yaml',
     backend: 'gce',
-    instance_provision: 'spot',
+    provision_type: 'spot',
     scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/bionic/master/latest/scylladb-manager-master/scylla-manager.list',
 
     timeout: [time: 30, unit: 'MINUTES'],

--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -47,9 +47,9 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('ip_ssh_connections', 'private')}",
                    description: 'private|public|ipv6',
                    name: 'ip_ssh_connections')
-            string(defaultValue: "${pipelineParams.get('instance_provision', 'spot_low_price')}",
+            string(defaultValue: "${pipelineParams.get('provision_type', 'spot_low_price')}",
                    description: 'on_demand|spot_low_price|spot',
-                   name: 'instance_provision')
+                   name: 'provision_type')
             string(defaultValue: "${pipelineParams.get('email_recipients', 'qa@scylladb.com')}",
                    description: 'email recipients of email report',
                    name: 'email_recipients')
@@ -120,7 +120,7 @@ def call(Map pipelineParams) {
 
                                                 export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
                                                 export SCT_IP_SSH_CONNECTIONS="${params.ip_ssh_connections}"
-                                                export SCT_INSTANCE_PROVISION="${params.instance_provision}"
+                                                export SCT_INSTANCE_PROVISION="${params.provision_type}"
 
                                                 echo "start test ......."
                                                 ./docker/env/hydra.sh run-test artifacts_test --backend ${params.backend} --logdir "`pwd`"


### PR DESCRIPTION
Remove inconsistency of artifacts jobs parameters with other jobs.

Fixes #2500 

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
