### PR TITLE
improvement(remove default from get method): Remove 'default' parameter from params.get() method

### DIFF
--- a/cdc_replication_test.py
+++ b/cdc_replication_test.py
@@ -391,8 +391,8 @@ class CDCReplicationTest(ClusterTester):
                            "grafana_snapshots": grafana_dataset.get("snapshots", []),
                            "nemesis_details": self.get_nemesises_stats(),
                            "nemesis_name": self.params.get("nemesis_class_name"),
-                           "scylla_ami_id": self.params.get("ami_id_db_scylla", "-"),
-                           "number_of_oracle_nodes": self.params.get("n_test_oracle_db_nodes", 1),
+                           "scylla_ami_id": self.params.get("ami_id_db_scylla") or "-",
+                           "number_of_oracle_nodes": self.params.get("n_test_oracle_db_nodes"),
                            "oracle_ami_id": self.params.get("ami_id_db_oracle"),
                            "oracle_db_version":
                                self.cs_db_cluster.nodes[0].scylla_version if self.cs_db_cluster else "N/A",

--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -1,4 +1,5 @@
 instance_provision: 'spot'
+spot_max_price: 0.60
 instance_provision_fallback_on_demand: false
 region_name:
   - eu-west-1
@@ -37,5 +38,8 @@ ami_db_scylla_user: 'centos'
 ami_loader_user: 'centos'
 ami_monitor_user: 'centos'
 aws_instance_profile_name: 'qa-scylla-manager-backup-instance-profile'
+
+ami_id_db_scylla: ''
+ami_id_db_oracle: ''
 
 use_preinstalled_scylla: true

--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -21,4 +21,9 @@ gce_root_disk_type_db: 'pd-ssd'
 gce_root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 3
 
+gce_pd_standard_disk_size_db: 0
+gce_pd_ssd_disk_size_db: 0
+gce_pd_ssd_disk_size_loader: 0
+gce_pd_ssd_disk_size_monitor: 0
+
 user_credentials_path: '~/.ssh/scylla-test'

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -1,10 +1,15 @@
 db_type: "scylla"
 
+test_duration: 60
+
 ip_ssh_connections: 'private'
 
 mgmt_port: 10090
+scylla_repo: ''
 scylla_repo_m: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylla-2020.1.repo'
 scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-2.2.repo'
+
+scylla_repo_loader: ''
 
 experimental: true
 round_robin: false
@@ -25,6 +30,8 @@ space_node_threshold: 0
 
 cluster_health_check: true
 
+add_node_cnt: 1
+
 reuse_cluster: false
 nemesis_class_name: 'NoOpMonkey'
 nemesis_during_prepare: true
@@ -37,7 +44,6 @@ seeds_selector: "first"
 seeds_num: 1
 
 instance_provision: "spot"
-spot_max_price: 0.60
 
 execute_post_behavior: false
 post_behavior_db_nodes: "keep-on-failure"
@@ -46,16 +52,27 @@ post_behavior_monitor_nodes: "keep-on-failure"
 
 cloud_credentials_path: '~/.ssh/support'
 use_cloud_manager: false
+cloud_prom_bearer_token: ''
 
 backtrace_decoding: true
+
+update_db_packages: ''
 
 logs_transport: "rsyslog"
 
 store_perf_results: false
 send_email: false
 email_recipients: ['qa@scylladb.com']
+email_subject_postfix: ''
 
 collect_logs: false
+
+hinted_handoff: 'enabled'
+
+server_encrypt: false
+client_encrypt: false
+
+scylla_encryption_options: ''
 
 loader_swap_size: 1024 # Size of swap file for loader node in bytes 1024 * 1MB
 monitor_swap_size: 8192 # Size of swap file for monitor node in bytes 8192 * 1MB
@@ -78,3 +95,42 @@ stop_test_on_stress_failure: true
 stress_cdc_log_reader_batching_enable: true
 use_legacy_cluster_init: false
 internode_encryption: 'all'
