### PR TITLE
fix(sdcm/nemesis): enable CorruptThenRepairMonkey for kube

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2212,9 +2212,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         if verify_up:
             self.wait_db_up(timeout=timeout)
         if not self.is_ubuntu14():
-            self.remoter.run('sudo systemctl stop scylla-server.service', timeout=timeout, ignore_status=ignore_status)
+            self.remoter.sudo('systemctl stop scylla-server.service', timeout=timeout, ignore_status=ignore_status)
         else:
-            self.remoter.run('sudo service scylla-server stop', timeout=timeout, ignore_status=ignore_status)
+            self.remoter.sudo('service scylla-server stop', timeout=timeout, ignore_status=ignore_status)
         if verify_down:
             self.wait_db_down(timeout=timeout)
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -383,8 +383,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         ks_cf_for_destroy = random.choice(ks_cfs)  # expected value as: 'keyspace1.standard1'
 
         ks_cf_for_destroy = ks_cf_for_destroy.replace('.', '/')
-        files = self.target_node.remoter.run("sudo sh -c 'find /var/lib/scylla/data/%s-* -maxdepth 1 -type f'"
-                                             % ks_cf_for_destroy, verbose=False)
+        files = self.target_node.remoter.sudo("find /var/lib/scylla/data/%s-* -maxdepth 1 -type f"
+                                              % ks_cf_for_destroy, verbose=False)
         if files.stderr:
             raise NoFilesFoundToDestroy(
                 'Failed to get data files for destroy in {}. Error: {}'.format(ks_cf_for_destroy,
@@ -433,7 +433,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             for _ in range(5):
                 file_for_destroy = self._choose_file_for_destroy(ks_cfs)
 
-                result = self.target_node.remoter.run('sudo rm -f %s' % file_for_destroy)
+                result = self.target_node.remoter.sudo('rm -f %s' % file_for_destroy)
                 if result.stderr:
                     raise FilesNotCorrupted('Files were not corrupted. CorruptThenRepair nemesis can\'t be run. '
                                             'Error: {}'.format(result))
@@ -2349,6 +2349,7 @@ class DrainerMonkey(Nemesis):
 
 class CorruptThenRepairMonkey(Nemesis):
     disruptive = True
+    kubernetes = True
 
     @log_time_elapsed_and_status
     def disrupt(self):


### PR DESCRIPTION
https://trello.com/c/7Q9ec813/2277-k8s-corruptthenrepairmonkey

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
