### PR TITLE
fix(improve spot request): Improve spot duration request time calculation

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -1,4 +1,5 @@
-instance_provision: 'spot_low_price'
+instance_provision: 'spot'
+instance_provision_fallback_on_demand: false
 region_name:
   - eu-west-1
 user_credentials_path: '~/.ssh/scylla-qa-ec2'

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -64,6 +64,7 @@ LOGGER = logging.getLogger('utils')
 DEFAULT_AWS_REGION = "eu-west-1"
 DOCKER_CGROUP_RE = re.compile("/docker/([0-9a-f]+)")
 SCYLLA_AMI_OWNER_ID = "797456418907"
+MAX_SPOT_DURATION_TIME = 360
 
 
 def deprecation(message):

--- a/vars/byoLongevityPipeline.groovy
+++ b/vars/byoLongevityPipeline.groovy
@@ -54,9 +54,12 @@ def call() {
                    description: 'If empty - the default manager version will be taken',
                    name: 'scylla_mgmt_repo')
 
-            string(defaultValue: "spot_low_price",
-                   description: 'spot_low_price|on_demand|spot_fleet|spot_low_price|spot_duration',
+            string(defaultValue: "spot",
+                   description: 'spot|on_demand|spot_fleet',
                    name: 'provision_type')
+            string(defaultValue: "${pipelineParams.get('instance_provision_fallback_on_demand', 'false')}",
+                   description: 'true|false',
+                   name: 'instance_provision_fallback_on_demand')
 
             string(defaultValue: "private",
                    description: 'private|public|ipv6',

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -33,9 +33,12 @@ def call(Map pipelineParams) {
             string(defaultValue: '', description: '', name: 'scylla_ami_id')
             string(defaultValue: '', description: '', name: 'scylla_version')
             string(defaultValue: '', description: '', name: 'scylla_repo')
-            string(defaultValue: "${pipelineParams.get('provision_type', 'spot_low_price')}",
-                   description: 'spot_low_price|on_demand|spot_fleet|spot_duration',
+            string(defaultValue: "${pipelineParams.get('provision_type', 'spot')}",
+                   description: 'spot|on_demand|spot_fleet',
                    name: 'provision_type')
+            string(defaultValue: "${pipelineParams.get('instance_provision_fallback_on_demand', 'false')}",
+                   description: 'true|false',
+                   name: 'instance_provision_fallback_on_demand')
 
             string(defaultValue: "${pipelineParams.get('post_behavior_db_nodes', 'keep-on-failure')}",
                    description: 'keep|keep-on-failure|destroy',

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -33,9 +33,12 @@ def call(Map pipelineParams) {
             string(defaultValue: '', description: '', name: 'scylla_ami_id')
             string(defaultValue: "${pipelineParams.get('scylla_version', '')}", description: '', name: 'scylla_version')
             string(defaultValue: '', description: '', name: 'scylla_repo')
-            string(defaultValue: "${pipelineParams.get('provision_type', 'spot_low_price')}",
-                   description: 'spot_low_price|on_demand|spot_fleet|spot_duration',
+            string(defaultValue: "${pipelineParams.get('provision_type', 'spot')}",
+                   description: 'spot|on_demand|spot_fleet',
                    name: 'provision_type')
+            string(defaultValue: "${pipelineParams.get('instance_provision_fallback_on_demand', 'false')}",
+                   description: 'true|false',
+                   name: 'instance_provision_fallback_on_demand')
 
             string(defaultValue: "${pipelineParams.get('post_behavior_db_nodes', 'keep-on-failure')}",
                    description: 'keep|keep-on-failure|destroy',

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -33,6 +33,7 @@ def call(Map params, String region){
     export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
     export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"
     export SCT_INSTANCE_PROVISION="${params.get('provision_type', '')}"
+    export SCT_INSTANCE_PROVISION_FALLBACK_ON_DEMAND="${params.get('instance_provision_fallback_on_demand', '')}"
     export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$GIT_BRANCH | sed -E 's+(origin/|origin/branch-)++')
     export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$SCT_AMI_ID_DB_SCYLLA_DESC | tr ._ - | cut -c1-8 )
     if [[ ${params.update_db_packages} != null ]]; then


### PR DESCRIPTION
There are the changes in this commit:
1. Verify test duration on the early stage, when test started
2. Use "floor" operator instead of "round" when calculate spot duration
because of "floor" round float to lower.
Example:
if we have test duration 350, we will get round(350/60)*60+60 > 360, but the maximum is 360
3. fall back (if possible depend on test_duration) to spot_duration when regular spot failed
due to errors. If can't create spot_duration instance, create on_demand
4. Add handling of price-too-low, capacity-not-available errors
5. If spot fleet creation fails - doesn't try to request the other type of instance

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