+
+use_mgmt: false
+manager_prometheus_port: 5090
+scylla_mgmt_pkg: ''
+
+skip_download: false
+
+authenticator_user: ''
+authenticator_password: ''
+
+# gemini defaults
+gemini_version: '0.9.2'
+n_test_oracle_db_nodes: 1
+gemini_seed: 0
+oracle_scylla_version: ''
+
+# cassandra-stress defaults
+stress_multiplier: 1
+keyspace_num: 1
+cs_user_profiles: []
+cs_duration: '50m'
+batch_size: 1
+pre_create_schema: false
+user_profile_table_count: 1
+cassandra_stress_population_size: 1000000
+cassandra_stress_threads: 1000
+
+# upgrade params
+new_scylla_repo: ''
+new_version: ''
+upgrade_node_packages: ''
+test_sst3: false
+authorization_in_upgrade: ''
+new_introduced_pkgs: ''
+recover_system_tables: false
+scylla_version: ''
+remove_authorization_in_rollback: false
+test_upgrade_from_installed_3_1_0: false
+target_upgrade_version: ''

--- a/gemini_test.py
+++ b/gemini_test.py
@@ -55,7 +55,7 @@ class GeminiTest(ClusterTester):
         test_queue = self.run_gemini(cmd=cmd)
 
         # sleep before run nemesis test_duration * .25
-        sleep_before_start = float(self.params.get('test_duration', 5)) * 60 * .1
+        sleep_before_start = float(self.params.get('test_duration')) * 60 * .1
         self.log.info('Sleep interval {}'.format(sleep_before_start))
         time.sleep(sleep_before_start)
 
@@ -108,7 +108,7 @@ class GeminiTest(ClusterTester):
                            "gemini_version": gemini_version,
                            "nemesis_details": self.get_nemesises_stats(),
                            "nemesis_name": self.params.get("nemesis_class_name"),
-                           "number_of_oracle_nodes": self.params.get("n_test_oracle_db_nodes", 1),
+                           "number_of_oracle_nodes": self.params.get("n_test_oracle_db_nodes"),
                            "oracle_ami_id": self.params.get("ami_id_db_oracle"),
                            "oracle_db_version":
                                self.cs_db_cluster.nodes[0].scylla_version if self.cs_db_cluster else "N/A",

