### PR TITLE
improvement(result_analyze): Added email_subject_postfix to regression check

### DIFF
--- a/sdcm/results_analyze/__init__.py
+++ b/sdcm/results_analyze/__init__.py
@@ -364,7 +364,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
                     param, src[param], dst[param], version_dst))
         return cmp_res
 
-    def check_regression(self, test_id, is_gce=False):
+    def check_regression(self, test_id, is_gce=False, email_subject_postfix=None):
         """
         Get test results by id, filter similar results and calculate max values for each version,
         then compare with max in the test version and all the found versions.
@@ -511,6 +511,8 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
         subject = f'Performance Regression Compare Results - {test_name} - {test_version} - {str(test_start_time)}'
         if ycsb:
             subject = f'(Alternator) Performance Regression - {test_name} - {test_version} - {str(test_start_time)}'
+        if email_subject_postfix:
+            subject = f'{subject} {email_subject_postfix}'
         html = self.render_to_html(results)
         self.send_email(subject, html)
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1988,7 +1988,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                                       email_recipients=self.params.get('email_recipients', default=None))
         is_gce = bool(self.params.get('cluster_backend') == 'gce')
         try:
-            results_analyzer.check_regression(self._test_id, is_gce)
+            results_analyzer.check_regression(self._test_id, is_gce,
+                                              email_subject_postfix=self.params.get('email_subject_postfix', ''))
         except Exception as ex:  # pylint: disable=broad-except
             self.log.exception('Failed to check regression: %s', ex)
 


### PR DESCRIPTION

	in order to support various postfixes on performance email,
	this fix allow adding ending text like 'Cloud backend'

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
