### PR TITLE
fix(fill_db_data.py): Changing "caching" value to dict

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -888,7 +888,7 @@ class FillDatabaseData(ClusterTester):
                                AND compaction = { 'class' : 'LeveledCompactionStrategy',
                                                   'sstable_size_in_mb' : 10 }
                                AND compression = { 'sstable_compression' : '' }
-                               AND caching = 'all'"""],
+                               AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}"""],
             'truncates': ['TRUNCATE table_options_test'],
             'inserts': [],
             'queries': ["""


### PR DESCRIPTION
* Replace old chahing value (string) to dict value (
   https://github.com/scylladb/scylla/issues/6435)


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
