### PR TITLE
fix(get gemini version): email creation fails if loaders were not created

### DIFF
--- a/gemini_test.py
+++ b/gemini_test.py
@@ -97,8 +97,15 @@ class GeminiTest(ClusterTester):
         self.log.info('Prepare data for email')
 
         email_data = self._get_common_email_data()
+
+        if self.loaders:
+            gemini_version = self.loaders.gemini_version
+        else:
+            self.log.warning("Failed to get gemini version as loader instance is not created")
+            gemini_version = ""
+
         email_data.update({"gemini_cmd": self.gemini_results["cmd"],
-                           "gemini_version": self.loaders.gemini_version,
+                           "gemini_version": gemini_version,
                            "nemesis_details": self.get_nemesises_stats(),
                            "nemesis_name": self.params.get("nemesis_class_name"),
                            "number_of_oracle_nodes": self.params.get("n_test_oracle_db_nodes", 1),


### PR DESCRIPTION
If loader was not created (on failed to get spot, for example) email creation failed
with exception: 'NoneType' object has no attribute 'gemini_version'

[Task](https://trello.com/c/Y9PVhXPP/2377-email-is-empty-because-of-exception-nonetype-object-has-no-attribute-geminiversion)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
