### PR TITLE
fix(stop_scylla_server): Added workaround for stop scylla server

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2181,7 +2181,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         if verify_up:
             self.wait_jmx_up(timeout=timeout)
 
-    @retrying(n=3, sleep_time=5, allowed_exceptions=NETWORK_EXCEPTIONS,
+    @retrying(n=3, sleep_time=5, allowed_exceptions=NETWORK_EXCEPTIONS + (CommandTimedOut, ),
               message="Failed to stop scylla.server, retrying...")
     def stop_scylla_server(self, verify_up=False, verify_down=True, timeout=300, ignore_status=False):
         if verify_up:

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -506,7 +506,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.target_node.run_nodetool("status", ignore_status=True, verbose=True)
 
         if result is not None:
-            self.target_node.stop_scylla_server(verify_up=False, verify_down=True)
+            # workaround for issue #7332: don't interrupt test and don't raise exception
+            # for UnexpectedExit, Failure and CommandTimedOut if "scylla-server stop" failed
+            # or scylla-server was stopped gracefully.
+            self.target_node.stop_scylla_server(verify_up=False, verify_down=True, ignore_status=True)
             self.target_node.start_scylla_server(verify_up=True, verify_down=False)
 
     @retrying(n=3, sleep_time=60, allowed_exceptions=(NodeSetupFailed, NodeSetupTimeout))


### PR DESCRIPTION
After node drained, stopping scylla server could cause an issue https://github.com/scylladb/scylla/issues/7332.
But if stopping scylla sever failed, the next start could successuly
executed.
Added workaround: not fail nemesis just report the error

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (CI)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
