### PR TITLE
fix(manager): deleting automatic repair when adding cluster by default

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3794,7 +3794,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         if not mgr_cluster:
             self.log.debug("Could not find cluster : {} on Manager. Adding it to Manager".format(cluster_name))
             target = self.nodes[0].ip_address
-            mgr_cluster = manager_tool.add_cluster(name=cluster_name, host=target, disable_automatic_repair=True,
+            mgr_cluster = manager_tool.add_cluster(name=cluster_name, host=target,
                                                    auth_token=Setup.tester_obj().monitors.mgmt_auth_token)
         return mgr_cluster
 

--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -846,7 +846,7 @@ class ScyllaManagerTool(ScyllaManagerBase):
     def get_cluster_hosts_with_ips(db_cluster):
         return [[n, n.ip_address] for n in db_cluster.nodes]
 
-    def add_cluster(self, name, host=None, db_cluster=None, client_encrypt=None, disable_automatic_repair=False,  # pylint: disable=too-many-arguments
+    def add_cluster(self, name, host=None, db_cluster=None, client_encrypt=None, disable_automatic_repair=True,  # pylint: disable=too-many-arguments
                     auth_token=None):
         """
         :param name: cluster name


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
