### PR TITLE
fix(gemini-1tb-10h): tune test_duration to meaningfull value

### DIFF
--- a/test-cases/gemini/gemini-1tb-10h.yaml
+++ b/test-cases/gemini/gemini-1tb-10h.yaml
@@ -1,4 +1,4 @@
-test_duration: 6500
+test_duration: 780
 n_db_nodes: 3
 n_test_oracle_db_nodes: 1
 n_loaders: 1


### PR DESCRIPTION
https://trello.com/c/TxFVMgcR/2370-duration-for-sct-runner-is-set-incorrectly
Also fixes - https://github.com/scylladb/scylla-cluster-tests/issues/2661

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
