### PR TITLE
fix(manger-upgrade-pipelines): update to start upgrades from manager-2.1

### DIFF
--- a/jenkins-pipelines/manager/ubuntu16-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu16-manager-upgrade.jenkinsfile
@@ -12,8 +12,9 @@ managerPipeline(
 
     target_scylla_mgmt_server_repo: 'http://downloads.scylladb.com/manager/deb/unstable/xenial/master/latest/scylla-manager-master/scylla-manager.list',
     target_scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
-    scylla_mgmt_repo: 'http://downloads.scylladb.com/manager/deb/unstable/xenial/master/latest/scylla-manager-master/scylla-manager.list',
-    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+
+    scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-2.1-xenial.list',
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.1.repo',
     scylla_version: 'master:latest',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',

--- a/jenkins-pipelines/manager/ubuntu18-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu18-manager-upgrade.jenkinsfile
@@ -13,7 +13,7 @@ managerPipeline(
     target_scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
 
     scylla_mgmt_repo: 'http://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.1-bionic.list',
-    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.1.repo,
     scylla_version: 'master:latest',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',


### PR DESCRIPTION
by mistake we changes all the debian base upgrade pipeline to start
from the wrong versions
