### PR TITLE
fix(logcollector): support of ipv6 in grafana urls

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -19,7 +19,7 @@ from selenium.webdriver.common.by import By
 from sdcm.utils.common import (S3Storage, list_instances_aws, list_instances_gce,
                                ParallelObject, remove_files, get_builder_by_test_id,
                                get_testrun_dir, search_test_id_in_latest, filter_aws_instances_by_type,
-                               filter_gce_instances_by_type, get_sct_root_path)
+                               filter_gce_instances_by_type, get_sct_root_path, normalize_ipv6_url)
 from sdcm.utils.decorators import retrying
 from sdcm.utils.get_username import get_username
 from sdcm.db_stats import PrometheusDBStats
@@ -298,7 +298,7 @@ class MonitoringStack(BaseMonitoringEntity):
             return ""
         archive_name = "monitoring_data_stack_{monitor_branch}_{monitor_version}.tar.gz".format(**locals())
 
-        annotations_json = self.get_grafana_annotations(node.grafana_address)
+        annotations_json = self.get_grafana_annotations(normalize_ipv6_url(node.grafana_address))
         tmp_dir = tempfile.mkdtemp()
         with io.open(os.path.join(tmp_dir, 'annotations.json'), 'w', encoding='utf-8') as f:  # pylint: disable=invalid-name
             f.write(annotations_json)
@@ -433,7 +433,7 @@ class GrafanaScreenShot(GrafanaEntity):
             self.remote_browser = RemoteBrowser(node)
 
             for screenshot in self.grafana_entity_names:
-                dashboard_exists = MonitoringStack.dashboard_exists(grafana_ip=node.grafana_address,
+                dashboard_exists = MonitoringStack.dashboard_exists(grafana_ip=normalize_ipv6_url(node.grafana_address),
                                                                     uid="-".join([screenshot['name'],
                                                                                   version])
                                                                     )
@@ -444,7 +444,7 @@ class GrafanaScreenShot(GrafanaEntity):
                     version=version,
                     dashboard_name=screenshot['name'])
                 grafana_url = self.grafana_entity_url_tmpl.format(
-                    node_ip=node.grafana_address,
+                    node_ip=normalize_ipv6_url(node.grafana_address),
                     grafana_port=self.grafana_port,
                     path=path,
                     st=self.start_time)
@@ -547,7 +547,7 @@ class GrafanaSnapshot(GrafanaEntity):
             snapshots = []
             for snapshot in self.grafana_entity_names:
                 version = monitoring_version.replace('.', '-')
-                dashboard_exists = MonitoringStack.dashboard_exists(grafana_ip=node.grafana_address,
+                dashboard_exists = MonitoringStack.dashboard_exists(grafana_ip=normalize_ipv6_url(node.grafana_address),
                                                                     uid="-".join([snapshot['name'],
                                                                                   version])
                                                                     )
@@ -558,7 +558,7 @@ class GrafanaSnapshot(GrafanaEntity):
                     version=version,
                     dashboard_name=snapshot['name'])
                 grafana_url = self.grafana_entity_url_tmpl.format(
-                    node_ip=node.grafana_address,
+                    node_ip=normalize_ipv6_url(node.grafana_address),
                     grafana_port=self.grafana_port,
                     path=path,
                     st=self.start_time)


### PR DESCRIPTION
seem like some of the code in the collector isn't take ipv6 into
account

failing test like that:
```
Port could not be cast to integer value as 'd018:eb8:3100:e9c6:8ec0:7c58:22'
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- ~~[ ] New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- ~~[ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- ~~[ ] I have updated the Readme/doc folder accordingly (if needed)~~
