### PR TITLE
fix(nemesis): nemesis running nodetool status on a dead node

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1779,7 +1779,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         node_to_remove = self.target_node
         up_normal_nodes = self.cluster.get_nodes_up_and_normal(verification_node=node_to_remove)
         # node_to_remove must be different than node
-        node = random.choice([n for n in self.cluster.nodes if n is not node_to_remove])
+        verification_node = random.choice([n for n in self.cluster.nodes if n is not node_to_remove])
 
         # node_to_remove must not be the only seed in cluster
         num_of_seed_nodes = len(self.cluster.seed_nodes)
@@ -1788,7 +1788,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         # get node's host_id
         removed_node_status = self.cluster.get_node_status_dictionary(
-            ip_address=node_to_remove.ip_address, verification_node=node)
+            ip_address=node_to_remove.ip_address, verification_node=verification_node)
         assert removed_node_status is not None, "failed to get host_id using nodetool status"
         host_id = removed_node_status["host_id"]
 
@@ -1820,7 +1820,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         # verify node is removed by nodetool status
         removed_node_status = self.cluster.get_node_status_dictionary(
-            ip_address=node_to_remove.ip_address, verification_node=node)
+            ip_address=node_to_remove.ip_address, verification_node=verification_node)
         assert removed_node_status is None, "Node was not removed properly (Node status:{})".format(removed_node_status)
 
         # add new node


### PR DESCRIPTION
`disrupt_remove_node_then_add_node` code was shadowing the node variable
in a for loop, cause the `target_node` to be assigned to `node`
hence failing randomly

```
26ce06ee-8 [13.48.133.167 | 10.0.2.189] (seed: False) duration=594
error=Unable to run "nodetool  status ": failed connecting to "10.0.2.189" during 60s
Traceback (most recent call last):
File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 2317, in wrapper
result = method(*args, **kwargs)
File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 2584, in disrupt
self.call_random_disrupt_method()
File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 759, in call_random_disrupt_method
disrupt_method()
File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 1822, in disrupt_remove_node_then_ad
removed_node_status = self.cluster.get_node_status_dictionary(
File "/home/ubuntu/scylla-cluster-tests/sdcm/cluster.py", line 3444, in get_node_status_dictionary
status = self.get_nodetool_status(verification_node=verification_node)
File "/home/ubuntu/scylla-cluster-tests/sdcm/utils/decorators.py", line 61, in inner
return func(*args, **kwargs)
File "/home/ubuntu/scylla-cluster-tests/sdcm/cluster.py", line 3321, in get_nodetool_status
res = verification_node.run_nodetool('status')
File "/home/ubuntu/scylla-cluster-tests/sdcm/cluster.py", line 2388, in run_nodetool
result = self.remoter.run(cmd, timeout=timeout, ignore_status=ignore_status, verbose=verbose)
File "/home/ubuntu/scylla-cluster-tests/sdcm/remote/remote_base.py", line 601, in run
result = _run()
File "/home/ubuntu/scylla-cluster-tests/sdcm/utils/decorators.py", line 61, in inner
return func(*args, **kwargs)
File "/home/ubuntu/scylla-cluster-tests/sdcm/remote/remote_base.py", line 591, in _run
self._run_pre_run(cmd, timeout, ignore_status, verbose, new_session, log_file, retry, watchers)
File "/home/ubuntu/scylla-cluster-tests/sdcm/remote/remote_cmd_runner.py", line 106, in _run_pre_ru
raise SSHConnectTimeoutError(
sdcm.remote.base.SSHConnectTimeoutError:
Unable to run "nodetool  status ": failed connecting to "10.0.2.189" during 60s
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
