### PR TITLE
fix(artifact_tests): set gce_image_db

### DIFF
--- a/test-cases/artifacts/centos7.yaml
+++ b/test-cases/artifacts/centos7.yaml
@@ -1,6 +1,6 @@
 backtrace_decoding: false
 cluster_backend: 'gce'
-gce_image: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
+gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
 gce_instance_type_db: 'n1-standard-2'
 gce_root_disk_type_db: 'pd-ssd'
 gce_root_disk_size_db: 50

--- a/test-cases/artifacts/centos8.yaml
+++ b/test-cases/artifacts/centos8.yaml
@@ -1,6 +1,6 @@
 backtrace_decoding: false
 cluster_backend: 'gce'
-gce_image: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-8'
+gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-8'
 gce_instance_type_db: 'n1-standard-2'
 gce_root_disk_type_db: 'pd-ssd'
 gce_root_disk_size_db: 50

--- a/test-cases/artifacts/debian10.yaml
+++ b/test-cases/artifacts/debian10.yaml
@@ -1,6 +1,6 @@
 backtrace_decoding: false
 cluster_backend: 'gce'
-gce_image: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-10'
+gce_image_db: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-10'
 gce_instance_type_db: 'n1-standard-2'
 gce_root_disk_type_db: 'pd-ssd'
 gce_root_disk_size_db: 50

--- a/test-cases/artifacts/debian9.yaml
+++ b/test-cases/artifacts/debian9.yaml
@@ -1,6 +1,6 @@
 backtrace_decoding: false
 cluster_backend: 'gce'
-gce_image: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-9'
+gce_image_db: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-9'
 gce_instance_type_db: 'n1-standard-2'
 gce_root_disk_type_db: 'pd-ssd'
 gce_root_disk_size_db: 50

--- a/test-cases/artifacts/rhel7.yaml
+++ b/test-cases/artifacts/rhel7.yaml
@@ -1,6 +1,6 @@
 backtrace_decoding: false
 cluster_backend: 'gce'
-gce_image: 'https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/family/rhel-7'
+gce_image_db: 'https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/family/rhel-7'
 gce_instance_type_db: 'n1-standard-2'
 gce_root_disk_type_db: 'pd-ssd'
 gce_root_disk_size_db: 50

--- a/test-cases/artifacts/rhel8.yaml
+++ b/test-cases/artifacts/rhel8.yaml
@@ -1,6 +1,6 @@
 backtrace_decoding: false
 cluster_backend: 'gce'
-gce_image: 'https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/family/rhel-8'
+gce_image_db: 'https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/family/rhel-8'
 gce_instance_type_db: 'n1-standard-2'
 gce_root_disk_type_db: 'pd-ssd'
 gce_root_disk_size_db: 50

--- a/test-cases/artifacts/ubuntu1604.yaml
+++ b/test-cases/artifacts/ubuntu1604.yaml
@@ -1,6 +1,6 @@
 backtrace_decoding: false
 cluster_backend: 'gce'
-gce_image: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts'
+gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts'
 gce_instance_type_db: 'n1-standard-2'
 gce_root_disk_type_db: 'pd-ssd'
 gce_root_disk_size_db: 50

--- a/test-cases/artifacts/ubuntu1804.yaml
+++ b/test-cases/artifacts/ubuntu1804.yaml
@@ -1,6 +1,6 @@
 backtrace_decoding: false
 cluster_backend: 'gce'
-gce_image: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-1804-lts'
+gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-1804-lts'
 gce_instance_type_db: 'n1-standard-2'
 gce_root_disk_type_db: 'pd-ssd'
 gce_root_disk_size_db: 50


### PR DESCRIPTION
Regression since https://github.com/scylladb/scylla-cluster-tests/pull/2540, caused artifact tests to fail

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
