### PR TITLE
fix(upgrade): replace .run('sudo ...') with .sudo('...')

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -1008,7 +1008,7 @@ class FillDatabaseData(ClusterTester):
                         "SELECT v1, v2 FROM range_tombstones_test WHERE k = %d" % 2,
                         "SELECT v1, v2 FROM range_tombstones_test WHERE k = %d" % 3,
                         "SELECT v1, v2 FROM range_tombstones_test WHERE k = %d" % 4,
-                        "#REMOTER_RUN sudo nodetool flush",
+                        "#REMOTER_SUDO nodetool flush",
                         "SELECT v1, v2 FROM range_tombstones_test WHERE k = %d" % 0,
                         "SELECT v1, v2 FROM range_tombstones_test WHERE k = %d" % 1,
                         "SELECT v1, v2 FROM range_tombstones_test WHERE k = %d" % 2,
@@ -1050,10 +1050,10 @@ class FillDatabaseData(ClusterTester):
             'truncates': [],
             'inserts': ["INSERT INTO range_tombstones_compaction_test (k, c1, c2, v1) VALUES (0, %d, %d, '%s')" % (
                 c1, c2, '%i%i' % (c1, c2)) for c1 in range(0, 4) for c2 in range(0, 2)],
-            'queries': ["#REMOTER_RUN sudo nodetool flush",
+            'queries': ["#REMOTER_SUDO nodetool flush",
                         "DELETE FROM range_tombstones_compaction_test WHERE k = 0 AND c1 = 1",
-                        "#REMOTER_RUN sudo nodetool flush",
-                        "#REMOTER_RUN sudo nodetool compact",
+                        "#REMOTER_SUDO nodetool flush",
+                        "#REMOTER_SUDO nodetool compact",
                         "SELECT v1 FROM range_tombstones_compaction_test WHERE k = 0"],
             'results': [None,
                         [],
@@ -2436,9 +2436,9 @@ class FillDatabaseData(ClusterTester):
                 "CREATE TABLE collection_flush_test (k int PRIMARY KEY, s set<int>)"],
             'truncates': ["TRUNCATE collection_flush_test"],
             'inserts': ["INSERT INTO collection_flush_test(k, s) VALUES (1, {1})",
-                        "#REMOTER_RUN sudo nodetool flush",
+                        "#REMOTER_SUDO nodetool flush",
                         "INSERT INTO collection_flush_test(k, s) VALUES (1, {2})",
-                        "#REMOTER_RUN sudo nodetool flush"],
+                        "#REMOTER_SUDO nodetool flush"],
             'queries': ["SELECT * FROM collection_flush_test"],
             'results': [[[1, set([2])]]],
             'min_version': '',
@@ -3002,9 +3002,9 @@ class FillDatabaseData(ClusterTester):
                     session.default_fetch_size = default_fetch_size
                 for insert in item['inserts']:
                     try:
-                        if insert.startswith("#REMOTER_RUN"):
+                        if insert.startswith("#REMOTER_SUDO"):
                             for node in self.db_cluster.nodes:
-                                node.remoter.run(insert.replace('#REMOTER_RUN', ''))
+                                node.remoter.sudo(insert.replace('#REMOTER_SUDO', ''))
                         else:
                             session.execute(insert)
                     except Exception as ex:
@@ -3031,9 +3031,9 @@ class FillDatabaseData(ClusterTester):
                         if item['queries'][i].startswith("#SORTED"):
                             res = session.execute(item['queries'][i].replace('#SORTED', ''))
                             self.assertEqual(sorted([list(row) for row in res]), item['results'][i])
-                        elif item['queries'][i].startswith("#REMOTER_RUN"):
+                        elif item['queries'][i].startswith("#REMOTER_SUDO"):
                             for node in self.db_cluster.nodes:
-                                node.remoter.run(item['queries'][i].replace('#REMOTER_RUN', ''))
+                                node.remoter.sudo(item['queries'][i].replace('#REMOTER_SUDO', ''))
                         elif item['queries'][i].startswith("#LENGTH"):
                             res = session.execute(item['queries'][i].replace('#LENGTH', ''))
                             self.assertEqual(len([list(row) for row in res]), item['results'][i])

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -325,8 +325,8 @@ class UpgradeTest(FillDatabaseData):
 
         def wait_for_node_to_finish():
             try:
-                result = node.remoter.run(
-                    "sudo find /var/lib/scylla/data/system -type f ! -path '*snapshots*' | xargs -I{} basename {}")
+                result = node.remoter.sudo(
+                    r"find /var/lib/scylla/data/system -type f ! -path '*snapshots*' -printf %f\\n")
                 all_sstable_files = result.stdout.splitlines()
 
                 sstable_version_regex = re.compile(r'(\w+)-\d+-(.+)\.(db|txt|sha1|crc32)')


### PR DESCRIPTION
To eliminate "Cut off `sudo'" error messages in the log for k8s runs.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
