### PR TITLE
feature(sdcm.utils.common): `find_scylla_repo()` for branch version

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -15,7 +15,7 @@ from distutils.util import strtobool  # pylint: disable=import-error,no-name-in-
 
 import anyconfig
 
-from sdcm.utils.common import get_s3_scylla_repos_mapping, get_scylla_ami_versions, get_branched_ami, get_ami_tags, \
+from sdcm.utils.common import find_scylla_repo, get_scylla_ami_versions, get_branched_ami, get_ami_tags, \
     ami_built_by_scylla
 from sdcm.utils.version_utils import get_branch_version, get_branch_version_for_multiple_repositories
 
@@ -1111,14 +1111,7 @@ class SCTConfiguration(dict):
                         raise ValueError("AMI for scylla version {} wasn't found".format(scylla_version))
                 self['ami_id_db_scylla'] = " ".join(ami_list)
             elif 'scylla_repo' not in self:
-                repo_map = get_s3_scylla_repos_mapping(dist_type, dist_version)
-
-                for key in repo_map.keys():
-                    if scylla_version.startswith(key):
-                        self['scylla_repo'] = repo_map[key]
-                        break
-                else:
-                    raise ValueError("repo for scylla version {} wasn't found".format(scylla_version))
+                self['scylla_repo'] = find_scylla_repo(scylla_version, dist_type, dist_version)
             else:
                 raise ValueError("'scylla_version' can't used together with  'ami_id_db_scylla' or with 'scylla_repo'")
 
@@ -1127,14 +1120,7 @@ class SCTConfiguration(dict):
                 dist_type_loader = scylla_linux_distro_loader.split('-')[0]
                 dist_version_loader = scylla_linux_distro_loader.split('-')[-1]
 
-                repo_map = get_s3_scylla_repos_mapping(dist_type_loader, dist_version_loader)
-
-                for key in repo_map.keys():
-                    if scylla_version.startswith(key):
-                        self['scylla_repo_loader'] = repo_map[key]
-                        break
-                else:
-                    raise ValueError("repo for scylla version {} wasn't found in []".format(scylla_version))
+                self['scylla_repo_loader'] = find_scylla_repo(scylla_version, dist_type_loader, dist_version_loader)
 
         # 5.1) handle oracle scylla_version if exists
         oracle_scylla_version = self.get('oracle_scylla_version', None)
@@ -1165,14 +1151,7 @@ class SCTConfiguration(dict):
                 raise ValueError("'new_version' isn't supported for AWS AMIs")
 
             elif 'new_scylla_repo' not in self:
-                repo_map = get_s3_scylla_repos_mapping(dist_type, dist_version)
-
-                for key in repo_map.keys():
-                    if scylla_version.startswith(key):
-                        self['new_scylla_repo'] = repo_map[key]
-                        break
-                else:
-                    raise ValueError("repo for scylla version {} wasn't found".format(new_scylla_version))
+                self['new_scylla_repo'] = find_scylla_repo(new_scylla_version, dist_type, dist_version)
 
         # 7) append username or ami_id_db_scylla_desc to the user_prefix
         version_tag = self.get('ami_id_db_scylla_desc', default=None)

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1173,6 +1173,64 @@ def can_connect_to(ip: str, port: int, timeout: int = 1) -> bool:
     return result == 0
 
 
+def find_scylla_repo(scylla_version, dist_type='centos', dist_version=None):
+    """
+    Get a repo/list of scylla, based on scylla version match
+
+    :param scylla_version: branch version to look for, ex. 'branch-2019.1:latest', 'branch-3.1:l'
+    :param dist_type: one of ['centos', 'ubuntu', 'debian']
+    :param dist_version: family name of the distro version
+    :raises: ValueError if not found
+
+    :return: str url repo/list
+    """
+    if ':' in scylla_version:
+        branch_repo = get_branched_repo(scylla_version, dist_type)
+        if branch_repo:
+            return branch_repo
+
+    repo_map = get_s3_scylla_repos_mapping(dist_type, dist_version)
+
+    for key in repo_map:
+        if scylla_version.startswith(key):
+            return repo_map[key]
+    else:
+        raise ValueError(f"repo for scylla version {scylla_version} wasn't found")
+
+
+def get_branched_repo(scylla_version, dist_type='centos'):
+    """
+    Get a repo/list of scylla, based on scylla version match
+
+    :param scylla_version: branch version to look for, ex. 'branch-2019.1:latest', 'branch-3.1:l'
+    :param dist_type: one of ['centos', 'ubuntu', 'debian']
+    :return: str url repo/list, or None if not found
+    """
+    branch, branch_version = scylla_version.split(':', maxsplit=1)
+    s3_client: S3Client = boto3.client('s3', region_name=DEFAULT_AWS_REGION)
+    bucket = 'downloads.scylladb.com'
+
+    if dist_type == 'centos':
+        response = s3_client.list_objects(
+            Bucket=bucket, Prefix=f'rpm/unstable/centos/{branch}/{branch_version}/', Delimiter='/')
+        if 'Contents' not in response:
+            return
+        for repo_file in response['Contents']:
+            filename = os.path.basename(repo_file['Key'])
+            if filename == 'scylla.repo':
+                return f"https://s3.amazonaws.com/{bucket}/{repo_file['Key']}"
+
+    elif dist_type in ('ubuntu', 'debian'):
+        response = s3_client.list_objects(
+            Bucket=bucket, Prefix=f'deb/unstable/unified/{branch}/{branch_version}/scylladb-master/', Delimiter='/')
+        if 'Contents' not in response:
+            return
+        for repo_file in response['Contents']:
+            filename = os.path.basename(repo_file['Key'])
+            if filename == 'scylla.list':
+                return f"https://s3.amazonaws.com/{bucket}/{repo_file['Key']}"
+
+
 def get_branched_ami(ami_version, region_name):
     """
     Get a list of AMIs, based on version match


### PR DESCRIPTION
now that we have unified debain package for a while, and relang introduced
latest list/repo for all of them

we can now search by branch (i.e. 'master:latest', 'branch-4.2:latest')
like we are doing for AMIs

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- ~~[ ] New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- ~~[ ] I have updated the Readme/doc folder accordingly (if needed)~~
