### PR TITLE
fix(ssl_files_location): get location on demand

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -25,6 +25,7 @@ import threading
 import os
 import re
 import traceback
+import json
 
 from typing import List, Optional
 from collections import OrderedDict, defaultdict
@@ -2081,8 +2082,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 raise LogContentNotFound('Reload SSL message not found in node log')
             return msg.stdout
 
-        ssl_files_location = '/etc/scylla/ssl_conf'
-        in_place_crt = self.target_node.remoter.run(f"cat {os.path.join(ssl_files_location, 'db.crt')}",
+        ssl_files_location = json.loads(
+            self.target_node.get_scylla_config_param("server_encryption_options"))["certificate"]
+        in_place_crt = self.target_node.remoter.run(f"cat {ssl_files_location}",
                                                     ignore_status=True).stdout
         update_certificates()
         time_now = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
@@ -2091,12 +2093,11 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         for node in self.cluster.nodes:
             node.remoter.run(f"sudo cp -f /tmp/db.crt {ssl_files_location}")
         for node in self.cluster.nodes:
-            new_crt = node.remoter.run(f"cat {os.path.join(ssl_files_location, 'db.crt')}").stdout
+            new_crt = node.remoter.run(f"cat {ssl_files_location}").stdout
             if in_place_crt == new_crt:
                 raise Exception('The CRT file was not replaced with the new one')
-            reload = check_ssl_reload_log(target_node=node, file_path=os.path.join(ssl_files_location, 'db.crt'),
+            reload = check_ssl_reload_log(target_node=node, file_path=ssl_files_location,
                                           since_time=time_now)
-
             if not reload:
                 raise Exception('SSL auto Reload did not happen')
 


### PR DESCRIPTION
test originally had this value hard coded, and
we saw issues on different OSes.
Now the nemesis is getting if from the node's
scylla.yaml config file.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
