### PR TITLE
Add a CDC replication longevity test

### DIFF
--- a/cdc_replication_test.py
+++ b/cdc_replication_test.py
@@ -17,9 +17,10 @@ import shutil
 import sys
 import os
 import time
+import random
 from enum import Enum
 from textwrap import dedent
-from typing import Optional
+from typing import Optional, Tuple
 
 from cassandra import ConsistencyLevel
 from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
@@ -73,24 +74,26 @@ class CDCReplicationTest(ClusterTester):
 
     def collect_data_for_analysis(self,
                                   migrate_log_path: Optional[str], replicator_log_path: str,
-                                  master_node: cluster.BaseNode, replica_node: cluster.BaseNode) -> None:
+                                  master_node: cluster.BaseNode, replica_node: cluster.BaseNode,
+                                  fetch_tables: bool = True) -> None:
         if migrate_log_path:
             self.log.info('scylla-migrate log:')
             print_file_to_stdout(migrate_log_path)
         self.log.info('Replicator log:')
         print_file_to_stdout(replicator_log_path)
 
-        with self.db_cluster.cql_connection_patient(node=master_node) as sess:
-            self.log.info('Fetching master table...')
-            res = sess.execute(SimpleStatement(f'select * from {self.KS_NAME}.{self.TABLE_NAME}',
-                                               consistency_level=ConsistencyLevel.QUORUM, fetch_size=1000))
-            write_cql_result(res, os.path.join(self.logdir, 'master-table'))
+        if fetch_tables:
+            with self.db_cluster.cql_connection_patient(node=master_node) as sess:
+                self.log.info('Fetching master table...')
+                res = sess.execute(SimpleStatement(f'select * from {self.KS_NAME}.{self.TABLE_NAME}',
+                                                   consistency_level=ConsistencyLevel.QUORUM, fetch_size=1000))
+                write_cql_result(res, os.path.join(self.logdir, 'master-table'))
 
-        with self.cs_db_cluster.cql_connection_patient(node=replica_node) as sess:
-            self.log.info('Fetching replica table...')
-            res = sess.execute(SimpleStatement(f'select * from {self.KS_NAME}.{self.TABLE_NAME}',
-                                               consistency_level=ConsistencyLevel.QUORUM, fetch_size=1000))
-            write_cql_result(res, os.path.join(self.logdir, 'replica-table'))
+            with self.cs_db_cluster.cql_connection_patient(node=replica_node) as sess:
+                self.log.info('Fetching replica table...')
+                res = sess.execute(SimpleStatement(f'select * from {self.KS_NAME}.{self.TABLE_NAME}',
+                                                   consistency_level=ConsistencyLevel.QUORUM, fetch_size=1000))
+                write_cql_result(res, os.path.join(self.logdir, 'replica-table'))
 
     def test_replication_cs(self) -> None:
         self.log.info('Using cassandra-stress to generate workload.')
@@ -109,6 +112,86 @@ class CDCReplicationTest(ClusterTester):
     def test_replication_gemini_postimage(self) -> None:
         self.test_replication_gemini(Mode.POSTIMAGE)
 
