### PR TITLE
fix(wait node up and normal): wait when node setup is completed

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3024,7 +3024,6 @@ def wait_for_init_wrap(method):
                 start_time = time.perf_counter()
                 node_setup(node)
                 verify_node_setup(start_time)
-                cl_inst.wait_for_nodes_up_and_normal(nodes=init_nodes, verification_node=node)
             else:
                 setup_thread = threading.Thread(target=node_setup, name='NodeSetupThread',
                                                 args=(node,), daemon=True)
@@ -3033,6 +3032,9 @@ def wait_for_init_wrap(method):
 
         while len(results) != len(node_list):
             verify_node_setup(start_time)
+
+        if isinstance(cl_inst, BaseScyllaCluster):
+            cl_inst.wait_for_nodes_up_and_normal(nodes=node_list)
 
         time_elapsed = time.perf_counter() - start_time
         cl_inst.log.debug('Setup duration -> %s s', int(time_elapsed))
@@ -3604,9 +3606,8 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
 
         if wait_db_up:
             node.wait_db_up(verbose=verbose, timeout=timeout)
-            nodes_status = node.get_nodes_status()
-            check_nodes_status(nodes_status=nodes_status, current_node=node,
-                               removed_nodes_list=self.dead_nodes_ip_address_list)  # pylint: disable=no-member
+            # Wait the node is UN and then run "nodetool status"
+            self.wait_for_nodes_up_and_normal(nodes=[node], verification_node=node)
             self.clean_replacement_node_ip(node)
 
     def _scylla_install(self, node):


### PR DESCRIPTION
When cluster setup create the nodes in parallel, may happens that one node setup is completed
and run node status validation for all nodes in time the another node is not UN yet. 
In this case ClusterHealthValidator critical error will be raised and fails the test

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