--- a/grow_cluster_test.py
+++ b/grow_cluster_test.py
@@ -60,10 +60,10 @@ class GrowClusterTest(ClusterTester):
         :rtype: basestring
         """
         ip = self.db_cluster.get_node_private_ips()[0]
-        population_size = self.params.get('cassandra_stress_population_size', default=1000000)
+        population_size = self.params.get('cassandra_stress_population_size')
         if not duration:
-            duration = self.params.get('test_duration', default=60)
-        threads = self.params.get('cassandra_stress_threads', default=1000)
+            duration = self.params.get('test_duration')
+        threads = self.params.get('cassandra_stress_threads')
 
         return ("cassandra-stress %s cl=QUORUM duration=%sm "
                 "-schema 'replication(factor=3)' -port jmx=6868 -col 'size=FIXED(2) n=FIXED(1)' "
@@ -82,7 +82,7 @@ class GrowClusterTest(ClusterTester):
         self.db_cluster.add_nemesis(nemesis=self.get_nemesis_class(),
                                     tester_obj=self)
         # default=1440 min (one day) if test_duration is not defined
-        duration = self.params.get('test_duration', default=1440)
+        duration = self.params.get('test_duration')
         cs_thread_pool = self.run_stress_thread(stress_cmd=stress_cmd,
                                                 duration=duration)
 
@@ -91,7 +91,7 @@ class GrowClusterTest(ClusterTester):
         start = datetime.datetime.now()
         self.log.info('Starting to grow cluster: %s', str(start))
 
-        add_node_cnt = self.params.get('add_node_cnt', default=1)
+        add_node_cnt = self.params.get('add_node_cnt')
         node_cnt = len(self.db_cluster.nodes)
         while node_cnt < cluster_target_size:
             time.sleep(60)

--- a/longevity_large_partition_test.py
+++ b/longevity_large_partition_test.py
@@ -6,7 +6,7 @@ from test_lib.scylla_bench_tools import create_scylla_bench_table_query
 class LargePartitionLongevityTest(LongevityTest):
 
     def test_large_partition_longevity(self):
-        compaction_strategy = self.params.get('compaction_strategy', default=CompactionStrategy.SIZE_TIERED.value)
+        compaction_strategy = self.params.get('compaction_strategy')
         self.pre_create_large_partitions_schema(compaction_strategy=compaction_strategy)
         self.test_custom_time()
 

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -154,7 +154,7 @@ class BackupFunctionsMixIn:
         if not isinstance(stress_cmds, list):
             stress_cmds = [stress_cmds]
         # In some cases we want the same stress_cmd to run several times (can be used with round_robin or not).
-        stress_multiplier = self.params.get('stress_multiplier', default=1)
+        stress_multiplier = self.params.get('stress_multiplier')
         if stress_multiplier > 1:
             stress_cmds *= stress_multiplier
 
@@ -174,8 +174,8 @@ class BackupFunctionsMixIn:
     def run_prepare_write_cmd(self):
         # In some cases (like many keyspaces), we want to create the schema (all keyspaces & tables) before the load
         # starts - due to the heavy load, the schema propogation can take long time and c-s fails.
-        prepare_write_cmd = self.params.get('prepare_write_cmd', default=None)
-        keyspace_num = self.params.get('keyspace_num', default=1)
+        prepare_write_cmd = self.params.get('prepare_write_cmd')
+        keyspace_num = self.params.get('keyspace_num')
         write_queue = list()
 
         # When the load is too heavy for one loader when using MULTI-KEYSPACES, the load is spreaded evenly across
@@ -354,8 +354,8 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
 
         email_data = self._get_common_email_data()
         email_data.update({"manager_server_repo": self.params.get("scylla_mgmt_repo"),
-                           "manager_agent_repo": self.params.get("scylla_mgmt_agent_repo",
-                                                                 self.params.get("scylla_mgmt_repo")), })
+                           "manager_agent_repo": self.params.get("scylla_mgmt_agent_repo") or
+                           self.params.get("scylla_mgmt_repo"), })
 
         return email_data
 

--- a/mgmt_upgrade_test.py
+++ b/mgmt_upgrade_test.py
@@ -180,8 +180,8 @@ class ManagerUpgradeTest(BackupFunctionsMixIn, ClusterTester):
 
         email_data = self._get_common_email_data()
         email_data.update({"manager_server_repo": self.params.get("scylla_mgmt_repo"),
-                           "manager_agent_repo": self.params.get("scylla_mgmt_agent_repo",
-                                                                 self.params.get("scylla_mgmt_repo")),
+                           "manager_agent_repo": (self.params.get("scylla_mgmt_agent_repo") or
+                                                  self.params.get("scylla_mgmt_repo")),
                            "target_manager_server_repo": self.params.get('target_scylla_mgmt_server_repo'),
                            "target_manager_agent_repo": self.params.get('target_scylla_mgmt_agent_repo')})
 

--- a/performance_regression_alternator_test.py
+++ b/performance_regression_alternator_test.py
@@ -115,7 +115,7 @@ class PerformanceRegressionAlternatorTest(PerformanceRegressionTest):
         """
         # run a write workload
         base_cmd_w = self.params.get('stress_cmd_w')
-        stress_multiplier = self.params.get('stress_multiplier', default=1)
+        stress_multiplier = self.params.get('stress_multiplier')
 
         self.create_cql_ks_and_table(field_number=10)
 
@@ -148,7 +148,7 @@ class PerformanceRegressionAlternatorTest(PerformanceRegressionTest):
         node = self.db_cluster.nodes[0]
 
         base_cmd_r = self.params.get('stress_cmd_r')
-        stress_multiplier = self.params.get('stress_multiplier', default=1)
+        stress_multiplier = self.params.get('stress_multiplier')
         self.run_fstrim_on_all_db_nodes()
         # run a prepare write workload
         self.create_cql_ks_and_table(field_number=10)
@@ -183,7 +183,7 @@ class PerformanceRegressionAlternatorTest(PerformanceRegressionTest):
         node = self.db_cluster.nodes[0]
 
         base_cmd_m = self.params.get('stress_cmd_m')
-        stress_multiplier = self.params.get('stress_multiplier', default=1)
+        stress_multiplier = self.params.get('stress_multiplier')
         self.run_fstrim_on_all_db_nodes()
 
         self.create_cql_ks_and_table(field_number=10)

--- a/performance_regression_row_level_repair_test.py
+++ b/performance_regression_row_level_repair_test.py
@@ -74,7 +74,7 @@ class PerformanceRegressionRowLevelRepairTest(ClusterTester):
             # Check if the prepare_cmd is a list of commands
             if not isinstance(prepare_write_cmd, six.string_types) and len(prepare_write_cmd) > 1:
                 # Check if it should be round_robin across loaders
