### PR TITLE
fix(sdcm/nemesis): enable SoftRebootNodeMonkey for kube

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -922,7 +922,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             if not self.remoter.is_up(60):
                 raise RuntimeError('Target host is down')
             try:
-                self.remoter.run('sudo reboot', ignore_status=True, retry=0)
+                self.remoter.sudo('reboot', ignore_status=True, retry=0)
             except Exception:  # pylint: disable=broad-except
                 pass
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2333,6 +2333,7 @@ class HardRebootNodeMonkey(Nemesis):
 
 class SoftRebootNodeMonkey(Nemesis):
     disruptive = True
+    kubernetes = True
 
     @log_time_elapsed_and_status
     def disrupt(self):

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h.yaml
@@ -13,7 +13,7 @@ n_db_nodes: 3
 n_loaders: 2
 n_monitor_nodes: 1
 
-nemesis_class_name: 'KubernetesScyllaOperatorMonkey'
+nemesis_class_name: 'SoftRebootNodeMonkey'
 nemesis_interval: 5
 
 user_prefix: 'k8s-longevity-10gb-3h'


### PR DESCRIPTION
https://trello.com/c/HBdL4eoB/2276-k8s-softrebootnodemonkey
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
