### PR TITLE
fix(replacement node with public): replacement node procedure fix when ip_ssh_connections is public

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -600,7 +600,7 @@ class AWSNode(cluster.BaseNode):
             output = self.remoter.run('sudo grep replace_address: /etc/scylla/scylla.yaml', ignore_status=True)
             if 'replace_address_first_boot:' not in output.stdout:
                 self.remoter.run('echo replace_address_first_boot: %s |sudo tee --append /etc/scylla/scylla.yaml' %
-                                 self._instance.private_ip_address)
+                                 self.ip_address)
         self._instance.stop()
         self._instance_wait_safe(self._instance.wait_until_stopped)
         self._instance.start()


### PR DESCRIPTION
If disrupt_restart_then_repair_node nemesis is run with ip_ssh_connections='public'
replacement node procedure should be initiated also, not like for private

[Task](https://trello.com/c/X1uyyhS6/2316-change-disruptrestartthenrepairnode-nemesis-to-be-able-to-run-it-when-ipsshconnectionspublic)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
