### PR TITLE
fix cluster init

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -902,7 +902,7 @@ class ScyllaAWSCluster(cluster.BaseScyllaCluster, AWSCluster):
 
             # make sure scylla-ami-setup finishes, flag file is deleted, and first start fails as expected.
             result = node.remoter.run('systemctl status scylla-server', ignore_status=True)
-            return 'Failed to start Scylla Server.' in result.stdout
+            return 'Failed to start Scylla Server.' in result.stdout or 'Active: failed' in result.stdout
 
         wait.wait_for(scylla_ami_setup_done, step=10, timeout=300)
 


### PR DESCRIPTION
In legacy cluster init, multiple nodes are inited in parallel, when one
node is ready (UP), other nodes might be UJ (joining) status.

The first patch changed to only check status of current node for legacy
cluster init.

The second patch added a new pattern to match the start fail.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
