### PR TITLE
fix(sdcm/cluseter): fix retrying logic

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2185,7 +2185,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         if verify_up:
             self.wait_jmx_up(timeout=timeout)
 
-    @retrying(n=3, sleep_time=5, allowed_exceptions=(CommandTimedOut, NoValidConnectionsError,),
+    @retrying(n=3, sleep_time=5, allowed_exceptions=NETWORK_EXCEPTIONS,
               message="Failed to stop scylla.server, retrying...")
     def stop_scylla_server(self, verify_up=False, verify_down=True, timeout=300, ignore_status=False):
         if verify_up:
@@ -3449,7 +3449,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                 break
         return node_status
 
-    @retrying(n=60, sleep_time=3, allowed_exceptions=(ClusterNodesNotReady, UnexpectedExit),
+    @retrying(n=60, sleep_time=3, allowed_exceptions=NETWORK_EXCEPTIONS + (ClusterNodesNotReady,),
               message="Waiting for nodes to join the cluster")
     def wait_for_nodes_up_and_normal(self, nodes, verification_node=None):
         self.check_nodes_up_and_normal(nodes=nodes, verification_node=verification_node)


### PR DESCRIPTION
https://trello.com/c/QL5fUshy/2353-tests-failing-on-stopscyllaserver

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
