### PR TITLE
fix(alternator email failure): check if cluster object was created

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2284,8 +2284,12 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         if self.create_stats:
             nemesis_stats = self.get_doc_data(key='nemesis')
         else:
-            for nem in self.db_cluster.nemesis:
-                nemesis_stats.update(nem.stats)
+            if self.db_cluster:
+                for nem in self.db_cluster.nemesis:
+                    nemesis_stats.update(nem.stats)
+            else:
+                self.log.warning("No nemesises as cluster was not created")
+
         if nemesis_stats:
             for detail in nemesis_stats.values():
                 for run in detail.get('runs', []):


### PR DESCRIPTION
When alternator test failed because of can't receive the instances, email body failed to be created
with exception: 'NoneType' object has no attribute 'nemesis'
It happened when the test is not save the stats (store_results_in_elasticsearch: false)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
