### PR TITLE
fix(scdm/nemesis): enable RefreshMonkey for kube

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1147,10 +1147,10 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         if uuid_exists and not mark_exists:
             result = self.remoter.run('cat %s' % uuid_path, verbose=verbose)
             self.remoter.run(cmd % result.stdout.strip(), ignore_status=True)
-            if self.is_docker():  # in docker we don't have scylla user and run as root
-                self.remoter.sudo('touch %s' % mark_path, verbose=verbose)
+            if self.is_docker():
+                self.remoter.run('touch %s' % mark_path, verbose=verbose)
             else:
-                self.remoter.run('sudo -u scylla touch %s' % mark_path, verbose=verbose)
+                self.remoter.sudo('touch %s' % mark_path, verbose=verbose, user='scylla')
 
     def wait_db_up(self, verbose=True, timeout=3600):
         text = None

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -581,7 +581,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self._set_current_disruption('MajorCompaction %s' % self.target_node)
         self.target_node.run_nodetool("compact")
 
-    def disrupt_nodetool_refresh(self, big_sstable=True, skip_download=False):
+    def disrupt_nodetool_refresh(self, big_sstable: bool):
         self._set_current_disruption('Refresh keyspace1.standard1 on {}'.format(self.target_node.name))
 
         # Checking the columns number of keyspace1.standard1
@@ -631,13 +631,12 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         result = self.target_node.run_nodetool(sub_cmd="cfstats", args="keyspace1.standard1")
 
         def do_refresh(node):
-            if not skip_download:
-                key_store = KeyStore()
-                creds = key_store.get_scylladb_upload_credentials()
-                # Download the sstable files from S3
-                remote_get_file(node.remoter, sstable_url, sstable_file,
-                                hash_expected=sstable_md5, retries=2,
-                                user_agent=creds['user_agent'])
+            key_store = KeyStore()
+            creds = key_store.get_scylladb_upload_credentials()
+            # Download the sstable files from S3
+            remote_get_file(node.remoter, sstable_url, sstable_file,
+                            hash_expected=sstable_md5, retries=2,
+                            user_agent=creds['user_agent'])
             result = node.remoter.run("sudo ls -t /var/lib/scylla/data/keyspace1/")
             upload_dir = result.stdout.split()[0]
             node.remoter.run('sudo -u scylla tar xvfz {} -C /var/lib/scylla/data/keyspace1/{}/upload/'.format(
@@ -2408,7 +2407,7 @@ class RefreshMonkey(Nemesis):
 
     @log_time_elapsed_and_status
     def disrupt(self):
-        self.disrupt_nodetool_refresh()
+        self.disrupt_nodetool_refresh(big_sstable=False)
 
 
 class RefreshBigMonkey(Nemesis):
@@ -2417,7 +2416,7 @@ class RefreshBigMonkey(Nemesis):
 
     @log_time_elapsed_and_status
     def disrupt(self):
-        self.disrupt_nodetool_refresh(big_sstable=True, skip_download=False)
+        self.disrupt_nodetool_refresh(big_sstable=True)
 
 
 class EnospcMonkey(Nemesis):

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -637,15 +637,17 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             remote_get_file(node.remoter, sstable_url, sstable_file,
                             hash_expected=sstable_md5, retries=2,
                             user_agent=creds['user_agent'])
-            result = node.remoter.run("sudo ls -t /var/lib/scylla/data/keyspace1/")
+            result = node.remoter.sudo("ls -t /var/lib/scylla/data/keyspace1/")
             upload_dir = result.stdout.split()[0]
-            node.remoter.run('sudo -u scylla tar xvfz {} -C /var/lib/scylla/data/keyspace1/{}/upload/'.format(
-                sstable_file, upload_dir))
+            if node.is_docker():
+                node.remoter.run(f'tar xvfz {sstable_file} -C /var/lib/scylla/data/keyspace1/{upload_dir}/upload/')
+            else:
+                node.remoter.sudo(
+                    f'tar xvfz {sstable_file} -C /var/lib/scylla/data/keyspace1/{upload_dir}/upload/', user='scylla')
+
             # Scylla Enterprise 2019.1 doesn't support to load schema.cql and manifest.json, let's remove them
-            node.remoter.run(
-                'sudo rm -f /var/lib/scylla/data/keyspace1/{}/upload/schema.cql'.format(upload_dir))
-            node.remoter.run(
-                'sudo rm -f /var/lib/scylla/data/keyspace1/{}/upload/manifest.json'.format(upload_dir))
+            node.remoter.sudo(f'rm -f /var/lib/scylla/data/keyspace1/{upload_dir}/upload/schema.cql')
+            node.remoter.sudo(f'rm -f /var/lib/scylla/data/keyspace1/{upload_dir}/upload/manifest.json')
             self.log.debug(f'Loading {keys_num} keys to {node.name} by refresh')
             node.run_nodetool(sub_cmd="refresh", args="-- keyspace1 standard1")
 
@@ -2404,6 +2406,7 @@ class MajorCompactionMonkey(Nemesis):
 class RefreshMonkey(Nemesis):
     disruptive = False
     run_with_gemini = False
+    kubernetes = True
 
     @log_time_elapsed_and_status
     def disrupt(self):
@@ -2413,6 +2416,7 @@ class RefreshMonkey(Nemesis):
 class RefreshBigMonkey(Nemesis):
     disruptive = False
     run_with_gemini = False
+    kubernetes = True
 
     @log_time_elapsed_and_status
     def disrupt(self):

--- a/sdcm/remote/base.py
+++ b/sdcm/remote/base.py
@@ -111,8 +111,14 @@ class CommandRunner(metaclass=ABCMeta):
              new_session: bool = False,
              log_file: Optional[str] = None,
              retry: int = 1,
-             watchers: Optional[List[StreamWatcher]] = None) -> Result:
-        return self.run(cmd=cmd if self.user == "root" else f"sudo {cmd}",
+             watchers: Optional[List[StreamWatcher]] = None,
+             user: Optional[str] = 'root') -> Result:
+        if user != self.user:
+            if user == 'root':
+                cmd = f"sudo {cmd}"
+            else:
+                cmd = f"sudo -u {user} {cmd}"
+        return self.run(cmd=cmd,
                         timeout=timeout,
                         ignore_status=ignore_status,
                         verbose=verbose,


### PR DESCRIPTION
https://trello.com/c/VoFswDGm/2286-k8s-refreshmonkey

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
