### PR TITLE
feature(artifact test): support offline installer

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -112,6 +112,8 @@ class ArtifactsTest(ClusterTester):
             scylla_packages = ['No scylla packages are installed. Please check log files.']
         email_data.update({"scylla_node_image": node.image if node else 'Node has not been initialized',
                            "scylla_packages_installed": scylla_packages,
+                           "unified_package": self.params.get("unified_package"),
+                           "nonroot_offline_install": self.params.get("nonroot_offline_install"),
                            "scylla_repo": self.params.get("scylla_repo"), })
 
         return email_data

--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -37,7 +37,8 @@ class ArtifactsTest(ClusterTester):
                         f"Cluster name: {self.db_cluster.name}")
 
     def run_cassandra_stress(self, args: str):
-        result = self.node.remoter.run(f"{STRESS_CMD} {args} -node {self.node.ip_address}")
+        result = self.node.remoter.run(
+            f"{self.node.add_install_prefix(STRESS_CMD)} {args} -node {self.node.ip_address}")
         assert "java.io.IOException" not in result.stdout
         assert "java.io.IOException" not in result.stderr
 

--- a/ics_space_amplification_goal_test.py
+++ b/ics_space_amplification_goal_test.py
@@ -194,7 +194,7 @@ class IcsSpaceAmplificationTest(LongevityTest):
         InfoEvent(message="Wait for compactions to finish after write is done.")
         self.wait_no_compactions_running()
 
-        stress_cmd = self.params.get('stress_cmd', default=None)
+        stress_cmd = self.params.get('stress_cmd')
         sag_testing_values = [None, '1.5', '1.2', '1.5', None]
         column_size = 205
         num_of_columns = 5

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3765,6 +3765,10 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                 node.remoter.run(f'{INSTALL_DIR}/sbin/scylla_setup --no-raid-setup --no-io-setup', ignore_status=True)
                 node.remoter.send_files(src='./configurations/io.conf', dst=f'{INSTALL_DIR}/etc/scylla.d/')
                 node.remoter.send_files(src='./configurations/io_properties.yaml', dst=f'{INSTALL_DIR}/etc/scylla.d/')
+                node.remoter.run(
+                    f"sed -ie 's/io-properties-file=/io-properties-file=\/home\/{TEST_USER}\/scylladb/g' {INSTALL_DIR}/etc/scylla.d/io.conf")
+                node.remoter.run(
+                    f"sed -ie 's/mountpoint: .*/mountpoint: \/home\/{TEST_USER}\/scylladb/g' {INSTALL_DIR}/etc/scylla.d/io_properties.yaml")
 
                 # simple config
                 node.remoter.run(

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1594,6 +1594,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                            sudo=True)
 
     def remote_scylla_yaml(self, path=SCYLLA_YAML_PATH):
+        path = self.add_install_prefix(path)
         return self._remote_yaml(path=path)
 
     def remote_manager_yaml(self, path=SCYLLA_MANAGER_YAML_PATH):
@@ -1739,7 +1740,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 self.remoter.sudo("md5sum /etc/encrypt_conf/*.pem", ignore_status=True)
 
         if append_scylla_args:
-            scylla_help = self.remoter.run("scylla --help", ignore_status=True).stdout
+            scylla_help = self.remoter.run(
+                f"{self.add_install_prefix('/usr/bin/scylla')} --help", ignore_status=True).stdout
             scylla_arg_parser = ScyllaArgParser.from_scylla_help(scylla_help)
             append_scylla_args = scylla_arg_parser.filter_args(append_scylla_args)
 
@@ -2050,9 +2052,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
     def get_scylla_version(self) -> str:
         self.scylla_version = self.scylla_version_detailed = ""
-
-        cmd = "scylla --version"
-        result = self.remoter.run(cmd, ignore_status=True)
+        scylla_path = self.add_install_prefix("/usr/bin/scylla")
+        result = self.remoter.run(f"{scylla_path} --version", ignore_status=True)
         if result.ok:
             self.scylla_version_detailed = result.stdout.strip()
             if build_id := self.get_scylla_build_id():
