### PR TITLE
fix(manager): Got rid of port check in wait_manager_up

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1165,11 +1165,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
     def is_manager_agent_up(self, port=None):
         port = port if port else self.MANAGER_AGENT_PORT
-        if self.is_port_used(port=port, service_name="scylla-manager-agent"):
-            # When the agent is IP, it should answer an https request of https://NODE_IP:10001/ping with status code 204
-            response = requests.get(f"https://{normalize_ipv6_url(self.ip_address)}:{port}/ping", verify=False)
-            return response.status_code == 204
-        return False
+        # When the agent is IP, it should answer an https request of https://NODE_IP:10001/ping with status code 204
+        response = requests.get(f"https://{normalize_ipv6_url(self.ip_address)}:{port}/ping", verify=False)
+        return response.status_code == 204
 
     def wait_manager_agent_up(self, verbose=True, timeout=180):
         text = None
@@ -1179,15 +1177,14 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
     def is_manager_server_up(self, port=None):
         port = port if port else self.MANAGER_SERVER_PORT
-        if self.is_port_used(port=port, service_name="scylla-manager"):
-            # When the manager has started,
-            # it should answer an http request of https://127.0.0.1:5080/ping with status code 204
-            curl_output = self.remoter.run(
-                f'''curl --write-out "%{{http_code}}\n" --silent --output /dev/null "http://127.0.0.1:{port}/ping"''',
-                ignore_status=True)
-            http_status_code = int(curl_output.stdout.strip())
-            return http_status_code == 204
-        return False
+        # When the manager has started,
+        # it should answer an http request of https://127.0.0.1:5080/ping with status code 204
+        # The port is only open locally, hence using curl instead
+        curl_output = self.remoter.run(
+            f'''curl --write-out "%{{http_code}}\n" --silent --output /dev/null "http://127.0.0.1:{port}/ping"''',
+            verbose=True, ignore_status=True)
+        http_status_code = int(curl_output.stdout.strip())
+        return http_status_code == 204
 
     def wait_manager_server_up(self, verbose=True, timeout=300):
         text = None


### PR DESCRIPTION
Since the is_port_used check was unnecessary,
I removed it from is_manager_server_up and is_manager_agent_up

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
