### PR TITLE
fix(get_non_system_ks_cf_list): Add missing column to cql query

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3108,7 +3108,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
             is_column_type = entity_type == "column"
             column_names = regular_column_names
             if is_column_type:
-                cmd = f"SELECT {column_names[0]}, {column_names[1]} FROM system_schema.columns"
+                cmd = f"SELECT {column_names[0]}, {column_names[1]}, type FROM system_schema.columns"
             elif entity_type == "view":
                 column_names = materialized_view_column_names
                 cmd = f"SELECT {column_names[0]}, {column_names[1]} FROM system_schema.views"


### PR DESCRIPTION
filtering table with counters uses column 'type' which is missing
in query

Cause an error during nemesis:
File "/home/ubuntu/scylla-cluster-tests/sdcm/cluster.py", line 3142, in get_non_system_ks_cf_list
regular_table_names = execute_cmd(cql_session=session, entity_type="column")
File "/home/ubuntu/scylla-cluster-tests/sdcm/cluster.py", line 3132, in execute_cmd
elif is_column_type and (filter_out_table_with_counter and "counter" in row.type):
AttributeError: 'Row' object has no attribute 'type'

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (CI)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
