### PR TITLE
fix(config): name gce_network env variable correctly

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -122,7 +122,7 @@
 | **<a name="backup_bucket_location">backup_bucket_location</a>**  | This is the bucket name to be used for backup with its region<br>(e.g. backup_bucket_location: 'manager-backup-tests') | N/A | SCT_BACKUP_BUCKET_LOCATION
 | **<a name="tag_ami_with_result">tag_ami_with_result</a>**  | If True, would tag the ami with the test final result | N/A | SCT_TAG_AMI_WITH_RESULT
 | **<a name="gce_datacenter">gce_datacenter</a>**  | Supported: us-east1 - means that the zone will be selected automatically or you can mention the zone explicitly, for example: us-east1-b | N/A | SCT_GCE_DATACENTER
-| **<a name="gce_network">gce_network</a>**  |  | N/A | SCT_GCE_DATACENTER
+| **<a name="gce_network">gce_network</a>**  |  | N/A | SCT_GCE_NETWORK
 | **<a name="gce_image">gce_image</a>**  |  | N/A | SCT_GCE_IMAGE
 | **<a name="gce_image_db">gce_image_db</a>**  |  | N/A | SCT_GCE_IMAGE_DB
 | **<a name="gce_image_monitor">gce_image_monitor</a>**  |  | N/A | SCT_GCE_IMAGE_MONITOR

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -538,7 +538,7 @@ class SCTConfiguration(dict):
              help="Supported: us-east1 - means that the zone will be selected automatically or "
                   "you can mention the zone explicitly, for example: us-east1-b"),
 
-        dict(name="gce_network", env="SCT_GCE_DATACENTER", type=str,
+        dict(name="gce_network", env="SCT_GCE_NETWORK", type=str,
              help=""),
 
         dict(name="gce_image", env="SCT_GCE_IMAGE", type=str,


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
