### PR TITLE
fix(docker): workaround for scylladb/scylla#7560

### DIFF
--- a/docker/scylla-sct/Dockerfile
+++ b/docker/scylla-sct/Dockerfile
@@ -13,6 +13,7 @@ ENV USER scylla-test
 #
 # For more details see man page for useradd(8)
 RUN yum -y install \
+        iproute \
         sudo \
         collectd \
         rsync && \

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -153,7 +153,9 @@ class BasePodContainer(cluster.BaseNode):
 
     def init(self) -> None:
         super().init()
-        self.remoter.run('mkdir -p /var/lib/scylla/coredumps', ignore_status=True)
+        if self.distro.is_rhel_like:
+            self.remoter.sudo("rpm -q iproute || yum install -y iproute")  # need this because of scylladb/scylla#7560
+        self.remoter.sudo('mkdir -p /var/lib/scylla/coredumps', ignore_status=True)
 
     @staticmethod
     def is_docker() -> bool:


### PR DESCRIPTION
Workaround for scylladb/scylla#7560

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
