### PR TITLE
Support to set internode_encryption for server encrypt

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -77,3 +77,4 @@ stop_test_on_stress_failure: true
 
 stress_cdc_log_reader_batching_enable: true
 use_legacy_cluster_init: true
+internode_encryption: 'all'

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1525,7 +1525,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                      listen_on_all_interfaces=False,
                      ip_ssh_connections=None,
                      alternator_enforce_authorization=False,
-                     internode_compression=None):
+                     internode_compression=None,
+                     internode_encryption=None):
         with self.remote_scylla_yaml(yaml_file) as scylla_yml:
             if seed_address:
                 # Set seeds
@@ -1597,7 +1598,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             if server_encrypt or client_encrypt:
                 self.config_client_encrypt()
             if server_encrypt:
-                scylla_yml['server_encryption_options'] = dict(internode_encryption='all',
+                scylla_yml['server_encryption_options'] = dict(internode_encryption=internode_encryption,
                                                                certificate='/etc/scylla/ssl_conf/db.crt',
                                                                keyfile='/etc/scylla/ssl_conf/db.key',
                                                                truststore='/etc/scylla/ssl_conf/cadb.pem')
@@ -3549,7 +3550,8 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                           alternator_port=self.params.get('alternator_port'),
                           murmur3_partitioner_ignore_msb_bits=murmur3_partitioner_ignore_msb_bits,
                           alternator_enforce_authorization=self.params.get('alternator_enforce_authorization'),
-                          internode_compression=self.params.get('internode_compression'))
+                          internode_compression=self.params.get('internode_compression'),
+                          internode_encryption=self.params.get('internode_encryption'))
 
     def node_setup(self, node: BaseNode, verbose: bool = False, timeout: int = 3600, wait_db_up: bool = True):  # pylint: disable=too-many-branches
         node.wait_ssh_up(verbose=verbose, timeout=timeout)

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -859,6 +859,8 @@ class ScyllaAWSCluster(cluster.BaseScyllaCluster, AWSCluster):
             murmur3_partitioner_ignore_msb_bits=murmur3_partitioner_ignore_msb_bits,
             ip_ssh_connections=self.params.get('ip_ssh_connections'),
             alternator_enforce_authorization=self.params.get('alternator_enforce_authorization'),
+            internode_compression=self.params.get('internode_compression'),
+            internode_encryption=self.params.get('internode_encryption'),
         )
         if cluster.Setup.INTRA_NODE_COMM_PUBLIC:
             setup_params.update(dict(

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -946,6 +946,8 @@ class SCTConfiguration(dict):
                   "only effect GCE backend"),
         dict(name="internode_compression", env="SCT_INTERNODE_COMPRESSION", type=str,
              help="scylla option: internode_compression"),
+        dict(name="internode_encryption", env="SCT_INTERNODE_ENCRYPTION", type=str,
+             help="scylla sub option of server_encryption_options: internode_encryption"),
 
         dict(name="loader_swap_size", env="SCT_LOADER_SWAP_SIZE", type=int,
              help="The size of the swap file for the loaders. Its size in bytes calculated by x * 1MB"),

--- a/test-cases/longevity/longevity-counters-multidc.yaml
+++ b/test-cases/longevity/longevity-counters-multidc.yaml
@@ -20,3 +20,4 @@ nemesis_interval: 15
 use_mgmt: true
 
 server_encrypt: true
+internode_encryption: 'dc'

--- a/test-cases/longevity/longevity-lwt-24h-multidc.yaml
+++ b/test-cases/longevity/longevity-lwt-24h-multidc.yaml
@@ -17,4 +17,5 @@ space_node_threshold: 64424
 user_prefix: 'lwt-longevity-multi-dc-24h'
 
 server_encrypt: true
+internode_encryption: 'dc'
 client_encrypt: true


### PR DESCRIPTION
Ticket: https://trello.com/c/8L1hyiKd/2273-support-more-serverencrypt-internode-encryption-options

Currently we always use 'all' for internode_encryption when server encrypt is enabled.
This PR added support to set it, and set 'dc' internode_encryption for two multiple dc longevity jobs.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
