### PR TITLE
improvement(resharding nemesis): throw event in the resharding Nemesis instead of logging error in the log

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2371,9 +2371,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 self.log.debug(f'Resharding has been finished successfully '
                                f'(murmur3_partitioner_ignore_msb_bits={murmur3_partitioner_ignore_msb_bits})')
             else:
-                self.log.error(f'Resharding has not been started '
-                               f'(murmur3_partitioner_ignore_msb_bits={murmur3_partitioner_ignore_msb_bits}) '
-                               'Check the log for the details')
+                raise Exception(f'Resharding has not been started '
+                                f'(murmur3_partitioner_ignore_msb_bits={murmur3_partitioner_ignore_msb_bits}) '
+                                'Check the log for the details')
             return
         else:
             # Decrease nodetool compactionstats calls from 5sec to 1min to avoid the noise
@@ -2381,9 +2381,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                                                 text="Wait for re-sharding to be finished", status='finish')
 
             if not resharding_finished:
-                self.log.error('Resharding was not finished! '
-                               f'(murmur3_partitioner_ignore_msb_bits={murmur3_partitioner_ignore_msb_bits}) '
-                               'Check the log for the details')
+                raise Exception('Resharding was not finished! '
+                                f'(murmur3_partitioner_ignore_msb_bits={murmur3_partitioner_ignore_msb_bits}) '
+                                'Check the log for the details')
             else:
                 self.log.debug('Resharding has been finished successfully '
                                f'(murmur3_partitioner_ignore_msb_bits={murmur3_partitioner_ignore_msb_bits})')


### PR DESCRIPTION
Throw event in the resharding Nemesis instead of logging error in the log
when reshardin nemesis fails

[Task](https://trello.com/c/UwbOteMi/2318-throw-event-in-the-resharding-nemesis-instead-of-logging-error-in-the-log)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
