### PR TITLE
fix(k8s scylla_repo_loader): not search scylla_repo for loader

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1124,7 +1124,10 @@ class SCTConfiguration(dict):
                 dist_type_loader = scylla_linux_distro_loader.split('-')[0]
                 dist_version_loader = scylla_linux_distro_loader.split('-')[-1]
 
-                self['scylla_repo_loader'] = find_scylla_repo(scylla_version, dist_type_loader, dist_version_loader)
+                scylla_version_for_loader = "nightly" if scylla_version == "latest" else scylla_version
+
+                self['scylla_repo_loader'] = find_scylla_repo(scylla_version_for_loader,
+                                                              dist_type_loader, dist_version_loader)
 
         # 5.1) handle oracle scylla_version if exists
         oracle_scylla_version = self.get('oracle_scylla_version', None)

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -219,6 +219,20 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         self.assertEqual(conf.get('scylla_repo_loader'),
                          "https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-3.0.repo")
 
+    def test_12_k8s_scylla_version_ubuntu_loader_centos(self):  # pylint: disable=invalid-name
+        os.environ['SCT_CLUSTER_BACKEND'] = 'k8s-gce-minikube'
+        os.environ['SCT_SCYLLA_LINUX_DISTRO'] = 'ubuntu-xenial'
+        os.environ['SCT_SCYLLA_LINUX_DISTRO_LOADER'] = 'centos'
+        os.environ['SCT_SCYLLA_VERSION'] = 'latest'
+        conf = SCTConfiguration()
+        conf.verify_configuration()
+
+        self.assertIn('scylla_repo', conf.dump_config())
+        self.assertEqual(conf.get('scylla_repo'),
+                         None)
+        self.assertEqual(conf.get('scylla_repo_loader'),
+                         'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-nightly.repo')
+
     def test_13_scylla_version_ami_branch(self):  # pylint: disable=invalid-name
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
         os.environ['SCT_SCYLLA_VERSION'] = 'branch-3.1:9'


### PR DESCRIPTION
Not search scylla_repo for loader for 'k8s-gce-minikube' backend.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
