### PR TITLE
refactor(ycsb-install): remove ycsb installation from docker

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3928,14 +3928,6 @@ class BaseLoaderSet():
         node.remoter.run("source $HOME/.bashrc")
         node.remoter.run("go get github.com/scylladb/scylla-bench")
 
-        # install ycsb
-        ycsb_install = dedent("""
-            cd ~/
-            curl -O --location https://github.com/brianfrankcooper/YCSB/releases/download/0.15.0/ycsb-0.15.0.tar.gz
-            tar xfvz ycsb-0.15.0.tar.gz
-        """)
-        node.remoter.run('bash -cxe "%s"' % ycsb_install)
-
         # install docker
         docker_install = dedent("""
             curl -fsSL get.docker.com -o get-docker.sh


### PR DESCRIPTION
since we already running ycsb from docker images,
installing it on the loader is a waste of our time and money