### PR TITLE
refactor(manager): Removed Enum from TaskStatus

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -83,8 +83,7 @@ class BackupFunctionsMixIn:
         for node in self.db_cluster.nodes:
             install_dependencies(node=node, destination=self.DESTINATION)
             node_data_path = '/var/lib/scylla/data'
-            nodetool_info = self.db_cluster.get_nodetool_info(node)
-            node_id = nodetool_info['ID']
+            node_id = node.host_id
             for keyspace, tables in keyspace_and_table_list.items():
                 keyspace_path = os.path.join(node_data_path, keyspace)
                 for table in tables:

--- a/mgmt_upgrade_test.py
+++ b/mgmt_upgrade_test.py
@@ -142,8 +142,7 @@ class ManagerUpgradeTest(BackupFunctionsMixIn, ClusterTester):
             per_node_backup_file_paths = mgr_cluster.get_backup_files_dict(
                 snapshot_tag=rerunning_backup_task.get_snapshot_tag())
             for node in self.db_cluster.nodes:
-                nodetool_info = self.db_cluster.get_nodetool_info(node)
-                node_id = nodetool_info['ID']
+                node_id = node.host_id
                 # making sure that the files of the missing table isn't in s3
                 assert "cf1" not in per_node_backup_file_paths[node_id]["ks1"], \
                     "The missing table is still in s3, even though it should have been purged"

--- a/mgmt_upgrade_test.py
+++ b/mgmt_upgrade_test.py
@@ -135,6 +135,10 @@ class ManagerUpgradeTest(BackupFunctionsMixIn, ClusterTester):
             for i in range(2, 4):
                 LOGGER.debug(f"rerunning the backup task for the {i} time")
                 rerunning_backup_task.start(continue_task=False)
+                rerunning_backup_task.wait_and_get_final_status(step=5)
+                assert rerunning_backup_task.status == TaskStatus.DONE, \
+                    f"backup {rerunning_backup_task.id} that was rerun again from the start has failed to reach " \
+                    f"status DONE within expected time limit"
             per_node_backup_file_paths = mgr_cluster.get_backup_files_dict(
                 snapshot_tag=rerunning_backup_task.get_snapshot_tag())
             for node in self.db_cluster.nodes:

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -477,6 +477,14 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
     def region(self):
         raise NotImplementedError()
 
+    @property
+    def host_id(self):
+        full_nodetool_status = self.parent_cluster.get_nodetool_status(verification_node=self)
+        for data_center in full_nodetool_status:
+            if self.ip_address in full_nodetool_status[data_center]:
+                return full_nodetool_status[data_center][self.ip_address]['host_id']
+        raise AssertionError(f"Could not find the requested node {self.ip_address} in nodetool status")
+
     def refresh_ip_address(self):
         self.ssh_login_info["hostname"] = self.external_address
         self.remoter.hostname = self.external_address

--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -83,7 +83,7 @@ class HostRestStatus(Enum):
             raise ScyllaManagerError("Could not recognize returned host rest status: {}".format(output_str))
 
 
-class TaskStatus(Enum):
+class TaskStatus:
     NEW = "NEW"
     RUNNING = "RUNNING"
     DONE = "DONE"
@@ -144,9 +144,6 @@ class ManagerTask(ScyllaManagerBase):
         if not continue_task:
             cmd += " --no-continue"
         self.sctool.run(cmd=cmd, is_verify_errorless_result=True)
-        list_all_task_status = [s for s in TaskStatus.__dict__ if not s.startswith("__")]
-        list_expected_task_status = [status for status in list_all_task_status if status != TaskStatus.STOPPED]
-        return self.wait_for_status(list_status=list_expected_task_status, timeout=30, step=3)
 
     @staticmethod
     def _add_kwargs_to_cmd(cmd, **kwargs):
@@ -343,8 +340,7 @@ class ManagerTask(ScyllaManagerBase):
         :return:
         """
         list_final_status = [TaskStatus.ERROR, TaskStatus.STOPPED, TaskStatus.DONE]
-        LOGGER.debug("Waiting for task: {} getting to a final status ({})..".format(self.id, [str(s) for s in
-                                                                                              list_final_status]))
+        LOGGER.debug("Waiting for task: {} getting to a final status ({})..".format(self.id, str(list_final_status)))
         res = self.wait_for_status(list_status=list_final_status, timeout=timeout, step=step)
         if not res:
             raise ScyllaManagerError("Unexpected result on waiting for task {} status".format(self.id))


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