+    # In this test we run a sequence of ~30 minute rounds of replication;
+    # after each round we stop generating workload and check consistency.
+    def test_replication_longevity(self) -> None:
+        loader_node = self.loaders.nodes[0]
+        self.setup_tools(loader_node)
+
+        self.log.info('Waiting for the latest CDC generation to start...')
+        # 2 * ring_delay (ring_delay = 30s) + leeway
+        time.sleep(70)
+
+        # We'll use the same seed for each round, so that gemini uses the same schema each time.
+        # This way we preserve tables from the previous round.
+        # The purpose of preserving tables is to have the cluster store more data, which
+        # puts strain on the cluster by causing more compactions, for example.
+        gemini_seed = random.randint(1, 1000)
+
+        self.log.info('Starting gemini.')
+        stress_thread = self.start_gemini(gemini_seed)
+
+        # Wait for gemini to create keyspaces/tables/UTs
+        self.log.info('Let gemini run for a while...')
+        time.sleep(20)
+
+        self.copy_master_schema_to_replica()
+
+        self.start_replicator(Mode.DELTA)
+
+        self.consistency_ok = True
+
+        no_rounds = 12 # 12 rounds, ~30 minutes each -> ~6 hours
+        for rnd in range(no_rounds):
+            self.log.info('Starting round {}'.format(rnd))
+
+            self.log.info('Starting nemesis')
+            self.db_cluster.add_nemesis(nemesis=self.get_nemesis_class(), tester_obj=self)
+            self.db_cluster.start_nemesis()
+
+            self.log.info('Waiting for workload generation to finish (~30 minutes)...')
+            stress_results = self.verify_gemini_results(queue=stress_thread)
+            self.log.info('gemini results: {}'.format(stress_results))
+
+            self.log.info('Waiting for replicator to finish (sleeping 60s)...')
+            time.sleep(60)
+
+            self.log.info('Stopping nemesis...')
+            self.db_cluster.stop_nemesis(timeout=1800)
+            self.log.info('Nemesis stopped.')
+
+            self.log.info('Fetching replicator logs...')
+            replicator_log_path = os.path.join(self.logdir, 'replicator.log')
+            loader_node.remoter.receive_files(src='replicatorlog', dst=replicator_log_path)
+
+            migrate_log_path = os.path.join(self.logdir, 'scylla-migrate.log')
+            (migrate_ok, consistency_ok) = self.check_consistency(migrate_log_path)
+            self.consistency_ok = consistency_ok
+
+            if not (self.consistency_ok and migrate_ok):
+                break
+
+            if rnd != no_rounds - 1:
+                self.log.info('Starting gemini.')
+                stress_thread = self.start_gemini(gemini_seed)
+
+        if not self.consistency_ok:
+            self.log.error('Inconsistency detected.')
+
+        if self.consistency_ok and migrate_ok:
+            self.log.info('Consistency check successful.')
+        else:
+            # We don't fetch tables in this test since they are way too large.
+            # Besides, the data is not that useful anyway; scylla-migrate already shows what the inconsistency is.
+            # If the test fails, one should connect to the cluster manually and investigate there,
+            # or try to reproduce based on the logs in a smaller test.
+            self.collect_data_for_analysis(
+                migrate_log_path, replicator_log_path,
+                self.db_cluster.nodes[0], self.cs_db_cluster.nodes[0],
+                fetch_tables=False)
+            self.fail('Consistency check failed.')
+
+
     # pylint: disable=too-many-statements,too-many-branches,too-many-locals
     def test_replication(self, is_gemini_test: bool, mode: Mode) -> None:
         assert is_gemini_test or (mode == Mode.DELTA), "cassandra-stress doesn't work with preimage/postimage modes"
@@ -119,89 +202,27 @@ class CDCReplicationTest(ClusterTester):
         # 2 * ring_delay (ring_delay = 30s) + leeway
         time.sleep(70)
 
-        self.log.info('Starting stressor.')
         if is_gemini_test:
-            stress_thread = GeminiStressThread(
-                test_cluster=self.db_cluster,
-                oracle_cluster=None,
-                loaders=self.loaders,
-                gemini_cmd=self.params.get('gemini_cmd'),
-                timeout=self.get_duration(None),
-                outputdir=self.loaders.logdir,
-                params=self.params).run()
+            self.log.info('Starting gemini.')
+            stress_thread = self.start_gemini()
         else:
+            self.log.info('Starting cassandra-stress.')
             stress_thread = self.run_stress_cassandra_thread(stress_cmd=self.params.get('stress_cmd'))
 
         self.log.info('Let stressor run for a while...')
-        # Wait for C-S to create keyspaces/tables/UTs
+        # Wait for gemini/C-S to create keyspaces/tables/UTs
         time.sleep(20)
 
