### PR TITLE
Support ScyllaDB YCSB workload

### DIFF
--- a/longevity_test.py
+++ b/longevity_test.py
@@ -513,11 +513,18 @@ class LongevityTest(ClusterTester):
                             self.log.debug('extra definition for [{}] exists [{}]'.format(table_name, str(exc)))
 
     def _pre_create_keyspace(self):
-        query = self.params.get('pre_create_keyspace')
+        cmds = self.params.get('pre_create_keyspace')
         node = self.db_cluster.nodes[0]
-        # pylint: disable=no-member
-        with self.db_cluster.cql_connection_patient(node) as session:
-            session.execute(query)
+
+        if not isinstance(cmds, list):
+            cmds = [cmds]
+
+        for cmd in cmds:
+            # Run all stress commands
+            self.log.debug('pre_create_keyspace cmd: {}'.format(cmd))
+            # pylint: disable=no-member
+            with self.db_cluster.cql_connection_patient(node) as session:
+                session.execute(cmd)
 
     def _flush_all_nodes(self):
         """

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -847,6 +847,8 @@ class LoaderLogCollector(LogCollector):
                 search_locally=True),
         FileLog(name='*cassandra-stress*.log',
                 search_locally=True),
+        FileLog(name='*ycsb*.log',
+                search_locally=True),
         FileLog(name='*gemini-l*.log',
                 search_locally=True),
         FileLog(name='gemini_result*.log',

--- a/test-cases/longevity/longevity-ycsb-a-10M.yaml
+++ b/test-cases/longevity/longevity-ycsb-a-10M.yaml
@@ -1,0 +1,60 @@
+# [Ivan]: I am currently testing CRDB vs ScyllaDB with YCSB workloads.
+#         This scenario shows how to run YCSB workload A against Scylla.
+#         It can be run with Jenkins BYO as in https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/ivan/job/ivan-byo-longevity/23/:
+#         test_name: longevity_test.LongevityTest.test_custom_time.
+#
+# avg load speed per 2*2*128 threads 44K ops/s each
+# 10M / 44K = ~3 minutes
+#
+# 240 = 4 hours * 60
+# 480 = 8 hours * 60
+# 10900 = 7 days * 24 hours a day * 60 minutes an hour
+test_duration: 480
+
+pre_create_keyspace: [
+  "CREATE KEYSPACE ycsb WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor': 3 };",
+  "CREATE TABLE ycsb.usertable (y_id varchar primary key, field0 varchar, field1 varchar, field2 varchar, field3 varchar, field4 varchar, field5 varchar, field6 varchar, field7 varchar, field8 varchar, field9 varchar);"
+]
+
+prepare_write_cmd:
+  - >-
+    bin/ycsb load cassandra-cql -P workloads/workloada -threads 128 -p recordcount=10000000
+    -p cassandra.readconsistencylevel=ONE -p cassandra.writeconsistencylevel=ONE
+    -p readproportion=0 -p updateproportion=1
+    -p fieldcount=10 -p fieldlength=128
+    -p insertstart=0 -p insertcount=5000000
+    -p cassandra.username=cassandra -p cassandra.password=cassandra
+
+  - >-
+    bin/ycsb load cassandra-cql -P workloads/workloada -threads 128 -p recordcount=10000000
+    -p cassandra.readconsistencylevel=ONE -p cassandra.writeconsistencylevel=ONE
+    -p readproportion=0 -p updateproportion=1
+    -p fieldcount=10 -p fieldlength=128
+    -p insertstart=5000000 -p insertcount=5000000
+    -p cassandra.username=cassandra -p cassandra.password=cassandra
+
+stress_cmd: [
+    "bin/ycsb run cassandra-cql -P workloads/workloada -threads 35 -p recordcount=10000000 -p fieldcount=10 -p fieldlength=128 -p operationcount=10000000 -p cassandra.username=cassandra -p cassandra.password=cassandra",
+    "bin/ycsb run cassandra-cql -P workloads/workloada -threads 35 -p recordcount=10000000 -p fieldcount=10 -p fieldlength=128 -p operationcount=10000000 -p cassandra.username=cassandra -p cassandra.password=cassandra",
+]
+
+round_robin: true
+
+n_db_nodes: 3
+n_loaders: 2
+n_monitor_nodes: 1
+
+instance_type_db: 'i3.4xlarge'
+instance_type_loader: 'm5.2xlarge' # 8 vCPU (4 cores), 32 GB RAM
+
+nemesis_class_name: 'NoOpMonkey'
+nemesis_interval: 5
+
+authenticator: 'PasswordAuthenticator'
+authenticator_user: cassandra
+authenticator_password: cassandra
+authorizer: 'CassandraAuthorizer'
+
+user_prefix: 'longevity-ycsb-a-10M-8h'
+space_node_threshold: 64424
+store_results_in_elasticsearch: false

--- a/test-cases/longevity/longevity-ycsb-a-1B.yaml
+++ b/test-cases/longevity/longevity-ycsb-a-1B.yaml
@@ -1,0 +1,78 @@
+# [Ivan]: I am currently testing CRDB vs ScyllaDB with YCSB workloads.
+#         This scenario shows how to run YCSB workload A against Scylla.
+#         It can be run with Jenkins BYO as in https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/ivan/job/ivan-byo-longevity/23/:
+#         test_name: longevity_test.LongevityTest.test_custom_time.
+#
+# avg load speed per 2*2*128 threads 44K ops/s each
+# 10M / 44K = ~3 minutes
+# 1B / 44K = ~63 hours
+#
+# 10900 = 7 days * 24 hours a day * 60 minutes an hour
+test_duration: 10900
+
+pre_create_keyspace: [
+  "CREATE KEYSPACE ycsb WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor': 3 };",
+  "CREATE TABLE ycsb.usertable (y_id varchar primary key, field0 varchar, field1 varchar, field2 varchar, field3 varchar, field4 varchar, field5 varchar, field6 varchar, field7 varchar, field8 varchar, field9 varchar);"
+]
+
+prepare_write_cmd:
+  - >-
+    bin/ycsb load cassandra-cql -P workloads/workloada -threads 128 -p recordcount=1000000000
+    -p cassandra.readconsistencylevel=ONE -p cassandra.writeconsistencylevel=ONE
+    -p readproportion=0 -p updateproportion=1
+    -p fieldcount=10 -p fieldlength=128
+    -p insertstart=0 -p insertcount=250000000
+    -p cassandra.username=cassandra -p cassandra.password=cassandra
+
+  - >-
+    bin/ycsb load cassandra-cql -P workloads/workloada -threads 128 -p recordcount=1000000000
+    -p cassandra.readconsistencylevel=ONE -p cassandra.writeconsistencylevel=ONE
+    -p readproportion=0 -p updateproportion=1
+    -p fieldcount=10 -p fieldlength=128
+    -p insertstart=250000000 -p insertcount=250000000
+    -p cassandra.username=cassandra -p cassandra.password=cassandra
+
+  - >-
+    bin/ycsb load cassandra-cql -P workloads/workloada -threads 128 -p recordcount=1000000000
+    -p cassandra.readconsistencylevel=ONE -p cassandra.writeconsistencylevel=ONE
+    -p readproportion=0 -p updateproportion=1
+    -p fieldcount=10 -p fieldlength=128
+    -p insertstart=500000000 -p insertcount=250000000
+    -p cassandra.username=cassandra -p cassandra.password=cassandra
+
+  - >-
+    bin/ycsb load cassandra-cql -P workloads/workloada -threads 128 -p recordcount=1000000000
+    -p cassandra.readconsistencylevel=ONE -p cassandra.writeconsistencylevel=ONE
+    -p readproportion=0 -p updateproportion=1
+    -p fieldcount=10 -p fieldlength=128
+    -p insertstart=750000000 -p insertcount=250000000
+    -p cassandra.username=cassandra -p cassandra.password=cassandra
+
+stress_cmd: [
+    "bin/ycsb run cassandra-cql -P workloads/workloada -threads 128 -p recordcount=1000000000 -p fieldcount=10 -p fieldlength=128 -p operationcount=2140000000 -p cassandra.username=cassandra -p cassandra.password=cassandra",
+    "bin/ycsb run cassandra-cql -P workloads/workloada -threads 128 -p recordcount=1000000000 -p fieldcount=10 -p fieldlength=128 -p operationcount=2140000000 -p cassandra.username=cassandra -p cassandra.password=cassandra",
+    "bin/ycsb run cassandra-cql -P workloads/workloada -threads 128 -p recordcount=1000000000 -p fieldcount=10 -p fieldlength=128 -p operationcount=2140000000 -p cassandra.username=cassandra -p cassandra.password=cassandra",
+    "bin/ycsb run cassandra-cql -P workloads/workloada -threads 128 -p recordcount=1000000000 -p fieldcount=10 -p fieldlength=128 -p operationcount=2140000000 -p cassandra.username=cassandra -p cassandra.password=cassandra",
+    "bin/ycsb run cassandra-cql -P workloads/workloada -threads 128 -p recordcount=1000000000 -p fieldcount=10 -p fieldlength=128 -p operationcount=2140000000 -p cassandra.username=cassandra -p cassandra.password=cassandra"
+]
+
+round_robin: true
+
+n_db_nodes: 3
+n_loaders: 5
+n_monitor_nodes: 1
+
+instance_type_db: 'i3.4xlarge'
+instance_type_loader: 'm5.2xlarge' # 8 vCPU (4 cores), 32 GB RAM
+
+nemesis_class_name: 'NoOpMonkey'
+nemesis_interval: 5
+
+authenticator: 'PasswordAuthenticator'
+authenticator_user: cassandra
+authenticator_password: cassandra
+authorizer: 'CassandraAuthorizer'
+
+user_prefix: 'longevity-ycsb-a-1B-7d'
+space_node_threshold: 64424
+store_results_in_elasticsearch: false

--- a/test-cases/longevity/longevity-ycsb-a-1M.yaml
+++ b/test-cases/longevity/longevity-ycsb-a-1M.yaml
@@ -1,0 +1,56 @@
+# [Ivan]: I am currently testing CRDB vs ScyllaDB with YCSB workloads.
+#         This scenario shows how to run YCSB workload A against Scylla.
+#         It can be run with Jenkins BYO as in https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/ivan/job/ivan-byo-longevity/23/:
+#         test_name: longevity_test.LongevityTest.test_custom_time.
+#
+# 240 = 4 hours * 60
+# 10900 = 7 days * 24 hours a day * 60 minutes an hour
+test_duration: 240
+
+pre_create_keyspace: [
+  "CREATE KEYSPACE ycsb WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor': 3 };",
+  "CREATE TABLE ycsb.usertable (y_id varchar primary key, field0 varchar, field1 varchar, field2 varchar, field3 varchar, field4 varchar, field5 varchar, field6 varchar, field7 varchar, field8 varchar, field9 varchar);"
+]
+
+prepare_write_cmd:
+  - >-
+    bin/ycsb load cassandra-cql -P workloads/workloada -threads 128 -p recordcount=500000
+    -p cassandra.readconsistencylevel=ONE -p cassandra.writeconsistencylevel=ONE
+    -p readproportion=0 -p updateproportion=1
+    -p fieldcount=10 -p fieldlength=128
+    -p insertstart=0 -p insertcount=500000
+    -p cassandra.username=cassandra -p cassandra.password=cassandra
+
+  - >-
+    bin/ycsb load cassandra-cql -P workloads/workloada -threads 128 -p recordcount=500000
+    -p cassandra.readconsistencylevel=ONE -p cassandra.writeconsistencylevel=ONE
+    -p readproportion=0 -p updateproportion=1
+    -p fieldcount=10 -p fieldlength=128
+    -p insertstart=500000 -p insertcount=500000
+    -p cassandra.username=cassandra -p cassandra.password=cassandra
+
+stress_cmd: [
+    "bin/ycsb run cassandra-cql -P workloads/workloada -threads 35 -p recordcount=1000000 -p fieldcount=10 -p fieldlength=128 -p operationcount=1000000 -p cassandra.username=cassandra -p cassandra.password=cassandra",
+    "bin/ycsb run cassandra-cql -P workloads/workloada -threads 35 -p recordcount=1000000 -p fieldcount=10 -p fieldlength=128 -p operationcount=1000000 -p cassandra.username=cassandra -p cassandra.password=cassandra",
+]
+
+round_robin: true
+
+n_db_nodes: 3
+n_loaders: 2
+n_monitor_nodes: 1
+
+instance_type_db: 'i3.4xlarge'
+instance_type_loader: 'm5.2xlarge' # 8 vCPU (4 cores), 32 GB RAM
+
+nemesis_class_name: 'NoOpMonkey'
+nemesis_interval: 5
+
+authenticator: 'PasswordAuthenticator'
+authenticator_user: cassandra
+authenticator_password: cassandra
+authorizer: 'CassandraAuthorizer'
+
+user_prefix: 'longevity-ycsb-a-1M-4h'
+space_node_threshold: 64424
+store_results_in_elasticsearch: false


### PR DESCRIPTION
This PR adds support to a YCSB workload A scenario for Scylla.

It also extends the functionality to support:

- multi statements keyspace preparation
- log collection for ycsb

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
