### PR TITLE
feature(get_scylla_version): output scylla full version

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1914,6 +1914,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             self.scylla_version_detailed = result.stdout.strip()
             if build_id := self.get_scylla_build_id():
                 self.scylla_version_detailed += f" with build-id {build_id}"
+                self.log.info(f"Found ScyllaDB version with details: {self.scylla_version_detailed}")
         else:
             if self.distro.is_rhel_like:
                 cmd = f"rpm --query --queryformat '%{{VERSION}}' {self.scylla_pkg()}"


### PR DESCRIPTION
Currently we only output the major version (eg: 4.1.2), the full version
(contains the build data and commit prefix) of each node won't be
outputed.

This patch changed to output detailed version by info level, then we can see it
early in jenkins log.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
