### PR TITLE
test(mgmt_upgrade_test.py): Upgrading manager with non default port

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -20,7 +20,8 @@ from invoke import exceptions
 
 from sdcm import mgmt
 from sdcm.group_common_events import ignore_no_space_errors
-from sdcm.mgmt import HostStatus, HostSsl, HostRestStatus, TaskStatus, ScyllaManagerError, ScyllaManagerTool
+from sdcm.mgmt import HostStatus, HostSsl, HostRestStatus, TaskStatus, ScyllaManagerError, ScyllaManagerTool, \
+    SCYLLA_MANAGER_AGENT_YAML_PATH
 from sdcm.nemesis import MgmtRepair, DbEventsFilter
 from sdcm.utils.common import reach_enospc_on_node, clean_enospc_on_node
 from sdcm.tester import ClusterTester
@@ -132,12 +133,11 @@ class BackupFunctionsMixIn:
     def update_config_file(self):
         # FIXME: add to the nodes not in the same region as the bucket the bucket's region
         # this is a temporary fix, after https://github.com/scylladb/mermaid/issues/1456 is fixed, this is not necessary
-        config_file = '/etc/scylla-manager-agent/scylla-manager-agent.yaml'
         if self.params.get('cluster_backend') == 'aws':
             self.region = self.params.get('region_name').split()
             self.bucket_name = f"s3:{self.params.get('backup_bucket_location').split()[0]}"
             for node in self.db_cluster.nodes:
-                mgmt.update_config_file(node=node, region=self.region[0], config_file=config_file)
+                mgmt.update_config_file(node=node, region=self.region[0], config_file=SCYLLA_MANAGER_AGENT_YAML_PATH)
         elif self.params.get('cluster_backend') == 'gce':
             self.region = self.params.get('gce_datacenter')
             self.bucket_name = f"gcs:{self.params.get('backup_bucket_location')}"

--- a/mgmt_upgrade_test.py
+++ b/mgmt_upgrade_test.py
@@ -42,6 +42,12 @@ class ManagerUpgradeTest(BackupFunctionsMixIn, ClusterTester):
         target_upgrade_server_version = self.params.get('target_scylla_mgmt_server_repo')
         target_upgrade_agent_version = self.params.get('target_scylla_mgmt_agent_repo')
         manager_node = self.monitors.nodes[0]
+
+        with manager_node.remote_manager_yaml() as scylla_manager_ymal:
+            node_ip = scylla_manager_ymal["http"].split(":", maxsplit=1)[0]
+            scylla_manager_ymal["http"] = f"{node_ip}:{self.params['mgmt_port']}"
+            scylla_manager_ymal["prometheus"] = f"{node_ip}:{self.params['manager_prometheus_port']}"
+            LOGGER.info("The new Scylla Manager is:\n{}".format(scylla_manager_ymal))
         manager_tool = get_scylla_manager_tool(manager_node=manager_node)
         manager_tool.add_cluster(name="cluster_under_test", db_cluster=self.db_cluster,
                                  auth_token=self.monitors.mgmt_auth_token)

--- a/mgmt_upgrade_test.py
+++ b/mgmt_upgrade_test.py
@@ -2,7 +2,8 @@ import logging
 from time import sleep
 
 from sdcm.tester import ClusterTester
-from sdcm.mgmt import get_scylla_manager_tool, TaskStatus, update_config_file, RepairTask
+from sdcm.mgmt import get_scylla_manager_tool, TaskStatus, update_config_file, RepairTask, \
+    SCYLLA_MANAGER_AGENT_YAML_PATH
 from mgmt_cli_test import BackupFunctionsMixIn
 
 
@@ -160,10 +161,9 @@ class ManagerUpgradeTest(BackupFunctionsMixIn, ClusterTester):
                                                f" is '{current_arg_string}'"
 
     def update_all_agent_config_files(self):
-        config_file = '/etc/scylla-manager-agent/scylla-manager-agent.yaml'
         region_name = self.params.get('region_name').split()[0]
         for node in self.db_cluster.nodes:
-            update_config_file(node=node, region=region_name, config_file=config_file)
+            update_config_file(node=node, region=region_name, config_file=SCYLLA_MANAGER_AGENT_YAML_PATH)
         sleep(60)
 
     def get_email_data(self):

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -85,7 +85,6 @@ TASK_QUEUE = 'task_queue'
 RES_QUEUE = 'res_queue'
 WORKSPACE = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 SCYLLA_YAML_PATH = "/etc/scylla/scylla.yaml"
-SCYLLA_MANAGER_YAML_PATH = "/etc/scylla-manager/scylla-manager.yaml"
 SCYLLA_DIR = "/var/lib/scylla"
 
 INSTANCE_PROVISION_ON_DEMAND = 'on_demand'
@@ -2147,47 +2146,6 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         self.remoter.run(cmd, ignore_status=True, verbose=True)
         self._scylla_manager_journal_thread.join(timeout)
         self._scylla_manager_journal_thread = None
