### PR TITLE
fix(get_branched_ami): split by first colon only

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -342,6 +342,9 @@ def list_ami_branch(region, version):
     def get_tags(ami):
         return {i['Key']: i['Value'] for i in ami.tags}
 
+    if ":" not in version:
+        version += ":all"
+
     amis = get_branched_ami(version, region_name=region)
     tbl = PrettyTable(["Name", "ImageId", "CreationDate", "BuildId", "Test Status"])
     tbl.align = "l"

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1320,7 +1320,7 @@ def get_branched_ami(ami_version, region_name):
     :param region_name: the region to look AMIs in
     :return: list of ec2.images
     """
-    branch, build_id = ami_version.split(':')
+    branch, build_id = ami_version.split(':', 1)
     ec2_resource: EC2ServiceResource = boto3.resource('ec2', region_name=region_name)
 
     LOGGER.info("Looking for AMI match [%s]", ami_version)


### PR DESCRIPTION
Should fix fails like this: https://jenkins.scylladb.com/job/scylla-master/job/reproducers/job/byo-throughput-test-clang/6/console

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
