### PR TITLE
fix(killscylla): wait_db_down has too large wait

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1272,11 +1272,11 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         wait.wait_for(func=lambda: not self.apt_running(), step=60,
                       text=text)
 
-    def wait_db_down(self, verbose=True, timeout=3600):
+    def wait_db_down(self, verbose=True, timeout=3600, check_interval=60):
         text = None
         if verbose:
             text = '%s: Waiting for DB services to be down' % self
-        wait.wait_for(func=lambda: not self.db_up(), step=60, text=text, timeout=timeout, throw_exc=True)
+        wait.wait_for(func=lambda: not self.db_up(), step=check_interval, text=text, timeout=timeout, throw_exc=True)
 
     def wait_cs_installed(self, verbose=True):
         text = None

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -266,7 +266,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.target_node.remoter.run(kill_cmd, ignore_status=True)
 
         # Wait for the process to be down before waiting for service to be restarted
-        self.target_node.wait_db_down()
+        self.target_node.wait_db_down(check_interval=2)
 
         # Let's wait for the target Node to have their services re-started
         self.log.info('Waiting scylla services to be restarted after we killed them...')


### PR DESCRIPTION
the function wait_db_down had too large wait between
the tries, so we missed the time window where
the port stopped replying, and the test got stuck
on waiting for db down, when it was already up.
Reducing the time between tries will give us better
coverage for the time the port stops listening

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
