### PR TITLE
fix(health cluster validator): fix source data for schema validation

### DIFF
--- a/sdcm/utils/health_checker.py
+++ b/sdcm/utils/health_checker.py
@@ -172,7 +172,7 @@ def check_schema_version(gossip_info, peers_details, nodes_status, current_node)
     if len(set(schema_version_on_all_nodes)) > 1:
         LOGGER.debug(debug_message)
         peers_info_str = '\n'.join(
-            f"{ip}: {schema_version['schema_version']}" for ip, schema_version in gossip_info.items())
+            f"{ip}: {schema_version['schema_version']}" for ip, schema_version in peers_details.items())
         ClusterHealthValidatorEvent(type='warning', name='NodeSchemaVersion', status=Severity.WARNING,
                                     node=current_node.name,
                                     message=f'Current node {current_node.ip_address}. Schema version is not same on all '


### PR DESCRIPTION
Alternator test failed with error 'KeyError: schema_version' because of wrong data
source was used: gossip_info instead of peers_details. gossip_info dict has no
'schema_version' key

Error:
```
2020-08-18 02:24:39.573: (ThreadFailedEvent Severity.ERROR): message='schema_version'
Traceback (most recent call last):
File "/home/ubuntu/scylla-cluster-tests/sdcm/sct_events.py", line 1048, in wrapper
result = func(*args, **kwargs)
File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 198, in run
self.disrupt()
File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 2225, in wrapper
args[0].cluster.check_cluster_health()
File "/home/ubuntu/scylla-cluster-tests/sdcm/cluster.py", line 3563, in check_cluster_health
node.check_node_health()
File "/home/ubuntu/scylla-cluster-tests/sdcm/cluster.py", line 2626, in check_node_health
check_schema_version(gossip_info, peers_details, nodes_status, current_node=self)
File "/home/ubuntu/scylla-cluster-tests/sdcm/utils/health_checker.py", line 174, in check_schema_version
peers_info_str = '\n'.join(
File "/home/ubuntu/scylla-cluster-tests/sdcm/utils/health_checker.py", line 175, in <genexpr>
f"{ip}: {schema_version['schema_version']}" for ip, schema_version in gossip_info.items())
KeyError: 'schema_version'
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
