### PR TITLE
Fix operator loggging

### DIFF
--- a/sdcm/cluster_k8s.py
+++ b/sdcm/cluster_k8s.py
@@ -38,7 +38,7 @@ from sdcm.sct_config import sct_abs_path
 from sdcm.sct_events import TestFrameworkEvent
 from sdcm.utils.k8s import KubernetesOps, JSON_PATCH_TYPE
 from sdcm.utils.common import get_free_port, wait_for_port
-from sdcm.utils.decorators import log_run_info
+from sdcm.utils.decorators import log_run_info, timeout
 from sdcm.utils.docker_utils import ContainerManager
 from sdcm.utils.remote_logger import get_system_logging_thread, CertManagerLogger, ScyllaOperatorLogger
 
@@ -684,10 +684,10 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):
         if monitors := cluster.Setup.tester_obj().monitors:
             monitors.reconfigure_scylla_monitoring()
 
+    @timeout(message="Wait for pod(s) to be ready...", timeout=600)
     def wait_for_pods_readiness(self, count: Optional[int] = None):
         if count is None:
             count = len(self.nodes)
-        LOGGER.debug("Wait for %d pod(s) to be ready...", count)
         for _ in range(count):
             time.sleep(SCYLLA_POD_READINESS_DELAY)
             self.k8s_cluster.kubectl(f"wait --timeout={SCYLLA_POD_READINESS_TIMEOUT}m --all --for=condition=Ready pod",


### PR DESCRIPTION
https://trello.com/c/39kTqNGY/2334-scylla-k8s-node-logs-are-not-streamed-when-pods-are-restarted

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
