### PR TITLE
fix(hydra): clean know hosts when running on SCT Runner

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -118,6 +118,7 @@ if [[ "$1" == "--execute-on-runner" ]]; then
         echo "Going to run a Hydra commands on SCT runner '$SCT_RUNNER_IP'..."
         HOME_DIR="/home/ubuntu"
         echo "Syncing ${SCT_DIR} to the SCT runner instance..."
+        ssh-keygen -R "$SCT_RUNNER_IP" || true
         rsync -ar -e "ssh -o StrictHostKeyChecking=no" --delete ${SCT_DIR} ubuntu@${SCT_RUNNER_IP}:/home/ubuntu/
         if [[ -z "$AWS_OPTIONS" ]]; then
           echo "AWS credentials were not passed using AWS_* environment variables!"


### PR DESCRIPTION
Fixes issue: #2691.

Sometimes it happen that AWS creates a SCT Runner instance
with the same public IP address that was used for other
SCT Runner instance past. In this case Hydra won't start
on that SCT Runner since when running Docker on remote host
we can pass SSH options. Hence we need to clean the known
hosts file.

Example of the error message that we get:
```
15:51:45  docker: error during connect: Post http://docker/v1.40/containers/create?name=c2953363-6dfd-44c6-8d0e-2b6dccc3fd9c_1600865481: command [ssh -l ubuntu -- 13.53.69.113 docker system dial-stdio] has exited with exit status 255, please make sure the URL is valid, and Docker 18.09 or later is installed on the remote host: stderr=@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
15:51:45  @    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @
15:51:45  @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
15:51:45  IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!
15:51:45  Someone could be eavesdropping on you right now (man-in-the-middle attack)!
15:51:45  It is also possible that a host key has just been changed.
15:51:45  The fingerprint for the ECDSA key sent by the remote host is
15:51:45  SHA256:Fx0iXClqOnak5pdT6z6m+ROd5Rs/zzsPbxBxftv9DrA.
15:51:45  Please contact your system administrator.
15:51:45  Add correct host key in /home/jenkins/.ssh/known_hosts to get rid of this message.
15:51:45  Offending ECDSA key in /home/jenkins/.ssh/known_hosts:32
15:51:45    remove with:
15:51:45    ssh-keygen -f "/home/jenkins/.ssh/known_hosts" -R "13.53.69.113"
15:51:45  ECDSA host key for 13.53.69.113 has changed and you have requested strict checking.
15:51:45  Host key verification failed.
```
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