-        self.log.info('Fetching schema definitions from master cluster.')
-        master_node = self.db_cluster.nodes[0]
-        with self.db_cluster.cql_connection_patient(node=master_node) as sess:
-            sess.cluster.refresh_schema_metadata()
-            # For some reason, `refresh_schema_metadata` doesn't refresh immediatelly...
-            time.sleep(10)
-            ks = sess.cluster.metadata.keyspaces[self.KS_NAME]
-            ut_ddls = [t[1].as_cql_query() for t in ks.user_types.items()]
-            table_ddls = []
-            for name, table in ks.tables.items():
-                if name.endswith('_scylla_cdc_log'):
-                    continue
-                # Don't enable CDC on the replica cluster
-                if 'cdc' in table.extensions:
-                    del table.extensions['cdc']
-                table_ddls.append(table.as_cql_query())
-
-        if ut_ddls:
-            self.log.info('User types:\n{}'.format('\n'.join(ut_ddls)))
-        self.log.info('Table definitions:\n{}'.format('\n'.join(table_ddls)))
-
-        self.log.info('Creating schema on replica cluster.')
-        replica_node = self.cs_db_cluster.nodes[0]
-        with self.cs_db_cluster.cql_connection_patient(node=replica_node) as sess:
-            sess.execute(f"create keyspace if not exists {self.KS_NAME}"
-                         " with replication = {'class': 'SimpleStrategy', 'replication_factor': 1}")
-            for stmt in ut_ddls + table_ddls:
-                sess.execute(stmt)
+        self.copy_master_schema_to_replica()
 
         self.log.info('Starting nemesis.')
         self.db_cluster.add_nemesis(nemesis=self.get_nemesis_class(), tester_obj=self)
         self.db_cluster.start_nemesis()
 
         loader_node = self.loaders.nodes[0]
+        self.setup_tools(loader_node)
 
-        self.log.info('Installing tmux on loader node.')
-        res = loader_node.remoter.run(cmd='sudo yum install -y tmux')
-        if res.exit_status != 0:
-            self.fail('Could not install tmux.')
-
-        self.log.info('Getting scylla-migrate on loader node.')
-        res = loader_node.remoter.run(cmd=f'wget {SCYLLA_MIGRATE_URL} -O scylla-migrate && chmod +x scylla-migrate')
-        if res.exit_status != 0:
-            self.fail('Could not obtain scylla-migrate.')
-
-        self.log.info('Getting replicator on loader node.')
-        res = loader_node.remoter.run(cmd=f'wget {REPLICATOR_URL} -O replicator.jar')
-        if res.exit_status != 0:
-            self.fail('Could not obtain CDC replicator.')
-
-        # We run the replicator in a tmux session so that remoter.run returns immediately
-        # (the replicator will run in the background). We redirect the output to a log file for later extraction.
-        replicator_script = dedent("""
-            (cat >runreplicator.sh && chmod +x runreplicator.sh && tmux new-session -d -s 'replicator' ./runreplicator.sh) <<'EOF'
-            #!/bin/bash
-
-            java -cp replicator.jar com.scylladb.scylla.cdc.replicator.Main -k {} -t {} -s {} -d {} -cl {} -m {} 2>&1 | tee replicatorlog
-            EOF
-        """.format(self.KS_NAME, self.TABLE_NAME, master_node.external_address, replica_node.external_address, 'one', mode_str(mode)))
-
-        self.log.info('Replicator script:\n{}'.format(replicator_script))
-
-        self.log.info('Starting replicator.')
-        res = loader_node.remoter.run(cmd=replicator_script)
-        if res.exit_status != 0:
-            self.fail('Could not start CDC replicator.')
+        self.start_replicator(mode)
 
         self.log.info('Let stressor run for a while...')
         time.sleep(30)
@@ -239,30 +260,22 @@ class CDCReplicationTest(ClusterTester):
         replicator_log_path = os.path.join(self.logdir, 'replicator.log')
         loader_node.remoter.receive_files(src='replicatorlog', dst=replicator_log_path)
 
+        master_node = self.db_cluster.nodes[0]
+        replica_node = self.cs_db_cluster.nodes[0]
+
         migrate_log_path = None
         migrate_ok = True
         if mode == Mode.PREIMAGE:
             with open(replicator_log_path) as file:
                 self.consistency_ok = not 'Inconsistency detected.\n' in (line for line in file)
         else:
-            self.log.info('Comparing table contents using scylla-migrate...')
-            res = loader_node.remoter.run(cmd='./scylla-migrate check --master-address {} --replica-address {}'
-                                          ' --ignore-schema-difference {} {}.{} 2>&1 | tee migratelog'.format(
-                                              master_node.external_address, replica_node.external_address,
-                                              # Timestamps don't have to match in postimage mode
-                                              '--no-writetime' if mode == Mode.POSTIMAGE else '',
-                                              self.KS_NAME, self.TABLE_NAME))
-            migrate_ok = res.ok
-
             migrate_log_path = os.path.join(self.logdir, 'scylla-migrate.log')
