### PR TITLE
fix(network exception): add missed network exceptions

### DIFF
--- a/sdcm/remote/__init__.py
+++ b/sdcm/remote/__init__.py
@@ -24,5 +24,7 @@ __all__ = (
 )
 
 
-NETWORK_EXCEPTIONS = RemoteLibSSH2CmdRunner.get_retryable_exceptions() + RemoteCmdRunner.get_retryable_exceptions()
+NETWORK_EXCEPTIONS = (SSHConnectTimeoutError, RetryableNetworkException) + \
+    RemoteLibSSH2CmdRunner.get_retryable_exceptions() + \
+    RemoteCmdRunner.get_retryable_exceptions()
 LOCALRUNNER = LocalCmdRunner()


### PR DESCRIPTION
Two network errors are missed in the exception_retryable:
SSHConnectTimeoutError, RetryableNetworkException

NETWORK_EXCEPTIONS is defined in the sdcm.remote.init.py and collect exception_retryable
values from sdcm/remote/remote_libssh_cmd_runner.py and sdcm/remote/remote_cmd_runner.py.
It used as allowed_exceptions in retrying for get_core_pids.

The coredump thread in the test from description failed because of got SSHConnectTimeoutError.
Because of this exception is not allowed (that is wrong), the exception was raised and
failed the thread.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
