### PR TITLE
fix(runSctTest): export SCT_UPDATE_DB_PACKAGES

### DIFF
--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -35,6 +35,9 @@ def call(Map params, String region){
     export SCT_INSTANCE_PROVISION="${params.get('provision_type', '')}"
     export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$GIT_BRANCH | sed -E 's+(origin/|origin/branch-)++')
     export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$SCT_AMI_ID_DB_SCYLLA_DESC | tr ._ - | cut -c1-8 )
+    if [[ ${params.update_db_packages} != null ]]; then
+        export SCT_UPDATE_DB_PACKAGES="${params.update_db_packages}"
+    fi
 
     export SCT_TAG_AMI_WITH_RESULT="${params.tag_ami_with_result}"
     export SCT_IP_SSH_CONNECTIONS="${params.ip_ssh_connections}"


### PR DESCRIPTION
In byo longevity job, the assigned update_db_packages can't be used to
replace scylla in AMI.

This patch added an export to pass the value to test.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