-            loader_node.remoter.receive_files(src='migratelog', dst=migrate_log_path)
-            with open(migrate_log_path) as file:
-                self.consistency_ok = 'Consistency check OK.\n' in (line for line in file)
+            (migrate_ok, consistency_ok) = self.check_consistency(migrate_log_path,
+                                                                  compare_timestamps=(mode != Mode.POSTIMAGE))
+            self.consistency_ok = consistency_ok
 
         if not self.consistency_ok:
             self.log.error('Inconsistency detected.')
-        if not migrate_ok:
-            self.log.error('scylla-migrate command returned status {}'.format(res.exit_status))
 
         if self.consistency_ok and migrate_ok:
             self.log.info('Consistency check successful.')
@@ -272,7 +285,104 @@ class CDCReplicationTest(ClusterTester):
                 master_node, replica_node)
             self.fail('Consistency check failed.')
 
-    def get_email_data(self):
+    # Compares tables using the scylla-migrate tool.
+    def check_consistency(self, migrate_log_dst_path: str, compare_timestamps: bool = True) -> Tuple[bool, bool]:
+        loader_node = self.loaders.nodes[0]
+        self.log.info('Comparing table contents using scylla-migrate...')
+        res = loader_node.remoter.run(cmd='./scylla-migrate check --master-address {} --replica-address {}'
+                                      ' --ignore-schema-difference {} {}.{} 2>&1 | tee migratelog'.format(
+                                          self.db_cluster.nodes[0].external_address,
+                                          self.cs_db_cluster.nodes[0].external_address,
+                                          '' if compare_timestamps else '--no-writetime',
+                                          self.KS_NAME, self.TABLE_NAME))
+        loader_node.remoter.receive_files(src='migratelog', dst=migrate_log_dst_path)
+
+        migrate_ok = res.ok
+        if not migrate_ok:
+            self.log.error('scylla-migrate command returned status {}'.format(res.exit_status))
+        with open(migrate_log_dst_path) as file:
+            consistency_ok = 'Consistency check OK.\n' in (line for line in file)
+
+        return (migrate_ok, consistency_ok)
+
+    def copy_master_schema_to_replica(self) -> None:
+        self.log.info('Fetching schema definitions from master cluster.')
+        with self.db_cluster.cql_connection_patient(node=self.db_cluster.nodes[0]) as sess:
+            sess.cluster.refresh_schema_metadata()
+            # For some reason, `refresh_schema_metadata` doesn't refresh immediatelly...
+            time.sleep(10)
+            ks = sess.cluster.metadata.keyspaces[self.KS_NAME]
+            ut_ddls = [t[1].as_cql_query() for t in ks.user_types.items()]
+            table_ddls = []
+            for name, table in ks.tables.items():
+                if name.endswith('_scylla_cdc_log'):
+                    continue
+                # Don't enable CDC on the replica cluster
+                if 'cdc' in table.extensions:
+                    del table.extensions['cdc']
+                table_ddls.append(table.as_cql_query())
+
+        if ut_ddls:
+            self.log.info('User types:\n{}'.format('\n'.join(ut_ddls)))
+        self.log.info('Table definitions:\n{}'.format('\n'.join(table_ddls)))
+
+        self.log.info('Creating schema on replica cluster.')
+        replica_node = self.cs_db_cluster.nodes[0]
+        with self.cs_db_cluster.cql_connection_patient(node=replica_node) as sess:
+            sess.execute(f"create keyspace if not exists {self.KS_NAME}"
+                         " with replication = {'class': 'SimpleStrategy', 'replication_factor': 1}")
+            for stmt in ut_ddls + table_ddls:
+                sess.execute(stmt)
+
+    def start_replicator(self, mode: Mode) -> None:
+        # We run the replicator in a tmux session so that remoter.run returns immediately
+        # (the replicator will run in the background). We redirect the output to a log file for later extraction.
+        replicator_script = dedent("""
+            (cat >runreplicator.sh && chmod +x runreplicator.sh && tmux new-session -d -s 'replicator' ./runreplicator.sh) <<'EOF'
+            #!/bin/bash
+
+            java -cp replicator.jar com.scylladb.scylla.cdc.replicator.Main -k {} -t {} -s {} -d {} -cl one -m {} 2>&1 | tee replicatorlog
+            EOF
+        """.format(self.KS_NAME, self.TABLE_NAME,
+                   self.db_cluster.nodes[0].external_address,
+                   self.cs_db_cluster.nodes[0].external_address,
+                   mode_str(mode)))
+
+        self.log.info('Replicator script:\n{}'.format(replicator_script))
+
+        self.log.info('Starting replicator.')
+        res = self.loaders.nodes[0].remoter.run(cmd=replicator_script)
+        if res.exit_status != 0:
+            self.fail('Could not start CDC replicator.')
+
+    def start_gemini(self, seed: Optional[int] = None) -> GeminiStressThread:
+        params = {'gemini_seed': seed} if seed else {}
+        return GeminiStressThread(
+            test_cluster=self.db_cluster,
+            oracle_cluster=None,
+            loaders=self.loaders,
+            gemini_cmd=self.params.get('gemini_cmd'),
+            timeout=self.get_duration(None),
+            outputdir=self.loaders.logdir,
+            params=params).run()
+
+    def setup_tools(self, loader_node) -> None:
+        self.log.info('Installing tmux on loader node.')
+        res = loader_node.remoter.run(cmd='sudo yum install -y tmux')
+        if res.exit_status != 0:
+            self.fail('Could not install tmux.')
+
+        self.log.info('Getting scylla-migrate on loader node.')
+        res = loader_node.remoter.run(cmd=f'wget {SCYLLA_MIGRATE_URL} -O scylla-migrate && chmod +x scylla-migrate')
+        if res.exit_status != 0:
+            self.fail('Could not obtain scylla-migrate.')
+
+        self.log.info('Getting replicator on loader node.')
+        res = loader_node.remoter.run(cmd=f'wget {REPLICATOR_URL} -O replicator.jar')
+        if res.exit_status != 0:
+            self.fail('Could not obtain CDC replicator.')
+
+    def get_email_data(self) -> dict:
         self.log.info("Prepare data for email")
 
         email_data = self._get_common_email_data()

