### PR TITLE
fix(DockerClient): support ipv6 when passing base_url with port

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -484,8 +484,10 @@ def list_clients_docker(builder_name: Optional[str] = None, verbose: bool = Fals
         try:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
+                # since a bug in docker package https://github.com/docker-library/python/issues/517 that need
+                # to explicitly pass down the port for supporting ipv6
                 client = docker.DockerClient(
-                    base_url=f"ssh://{builder['user']}@{normalize_ipv6_url(builder['public_ip'])}")
+                    base_url=f"ssh://{builder['user']}@{normalize_ipv6_url(builder['public_ip'])}:22")
             client.ping()
             log.info("%(name)s: connected via SSH (%(user)s@%(public_ip)s)", builder)
         except:

--- a/sdcm/utils/remotewebbrowser.py
+++ b/sdcm/utils/remotewebbrowser.py
@@ -44,7 +44,9 @@ class WebDriverContainerMixin:
         if not self.ssh_login_info:
             return None
         SSHAgent.add_keys((self.ssh_login_info["key_file"], ))
-        return DockerClient(base_url=f"ssh://{self.ssh_login_info['user']}@{normalize_ipv6_url(self.ssh_login_info['hostname'])}",
+        # since a bug in docker package https://github.com/docker-library/python/issues/517 that need to explicitly
+        # pass down the port for supporting ipv6
+        return DockerClient(base_url=f"ssh://{self.ssh_login_info['user']}@{normalize_ipv6_url(self.ssh_login_info['hostname'])}:22",
                             timeout=DOCKER_API_CALL_TIMEOUT)
 
 


### PR DESCRIPTION
eccef5cebab131dd69b9e475a91626b0b7a022a1 wasn't enough to fix the issue
since a bug in docker package https://github.com/docker-library/python/issues/517

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- ~~[ ] New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- ~~[ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- ~~[ ] I have updated the Readme/doc folder accordingly (if needed)~~
