### PR TITLE
manager pipeline: set default value for SCT jobs

### DIFF
--- a/jenkins-pipelines/manager-backup.jenkinsfile
+++ b/jenkins-pipelines/manager-backup.jenkinsfile
@@ -12,6 +12,10 @@ longevityPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_backup_feature',
     test_config: 'test-cases/manager/manager-regression-multiDC-set-distro.yaml',
 
+    scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+    scylla_version: 'master:latest',
+
     timeout: [time: 500, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',

--- a/jenkins-pipelines/manager/centos-manager-sanity-ipv6.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-sanity-ipv6.jenkinsfile
@@ -12,6 +12,10 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: 'test-cases/manager/manager-regression-ipv6.yaml',
 
+    scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+    scylla_version: 'master:latest',
+
     timeout: [time: 120, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',

--- a/jenkins-pipelines/manager/centos-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-sanity.jenkinsfile
@@ -12,6 +12,10 @@ managerPipeline(
     aws_region: '''["us-east-1", "us-west-2"]''',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: 'test-cases/manager/manager-regression-multiDC-set-distro.yaml',
+    
+    scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+    scylla_version: 'master:latest',
 
     timeout: [time: 120, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',

--- a/jenkins-pipelines/manager/debian9-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/debian9-manager-sanity.jenkinsfile
@@ -12,6 +12,10 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/debian9.yaml"]''',
 
+    scylla_mgmt_repo: 'http://downloads.scylladb.com/manager/deb/unstable/stretch/master/latest/scylladb-manager-master/scylla-manager.list',
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+    scylla_version: 'master:latest',
+
     timeout: [time: 120, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',

--- a/jenkins-pipelines/manager/debian9-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian9-manager-upgrade.jenkinsfile
@@ -11,7 +11,10 @@ managerPipeline(
 
     target_scylla_mgmt_server_repo: '',
     target_scylla_mgmt_agent_repo: '',
-    scylla_mgmt_repo: 'http://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.1-stretch.list',
+    
+    scylla_mgmt_repo: 'http://downloads.scylladb.com/manager/deb/unstable/stretch/master/latest/scylladb-manager-master/scylla-manager.list',
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+    scylla_version: 'master:latest',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/debian9.yaml"]''',

--- a/jenkins-pipelines/manager/manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/manager-upgrade.jenkinsfile
@@ -12,6 +12,8 @@ managerPipeline(
     target_scylla_mgmt_server_repo: '',
     target_scylla_mgmt_agent_repo: '',
     scylla_mgmt_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.1.repo',
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.1.repo',
+    scylla_version: 'master:latest',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: 'test-cases/upgrades/manager-upgrade.yaml',

--- a/jenkins-pipelines/manager/ubuntu16-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu16-manager-sanity.jenkinsfile
@@ -12,6 +12,10 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/ubuntu16.yaml"]''',
 
+    scylla_mgmt_repo: 'http://downloads.scylladb.com/manager/deb/unstable/xenial/master/latest/scylla-manager-master/scylla-manager.list',
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+    scylla_version: 'master:latest',
+
     timeout: [time: 120, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',

--- a/jenkins-pipelines/manager/ubuntu16-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu16-manager-upgrade.jenkinsfile
@@ -11,7 +11,9 @@ managerPipeline(
 
     target_scylla_mgmt_server_repo: '',
     target_scylla_mgmt_agent_repo: '',
-    scylla_mgmt_repo: 'http://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.1-xenial.list',
+    scylla_mgmt_repo: 'http://downloads.scylladb.com/manager/deb/unstable/xenial/master/latest/scylla-manager-master/scylla-manager.list',
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+    scylla_version: 'master:latest',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/ubuntu16.yaml"]''',

--- a/jenkins-pipelines/manager/ubuntu18-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu18-manager-sanity.jenkinsfile
@@ -11,6 +11,9 @@ managerPipeline(
     aws_region: '''["us-east-1", "us-west-2"]''',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/ubuntu18.yaml"]''',
+    scylla_mgmt_repo: 'http://downloads.scylladb.com/manager/deb/unstable/xenial/master/latest/scylla-manager-master/scylla-manager.list'
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+    scylla_version: 'master:latest',
 
     timeout: [time: 120, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',

--- a/jenkins-pipelines/manager/ubuntu18-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu18-manager-upgrade.jenkinsfile
@@ -12,6 +12,8 @@ managerPipeline(
     target_scylla_mgmt_server_repo: '',
     target_scylla_mgmt_agent_repo: '',
     scylla_mgmt_repo: 'http://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.1-bionic.list',
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+    scylla_version: 'master:latest',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/ubuntu18.yaml"]''',

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -25,7 +25,7 @@ def call(Map pipelineParams) {
 
 
             string(defaultValue: '', description: '', name: 'scylla_ami_id')
-            string(defaultValue: '', description: '', name: 'scylla_version')
+            string(defaultValue: "${pipelineParams.get('scylla_version', '')}", description: '', name: 'scylla_version')
             string(defaultValue: '', description: '', name: 'scylla_repo')
             string(defaultValue: "${pipelineParams.get('provision_type', 'spot_low_price')}",
                    description: 'spot_low_price|on_demand|spot_fleet|spot_duration',
@@ -49,7 +49,7 @@ def call(Map pipelineParams) {
                    description: 'private|public|ipv6',
                    name: 'ip_ssh_connections')
 
-            string(defaultValue: '',
+            string(defaultValue: "${pipelineParams.get('scylla_mgmt_repo', '')}",
                    description: 'If empty - the default manager version will be taken',
                    name: 'scylla_mgmt_repo')
 


### PR DESCRIPTION
following scylladb/scylla-pkg#1405 , we want
to trigger all SCT jobs only once a day. Since the jobs configured in
Jenkins are still free-style and not pipeline, we are setting a default
for SCT jobs so they will start only once a day regardless to number of
new commits