### PR TITLE
improvement(config_setup): set FinalKillSignal to SIGABRT

### DIFF
--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -23,6 +23,12 @@ SCYLLA_VERSION_RE = re.compile(r"\d+(\.\d+)?\.[\d\w]+([.~][\d\w]+)?")
 SSTABLE_FORMAT_VERSION_REGEX = re.compile(r'Feature (.*)_SSTABLE_FORMAT is enabled')
 PRIMARY_XML_GZ_REGEX = re.compile(r'="(.*?primary.xml.gz)"')
 
+# Example of output for `systemctl --version' command:
+#   $ systemctl --version
+#   systemd 237
+#   +PAM ... default-hierarchy=hybrid
+SYSTEMD_VERSION_RE = re.compile(r"^systemd (?P<version>\d+)")
+
 REPOMD_XML_PATH = "repodata/repomd.xml"
 
 BUILD_ID_RE = re.compile(r"Build ID: (?P<build_id>\w+)")
@@ -174,3 +180,12 @@ def get_node_supported_sstable_versions(node_system_log) -> List[str]:
             if match := SSTABLE_FORMAT_VERSION_REGEX.search(line):
                 output.append(match.group(1).lower())
     return output
+
+
+def get_systemd_version(output: str) -> int:
+    if match := SYSTEMD_VERSION_RE.match(output):
+        try:
+            return int(match.group("version"))
+        except ValueError:
+            pass
+    return 0


### PR DESCRIPTION
Trello: https://trello.com/c/t7H1OopH/2211-in-sct-override-scylla-serverservice-finalkillsignal-to-sigabrt-so-we-can-get-a-core-in-such-cases

This feature supported since systemd v240+ (Debian 10 and Ubuntu 20.04 for now)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
