### PR TITLE
fix(wait for node up): wait for the target node up after reboot

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -349,6 +349,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.target_node.wait_db_up()
         self.log.info('Waiting JMX services to start after node reboot')
         self.target_node.wait_jmx_up()
+        self.cluster.wait_for_nodes_up_and_normal(nodes=[self.target_node])
 
     def disrupt_multiple_hard_reboot_node(self):  # pylint: disable=invalid-name
         num_of_reboots = random.randint(2, 10)
@@ -362,6 +363,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             else:
                 self.log.info('Waiting JMX services to start after node reboot')
                 self.target_node.wait_jmx_up()
+            self.cluster.wait_for_nodes_up_and_normal(nodes=[self.target_node])
             sleep_time = random.randint(0, 100)
             self.log.info(
                 'Sleep {} seconds after hard reboot and service-up for node {}'.format(sleep_time, self.target_node))
@@ -374,6 +376,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.target_node.wait_db_up()
         self.log.info('Waiting JMX services to start after node reboot')
         self.target_node.wait_jmx_up()
+        self.cluster.wait_for_nodes_up_and_normal(nodes=[self.target_node])
 
     def disrupt_restart_with_resharding(self):
         self._set_current_disruption('RestartNodeWithResharding %s' % self.target_node)


### PR DESCRIPTION
Wait for target node is up and normal after reboot to prevent failure due the node during
the start and in DN status

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
