### PR TITLE
fix(sdcm/nemesis.py): enable ScyllaKillMonkey and MajorCompactionMonkey for kube

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -285,8 +285,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def _kill_scylla_daemon(self):
         self.log.info('Kill all scylla processes in %s', self.target_node)
-        kill_cmd = "sudo pkill -9 scylla"
-        self.target_node.remoter.run(kill_cmd, ignore_status=True)
+        self.target_node.remoter.sudo("pkill -9 scylla", ignore_status=True)
 
         # Wait for the process to be down before waiting for service to be restarted
         self.target_node.wait_db_down(check_interval=2)
@@ -2393,6 +2392,7 @@ class NoCorruptRepairMonkey(Nemesis):
 
 class MajorCompactionMonkey(Nemesis):
     disruptive = False
+    kubernetes = True
 
     @log_time_elapsed_and_status
     def disrupt(self):
@@ -2727,6 +2727,7 @@ class NodeTerminateAndReplace(Nemesis):
 
 class ScyllaKillMonkey(Nemesis):
     disruptive = True
+    kubernetes = True
 
     @log_time_elapsed_and_status
     def disrupt(self):


### PR DESCRIPTION
https://trello.com/c/P5OW0lbe/2283-k8s-scyllakillmonkey-and-majorcompactionmonkey

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
