### PR TITLE
fix(should_keep_alive): use correct substring to match node type

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -216,11 +216,11 @@ class Setup:
             return True
         if node_type is None:
             return False
-        if "db_nodes" in node_type:
+        if "db" in node_type:
             return cls.KEEP_ALIVE_DB_NODES
-        if "loader_nodes" in node_type:
+        if "loader" in node_type:
             return cls.KEEP_ALIVE_LOADER_NODES
-        if "monitor_nodes" in node_type:
+        if "monitor" in node_type:
             return cls.KEEP_ALIVE_MONITOR_NODES
         return False
 


### PR DESCRIPTION


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
