### PR TITLE
fix(test_duration_alternator): Fix test duration for alternator tests

### DIFF
--- a/jenkins-pipelines/longevity-alternator-200gb-48h.jenkinsfile
+++ b/jenkins-pipelines/longevity-alternator-200gb-48h.jenkinsfile
@@ -11,6 +11,6 @@ longevityPipeline(
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-alternator-200GB-48h.yaml',
 
-    timeout: [time: 3120, unit: 'MINUTES'],
+    timeout: [time: 3200, unit: 'MINUTES'],
     email_recipients: 'qa@scylladb.com,alternator@scylladb.com'
 )

--- a/jenkins-pipelines/longevity-alternator-3h-multidc.jenkinsfile
+++ b/jenkins-pipelines/longevity-alternator-3h-multidc.jenkinsfile
@@ -11,6 +11,6 @@ longevityPipeline(
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-alternator-3h-multidc.yaml',
 
-    timeout: [time: 320, unit: 'MINUTES'],
+    timeout: [time: 400, unit: 'MINUTES'],
     email_recipients: 'qa@scylladb.com,alternator@scylladb.com'
 )

--- a/test-cases/longevity/longevity-alternator-200GB-48h.yaml
+++ b/test-cases/longevity/longevity-alternator-200GB-48h.yaml
@@ -1,4 +1,4 @@
-test_duration: 2880
+test_duration: 3000
 prepare_write_cmd:
   - >-
     bin/ycsb load dynamodb -P workloads/workloadc -threads 20 -p recordcount=200200300

--- a/test-cases/longevity/longevity-alternator-3h-multidc.yaml
+++ b/test-cases/longevity/longevity-alternator-3h-multidc.yaml
@@ -1,4 +1,4 @@
-test_duration: 200
+test_duration: 300
 prepare_write_cmd:
   - >-
     bin/ycsb load dynamodb -P workloads/workloadc -threads 80 -p recordcount=6990500


### PR DESCRIPTION
Increase alternator test duration to avoid job aborting.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] ~I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)~
- [ ] ~I didn't leave commented-out/debugging code~
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (CI)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
