### PR TITLE
fix(rolling upgrade): increase test_duration to 250m

### DIFF
--- a/test-cases/upgrades/rolling-upgrade.yaml
+++ b/test-cases/upgrades/rolling-upgrade.yaml
@@ -1,6 +1,6 @@
 # TODO: need to qualify on GCE and AWS
 
-test_duration: 220
+test_duration: 250
 
 # workloads
 write_stress_during_entire_test: cassandra-stress write no-warmup cl=QUORUM n=20100200 -schema 'keyspace=keyspace_entire_test replication(factor=3) compression=LZ4Compressor' -port jmx=6868 -mode cql3 native compression=lz4 -rate threads=100 -pop seq=1..20100200 -log interval=5


### PR DESCRIPTION
Increase timeout due to the test failures

Failed test example:
https://jenkins.scylladb.com/view/master/job/scylla-master/job/rolling-upgrade/job/rolling-upgrade-ubuntu16.04-test/63/


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
