### PR TITLE
fix(remove spot_low_price): remove hard coded using of spot_low_price provision

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -36,7 +36,7 @@ nemesis_filter_seeds: true
 seeds_selector: "first"
 seeds_num: 1
 
-instance_provision: "spot_low_price"
+instance_provision: "spot"
 spot_max_price: 0.60
 
 execute_post_behavior: false

--- a/test-cases/PR-provision-test.yaml
+++ b/test-cases/PR-provision-test.yaml
@@ -18,7 +18,7 @@ nemesis_class_name: NonDisruptiveMonkey
 nemesis_interval: 1
 
 user_prefix: 'PR-provision-test'
-instance_provision: 'spot_low_price'
+instance_provision: 'spot'
 
 gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
 

--- a/test-cases/artifacts/amazon2.yaml
+++ b/test-cases/artifacts/amazon2.yaml
@@ -4,7 +4,7 @@ aws_root_disk_size_db: 50
 backtrace_decoding: false
 cluster_backend: 'aws'
 instance_type_db: 'i3.large'
-instance_provision: "spot_low_price"
+instance_provision: "spot"
 logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0

--- a/test-cases/artifacts/ami.yaml
+++ b/test-cases/artifacts/ami.yaml
@@ -3,7 +3,7 @@ aws_root_disk_size_db: 50
 backtrace_decoding: false
 cluster_backend: 'aws'
 instance_type_db: 'i3.large'
-instance_provision: "spot_low_price"
+instance_provision: "spot"
 logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0

--- a/test-cases/artifacts/oel76.yaml
+++ b/test-cases/artifacts/oel76.yaml
@@ -4,7 +4,7 @@ aws_root_disk_size_db: 50
 backtrace_decoding: false
 cluster_backend: 'aws'
 instance_type_db: 'i3.large'
-instance_provision: "spot_low_price"
+instance_provision: "spot"
 logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0


### PR DESCRIPTION
According to https://github.com/scylladb/scylla-cluster-tests/pull/2538
change default instance provision type to 'spot'

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
