### PR TITLE
fix(k8s defaul scylla_version): set default scylla_version to 4.1.7

### DIFF
--- a/vars/operatorPipeline.groovy
+++ b/vars/operatorPipeline.groovy
@@ -19,7 +19,7 @@ def call(Map pipelineParams) {
             string(defaultValue: 'scylladb/scylla-operator:v0.2.3',
                    description: '',
                    name: 'k8s_scylla_operator_docker_image')
-            string(defaultValue: 'latest',
+            string(defaultValue: '4.1.7',
                    description: '',
                    name: 'scylla_version')
             string(defaultValue: '2.0.2',


### PR DESCRIPTION
As we can't use 'latest' in scylla_version (issue
https://github.com/scylladb/scylla-operator/issues/180) change default version
to 4.1.7

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
