### PR TITLE
feature(nemesis.py): extend no_corrupt_repair

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -611,7 +611,22 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def disrupt_no_corrupt_repair(self):
         self._set_current_disruption('NoCorruptRepair %s' % self.target_node)
-        self.repair_nodetool_repair()
+
+        # prepare test tables and fill test data
+        for i in range(10):
+            self.log.debug('Prepare test tables if they do not exist')
+            self._prepare_test_table(ks='drop_table_during_repair_ks', table=f'drop_table_during_repair_{i}')
+
+        self.log.debug("Start repair target_node in background")
+        thread1 = threading.Thread(target=self.repair_nodetool_repair, name='NodeToolRepairThread', daemon=True)
+        thread1.start()
+
+        # drop test tables one by one during repair
+        for i in range(10):
+            time.sleep(random.randint(0, 300))
+            with self.cluster.cql_connection_patient(self.target_node) as session:
+                session.execute(f'DROP TABLE drop_table_during_repair_ks.drop_table_during_repair_{i}')
+        thread1.join(timeout=120)
 
     def disrupt_major_compaction(self):
         self._set_current_disruption('MajorCompaction %s' % self.target_node)


### PR DESCRIPTION
Ticket: https://trello.com/c/iPWbW9OJ/2166-drop-table-during-repair

There is a new change in scylla to ignore the error of removed table
during repair, this new nemesis covered this case.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
