### PR TITLE
fix(1tb-longevity): Added use_legacy_cluster_init flag to the config

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -76,5 +76,5 @@ region_aware_loader: false
 stop_test_on_stress_failure: true
 
 stress_cdc_log_reader_batching_enable: true
-use_legacy_cluster_init: true
+use_legacy_cluster_init: false
 internode_encryption: 'all'

--- a/test-cases/cdc/cdc-15m-replication-gemini.yaml
+++ b/test-cases/cdc/cdc-15m-replication-gemini.yaml
@@ -3,8 +3,6 @@ test_duration: 120
 user_prefix: 'cdc-replication-gemini'
 db_type: mixed_scylla
 
-use_legacy_cluster_init: false
-
 n_db_nodes: 3
 instance_type_db: 'i3.large'
 

--- a/test-cases/cdc/cdc-15m-replication-postimage.yaml
+++ b/test-cases/cdc/cdc-15m-replication-postimage.yaml
@@ -3,8 +3,6 @@ test_duration: 120
 user_prefix: 'cdc-replication-gemini'
 db_type: mixed_scylla
 
-use_legacy_cluster_init: false
-
 n_db_nodes: 3
 instance_type_db: 'i3.large'
 

--- a/test-cases/cdc/cdc-15m-replication-preimage.yaml
+++ b/test-cases/cdc/cdc-15m-replication-preimage.yaml
@@ -3,8 +3,6 @@ test_duration: 120
 user_prefix: 'cdc-replication-gemini'
 db_type: mixed_scylla
 
-use_legacy_cluster_init: false
-
 n_db_nodes: 3
 instance_type_db: 'i3.large'
 

--- a/test-cases/cdc/cdc-15m-replication.yaml
+++ b/test-cases/cdc/cdc-15m-replication.yaml
@@ -3,8 +3,6 @@ test_duration: 120
 user_prefix: 'cdc-replication-cs'
 db_type: mixed_scylla
 
-use_legacy_cluster_init: false
-
 n_db_nodes: 3
 instance_type_db: 'i3.large'
 

--- a/test-cases/cdc/cdc-replication-longevity.yaml
+++ b/test-cases/cdc/cdc-replication-longevity.yaml
@@ -3,8 +3,6 @@ test_duration: 600
 user_prefix: 'cdc-replication-longevity'
 db_type: mixed_scylla
 
-use_legacy_cluster_init: false
-
 n_db_nodes: 3
 instance_type_db: 'i3.large'
 

--- a/test-cases/features/scale-cluster.yaml
+++ b/test-cases/features/scale-cluster.yaml
@@ -16,6 +16,7 @@ instance_type_db: 'i3.large'
 user_prefix: 'cluster-scale-test'
 ssh_transport: 'libssh2'
 experimental: false
+use_legacy_cluster_init: true
 
 nemesis_interval: 5
 nemesis_class_name: 'ChaosMonkey'

--- a/test-cases/longevity/longevity-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-100gb-4h.yaml
@@ -23,5 +23,3 @@ space_node_threshold: 64424
 use_mgmt: true
 pre_create_schema: True
 sstable_size: 100
-
-use_legacy_cluster_init: false

--- a/test-cases/longevity/longevity-5000-tables.yaml
+++ b/test-cases/longevity/longevity-5000-tables.yaml
@@ -43,5 +43,3 @@ append_scylla_args: '--blocked-reactor-notify-ms 500'
 
 # TODO: remove when https://github.com/scylladb/scylla-tools-java/issues/175 resolved
 stop_test_on_stress_failure: false
-
-use_legacy_cluster_init: false

--- a/test-cases/upgrades/rolling-upgrade.yaml
+++ b/test-cases/upgrades/rolling-upgrade.yaml
@@ -31,8 +31,6 @@ recover_system_tables: true
 
 append_scylla_args: '--blocked-reactor-notify-ms 500 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1'
 
-use_legacy_cluster_init: false
-
 # those are needed to be give by the job, via environment variable
 # for the base version
 # SCT_SCYLLA_VERSION=3.0 or SCT_SCYLLA_REPO=


### PR DESCRIPTION
Since there is more than one seed, the longevity fail on startup
since  the seeds fail to communicate with eachother. To pervent this issue,
I disabled the parallel node setup

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
