### PR TITLE
fix(scyllakill): waiting for db to be down before

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -264,6 +264,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         kill_cmd = "sudo pkill -9 scylla"
         self.target_node.remoter.run(kill_cmd, ignore_status=True)
 
+        # Wait for the process to be down before waiting for service to be restarted
+        self.target_node.wait_db_down()
+
         # Let's wait for the target Node to have their services re-started
         self.log.info('Waiting scylla services to be restarted after we killed them...')
         self.target_node.wait_db_up(timeout=14400)


### PR DESCRIPTION
it will be restarted by the service.
It was found in a job run by @aleksbykov.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
