### PR TITLE
fix(DockerClient): support ipv6 when passing base_url

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -484,7 +484,8 @@ def list_clients_docker(builder_name: Optional[str] = None, verbose: bool = Fals
         try:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
-                client = docker.DockerClient(base_url=f"ssh://{builder['user']}@{builder['public_ip']}")
+                client = docker.DockerClient(
+                    base_url=f"ssh://{builder['user']}@{normalize_ipv6_url(builder['public_ip'])}")
             client.ping()
             log.info("%(name)s: connected via SSH (%(user)s@%(public_ip)s)", builder)
         except:

--- a/sdcm/utils/remotewebbrowser.py
+++ b/sdcm/utils/remotewebbrowser.py
@@ -20,7 +20,7 @@ from docker import DockerClient  # pylint: disable=wrong-import-order
 from selenium.webdriver import Remote, ChromeOptions
 
 from sdcm.utils.docker_utils import ContainerManager, DOCKER_API_CALL_TIMEOUT
-from sdcm.utils.common import get_free_port, wait_for_port
+from sdcm.utils.common import get_free_port, wait_for_port, normalize_ipv6_url
 from sdcm.utils.ssh_agent import SSHAgent
 
 
@@ -44,7 +44,7 @@ class WebDriverContainerMixin:
         if not self.ssh_login_info:
             return None
         SSHAgent.add_keys((self.ssh_login_info["key_file"], ))
-        return DockerClient(base_url=f"ssh://{self.ssh_login_info['user']}@{self.ssh_login_info['hostname']}",
+        return DockerClient(base_url=f"ssh://{self.ssh_login_info['user']}@{normalize_ipv6_url(self.ssh_login_info['hostname'])}",
                             timeout=DOCKER_API_CALL_TIMEOUT)
 
 


### PR DESCRIPTION
In manager ipv6 I've seen failures like this, coming from `DockerClient.__init__`:

```
2020-09-08 21:27:53.828: (TestFrameworkEvent Severity.ERROR),
source=MgmtCliTest.update_test_with_errors() message=update_test_with_errors
(silenced) failed with:
exception=Port could not be cast to integer value as 'd018:eb8:3100:fa28:ae78:d480:22'
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
