### PR TITLE
Make nemesis restartable

### DIFF
--- a/corrupt_then_rebuild_test.py
+++ b/corrupt_then_rebuild_test.py
@@ -30,7 +30,7 @@ class CorruptThenRebuildTest(ClusterTester):
 
         # run rebuild
         current_nemesis = nemesis.CorruptThenRebuildMonkey(
-            tester_obj=self, termination_event=self.db_cluster.termination_event)
+            tester_obj=self, termination_event=self.db_cluster.nemesis_termination_event)
         current_nemesis.disrupt()
 
         for stress in write_queue:

--- a/destroy_data_then_repair_test.py
+++ b/destroy_data_then_repair_test.py
@@ -27,7 +27,7 @@ class CorruptThenRepair(ClusterTester):
 
         # run rebuild
         current_nemesis = nemesis.CorruptThenRepairMonkey(
-            tester_obj=self, termination_event=self.db_cluster.termination_event)
+            tester_obj=self, termination_event=self.db_cluster.nemesis_termination_event)
         current_nemesis.disrupt()
 
         for stress in write_queue:

--- a/grow_cluster_test.py
+++ b/grow_cluster_test.py
@@ -163,7 +163,7 @@ class GrowClusterTest(ClusterTester):
                 self.log.info('Remove %s nodes from cluster', rm_cnt)
                 for _ in range(rm_cnt):
                     decommision_nemesis = nemesis.DecommissionMonkey(
-                        tester_obj=self, termination_event=self.db_cluster.termination_event)
+                        tester_obj=self, termination_event=self.db_cluster.nemesis_termination_event)
                     decommision_nemesis.disrupt_nodetool_decommission(add_node=False)
             duration = (datetime.datetime.now() - start).seconds / 60  # current duration in minutes
             self.log.info('Count of nodes in cluster: %s', len(self.db_cluster.nodes))

--- a/longevity_lwt_test.py
+++ b/longevity_lwt_test.py
@@ -49,7 +49,6 @@ class LWTLongevityTest(LongevityTest):
             self.start_nemesis()
 
     def start_nemesis(self):
-        self.db_cluster.termination_event.clear()
         self.db_cluster.start_nemesis()
 
     def test_lwt_longevity(self):

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -162,7 +162,7 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         """
         self.generate_load_and_wait_for_results()
         self.log.debug("test_mgmt_cli: initialize MgmtRepair nemesis")
-        mgmt_nemesis = MgmtRepair(tester_obj=self, termination_event=self.db_cluster.termination_event)
+        mgmt_nemesis = MgmtRepair(tester_obj=self, termination_event=self.db_cluster.nemesis_termination_event)
         mgmt_nemesis.disrupt()
 
     def test_mgmt_cluster_crud(self):

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -199,7 +199,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if interval:
             self.interval = interval * 60
         self.log.info('Interval: %s s', self.interval)
-        while not self.termination_event.isSet():
+        while not self.termination_event.is_set():
             cur_interval = self.interval
             self.set_target_node()
             self._set_current_disruption(report=False)


### PR DESCRIPTION
The start_nemesis() function now clears the Event responsible for
telling nemesis threads to stop.

`BaseScyllaCluster.termination_event` was renamed to `BaseScyllaCluster.nemesis_termination_event` since it's only being used to notify nemesis threads to terminate.

Fixes #2724.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
