### PR TITLE
fix(disrupt_nodetool_enospc): fix to work on kubernetes, except minikube

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -50,6 +50,7 @@ from sdcm.sct_events import DisruptionEvent, DbEventsFilter, Severity, InfoEvent
 from sdcm.db_stats import PrometheusDBStats
 from sdcm.remote.libssh2_client.exceptions import UnexpectedExit as Libssh2UnexpectedExit
 from sdcm.cluster_k8s import PodCluster
+from sdcm.cluster_k8s.minikube import MinikubeScyllaPodCluster
 from test_lib.compaction import CompactionStrategy, get_compaction_strategy, get_compaction_random_additional_params
 from test_lib.cql_types import CQLTypeBuilder
 
@@ -734,6 +735,12 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             assert '(1 rows)' in result.stdout, 'The key is not loaded by `nodetool refresh`'
 
     def disrupt_nodetool_enospc(self, sleep_time=30, all_nodes=False):
+        if isinstance(self.cluster, MinikubeScyllaPodCluster):
+            self.log.info('disrupt_nodetool_enospc is not supported on minikube cluster')
+            # Minikube cluster has shared file system, it is shared not only between cluster nodes
+            # but also between kubernetes services too, which make kubernetes inoperational once enospc is reached
+            return
+
         if all_nodes:
             nodes = self.cluster.nodes
         else:
@@ -2608,6 +2615,7 @@ class RefreshBigMonkey(Nemesis):
 
 class EnospcMonkey(Nemesis):
     disruptive = True
+    kubernetes = True
 
     @log_time_elapsed_and_status
     def disrupt(self):
@@ -2616,6 +2624,7 @@ class EnospcMonkey(Nemesis):
 
 class EnospcAllNodesMonkey(Nemesis):
     disruptive = True
+    kubernetes = True
 
     @log_time_elapsed_and_status
     def disrupt(self):


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
