### PR TITLE
fix(scylla version for k8s): not check scylla version parameter

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1096,7 +1096,7 @@ class SCTConfiguration(dict):
         dist_version = scylla_linux_distro.split('-')[-1]
 
         if scylla_version:
-            if self.get("cluster_backend") == "docker":
+            if self.get("cluster_backend") in ["docker", "k8s-gce-minikube"]:
                 self.log.info("Assume that Scylla Docker image has repo file pre-installed.")
             elif 'ami_id_db_scylla' not in self and self.get('cluster_backend') == 'aws':
                 ami_list = []


### PR DESCRIPTION
Do not check Scylla version for 'k8s-gce-minikube' backend.
It'll take the docker for selected version

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