@@ -2294,6 +2295,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             '/usr/bin/scylla': f'{INSTALL_DIR}/bin/scylla',
             '/usr/bin/nodetool': f'{INSTALL_DIR}/share/cassandra/bin/nodetool',
             '/usr/bin/cqlsh': f'{INSTALL_DIR}/share/cassandra/bin/cqlsh',
+            '/usr/bin/cassandra-stress': f'{INSTALL_DIR}/share/cassandra/bin/cassandra-stress',
         }
         return checklist.get(abs_path, INSTALL_DIR + abs_path)
 
@@ -2505,7 +2507,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         credentials = self.parent_cluster.get_db_auth()
         if credentials:
             options += '-u {} -pw {} '.format(*credentials)
-        return "nodetool {options} {sub_cmd} {args}".format(options=options, sub_cmd=sub_cmd, args=args)
+        return f"{self.add_install_prefix('/usr/bin/nodetool')} {options} {sub_cmd} {args}"
 
     def run_nodetool(self, sub_cmd, args="", options="", timeout=None,
                      ignore_status=False, verbose=True, coredump_on_timeout=False):
@@ -3763,6 +3765,17 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                 node.remoter.run(f'{INSTALL_DIR}/sbin/scylla_setup --no-raid-setup --no-io-setup', ignore_status=True)
                 node.remoter.send_files(src='./configurations/io.conf', dst=f'{INSTALL_DIR}/etc/scylla.d/')
                 node.remoter.send_files(src='./configurations/io_properties.yaml', dst=f'{INSTALL_DIR}/etc/scylla.d/')
+
+                # simple config
+                node.remoter.run(
+                    f"echo 'cluster_name: \"{self.name}\"' >> {INSTALL_DIR}/etc/scylla/scylla.yaml")  # pylint: disable=no-member
+                node.remoter.run(
+                    f"sed -ie 's/- seeds: .*/- seeds: {node.ip_address}/g' {INSTALL_DIR}/etc/scylla/scylla.yaml")
+                node.remoter.run(
+                    f"sed -ie 's/^listen_address: .*/listen_address: {node.ip_address}/g' {INSTALL_DIR}/etc/scylla/scylla.yaml")
+                node.remoter.run(
+                    f"sed -ie 's/^rpc_address: .*/rpc_address: {node.ip_address}/g' {INSTALL_DIR}/etc/scylla/scylla.yaml")
+
                 node.start_scylla_server(verify_up=False, verify_up_timeout=timeout)
                 node.wait_db_up(verbose=verbose, timeout=timeout)
                 return

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -32,7 +32,8 @@ from selenium.webdriver.common.by import By
 from sdcm.utils.common import (S3Storage, list_instances_aws, list_instances_gce,
                                ParallelObject, remove_files, get_builder_by_test_id,
                                get_testrun_dir, search_test_id_in_latest, filter_aws_instances_by_type,
-                               filter_gce_instances_by_type, get_sct_root_path, normalize_ipv6_url)
+                               filter_gce_instances_by_type, get_sct_root_path, normalize_ipv6_url,
+                               SCYLLA_YAML_PATH)
 from sdcm.utils.decorators import retrying
 from sdcm.utils.get_username import get_username
 from sdcm.db_stats import PrometheusDBStats
@@ -801,7 +802,8 @@ class ScyllaLogCollector(LogCollector):
                     CommandLog(name='vmstat',
                                command='cat /proc/vmstat'),
                     CommandLog(name='scylla.yaml',
-                               command='cat /etc/scylla/scylla.yaml'),
+                               # Fixme: command=f'cat {self.add_install_prefix(SCYLLA_YAML_PATH)}'),
+                               command=f'cat {SCYLLA_YAML_PATH}'),
                     CommandLog(name='coredumps.info',
                                command='sudo coredumpctl info')
                     ]

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -154,6 +154,12 @@ class SCTConfiguration(dict):
         dict(name="scylla_repo", env="SCT_SCYLLA_REPO", type=str,
              help="Url to the repo of scylla version to install scylla"),
 
