### PR TITLE
fix(runscttest.grovy): Fix if condition for updatedbpackages

### DIFF
--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -35,7 +35,7 @@ def call(Map params, String region){
     export SCT_INSTANCE_PROVISION="${params.get('provision_type', '')}"
     export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$GIT_BRANCH | sed -E 's+(origin/|origin/branch-)++')
     export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$SCT_AMI_ID_DB_SCYLLA_DESC | tr ._ - | cut -c1-8 )
-    if [[ ${params.update_db_packages} != null ]]; then
+    if [[ ! -z "${params.update_db_packages}" ]]; then
         export SCT_UPDATE_DB_PACKAGES="${params.update_db_packages}"
     fi
 


### PR DESCRIPTION
When run job basde on byopipeline with empty update_db_packages
jenkins job failed with error:
line 30: conditional binary operator expected
example : https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/abykov/job/BYO-abykov-staging/23/
Change to check empty string

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] ~I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)~
- [ ] ~I didn't leave commented-out/debugging code~
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (CI)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
