### PR TITLE
improvement(db_stats): make update_test_details more stable

### DIFF
--- a/performance_regression_row_level_repair_test.py
+++ b/performance_regression_row_level_repair_test.py
@@ -159,7 +159,7 @@ class PerformanceRegressionRowLevelRepairTest(ClusterTester):
         requires: export SCT_HINTED_HANDOFF_DISABLED=true
         :return:
         """
-        dict_specific_tested_stats = {}
+        stats = {}
 
         self._pre_create_schema_large_scale()
         node1 = self.db_cluster.nodes[-1]
@@ -189,7 +189,7 @@ class PerformanceRegressionRowLevelRepairTest(ClusterTester):
         repair_time = self._run_repair(node=node1)[0]  # pylint: disable=unsubscriptable-object
         self.log.info('Repair (0% synced) time on node: {} is: {}'.format(node1.name, repair_time))
 
-        dict_specific_tested_stats['repair_runtime_all_diff'] = repair_time
+        stats['repair_runtime_all_diff'] = repair_time
 
         self.wait_no_compactions_running()
 
@@ -197,10 +197,10 @@ class PerformanceRegressionRowLevelRepairTest(ClusterTester):
         repair_time = self._run_repair(node=node1)[0]  # pylint: disable=unsubscriptable-object
         self.log.info('Repair (100% synced) time on node: {} is: {}'.format(node1.name, repair_time))
 
-        dict_specific_tested_stats['repair_runtime_no_diff'] = repair_time
-        self.update_test_details(scylla_conf=True, dict_specific_tested_stats=dict_specific_tested_stats)
+        stats['repair_runtime_no_diff'] = repair_time
+        self.update_test_details(scylla_conf=True, extra_stats=stats)
 
-        self.check_specified_stats_regression(dict_specific_tested_stats=dict_specific_tested_stats)
+        self.check_specified_stats_regression(stats)
 
     def test_row_level_repair_3_nodes_small_diff(self):
         """
@@ -249,11 +249,11 @@ class PerformanceRegressionRowLevelRepairTest(ClusterTester):
 
         self.log.info('Repair (99.8% synced) time on node: {} is: {}'.format(node3.name, repair_time))
 
-        dict_specific_tested_stats = {'repair_runtime_small_diff': repair_time}
+        stats = {'repair_runtime_small_diff': repair_time}
 
-        self.update_test_details(scylla_conf=True, dict_specific_tested_stats=dict_specific_tested_stats)
+        self.update_test_details(scylla_conf=True, extra_stats=stats)
 
-        self.check_specified_stats_regression(dict_specific_tested_stats=dict_specific_tested_stats)
+        self.check_specified_stats_regression(stats)
 
     def _populate_scylla_bench_data_in_parallel(self, base_cmd, partition_count, clustering_row_count,
                                                 consistency_level="all"):
@@ -328,11 +328,11 @@ class PerformanceRegressionRowLevelRepairTest(ClusterTester):
 
         self.log.info('Repair (with large partitions) time on node: {} is: {}'.format(node3.name, repair_time))
 
-        dict_specific_tested_stats = {'repair_runtime_large_partitions': repair_time}
+        stats = {'repair_runtime_large_partitions': repair_time}
 
-        self.update_test_details(scylla_conf=True, dict_specific_tested_stats=dict_specific_tested_stats)
+        self.update_test_details(scylla_conf=True, extra_stats=stats)
 
-        self.check_specified_stats_regression(dict_specific_tested_stats=dict_specific_tested_stats)
+        self.check_specified_stats_regression(stats)
 
     def test_row_level_repair_during_load(self, preload_data=True):
         """
@@ -375,8 +375,8 @@ class PerformanceRegressionRowLevelRepairTest(ClusterTester):
 
         self.log.info('Repair (during r/w load) time on node: {} is: {}'.format(node1.name, repair_time))
 
-        dict_specific_tested_stats = {'repair_runtime_during_load': repair_time}
+        stats = {'repair_runtime_during_load': repair_time}
 
-        self.update_test_details(scylla_conf=True, dict_specific_tested_stats=dict_specific_tested_stats)
+        self.update_test_details(scylla_conf=True, extra_stats=stats)
 
-        self.check_specified_stats_regression(dict_specific_tested_stats=dict_specific_tested_stats)
+        self.check_specified_stats_regression(stats)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -996,23 +996,6 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         if self._docker_log_process:
             self._docker_log_process.kill()
 
-    def get_cpumodel(self):
-        """Get cpu model from /proc/cpuinfo
-
-        Get cpu model from /proc/cpuinfo of node
-        """
-        cpuinfo_cmd = 'cat /proc/cpuinfo'
-
-        try:
-            result = self.remoter.run(cmd=cpuinfo_cmd, verbose=False)
-            model = re.findall(r'^model\sname\s:(.+)$', result.stdout.strip(), re.MULTILINE)
-            return model[0].strip()
-
-        except Exception as details:  # pylint: disable=broad-except
-            self.log.error('Error retrieving CPU model info : %s',
-                           details)
-            return None
-
     def get_installed_packages(self):
         """Get installed packages on node
 
@@ -1030,21 +1013,6 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         except Exception as details:  # pylint: disable=broad-except
             self.log.error('Error retrieving installed packages: %s',
                            details)
