### PR TITLE
feature(scylla-bench authentication): add username and password to scylla-bench command

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1218,6 +1218,14 @@ class SCTConfiguration(dict):
                     f'Test duration too long for spot_duration instance type. ' \
                     f'Max possible test duration time for this instance type is {MAX_SPOT_DURATION_TIME} minutes'
 
+        # 11) validate authenticator parameters
+        if self.get('authenticator') and self.get('authenticator') == "PasswordAuthenticator":
+            authenticator_user = self.get("authenticator_user")
+            authenticator_password = self.get("authenticator_password")
+            if not (authenticator_password and authenticator_user):
+                raise ValueError("For PasswordAuthenticator authenticator authenticator_user and authenticator_password"
+                                 " have to be provided")
+
         self._update_environment_variables()
 
     def log_config(self):


### PR DESCRIPTION
If test is running with PasswordAuthenticator, scylla-bench failed to start
because of authentication required.

It relevant for TruncateLargeParititionMonkey nemesis as well

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
