### PR TITLE
feature(resharding before uploading): nodetool refresh - check resharding before uploading

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -671,7 +671,41 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             node.remoter.sudo(f'rm -f /var/lib/scylla/data/keyspace1/{upload_dir}/upload/schema.cql')
             node.remoter.sudo(f'rm -f /var/lib/scylla/data/keyspace1/{upload_dir}/upload/manifest.json')
             self.log.debug(f'Loading {keys_num} keys to {node.name} by refresh')
+
+            # Resharding of the loaded sstable files is performed before they are moved from upload to the main folder.
+            # So we need to validate that resharded files are placed in the "upload" folder before moving.
+            # Find the compaction output that reported about the resharding
+
+            search_reshard = node.follow_system_log(patterns=['Resharded.*\[/'])
             node.run_nodetool(sub_cmd="refresh", args="-- keyspace1 standard1")
+            resharding_done = list(search_reshard)
+            return resharding_done
+
+        def validate_resharding_after_refresh(resharding_done):
+            """
+            # Validate that files after resharding were saved in the "upload" folder.
+            # Example of compaction output:
+
+            #   scylla[6653]:  [shard 0] compaction - [Reshard keyspace1.standard1 3cad4140-f8c3-11ea-acb1-000000000002]
+            #   Resharded 1 sstables to [
+            #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-9-big-Data.db:level=0,
+            #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-10-big-Data.db:level=0,
+            #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-11-big-Data.db:level=0,
+            #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-12-big-Data.db:level=0,
+            #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-13-big-Data.db:level=0,
+            #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-22-big-Data.db:level=0,
+            #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-15-big-Data.db:level=0,
+            #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-16-big-Data.db:level=0,
+            #   ]. 91MB to 92MB (~100% of original) in 5009ms = 18MB/s. ~370176 total partitions merged to 370150
+            """
+            assert resharding_done, "Resharding wasn't run"
+            self.log.debug(f"Found resharding: {resharding_done}")
+
+            for line in resharding_done:
+                # Find all files that were created after resharding
+                for one_file in re.findall(r"(/var/.*?),", line, re.IGNORECASE):
+                    # The file path have to include "upload" folder
+                    assert '/upload/' in one_file, "Loaded file was resharded not in 'upload' folder"
 
         if result is not None and result.exit_status == 0:
             # Check one special key before refresh, we will verify refresh by query in the end
@@ -686,7 +720,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
             # Executing rolling refresh one by one
             for node in self.cluster.nodes:
-                do_refresh(node)
+                resharding_done = do_refresh(node)
+                validate_resharding_after_refresh(resharding_done)
 
             # Verify that the special key is loaded by SELECT query
             result = self.target_node.run_cqlsh(query_verify)


### PR DESCRIPTION
[Task](https://trello.com/c/J2hnub1J/2170-nodetool-refresh-resharding-before-uploading)
[Scylla commit](https://github.com/scylladb/scylla/commit/94634d9945064d7be41b21ac2af0ae36cef37873)

Refresh procedure is:

put the db files for refresh in the "upload" folder
run "nodetool refresh"
refresh command will start resharding
files after resharding are placed into "upload" folder
move resharded files from "upload" to main folder

Add the validation to make sure the resharding is performed in the "upload" folder, not main.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
