### PR TITLE
fix(whitespaces): manager pipeline: set default value for SCT job

### DIFF
--- a/jenkins-pipelines/manager/centos-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-sanity.jenkinsfile
@@ -12,7 +12,7 @@ managerPipeline(
     aws_region: '''["us-east-1", "us-west-2"]''',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: 'test-cases/manager/manager-regression-multiDC-set-distro.yaml',
-    
+
     scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
     scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
     scylla_version: 'master:latest',

--- a/jenkins-pipelines/manager/debian9-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian9-manager-upgrade.jenkinsfile
@@ -11,7 +11,7 @@ managerPipeline(
 
     target_scylla_mgmt_server_repo: '',
     target_scylla_mgmt_agent_repo: '',
-    
+
     scylla_mgmt_repo: 'http://downloads.scylladb.com/manager/deb/unstable/stretch/master/latest/scylladb-manager-master/scylla-manager.list',
     scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
     scylla_version: 'master:latest',


### PR DESCRIPTION
f3f607f9546046fdca2142bfdefba39ef6d4d9da introduced a some trailing-whitespaces
in some files

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
