### PR TITLE
fix(manager-timeouts): manager test-cases missing `test_duration`

### DIFF
--- a/jenkins-pipelines/manager-backup.jenkinsfile
+++ b/jenkins-pipelines/manager-backup.jenkinsfile
@@ -3,7 +3,7 @@
 // trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
 def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
-longevityPipeline(
+managerPipeline(
     params: params,
 
     backend: 'aws',

--- a/jenkins-pipelines/manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager-sanity.jenkinsfile
@@ -3,7 +3,7 @@
 // trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
 def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
-longevityPipeline(
+managerPipeline(
     params: params,
 
     backend: 'aws',

--- a/test-cases/manager/manager-regression-ipv6.yaml
+++ b/test-cases/manager/manager-regression-ipv6.yaml
@@ -1,3 +1,5 @@
+test_duration: 120
+
 stress_cmd: "cassandra-stress write cl=QUORUM n=1200300 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=200 -pop seq=400200300..600200300"
 
 instance_type_db: 'i3.large'

--- a/test-cases/manager/manager-regression-multiDC-set-distro.yaml
+++ b/test-cases/manager/manager-regression-multiDC-set-distro.yaml
@@ -1,3 +1,5 @@
+test_duration: 120
+
 stress_cmd: "cassandra-stress write cl=QUORUM n=1200300 -schema 'replication(strategy=NetworkTopologyStrategy,us-eastscylla_node_east=2,us-west-2scylla_node_west=1)' -port jmx=6868 -mode cql3 native -rate threads=200 -pop seq=400200300..600200300"
 
 instance_type_db: 'i3.large'

--- a/test-cases/upgrades/manager-upgrade.yaml
+++ b/test-cases/upgrades/manager-upgrade.yaml
@@ -1,3 +1,5 @@
+test_duration: 360
+
 stress_cmd: "cassandra-stress write cl=QUORUM n=1200300 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -pop seq=400200300..600200300"
 
 instance_type_db: 'i3.large'


### PR DESCRIPTION
And cause of the the default of 60min kicked in togther
with recent changes to timeout control, and tests are
timing out before ending.
