### PR TITLE
feature(upgrade_test): add second index in complex schema

### DIFF
--- a/data_dir/complex_schema.yaml
+++ b/data_dir/complex_schema.yaml
@@ -70,6 +70,7 @@ table_definition: |
 extra_definitions:
   - CREATE TYPE IF NOT EXISTS hash_and_basename (md5 text, basename text);
   - CREATE TYPE IF NOT EXISTS address (street text, city text, zip_code int, phones set<text>, map1 map<text,text>, map2 map<int,text>);
+  - CREATE INDEX IF NOT EXISTS email_ind ON keyspace_complex.user_with_ck (email);
 
 ### Column Distribution Specifications ###
 
@@ -91,6 +92,9 @@ queries:
     fields: samerow
   read2:
     cql: select * from user_with_ck where key = ? and md5 = ? LIMIT 1
+    fields: samerow
+  read3:
+    cql: select * from user_with_ck where email = ? LIMIT 1
     fields: samerow
   update_static:
     cql: update user_with_ck USING TTL 5 set static_int = ? where key = ?

--- a/test-cases/upgrades/rolling-upgrade.yaml
+++ b/test-cases/upgrades/rolling-upgrade.yaml
@@ -10,8 +10,8 @@ stress_cmd_read_cl_quorum: cassandra-stress read no-warmup cl=QUORUM n=10100200 
 stress_cmd_read_10m: cassandra-stress read no-warmup cl=QUORUM duration=10m -schema 'replication(factor=3) compression=SnappyCompressor' -port jmx=6868 -mode cql3 native compression=snappy -rate threads=1000 -pop seq=1..10100200 -log interval=5
 stress_cmd_read_60m: cassandra-stress read no-warmup cl=QUORUM duration=60m -schema 'replication(factor=3) compression=LZ4Compressor' -port jmx=6868 -mode cql3 native compression=lz4 -rate threads=1000 -pop seq=1..10100200 -log interval=5
 stress_cmd_complex_prepare: cassandra-stress user no-warmup profile=/tmp/complex_schema.yaml  ops'(insert=1)' cl=ALL n=5000000 -mode cql3 native -rate threads=1000 -pop seq=1..5000000
-stress_cmd_complex_verify_read: cassandra-stress user no-warmup profile=/tmp/complex_schema.yaml  ops'(read1=1)' cl=ONE n=5000000 -mode cql3 native -rate threads=1000 -pop seq=1..5000000
-stress_cmd_complex_verify_more: cassandra-stress user no-warmup profile=/tmp/complex_schema.yaml  ops'(read1=1,read2=1,update_static=1,update_ttl=1,update_diff1_ts=1,update_diff2_ts=1,update_same1_ts=1,update_same2_ts=1)' cl=ALL n=5000000 -mode cql3 native -rate threads=200 -pop seq=1..5000000
+stress_cmd_complex_verify_read: cassandra-stress user no-warmup profile=/tmp/complex_schema.yaml  ops'(read1=1,read3=1)' cl=ONE n=5000000 -mode cql3 native -rate threads=1000 -pop seq=1..5000000
+stress_cmd_complex_verify_more: cassandra-stress user no-warmup profile=/tmp/complex_schema.yaml  ops'(read1=1,read2=1,read3=1,update_static=1,update_ttl=1,update_diff1_ts=1,update_diff2_ts=1,update_same1_ts=1,update_same2_ts=1)' cl=ALL n=5000000 -mode cql3 native -rate threads=200 -pop seq=1..5000000
 stress_cmd_complex_verify_delete: cassandra-stress user no-warmup profile=/tmp/complex_schema.yaml  ops'(delete_row=1)' cl=ALL n=500000 -mode cql3 native -rate threads=200 -pop seq=1..500000
 
 n_db_nodes: 4


### PR DESCRIPTION
Current complex schema workload doesn't use second index.
Roy asked to add this in upgrade test.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
