### PR TITLE
fix(partition range validation): fix mistake in partition_range validation

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1365,7 +1365,7 @@ class SCTConfiguration(dict):
 
             partition_range_splitted = partition_range_with_data_validation.split('-')
 
-            if not (partition_range_splitted[0].isdigit() and partition_range_splitted[0].isdigit()):
+            if not (partition_range_splitted[0].isdigit() and partition_range_splitted[1].isdigit()):
                 raise ValueError(error_message_template.format('PK values should be integer. '))
 
             if int(partition_range_splitted[1]) < int(partition_range_splitted[0]):


### PR DESCRIPTION
Fix mistake in partition_range validation

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