-                if self.params.get('round_robin', default='').lower() == 'true':
+                if self.params.get('round_robin').lower() == 'true':
                     self.log.debug('Populating data using round_robin')
                     params.update({'stress_num': 1, 'round_robin': True})
 

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -188,7 +188,7 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
         self.create_test_stats(sub_type='read', doc_id_with_timestamp=True)
         stress_queue = self.run_stress_thread(stress_cmd=base_cmd_r, stress_num=1, stats_aggregate_cmds=False)
         if nemesis:
-            interval = self.params.get('nemesis_interval', default=10)
+            interval = self.params.get('nemesis_interval')
             time.sleep(interval)  # Sleeping one interval before starting the nemesis
             self.db_cluster.add_nemesis(nemesis=self.get_nemesis_class(), tester_obj=self)
             self.db_cluster.start_nemesis(interval=interval)
@@ -205,7 +205,7 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
         stress_queue = self.run_stress_thread(stress_cmd=base_cmd_w, stress_num=1, stats_aggregate_cmds=False)
         if nemesis:
             self.db_cluster.add_nemesis(nemesis=self.get_nemesis_class(), tester_obj=self)
-            self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval', default=10))
+            self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
         results = self.get_stress_results(queue=stress_queue)
         self.update_test_details()
         self.display_results(results, test_name='test_latency')
@@ -219,7 +219,7 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
         stress_queue = self.run_stress_thread(stress_cmd=base_cmd_m, stress_num=1, stats_aggregate_cmds=False)
         if nemesis:
             self.db_cluster.add_nemesis(nemesis=self.get_nemesis_class(), tester_obj=self)
-            self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval', default=10))
+            self.db_cluster.start_nemesis(interval=self.params.get('nemesis_interval'))
         results = self.get_stress_results(queue=stress_queue)
         self.update_test_details(scylla_conf=True)
         self.display_results(results, test_name='test_latency')
@@ -232,7 +232,7 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
         self.create_test_stats(sub_type=sub_type, doc_id_with_timestamp=True)
         stress_queue = self.run_stress_thread(stress_cmd=stress_cmd, stress_num=1, stats_aggregate_cmds=False)
         if nemesis:
-            interval = self.params.get('nemesis_interval', default=15)
+            interval = self.params.get('nemesis_interval')
             time.sleep(interval * 60)  # Sleeping one interval (in minutes) before starting the nemesis
             self.db_cluster.add_nemesis(nemesis=self.get_nemesis_class(), tester_obj=self)
             self.db_cluster.start_nemesis(interval=interval)
@@ -584,7 +584,7 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
             self.log.debug('Finish dropping materialized view {}'.format(mv_name))
 
         test_name = 'test_mv_write'
-        duration = self.params.get('test_duration', default='60m')
+        duration = self.params.get('test_duration')
         self.log.debug('Start materialized views performance test. Test duration {} minutes'.format(duration))
         self.create_test_stats()
         cmd_no_mv = self.params.get('stress_cmd_no_mv')

--- a/performance_regression_user_profiles_test.py
+++ b/performance_regression_user_profiles_test.py
@@ -42,8 +42,8 @@ class PerformanceRegressionUserProfilesTest(ClusterTester):
         """
         Run workload using user profiles
         """
-        duration = self.params.get('cs_duration', default='50m')
-        user_profiles = self.params.get('cs_user_profiles', default=[])
+        duration = self.params.get('cs_duration')
+        user_profiles = self.params.get('cs_user_profiles')
         assert user_profiles is not None, 'No user profiles defined!'
         for cs_profile in user_profiles:
             assert os.path.exists(cs_profile), 'File not found: {}'.format(cs_profile)

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -122,7 +122,7 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
     def _create_spot_instances(self, count, interfaces, ec2_user_data='', dc_idx=0):  # pylint: disable=too-many-arguments
         # pylint: disable=too-many-locals
         ec2 = ec2_client.EC2ClientWarpper(region_name=self.region_names[dc_idx],
-                                          spot_max_price_percentage=self.params.get('spot_max_price', default=0.60))
+                                          spot_max_price_percentage=self.params.get('spot_max_price'))
         subnet_info = ec2.get_subnet_info(self._ec2_subnet_id[dc_idx])
         spot_params = dict(instance_type=self._ec2_instance_type,
                            image_id=self._ec2_ami_id[dc_idx],
@@ -292,7 +292,7 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
             raise ValueError("test_id should be configured for using reuse_cluster")
 
         ec2 = ec2_client.EC2ClientWarpper(region_name=self.region_names[dc_idx],
-                                          spot_max_price_percentage=self.params.get('spot_max_price', default=0.60))
+                                          spot_max_price_percentage=self.params.get('spot_max_price'))
         results = list_instances_aws(tags_dict={'TestId': test_id, 'NodeType': self.node_type},
                                      region_name=self.region_names[dc_idx], group_as_region=True)
         instances = results[self.region_names[dc_idx]]

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -312,7 +312,8 @@ class GCECluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
         # lowercase letters, numbers, or hyphens, and cannot end with a hyphen
         assert len(name) <= 63, "Max length of instance name is 63"
         startup_script = cluster.Setup.get_startup_script()
