### PR TITLE
fix(manager-timeouts): manager gce test-case missing `test_duration`

### DIFF
--- a/test-cases/manager/manager-regression-gce.yaml
+++ b/test-cases/manager/manager-regression-gce.yaml
@@ -1,3 +1,5 @@
+test_duration: 360
+
 stress_cmd: "cassandra-stress write cl=QUORUM n=1200300 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -pop seq=400200300..600200300"
 
 n_db_nodes: 3


### PR DESCRIPTION
And cause of the the default of 60min kicked in togther
with recent changes to timeout control, and tests are
timing out before ending.
