### PR TITLE
fix(clean_scylla_data): don't delete the data directory

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1743,7 +1743,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         See https://docs.scylladb.com/operating-scylla/procedures/cluster-management/clear_data/
         """
         clean_commands_list = [
-            "rm -rf /var/lib/scylla/data",
+            "rm -rf /var/lib/scylla/data/*",
             "find /var/lib/scylla/commitlog -type f -delete",
             "find /var/lib/scylla/hints -type f -delete",
             "find /var/lib/scylla/view_hints -type f -delete"


### PR DESCRIPTION
Old scylla won't create /var/lib/data directory if it doesn't exist,
the service will fail to start.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
