### PR TITLE
fix(get_grafana_annotations): make the limit much larger

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4555,7 +4555,7 @@ class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-inst
             self.start_node_exporter(node)
 
     def get_grafana_annotations(self, node):
-        annotations_url = "http://{node_ip}:{grafana_port}/api/annotations"
+        annotations_url = "http://{node_ip}:{grafana_port}/api/annotations?limit=10000"
         try:
             res = requests.get(url=annotations_url.format(node_ip=normalize_ipv6_url(node.grafana_address),
                                                           grafana_port=self.grafana_port))


### PR DESCRIPTION
Now the default limit in grafana API is 100, which mean we extract only 100 of the last events
and when we use `hydra investigate show-monitor` we have last 100 events available.

In longer runs like 48h and more, this isn't helpful, and we are the context like that.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
