### PR TITLE
fix(5000 tables test): increase nemesis interval

### DIFF
--- a/test-cases/longevity/longevity-5000-tables.yaml
+++ b/test-cases/longevity/longevity-5000-tables.yaml
@@ -31,7 +31,7 @@ regions_data:
 cluster_health_check: false
 
 nemesis_class_name: 'ChaosMonkey'
-nemesis_interval: 30
+nemesis_interval: 60
 
 store_results_in_elasticsearch: False
 


### PR DESCRIPTION
Increase nemesis interval to 60 min. We need it to low nemesis impact on the test.

Fix instead of PR #2405 .

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
