### PR TITLE
fix(add verification node): set verification node when call wait_for_nodes_up_and_normal

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3066,7 +3066,7 @@ def wait_for_init_wrap(method):
             verify_node_setup(start_time)
 
         if isinstance(cl_inst, BaseScyllaCluster):
-            cl_inst.wait_for_nodes_up_and_normal(nodes=node_list)
+            cl_inst.wait_for_nodes_up_and_normal(nodes=node_list, verification_node=node_list[0])
 
         time_elapsed = time.perf_counter() - start_time
         cl_inst.log.debug('Setup duration -> %s s', int(time_elapsed))


### PR DESCRIPTION
When node setup is performs in parallel and there are non-seed nodes, verification
for seed nodes may fail if verification node is not defined and non-seed node
was selected randomly

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
