### PR TITLE
test(manager): tests for intensity and parallel repair options

### DIFF
--- a/jenkins-pipelines/manager/centos-manager-repair-intensity-multiple-repaired-nodes.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-repair-intensity-multiple-repaired-nodes.jenkinsfile
@@ -1,0 +1,22 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+managerPipeline(
+    params: params,
+
+    manager: true,
+    backend: 'aws',
+    test_name: 'mgmt_cli_test.MgmtCliTest.test_repair_intensity_feature_on_multiple_node',
+    test_config: 'test-cases/manager/manager-repair-intensity-multiple-repaired-nodes.yaml',
+
+    scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+    scylla_version: 'master:latest',
+
+    timeout: [time: 1260, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'keep-on-failure'
+)

--- a/jenkins-pipelines/manager/centos-manager-repair-intensity-single-repaired-nodes.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-repair-intensity-single-repaired-nodes.jenkinsfile
@@ -1,0 +1,22 @@
+#!groovy
+￼
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+managerPipeline(
+    params: params,
+
+    manager: true,
+    backend: 'aws',
+    test_name: 'mgmt_cli_test.MgmtCliTest.test_repair_intensity_feature_on_single_node',
+    test_config: 'test-cases/manager/manager-repair-intensity-single-repaired-nodes.yaml',
+
+    scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+    scylla_version: 'master:latest',
+
+    timeout: [time: 1620, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'keep-on-failure'
+)

--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -305,6 +305,20 @@ class ManagerTask(ScyllaManagerBase):
         relevant_key = [key for key in parsed_progress_table.keys() if parsed_progress_table[key]][0]
         return parsed_progress_table[relevant_key]
 
+    @property
+    def duration(self):
+        if self.status in [TaskStatus.NEW, TaskStatus.STARTING]:
+            return duration_to_timedelta(duration_string="0")
+        cmd = "task progress {} -c {}".format(self.id, self.cluster_id)
+        res = self.sctool.run(cmd=cmd)
+        duration_string = "0"
+        for task_property in res:
+            if task_property[0].startswith("Duration"):
+                duration_string = task_property[0].split(':')[1]
+                break
+        duration_timedelta = duration_to_timedelta(duration_string=duration_string)
+        return duration_timedelta
+
     def wait_for_task_done_status(self, timeout=10800):
         start_time = time.time()
         while start_time + timeout > time.time():
@@ -352,6 +366,22 @@ class ManagerTask(ScyllaManagerBase):
         if not res:
             raise ScyllaManagerError("Unexpected result on waiting for task {} status".format(self.id))
         return self.status
+
+
+def duration_to_timedelta(duration_string):
+    total_seconds = 0
+    if "d" in duration_string:
+        total_seconds += int(duration_string[:duration_string.find('d')]) * 86400
+        duration_string = duration_string[duration_string.find('d') + 1:]
+    if "h" in duration_string:
+        total_seconds += int(duration_string[:duration_string.find('h')]) * 3600
+        duration_string = duration_string[duration_string.find('h') + 1:]
+    if "m" in duration_string:
+        total_seconds += int(duration_string[:duration_string.find('m')]) * 60
+        duration_string = duration_string[duration_string.find('m') + 1:]
+    if "s" in duration_string:
+        total_seconds += int(duration_string[:duration_string.find('s')])
+    return datetime.timedelta(seconds=total_seconds)
 
 
 class RepairTask(ManagerTask):
@@ -479,7 +509,7 @@ class ManagerCluster(ScyllaManagerBase):
 
     def create_repair_task(self, dc_list=None,  # pylint: disable=too-many-arguments
                            keyspace=None, interval=None, num_retries=None, fail_fast=None,
-                           intensity=None):
+                           intensity=None, parallel=None):
         # the interval string:
         # Amount of time after which a successfully completed task would be run again. Supported time units include:
         #
@@ -501,6 +531,8 @@ class ManagerCluster(ScyllaManagerBase):
             cmd += " --fail-fast"
         if intensity is not None:
             cmd += f" --intensity {intensity}"
+        if parallel is not None:
+            cmd += f" --parallel {parallel}"
 
         res = self.sctool.run(cmd=cmd, parse_table_res=False)
         if not res:

--- a/test-cases/manager/manager-repair-intensity-multiple-repaired-nodes.yaml
+++ b/test-cases/manager/manager-repair-intensity-multiple-repaired-nodes.yaml
@@ -1,0 +1,25 @@
+test_duration: 1200
+
+prepare_write_cmd: [
+    "cassandra-stress write cl=QUORUM n=73242192 -schema 'replication(factor=3)' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..73242192 -port jmx=6868 -mode cql3 native -rate threads=200 -log interval=5",
+    "cassandra-stress write cl=QUORUM n=73242192 -schema 'replication(factor=3)' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=73242193..146484384 -port jmx=6868 -mode cql3 native -rate threads=200 -log interval=5",
+    "cassandra-stress write cl=QUORUM n=73242192 -schema 'replication(factor=3)' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=146484385..219726576 -port jmx=6868 -mode cql3 native -rate threads=200 -log interval=5",
+    "cassandra-stress write cl=QUORUM n=73242192 -schema 'replication(factor=3)' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=219726577..292968768 -port jmx=6868 -mode cql3 native -rate threads=200 -log interval=5",
+]
+stress_read_cmd: "cassandra-stress read cl=QUORUM duration=1020m -schema 'replication(factor=3)' -col 'size=FIXED(1024) n=FIXED(1)' -port jmx=6868 -mode cql3 native -rate threads=125 throttle=<THROTTLE_PLACE_HOLDER>/s -log interval=5"
+round_robin: true
+
+hinted_handoff: 'disabled'  # Turned off so it would not interfere with the creation of missing rows and with the repair
+
+instance_type_db: 'i3.2xlarge'
+instance_type_loader: 'c5.2xlarge'
+
+n_db_nodes: 9
+n_loaders: 4
+n_monitor_nodes: 1
+
+user_prefix: manager-repair
+space_node_threshold: 6442
+
+use_mgmt: true
+mgmt_port: 10090

--- a/test-cases/manager/manager-repair-intensity-single-repaired-nodes.yaml
+++ b/test-cases/manager/manager-repair-intensity-single-repaired-nodes.yaml
@@ -1,0 +1,25 @@
+test_duration: 1560
+
+prepare_write_cmd: [
+    "cassandra-stress write cl=QUORUM n=48828128 -schema 'replication(factor=3)' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..48828128 -port jmx=6868 -mode cql3 native -rate threads=200 -log interval=5",
+    "cassandra-stress write cl=QUORUM n=48828128 -schema 'replication(factor=3)' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=48828129..97656257 -port jmx=6868 -mode cql3 native -rate threads=200 -log interval=5",
+    "cassandra-stress write cl=QUORUM n=48828128 -schema 'replication(factor=3)' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=97656258..146484386 -port jmx=6868 -mode cql3 native -rate threads=200 -log interval=5",
+    "cassandra-stress write cl=QUORUM n=48828128 -schema 'replication(factor=3)' -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=146484387..195312515 -port jmx=6868 -mode cql3 native -rate threads=200 -log interval=5",
+]
+stress_read_cmd: "cassandra-stress read cl=QUORUM duration=1500m -schema 'replication(factor=3)' -col 'size=FIXED(1024) n=FIXED(1)' -port jmx=6868 -mode cql3 native -rate threads=125 throttle=<THROTTLE_PLACE_HOLDER>/s -log interval=5"
+round_robin: true
+
+hinted_handoff: 'disabled'  # Turned off so it would not interfere with the creation of missing rows and with the repair
+
+instance_type_db: 'i3.2xlarge'
+instance_type_loader: 'c5.2xlarge'
+
+n_db_nodes: 6
+n_loaders: 4
+n_monitor_nodes: 1
+
+user_prefix: manager-repair
+space_node_threshold: 6442
+
+use_mgmt: true
+mgmt_port: 10090


### PR DESCRIPTION
Added 2, albeit very similar, new test scenarios which consists of the following loop:
The test starts a new cluster with ~100 GB of data per node and starts a loop,
in it a fault in the data is created and a manager repair is started with certain
--intensity and --parallel parameter values, in order to view the effect of the repair
on the cluster.

The difference between the two scenarios is the amount and location of the fault:
In one scenario all of the files of the test keyspace is being deleted from a pre selected node
and in the second scenario an additional C-S is being ran in such a way that almost
every node has missing rows that require repair

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