-
-    def config_scylla_manager(self, mgmt_port, db_hosts):
-        """
-        this code was took out from  install_mgmt() method.
-        it may be usefull for manager testing future enhancements.
-
-        Usage may be:
-            if self.params.get('mgmt_db_local', default=True):
-                mgmt_db_hosts = ['127.0.0.1']
-            else:
-                mgmt_db_hosts = [str(trg) for trg in self.targets['db_nodes']]
-            node.config_scylla_manager(mgmt_port=self.params.get('mgmt_port', default=10090),
-                              db_hosts=mgmt_db_hosts)
-
-        :param mgmt_port:
-        :param db_hosts:
-        :return:
-        """
-        # only support for centos
-        self.log.debug('Install scylla-manager')
-        rsa_id_dst = '/tmp/scylla-test'
-        mgmt_conf_tmp = '/tmp/scylla-manager.yaml'
-        mgmt_conf_dst = '/etc/scylla-manager/scylla-manager.yaml'
-
-        mgmt_conf = {'http': '0.0.0.0:{}'.format(mgmt_port),
-                     'database':
-                         {'hosts': db_hosts,
-                          'timeout': '5s'},
-                     'ssh':
-                         {'user': self.ssh_login_info['user'],
-                          'identity_file': rsa_id_dst}
-                     }
-        (_, conf_file) = tempfile.mkstemp(dir='/tmp')
-        with open(conf_file, 'w') as fd:
-            yaml.dump(mgmt_conf, fd, default_flow_style=False)
-        self.remoter.send_files(src=conf_file, dst=mgmt_conf_tmp)  # pylint: disable=not-callable
-        self.remoter.run('sudo cp {} {}'.format(mgmt_conf_tmp, mgmt_conf_dst))
-        if self.is_docker():
-            self.remoter.run('sudo supervisorctl start scylla-manager')
-        else:
-            self.remoter.run('sudo systemctl restart scylla-manager.service')
 
     def start_scylla_server(self, verify_up=True, verify_down=False, timeout=300, verify_up_timeout=300):
         if verify_down:

--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -26,6 +26,8 @@ STATUS_ERROR = 'error'
 MANAGER_IDENTITY_FILE_DIR = '/root/.ssh'
 MANAGER_IDENTITY_FILE_NAME = 'scylla-manager.pem'
 MANAGER_IDENTITY_FILE = os.path.join(MANAGER_IDENTITY_FILE_DIR, MANAGER_IDENTITY_FILE_NAME)
+SCYLLA_MANAGER_YAML_PATH = "/etc/scylla-manager/scylla-manager.yaml"
+SCYLLA_MANAGER_AGENT_YAML_PATH = "/etc/scylla-manager-agent/scylla-manager-agent.yaml"
 SSL_CONF_DIR = '/tmp/ssl_conf'
 SSL_USER_CERT_FILE = SSL_CONF_DIR + '/db.crt'
 SSL_USER_KEY_FILE = SSL_CONF_DIR + '/db.key'
@@ -101,7 +103,7 @@ class TaskStatus(Enum):
             raise ScyllaManagerError("Could not recognize returned task status: {}".format(output_str))
 
 
-def update_config_file(node, region, config_file='/etc/scylla-manager-agent/scylla-manager-agent.yaml'):
+def update_config_file(node, region, config_file=SCYLLA_MANAGER_AGENT_YAML_PATH):
     # FIXME: if the bucket and the node are in the same region, no need to update config file
     # the problem is that with multi DC is that i get 2 regions and 2 buckets:
     # 'us-east-1 us-west-2' and 'manager-backup-tests-us-east-1 manager-backup-tests-eu-west-2'

--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -17,6 +17,7 @@ import requests
 
 
 from sdcm import wait
+from sdcm.remote.remote_file import remote_file
 from sdcm.utils.distro import Distro
 
 LOGGER = logging.getLogger(__name__)

--- a/test-cases/upgrades/manager-upgrade.yaml
+++ b/test-cases/upgrades/manager-upgrade.yaml
@@ -19,7 +19,8 @@ space_node_threshold: 6442
 ip_ssh_connections: 'private'
 
 use_mgmt: true
-mgmt_port: 10090
+mgmt_port: 12345
+manager_prometheus_port: 10091
 scylla_mgmt_agent_repo: "http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.1.repo"
 
 aws_instance_profile_name: 'qa-scylla-manager-backup-instance-profile'


### PR DESCRIPTION
* Create new "remote_scylla_manager_yaml" function under "ScyllaManagerBase" class
* Create new "remote_manager_yaml" function under "BaseNode" class
* Remove "mgmt_port" variable from "manager-upgrade.yaml" and use
   "manager_prometheus_port" variable
* Change the "mgmt_port" to "12345" and "prometheus_port" to "10091"
* Trello URL: https://trello.com/c/NiSj7KwE

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
