### PR TITLE
fix(sdcm/remote/remote_libssh_cmd_runner.py): stop running keep-alive thread to reduce possibility of hitting segmentation fault

### DIFF
--- a/sdcm/remote/libssh2_client/__init__.py
+++ b/sdcm/remote/libssh2_client/__init__.py
@@ -336,11 +336,13 @@ class Client:  # pylint: disable=too-many-instance-attributes
         self._auth()
 
     def _init_tune(self):
+        if self.keepalive_thread:
+            self.keepalive_thread.stop()
         if self.timings.keepalive_timeout:
+            # This part of logic is disabled
+            # TODO: Make sure it works with no keep-alive packets and remove it if it does
             with self.session.lock:
                 self.session.keepalive_config(False, self.timings.keepalive_timeout)
-            if self.keepalive_thread:
-                self.keepalive_thread.stop()
             self.keepalive_thread = KeepAliveThread(
                 self.session, keepalive_timeout=self.timings.keepalive_sending_timeout)
             self.keepalive_thread.start()

--- a/sdcm/remote/remote_libssh_cmd_runner.py
+++ b/sdcm/remote/remote_libssh_cmd_runner.py
@@ -52,7 +52,7 @@ class RemoteLibSSH2CmdRunner(RemoteCmdRunnerBase, ssh_transport='libssh2'):  # p
             user=self.user,
             port=self.port,
             pkey=os.path.expanduser(self.key_file),
-            timings=Timings(keepalive_timeout=300, connect_timeout=self.connect_timeout)
+            timings=Timings(keepalive_timeout=0, connect_timeout=self.connect_timeout)
         )
 
     def is_up(self, timeout: float = 30) -> bool:


### PR DESCRIPTION

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
