### PR TITLE
fix(is_manager_agent_up): ipv6 support

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1198,7 +1198,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         port = port if port else self.MANAGER_AGENT_PORT
         if self.is_port_used(port=port, service_name="scylla-manager-agent"):
             # When the agent is IP, it should answer an https request of https://NODE_IP:10001/ping with status code 204
-            response = requests.get(f"https://{self.ip_address}:{port}/ping", verify=False)
+            response = requests.get(f"https://{normalize_ipv6_url(self.ip_address)}:{port}/ping", verify=False)
             return response.status_code == 204
         return False
 


### PR DESCRIPTION
was failing with the following exception:
```
requests.exceptions.InvalidURL: Failed to parse: 2a05:d018:eb8:3100:b8c9:4e23:966c:c8c1:10001
```

since we didn't escape the address correctly

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
