### PR TITLE
fix(delete by partition nemesis): change exception when missed max_partitions_in_test_table parameter

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -936,7 +936,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                     del added_columns_info['column_names'][column_name]
         if add:
             cmd = f"ALTER TABLE {self._add_drop_column_target_table[1]} " \
-                  f"ADD ( {', '.join(['%s %s' % (col[0], col[1]) for col in add])} );"
+                f"ADD ( {', '.join(['%s %s' % (col[0], col[1]) for col in add])} );"
             if self._add_drop_column_run_cql_query(cmd, self._add_drop_column_target_table[0]):
                 for column_name, column_type in add:
                     added_columns_info['column_names'][column_name] = column_type
@@ -957,7 +957,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         max_partitions_in_test_table = self.cluster.params.get('max_partitions_in_test_table')
 
         if not max_partitions_in_test_table:
-            raise NoMandatoryParameter('This nemesis expects "max_partitions_in_test_table" to be set')
+            raise UnsupportedNemesis(
+                'This nemesis expects mandatory "max_partitions_in_test_table" parameter to be set')
 
     def choose_partitions_for_delete(self, partitions_amount, ks_cf, with_clustering_key_data=False,
                                      exclude_partitions=None):
@@ -1687,7 +1688,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             # nodetool removenode 'host_id'
             rnd_node = random.choice([n for n in self.cluster.nodes if n is not self.target_node])
             self.log.info("Running removenode command on {}, Removing node with the following host_id: {}"
-                          .format(rnd_node.ip_address,host_id))
+                          .format(rnd_node.ip_address, host_id))
             res = rnd_node.run_nodetool("removenode {}".format(host_id), ignore_status=True, verbose=True)
             return res.exit_status
 
@@ -2906,6 +2907,7 @@ class TerminateAndRemoveNodeMonkey(Nemesis):
 #     @log_time_elapsed_and_status
 #     def disrupt(self):
 #         self.disrupt_repair_streaming_err()
+
 
 RELATIVE_NEMESIS_SUBCLASS_LIST = [NotSpotNemesis]
 

--- a/test-cases/PR-provision-test.yaml
+++ b/test-cases/PR-provision-test.yaml
@@ -1,4 +1,5 @@
 test_duration: 10
+max_partitions_in_test_table: 10
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=1m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5",
              "cassandra-stress counter_write cl=QUORUM duration=1m -schema 'replication(factor=3) compaction(strategy=DateTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=5 -pop seq=1..10000000"
              ]


### PR DESCRIPTION
1. Raise UnsupportedNemesis exception when missed max_partitions_in_test_table parameter
in DeleteByPartitionsMonkey and DeleteByRowsRangeMonkey
2. Add max_partitions_in_test_table to test-cases/PR-provision-test.yaml

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
