### PR TITLE
fix(kubernetes_cmd_runner.py): fix run for 'sudo -u scylla' case

### DIFF
--- a/cdc_replication_test.py
+++ b/cdc_replication_test.py
@@ -141,7 +141,7 @@ class CDCReplicationTest(ClusterTester):
 
         self.consistency_ok = True
 
-        no_rounds = 12 # 12 rounds, ~30 minutes each -> ~6 hours
+        no_rounds = 12  # 12 rounds, ~30 minutes each -> ~6 hours
         for rnd in range(no_rounds):
             self.log.info('Starting round {}'.format(rnd))
 
@@ -191,8 +191,8 @@ class CDCReplicationTest(ClusterTester):
                 fetch_tables=False)
             self.fail('Consistency check failed.')
 
-
     # pylint: disable=too-many-statements,too-many-branches,too-many-locals
+
     def test_replication(self, is_gemini_test: bool, mode: Mode) -> None:
         assert is_gemini_test or (mode == Mode.DELTA), "cassandra-stress doesn't work with preimage/postimage modes"
 

--- a/sdcm/remote/kubernetes_cmd_runner.py
+++ b/sdcm/remote/kubernetes_cmd_runner.py
@@ -134,12 +134,16 @@ class KubernetesCmdRunner(CommandRunner):
         watchers = self._setup_watchers(verbose=verbose, log_file=log_file, additional_watchers=watchers)
 
         # TODO: This should be removed than sudo calls will be done in more organized way.
-        if cmd.startswith("sudo "):
+        tmp = cmd.split(maxsplit=3)
+        if tmp[0] == 'sudo':
             deprecation("Using `sudo' in cmd string is deprecated.  Use `remoter.sudo()' instead.")
             frame = inspect.stack()[1]
             self.log.error("Cut off `sudo' from the cmd string: %s (%s:%s: %s)",
                            cmd, frame.filename, frame.lineno, frame.code_context[0].rstrip())
-            cmd = cmd[5:]
+            if tmp[1] == '-u':
+                cmd = tmp[3]
+            else:
+                cmd = cmd[cmd.find('sudo') + 5:]
 
         @retrying(n=retry or 1)
         def _run():


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
