### PR TITLE
fix(manager): fixed wait_for_uploading_stage

### DIFF
--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -401,7 +401,7 @@ class BackupTask(ManagerTask):
         full_progress_string = self.sctool.run("task progress {} -c {}".format(self.id, self.cluster_id),
                                                parse_table_res=False,
                                                is_verify_errorless_result=True).stdout.lower()
-        return "upload" in full_progress_string
+        return "uploading data" in full_progress_string.lower()
 
     def wait_for_uploading_stage(self, timeout=1440, step=10):
         text = "Waiting until backup task: {} starts to upload snapshots".format(self.id)


### PR DESCRIPTION
Due to clarification from the manager team, changed the status
the wait_for_uploading_stage function waits for, from 'uploading schema' to 'uploading data',
since 'uploading schema' isn't resumable

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
