### PR TITLE
fix(k8s-gke): wait for clusters readiness

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -42,6 +42,7 @@ from sdcm.cluster_k8s.operator_monitoring import ScyllaOperatorLogMonitoring, Sc
 SCYLLA_OPERATOR_CONFIG = sct_abs_path("sdcm/k8s_configs/operator.yaml")
 SCYLLA_API_VERSION = "scylla.scylladb.com/v1alpha1"
 SCYLLA_CLUSTER_RESOURCE_KIND = "Cluster"
+DEPLOY_SCYLLA_CLUSTER_DELAY = 15  # seconds
 SCYLLA_POD_READINESS_DELAY = 30  # seconds
 SCYLLA_POD_READINESS_TIMEOUT = 5  # minutes
 SCYLLA_POD_TERMINATE_TIMEOUT = 30  # minutes
@@ -116,6 +117,9 @@ class KubernetesCluster:  # pylint: disable=too-few-public-methods
         LOGGER.debug("Check Scylla cluster")
         self.kubectl("get clusters.scylla.scylladb.com", namespace="scylla")
         self.kubectl("get pods", namespace="scylla")
+
+        LOGGER.debug("Wait for %d secs before we start to apply changes to the cluster", DEPLOY_SCYLLA_CLUSTER_DELAY)
+        time.sleep(DEPLOY_SCYLLA_CLUSTER_DELAY)
 
     @log_run_info
     def stop_k8s_task_threads(self, timeout=10):

--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -140,7 +140,9 @@ class GkeCluster(KubernetesCluster, cluster.BaseCluster):
 
     @cluster.wait_for_init_wrap
     def wait_for_init(self):
-        pass
+        LOGGER.info("--- List of nodes in GKE cluster `%s': ---\n%s\n", self.name, self.kubectl("get nodes").stdout)
+        LOGGER.info("--- List of pods in GKE cluster `%s': ---\n%s\n", self.name, self.kubectl("get pods -A").stdout)
+        self.kubectl("wait --timeout=10m -A --all --for=condition=Ready pod")
 
     def destroy(self):
         pass


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