-            return None
-
-    def get_system_info(self):
-        """Get system info by uname -a
-
-        Get system info as a result of uname -a
-        """
-
-        cmd = 'uname -a'
-        try:
-            result = self.remoter.run(cmd, verbose=False)
-            return result.stdout.strip()
-        except Exception as details:  # pylint: disable=broad-except
-            self.log.error('Error retrieving command \'%s\' result : %s',
-                           (cmd, details))
             return None
 
     def destroy(self):

--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -616,7 +616,7 @@ class TestStatsMixin(Stats):
                 total_stats[stat] = total
         self._stats['results']['stats_total'] = total_stats
 
-    def update_test_details(self, errors=None, coredumps=None, scylla_conf=False, dict_specific_tested_stats=None, alternator=False):  # pylint: disable=too-many-arguments
+    def update_test_details(self, errors=None, coredumps=None, scylla_conf=False, extra_stats=None, alternator=False):  # pylint: disable=too-many-arguments
         if not self.create_stats:
             return
 
@@ -662,12 +662,12 @@ class TestStatsMixin(Stats):
             update_data.update({'errors': errors})
         if coredumps:
             update_data.update({'coredumps': coredumps})
-        if dict_specific_tested_stats:
-            self.log.debug("Updating specific stats of: {}".format(dict_specific_tested_stats))
-            for key, value in dict_specific_tested_stats.items():
+        if extra_stats:
+            self.log.debug("Updating specific stats of: {}".format(extra_stats))
+            for key, value in extra_stats.items():
                 self.log.debug("k: {} v: {}".format(key, value))
-            self._stats['results'].update(dict_specific_tested_stats)
-            update_data.update(dict_specific_tested_stats)
+            self._stats['results'].update(extra_stats)
+            update_data.update(extra_stats)
         self.update(update_data)
 
     def get_doc_data(self, key):

--- a/sdcm/results_analyze/__init__.py
+++ b/sdcm/results_analyze/__init__.py
@@ -123,7 +123,7 @@ class SpecifiedStatsPerformanceAnalyzer(BaseResultsAnalyzer):
             return None
         return test_doc['_source']['results']
 
-    def check_regression(self, test_id, dict_specific_tested_stats):  # pylint: disable=too-many-locals, too-many-branches, too-many-statements
+    def check_regression(self, test_id, stats):  # pylint: disable=too-many-locals, too-many-branches, too-many-statements
         """
         Get test results by id, filter similar results and calculate DB values for each version,
         then compare with max-allowed in the tested version (and report all the found versions).
@@ -147,7 +147,7 @@ class SpecifiedStatsPerformanceAnalyzer(BaseResultsAnalyzer):
                        '.'.join([es_source_path, 'results', 'throughput']),
                        '.'.join([es_source_path, 'versions'])]
 
-        for stat in dict_specific_tested_stats.keys():  # Add all requested specific-stats to be retrieved from ES DB.
+        for stat in stats.keys():  # Add all requested specific-stats to be retrieved from ES DB.
             stat_path = '.'.join([es_source_path, stat])
             filter_path.append(stat_path)
 
@@ -158,7 +158,7 @@ class SpecifiedStatsPerformanceAnalyzer(BaseResultsAnalyzer):
             self.log.info('Cannot find tests with the same parameters as {}'.format(test_id))
             return False
         cur_test_version = None
-        tested_params = dict_specific_tested_stats.keys()
+        tested_params = stats.keys()
         group_by_version = dict()
         # repair_runtime result example:
         # { u'_id': u'20190303-105120-405065',
@@ -214,7 +214,7 @@ class SpecifiedStatsPerformanceAnalyzer(BaseResultsAnalyzer):
             raise ValueError("Could not retrieve current test details from database")
         for param in tested_params:
             if param in group_by_version[cur_test_version]:
-                cur_test_param_result = dict_specific_tested_stats[param]
+                cur_test_param_result = stats[param]
                 list_param_stats = group_by_version[cur_test_version][param]
                 param_avg = sum(list_param_stats) / float(len(list_param_stats))
                 deviation_limit = param_avg * allowed_deviation

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1988,14 +1988,12 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         except Exception as ex:  # pylint: disable=broad-except
             self.log.exception('Failed to check regression: %s', ex)
 
-    def check_specified_stats_regression(self, dict_specific_tested_stats):
-
+    def check_specified_stats_regression(self, stats):
         perf_analyzer = SpecifiedStatsPerformanceAnalyzer(es_index=self._test_index, es_doc_type=self._es_doc_type,
                                                           send_email=self.params.get('send_email', default=True),
                                                           email_recipients=self.params.get('email_recipients', default=None))
         try:
-            perf_analyzer.check_regression(
-                self._test_id, dict_specific_tested_stats=dict_specific_tested_stats)
+            perf_analyzer.check_regression(self._test_id, stats)
         except Exception as ex:  # pylint: disable=broad-except
             self.log.exception('Failed to check regression: %s', ex)
 

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -155,17 +155,6 @@ def verify_scylla_repo_file(content, is_rhel_like=True):
         assert valid_prefix, 'Repository content has invalid line: {}'.format(line)
 
 
-def remove_comments(data):
-    """Remove comments line from data
-
-    Remove any string which is start from # in data
-
-    Arguments:
-        data {str} -- data expected the command output, file contents
-    """
-    return '\n'.join([i.strip() for i in data.split('\n') if not i.startswith('#')])
-
-
 class S3Storage():
 
     bucket_name = 'cloudius-jenkins-test'


### PR DESCRIPTION
Trello: https://trello.com/c/XGIdgOvF/1676-make-updatetestdetails-more-stable

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
