### PR TITLE
improvement(mgmt_upgrade_test.py): Test backup force param removal on 2.2 upgrade

### DIFF
--- a/jenkins-pipelines/manager/centos-manager-upgrade-backup-force.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-upgrade-backup-force.jenkinsfile
@@ -1,0 +1,23 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+managerPipeline(
+    params: params,
+    manager: true,
+    backend: 'aws',
+    aws_region: 'us-east-1',
+
+    target_scylla_mgmt_server_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+    target_scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+
+    scylla_mgmt_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.1.repo',
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.1.repo',
+    scylla_version: 'master:latest',
+
+    test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_backup_force_param_on_upgrade',
+    test_config: 'test-cases/upgrades/manager-upgrade.yaml',
+
+    timeout: [time: 360, unit: 'MINUTES']
+)


### PR DESCRIPTION
	The backup force param of manager 2.1 is not supported on version 2.2
	so an upgrade where a backup task uses it, should prevent the task rerun.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