-        if self.params.get("scylla_linux_distro", "") in ("ubuntu-bionic", "ubuntu-xenial", "ubuntu-focal", ):
+
+        if self.params.get("scylla_linux_distro") in ("ubuntu-bionic", "ubuntu-xenial", "ubuntu-focal",):
             # we need to disable sshguard to prevent blocking connections from the builder
             startup_script += dedent("""
                 sudo systemctl disable sshguard

--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -467,7 +467,7 @@ class TestStatsMixin(Stats):
         test_details['job_name'] = get_job_name()
         test_details['job_url'] = os.environ.get('BUILD_URL', '')
         test_details['start_host'] = platform.node()
-        test_details['test_duration'] = self.params.get(key='test_duration', default=60)
+        test_details['test_duration'] = self.params.get(key='test_duration')
         test_details['start_time'] = time.time()
         test_details['grafana_snapshots'] = []
         test_details['grafana_screenshots'] = []

--- a/sdcm/gemini_thread.py
+++ b/sdcm/gemini_thread.py
@@ -72,7 +72,7 @@ class GeminiStressThread():  # pylint: disable=too-many-instance-attributes
         return self._gemini_result_file
 
     def _generate_gemini_command(self):
-        seed = self.params.get('gemini_seed', None)
+        seed = self.params.get('gemini_seed')
         table_options = self.params.get('gemini_table_options')
         if not seed:
             seed = random.randint(1, 100)

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -100,7 +100,7 @@ class BaseMonitoringEntity(BaseLogEntity):
         # Avoid cyclic dependencies
         if hasattr(node, "parent_cluster") and node.parent_cluster:
             return node.parent_cluster.monitor_install_path_base
-        return self.get_monitoring_stack(self._params.get('cluster_backend', None)).get_monitor_install_path_base(node)
+        return self.get_monitoring_stack(self._params.get('cluster_backend')).get_monitor_install_path_base(node)
 
     @staticmethod
     def get_monitoring_stack(backend):

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -821,7 +821,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 # Adjust the rate according to the test duration. Try to call more unique
                 # methods and don't wait to long time to meet the balance if the test
                 # duration is short.
-                test_duration = self.cluster.params.get('test_duration', default=180)
+                test_duration = self.cluster.params.get('test_duration')
                 if test_duration < 600:  # less than 10 hours
                     rate = 1
                 elif test_duration < 4320:  # less than 3 days
@@ -1489,8 +1489,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def _mgmt_backup(self, backup_specific_tables):
         # TODO: When cloud backup is supported - add this to the below 'if' statement:
-        #  and not self.cluster.params.get('use_cloud_manager', default=None)
-        if not self.cluster.params.get('use_mgmt', default=None):
+        #  and not self.cluster.params.get('use_cloud_manager')
+        if not self.cluster.params.get('use_mgmt'):
             raise UnsupportedNemesis('Scylla-manager configuration is not defined!')
         if not self.cluster.params.get('backup_bucket_location'):
             raise UnsupportedNemesis('backup bucket location configuration is not defined!')
@@ -1522,8 +1522,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def disrupt_mgmt_repair_cli(self):
         self._set_current_disruption('ManagementRepair')
-        if not self.cluster.params.get('use_mgmt', default=None) and not self.cluster.params.get('use_cloud_manager',
-                                                                                                 default=None):
+        if not self.cluster.params.get('use_mgmt') and not self.cluster.params.get('use_cloud_manager'):
             raise UnsupportedNemesis('Scylla-manager configuration is not defined!')
         mgr_cluster = self.cluster.get_cluster_manager()
         mgr_task = mgr_cluster.create_repair_task()
@@ -1589,7 +1588,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             during short stop of one of the nodes in cluster
         """
         self._set_current_disruption("ValidateHintedHandoffShortDowntime")
-        if self.cluster.params.get('hinted_handoff', 'enabled') == 'disabled':
+        if self.cluster.params.get('hinted_handoff') == 'disabled':
             raise UnsupportedNemesis('For this nemesis to work, `hinted_handoff` needs to be set to `enabled`')
 
         start_time = time.time()
@@ -2366,7 +2365,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         This test will create and reload new certificates for the inter node communication.
         '''
         self._set_current_disruption('ServerSslHotReloadingNemesis')
-        if not self.cluster.params.get('server_encrypt', None):
+        if not self.cluster.params.get('server_encrypt'):
             raise UnsupportedNemesis('Server Encryption is not enabled, hence skipping')
 
         @retrying(n=30, allowed_exceptions=(LogContentNotFound, ))

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1524,7 +1524,7 @@ def download_dir_from_cloud(url):
     :param url: a url that starts with `s3://` or `gs://`
     :return: the temp directory create with the downloaded content
     """
-    if url is None:
+    if not url:
         return url
 
     md5 = hashlib.md5()  # deepcode ignore insecureHash: can't change it

--- a/sdcm/utils/data_validator.py
+++ b/sdcm/utils/data_validator.py
@@ -167,7 +167,7 @@ class LongevityDataValidator:
     @property
     def keyspace_name(self):
         if not self._keyspace_name:
-            prepare_write_cmd = self.longevity_self_object.params.get(self.stress_cmds_part, default=[])
+            prepare_write_cmd = self.longevity_self_object.params.get(self.stress_cmds_part) or []
             profiles = [cmd for cmd in prepare_write_cmd if self.user_profile_name in cmd]
             if not profiles:
                 self._validate_not_updated_data = False
@@ -251,7 +251,7 @@ class LongevityDataValidator:
         mv_names = []
 
         if not cs_profile:
-            stress_cmd = self.longevity_self_object.params.get(self.stress_cmds_part, default=[])
+            stress_cmd = self.longevity_self_object.params.get(self.stress_cmds_part) or []
             cs_profile = [cmd for cmd in stress_cmd if self.user_profile_name in cmd]
 
         if not cs_profile:

--- a/test-cases/longevity/longevity-5000-tables.yaml
+++ b/test-cases/longevity/longevity-5000-tables.yaml
@@ -4,6 +4,8 @@ cs_duration: '55m'
 cs_user_profiles:
     - scylla-qa-internal/cust_d/templated_tables_mv.yaml
 
+pre_create_schema: true
+
 user_profile_table_count: 5000
 batch_size: 200
 

--- a/test-cases/longevity/longevity-multi-keyspaces.yaml
+++ b/test-cases/longevity/longevity-multi-keyspaces.yaml
@@ -3,6 +3,7 @@ test_duration: 3600
 prepare_write_cmd: ["cassandra-stress write no-warmup cl=QUORUM n=4000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=20 -pop seq=1..4000000 -log interval=30"]
 stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=48h -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..4000000 -log interval=90"]
 run_fullscan: 'random, 30'
+pre_create_schema: true
 
 keyspace_num: 1000
 batch_size: 100

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -228,8 +228,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         conf.verify_configuration()
 
         self.assertIn('scylla_repo', conf.dump_config())
-        self.assertEqual(conf.get('scylla_repo'),
-                         None)
+        self.assertFalse(conf.get('scylla_repo'))
         self.assertEqual(conf.get('scylla_repo_loader'),
                          'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-nightly.repo')
 
@@ -244,7 +243,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
 
     def test_13_scylla_version_ami_branch_latest(self):  # pylint: disable=invalid-name
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
-        os.environ['SCT_SCYLLA_VERSION'] = 'branch-4.0:latest'
+        os.environ['SCT_SCYLLA_VERSION'] = 'branch-4.2:latest'
         os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/multi_region_dc_test_case.yaml'
         conf = SCTConfiguration()
         conf.verify_configuration()


### PR DESCRIPTION
Because of most of defaults are stored in the default yamls
and to prevent adding defaults in code it's better to remove
this parameter.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