--- a/jenkins-pipelines/feature-cdc-replication-longevity.jenkinsfile
+++ b/jenkins-pipelines/feature-cdc-replication-longevity.jenkinsfile
@@ -1,0 +1,16 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+cdcReplicationPipeline(
+    params: params,
+
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'cdc_replication_test.CDCReplicationTest.test_replication_longevity',
+    test_config: 'test-cases/cdc/cdc-replication-longevity.yaml',
+
+    timeout: [time: 600, unit: 'MINUTES'],
+    email_recipients: 'kbraun@scylladb.com,piotr@scylladb.com,alex.bykov@scylladb.com'
+)

--- a/test-cases/cdc/cdc-replication-longevity.yaml
+++ b/test-cases/cdc/cdc-replication-longevity.yaml
@@ -1,0 +1,27 @@
+test_duration: 600
+
+user_prefix: 'cdc-replication-longevity'
+db_type: mixed_scylla
+
+use_legacy_cluster_init: false
+
+n_db_nodes: 3
+instance_type_db: 'i3.large'
+
+n_test_oracle_db_nodes: 1
+instance_type_db_oracle: 'i3.large'
+
+n_loaders: 1
+instance_type_loader: 'c4.large'
+
+n_monitor_nodes: 0
+# instance_type_monitor: 't3.small'
+
+nemesis_class_name: 'ChaosMonkey'
+nemesis_interval: 5
+
+gemini_cmd: "gemini --duration 30m --warmup 0s -c 5 -m write --non-interactive --cql-features basic --max-mutation-retries 100 --max-mutation-retries-backoff 100ms --replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '3'}\" --table-options \"cdc = {'enabled': true, 'ttl': 7200}\""
+
+gemini_version: 'latest'
+# Required by SCT, although not used:
+gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json'


### PR DESCRIPTION
This is yet another CDC replication test. The previous tests worked as follows:
1. start cluster
2. run workload for 15 minutes, bootstrap a node in the middle
3. check consistency

This test is a longevity test, supposed to run over the period of several hours. The test works in rounds; each round consists of generating workload for about 30 minutes and checking consistency after. The test performs 12 rounds which should result in about 6 hours of testing.

The purpose of splitting the test into rounds and not just checking consistency after a total of 6 hours of workload is to catch any occurring inconsistencies earlier.

The test also runs the ChaosMonkey nemesis during the rounds.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
