### PR TITLE
fix(cluster_aws): moved var-lib-scylla.mount away after restart

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -675,6 +675,12 @@ class AWSNode(cluster.BaseNode):
             try:
                 self.stop_scylla_server(verify_down=False)
 
+                # Moving var-lib-scylla.mount away, since scylla_create_devices fails if it already exists
+                mount_path = "/etc/systemd/system/var-lib-scylla.mount"
+                existance_check = self.remoter.run(f'sudo test -e {mount_path}', ignore_status=True)
+                if existance_check.exit_status == 0:
+                    self.remoter.run(f'sudo mv {mount_path} /tmp/')
+
                 # the scylla_create_devices has been moved to the '/opt/scylladb' folder in the master branch
                 for create_devices_file in ['/usr/lib/scylla/scylla-ami/scylla_create_devices',
                                             '/opt/scylladb/scylla-ami/scylla_create_devices',


### PR DESCRIPTION
Since scylla_create_devices fails if var-lib-scylla.mount already exists during its execution,
I moved var-lib-scylla.mount from its regular location

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
