### PR TITLE
fix(operator): make user_prefix shorter for GKE

### DIFF
--- a/test-cases/scylla-operator/kubernetes-scylla-upgrade-gke.yaml
+++ b/test-cases/scylla-operator/kubernetes-scylla-upgrade-gke.yaml
@@ -8,7 +8,8 @@ n_db_nodes: 3
 n_loaders: 1
 n_monitor_nodes: 1
 
-user_prefix: 'k8s-scylla-upgrade-gke'
+# Need to keep rendered name less than 40 chars because of GKE restrictions. Note, that backend name included automatically.
+user_prefix: 'upgrade'
 
 new_version: '4.1.7'
 

--- a/test-cases/scylla-operator/kubernetes-scylla-upgrade-minikube.yaml
+++ b/test-cases/scylla-operator/kubernetes-scylla-upgrade-minikube.yaml
@@ -16,7 +16,7 @@ n_db_nodes: 3
 n_loaders: 1
 n_monitor_nodes: 1
 
-user_prefix: 'k8s-scylla-upgrade-minikube'
+user_prefix: 'k8s-scylla-upgrade'
 
 new_version: '4.1.7'
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-gke.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-gke.yaml
@@ -9,5 +9,7 @@ n_monitor_nodes: 1
 nemesis_class_name: 'KubernetesScyllaOperatorMonkey'
 nemesis_interval: 5
 
-user_prefix: 'k8s-longevity-10gb-3h-gke'
+# Need to keep rendered name less than 40 chars because of GKE restrictions. Note, that backend name included automatically.
+user_prefix: 'long-10gb-3h'
+
 space_node_threshold: 64424

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-minikube.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-minikube.yaml
@@ -16,5 +16,5 @@ n_monitor_nodes: 1
 nemesis_class_name: 'KubernetesScyllaOperatorMonkey'
 nemesis_interval: 5
 
-user_prefix: 'k8s-longevity-10gb-3h-minikube'
+user_prefix: 'k8s-longevity-10gb-3h'
 space_node_threshold: 64424


### PR DESCRIPTION
Need this because of `message=Cluster.name must be less than 40 characters` error

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