+        dict(name="unified_package", env="SCT_UNIFIED_PACKAGE", type=str,
+             help="Url to the unified package of scylla version to install scylla"),
+
+        dict(name="nonroot_offline_install", env="SCT_NONROOT_OFFLINE_INSTALL", type=boolean,
+             help="Install Scylla without required root priviledge"),
+
         dict(name="scylla_version", env="SCT_SCYLLA_VERSION",
              type=str,
              help="""Version of scylla to install, ex. '2.3.1'

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -67,6 +67,7 @@ DEFAULT_AWS_REGION = "eu-west-1"
 DOCKER_CGROUP_RE = re.compile("/docker/([0-9a-f]+)")
 SCYLLA_AMI_OWNER_ID = "797456418907"
 MAX_SPOT_DURATION_TIME = 360
+SCYLLA_YAML_PATH = "/etc/scylla/scylla.yaml"
 
 
 def deprecation(message):

--- a/sdcm/utils/remote_logger.py
+++ b/sdcm/utils/remote_logger.py
@@ -38,6 +38,7 @@ class SSHLoggerBase(NodeLoggerBase):
     def __init__(self, node, target_log_file: str):
         super().__init__(node, target_log_file)
         self._termination_event = Event()
+        self.node = node
         self._remoter = None
         self._remoter_params = node.remoter.get_init_arguments()
         self._child_process = Process(target=self._journal_thread, daemon=True)
@@ -102,7 +103,8 @@ class SSHLoggerBase(NodeLoggerBase):
 class SSHScyllaSystemdLogger(SSHLoggerBase):
     @property
     def _logger_cmd(self) -> str:
-        return 'sudo journalctl -f --no-tail --no-pager --utc {since} ' \
+        return f'{self.node.journalctl} -f --no-tail --no-pager ' \
+               '--utc {since} ' \
                '-u scylla-ami-setup.service ' \
                '-u scylla-image-setup.service ' \
                '-u scylla-io-setup.service ' \

--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -20,6 +20,12 @@ def call(Map pipelineParams) {
             string(defaultValue: '',
                    description: 'a Scylla repo to run against (for .rpm/.deb tests, should be blank otherwise)',
                    name: 'scylla_repo')
+            string(defaultValue: "${pipelineParams.get('unified_package', '')}",
+                   description: 'Url to the unified package of scylla version to install scylla',
+                   name: 'unified_package')
+            booleanParam(defaultValue: "${pipelineParams.get('nonroot_offline_install', false)}",
+                   description: 'Install Scylla without required root priviledge',
+                   name: 'nonroot_offline_install')
             string(defaultValue: "${pipelineParams.get('scylla_mgmt_repo', '')}",
                    description: 'a Scylla Manager repo to run against (for .rpm/.deb tests, should be blank otherwise)',
                    name: 'scylla_mgmt_repo')
@@ -99,8 +105,11 @@ def call(Map pipelineParams) {
                                                         export SCT_SCYLLA_REPO_M="${params.scylla_repo}"
                                                         export SCT_SCYLLA_MGMT_REPO="${params.scylla_mgmt_repo}"
                                                     fi
+                                                elif [[ ! -z "${params.unified_package}" ]]; then
+                                                    export SCT_UNIFIED_PACKAGE="${params.unified_package}"
+                                                    export SCT_NONROOT_OFFLINE_INSTALL=${params.nonroot_offline_install}
                                                 else
-                                                    echo "need to choose one of SCT_GCE_IMAGE_DB | SCT_AMI_ID_DB_SCYLLA | SCT_SCYLLA_VERSION | SCT_SCYLLA_REPO"
+                                                    echo "need to choose one of SCT_GCE_IMAGE_DB | SCT_AMI_ID_DB_SCYLLA | SCT_SCYLLA_VERSION | SCT_SCYLLA_REPO | SCT_UNIFIED_PACKAGE"
                                                     exit 1
                                                 fi
 


### PR DESCRIPTION
Trello: https://trello.com/c/uQpbi8EI/399-offline-installer-artifact-test

The latest offline installer uses unified pacakge, currently the nonroot
install will fail for known issue.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
