### PR TITLE
fix(sdcm/nemesis.py): enable NoCorruptRepairMonkey for kube

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2385,6 +2385,7 @@ class DecommissionSeedNode(Nemesis):
 
 class NoCorruptRepairMonkey(Nemesis):
     disruptive = False
+    kubernetes = True
 
     @log_time_elapsed_and_status
     def disrupt(self):


### PR DESCRIPTION
https://trello.com/c/Roq15ziJ/2285-k8s-nocorruptrepairmonkey

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
