### PR TITLE
Set multi-dc jobs to use server encryption (internode_encryption)

### DIFF
--- a/test-cases/longevity/longevity-counters-multidc.yaml
+++ b/test-cases/longevity/longevity-counters-multidc.yaml
@@ -18,3 +18,6 @@ nemesis_class_name: 'ChaosMonkey'
 nemesis_interval: 15
 
 use_mgmt: true
+
+server_encrypt: true
+client_encrypt: true

--- a/test-cases/longevity/longevity-lwt-24h-multidc.yaml
+++ b/test-cases/longevity/longevity-lwt-24h-multidc.yaml
@@ -15,3 +15,6 @@ nemesis_during_prepare: false
 space_node_threshold: 64424
 
 user_prefix: 'lwt-longevity-multi-dc-24h'
+
+server_encrypt: true
+client_encrypt: true


### PR DESCRIPTION
Enabling internode_connection for multi-dc longevity jobs.

For now set to "all".
There is a trello task to support also other options "rack, dc".
Then, one should be change to "dc".

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
