### PR TITLE
fix(counter_multidc_test): Fix counter multidc test to use public ip

### DIFF
--- a/jenkins-pipelines/longevity-counters-multidc.jenkinsfile
+++ b/jenkins-pipelines/longevity-counters-multidc.jenkinsfile
@@ -9,5 +9,5 @@ longevityPipeline(
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-counters-multidc.yaml',
 
-    timeout: [time: 500, unit: 'MINUTES']
+    timeout: [time: 550, unit: 'MINUTES']
 )

--- a/test-cases/longevity/longevity-counters-multidc.yaml
+++ b/test-cases/longevity/longevity-counters-multidc.yaml
@@ -1,4 +1,4 @@
-test_duration: 400
+test_duration: 500
 
 pre_create_keyspace: "CREATE KEYSPACE scylla_bench WITH replication = {'class': 'NetworkTopologyStrategy', 'us-eastscylla_node_east': '3', 'us-west-2scylla_node_west': '3', 'eu-westscylla_node_west': '3'};"
 stress_cmd:      "scylla-bench -workload=uniform -mode=counter_update -replication-factor=3 -partition-count=1000 -clustering-row-count=10 -concurrency 1024 -duration 360m -validate-data"
@@ -21,3 +21,7 @@ use_mgmt: true
 
 server_encrypt: true
 internode_encryption: 'dc'
+
+ip_ssh_connections: 'public'
+
+use_legacy_cluster_init: false


### PR DESCRIPTION
With multidc tests ip_ssh_connections "public" should be use.
Also fix LongevityTest.test_custom_time method to use
config params pre_create_keyspace if prepare_write_cmd is not set

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (CI)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
