### PR TITLE
fix(wait node up and normal): wait when node setup is competed 

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3604,6 +3604,8 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
 
         if wait_db_up:
             node.wait_db_up(verbose=verbose, timeout=timeout)
+            # Wait the node is UN and then run "nodetool status" to prevent test failure
+            self.wait_for_nodes_up_and_normal(nodes=[node])
             nodes_status = node.get_nodes_status()
             check_nodes_status(nodes_status=nodes_status, current_node=node,
                                removed_nodes_list=self.dead_nodes_ip_address_list)  # pylint: disable=no-member


### PR DESCRIPTION
Rolling upgrade test (running on GCE) failed because of 'nodetool status' was run 30 sec before the
 node setup was completed and ClusterHealthValidator failed the test due node 4 wasn't in the UN
status.
Wait for node up and normal before check node status.

[Task](https://trello.com/c/zhLoxygh/2376-upgrade-test-failed-because-of-last-node-setup-finished-2-minutes-later-then-others)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
