### PR TITLE
refactor(remote): get rid of unconventional ternary operators

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -49,7 +49,7 @@ from sdcm.collectd import ScyllaCollectdSetup
 from sdcm.mgmt import ScyllaManagerError, update_config_file, SCYLLA_MANAGER_YAML_PATH, SCYLLA_MANAGER_AGENT_YAML_PATH
 from sdcm.prometheus import start_metrics_server, PrometheusAlertManagerListener, AlertSilencer
 from sdcm.log import SDCMAdapter
-from sdcm.remote import RemoteCmdRunnerBase, LOCALRUNNER, NETWORK_EXCEPTIONS
+from sdcm.remote import RemoteCmdRunnerBase, LOCALRUNNER, NETWORK_EXCEPTIONS, shell_script_cmd
 from sdcm.remote.remote_file import remote_file
 from sdcm import wait, mgmt
 from sdcm.utils import alternator
@@ -1671,12 +1671,12 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                                                                "system_info_encryption",
                                                                "kmip_hosts:", )):
                 self.remoter.send_files(src="./data_dir/encrypt_conf", dst="/tmp/")
-                self.remoter.run_shell_script("""\
+                self.remoter.sudo(shell_script_cmd("""\
                     rm -rf /etc/encrypt_conf
                     mv -f /tmp/encrypt_conf /etc
                     mkdir -p /etc/scylla/encrypt_conf /etc/encrypt_conf/system_key_dir
                     chown -R scylla:scylla /etc/scylla /etc/encrypt_conf
-                """, sudo=True)
+                """))
                 self.remoter.sudo("md5sum /etc/encrypt_conf/*.pem", ignore_status=True)
 
         if append_scylla_args:
@@ -3182,12 +3182,12 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             else:
                 binary_path = '/usr/bin/scylla'
             # replace the binary
-            node.remoter.run_shell_script(f"""\
+            node.remoter.sudo(shell_script_cmd(f"""\
                 cp -f {binary_path} {binary_path}.origin
                 cp -f /tmp/scylla {binary_path}
                 chown root:root {binary_path}
                 chmod +x {binary_path}
-            """, sudo=True)
+            """))
             _queue.put(node)
             _queue.task_done()
 
@@ -3765,10 +3765,10 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             node.stop_scylla_server()
 
         for node in self.nodes:
-            node.remoter.run_shell_script(f"""\
+            node.remoter.sudo(shell_script_cmd(f"""\
                 rm -rf '/var/lib/scylla/data/{ks}'
                 cp -r '/var/lib/scylla/data/{backup_name}' '/var/lib/scylla/data/{ks}'
-            """, sudo=True)
+            """))
 
         for node in self.nodes:
             node.start_scylla_server()

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -34,7 +34,7 @@ from invoke.exceptions import UnexpectedExit
 
 from sdcm import cluster, cluster_gce, cluster_docker
 from sdcm.cluster import ClusterNodesNotReady
-from sdcm.remote import LOCALRUNNER
+from sdcm.remote import LOCALRUNNER, shell_script_cmd
 from sdcm.remote.kubernetes_cmd_runner import KubernetesCmdRunner
 from sdcm.sct_config import sct_abs_path
 from sdcm.sct_events import TestFrameworkEvent
@@ -808,7 +808,7 @@ class MinikubeScyllaPodCluster(ScyllaPodCluster):
             LOGGER.debug("Found following nodes to apply new iptables rules: %s", nodes_to_update)
             iptables_rules = "\n".join(self.nodes_iptables_redirect_rules(command=command, nodes=nodes))
             for node in nodes_to_update:
-                node.remoter.run_shell_script(cmd=iptables_rules, sudo=True)
+                node.remoter.sudo(shell_script_cmd(iptables_rules))
 
     def add_nodes(self,
                   count: int,
@@ -826,10 +826,12 @@ class MinikubeScyllaPodCluster(ScyllaPodCluster):
                                            selector=f"statefulset.kubernetes.io/pod-name={node.name}",
                                            namespace=self.namespace)
 
-        LOCALRUNNER.run_shell_script(cmd="\n".join(self.hydra_iptables_redirect_rules(nodes=new_nodes)), sudo=True)
-        atexit.register(LOCALRUNNER.run_shell_script,
-                        cmd="\n".join(self.hydra_iptables_redirect_rules(command="D", nodes=new_nodes)),
-                        sudo=True)
+        add_rules_commands = self.hydra_iptables_redirect_rules(nodes=new_nodes)
+        del_rules_commands = self.hydra_iptables_redirect_rules(command="D", nodes=new_nodes)
+
+        LOCALRUNNER.sudo(shell_script_cmd("\n".join(add_rules_commands)))
+        atexit.register(LOCALRUNNER.sudo, shell_script_cmd("\n".join(del_rules_commands)))
+
         self.update_nodes_iptables_redirect_rules(nodes=new_nodes)
 
         return new_nodes

--- a/sdcm/remote/__init__.py
+++ b/sdcm/remote/__init__.py
@@ -15,12 +15,13 @@ from .local_cmd_runner import LocalCmdRunner
 from .remote_cmd_runner import RemoteCmdRunner
 from .remote_libssh_cmd_runner import RemoteLibSSH2CmdRunner
 from .remote_base import RemoteCmdRunnerBase
