### PR TITLE
fix(sdcm/cluster.py): enable coredump collecting on loaders

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -945,6 +945,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         if 'db-node' in self.name:  # this should be replaced when DbNode class will be created
             self.start_backtrace_thread()
             self.start_db_log_reader_thread()
+        elif 'loader' in self.name:
+            self.start_backtrace_thread()
         elif 'monitor' in self.name:
             # TODO: start alert manager thread here when start_task_threads will be run after node setup
             # self.start_alert_manager_thread()
@@ -3874,6 +3876,8 @@ class BaseLoaderSet():
             node.config_client_encrypt()
 
         result = node.remoter.run('test -e ~/PREPARED-LOADER', ignore_status=True)
+        node.remoter.sudo("bash -cxe \"echo '*\t\thard\tcore\t\tunlimited\n*\t\tsoft\tcore\t\tunlimited' "
+                          ">> /etc/security/limits.d/20-coredump.conf\"")
         if result.exit_status == 0:
             self.log.debug('Skip loader setup for using a prepared AMI')
             return


### PR DESCRIPTION
https://trello.com/c/kr7qqiaf/2359-handle-c-s-java-crashes

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
