### PR TITLE
improvement(unit_tests): speed up update_db_packages tests

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1446,6 +1446,11 @@ def update_certificates(db_csr='data_dir/ssl_conf/example/db.csr', cadb_pem='dat
     return new_crt
 
 
+# Make it mockable.
+def _s3_download_file(client, bucket, key, local_file_path):
+    return client.download_file(bucket, key, local_file_path)
+
+
 def s3_download_dir(bucket, path, target):
     """
     Downloads recursively the given S3 path to the target directory.
@@ -1473,7 +1478,7 @@ def s3_download_dir(bucket, path, target):
             local_file_dir = os.path.dirname(local_file_path)
             os.makedirs(local_file_dir, exist_ok=True)
             LOGGER.info("Downloading %s from s3 to %s", key['Key'], local_file_path)
-            client.download_file(bucket, key['Key'], local_file_path)
+            _s3_download_file(client, bucket, key['Key'], local_file_path)
 
 
 def gce_download_dir(bucket, path, target):


### PR DESCRIPTION
Keep it almost real except getting files content over the network. Just touch files on local side.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
