### PR TITLE
fix(longevity_5000_tables): Enable sequentially init cluster

### DIFF
--- a/test-cases/longevity/longevity-5000-tables.yaml
+++ b/test-cases/longevity/longevity-5000-tables.yaml
@@ -43,3 +43,5 @@ append_scylla_args: '--blocked-reactor-notify-ms 500'
 
 # TODO: remove when https://github.com/scylladb/scylla-tools-java/issues/175 resolved
 stop_test_on_stress_failure: false
+
+use_legacy_cluster_init: false


### PR DESCRIPTION
Enable sequentially node adding to cluster with bootstrap.

Due to issue 7165, when repair_based_operations is enabled 
the default behavior for scylla master and 4.2,
Add node takes more time for each node to bootstrap with 5000 tables 
and when we're not waiting for the other nodes to join 
their bootstrap get stuck.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] ~I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)~
- [ ] ~I didn't leave commented-out/debugging code~
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (CI)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
