### PR TITLE
fix(manager-restore): pindown awscli version

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -58,8 +58,7 @@ class BackupFunctionsMixIn:
         cmd = f'''sudo yum install -y epel-release
                   sudo yum install -y python-pip
                   sudo yum remove -y epel-release
-                  sudo pip install awscli
-                  sudo pip install boto3
+                  sudo pip install awscli==1.18.140
                   mkdir -p {destination}'''
         self.run_cmd_with_retry(cmd=cmd, node=node)
 


### PR DESCRIPTION
since https://github.com/boto/boto3/issues/2596 we got the following error:
```
ImportError: cannot import name 'docevents'
```