### PR TITLE
refactor(manger-upgrade): add defaults targets repos

### DIFF
--- a/jenkins-pipelines/manager/centos-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-upgrade.jenkinsfile
@@ -9,8 +9,9 @@ managerPipeline(
     backend: 'aws',
     aws_region: 'us-east-1',
 
-    target_scylla_mgmt_server_repo: '',
-    target_scylla_mgmt_agent_repo: '',
+    target_scylla_mgmt_server_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+    target_scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+
     scylla_mgmt_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.1.repo',
     scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.1.repo',
     scylla_version: 'master:latest',

--- a/jenkins-pipelines/manager/debian9-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian9-manager-upgrade.jenkinsfile
@@ -9,8 +9,8 @@ managerPipeline(
     backend: 'aws',
     aws_region: 'us-east-1',
 
-    target_scylla_mgmt_server_repo: '',
-    target_scylla_mgmt_agent_repo: '',
+    target_scylla_mgmt_server_repo: 'http://downloads.scylladb.com/manager/deb/unstable/stretch/master/latest/scylladb-manager-master/scylla-manager.list',
+    target_scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
 
     scylla_mgmt_repo: 'http://downloads.scylladb.com/manager/deb/unstable/stretch/master/latest/scylladb-manager-master/scylla-manager.list',
     scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',

--- a/jenkins-pipelines/manager/ubuntu16-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu16-manager-upgrade.jenkinsfile
@@ -9,8 +9,9 @@ managerPipeline(
     backend: 'aws',
     aws_region: 'us-east-1',
 
-    target_scylla_mgmt_server_repo: '',
-    target_scylla_mgmt_agent_repo: '',
+
+    target_scylla_mgmt_server_repo: 'http://downloads.scylladb.com/manager/deb/unstable/xenial/master/latest/scylla-manager-master/scylla-manager.list',
+    target_scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
     scylla_mgmt_repo: 'http://downloads.scylladb.com/manager/deb/unstable/xenial/master/latest/scylla-manager-master/scylla-manager.list',
     scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
     scylla_version: 'master:latest',

--- a/jenkins-pipelines/manager/ubuntu18-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu18-manager-upgrade.jenkinsfile
@@ -9,8 +9,9 @@ managerPipeline(
     backend: 'aws',
     aws_region: 'us-east-1',
 
-    target_scylla_mgmt_server_repo: '',
-    target_scylla_mgmt_agent_repo: '',
+    target_scylla_mgmt_server_repo: 'http://downloads.scylladb.com/manager/deb/unstable/xenial/master/latest/scylla-manager-master/scylla-manager.list',
+    target_scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+
     scylla_mgmt_repo: 'http://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.1-bionic.list',
     scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
     scylla_version: 'master:latest',

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -57,11 +57,11 @@ def call(Map pipelineParams) {
                    description: 'manager agent repo',
                    name: 'scylla_mgmt_agent_repo')
 
-            string(defaultValue: '',
+            string(defaultValue: "${pipelineParams.get('target_scylla_mgmt_server_repo', '')}",
                    description: 'Link to the repository of the manager that will be used as a target of the manager server in the manager upgrade test',
                    name: 'target_scylla_mgmt_server_repo')
 
-            string(defaultValue: '',
+            string(defaultValue: "${pipelineParams.get('target_scylla_mgmt_agent_repo', '')}",
                    description: 'Link to the repository of the manager that will be used as a target of the manager agents in the manager upgrade test',
                    name: 'target_scylla_mgmt_agent_repo')
 


### PR DESCRIPTION
Adding defaults to latest for `target_scylla_mgmt_server_repo` and for
`target_scylla_mgmt_agent_repo`, so master should need to be triggered with
specific versions

Also renamed `centos-manager-upgrade.jenkinsfile` to match other pipeline files.

TODO:
* [ ] - rename the pipeline in job: https://jenkins.scylladb.com/view/mermaid/job/mermaid-master/job/centos-upgrade-test/
