### PR TITLE
fix(scyllakillmonkey): reduce severity of event

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -46,7 +46,8 @@ from sdcm.log import SDCMAdapter
 from sdcm.keystore import KeyStore
 from sdcm.prometheus import nemesis_metrics_obj
 from sdcm import wait
-from sdcm.sct_events import DisruptionEvent, DbEventsFilter, Severity, InfoEvent, raise_event_on_failure
+from sdcm.sct_events import DisruptionEvent, DbEventsFilter, Severity, InfoEvent, raise_event_on_failure, \
+    CassandraStressLogEvent, EventsSeverityChangerFilter
 from sdcm.db_stats import PrometheusDBStats
 from sdcm.remote.libssh2_client.exceptions import UnexpectedExit as Libssh2UnexpectedExit
 from sdcm.cluster_k8s import KubernetesCluster
@@ -307,17 +308,19 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             return str(self.__class__)
 
     def _kill_scylla_daemon(self):
-        self.log.info('Kill all scylla processes in %s', self.target_node)
-        self.target_node.remoter.sudo("pkill -9 scylla", ignore_status=True)
+        with EventsSeverityChangerFilter(event_class=CassandraStressLogEvent, regex=".*Connection reset by peer.*",
+                                         severity=Severity.WARNING, extra_time_to_expiration=30):
+            self.log.info('Kill all scylla processes in %s', self.target_node)
+            self.target_node.remoter.sudo("pkill -9 scylla", ignore_status=True)
 
-        # Wait for the process to be down before waiting for service to be restarted
-        self.target_node.wait_db_down(check_interval=2)
+            # Wait for the process to be down before waiting for service to be restarted
+            self.target_node.wait_db_down(check_interval=2)
 
-        # Let's wait for the target Node to have their services re-started
-        self.log.info('Waiting scylla services to be restarted after we killed them...')
-        self.target_node.wait_db_up(timeout=14400)
-        self.log.info('Waiting JMX services to be restarted after we killed them...')
-        self.target_node.wait_jmx_up()
+            # Let's wait for the target Node to have their services re-started
+            self.log.info('Waiting scylla services to be restarted after we killed them...')
+            self.target_node.wait_db_up(timeout=14400)
+            self.log.info('Waiting JMX services to be restarted after we killed them...')
+            self.target_node.wait_jmx_up()
         self.cluster.wait_for_schema_agreement()
 
     def disrupt_stop_wait_start_scylla_server(self, sleep_time=300):  # pylint: disable=invalid-name

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1178,8 +1178,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self.log.warning('There is no stress results, probably stress thread has failed.')
         errors = errors[-5:]
         if errors:
-            self.fail("cassandra-stress errors on "
-                      "nodes:\n%s" % "\n".join(errors))
+            self.log.warning("cassandra-stress errors on "
+                             "nodes:\n%s" % "\n".join(errors))
 
     def get_stress_results(self, queue, store_results=True):
         results = queue.get_results()


### PR DESCRIPTION
we have seen IOExceptions raised by c-s as error
failing the whole test when a nemesis kills Scylla
process (hence the exception is expected) and the
load doesn't stop, so, lowering the severity of the
event during the specific nemesis.
Also, had to change in verify_stress_thread not to
fail the test when this IOException is found in the
loader's log, as we are already raising an event
if it is found (so this became redundant).

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
