### PR TITLE
fix(tester.py): Disabling set_system_auth_rf function for Siren cloud

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -415,6 +415,12 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self.db_cluster.validate_seeds_on_all_nodes()
 
     def set_system_auth_rf(self):
+        # No need to change system tables when running via scylla-cloud
+        # Also, when running a Alternator via scylla-cloud, we don't have CQL access to the cluster
+        if self.params.get("cluster_backend") == 'aws-siren':
+            # TODO: move this skip to siren-tools when possible
+            self.log.warning("Skipping this function due this job run from Siren cloud!")
+            return
         # change RF of system_auth
         system_auth_rf = self.params.get('system_auth_rf')
         if system_auth_rf > 1 and not Setup.REUSE_CLUSTER:


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
