### PR TITLE
refactor(runSctTest): simplify 'params.x is null or empty string' case

### DIFF
--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -1,7 +1,7 @@
 #! groovy
 
 def call(Map pipelineParams) {
-    def builder = getJenkinsLabels(params.backend, params.get('region_name', 'eu-west-1'))
+    def builder = getJenkinsLabels(params.backend, params.region_name))
 
     pipeline {
         agent {

--- a/vars/cdcReplicationPipeline.groovy
+++ b/vars/cdcReplicationPipeline.groovy
@@ -40,7 +40,7 @@ def runSctTest(Map params, String region){
     export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
     export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
     export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"
-    export SCT_INSTANCE_PROVISION="${params.get('provision_type', '')}"
+    export SCT_INSTANCE_PROVISION="${params.provision_type}"
     export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$GIT_BRANCH | sed -E 's+(origin/|origin/branch-)++')
     export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$SCT_AMI_ID_DB_SCYLLA_DESC | tr ._ - | cut -c1-8 )
 

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -186,7 +186,7 @@ def call(Map pipelineParams) {
                                         export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
                                         export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
                                         export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"
-                                        export SCT_INSTANCE_PROVISION="${pipelineParams.params.get('provision_type', '')}"
+                                        export SCT_INSTANCE_PROVISION="${params.provision_type}"
                                         export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$GIT_BRANCH | sed -E 's+(origin/|origin/branch-)++')
                                         export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$SCT_AMI_ID_DB_SCYLLA_DESC | tr ._ - | cut -c1-8 )
 

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -112,7 +112,7 @@ def call(Map pipelineParams) {
                                                         export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
                                                         export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
                                                         export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"
-                                                        export SCT_INSTANCE_PROVISION=${pipelineParams.params.get('provision_type', '')}
+                                                        export SCT_INSTANCE_PROVISION=${params.provision_type}
                                                         export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$GIT_BRANCH | sed -E 's+(origin/|origin/branch-)++')
                                                         export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$SCT_AMI_ID_DB_SCYLLA_DESC | tr ._ - | cut -c1-8 )
 

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -82,7 +82,7 @@ def call(Map pipelineParams) {
                                                         export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
                                                         export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
                                                         export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"
-                                                        export SCT_INSTANCE_PROVISION="${pipelineParams.params.get('provision_type', '')}"
+                                                        export SCT_INSTANCE_PROVISION="${params.provision_type}"
                                                         export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$GIT_BRANCH | sed -E 's+(origin/|origin/branch-)++')
                                                         export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$SCT_AMI_ID_DB_SCYLLA_DESC | tr ._ - | cut -c1-8 )
 

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -5,14 +5,6 @@ def call(Map params, String region){
     def aws_region = initAwsRegionParam(params.aws_region, region)
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)
     def cloud_provider = params.backend.trim().toLowerCase()
-    def update_db_packages = ""
-    if ( params.update_db_packages != null ) {
-        update_db_packages = params.update_db_packages
-    }
-    def instance_provision_fallback_on_demand = ""
-    if ( params.instance_provision_fallback_on_demand != null ) {
-        instance_provision_fallback_on_demand = params.instance_provision_fallback_on_demand
-    }
 
     sh """
     #!/bin/bash
@@ -41,11 +33,11 @@ def call(Map params, String region){
     export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
     export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"
     export SCT_INSTANCE_PROVISION="${params.provision_type}"
-    export SCT_INSTANCE_PROVISION_FALLBACK_ON_DEMAND="${instance_provision_fallback_on_demand}"
+    export SCT_INSTANCE_PROVISION_FALLBACK_ON_DEMAND="${params.instance_provision_fallback_on_demand ? params.instance_provision_fallback_on_demand : ''}"
     export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$GIT_BRANCH | sed -E 's+(origin/|origin/branch-)++')
     export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$SCT_AMI_ID_DB_SCYLLA_DESC | tr ._ - | cut -c1-8 )
-    if [[ -n "${update_db_packages}" ]] ; then
-        export SCT_UPDATE_DB_PACKAGES="${update_db_packages}"
+    if [[ "${params.update_db_packages || false}" == "true" ]] ; then
+        export SCT_UPDATE_DB_PACKAGES="${params.update_db_packages}"
     fi
 
     export SCT_TAG_AMI_WITH_RESULT="${params.tag_ami_with_result}"


### PR DESCRIPTION
In discussion with @dkropachev, we found a better way to perform check "params.x is null or empty string".

The problem that `params` is unmodifiable Map and call `params.get(key, default_value)` will throw exception if there is no such key:

```groovy
>>> ["x": ""].asUnmodifiable().get("y", "")

java.lang.UnsupportedOperationException
	at Script1.run(Script1.groovy:1)
```

This PR demonstrates two ways around this issue:

1. Just check (unfortunately, `x as Boolean` will return `null` if `x` is `null`):

```groovy

>>> def map = ["x": "", "y": "foo"].asUnmodifiable()
>>> println(map.z || false)
false

>>> println(map.x || false)
false 

>>> println(map.y || false)
true
```

2. Emulate .get() with default value:

```groovy 
>>> def map = ["x": "", "y": "foo"].asUnmodifiable()
>>> println(map.z ? map.z : "bar")
bar

>>> println(map.x ? map.x : "bar")
bar 

>>> println(map.y ? map.y : "bar")
foo

```

Also removed all occurrences of `params.get(key, default_value)` in our jobs.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
