### PR TITLE
fix(sdcm/nemesis.py): remove ScyllaOperatorGrowShrinkClusterNemesis from being executed

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3012,7 +3012,6 @@ class MemoryStressMonkey(Nemesis):
 
 
 class ScyllaOperatorGrowShrinkClusterNemesis(GrowShrinkClusterNemesis):
-    kubernetes = True
 
     def set_target_node(self):
         self.target_node = self.cluster.nodes[-1]  # can withdraw last node only


### PR DESCRIPTION
https://trello.com/c/OHVoC9sq/2270-sdcmnemesiskubernetesscyllaoperatormonkey-no-monkey-to-run

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
