### PR TITLE
fix(ToggleICS): catching the wrong UnexpectedExit

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -48,6 +48,7 @@ from sdcm.prometheus import nemesis_metrics_obj
 from sdcm import wait
 from sdcm.sct_events import DisruptionEvent, DbEventsFilter, Severity, InfoEvent, raise_event_on_failure
 from sdcm.db_stats import PrometheusDBStats
+from sdcm.remote.libssh2_client.exceptions import UnexpectedExit as Libssh2UnexpectedExit
 from test_lib.compaction import CompactionStrategy, get_compaction_strategy, get_compaction_random_additional_params
 from test_lib.cql_types import CQLTypeBuilder
 
@@ -1237,7 +1238,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.log.debug("Toggle table ICS query to execute: {}".format(cmd))
         try:
             self.target_node.run_cqlsh(cmd)
-        except UnexpectedExit as unexpected_exit:
+        except (UnexpectedExit, Libssh2UnexpectedExit) as unexpected_exit:
             if "Unable to find compaction strategy" in str(unexpected_exit):
                 raise UnsupportedNemesis("for this nemesis to work, you need ICS supported scylla version.")
             raise unexpected_exit


### PR DESCRIPTION
seem like in the code we are expecting to get `invoke.UnexpectedExit`
but insted we are getting `sdcm.remote.libssh2_client.exceptions.UnexpectedExit`

this is a temporary fix, since `UnexpectedExit` is used in more places that
need to be checked if that the correct one.