### PR TITLE
fix(sdcm/nemesis): enable EnospcMonkey on kube

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2184,9 +2184,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         if verify_down:
             self.wait_db_down(timeout=timeout)
         if not self.is_ubuntu14():
-            self.remoter.run('sudo systemctl start scylla-server.service', timeout=timeout)
+            self.remoter.sudo('systemctl start scylla-server.service', timeout=timeout)
         else:
-            self.remoter.run('sudo service scylla-server start', timeout=timeout)
+            self.remoter.sudo('service scylla-server start', timeout=timeout)
         if verify_up:
             self.wait_db_up(timeout=verify_up_timeout)
 
@@ -2194,9 +2194,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         if verify_down:
             self.wait_jmx_down(timeout=timeout)
         if not self.is_ubuntu14():
-            self.remoter.run('sudo systemctl start scylla-jmx.service', timeout=timeout)
+            self.remoter.sudo('systemctl start scylla-jmx.service', timeout=timeout)
         else:
-            self.remoter.run('sudo service scylla-jmx start', timeout=timeout)
+            self.remoter.sudo('service scylla-jmx start', timeout=timeout)
         if verify_up:
             self.wait_jmx_up(timeout=verify_up_timeout)
 
@@ -2222,9 +2222,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         if verify_up:
             self.wait_jmx_up(timeout=timeout)
         if not self.is_ubuntu14():
-            self.remoter.run('sudo systemctl stop scylla-jmx.service', timeout=timeout)
+            self.remoter.sudo('systemctl stop scylla-jmx.service', timeout=timeout)
         else:
-            self.remoter.run('sudo service scylla-jmx stop', timeout=timeout)
+            self.remoter.sudo('service scylla-jmx stop', timeout=timeout)
         if verify_down:
             self.wait_jmx_down(timeout=timeout)
 
@@ -2238,11 +2238,11 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         if verify_up_before:
             self.wait_db_up(timeout=timeout)
         if not self.distro.is_ubuntu14:
-            self.remoter.run("sudo systemctl restart scylla-server.service",
-                             timeout=timeout, ignore_status=ignore_status)
+            self.remoter.sudo("systemctl restart scylla-server.service",
+                              timeout=timeout, ignore_status=ignore_status)
         else:
-            self.remoter.run("sudo service scylla-server restart",
-                             timeout=timeout, ignore_status=ignore_status)
+            self.remoter.sudo("service scylla-server restart",
+                              timeout=timeout, ignore_status=ignore_status)
         if verify_up_after:
             self.wait_db_up(timeout=timeout)
 
@@ -2250,9 +2250,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         if verify_up_before:
             self.wait_jmx_up(timeout=timeout)
         if not self.distro.is_ubuntu14:
-            self.remoter.run("sudo systemctl restart scylla-jmx.service", timeout=timeout)
+            self.remoter.sudo("systemctl restart scylla-jmx.service", timeout=timeout)
         else:
-            self.remoter.run("sudo service scylla-jmx restart", timeout=timeout)
+            self.remoter.sudo("service scylla-jmx restart", timeout=timeout)
         if verify_up_after:
             self.wait_jmx_up(timeout=timeout)
 

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1833,41 +1833,29 @@ def get_docker_stress_image_name(tool_name=None):
     return result.strip()
 
 
-def search_database_enospc(node):
-    """
-    Search system log by executing cmd inside node, use shell tool to
-    avoid return and process huge data.
-    """
-    cmd = "sudo journalctl --no-tail --no-pager -u scylla-server.service|grep 'No space left on device'|wc -l"
-    result = node.remoter.run(cmd, verbose=True)
-    return int(result.stdout)
-
-
-def approach_enospc(node, orig_errors):
-    # get the size of free space (default unit: KB)
-    result = node.remoter.run("df -l|grep '/var/lib/scylla'")
-    free_space_size = result.stdout.split()[3]
-
-    occupy_space_size = int(int(free_space_size) * 90 / 100)
-    occupy_space_cmd = 'sudo fallocate -l {}K /var/lib/scylla/occupy_90percent.{}'.format(
-        occupy_space_size, datetime.datetime.now().strftime('%s'))
-    LOGGER.debug('Cost 90% free space on /var/lib/scylla/ by {}'.format(occupy_space_cmd))
-    try:
-        node.remoter.run(occupy_space_cmd, verbose=True)
-    except Exception as details:  # pylint: disable=broad-except
-        LOGGER.error(str(details))
-    return search_database_enospc(node) > orig_errors
-
-
 def reach_enospc_on_node(target_node):
-    # check original ENOSPC error
-    orig_errors = search_database_enospc(target_node)
+    no_space_log_reader = target_node.follow_system_log(patterns=['No space left on device'])
+
+    def approach_enospc():
+        if bool(list(no_space_log_reader)):
+            return True
+        result = target_node.remoter.run("df -al | grep '/var/lib/scylla'")
+        free_space_size = int(result.stdout.split()[3])
+        total_space = int(result.stdout.split()[1])
+        occupy_space_size = int(free_space_size * 90 / 100)
+        occupy_space_cmd = f'fallocate -l {occupy_space_size}K /var/lib/scylla/occupy_90percent.{time.time()}'
+        LOGGER.debug(f'Cost 90% free space on /var/lib/scylla/ by {occupy_space_cmd}')
+        try:
+            target_node.remoter.sudo(occupy_space_cmd, verbose=True)
+        except Exception as details:  # pylint: disable=broad-except
+            LOGGER.warning(str(details))
+        return bool(list(no_space_log_reader))
+
     wait.wait_for(func=approach_enospc,
                   timeout=300,
                   step=5,
                   text='Wait for new ENOSPC error occurs in database',
-                  node=target_node,
-                  orig_errors=orig_errors)
+                  )
 
 
 def clean_enospc_on_node(target_node, sleep_time):
@@ -1875,11 +1863,11 @@ def clean_enospc_on_node(target_node, sleep_time):
     time.sleep(sleep_time)
 
     LOGGER.debug('Delete occupy_90percent file to release space to scylla-server')
-    target_node.remoter.run('sudo rm -rf /var/lib/scylla/occupy_90percent.*')
+    target_node.remoter.sudo('rm -rf /var/lib/scylla/occupy_90percent.*')
 
     LOGGER.debug('Sleep a while before restart scylla-server')
     time.sleep(sleep_time / 2)
-    target_node.remoter.run('sudo systemctl restart scylla-server.service')
+    target_node.restart_scylla_server()
     target_node.wait_db_up()
 
 


### PR DESCRIPTION
https://trello.com/c/k9nSQKGh/2315-k8s-enospcmonkey-and-enospcallnodesmonkey

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
