### PR TITLE
improvement(increase fd limit): Increase limit of open FDs on SCT runners

### DIFF
--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -27,7 +27,7 @@ class ImageType(Enum):
 
 class SctRunner:
     """Provisions and configures the SCT runner"""
-    VERSION = 1.1  # Version of the Image
+    VERSION = 1.2  # Version of the Image
     IMAGE_NAME = f"sct-runner-{VERSION}"
     NODE_TYPE = "sct-runner"
     RUNNER_NAME = "SCT-Runner"
@@ -67,6 +67,9 @@ class SctRunner:
         LOGGER.info("Installing required packages...")
         prereqs_script = dedent(f"""
             echo "fs.aio-max-nr = 65536" >> /etc/sysctl.conf
+            echo "ubuntu soft nofile 4096" >> /etc/security/limits.conf
+            echo "jenkins soft nofile 4096" >> /etc/security/limits.conf
+            echo "root soft nofile 4096" >> /etc/security/limits.conf
             mkdir -p -m 777 /home/ubuntu/sct-results
             chown ubuntu:ubuntu /home/ubuntu/sct-results
             echo "cd ~/sct-results" >> /home/ubuntu/.bashrc
@@ -94,6 +97,7 @@ class SctRunner:
             # Jenkins pipelines run /bin/sh for some reason
             unlink /bin/sh
             ln -s /bin/bash /bin/sh
+
         """)
         remoter = self.get_remoter(host=public_ip)
         result = remoter.run(f"sudo bash -cxe '{prereqs_script}'", ignore_status=True)


### PR DESCRIPTION
Set soft limit on SCT Runner to 4096. Opened FDs limit could be a reason, why the job with 5000
tables failed on during attempt to connect to Scylla server

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
