### PR TITLE
fix(cluster.py): Fixing cql_connection function

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3057,9 +3057,10 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
                        password=None, compression=True, protocol_version=None,
                        port=None, ssl_opts=None, connect_timeout=100, verbose=True):
         node_ips = self.get_node_external_ips()
+        wlrr = WhiteListRoundRobinPolicy(node_ips)
         return self._create_session(node=node, keyspace=keyspace, user=user, password=password,
                                     compression=compression, protocol_version=protocol_version,
-                                    port=port, ssl_opts=ssl_opts, node_ips=self.get_node_external_ips(),
+                                    load_balancing_policy=wlrr, port=port, ssl_opts=ssl_opts, node_ips=node_ips,
                                     connect_timeout=connect_timeout, verbose=verbose)
 
     def cql_connection_exclusive(self, node, keyspace=None, user=None,  # pylint: disable=too-many-arguments
@@ -3083,7 +3084,6 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
 
         If the timeout is exceeded, the exception is raised.
         """
-        # pylint: disable=unused-argument
         kwargs = locals()
         del kwargs["self"]
         return self.cql_connection(**kwargs)


### PR DESCRIPTION
* Adding WhiteListRoundRobinPolicy of all node IPs to create a new cql session

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
