### PR TITLE
fix(test-cases/longevity/longevity-100gb-4h.yaml): set test_duration to 6 hours

### DIFF
--- a/test-cases/longevity/longevity-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-100gb-4h.yaml
@@ -1,4 +1,4 @@
-test_duration: 260
+test_duration: 360
 
 prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=20971520 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
 


### PR DESCRIPTION
It is currently set to unrealistic 4hours 20 minutes, jobs are unually running for 5hours - 5hours 40 minutes. 

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
