### PR TITLE
improvement(mgmt_upgrade_test.py): Test backup force param removal on 2.2 upgrade

### DIFF
--- a/mgmt_upgrade_test.py
+++ b/mgmt_upgrade_test.py
@@ -66,8 +66,9 @@ class ManagerUpgradeTest(BackupFunctionsMixIn, ClusterTester):
             pre_upgrade_backup_task_files = mgr_cluster.get_backup_files_dict(backup_task_snapshot)
 
         with self.subTest("Creating a backup task and stopping it"):
+            legacy_args = "--force" if manager_tool.client_version.startswith("2.1") else None
             pausable_backup_task = mgr_cluster.create_backup_task(interval="1d", location_list=location_list,
-                                                                  keyspace_list=["system_*"])
+                                                                  keyspace_list=["system_*"], legacy_args=legacy_args)
             pausable_backup_task.wait_for_status(list_status=[TaskStatus.RUNNING], timeout=180, step=2)
             pausable_backup_task.stop()
 


### PR DESCRIPTION

            The backup force param of manager 2.1 is not supported on version 2.2
            so an upgrade where a backup task uses it, should be removed and rerun ok.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
