### PR TITLE
DO NOT MERGE - fix(wait_nodes_up_and_normal): Increased time for wait nodes up and normal

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3510,7 +3510,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                 break
         return node_status
 
-    @retrying(n=60, sleep_time=3, allowed_exceptions=NETWORK_EXCEPTIONS + (ClusterNodesNotReady,),
+    @retrying(n=1800, sleep_time=30, allowed_exceptions=NETWORK_EXCEPTIONS + (ClusterNodesNotReady,),
               message="Waiting for nodes to join the cluster")
     def wait_for_nodes_up_and_normal(self, nodes, verification_node=None):
         self.check_nodes_up_and_normal(nodes=nodes, verification_node=verification_node)


### PR DESCRIPTION
New processes during node bootstrapping such as Resharding/Reshaping
or large set of data (keyspaces/tables/data) could take more time
to joingin node to cluster. For latest test it shows that it could
take up to 15h.
Set new common timeout of waiting nodes up and normal up to 15h.

This commit ab4d88616c5f9022b58845bb0be0d58d27b0e261 added to wait_for_init_wrap
new checks that added nodes are up_and_normal.
But result waiting time in some cases is not enough.

After increasing the result timeout: jobs with/without rbo are passed.
Most critical were 1000 ks.
Without rbo with several decommission successfully passed: https://jenkins.scylladb.com/view/scylla-4.2/job/scylla-4.2/job/Reproducers/job/repo-longevity-multi-keyspaces-rbo-disabled/2 (manually aborted)
with rbo job sucessfully passed:
https://jenkins.scylladb.com/view/scylla-4.2/job/scylla-4.2/job/Reproducers/job/repro-longevity-multi-ks-rbo-enabled/4

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] ~I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)~
- [ ] ~I didn't leave commented-out/debugging code~
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] I~ have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (CI)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
