### PR TITLE
fix(loader): bring shard awarness back

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -7,25 +7,25 @@ instance_type_loader: 'c5.xlarge'
 instance_type_monitor: 't3.large'
 regions_data:
   us-east-1: # US East (N. Virginia)
-    ami_id_loader: 'ami-0d4b148c38f2a4308' # Loader dedicated AMI v13
+    ami_id_loader: 'ami-08516c9b78d5d6d1e' # Loader dedicated AMI v16
     ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
     backup_bucket_location: 'manager-backup-tests-us-east-1'
   us-west-2: # US West (Oregon)
-    ami_id_loader: 'ami-09a0be4a0ca76e866' # Loader dedicated AMI v13
+    ami_id_loader: 'ami-06adafd91151c1334' # Loader dedicated AMI v16
     ami_id_monitor: 'ami-01ed306a12b7d1c96' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
     backup_bucket_location: 'manager-backup-tests-eu-west-2'
   eu-west-1: # Europe (Ireland)
-    ami_id_loader: 'ami-057289dc761a68962' # Loader dedicated AMI v13
+    ami_id_loader: 'ami-0c58e9a952081d5d9' # Loader dedicated AMI v16
     ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
     backup_bucket_location: 'manager-backup-tests-eu-west-1'
   eu-west-2: # Europe (London)
-    ami_id_loader: 'ami-0da9b678f6ae18c7a' # Loader dedicated AMI v13
+    ami_id_loader: 'ami-03071e9f413b8e2bd' # Loader dedicated AMI v16
     ami_id_monitor: 'ami-0eab3a90fc693af19' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
   eu-north-1: # Europe (Stockholm)
-    ami_id_loader: 'ami-0cf6766b00fd3e649' # Loader dedicated AMI v13
+    ami_id_loader: 'ami-0e7be192027c68454' # Loader dedicated AMI v16
     ami_id_monitor: 'ami-5ee66f20' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
   eu-central-1: # Europe (Frankfurt)
-    ami_id_loader: 'ami-04089daa36f57a348' # Loader dedicated AMI v13
+    ami_id_loader: 'ami-01765997963d20e38' # Loader dedicated AMI v16
     ami_id_monitor: 'ami-04cf43aca3e6f3de3' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
 
 availability_zone: 'a'

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -523,7 +523,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
     def cassandra_stress_version(self):
         if not self._cassandra_stress_version:
             result = self.remoter.run(cmd="cassandra-stress version", ignore_status=True, verbose=True)
-            match = re.match("Version: (.*)", result.stdout)
+            match = re.search("Version: (.*)", result.stdout)
             if match:
                 self._cassandra_stress_version = match.group(1)
             else:


### PR DESCRIPTION
https://trello.com/c/fnElfYAu/2397-c-s-fails-with-cannot-initialize-optimized-memory-deallocator-some-data-both-in-memory-and-on-disk-may-live-longer-due-to-garbag

Somewhere on the way to new loader we have introduced cassandra-driver jars into to the lib directory on the loader.
As result c-s started to use cassandra-driver instead of scylla-driver and we lost shard awarness due to that.
This PR is to bring it back.  

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
