### PR TITLE
fix(disrupt_nodetool_decommission): Make it work on kubernetes all the times

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -538,6 +538,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.monitoring_set.reconfigure_scylla_monitoring()
 
     def disrupt_nodetool_decommission(self, add_node=True, disruption_name=None):
+        if self._is_it_on_kubernetes() and disruption_name is None:
+            self.set_last_node_as_target()
         self._set_current_disruption(f"{disruption_name or 'Decommission'} {self.target_node}")
         self.cluster.decommission(self.target_node)
         new_node = None


### PR DESCRIPTION
https://trello.com/c/wbzEvLCX/2420-qualify-nemesis-to-run-on-gke

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
