### PR TITLE
feature(snapshot multiple tables): extend disrupt_snapshot_operations nemesis

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2881,6 +2881,13 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
 
     def get_non_system_ks_cf_list(self, db_node,  # pylint: disable=too-many-arguments
                                   filter_out_table_with_counter=False, filter_out_mv=False, filter_empty_tables=True) -> List[str]:
+        return self.get_any_ks_cf_list(db_node, filter_out_table_with_counter=filter_out_table_with_counter,
+                                       filter_out_mv=filter_out_mv, filter_empty_tables=filter_empty_tables,
+                                       filter_out_system=True)
+
+    def get_any_ks_cf_list(self, db_node,  # pylint: disable=too-many-arguments
+                           filter_out_table_with_counter=False, filter_out_mv=False, filter_empty_tables=True,
+                           filter_out_system=False) -> List[str]:
         regular_column_names = ["keyspace_name", "table_name"]
         materialized_view_column_names = ["keyspace_name", "view_name"]
         regular_table_names, materialized_view_table_names = set(), set()
@@ -2901,13 +2908,27 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
                 is_valid_table = True
                 table_name = f"{getattr(row, column_names[0])}.{getattr(row, column_names[1])}"
 
-                if getattr(row, column_names[0]).startswith(("system", "alternator_usertable")):
+                if filter_out_system and getattr(row, column_names[0]).startswith(("system", "alternator_usertable")):
                     is_valid_table = False
                 elif is_column_type and (filter_out_table_with_counter and "counter" in row.type):
                     is_valid_table = False
-                elif is_column_type and (filter_empty_tables and not cql_session.execute(
-                        f"SELECT * FROM {table_name} LIMIT 1").current_rows):
-                    is_valid_table = False
+                elif is_column_type and filter_empty_tables:
+                    current_rows = 0
+                    # Scylls issue https://github.com/scylladb/scylla/issues/7186
+                    # Problem to read from system_schema.dropped_columns, column "dropped_time":
+                    # cassandra.DriverException: Failed decoding result column "dropped_time" of type timestamp:
+                    # date value out of range
+                    if table_name == 'system_schema.dropped_columns':
+                        continue
+
+                    try:
+                        current_rows = cql_session.execute(f"SELECT * FROM {table_name} LIMIT 1").current_rows
+                    except Exception as exc:  # pylint: disable=broad-except
+                        self.log.warning(f'Failed to get rows from {table_name} table. Error: {exc}')
+
+                    if not current_rows:
+                        is_valid_table = False
+
                 if is_valid_table:
                     result.add(table_name)
             return result

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -27,8 +27,9 @@ import re
 import traceback
 import json
 
+
 from typing import List, Optional, TypedDict, Type
-from collections import OrderedDict, defaultdict
+from collections import OrderedDict, defaultdict, Counter
 from functools import wraps, partial
 
 from invoke import UnexpectedExit
@@ -1473,8 +1474,79 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.tester.verify_no_drops_and_errors(starting_from=start_time)
 
     def disrupt_snapshot_operations(self):
+        """
+        Extend this nemesis to run 'nodetool snapshot' more options including multiple tables.
+        Random choose between:
+        - create snapshot of all keyspaces
+        - create snapshot of one keyspace
+        - create snapshot of few keyspaces
+        - create snapshot of few tables, including MVs
+        """
+        def _full_snapshot():
+            self.log.info("Take all keyspaces snapshot")
+            return 'snapshot'
+
+        def _ks_snapshot(one_ks):
+            self.log.info(f"Take {'one keyspace' if one_ks else 'few keyspaces'} snapshot")
+            # Prefer to take snapshot of test keyspace. Try to find it
+            ks_cf = self.cluster.get_non_system_ks_cf_list(db_node=self.target_node)
+            if not ks_cf:
+                # If test table wasn't found - take system keyspace snapshot
+                ks_cf = self.cluster.get_any_ks_cf_list(db_node=self.target_node)
+
+            if one_ks:
+                keyspace_table = random.choice(ks_cf)
+                keyspace, _ = keyspace_table.split('.')
+            else:
+                keyspaces = list(set([ks.split('.')[0] for ks in ks_cf]))
+                if len(keyspaces) == 1:
+                    ks_cf = self.cluster.get_any_ks_cf_list(db_node=self.target_node)
+                    keyspaces = list(set([ks.split('.')[0] for ks in ks_cf]))
+                keyspace = ','.join(keyspaces)
+
+            return f'snapshot -kc {keyspace}'
+
+        def _few_tables():
+            def get_ks_with_few_tables(keyspace_table):
+                ks_occurrences = Counter([ks.split('.')[0] for ks in keyspace_table])
+                repeated_ks = [ks for ks, count in ks_occurrences.items() if count > 1]
+                return repeated_ks
+
+            self.log.info("Take few tables snapshot")
+            # Prefer to take snapshot of test table. Try to find it
+            ks_cf = self.cluster.get_non_system_ks_cf_list(db_node=self.target_node)
+
+            if not ks_cf or len(ks_cf) == 1:
+                # If test table wasn't found - take system table snapshot
+                ks_cf = self.cluster.get_any_ks_cf_list(db_node=self.target_node)
+
+            ks_with_few_tables = get_ks_with_few_tables(ks_cf)
+            if not ks_with_few_tables:
+                any_ks_cf = self.cluster.get_any_ks_cf_list(db_node=self.target_node)
+                ks_with_few_tables = get_ks_with_few_tables(any_ks_cf)
+
+            if not ks_with_few_tables:
+                self.log.warning('Keyspace with few tables has not been found')
+                return _full_snapshot()
+
+            selected_keyspace = random.choice(ks_with_few_tables)
+            tables = ','.join([k_c.split('.')[1] for k_c in ks_cf if k_c.startswith(f"{selected_keyspace}.")])
+
+            return f'snapshot {selected_keyspace} -cf {tables}'
+
         self._set_current_disruption('SnapshotOperations')
-        result = self.target_node.run_nodetool('snapshot')
+        functions_map = [(_few_tables,), (_full_snapshot,), (_ks_snapshot, True),  (_ks_snapshot, False)]
+        snapshot_option = random.choice(functions_map)
+
+        try:
+            nodetool_cmd = snapshot_option[0]() if len(snapshot_option) == 1 else snapshot_option[0](snapshot_option[1])
+            if not nodetool_cmd:
+                raise ValueError(f"Failed to get nodetool command.")
+        except Exception as exc:  # pylint: disable=broad-except
+            raise ValueError(f"Failed to get nodetool command. Error: {exc}")
+
+        self.log.debug(f'Take snapshot with command: {nodetool_cmd}')
+        result = self.target_node.run_nodetool(nodetool_cmd)
         self.log.debug(result)
         snapshot_name = re.findall(r'(\d+)', result.stdout, re.MULTILINE)[0]
         result = self.target_node.run_nodetool('listsnapshots')


### PR DESCRIPTION
Per original issue reported by the customer:
https://github.com/scylladb/scylla-enterprise/issues/1350

We need to extend 'disrupt_snapshot_operations' to run 'nodetool snapshot' more options including
multiple tables. Random choose between:
- create snapshot of all keyspaces
- create snapshot of one keyspace
- create snapshot of few keyspaces
- create snapshot of few tables, including MVs

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
