### PR TITLE
fix(instance_type): using c5 type instead of c4

### DIFF
--- a/internal_test_data/multi_region_dc_test_case.yaml
+++ b/internal_test_data/multi_region_dc_test_case.yaml
@@ -13,7 +13,7 @@ ami_id_db_scylla_desc: VERSION
 use_mgmt: true
 mgmt_port: 10090
 
-instance_type_loader: 'c4.large'
+instance_type_loader: 'c5.large'
 instance_type_monitor: 't2.small'
 
 db_type: scylla

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -53,7 +53,7 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
 
     def __init__(self, ec2_ami_id, ec2_subnet_id, ec2_security_group_ids,  # pylint: disable=too-many-arguments
                  services, credentials, cluster_uuid=None,
-                 ec2_instance_type='c4.xlarge', ec2_ami_username='root',
+                 ec2_instance_type='c5.xlarge', ec2_ami_username='root',
                  ec2_user_data='', ec2_block_device_mappings=None,
                  cluster_prefix='cluster',
                  node_prefix='node', n_nodes=10, params=None, node_type=None, extra_network_interface=False):
@@ -713,7 +713,7 @@ class AWSNode(cluster.BaseNode):
 class ScyllaAWSCluster(cluster.BaseScyllaCluster, AWSCluster):
 
     def __init__(self, ec2_ami_id, ec2_subnet_id, ec2_security_group_ids,  # pylint: disable=too-many-arguments
-                 services, credentials, ec2_instance_type='c4.xlarge',
+                 services, credentials, ec2_instance_type='c5.xlarge',
                  ec2_ami_username='centos',
                  ec2_block_device_mappings=None,
                  user_prefix=None,
@@ -864,7 +864,7 @@ class ScyllaAWSCluster(cluster.BaseScyllaCluster, AWSCluster):
 class CassandraAWSCluster(ScyllaAWSCluster):
 
     def __init__(self, ec2_ami_id, ec2_subnet_id, ec2_security_group_ids,  # pylint: disable=too-many-arguments
-                 services, credentials, ec2_instance_type='c4.xlarge',
+                 services, credentials, ec2_instance_type='c5.xlarge',
                  ec2_ami_username='ubuntu',
                  ec2_block_device_mappings=None,
                  user_prefix=None,
@@ -952,7 +952,7 @@ class CassandraAWSCluster(ScyllaAWSCluster):
 class LoaderSetAWS(cluster.BaseLoaderSet, AWSCluster):
 
     def __init__(self, ec2_ami_id, ec2_subnet_id, ec2_security_group_ids,  # pylint: disable=too-many-arguments
-                 services, credentials, ec2_instance_type='c4.xlarge',
+                 services, credentials, ec2_instance_type='c5.xlarge',
                  ec2_block_device_mappings=None,
                  ec2_ami_username='centos',
                  user_prefix=None, n_nodes=10, params=None):
@@ -985,7 +985,7 @@ class LoaderSetAWS(cluster.BaseLoaderSet, AWSCluster):
 class MonitorSetAWS(cluster.BaseMonitorSet, AWSCluster):
 
     def __init__(self, ec2_ami_id, ec2_subnet_id, ec2_security_group_ids,  # pylint: disable=too-many-arguments
-                 services, credentials, ec2_instance_type='c4.xlarge',
+                 services, credentials, ec2_instance_type='c5.xlarge',
                  ec2_block_device_mappings=None,
                  ec2_ami_username='centos',
                  user_prefix=None, n_nodes=10, targets=None, params=None):

--- a/test-cases/cdc/cdc-15m-replication-gemini.yaml
+++ b/test-cases/cdc/cdc-15m-replication-gemini.yaml
@@ -12,7 +12,7 @@ n_test_oracle_db_nodes: 1
 instance_type_db_oracle: 'i3.large'
 
 n_loaders: 1
-instance_type_loader: 'c4.large'
+instance_type_loader: 'c5.large'
 
 n_monitor_nodes: 0
 # instance_type_monitor: 't3.small'

--- a/test-cases/cdc/cdc-15m-replication-postimage.yaml
+++ b/test-cases/cdc/cdc-15m-replication-postimage.yaml
@@ -12,7 +12,7 @@ n_test_oracle_db_nodes: 1
 instance_type_db_oracle: 'i3.large'
 
 n_loaders: 1
-instance_type_loader: 'c4.large'
+instance_type_loader: 'c5.large'
 
 n_monitor_nodes: 0
 # instance_type_monitor: 't3.small'

--- a/test-cases/cdc/cdc-15m-replication-preimage.yaml
+++ b/test-cases/cdc/cdc-15m-replication-preimage.yaml
@@ -12,7 +12,7 @@ n_test_oracle_db_nodes: 1
 instance_type_db_oracle: 'i3.large'
 
 n_loaders: 1
-instance_type_loader: 'c4.large'
+instance_type_loader: 'c5.large'
 
 n_monitor_nodes: 0
 # instance_type_monitor: 't3.small'

--- a/test-cases/cdc/cdc-15m-replication.yaml
+++ b/test-cases/cdc/cdc-15m-replication.yaml
@@ -12,7 +12,7 @@ n_test_oracle_db_nodes: 1
 instance_type_db_oracle: 'i3.large'
 
 n_loaders: 1
-instance_type_loader: 'c4.large'
+instance_type_loader: 'c5.large'
 
 n_monitor_nodes: 0
 # instance_type_monitor: 't3.small'

--- a/test-cases/features/dns-cluster-5min.yaml
+++ b/test-cases/features/dns-cluster-5min.yaml
@@ -9,7 +9,7 @@ n_loaders: 1
 n_monitor_nodes: 1
 
 instance_type_db: 'i3.2xlarge'
-instance_type_loader: 'c4.4xlarge'
+instance_type_loader: 'c5.4xlarge'
 instance_type_monitor: 't2.small'
 
 user_prefix: 'cases-dns'

--- a/test-cases/features/enospc-30mins.yaml
+++ b/test-cases/features/enospc-30mins.yaml
@@ -8,7 +8,7 @@ n_loaders: 4
 n_monitor_nodes: 1
 
 instance_type_db: 'c3.large' # for cassandra we'll use 'm3.large'
-instance_type_loader: 'c4.4xlarge'
+instance_type_loader: 'c5.4xlarge'
 instance_type_monitor: 't2.small'
 
 user_prefix: 'cases-enospc'

--- a/test-cases/features/ics_space_amplification_test.yaml
+++ b/test-cases/features/ics_space_amplification_test.yaml
@@ -7,7 +7,7 @@ n_loaders: 1
 n_monitor_nodes: 1
 
 instance_type_db: 'i3.4xlarge'
-instance_type_loader: 'c4.large'
+instance_type_loader: 'c5.large'
 
 nemesis_class_name: 'NoOpMonkey'
 user_prefix: 'ics_space_amplification'

--- a/test-cases/load/admission_control_overload_test.yaml
+++ b/test-cases/load/admission_control_overload_test.yaml
@@ -8,7 +8,7 @@ n_db_nodes: 1
 n_loaders: 12
 n_monitor_nodes: 1
 instance_type_db: 'i3.large'
-instance_type_loader: 'c4.4xlarge'
+instance_type_loader: 'c5.4xlarge'
 instance_type_monitor: 't3.small'
 user_prefix: 'overload_admission_control'
 system_auth_rf: 1

--- a/test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
+++ b/test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
@@ -18,7 +18,7 @@ n_loaders: 4
 n_monitor_nodes: 1
 
 instance_type_db: 'i3en.3xlarge'
-instance_type_loader: 'c4.2xlarge'
+instance_type_loader: 'c5.2xlarge'
 
 cluster_health_check: false
 nemesis_class_name: 'DisruptiveMonkey:1 NonDisruptiveMonkey:2'

--- a/test-cases/longevity/longevity-50GB-4days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-50GB-4days-authorization-and-tls-ssl.yaml
@@ -22,7 +22,7 @@ n_monitor_nodes: 1
 
 instance_type_db: 'i3.4xlarge'
 # Seems the c5.xlarge type is small for this load - I receive OOM on 2 loaders
-instance_type_loader: 'c4.2xlarge'
+instance_type_loader: 'c5.2xlarge'
 
 nemesis_class_name: 'ChaosMonkey'
 nemesis_interval: 5

--- a/test-cases/manager/manager-regression-ipv6.yaml
+++ b/test-cases/manager/manager-regression-ipv6.yaml
@@ -1,7 +1,7 @@
 stress_cmd: "cassandra-stress write cl=QUORUM n=1200300 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=200 -pop seq=400200300..600200300"
 
 instance_type_db: 'i3.large'
-instance_type_loader: 'c4.large'
+instance_type_loader: 'c5.large'
 
 region_name: 'eu-west-1'
 n_db_nodes: 3

--- a/test-cases/manager/manager-regression-multiDC-set-distro.yaml
+++ b/test-cases/manager/manager-regression-multiDC-set-distro.yaml
@@ -1,7 +1,7 @@
 stress_cmd: "cassandra-stress write cl=QUORUM n=1200300 -schema 'replication(strategy=NetworkTopologyStrategy,us-eastscylla_node_east=2,us-west-2scylla_node_west=1)' -port jmx=6868 -mode cql3 native -rate threads=200 -pop seq=400200300..600200300"
 
 instance_type_db: 'i3.large'
-instance_type_loader: 'c4.large'
+instance_type_loader: 'c5.large'
 
 region_name: 'us-east-1 us-west-2'
 n_db_nodes: '2 1'

--- a/test-cases/performance/perf-regression-alternator-latency-500gb-30min.yaml
+++ b/test-cases/performance/perf-regression-alternator-latency-500gb-30min.yaml
@@ -34,7 +34,7 @@ n_db_nodes: 3
 n_loaders: 3
 n_monitor_nodes: 1
 
-instance_type_loader: 'c4.2xlarge'
+instance_type_loader: 'c5.2xlarge'
 instance_type_monitor: 't3.small'
 instance_type_db: 'i3.4xlarge'
 

--- a/test-cases/performance/perf-regression-alternator.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression-alternator.100threads.30M-keys.yaml
@@ -43,7 +43,7 @@ n_loaders: 3
 n_monitor_nodes: 1
 
 instance_type_db: 'i3.2xlarge'
-instance_type_loader: 'c4.2xlarge'
+instance_type_loader: 'c5.2xlarge'
 instance_type_monitor: 't3.small'
 
 alternator_port: 8080

--- a/test-cases/performance/perf-regression-latency-1TB.yaml
+++ b/test-cases/performance/perf-regression-latency-1TB.yaml
@@ -14,7 +14,7 @@ n_loaders: 4
 n_monitor_nodes: 1
 
 instance_type_db: 'i3.4xlarge'
-instance_type_loader: 'c4.2xlarge'
+instance_type_loader: 'c5.2xlarge'
 instance_type_monitor: 't3.large'
 
 user_prefix: 'perf-regression-latency'

--- a/test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml
+++ b/test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml
@@ -13,7 +13,7 @@ nemesis_add_node_cnt: 3
 n_loaders: 4
 n_monitor_nodes: 1
 
-instance_type_loader: 'c4.2xlarge'
+instance_type_loader: 'c5.2xlarge'
 instance_type_monitor: 't3.large'
 instance_type_db: 'i3.2xlarge'
 

--- a/test-cases/performance/perf-regression-latency-500gb-30min.yaml
+++ b/test-cases/performance/perf-regression-latency-500gb-30min.yaml
@@ -12,7 +12,7 @@ n_db_nodes: 3
 n_loaders: 4
 n_monitor_nodes: 1
 
-instance_type_loader: 'c4.2xlarge'
+instance_type_loader: 'c5.2xlarge'
 instance_type_monitor: 't3.small'
 instance_type_db: 'i3.4xlarge'
 

--- a/test-cases/performance/perf-regression-latency-lwt-big.yaml
+++ b/test-cases/performance/perf-regression-latency-lwt-big.yaml
@@ -42,7 +42,7 @@ n_db_nodes: 3
 n_loaders: 1
 n_monitor_nodes: 1
 
-instance_type_loader: 'c4.2xlarge'
+instance_type_loader: 'c5.2xlarge'
 instance_type_monitor: 't3.small'
 instance_type_db: 'i3.xlarge'
 

--- a/test-cases/performance/perf-regression-latency-lwt-small.yaml
+++ b/test-cases/performance/perf-regression-latency-lwt-small.yaml
@@ -43,7 +43,7 @@ n_db_nodes: 3
 n_loaders: 1
 n_monitor_nodes: 1
 
-instance_type_loader: 'c4.2xlarge'
+instance_type_loader: 'c5.2xlarge'
 instance_type_monitor: 't3.small'
 instance_type_db: 'i3.xlarge'
 

--- a/test-cases/performance/perf-regression-throughput-cdc-mixed-poll-batching.yaml
+++ b/test-cases/performance/perf-regression-throughput-cdc-mixed-poll-batching.yaml
@@ -12,7 +12,7 @@ n_db_nodes: 3
 n_loaders: 4
 n_monitor_nodes: 1
 
-instance_type_loader: 'c4.2xlarge'
+instance_type_loader: 'c5.2xlarge'
 instance_type_monitor: 't3.small'
 instance_type_db: 'i3.2xlarge'
 

--- a/test-cases/performance/perf-regression-throughput-lwt-big.yaml
+++ b/test-cases/performance/perf-regression-throughput-lwt-big.yaml
@@ -45,7 +45,7 @@ n_db_nodes: 3
 n_loaders: 1
 n_monitor_nodes: 1
 
-instance_type_loader: 'c4.2xlarge'
+instance_type_loader: 'c5.2xlarge'
 instance_type_monitor: 't3.small'
 instance_type_db: 'i3.xlarge'
 

--- a/test-cases/performance/perf-regression-throughput-lwt-small.yaml
+++ b/test-cases/performance/perf-regression-throughput-lwt-small.yaml
@@ -44,7 +44,7 @@ n_db_nodes: 3
 n_loaders: 1
 n_monitor_nodes: 1
 
-instance_type_loader: 'c4.2xlarge'
+instance_type_loader: 'c5.2xlarge'
 instance_type_monitor: 't3.small'
 instance_type_db: 'i3.xlarge'
 

--- a/test-cases/performance/perf-regression-write-latency-cdc.yaml
+++ b/test-cases/performance/perf-regression-write-latency-cdc.yaml
@@ -5,7 +5,7 @@ n_db_nodes: 3
 n_loaders: 4
 n_monitor_nodes: 1
 
-instance_type_loader: 'c4.2xlarge'
+instance_type_loader: 'c5.2xlarge'
 instance_type_monitor: 't3.small'
 instance_type_db: 'i3.2xlarge'
 

--- a/test-cases/performance/perf-regression-write-throughput-cdc.yaml
+++ b/test-cases/performance/perf-regression-write-throughput-cdc.yaml
@@ -5,7 +5,7 @@ n_db_nodes: 3
 n_loaders: 4
 n_monitor_nodes: 1
 
-instance_type_loader: 'c4.2xlarge'
+instance_type_loader: 'c5.2xlarge'
 instance_type_monitor: 't3.small'
 instance_type_db: 'i3.2xlarge'
 

--- a/test-cases/performance/perf-regression.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys.yaml
@@ -10,7 +10,7 @@ n_loaders: 4
 n_monitor_nodes: 1
 
 instance_type_db: 'i3.2xlarge'
-instance_type_loader: 'c4.2xlarge'
+instance_type_loader: 'c5.2xlarge'
 instance_type_monitor: 't3.small'
 
 user_prefix: 'perf-regression'

--- a/test-cases/performance/perf-row-level-repair-1TB.yaml
+++ b/test-cases/performance/perf-row-level-repair-1TB.yaml
@@ -14,7 +14,7 @@ n_loaders: 8
 n_monitor_nodes: 1
 
 instance_type_db: 'i3.4xlarge'
-instance_type_loader: 'c4.2xlarge'
+instance_type_loader: 'c5.2xlarge'
 
 user_prefix: 'perf-row-level-repair'
 pre_create_schema: True

--- a/test-cases/upgrades/manager-upgrade.yaml
+++ b/test-cases/upgrades/manager-upgrade.yaml
@@ -1,7 +1,7 @@
 stress_cmd: "cassandra-stress write cl=QUORUM n=1200300 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -pop seq=400200300..600200300"
 
 instance_type_db: 'i3.large'
-instance_type_loader: 'c4.large'
+instance_type_loader: 'c5.large'
 
 region_name: 'us-east-1'
 n_db_nodes: '3'


### PR DESCRIPTION
c4 instance type is not available in some regions, moving to c5 instead.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