-from .base import FailuresWatcher, RetryableNetworkException, SSHConnectTimeoutError
+from .base import FailuresWatcher, RetryableNetworkException, SSHConnectTimeoutError, shell_script_cmd
 
 
 __all__ = (
     'LocalCmdRunner', 'RemoteLibSSH2CmdRunner', 'RemoteCmdRunner', 'NETWORK_EXCEPTIONS', 'LOCALRUNNER',
-    'RemoteCmdRunnerBase', 'FailuresWatcher', 'RetryableNetworkException', 'SSHConnectTimeoutError'
+    'RemoteCmdRunnerBase', 'FailuresWatcher', 'RetryableNetworkException', 'SSHConnectTimeoutError',
+    'shell_script_cmd',
 )
 
 

--- a/sdcm/remote/base.py
+++ b/sdcm/remote/base.py
@@ -11,7 +11,7 @@
 #
 # Copyright (c) 2020 ScyllaDB
 
-from typing import Optional, List
+from typing import Optional, List, Callable
 from abc import abstractmethod, ABCMeta
 import shlex
 import logging
@@ -126,29 +126,6 @@ class CommandRunner(metaclass=ABCMeta):
                         log_file=log_file,
                         retry=retry,
                         watchers=watchers)
-
-    # pylint: disable=too-many-arguments
-    def run_shell_script(self,
-                         cmd: str,
-                         timeout: Optional[float] = None,
-                         ignore_status: bool = False,
-                         verbose: bool = True,
-                         new_session: bool = False,
-                         log_file: Optional[str] = None,
-                         retry: int = 1,
-                         watchers: Optional[List[StreamWatcher]] = None,
-                         sudo: bool = False,
-                         shell_cmd: str = "bash -cxe",
-                         quote: str = '"',
-                         preprocessor=dedent) -> Result:
-        return (self.sudo if sudo else self.run)(cmd=f"{shell_cmd} {quote}{preprocessor(cmd)}{quote}",
-                                                 timeout=timeout,
-                                                 ignore_status=ignore_status,
-                                                 verbose=verbose,
-                                                 new_session=new_session,
-                                                 log_file=log_file,
-                                                 retry=retry,
-                                                 watchers=watchers)
 
     @abstractmethod
     def _create_connection(self):
@@ -303,3 +280,10 @@ class FailuresWatcher(Responder):
             self.callback(self.sentinel, line)
         if self.raise_exception:
             raise OutputCheckError(err)
+
+
+def shell_script_cmd(cmd: str,
+                     shell_cmd: str = "bash -cxe",
+                     quote: str = '"',
+                     preprocessor: Callable[[str], str] = dedent) -> str:
+    return f"{shell_cmd} {quote}{preprocessor(cmd)}{quote}"

--- a/sdcm/remote/remote_file.py
+++ b/sdcm/remote/remote_file.py
@@ -50,6 +50,7 @@ def remote_file(remoter, remote_path, serializer=StringIO.getvalue, deserializer
     LOGGER.debug("New content of `%s':\n%s", remote_path, content)
 
     remote_tempfile = remoter.run("mktemp").stdout.strip()
+    remote_tempfile_move_cmd = f"mv '{remote_tempfile}' '{remote_path}'"
     wait.wait_for(remoter.send_files,
                   step=10,
                   text=f"Waiting for updating of `{remote_path}' on {remoter.hostname}",
@@ -57,4 +58,7 @@ def remote_file(remoter, remote_path, serializer=StringIO.getvalue, deserializer
                   throw_exc=True,
                   src=local_tempfile,
                   dst=remote_tempfile)
-    (remoter.sudo if sudo else remoter.run)(f"mv '{remote_tempfile}' '{remote_path}'")
+    if sudo:
+        remoter.sudo(remote_tempfile_move_cmd)
+    else:
+        remoter.run(remote_tempfile_move_cmd)

--- a/unit_tests/test_remoter.py
+++ b/unit_tests/test_remoter.py
@@ -21,7 +21,7 @@ from logging import getLogger
 from parameterized import parameterized
 
 from sdcm.remote import RemoteLibSSH2CmdRunner, RemoteCmdRunner, LocalCmdRunner, RetryableNetworkException, \
-    SSHConnectTimeoutError
+    SSHConnectTimeoutError, shell_script_cmd
 from sdcm.remote.base import CommandRunner, Result
 from sdcm.remote.remote_file import remote_file
 
@@ -358,15 +358,8 @@ class TestSudoAndRunShellScript(unittest.TestCase):
         remoter.sudo("true")
         self.assertEqual(remoter.command_to_run, "sudo true")
 
-    def test_run_shell_script(self):
-        remoter = self.remoter_cls("localhost")
-        remoter.run_shell_script("true")
-        self.assertEqual(remoter.command_to_run, 'bash -cxe "true"')
-
-    def test_run_shell_script_sudo(self):
-        remoter = self.remoter_cls("localhost", user="joe")
-        remoter.run_shell_script("true", sudo=True)
-        self.assertEqual(remoter.command_to_run, 'sudo bash -cxe "true"')
+    def test_shell_script_cmd(self):
+        self.assertEqual(shell_script_cmd("true"), 'bash -cxe "true"')
 
 
 class TestRemoteFile(unittest.TestCase):


### PR DESCRIPTION
Address the latest changes in [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI) about usage of ternary operator.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
