### PR TITLE
fix(rolling upgrade): ignore PrometheusAlertManagerEvent error CassandraStressWriteTooSlow

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -25,7 +25,7 @@ from sdcm.fill_db_data import FillDatabaseData
 from sdcm import wait
 from sdcm.group_common_events import ignore_upgrade_schema_errors
 from sdcm.utils.version_utils import is_enterprise
-from sdcm.sct_events import IndexSpecialColumnErrorEvent
+from sdcm.sct_events import IndexSpecialColumnErrorEvent, EventsFilter, PrometheusAlertManagerEvent
 
 
 def truncate_entries(func):
@@ -439,231 +439,233 @@ class UpgradeTest(FillDatabaseData):
         we want to use this case to verify the read (cl=ALL) workload works
         well, upgrade all nodes to new version in the end.
         """
-        # In case the target version >= 3.1 we need to perform test for truncate entries
-        target_upgrade_version = self.params.get('target_upgrade_version', default='')
-        self.truncate_entries_flag = False
-        if target_upgrade_version and parse_version(target_upgrade_version) >= parse_version('3.1') and \
-                not is_enterprise(target_upgrade_version):
-            self.truncate_entries_flag = True
 
-        self.log.info('pre-test - prepare test keyspaces and tables')
-        # prepare test keyspaces and tables before upgrade to avoid schema change during mixed cluster.
-        self.prepare_keyspaces_and_tables()
-        self.fill_and_verify_db_data('BEFORE UPGRADE', pre_fill=True)
+        with EventsFilter(event_class=PrometheusAlertManagerEvent, regex="CassandraStressWriteTooSlow"):
+            # In case the target version >= 3.1 we need to perform test for truncate entries
+            target_upgrade_version = self.params.get('target_upgrade_version', default='')
+            self.truncate_entries_flag = False
+            if target_upgrade_version and parse_version(target_upgrade_version) >= parse_version('3.1') and \
+                    not is_enterprise(target_upgrade_version):
+                self.truncate_entries_flag = True
 
-        # write workload during entire test
-        self.log.info('Starting c-s write workload during entire test')
-        write_stress_during_entire_test = self.params.get('write_stress_during_entire_test')
-        entire_write_cs_thread_pool = self.run_stress_thread(stress_cmd=write_stress_during_entire_test)
+            self.log.info('pre-test - prepare test keyspaces and tables')
+            # prepare test keyspaces and tables before upgrade to avoid schema change during mixed cluster.
+            self.prepare_keyspaces_and_tables()
+            self.fill_and_verify_db_data('BEFORE UPGRADE', pre_fill=True)
 
-        # Let to write_stress_during_entire_test complete the schema changes
-        time.sleep(300)
+            # write workload during entire test
+            self.log.info('Starting c-s write workload during entire test')
+            write_stress_during_entire_test = self.params.get('write_stress_during_entire_test')
+            entire_write_cs_thread_pool = self.run_stress_thread(stress_cmd=write_stress_during_entire_test)
 
-        # Prepare keyspace and tables for truncate test
-        if self.truncate_entries_flag:
-            self.insert_rows = 10
-            self.fill_db_data_for_truncate_test(insert_rows=self.insert_rows)
+            # Let to write_stress_during_entire_test complete the schema changes
+            time.sleep(300)
 
-        # generate random order to upgrade
-        nodes_num = len(self.db_cluster.nodes)
-        # prepare an array containing the indexes
-        indexes = list(range(nodes_num))
-        # shuffle it so we will upgrade the nodes in a random order
-        random.shuffle(indexes)
+            # Prepare keyspace and tables for truncate test
+            if self.truncate_entries_flag:
+                self.insert_rows = 10
+                self.fill_db_data_for_truncate_test(insert_rows=self.insert_rows)
 
-        self.log.info('pre-test - Run stress workload before upgrade')
-        # complex workload: prepare write
-        self.log.info('Starting c-s complex workload (5M) to prepare data')
-        stress_cmd_complex_prepare = self.params.get('stress_cmd_complex_prepare')
-        complex_cs_thread_pool = self.run_stress_thread(
-            stress_cmd=stress_cmd_complex_prepare, profile='data_dir/complex_schema.yaml')
+            # generate random order to upgrade
+            nodes_num = len(self.db_cluster.nodes)
+            # prepare an array containing the indexes
+            indexes = list(range(nodes_num))
+            # shuffle it so we will upgrade the nodes in a random order
+            random.shuffle(indexes)
 
-        # wait for the complex workload to finish
-        self.verify_stress_thread(complex_cs_thread_pool)
+            self.log.info('pre-test - Run stress workload before upgrade')
+            # complex workload: prepare write
+            self.log.info('Starting c-s complex workload (5M) to prepare data')
+            stress_cmd_complex_prepare = self.params.get('stress_cmd_complex_prepare')
+            complex_cs_thread_pool = self.run_stress_thread(
+                stress_cmd=stress_cmd_complex_prepare, profile='data_dir/complex_schema.yaml')
 
-        # prepare write workload
-        self.log.info('Starting c-s prepare write workload (n=10000000)')
-        prepare_write_stress = self.params.get('prepare_write_stress')
-        prepare_write_cs_thread_pool = self.run_stress_thread(stress_cmd=prepare_write_stress)
-        self.log.info('Sleeping for 60s to let cassandra-stress start before the upgrade...')
-        time.sleep(60)
+            # wait for the complex workload to finish
+            self.verify_stress_thread(complex_cs_thread_pool)
 
-        with ignore_upgrade_schema_errors():
-
-            step = 'Step1 - Upgrade First Node '
-            self.log.info(step)
-            # upgrade first node
-            self.db_cluster.node_to_upgrade = self.db_cluster.nodes[indexes[0]]
-            self.log.info('Upgrade Node %s begin', self.db_cluster.node_to_upgrade.name)
-            self.upgrade_node(self.db_cluster.node_to_upgrade)
-            self.log.info('Upgrade Node %s ended', self.db_cluster.node_to_upgrade.name)
-            self.db_cluster.node_to_upgrade.check_node_health()
-
-            # wait for the prepare write workload to finish
-            self.verify_stress_thread(prepare_write_cs_thread_pool)
-
-            # read workload (cl=QUORUM)
-            self.log.info('Starting c-s read workload (cl=QUORUM n=10000000)')
-            stress_cmd_read_cl_quorum = self.params.get('stress_cmd_read_cl_quorum')
-            read_stress_queue = self.run_stress_thread(stress_cmd=stress_cmd_read_cl_quorum)
-            # wait for the read workload to finish
-            self.verify_stress_thread(read_stress_queue)
-            self.fill_and_verify_db_data('after upgraded one node')
-            self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
-                                                          step=step+' - after upgraded one node')
-
-            # read workload
-            self.log.info('Starting c-s read workload for 10m')
-            stress_cmd_read_10m = self.params.get('stress_cmd_read_10m')
-            read_10m_cs_thread_pool = self.run_stress_thread(stress_cmd=stress_cmd_read_10m)
-
+            # prepare write workload
+            self.log.info('Starting c-s prepare write workload (n=10000000)')
+            prepare_write_stress = self.params.get('prepare_write_stress')
+            prepare_write_cs_thread_pool = self.run_stress_thread(stress_cmd=prepare_write_stress)
             self.log.info('Sleeping for 60s to let cassandra-stress start before the upgrade...')
             time.sleep(60)
 
-            step = 'Step2 - Upgrade Second Node '
-            self.log.info(step)
-            # upgrade second node
-            self.db_cluster.node_to_upgrade = self.db_cluster.nodes[indexes[1]]
-            self.log.info('Upgrade Node %s begin', self.db_cluster.node_to_upgrade.name)
-            self.upgrade_node(self.db_cluster.node_to_upgrade)
-            self.log.info('Upgrade Node %s ended', self.db_cluster.node_to_upgrade.name)
-            self.db_cluster.node_to_upgrade.check_node_health()
+            with ignore_upgrade_schema_errors():
 
-            # wait for the 10m read workload to finish
-            self.verify_stress_thread(read_10m_cs_thread_pool)
-            self.fill_and_verify_db_data('after upgraded two nodes')
-            self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
-                                                          step=step+' - after upgraded two nodes')
-
-            # read workload (60m)
-            self.log.info('Starting c-s read workload for 60m')
-            stress_cmd_read_60m = self.params.get('stress_cmd_read_60m')
-            read_60m_cs_thread_pool = self.run_stress_thread(stress_cmd=stress_cmd_read_60m)
-            self.log.info('Sleeping for 60s to let cassandra-stress start before the rollback...')
-            time.sleep(60)
-
-            self.log.info('Step3 - Rollback Second Node ')
-            # rollback second node
-            self.log.info('Rollback Node %s begin', self.db_cluster.nodes[indexes[1]].name)
-            self.rollback_node(self.db_cluster.nodes[indexes[1]])
-            self.log.info('Rollback Node %s ended', self.db_cluster.nodes[indexes[1]].name)
-            self.db_cluster.nodes[indexes[1]].check_node_health()
-
-        step = 'Step4 - Verify data during mixed cluster mode '
-        self.log.info(step)
-        self.fill_and_verify_db_data('after rollback the second node')
-        self.log.info('Repair the first upgraded Node')
-        self.db_cluster.nodes[indexes[0]].run_nodetool(sub_cmd='repair')
-        self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
-                                                      step=step)
-
-        with ignore_upgrade_schema_errors():
-
-            step = 'Step5 - Upgrade rest of the Nodes '
-            self.log.info(step)
-            for i in indexes[1:]:
-                self.db_cluster.node_to_upgrade = self.db_cluster.nodes[i]
+                step = 'Step1 - Upgrade First Node '
+                self.log.info(step)
+                # upgrade first node
+                self.db_cluster.node_to_upgrade = self.db_cluster.nodes[indexes[0]]
                 self.log.info('Upgrade Node %s begin', self.db_cluster.node_to_upgrade.name)
                 self.upgrade_node(self.db_cluster.node_to_upgrade)
                 self.log.info('Upgrade Node %s ended', self.db_cluster.node_to_upgrade.name)
                 self.db_cluster.node_to_upgrade.check_node_health()
-                self.fill_and_verify_db_data('after upgraded %s' % self.db_cluster.node_to_upgrade.name)
+
+                # wait for the prepare write workload to finish
+                self.verify_stress_thread(prepare_write_cs_thread_pool)
+
+                # read workload (cl=QUORUM)
+                self.log.info('Starting c-s read workload (cl=QUORUM n=10000000)')
+                stress_cmd_read_cl_quorum = self.params.get('stress_cmd_read_cl_quorum')
+                read_stress_queue = self.run_stress_thread(stress_cmd=stress_cmd_read_cl_quorum)
+                # wait for the read workload to finish
+                self.verify_stress_thread(read_stress_queue)
+                self.fill_and_verify_db_data('after upgraded one node')
                 self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
-                                                              step=step)
+                                                              step=step+' - after upgraded one node')
 
-        self.log.info('Step6 - Verify stress results after upgrade ')
-        self.log.info('Waiting for stress threads to complete after upgrade')
-        # wait for the 60m read workload to finish
-        self.verify_stress_thread(read_60m_cs_thread_pool)
+                # read workload
+                self.log.info('Starting c-s read workload for 10m')
+                stress_cmd_read_10m = self.params.get('stress_cmd_read_10m')
+                read_10m_cs_thread_pool = self.run_stress_thread(stress_cmd=stress_cmd_read_10m)
 
-        self.verify_stress_thread(entire_write_cs_thread_pool)
+                self.log.info('Sleeping for 60s to let cassandra-stress start before the upgrade...')
+                time.sleep(60)
 
-        self.log.info('Step7 - Upgrade sstables to latest supported version ')
-        # figure out what is the last supported sstable version
-        self.expected_sstable_format_version = self.get_highest_supported_sstable_version()
+                step = 'Step2 - Upgrade Second Node '
+                self.log.info(step)
+                # upgrade second node
+                self.db_cluster.node_to_upgrade = self.db_cluster.nodes[indexes[1]]
+                self.log.info('Upgrade Node %s begin', self.db_cluster.node_to_upgrade.name)
+                self.upgrade_node(self.db_cluster.node_to_upgrade)
+                self.log.info('Upgrade Node %s ended', self.db_cluster.node_to_upgrade.name)
+                self.db_cluster.node_to_upgrade.check_node_health()
 
-        # run 'nodetool upgradesstables' on all nodes and check/wait for all file to be upgraded
-        upgradesstables = self.db_cluster.run_func_parallel(func=self.upgradesstables_if_command_available)
+                # wait for the 10m read workload to finish
+                self.verify_stress_thread(read_10m_cs_thread_pool)
+                self.fill_and_verify_db_data('after upgraded two nodes')
+                self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
+                                                              step=step+' - after upgraded two nodes')
 
-        # only check sstable format version if all nodes had 'nodetool upgradesstables' available
-        if all(upgradesstables):
-            self.log.info('Upgrading sstables if new version is available')
-            tables_upgraded = self.db_cluster.run_func_parallel(func=self.wait_for_sstable_upgrade)
-            assert all(tables_upgraded), "Failed to upgrade the sstable format {}".format(tables_upgraded)
+                # read workload (60m)
+                self.log.info('Starting c-s read workload for 60m')
+                stress_cmd_read_60m = self.params.get('stress_cmd_read_60m')
+                read_60m_cs_thread_pool = self.run_stress_thread(stress_cmd=stress_cmd_read_60m)
+                self.log.info('Sleeping for 60s to let cassandra-stress start before the rollback...')
+                time.sleep(60)
 
-        # Verify sstabledump
-        self.log.info('Starting sstabledump to verify correctness of sstables')
-        self.db_cluster.nodes[0].remoter.run(
-            'for i in `sudo find /var/lib/scylla/data/keyspace_complex/ -type f |grep -v manifest.json |'
-            'grep -v snapshots |head -n 1`; do echo $i; sudo sstabledump $i 1>/tmp/sstabledump.output || '
-            'exit 1; done', verbose=True)
+                self.log.info('Step3 - Rollback Second Node ')
+                # rollback second node
+                self.log.info('Rollback Node %s begin', self.db_cluster.nodes[indexes[1]].name)
+                self.rollback_node(self.db_cluster.nodes[indexes[1]])
+                self.log.info('Rollback Node %s ended', self.db_cluster.nodes[indexes[1]].name)
+                self.db_cluster.nodes[indexes[1]].check_node_health()
 
-        self.log.info('Step8 - Run stress and verify after upgrading entire cluster ')
-        self.log.info('Starting verify_stress_after_cluster_upgrade')
-        verify_stress_after_cluster_upgrade = self.params.get(  # pylint: disable=invalid-name
-            'verify_stress_after_cluster_upgrade')
-        verify_stress_cs_thread_pool = self.run_stress_thread(stress_cmd=verify_stress_after_cluster_upgrade)
-        self.verify_stress_thread(verify_stress_cs_thread_pool)
+            step = 'Step4 - Verify data during mixed cluster mode '
+            self.log.info(step)
+            self.fill_and_verify_db_data('after rollback the second node')
+            self.log.info('Repair the first upgraded Node')
+            self.db_cluster.nodes[indexes[0]].run_nodetool(sub_cmd='repair')
+            self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
+                                                          step=step)
 
-        # complex workload: verify data by simple read cl=ALL
-        self.log.info('Starting c-s complex workload to verify data by simple read')
-        stress_cmd_complex_verify_read = self.params.get('stress_cmd_complex_verify_read')
-        complex_cs_thread_pool = self.run_stress_thread(
-            stress_cmd=stress_cmd_complex_verify_read, profile='data_dir/complex_schema.yaml')
-        # wait for the read complex workload to finish
-        self.verify_stress_thread(complex_cs_thread_pool)
+            with ignore_upgrade_schema_errors():
 
-        # After adjusted the workloads, there is a entire write workload, and it uses a fixed duration for catching
-        # the data lose.
-        # But the execute time of workloads are not exact, so let only use basic prepare write & read verify for
-        # complex workloads,and comment two complex workloads.
-        #
-        # TODO: retest commented workloads and decide to enable or delete them.
-        #
-        # complex workload: verify data by multiple ops
-        # self.log.info('Starting c-s complex workload to verify data by multiple ops')
-        # stress_cmd_complex_verify_more = self.params.get('stress_cmd_complex_verify_more')
-        # complex_cs_thread_pool = self.run_stress_thread(stress_cmd=stress_cmd_complex_verify_more,
-        #                                                profile='data_dir/complex_schema.yaml')
+                step = 'Step5 - Upgrade rest of the Nodes '
+                self.log.info(step)
+                for i in indexes[1:]:
+                    self.db_cluster.node_to_upgrade = self.db_cluster.nodes[i]
+                    self.log.info('Upgrade Node %s begin', self.db_cluster.node_to_upgrade.name)
+                    self.upgrade_node(self.db_cluster.node_to_upgrade)
+                    self.log.info('Upgrade Node %s ended', self.db_cluster.node_to_upgrade.name)
+                    self.db_cluster.node_to_upgrade.check_node_health()
+                    self.fill_and_verify_db_data('after upgraded %s' % self.db_cluster.node_to_upgrade.name)
+                    self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
+                                                                  step=step)
 
-        # wait for the complex workload to finish
-        # self.verify_stress_thread(complex_cs_thread_pool)
+            self.log.info('Step6 - Verify stress results after upgrade ')
+            self.log.info('Waiting for stress threads to complete after upgrade')
+            # wait for the 60m read workload to finish
+            self.verify_stress_thread(read_60m_cs_thread_pool)
 
-        # complex workload: verify data by delete 1/10 data
-        # self.log.info('Starting c-s complex workload to verify data by delete')
-        # stress_cmd_complex_verify_delete = self.params.get('stress_cmd_complex_verify_delete')
-        # complex_cs_thread_pool = self.run_stress_thread(stress_cmd=stress_cmd_complex_verify_delete,
-        #                                                profile='data_dir/complex_schema.yaml')
-        # wait for the complex workload to finish
-        # self.verify_stress_thread(complex_cs_thread_pool)
+            self.verify_stress_thread(entire_write_cs_thread_pool)
 
-        # During the test we filter and ignore some specific errors, but we want to allow only certain amount of them
-        step = 'Step9 - Search for errors that we filter during the test '
-        self.log.info(step)
-        self.log.info('Checking how many failed_to_load_schem errors happened during the test')
-        error_factor = 3
-        schema_load_error_num = self.count_log_errors(search_pattern='Failed to load schema version',
-                                                      step=step)
-        # Warning example:
-        # workload prioritization - update_service_levels_from_distributed_data: an error occurred while retrieving
-        # configuration (exceptions::read_failure_exception (Operation failed for system_distributed.service_levels
-        # - received 0 responses and 1 failures from 1 CL=ONE.))
-        workload_prioritization_error_num = self.count_log_errors(search_pattern='workload prioritization.*read_failure_exception',
-                                                                  step=step, search_for_idx_token_error=False)
+            self.log.info('Step7 - Upgrade sstables to latest supported version ')
+            # figure out what is the last supported sstable version
+            self.expected_sstable_format_version = self.get_highest_supported_sstable_version()
 
-        self.log.info(f'schema_load_error_num: {schema_load_error_num}; '
-                      f'workload_prioritization_error_num: {workload_prioritization_error_num}')
+            # run 'nodetool upgradesstables' on all nodes and check/wait for all file to be upgraded
+            upgradesstables = self.db_cluster.run_func_parallel(func=self.upgradesstables_if_command_available)
 
-        # Issue #https://github.com/scylladb/scylla-enterprise/issues/1391
-        # By Eliran's comment: For 'Failed to load schema version' error which is expected and non offensive is
-        # to count the 'workload prioritization' warning and subtract that amount from the amount of overall errors.
-        load_error_num = schema_load_error_num-workload_prioritization_error_num
-        assert load_error_num <= error_factor * 8 * \
-            len(self.db_cluster.nodes), 'Only allowing shards_num * %d schema load errors per host during the ' \
-                                        'entire test, actual: %d' % (
-                error_factor, schema_load_error_num)
+            # only check sstable format version if all nodes had 'nodetool upgradesstables' available
+            if all(upgradesstables):
+                self.log.info('Upgrading sstables if new version is available')
+                tables_upgraded = self.db_cluster.run_func_parallel(func=self.wait_for_sstable_upgrade)
+                assert all(tables_upgraded), "Failed to upgrade the sstable format {}".format(tables_upgraded)
 
-        self.log.info('all nodes were upgraded, and last workaround is verified.')
+            # Verify sstabledump
+            self.log.info('Starting sstabledump to verify correctness of sstables')
+            self.db_cluster.nodes[0].remoter.run(
+                'for i in `sudo find /var/lib/scylla/data/keyspace_complex/ -type f |grep -v manifest.json |'
+                'grep -v snapshots |head -n 1`; do echo $i; sudo sstabledump $i 1>/tmp/sstabledump.output || '
+                'exit 1; done', verbose=True)
+
+            self.log.info('Step8 - Run stress and verify after upgrading entire cluster ')
+            self.log.info('Starting verify_stress_after_cluster_upgrade')
+            verify_stress_after_cluster_upgrade = self.params.get(  # pylint: disable=invalid-name
+                'verify_stress_after_cluster_upgrade')
+            verify_stress_cs_thread_pool = self.run_stress_thread(stress_cmd=verify_stress_after_cluster_upgrade)
+            self.verify_stress_thread(verify_stress_cs_thread_pool)
+
+            # complex workload: verify data by simple read cl=ALL
+            self.log.info('Starting c-s complex workload to verify data by simple read')
+            stress_cmd_complex_verify_read = self.params.get('stress_cmd_complex_verify_read')
+            complex_cs_thread_pool = self.run_stress_thread(
+                stress_cmd=stress_cmd_complex_verify_read, profile='data_dir/complex_schema.yaml')
+            # wait for the read complex workload to finish
+            self.verify_stress_thread(complex_cs_thread_pool)
+
+            # After adjusted the workloads, there is a entire write workload, and it uses a fixed duration for catching
+            # the data lose.
+            # But the execute time of workloads are not exact, so let only use basic prepare write & read verify for
+            # complex workloads,and comment two complex workloads.
+            #
+            # TODO: retest commented workloads and decide to enable or delete them.
+            #
+            # complex workload: verify data by multiple ops
+            # self.log.info('Starting c-s complex workload to verify data by multiple ops')
+            # stress_cmd_complex_verify_more = self.params.get('stress_cmd_complex_verify_more')
+            # complex_cs_thread_pool = self.run_stress_thread(stress_cmd=stress_cmd_complex_verify_more,
+            #                                                profile='data_dir/complex_schema.yaml')
+
+            # wait for the complex workload to finish
+            # self.verify_stress_thread(complex_cs_thread_pool)
+
+            # complex workload: verify data by delete 1/10 data
+            # self.log.info('Starting c-s complex workload to verify data by delete')
+            # stress_cmd_complex_verify_delete = self.params.get('stress_cmd_complex_verify_delete')
+            # complex_cs_thread_pool = self.run_stress_thread(stress_cmd=stress_cmd_complex_verify_delete,
+            #                                                profile='data_dir/complex_schema.yaml')
+            # wait for the complex workload to finish
+            # self.verify_stress_thread(complex_cs_thread_pool)
+
+            # During the test we filter and ignore some specific errors, but we want to allow only certain amount of them
+            step = 'Step9 - Search for errors that we filter during the test '
+            self.log.info(step)
+            self.log.info('Checking how many failed_to_load_schem errors happened during the test')
+            error_factor = 3
+            schema_load_error_num = self.count_log_errors(search_pattern='Failed to load schema version',
+                                                          step=step)
+            # Warning example:
+            # workload prioritization - update_service_levels_from_distributed_data: an error occurred while retrieving
+            # configuration (exceptions::read_failure_exception (Operation failed for system_distributed.service_levels
+            # - received 0 responses and 1 failures from 1 CL=ONE.))
+            workload_prioritization_error_num = self.count_log_errors(search_pattern='workload prioritization.*read_failure_exception',
+                                                                      step=step, search_for_idx_token_error=False)
+
+            self.log.info(f'schema_load_error_num: {schema_load_error_num}; '
+                          f'workload_prioritization_error_num: {workload_prioritization_error_num}')
+
+            # Issue #https://github.com/scylladb/scylla-enterprise/issues/1391
+            # By Eliran's comment: For 'Failed to load schema version' error which is expected and non offensive is
+            # to count the 'workload prioritization' warning and subtract that amount from the amount of overall errors.
+            load_error_num = schema_load_error_num-workload_prioritization_error_num
+            assert load_error_num <= error_factor * 8 * \
+                len(self.db_cluster.nodes), 'Only allowing shards_num * %d schema load errors per host during the ' \
+                                            'entire test, actual: %d' % (
+                    error_factor, schema_load_error_num)
+
+            self.log.info('all nodes were upgraded, and last workaround is verified.')
 
     def count_log_errors(self, search_pattern, step, search_for_idx_token_error=True):
         schema_load_error_num = 0


### PR DESCRIPTION
Add EventFilter to ignore prometheus error that cassandra-stress write too slow

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
