### PR TITLE
Revert "fix(rolling-upgrade): Removing internode_compression 'all' from upgrades"

### DIFF
--- a/jenkins-pipelines/rolling-upgrade-centos8.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-centos8.jenkinsfile
@@ -14,7 +14,7 @@ rollingUpgradePipeline(
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
     test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
     workaround_kernel_bug_for_iotune: false,
-    internode_compression: 'none',
+    internode_compression: 'all',
 
     timeout: [time: 360, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/rolling-upgrade-ubuntu18.04.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-ubuntu18.04.jenkinsfile
@@ -14,7 +14,7 @@ rollingUpgradePipeline(
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
     test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
     workaround_kernel_bug_for_iotune: false,
-    internode_compression: 'none',
+    internode_compression: 'all',
 
     timeout: [time: 360, unit: 'MINUTES']
 )


### PR DESCRIPTION
This reverts commit 9527209f3d650bab3353e0d205b9a1709510ff63.
Issue #6925 was fixed, reverting the change that removed internode_compression.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
