### PR TITLE
fix(disrupt_terminate_and_replace_node): make it valid for gke

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -792,6 +792,13 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         return self.ip_address
 
     @property
+    def instance_name(self) -> str:
+        """
+        Return name of the instance related to the node, when node is running in the cloud, or on the docker
+        """
+        return self.name
+
+    @property
     def is_spot(self):
         return False
 

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -166,7 +166,7 @@ class GCENode(cluster.BaseNode):
 
     def _safe_destroy(self):
         try:
-            self._gce_service.ex_get_node(self.name)
+            self._gce_service.ex_get_node(self.instance_name)
             self._instance.destroy()
         except ResourceNotFoundError:
             self.log.exception("Instance doesn't exist, skip destroy")


### PR DESCRIPTION
This nemesis is currently failing on the GKE due to the scylla-operator issue - https://github.com/scylladb/scylla-operator/issues/215

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
