### PR TITLE
fix(scrub nemesis): switch to use nodetool scrub from API

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2191,10 +2191,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         self.log.debug("Rebuild sstable file by scrub, corrupted data file will be skipped.")
         for ks_cf in self.cluster.get_non_system_ks_cf_list(self.target_node):
-            scrub_cmd = 'curl -s -X GET --header "Content-Type: application/json" --header ' \
-                        '"Accept: application/json" "http://127.0.0.1:10000/storage_service/keyspace_scrub/{}?skip_corrupted=true"'.format(
-                            ks_cf.split('.')[0])
-            self.target_node.remoter.run(scrub_cmd)
+            self.target_node.run_nodetool("scrub", args=f"{ks_cf.split('.')[0]}")
 
         self.log.debug('Refreshing the cache by restart the node, and verify the rebuild sstable can be loaded successfully.')
         self.target_node.stop_scylla_server(verify_up=False, verify_down=True)


### PR DESCRIPTION
The sub-command `scrub` had been implemented.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
