### PR TITLE
fix(disrupt_nodetool_enospc): raise UnsupportedNemesis instead of logging

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -739,10 +739,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def disrupt_nodetool_enospc(self, sleep_time=30, all_nodes=False):
         if isinstance(self.cluster, MinikubeScyllaPodCluster):
-            self.log.info('disrupt_nodetool_enospc is not supported on minikube cluster')
             # Minikube cluster has shared file system, it is shared not only between cluster nodes
             # but also between kubernetes services too, which make kubernetes inoperational once enospc is reached
-            return
+            raise UnsupportedNemesis('disrupt_nodetool_enospc is not supported on minikube cluster')
 
         if all_nodes:
             nodes = self.cluster.nodes


### PR DESCRIPTION

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
