### PR TITLE
fix(sct_runner): overwrite connect_timeout, 60s wasn't enough

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -808,7 +808,7 @@ def create_runner_instance(cloud_provider, region, availability_zone, test_id, d
     sct_runner = SctRunner(region_name=region)
     instance = sct_runner.create_instance(test_id=test_id, test_duration=duration, region_az=region + availability_zone)
     LOGGER.info("Verifying SSH connectivity...")
-    remoter = sct_runner.get_remoter(host=instance.public_ip_address)
+    remoter = sct_runner.get_remoter(host=instance.public_ip_address, connect_timeout=120)
     result = remoter.run("true", timeout=100, verbose=False, ignore_status=True)
     if result.exit_status == 0:
         LOGGER.info(f"Successfully connected the SCT Runner. Public IP:  {instance.public_ip_address}")

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -6,6 +6,7 @@ from enum import Enum
 from functools import lru_cache
 from math import ceil
 from textwrap import dedent
+from typing import Optional
 
 import boto3
 
@@ -56,11 +57,11 @@ class SctRunner:
         ks = KeyStore()
         return ks.get_ec2_ssh_key_pair()
 
-    def get_remoter(self, host):
+    def get_remoter(self, host, connect_timeout: Optional[float] = None):
         self._ssh_pkey_file = tempfile.NamedTemporaryFile(mode="w", delete=False)
         self._ssh_pkey_file.write(self.key_pair().private_key.decode())
         self._ssh_pkey_file.flush()
-        return RemoteCmdRunnerBase.create_remoter(hostname=host, user=self.LOGIN_USER, key_file=self._ssh_pkey_file.name)
+        return RemoteCmdRunnerBase.create_remoter(hostname=host, user=self.LOGIN_USER, key_file=self._ssh_pkey_file.name, connect_timeout=connect_timeout)
 
     def install_prereqs(self, public_ip):
         LOGGER.info("Installing required packages...")


### PR DESCRIPTION
even that we pass down `timeout=100` the `connect_timeout` default to
60s, and since it's a newly created machine, it's not always enoguh
time for it to be ready and available.

```
File "./sct.py", line 812, in create_runner_instance
   result = remoter.run("true", timeout=100, verbose=False, ignore_status=True)
File ".../sdcm/remote/remote_base.py", line 601, in run
   result = _run()
File ".../sdcm/utils/decorators.py", line 61, in inner
   return func(*args, **kwargs)
File ".../sdcm/remote/remote_base.py", line 591, in _run
   self._run_pre_run(cmd, timeout, ignore_status, verbose, new_session, log_file, retry, watchers)
File ".../sdcm/remote/remote_cmd_runner.py", line 106, in _run_pre_run
   raise SSHConnectTimeoutError(
sdcm.remote.base.SSHConnectTimeoutError: Unable to run "true":
failed connecting to "3.234.207.111" during 60s
```