### PR TITLE
fix(alternator-3h-multidc-yaml): remove c-s commands

### DIFF
--- a/test-cases/longevity/longevity-alternator-3h-multidc.yaml
+++ b/test-cases/longevity/longevity-alternator-3h-multidc.yaml
@@ -20,11 +20,7 @@ prepare_write_cmd:
     -p fieldcount=10 -p fieldlength=512 -p dataintegrity=true
     -p insertstart=3495250 -p insertcount=3495250 -p table=usertable_no_lwt
 
-  - cassandra-stress write cl=QUORUM n=6990500 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=80 -pop seq=1..6990500 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5
-
 stress_cmd: [
-  "cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=20 -pop seq=1..6990500 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
-  "cassandra-stress read  cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=20 -pop seq=1..6990500 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
   # with lwt table
   "bin/ycsb run dynamodb -P workloads/workloadc -threads 20 -p readproportion=0.5 -p updateproportion=0.5 -p recordcount=6990500 -p fieldcount=10 -p fieldlength=512 -p operationcount=200200300 -p dataintegrity=true",
   # no lwt table


### PR DESCRIPTION
current c-s commands use SizeTieredCompactionStrategy that is incompatable
with multi dc case. In multi dc case we need to use NetworkTopologyStrategy.
Per our discussion with Roy and Israel decided to remove the c-s command
since it is less important for Alternator test case.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
