### PR TITLE
fix(alternator/api.py): Creating Alternator resources with "None" region name

### DIFF
--- a/sdcm/utils/alternator/api.py
+++ b/sdcm/utils/alternator/api.py
@@ -31,7 +31,7 @@ class Alternator:
         if endpoint_url not in self.alternator_apis:
             aws_params = dict(endpoint_url=endpoint_url, aws_access_key_id=self.params.get("alternator_access_key_id"),
                               aws_secret_access_key=self.params.get("alternator_secret_access_key"),
-                              region_name=self.params.get("region_name") and self.params.get("region_name").split()[0])
+                              region_name="None")
             resource: DynamoDBServiceResource = boto3.resource('dynamodb', **aws_params)
             client: DynamoDBClient = boto3.client('dynamodb', **aws_params)
             self.alternator_apis[endpoint_url] = AlternatorApi(resource=resource, client=client)


### PR DESCRIPTION
Changing the value of "region_name" to "None" because we used custom endpoint and the value of the region is never mind

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)]~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)]~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)]~~

