### PR TITLE
fix(longevity-100gb-4h): Trying to bootstrap the cluster in sequential mode

### DIFF
--- a/test-cases/longevity/longevity-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-100gb-4h.yaml
@@ -23,3 +23,5 @@ space_node_threshold: 64424
 use_mgmt: true
 pre_create_schema: True
 sstable_size: 100
+
+use_legacy_cluster_init: false


### PR DESCRIPTION
Since we changed the test to use 3 seed nodes instead of 1 the setup phase fails.
Changing the bootstrap mode to start sequentially should solve the problem.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
