### PR TITLE
fix(manager-pipeline): typo in ubuntu18-manager-upgrade.jenkinsfile

### DIFF
--- a/jenkins-pipelines/manager/ubuntu18-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu18-manager-upgrade.jenkinsfile
@@ -13,7 +13,7 @@ managerPipeline(
     target_scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
 
     scylla_mgmt_repo: 'http://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.1-bionic.list',
-    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.1.repo,
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.1.repo',
     scylla_version: 'master:latest',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',


### PR DESCRIPTION
fix typo in f6a33e9d94cf6ce5876c4f145a2ae216d00bc615