### PR TITLE
fix(disrupt_kill_scylla): wait for schema agreement after disrupt_kill_scylla

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -273,6 +273,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.target_node.wait_db_up(timeout=14400)
         self.log.info('Waiting JMX services to be restarted after we killed them...')
         self.target_node.wait_jmx_up()
+        self.cluster.wait_for_schema_agreement()
 
     def disrupt_stop_wait_start_scylla_server(self, sleep_time=300):  # pylint: disable=invalid-name
         self._set_current_disruption('StopWaitStartService %s' % self.target_node)


### PR DESCRIPTION
Cluster health checker warned about schema disagreement because of it wasn't finished
after Scylla start. Added function to wait for schema agreement

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
