### PR TITLE
fix(cdc_repl_tests): Fix test timeouts for cdc replication tests

### DIFF
--- a/jenkins-pipelines/feature-cdc-replication-gemini-postimage.jenkinsfile
+++ b/jenkins-pipelines/feature-cdc-replication-gemini-postimage.jenkinsfile
@@ -11,6 +11,6 @@ cdcReplicationPipeline(
     test_name: 'cdc_replication_test.CDCReplicationTest.test_replication_gemini_postimage',
     test_config: 'test-cases/cdc/cdc-15m-replication-postimage.yaml',
 
-    timeout: [time: 100, unit: 'MINUTES'],
+    timeout: [time: 140, unit: 'MINUTES'],
     email_recipients: 'kbraun@scylladb.com,piotr@scylladb.com,alex.bykov@scylladb.com'
 )

--- a/jenkins-pipelines/feature-cdc-replication-gemini-preimage.jenkinsfile
+++ b/jenkins-pipelines/feature-cdc-replication-gemini-preimage.jenkinsfile
@@ -11,6 +11,6 @@ cdcReplicationPipeline(
     test_name: 'cdc_replication_test.CDCReplicationTest.test_replication_gemini_preimage',
     test_config: 'test-cases/cdc/cdc-15m-replication-preimage.yaml',
 
-    timeout: [time: 100, unit: 'MINUTES'],
+    timeout: [time: 140, unit: 'MINUTES'],
     email_recipients: 'kbraun@scylladb.com,piotr@scylladb.com,alex.bykov@scylladb.com'
 )

--- a/jenkins-pipelines/feature-cdc-replication-gemini.jenkinsfile
+++ b/jenkins-pipelines/feature-cdc-replication-gemini.jenkinsfile
@@ -11,6 +11,6 @@ cdcReplicationPipeline(
     test_name: 'cdc_replication_test.CDCReplicationTest.test_replication_gemini_delta',
     test_config: 'test-cases/cdc/cdc-15m-replication-gemini.yaml',
 
-    timeout: [time: 100, unit: 'MINUTES'],
+    timeout: [time: 140, unit: 'MINUTES'],
     email_recipients: 'kbraun@scylladb.com,piotr@scylladb.com,alex.bykov@scylladb.com'
 )

--- a/jenkins-pipelines/feature-cdc-replication-longevity.jenkinsfile
+++ b/jenkins-pipelines/feature-cdc-replication-longevity.jenkinsfile
@@ -11,6 +11,6 @@ cdcReplicationPipeline(
     test_name: 'cdc_replication_test.CDCReplicationTest.test_replication_longevity',
     test_config: 'test-cases/cdc/cdc-replication-longevity.yaml',
 
-    timeout: [time: 600, unit: 'MINUTES'],
+    timeout: [time: 650, unit: 'MINUTES'],
     email_recipients: 'kbraun@scylladb.com,piotr@scylladb.com,alex.bykov@scylladb.com'
 )

--- a/test-cases/cdc/cdc-15m-replication-gemini.yaml
+++ b/test-cases/cdc/cdc-15m-replication-gemini.yaml
@@ -1,4 +1,4 @@
-test_duration: 60
+test_duration: 120
 
 user_prefix: 'cdc-replication-gemini'
 db_type: mixed_scylla

--- a/test-cases/cdc/cdc-15m-replication-postimage.yaml
+++ b/test-cases/cdc/cdc-15m-replication-postimage.yaml
@@ -1,4 +1,4 @@
-test_duration: 60
+test_duration: 120
 
 user_prefix: 'cdc-replication-gemini'
 db_type: mixed_scylla

--- a/test-cases/cdc/cdc-15m-replication-preimage.yaml
+++ b/test-cases/cdc/cdc-15m-replication-preimage.yaml
@@ -1,4 +1,4 @@
-test_duration: 60
+test_duration: 120
 
 user_prefix: 'cdc-replication-gemini'
 db_type: mixed_scylla


### PR DESCRIPTION
Fix test duration for all cdc replication tests.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] ~I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)~
- [ ] ~I didn't leave commented-out/debugging code~
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (CI)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
