### PR TITLE
fix(sdcm/tester.py): store left threads into separate file

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -899,6 +899,8 @@ class SCTLogCollector(LogCollector):
                 search_locally=True),
         FileLog(name='sct.log',
                 search_locally=True),
+        FileLog(name='left_processes.log',
+                search_locally=True),
         FileLog(name='raw_events.log',
                 search_locally=True),
         FileLog(name='events.log',


### PR DESCRIPTION
https://trello.com/c/5s6JaFuY/2363-write-left-threads-and-processes-information-to-the-file
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
