### PR TITLE
fix(scylla_args): workaround for doubled scylla options

### DIFF
--- a/sdcm/utils/scylla_args.py
+++ b/sdcm/utils/scylla_args.py
@@ -38,7 +38,7 @@ class ScyllaArgError(Exception):
 
 class ScyllaArgParser(argparse.ArgumentParser):
     def __init__(self, prog: str) -> None:
-        super().__init__(prog=prog, argument_default=argparse.SUPPRESS, add_help=False)
+        super().__init__(prog=prog, argument_default=argparse.SUPPRESS, add_help=False, conflict_handler="resolve")
 
     def error(self, message: Text) -> NoReturn:
         LOGGER.error(message)


### PR DESCRIPTION
Workaround for https://github.com/scylladb/scylla-enterprise/issues/1473

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
