### PR TITLE
improvement(install scylla-bench): support scylla-bench when running test in docker

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -75,6 +75,7 @@ from sdcm.utils.scylla_args import ScyllaArgParser
 from sdcm.utils.file import File
 from sdcm.coredump import CoredumpExportSystemdThread
 
+
 CREDENTIALS = []
 DEFAULT_USER_PREFIX = getpass.getuser()
 # Test duration (min). Parameter used to keep instances produced by tests that
@@ -3978,14 +3979,7 @@ class BaseLoaderSet():
 
         node.wait_cs_installed(verbose=verbose)
 
-        # scylla-bench
-        node.remoter.run('sudo yum install git -y')
-        node.remoter.run('curl -LO https://storage.googleapis.com/golang/go1.13.linux-amd64.tar.gz')
-        node.remoter.run('sudo tar -C /usr/local -xvzf go1.13.linux-amd64.tar.gz')
-        node.remoter.run("echo 'export GOPATH=$HOME/go' >> $HOME/.bashrc")
-        node.remoter.run("echo 'export PATH=$PATH:/usr/local/go/bin' >> $HOME/.bashrc")
-        node.remoter.run("source $HOME/.bashrc")
-        node.remoter.run("go get github.com/scylladb/scylla-bench")
+        self.install_scylla_bench(node)
 
         # install docker
         docker_install = dedent("""
@@ -4273,6 +4267,19 @@ class BaseLoaderSet():
                 kill_result = loader.remoter.run('pkill -f -QUIT gemini', ignore_status=True)
                 if kill_result.exit_status != 0:
                     self.log.warning('Terminate gemini on node %s:\n%s', loader, kill_result)
+
+    @staticmethod
+    def install_scylla_bench(node):
+        cmd = dedent("""
+                    sudo yum install git -y
+                    curl -LO https://storage.googleapis.com/golang/go1.13.linux-amd64.tar.gz
+                    sudo tar -C /usr/local -xvzf go1.13.linux-amd64.tar.gz
+                    echo 'export GOPATH=$HOME/go' >> $HOME/.bashrc
+                    echo 'export PATH=$PATH:/usr/local/go/bin' >> $HOME/.bashrc
+                    source $HOME/.bashrc
+                    go get github.com/scylladb/scylla-bench
+                """)
+        node.remoter.run(cmd)
 
 
 class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-instance-attributes

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -25,7 +25,6 @@ from sdcm.remote import LOCALRUNNER
 from sdcm.utils.docker_utils import get_docker_bridge_gateway, Container, ContainerManager, DockerException
 from sdcm.utils.health_checker import check_nodes_status
 
-
 DEFAULT_SCYLLA_DB_IMAGE = "scylladb/scylla-nightly"
 DEFAULT_SCYLLA_DB_IMAGE_TAG = "latest"
 AIO_MAX_NR_RECOMMENDED_VALUE = 1048576
@@ -301,6 +300,9 @@ class LoaderSetDocker(cluster.BaseLoaderSet, DockerCluster):
 
     def node_setup(self, node, verbose=False, db_node_address=None, **kwargs):
         self.install_gemini(node=node)
+
+        self.install_scylla_bench(node)
+
         if self.params.get('client_encrypt'):
             node.config_client_encrypt()
 


### PR DESCRIPTION
When backend of the longevity is docker, it should be able to run
scylla-bench load. Add scylla-bench installation in the docker

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
