### PR TITLE
feature(scylla-bench): support not stopping a test when the tool failed

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4146,7 +4146,8 @@ class BaseLoaderSet():
 
         return ret
 
-    def run_stress_thread_bench(self, stress_cmd, timeout, node_list=None, round_robin=False, use_single_loader=False):  # pylint: disable=too-many-arguments
+    def run_stress_thread_bench(self, stress_cmd, timeout, node_list=None, round_robin=False, use_single_loader=False,
+                                stop_test_on_failure=False):  # pylint: disable=too-many-arguments
         _queue = {TASK_QUEUE: queue.Queue(), RES_QUEUE: queue.Queue()}
 
         def node_run_stress_bench(node, loader_idx, stress_cmd, node_list):
@@ -4178,7 +4179,8 @@ class BaseLoaderSet():
                 if "truncate: seastar::rpc::timeout_error" in errors_str:
                     event_type, event_severity = 'timeout', Severity.ERROR
                 else:
-                    event_type, event_severity = 'failure', Severity.CRITICAL
+                    event_type = 'failure'
+                    event_severity = Severity.CRITICAL if stop_test_on_failure else Severity.ERROR
 
                 ScyllaBenchEvent(type=event_type, node=str(node), stress_cmd=stress_cmd,
                                  log_file_name=log_file_name, severity=event_severity,

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -984,10 +984,13 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         timeout = self.get_duration(duration)
         if self.create_stats:
             self.update_stress_cmd_details(stress_cmd, stresser="scylla-bench", aggregate=stats_aggregate_cmds)
-        bench_thread = self.loaders.run_stress_thread_bench(stress_cmd, timeout,
-                                                            node_list=self.db_cluster.nodes,
-                                                            round_robin=round_robin,
-                                                            use_single_loader=use_single_loader)
+        bench_thread = self.loaders.run_stress_thread_bench(
+            stress_cmd, timeout,
+            node_list=self.db_cluster.nodes,
+            round_robin=round_robin,
+            use_single_loader=use_single_loader,
+            stop_test_on_failure=self.params.get("stop_test_on_stress_failure"),
+        )
         scylla_encryption_options = self.params.get('scylla_encryption_options')
         if scylla_encryption_options and 'write' in stress_cmd:
             # Configure encryption at-rest for all test tables, sleep a while to wait the workload starts and test tables are created


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
