### PR TITLE
fix(sct_config): Update of the help markdown

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -1,246 +1,258 @@
 # scylla-cluster-tests configuration options
 | Parameter | Description  | Default | Override environment<br>variable
 | :-------  | :----------  | :------ | :-------------------------------
-| **<a name="config_files">config_files</a>**  | a list of config files that would be used | N/A | SCT_CONFIG_FILES
-| **<a name="cluster_backend">cluster_backend</a>**  | backend that will be used, aws/gce/docker | N/A | SCT_CLUSTER_BACKEND
-| **<a name="test_duration">test_duration</a>**  | Test duration (min). Parameter used to keep instances produced by tests that are<br>supposed to run longer than 24 hours from being killed | N/A | SCT_TEST_DURATION
-| **<a name="n_db_nodes">n_db_nodes</a>**  | Number list of database nodes in multiple data centers. | N/A | SCT_N_DB_NODES
-| **<a name="n_test_oracle_db_nodes">n_test_oracle_db_nodes</a>**  | Number list of oracle test nodes in multiple data centers. | N/A | SCT_N_TEST_ORACLE_DB_NODES
-| **<a name="n_loaders">n_loaders</a>**  | Number list of loader nodes in multiple data centers | N/A | SCT_N_LOADERS
-| **<a name="n_monitor_nodes">n_monitor_nodes</a>**  | Number list of monitor nodes in multiple data centers | N/A | SCT_N_MONITORS_NODES
-| **<a name="intra_node_comm_public">intra_node_comm_public</a>**  | If True, all communication between nodes are via public addresses | N/A | SCT_INTRA_NODE_COMM_PUBLIC
-| **<a name="endpoint_snitch">endpoint_snitch</a>**  | The snitch class scylla would use<br><br>'GossipingPropertyFileSnitch' - default<br>'Ec2MultiRegionSnitch' - default on aws backend<br>'GoogleCloudSnitch' | N/A | SCT_ENDPOINT_SNITCH
-| **<a name="user_credentials_path">user_credentials_path</a>**  | Path to your user credentials. qa key are downloaded automatically from S3 bucket | N/A | SCT_USER_CREDENTIALS_PATH
-| **<a name="cloud_credentials_path">cloud_credentials_path</a>**  | Path to your user credentials. qa key are downloaded automatically from S3 bucket | ~/.ssh/support | SCT_CLOUD_CREDENTIALS_PATH
-| **<a name="cloud_cluster_id">cloud_cluster_id</a>**  | scylla cloud cluster id | N/A | SCT_CLOUD_CLUSTER_ID
-| **<a name="cloud_prom_bearer_token">cloud_prom_bearer_token</a>**  | scylla cloud promproxy bearer_token to federate monitoring data into our monitoring instance | N/A | SCT_CLOUD_PROM_BEARER_TOKEN
-| **<a name="cloud_prom_path">cloud_prom_path</a>**  | scylla cloud promproxy path to federate monitoring data into our monitoring instance | N/A | SCT_CLOUD_PROM_PATH
-| **<a name="cloud_prom_host">cloud_prom_host</a>**  | scylla cloud promproxy hostname to federate monitoring data into our monitoring instance | N/A | SCT_CLOUD_PROM_HOST
-| **<a name="ip_ssh_connections">ip_ssh_connections</a>**  | Type of IP used to connect to machine instances.<br>This depends on whether you are running your tests from a machine inside<br>your cloud provider, where it makes sense to use 'private', or outside (use 'public')<br><br>Default: Use public IPs to connect to instances (public)<br>Use private IPs to connect to instances (private)<br>Use IPv6 IPs to connect to instances (ipv6) | private | SCT_IP_SSH_CONNECTIONS
-| **<a name="scylla_repo">scylla_repo</a>**  | Url to the repo of scylla version to install scylla | N/A | SCT_SCYLLA_REPO
-| **<a name="scylla_version">scylla_version</a>**  | Version of scylla to install, ex. '2.3.1'<br>Automatically lookup AMIs and repo links for formal versions.<br>WARNING: can't be used together with 'scylla_repo' or 'ami_id_db_scylla' | N/A | SCT_SCYLLA_VERSION
-| **<a name="oracle_scylla_version">oracle_scylla_version</a>**  | Version of scylla to use as oracle cluster with gemini tests, ex. '3.0.11'<br>Automatically lookup AMIs for formal versions.<br>WARNING: can't be used together with 'ami_id_db_oracle' | N/A | SCT_ORACLE_SCYLLA_VERSION
-| **<a name="scylla_linux_distro">scylla_linux_distro</a>**  | The distro name and family name to use [centos/ubuntu-xenial/debian-jessie] | centos | SCT_SCYLLA_LINUX_DISTRO
-| **<a name="scylla_linux_distro_loader">scylla_linux_distro_loader</a>**  | The distro name and family name to use [centos/ubuntu-xenial/debian-jessie] | centos | SCT_SCYLLA_LINUX_DISTRO_LOADER
-| **<a name="scylla_repo_m">scylla_repo_m</a>**  | Url to the repo of scylla version to install scylla from for managment tests | http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylla-2019.1.repo | SCT_SCYLLA_REPO_M
-| **<a name="scylla_repo_loader">scylla_repo_loader</a>**  | Url to the repo of scylla version to install c-s for loader | N/A | SCT_SCYLLA_REPO_LOADER
-| **<a name="scylla_mgmt_repo">scylla_mgmt_repo</a>**  | Url to the repo of scylla manager version to install for management tests | http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-2.1.repo | SCT_SCYLLA_MGMT_REPO
-| **<a name="scylla_mgmt_agent_repo">scylla_mgmt_agent_repo</a>**  | Url to the repo of scylla manager agent version to install for management tests | N/A | SCT_SCYLLA_MGMT_AGENT_REPO
-| **<a name="scylla_mgmt_agent_version">scylla_mgmt_agent_version</a>**  |  | N/A | SCT_SCYLLA_MGMT_AGENT_VERSION
-| **<a name="scylla_mgmt_pkg">scylla_mgmt_pkg</a>**  | Url to the scylla manager packages to install for management tests | N/A | SCT_SCYLLA_MGMT_PKG
-| **<a name="stress_cmd_lwt_i">stress_cmd_lwt_i</a>**  | Stress command for LWT performance test for INSERT baseline | N/A | SCT_STRESS_CMD_LWT_I
-| **<a name="stress_cmd_lwt_d">stress_cmd_lwt_d</a>**  | Stress command for LWT performance test for DELETE baseline | N/A | SCT_STRESS_CMD_LWT_D
-| **<a name="stress_cmd_lwt_u">stress_cmd_lwt_u</a>**  | Stress command for LWT performance test for UPDATE baseline | N/A | SCT_STRESS_CMD_LWT_U
-| **<a name="stress_cmd_lwt_ine">stress_cmd_lwt_ine</a>**  | Stress command for LWT performance test for INSERT with IF NOT EXISTS | N/A | SCT_STRESS_CMD_LWT_INE
-| **<a name="stress_cmd_lwt_uc">stress_cmd_lwt_uc</a>**  | Stress command for LWT performance test for UPDATE with IF <condition> | N/A | SCT_STRESS_CMD_LWT_UC
-| **<a name="stress_cmd_lwt_ue">stress_cmd_lwt_ue</a>**  | Stress command for LWT performance test for UPDATE with IF EXISTS | N/A | SCT_STRESS_CMD_LWT_UE
-| **<a name="stress_cmd_lwt_de">stress_cmd_lwt_de</a>**  | Stress command for LWT performance test for DELETE with IF EXISTS | N/A | SCT_STRESS_CMD_LWT_DE
-| **<a name="stress_cmd_lwt_dc">stress_cmd_lwt_dc</a>**  | Stress command for LWT performance test for DELETE with IF condition> | N/A | SCT_STRESS_CMD_LWT_DC
-| **<a name="stress_cmd_lwt_mixed">stress_cmd_lwt_mixed</a>**  | Stress command for LWT performance test for mixed lwt load | N/A | SCT_STRESS_CMD_LWT_MIXED
-| **<a name="stress_cmd_lwt_mixed_baseline">stress_cmd_lwt_mixed_baseline</a>**  | Stress command for LWT performance test for mixed lwt load baseline | N/A | SCT_STRESS_CMD_LWT_MIXED_BASELINE
-| **<a name="use_cloud_manager">use_cloud_manager</a>**  | When define true, will install scylla cloud manager | N/A | SCT_USE_CLOUD_MANAGER
-| **<a name="use_mgmt">use_mgmt</a>**  | When define true, will install scylla management | N/A | SCT_USE_MGMT
-| **<a name="mgmt_port">mgmt_port</a>**  | The port of scylla management | 10090 | SCT_MGMT_PORT
-| **<a name="manager_prometheus_port">manager_prometheus_port</a>**  | Port to be used by the manager to contact Prometheus | N/A | SCT_MANAGER_PROMETHEUS_PORT
-| **<a name="target_scylla_mgmt_repo">target_scylla_mgmt_repo</a>**  | Url to the repo of scylla manager version used to upgrade the manager and agents | N/A | SCT_TARGET_SCYLLA_MGMT_REPO
-| **<a name="update_db_packages">update_db_packages</a>**  | A local directory of rpms to install a custom version on top of<br>the scylla installed (or from repo or from ami) | N/A | SCT_UPDATE_DB_PACKAGES
-| **<a name="monitor_branch">monitor_branch</a>**  | The port of scylla management | branch-3.4 | SCT_MONITOR_BRANCH
-| **<a name="db_type">db_type</a>**  | Db type to install into db nodes, scylla/cassandra | scylla | SCT_DB_TYPE
-| **<a name="user_prefix">user_prefix</a>**  | the prefix of the name of the cloud instances, defaults to username | N/A | SCT_USER_PREFIX
-| **<a name="ami_id_db_scylla_desc">ami_id_db_scylla_desc</a>**  | version name to report stats to Elasticsearch and tagged on cloud instances | N/A | SCT_AMI_ID_DB_SCYLLA_DESC
-| **<a name="store_results_in_elasticsearch">store_results_in_elasticsearch</a>**  | save the results in elasticsearch | True | SCT_STORE_RESULTS_IN_ELASTICSEARCH
-| **<a name="sct_public_ip">sct_public_ip</a>**  | Override the default hostname address of the sct test runner,<br>for the monitoring of the Nemesis.<br>can only work out of the box in AWS | N/A | SCT_SCT_PUBLIC_IP
-| **<a name="sct_ngrok_name">sct_ngrok_name</a>**  | Override the default hostname address of the sct test runner,<br>using ngrok server, see readme for more instructions | N/A | SCT_NGROK_NAME
-| **<a name="backtrace_decoding">backtrace_decoding</a>**  | If True, all backtraces found in db nodes would be decoded automatically | True | SCT_BACKTRACE_DECODING
-| **<a name="instance_provision">instance_provision</a>**  | instance_provision: on_demand|spot_fleet|spot_low_price|spot_duration | spot_low_price | SCT_INSTANCE_PROVISION
-| **<a name="reuse_cluster">reuse_cluster</a>**  | If reuse_cluster is set it should hold test_id of the cluster that will be reused.<br>`reuse_cluster: 7dc6db84-eb01-4b61-a946-b5c72e0f6d71` | N/A | SCT_REUSE_CLUSTER
-| **<a name="test_id">test_id</a>**  | test id to filter by | N/A | SCT_TEST_ID
-| **<a name="seeds_selector">seeds_selector</a>**  | How to select the seeds. Expected values: reflector/random/first | first | SCT_SEEDS_SELECTOR
-| **<a name="seeds_num">seeds_num</a>**  | Number of seeds to select | 1 | SCT_SEEDS_NUM
-| **<a name="send_email">send_email</a>**  | If true would send email out of the performance regression test | N/A | SCT_SEND_EMAIL
-| **<a name="email_recipients">email_recipients</a>**  | list of email of send the performance regression test to | ['qa@scylladb.com'] | SCT_EMAIL_RECIPIENTS
-| **<a name="email_subject_postfix">email_subject_postfix</a>**  | Email subject postfix | N/A | SCT_EMAIL_SUBJECT_POSTFIX
-| **<a name="enable_test_profiling">enable_test_profiling</a>**  | Turn on sct profiling | N/A | SCT_ENABLE_TEST_PROFILING
-| **<a name="bench_run">bench_run</a>**  | If true would kill the scylla-bench thread in the test teardown | N/A | SCT_BENCH_RUN
-| **<a name="fullscan">fullscan</a>**  | If true would kill the fullscan thread in the test teardown | N/A | SCT_FULLSCAN
-| **<a name="experimental">experimental</a>**  | when enabled scylla will use it's experimental features | True | SCT_EXPERIMENTAL
-| **<a name="server_encrypt">server_encrypt</a>**  | when enable scylla will use encryption on the server side | N/A | SCT_SERVER_ENCRYPT
-| **<a name="client_encrypt">client_encrypt</a>**  | when enable scylla will use encryption on the client side | N/A | SCT_CLIENT_ENCRYPT
-| **<a name="hinted_handoff">hinted_handoff</a>**  | when enable or disable scylla hinted handoff (enabled/disabled) | N/A | SCT_HINTED_HANDOFF
-| **<a name="authenticator">authenticator</a>**  | which authenticator scylla will use AllowAllAuthenticator/PasswordAuthenticator | N/A | SCT_AUTHENTICATOR
-| **<a name="authenticator_user">authenticator_user</a>**  | the username if PasswordAuthenticator is used | N/A | SCT_AUTHENTICATOR_USER
-| **<a name="authenticator_password">authenticator_password</a>**  | the password if PasswordAuthenticator is used | N/A | SCT_AUTHENTICATOR_PASSWORD
-| **<a name="authorizer">authorizer</a>**  | which authorizer scylla will use AllowAllAuthorizer/CassandraAuthorizer | N/A | SCT_AUTHORIZER
-| **<a name="system_auth_rf">system_auth_rf</a>**  | Replication factor will be set to system_auth | 3 | SCT_SYSTEM_AUTH_RF
-| **<a name="alternator_port">alternator_port</a>**  | Port to configure for alternator in scylla.yaml | N/A | SCT_ALTERNATOR_PORT
-| **<a name="dynamodb_primarykey_type">dynamodb_primarykey_type</a>**  | Type of dynamodb table to create with range key or not, can be HASH or HASH_AND_RANGE | HASH | SCT_DYNAMODB_PRIMARYKEY_TYPE
-| **<a name="alternator_write_isolation">alternator_write_isolation</a>**  | Set the write isolation for the alternator table, see https://github.com/scylladb/scylla/blob/master/docs/alternator/alternator.md#write-isolation-policies for more details | N/A | SCT_ALTERNATOR_WRITE_ISOLATION
-| **<a name="alternator_use_dns_routing">alternator_use_dns_routing</a>**  | If true, spawn a docker with a dns server for the ycsb loader to point to | N/A | SCT_ALTERNATOR_USE_DNS_ROUTING
-| **<a name="alternator_enforce_authorization">alternator_enforce_authorization</a>**  | If true, enable the authorization check in dynamodb api (alternator) | N/A | SCT_ALTERNATOR_ENFORCE_AUTHORIZATION
-| **<a name="alternator_access_key_id">alternator_access_key_id</a>**  | the aws_access_key_id that would be used for alternator | N/A | SCT_ALTERNATOR_ACCESS_KEY_ID
-| **<a name="alternator_secret_access_key">alternator_secret_access_key</a>**  | the aws_secret_access_key that would be used for alternator | N/A | SCT_ALTERNATOR_SECRET_ACCESS_KEY
-| **<a name="region_aware_loader">region_aware_loader</a>**  | When in multi region mode, run stress on loader that is located in the same region as db node | N/A | SCT_REGION_AWARE_LOADER
-| **<a name="append_scylla_args">append_scylla_args</a>**  | More arguments to append to scylla command line | --blocked-reactor-notify-ms 500 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1 --enable-sstable-key-validation 1 | SCT_APPEND_SCYLLA_ARGS
-| **<a name="append_scylla_args_oracle">append_scylla_args_oracle</a>**  | More arguments to append to oracle command line | N/A | SCT_APPEND_SCYLLA_ARGS_ORACLE
-| **<a name="append_scylla_yaml">append_scylla_yaml</a>**  | More configuration to append to /etc/scylla/scylla.yaml | N/A | SCT_APPEND_SCYLLA_YAML
-| **<a name="nemesis_class_name">nemesis_class_name</a>**  | Nemesis class to use (possible types in sdcm.nemesis).<br>Next syntax supporting:<br>- nemesis_class_name: "NemesisName"  Run one nemesis in single thread<br>- nemesis_class_name: "<NemesisName>:<num>" Run <NemesisName> in <num><br>parallel threads on different nodes. Ex.: "ChaosMonkey:2"<br>- nemesis_class_name: "<NemesisName1>:<num1> <NemesisName2>:<num2>" Run<br><NemesisName1> in <num1> parallel threads and <NemesisName2> in <num2><br>parallel threads. Ex.: "DisruptiveMonkey:1 NonDisruptiveMonkey:2" | NoOpMonkey | SCT_NEMESIS_CLASS_NAME
-| **<a name="nemesis_interval">nemesis_interval</a>**  | Nemesis sleep interval to use if None provided specifically in the test | 5 | SCT_NEMESIS_INTERVAL
-| **<a name="nemesis_during_prepare">nemesis_during_prepare</a>**  | Run nemesis during prepare stage of the test | True | SCT_NEMESIS_DURING_PREPARE
-| **<a name="nemesis_add_node_cnt">nemesis_add_node_cnt</a>**  | Add/remove nodes during GrowShrinkCluster nemesis | 1 | SCT_NEMESIS_ADD_NODE_CNT
-| **<a name="cluster_target_size">cluster_target_size</a>**  | Used for scale test: max size of the cluster | N/A | SCT_CLUSTER_TARGET_SIZE
-| **<a name="space_node_threshold">space_node_threshold</a>**  | Space node threshold before starting nemesis (bytes)<br>The default value is 6GB (6x1024^3 bytes)<br>This value is supposed to reproduce<br>https://github.com/scylladb/scylla/issues/1140 | N/A | SCT_SPACE_NODE_THRESHOLD
-| **<a name="nemesis_filter_seeds">nemesis_filter_seeds</a>**  | If true runs the nemesis only on non seed nodes | True | SCT_NEMESIS_FILTER_SEEDS
-| **<a name="stress_cmd">stress_cmd</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD
-| **<a name="gemini_version">gemini_version</a>**  | Version of download of the binaries of gemini tool | N/A | SCT_GEMINI_VERSION
-| **<a name="gemini_schema_url">gemini_schema_url</a>**  | Url of the schema/configuration the gemini tool would use | N/A | SCT_GEMINI_SCHEMA_URL
-| **<a name="gemini_cmd">gemini_cmd</a>**  | gemini command to run (for now used only in GeminiTest) | N/A | SCT_GEMINI_CMD
-| **<a name="gemini_seed">gemini_seed</a>**  | Seed number for gemini command | N/A | SCT_GEMINI_SEED
-| **<a name="gemini_table_options">gemini_table_options</a>**  | table options for created table. example:<br>["cdc={'enabled': true}"]<br>["cdc={'enabled': true}", "compaction={'class': 'IncrementalCompactionStrategy'}"] | N/A | SCT_GEMINI_TABLE_OPTIONS
-| **<a name="instance_type_loader">instance_type_loader</a>**  | AWS image type of the loader node | N/A | SCT_INSTANCE_TYPE_LOADER
-| **<a name="instance_type_monitor">instance_type_monitor</a>**  | AWS image type of the monitor node | N/A | SCT_INSTANCE_TYPE_MONITOR
-| **<a name="instance_type_db">instance_type_db</a>**  | AWS image type of the db node | N/A | SCT_INSTANCE_TYPE_DB
-| **<a name="instance_type_db_oracle">instance_type_db_oracle</a>**  | AWS image type of the oracle node | N/A | SCT_INSTANCE_TYPE_DB_ORACLE
-| **<a name="region_name">region_name</a>**  | AWS regions to use | N/A | SCT_REGION_NAME
-| **<a name="security_group_ids">security_group_ids</a>**  | AWS security groups ids to use | N/A | SCT_SECURITY_GROUP_IDS
-| **<a name="subnet_id">subnet_id</a>**  | AWS subnet ids to use | N/A | SCT_SUBNET_ID
-| **<a name="ami_id_db_scylla">ami_id_db_scylla</a>**  | AMS AMI id to use for scylla db node | N/A | SCT_AMI_ID_DB_SCYLLA
-| **<a name="ami_id_loader">ami_id_loader</a>**  | AMS AMI id to use for loader node | N/A | SCT_AMI_ID_LOADER
-| **<a name="ami_id_monitor">ami_id_monitor</a>**  | AMS AMI id to use for monitor node | N/A | SCT_AMI_ID_MONITOR
-| **<a name="ami_id_db_cassandra">ami_id_db_cassandra</a>**  | AMS AMI id to use for cassandra node | N/A | SCT_AMI_ID_DB_CASSANDRA
-| **<a name="ami_id_db_oracle">ami_id_db_oracle</a>**  | AMS AMI id to use for oracle node | N/A | SCT_AMI_ID_DB_ORACLE
-| **<a name="aws_root_disk_size_db">aws_root_disk_size_db</a>**  |  | N/A | SCT_AWS_ROOT_DISK_SIZE_DB
-| **<a name="aws_root_disk_size_monitor">aws_root_disk_size_monitor</a>**  |  | N/A | SCT_AWS_ROOT_DISK_SIZE_MONITOR
-| **<a name="aws_root_disk_size_loader">aws_root_disk_size_loader</a>**  |  | N/A | SCT_AWS_ROOT_DISK_SIZE_LOADER
-| **<a name="ami_db_scylla_user">ami_db_scylla_user</a>**  |  | N/A | SCT_AMI_DB_SCYLLA_USER
-| **<a name="ami_monitor_user">ami_monitor_user</a>**  |  | N/A | SCT_AMI_MONITOR_USER
-| **<a name="ami_loader_user">ami_loader_user</a>**  |  | N/A | SCT_AMI_LOADER_USER
-| **<a name="ami_db_cassandra_user">ami_db_cassandra_user</a>**  |  | N/A | SCT_AMI_DB_CASSANDRA_USER
-| **<a name="spot_max_price">spot_max_price</a>**  | The max percentage of the on demand price we set for spot/fleet instances | 0.6 | SCT_SPOT_MAX_PRICE
-| **<a name="extra_network_interface">extra_network_interface</a>**  | if true, create extra network interface on each node | N/A | SCT_EXTRA_NETWORK_INTERFACE
-| **<a name="aws_instance_profile_name">aws_instance_profile_name</a>**  | This is the name of the instance profile to set on all instances | N/A | SCT_AWS_INSTANCE_PROFILE_NAME
-| **<a name="backup_bucket_location">backup_bucket_location</a>**  | This is the bucket name to be used for backup with its region<br>(e.g. backup_bucket_location: 'manager-backup-tests') | N/A | SCT_BACKUP_BUCKET_LOCATION
-| **<a name="tag_ami_with_result">tag_ami_with_result</a>**  | If True, would tag the ami with the test final result | N/A | SCT_TAG_AMI_WITH_RESULT
-| **<a name="gce_datacenter">gce_datacenter</a>**  | Supported: us-east1 - means that the zone will be selected automatically or you can mention the zone explicitly, for example: us-east1-b | N/A | SCT_GCE_DATACENTER
-| **<a name="gce_network">gce_network</a>**  |  | N/A | SCT_GCE_NETWORK
-| **<a name="gce_image">gce_image</a>**  |  | N/A | SCT_GCE_IMAGE
-| **<a name="gce_image_db">gce_image_db</a>**  |  | N/A | SCT_GCE_IMAGE_DB
-| **<a name="gce_image_monitor">gce_image_monitor</a>**  |  | N/A | SCT_GCE_IMAGE_MONITOR
-| **<a name="gce_image_username">gce_image_username</a>**  |  | N/A | SCT_GCE_IMAGE_USERNAME
-| **<a name="gce_instance_type_loader">gce_instance_type_loader</a>**  |  | N/A | SCT_GCE_INSTANCE_TYPE_LOADER
-| **<a name="gce_root_disk_type_loader">gce_root_disk_type_loader</a>**  |  | N/A | SCT_GCE_ROOT_DISK_TYPE_LOADER
-| **<a name="gce_n_local_ssd_disk_loader">gce_n_local_ssd_disk_loader</a>**  |  | N/A | SCT_GCE_N_LOCAL_SSD_DISK_LOADER
-| **<a name="gce_instance_type_monitor">gce_instance_type_monitor</a>**  |  | N/A | SCT_GCE_INSTANCE_TYPE_MONITOR
-| **<a name="gce_root_disk_type_monitor">gce_root_disk_type_monitor</a>**  |  | N/A | SCT_GCE_ROOT_DISK_TYPE_MONITOR
-| **<a name="gce_root_disk_size_monitor">gce_root_disk_size_monitor</a>**  |  | N/A | SCT_GCE_ROOT_DISK_SIZE_MONITOR
-| **<a name="gce_n_local_ssd_disk_monitor">gce_n_local_ssd_disk_monitor</a>**  |  | N/A | SCT_GCE_N_LOCAL_SSD_DISK_MONITOR
-| **<a name="gce_instance_type_db">gce_instance_type_db</a>**  |  | N/A | SCT_GCE_INSTANCE_TYPE_DB
-| **<a name="gce_root_disk_type_db">gce_root_disk_type_db</a>**  |  | N/A | SCT_GCE_ROOT_DISK_TYPE_DB
-| **<a name="gce_root_disk_size_db">gce_root_disk_size_db</a>**  |  | N/A | SCT_GCE_ROOT_DISK_SIZE_DB
-| **<a name="gce_n_local_ssd_disk_db">gce_n_local_ssd_disk_db</a>**  |  | N/A | SCT_GCE_N_LOCAL_SSD_DISK_DB
-| **<a name="gce_image_minikube">gce_image_minikube</a>**  |  | N/A | SCT_GCE_IMAGE_MINIKUBE
-| **<a name="gce_instance_type_minikube">gce_instance_type_minikube</a>**  |  | N/A | SCT_GCE_INSTANCE_TYPE_MINIKUBE
-| **<a name="gce_root_disk_type_minikube">gce_root_disk_type_minikube</a>**  |  | N/A | SCT_GCE_ROOT_DISK_TYPE_MINIKUBE
-| **<a name="gce_root_disk_size_minikube">gce_root_disk_size_minikube</a>**  |  | N/A | SCT_GCE_ROOT_DISK_SIZE_MINIKUBE
-| **<a name="k8s_scylla_operator_docker_image">k8s_scylla_operator_docker_image</a>**  |  | N/A | SCT_K8S_SCYLLA_OPERATOR_DOCKER_IMAGE
-| **<a name="k8s_scylla_datacenter">k8s_scylla_datacenter</a>**  |  | N/A | SCT_K8S_SCYLLA_DATACENTER
-| **<a name="k8s_scylla_rack">k8s_scylla_rack</a>**  |  | N/A | SCT_K8S_SCYLLA_RACK
-| **<a name="k8s_scylla_cluster_name">k8s_scylla_cluster_name</a>**  |  | N/A | SCT_K8S_SCYLLA_CLUSTER_NAME
-| **<a name="k8s_scylla_cpu_n">k8s_scylla_cpu_n</a>**  |  | N/A | SCT_K8S_SCYLLA_CPU_N
-| **<a name="k8s_scylla_mem_gi">k8s_scylla_mem_gi</a>**  |  | N/A | SCT_K8S_SCYLLA_MEM_GI
-| **<a name="k8s_scylla_disk_gi">k8s_scylla_disk_gi</a>**  |  | N/A | SCT_K8S_SCYLLA_DISK_GI
-| **<a name="k8s_loader_cluster_name">k8s_loader_cluster_name</a>**  |  | N/A | SCT_K8S_LOADER_CLUSTER_NAME
-| **<a name="k8s_loader_cpu_n">k8s_loader_cpu_n</a>**  |  | N/A | SCT_K8S_LOADER_CPU_N
-| **<a name="k8s_loader_mem_gi">k8s_loader_mem_gi</a>**  |  | N/A | SCT_K8S_LOADER_MEM_GI
-| **<a name="minikube_version">minikube_version</a>**  |  | N/A | SCT_MINIKUBE_VERSION
-| **<a name="k8s_cert_manager_version">k8s_cert_manager_version</a>**  |  | N/A | SCT_K8S_CERT_MANAGER_VERSION
-| **<a name="gke_cluster_version">gke_cluster_version</a>**  |  | N/A | SCT_GKE_CLUSTER_VERSION
-| **<a name="gke_cluster_n_nodes">gke_cluster_n_nodes</a>**  |  | N/A | SCT_GKE_CLUSTER_N_NODES
-| **<a name="docker_image">docker_image</a>**  |  | N/A | SCT_DOCKER_IMAGE
-| **<a name="db_nodes_private_ip">db_nodes_private_ip</a>**  |  | N/A | SCT_DB_NODES_PRIVATE_IP
-| **<a name="db_nodes_public_ip">db_nodes_public_ip</a>**  |  | N/A | SCT_DB_NODES_PUBLIC_IP
-| **<a name="loaders_private_ip">loaders_private_ip</a>**  |  | N/A | SCT_LOADERS_PRIVATE_IP
-| **<a name="loaders_public_ip">loaders_public_ip</a>**  |  | N/A | SCT_LOADERS_PUBLIC_IP
-| **<a name="monitor_nodes_private_ip">monitor_nodes_private_ip</a>**  |  | N/A | SCT_MONITOR_NODES_PRIVATE_IP
-| **<a name="monitor_nodes_public_ip">monitor_nodes_public_ip</a>**  |  | N/A | SCT_MONITOR_NODES_PUBLIC_IP
-| **<a name="cassandra_stress_population_size">cassandra_stress_population_size</a>**  |  | N/A | SCT_CASSANDRA_STRESS_POPULATION_SIZE
-| **<a name="cassandra_stress_threads">cassandra_stress_threads</a>**  |  | N/A | SCT_CASSANDRA_STRESS_THREADS
-| **<a name="add_node_cnt">add_node_cnt</a>**  |  | N/A | SCT_ADD_NODE_CNT
-| **<a name="stress_multiplier">stress_multiplier</a>**  |  | N/A | SCT_STRESS_MULTIPLIER
-| **<a name="run_fullscan">run_fullscan</a>**  |  | N/A | SCT_RUN_FULLSCAN
-| **<a name="keyspace_num">keyspace_num</a>**  |  | N/A | SCT_KEYSPACE_NUM
-| **<a name="round_robin">round_robin</a>**  |  | N/A | SCT_ROUND_ROBIN
-| **<a name="batch_size">batch_size</a>**  |  | N/A | SCT_BATCH_SIZE
-| **<a name="pre_create_schema">pre_create_schema</a>**  |  | N/A | SCT_PRE_CREATE_SCHEMA
-| **<a name="pre_create_keyspace">pre_create_keyspace</a>**  | Command to create keysapce to be pre-create before running workload | N/A | SCT_PRE_CREATE_KEYSPACE
-| **<a name="compaction_strategy">compaction_strategy</a>**  | Choose a specific compaction strategy to pre-create schema with. | SizeTieredCompactionStrategy | SCT_COMPACTION_STRATEGY
-| **<a name="sstable_size">sstable_size</a>**  | Configure sstable size for the usage of pre-create-schema mode | N/A | SSTABLE_SIZE
-| **<a name="cluster_health_check">cluster_health_check</a>**  | When true, start cluster health checker for all nodes | True | SCT_CLUSTER_HEALTH_CHECK
-| **<a name="validate_partitions">validate_partitions</a>**  | when true, log of the partitions before and after the nemesis run is compacted | N/A | SCT_VALIDATE_PARTITIONS
-| **<a name="table_name">table_name</a>**  | table name to check for the validate_partitions check | N/A | SCT_TABLE_NAME
-| **<a name="primary_key_column">primary_key_column</a>**  | primary key of the table to check for the validate_partitions check | N/A | SCT_PRIMARY_KEY_COLUMN
-| **<a name="stress_read_cmd">stress_read_cmd</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_READ_CMD
-| **<a name="prepare_verify_cmd">prepare_verify_cmd</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_PREPARE_VERIFY_CMD
-| **<a name="user_profile_table_count">user_profile_table_count</a>**  | number of tables to create for template user c-s | N/A | SCT_USER_PROFILE_TABLE_COUNT
-| **<a name="scylla_mgmt_upgrade_to_repo">scylla_mgmt_upgrade_to_repo</a>**  | Url to the repo of scylla manager version to upgrade to for management tests | N/A | SCT_SCYLLA_MGMT_UPGRADE_TO_REPO
-| **<a name="partition_range_with_data_validation">partition_range_with_data_validation</a>**  | Relevant for scylla-bench. Hold range (min - max) of PKs values for partitions that data was<br>written with validate data and will be validate during the read.<br>Example: 0-250.<br>Optional parameter for DeleteByPartitionsMonkey and DeleteByRowsRangeMonkey | N/A | SCT_PARTITION_RANGE_WITH_DATA_VALIDATION
-| **<a name="max_partitions_in_test_table">max_partitions_in_test_table</a>**  | Relevant for scylla-bench. MAX partition keys (partition-count) in the scylla_bench.test table.<br>Mandatory parameter for DeleteByPartitionsMonkey and DeleteByRowsRangeMonkey | N/A | SCT_MAX_PARTITIONS_IN_TEST_TABLE
-| **<a name="stress_cmd_w">stress_cmd_w</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_W
-| **<a name="stress_cmd_r">stress_cmd_r</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_R
-| **<a name="stress_cmd_m">stress_cmd_m</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_M
-| **<a name="prepare_write_cmd">prepare_write_cmd</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_PREPARE_WRITE_CMD
-| **<a name="stress_cmd_no_mv">stress_cmd_no_mv</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_NO_MV
-| **<a name="stress_cmd_no_mv_profile">stress_cmd_no_mv_profile</a>**  |  | N/A | SCT_STRESS_CMD_NO_MV_PROFILE
-| **<a name="cs_user_profiles">cs_user_profiles</a>**  |  | N/A | SCT_CS_USER_PROFILES
-| **<a name="cs_duration">cs_duration</a>**  |  | N/A | SCT_CS_DURATION
-| **<a name="ssh_transport">ssh_transport</a>**  | Set type of ssh library to use. Could be 'fabric' or 'libssh2' | 'fabric' | SSH_TRANSPORT
-| **<a name="stress_cmd_mv">stress_cmd_mv</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_MV
-| **<a name="prepare_stress_cmd">prepare_stress_cmd</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_PREPARE_STRESS_CMD
-| **<a name="skip_download">skip_download</a>**  |  | N/A | SCT_SKIP_DOWNLOAD
-| **<a name="sstable_file">sstable_file</a>**  |  | N/A | SCT_SSTABLE_FILE
-| **<a name="sstable_url">sstable_url</a>**  |  | N/A | SCT_SSTABLE_URL
-| **<a name="sstable_md5">sstable_md5</a>**  |  | N/A | SCT_SSTABLE_MD5
-| **<a name="flush_times">flush_times</a>**  |  | N/A | SCT_FLUSH_TIMES
-| **<a name="flush_period">flush_period</a>**  |  | N/A | SCT_FLUSH_PERIOD
-| **<a name="new_scylla_repo">new_scylla_repo</a>**  |  | N/A | SCT_NEW_SCYLLA_REPO
-| **<a name="new_version">new_version</a>**  | Assign new upgrade version, use it to upgrade to specific minor release. eg: 3.0.1 | N/A | SCT_NEW_VERSION
-| **<a name="target_upgrade_version">target_upgrade_version</a>**  | Assign target upgrade version, use for decide if the truncate entries test should be run. This test should be performed in case the target upgrade version >= 3.1 | N/A | SCT_TAGRET_UPGRADE_VERSION
-| **<a name="upgrade_node_packages">upgrade_node_packages</a>**  |  | N/A | SCT_UPGRADE_NODE_PACKAGES
-| **<a name="test_sst3">test_sst3</a>**  |  | N/A | SCT_TEST_SST3
-| **<a name="test_upgrade_from_installed_3_1_0">test_upgrade_from_installed_3_1_0</a>**  | Enable an option for installed 3.1.0 for work around a scylla issue if it's true | N/A | SCT_TEST_UPGRADE_FROM_INSTALLED_3_1_0
-| **<a name="authorization_in_upgrade">authorization_in_upgrade</a>**  | Which Authorization to enable after upgrade | N/A | SCT_AUTHORIZATION_IN_UPGRADE
-| **<a name="remove_authorization_in_rollback">remove_authorization_in_rollback</a>**  | Disable Authorization after rollback to old Scylla | N/A | SCT_REMOVE_AUTHORIZATION_IN_ROLLBACK
-| **<a name="new_introduced_pkgs">new_introduced_pkgs</a>**  |  | N/A | SCT_NEW_INTRODUCED_PKGS
-| **<a name="recover_system_tables">recover_system_tables</a>**  |  | N/A | SCT_RECOVER_SYSTEM_TABLES
-| **<a name="stress_cmd_1">stress_cmd_1</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_1
-| **<a name="stress_cmd_complex_prepare">stress_cmd_complex_prepare</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_COMPLEX_PREPARE
-| **<a name="prepare_write_stress">prepare_write_stress</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_PREPARE_WRITE_STRESS
-| **<a name="stress_cmd_read_10m">stress_cmd_read_10m</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_READ_10M
-| **<a name="stress_cmd_read_cl_one">stress_cmd_read_cl_one</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure. | N/A | SCT_STRESS_CMD_READ_CL_ONE
-| **<a name="stress_cmd_read_60m">stress_cmd_read_60m</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_READ_60M
-| **<a name="stress_cmd_complex_verify_read">stress_cmd_complex_verify_read</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_COMPLEX_VERIFY_READ
-| **<a name="stress_cmd_complex_verify_more">stress_cmd_complex_verify_more</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_COMPLEX_VERIFY_MORE
-| **<a name="write_stress_during_entire_test">write_stress_during_entire_test</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_WRITE_STRESS_DURING_ENTIRE_TEST
-| **<a name="verify_data_after_entire_test">verify_data_after_entire_test</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure. | N/A | SCT_VERIFY_DATA_AFTER_ENTIRE_TEST
-| **<a name="stress_cmd_read_cl_quorum">stress_cmd_read_cl_quorum</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_READ_CL_QUORUM
-| **<a name="verify_stress_after_cluster_upgrade">verify_stress_after_cluster_upgrade</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_VERIFY_STRESS_AFTER_CLUSTER_UPGRADE
-| **<a name="stress_cmd_complex_verify_delete">stress_cmd_complex_verify_delete</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_COMPLEX_VERIFY_DELETE
-| **<a name="scylla_encryption_options">scylla_encryption_options</a>**  | options will be used for enable encryption at-rest for tables | N/A | SCT_SCYLLA_ENCRYPTION_OPTIONS
-| **<a name="logs_transport">logs_transport</a>**  | How to transport logs: rsyslog, ssh or docker | rsyslog | SCT_LOGS_TRANSPORT
-| **<a name="collect_logs">collect_logs</a>**  | Collect logs from instances and sct runner | N/A | SCT_COLLECT_LOGS
-| **<a name="execute_post_behavior">execute_post_behavior</a>**  | Run post behavior actions in sct teardown step | N/A | SCT_EXECUTE_POST_BEHAVIOR
-| **<a name="post_behavior_db_nodes">post_behavior_db_nodes</a>**  | Failure/post test behavior, i.e. what to do with the db cloud instances at the end of the test.<br><br>'destroy' - Destroy instances and credentials (default)<br>'keep' - Keep instances running and leave credentials alone<br>'keep-on-failure' - Keep instances if testrun failed | keep-on-failure | SCT_POST_BEHAVIOR_DB_NODES
-| **<a name="post_behavior_loader_nodes">post_behavior_loader_nodes</a>**  | Failure/post test behavior, i.e. what to do with the loader cloud instances at the end of the test.<br><br>'destroy' - Destroy instances and credentials (default)<br>'keep' - Keep instances running and leave credentials alone<br>'keep-on-failure' - Keep instances if testrun failed | destroy | SCT_POST_BEHAVIOR_LOADER_NODES
-| **<a name="post_behavior_monitor_nodes">post_behavior_monitor_nodes</a>**  | Failure/post test behavior, i.e. what to do with the monitor cloud instances at the end of the test.<br><br>'destroy' - Destroy instances and credentials (default)<br>'keep' - Keep instances running and leave credentials alone<br>'keep-on-failure' - Keep instances if testrun failed | keep-on-failure | SCT_POST_BEHAVIOR_MONITOR_NODES
-| **<a name="workaround_kernel_bug_for_iotune">workaround_kernel_bug_for_iotune</a>**  | Workaround a known kernel bug which causes iotune to fail in scylla_io_setup, only effect GCE backend | N/A | SCT_WORKAROUND_KERNEL_BUG_FOR_IOTUNE
-| **<a name="internode_compression">internode_compression</a>**  | scylla option: internode_compression | N/A | SCT_INTERNODE_COMPRESSION
-| **<a name="loader_swap_size">loader_swap_size</a>**  | The size of the swap file for the loaders. Its size in bytes calculated by x * 1MB | 1024 | SCT_LOADER_SWAP_SIZE
-| **<a name="monitor_swap_size">monitor_swap_size</a>**  | The size of the swap file for the monitors. Its size in bytes calculated by x * 1MB | 8192 | SCT_MONITOR_SWAP_SIZE
-| **<a name="store_perf_results">store_perf_results</a>**  | A flag that indicates whether or not to gather the prometheus stats at the end of the run.<br>Intended to be used in performance testing | N/A | SCT_STORE_PERF_RESULTS
-| **<a name="append_scylla_setup_args">append_scylla_setup_args</a>**  | More arguments to append to scylla_setup command line | N/A | SCT_APPEND_SCYLLA_SETUP_ARGS
-| **<a name="use_preinstalled_scylla">use_preinstalled_scylla</a>**  | Don't install/update ScyllaDB on DB nodes | N/A | SCT_USE_PREINSTALLED_SCYLLA
-| **<a name="stress_cdclog_reader_cmd">stress_cdclog_reader_cmd</a>**  | cdc-stressor command to read cdc_log table.<br>You can specify everything but the -node , -keyspace, -table, parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CDCLOG_READER_CMD
-| **<a name="store_cdclog_reader_stats_in_es">store_cdclog_reader_stats_in_es</a>**  | Add cdclog reader stats to ES for future performance result calculating | N/A | SCT_STORE_CDCLOG_READER_STATS_IN_ES
-| **<a name="stop_test_on_stress_failure">stop_test_on_stress_failure</a>**  | If set to True the test will be stopped immediately when stress command failed.<br>When set to False the test will continue to run even when there are errors in the<br>stress process | True | SCT_STOP_TEST_ON_STRESS_FAILURE
-| **<a name="stress_cdc_log_reader_batching_enable">stress_cdc_log_reader_batching_enable</a>**  | retrieving data from multiple streams in one poll | True | SCT_STRESS_CDC_LOG_READER_BATCHING_ENABLE
-| **<a name="use_legacy_cluster_init">use_legacy_cluster_init</a>**  | Use legacy cluster initialization with autobootsrap disabled and parallel node setup | True | SCT_USE_LEGACY_CLUSTER_INIT
-
+| **<a href="#user-content-config_files" name="config_files">config_files</a>**  | a list of config files that would be used | N/A | SCT_CONFIG_FILES
+| **<a href="#user-content-cluster_backend" name="cluster_backend">cluster_backend</a>**  | backend that will be used, aws/gce/docker | N/A | SCT_CLUSTER_BACKEND
+| **<a href="#user-content-test_duration" name="test_duration">test_duration</a>**  | Test duration (min). Parameter used to keep instances produced by tests<br>and for jenkins pipeline timeout and TimoutThread. | N/A | SCT_TEST_DURATION
+| **<a href="#user-content-n_db_nodes" name="n_db_nodes">n_db_nodes</a>**  | Number list of database nodes in multiple data centers. | N/A | SCT_N_DB_NODES
+| **<a href="#user-content-n_test_oracle_db_nodes" name="n_test_oracle_db_nodes">n_test_oracle_db_nodes</a>**  | Number list of oracle test nodes in multiple data centers. | N/A | SCT_N_TEST_ORACLE_DB_NODES
+| **<a href="#user-content-n_loaders" name="n_loaders">n_loaders</a>**  | Number list of loader nodes in multiple data centers | N/A | SCT_N_LOADERS
+| **<a href="#user-content-n_monitor_nodes" name="n_monitor_nodes">n_monitor_nodes</a>**  | Number list of monitor nodes in multiple data centers | N/A | SCT_N_MONITORS_NODES
+| **<a href="#user-content-intra_node_comm_public" name="intra_node_comm_public">intra_node_comm_public</a>**  | If True, all communication between nodes are via public addresses | N/A | SCT_INTRA_NODE_COMM_PUBLIC
+| **<a href="#user-content-endpoint_snitch" name="endpoint_snitch">endpoint_snitch</a>**  | The snitch class scylla would use<br><br>'GossipingPropertyFileSnitch' - default<br>'Ec2MultiRegionSnitch' - default on aws backend<br>'GoogleCloudSnitch' | N/A | SCT_ENDPOINT_SNITCH
+| **<a href="#user-content-user_credentials_path" name="user_credentials_path">user_credentials_path</a>**  | Path to your user credentials. qa key are downloaded automatically from S3 bucket | N/A | SCT_USER_CREDENTIALS_PATH
+| **<a href="#user-content-cloud_credentials_path" name="cloud_credentials_path">cloud_credentials_path</a>**  | Path to your user credentials. qa key are downloaded automatically from S3 bucket | ~/.ssh/support | SCT_CLOUD_CREDENTIALS_PATH
+| **<a href="#user-content-cloud_cluster_id" name="cloud_cluster_id">cloud_cluster_id</a>**  | scylla cloud cluster id | N/A | SCT_CLOUD_CLUSTER_ID
+| **<a href="#user-content-cloud_prom_bearer_token" name="cloud_prom_bearer_token">cloud_prom_bearer_token</a>**  | scylla cloud promproxy bearer_token to federate monitoring data into our monitoring instance | N/A | SCT_CLOUD_PROM_BEARER_TOKEN
+| **<a href="#user-content-cloud_prom_path" name="cloud_prom_path">cloud_prom_path</a>**  | scylla cloud promproxy path to federate monitoring data into our monitoring instance | N/A | SCT_CLOUD_PROM_PATH
+| **<a href="#user-content-cloud_prom_host" name="cloud_prom_host">cloud_prom_host</a>**  | scylla cloud promproxy hostname to federate monitoring data into our monitoring instance | N/A | SCT_CLOUD_PROM_HOST
+| **<a href="#user-content-ip_ssh_connections" name="ip_ssh_connections">ip_ssh_connections</a>**  | Type of IP used to connect to machine instances.<br>This depends on whether you are running your tests from a machine inside<br>your cloud provider, where it makes sense to use 'private', or outside (use 'public')<br><br>Default: Use public IPs to connect to instances (public)<br>Use private IPs to connect to instances (private)<br>Use IPv6 IPs to connect to instances (ipv6) | private | SCT_IP_SSH_CONNECTIONS
+| **<a href="#user-content-scylla_repo" name="scylla_repo">scylla_repo</a>**  | Url to the repo of scylla version to install scylla | N/A | SCT_SCYLLA_REPO
+| **<a href="#user-content-scylla_version" name="scylla_version">scylla_version</a>**  | Version of scylla to install, ex. '2.3.1'<br>Automatically lookup AMIs and repo links for formal versions.<br>WARNING: can't be used together with 'scylla_repo' or 'ami_id_db_scylla' | N/A | SCT_SCYLLA_VERSION
+| **<a href="#user-content-oracle_scylla_version" name="oracle_scylla_version">oracle_scylla_version</a>**  | Version of scylla to use as oracle cluster with gemini tests, ex. '3.0.11'<br>Automatically lookup AMIs for formal versions.<br>WARNING: can't be used together with 'ami_id_db_oracle' | N/A | SCT_ORACLE_SCYLLA_VERSION
+| **<a href="#user-content-scylla_linux_distro" name="scylla_linux_distro">scylla_linux_distro</a>**  | The distro name and family name to use [centos/ubuntu-xenial/debian-jessie] | centos | SCT_SCYLLA_LINUX_DISTRO
+| **<a href="#user-content-scylla_linux_distro_loader" name="scylla_linux_distro_loader">scylla_linux_distro_loader</a>**  | The distro name and family name to use [centos/ubuntu-xenial/debian-jessie] | centos | SCT_SCYLLA_LINUX_DISTRO_LOADER
+| **<a href="#user-content-scylla_repo_m" name="scylla_repo_m">scylla_repo_m</a>**  | Url to the repo of scylla version to install scylla from for managment tests | http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylla-2019.1.repo | SCT_SCYLLA_REPO_M
+| **<a href="#user-content-scylla_repo_loader" name="scylla_repo_loader">scylla_repo_loader</a>**  | Url to the repo of scylla version to install c-s for loader | N/A | SCT_SCYLLA_REPO_LOADER
+| **<a href="#user-content-scylla_mgmt_repo" name="scylla_mgmt_repo">scylla_mgmt_repo</a>**  | Url to the repo of scylla manager version to install for management tests | http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-2.1.repo | SCT_SCYLLA_MGMT_REPO
+| **<a href="#user-content-scylla_mgmt_agent_repo" name="scylla_mgmt_agent_repo">scylla_mgmt_agent_repo</a>**  | Url to the repo of scylla manager agent version to install for management tests | N/A | SCT_SCYLLA_MGMT_AGENT_REPO
+| **<a href="#user-content-scylla_mgmt_agent_version" name="scylla_mgmt_agent_version">scylla_mgmt_agent_version</a>**  |  | N/A | SCT_SCYLLA_MGMT_AGENT_VERSION
+| **<a href="#user-content-scylla_mgmt_pkg" name="scylla_mgmt_pkg">scylla_mgmt_pkg</a>**  | Url to the scylla manager packages to install for management tests | N/A | SCT_SCYLLA_MGMT_PKG
+| **<a href="#user-content-stress_cmd_lwt_i" name="stress_cmd_lwt_i">stress_cmd_lwt_i</a>**  | Stress command for LWT performance test for INSERT baseline | N/A | SCT_STRESS_CMD_LWT_I
+| **<a href="#user-content-stress_cmd_lwt_d" name="stress_cmd_lwt_d">stress_cmd_lwt_d</a>**  | Stress command for LWT performance test for DELETE baseline | N/A | SCT_STRESS_CMD_LWT_D
+| **<a href="#user-content-stress_cmd_lwt_u" name="stress_cmd_lwt_u">stress_cmd_lwt_u</a>**  | Stress command for LWT performance test for UPDATE baseline | N/A | SCT_STRESS_CMD_LWT_U
+| **<a href="#user-content-stress_cmd_lwt_ine" name="stress_cmd_lwt_ine">stress_cmd_lwt_ine</a>**  | Stress command for LWT performance test for INSERT with IF NOT EXISTS | N/A | SCT_STRESS_CMD_LWT_INE
+| **<a href="#user-content-stress_cmd_lwt_uc" name="stress_cmd_lwt_uc">stress_cmd_lwt_uc</a>**  | Stress command for LWT performance test for UPDATE with IF <condition> | N/A | SCT_STRESS_CMD_LWT_UC
+| **<a href="#user-content-stress_cmd_lwt_ue" name="stress_cmd_lwt_ue">stress_cmd_lwt_ue</a>**  | Stress command for LWT performance test for UPDATE with IF EXISTS | N/A | SCT_STRESS_CMD_LWT_UE
+| **<a href="#user-content-stress_cmd_lwt_de" name="stress_cmd_lwt_de">stress_cmd_lwt_de</a>**  | Stress command for LWT performance test for DELETE with IF EXISTS | N/A | SCT_STRESS_CMD_LWT_DE
+| **<a href="#user-content-stress_cmd_lwt_dc" name="stress_cmd_lwt_dc">stress_cmd_lwt_dc</a>**  | Stress command for LWT performance test for DELETE with IF condition> | N/A | SCT_STRESS_CMD_LWT_DC
+| **<a href="#user-content-stress_cmd_lwt_mixed" name="stress_cmd_lwt_mixed">stress_cmd_lwt_mixed</a>**  | Stress command for LWT performance test for mixed lwt load | N/A | SCT_STRESS_CMD_LWT_MIXED
+| **<a href="#user-content-stress_cmd_lwt_mixed_baseline" name="stress_cmd_lwt_mixed_baseline">stress_cmd_lwt_mixed_baseline</a>**  | Stress command for LWT performance test for mixed lwt load baseline | N/A | SCT_STRESS_CMD_LWT_MIXED_BASELINE
+| **<a href="#user-content-use_cloud_manager" name="use_cloud_manager">use_cloud_manager</a>**  | When define true, will install scylla cloud manager | N/A | SCT_USE_CLOUD_MANAGER
+| **<a href="#user-content-use_mgmt" name="use_mgmt">use_mgmt</a>**  | When define true, will install scylla management | N/A | SCT_USE_MGMT
+| **<a href="#user-content-mgmt_port" name="mgmt_port">mgmt_port</a>**  | The port of scylla management | 10090 | SCT_MGMT_PORT
+| **<a href="#user-content-manager_prometheus_port" name="manager_prometheus_port">manager_prometheus_port</a>**  | Port to be used by the manager to contact Prometheus | N/A | SCT_MANAGER_PROMETHEUS_PORT
+| **<a href="#user-content-target_scylla_mgmt_server_repo" name="target_scylla_mgmt_server_repo">target_scylla_mgmt_server_repo</a>**  | Url to the repo of scylla manager version used to upgrade the manager server | N/A | SCT_TARGET_SCYLLA_MGMT_SERVER_REPO
+| **<a href="#user-content-target_scylla_mgmt_agent_repo" name="target_scylla_mgmt_agent_repo">target_scylla_mgmt_agent_repo</a>**  | Url to the repo of scylla manager version used to upgrade the manager agents | N/A | SCT_TARGET_SCYLLA_MGMT_AGENT_REPO
+| **<a href="#user-content-update_db_packages" name="update_db_packages">update_db_packages</a>**  | A local directory of rpms to install a custom version on top of<br>the scylla installed (or from repo or from ami) | N/A | SCT_UPDATE_DB_PACKAGES
+| **<a href="#user-content-monitor_branch" name="monitor_branch">monitor_branch</a>**  | The port of scylla management | branch-3.5 | SCT_MONITOR_BRANCH
+| **<a href="#user-content-db_type" name="db_type">db_type</a>**  | Db type to install into db nodes, scylla/cassandra | scylla | SCT_DB_TYPE
+| **<a href="#user-content-user_prefix" name="user_prefix">user_prefix</a>**  | the prefix of the name of the cloud instances, defaults to username | N/A | SCT_USER_PREFIX
+| **<a href="#user-content-ami_id_db_scylla_desc" name="ami_id_db_scylla_desc">ami_id_db_scylla_desc</a>**  | version name to report stats to Elasticsearch and tagged on cloud instances | N/A | SCT_AMI_ID_DB_SCYLLA_DESC
+| **<a href="#user-content-store_results_in_elasticsearch" name="store_results_in_elasticsearch">store_results_in_elasticsearch</a>**  | save the results in elasticsearch | True | SCT_STORE_RESULTS_IN_ELASTICSEARCH
+| **<a href="#user-content-sct_public_ip" name="sct_public_ip">sct_public_ip</a>**  | Override the default hostname address of the sct test runner,<br>for the monitoring of the Nemesis.<br>can only work out of the box in AWS | N/A | SCT_SCT_PUBLIC_IP
+| **<a href="#user-content-sct_ngrok_name" name="sct_ngrok_name">sct_ngrok_name</a>**  | Override the default hostname address of the sct test runner,<br>using ngrok server, see readme for more instructions | N/A | SCT_NGROK_NAME
+| **<a href="#user-content-backtrace_decoding" name="backtrace_decoding">backtrace_decoding</a>**  | If True, all backtraces found in db nodes would be decoded automatically | True | SCT_BACKTRACE_DECODING
+| **<a href="#user-content-instance_provision" name="instance_provision">instance_provision</a>**  | instance_provision: spot|on_demand|spot_fleet | spot | SCT_INSTANCE_PROVISION
+| **<a href="#user-content-instance_provision_fallback_on_demand" name="instance_provision_fallback_on_demand">instance_provision_fallback_on_demand</a>**  | instance_provision_fallback_on_demand: create instance on_demand provision type if instance with selected 'instance_provision' type creation failed. Expected values: true|false (default - false | N/A | SCT_INSTANCE_PROVISION_FALLBACK_ON_DEMAND
+| **<a href="#user-content-reuse_cluster" name="reuse_cluster">reuse_cluster</a>**  | If reuse_cluster is set it should hold test_id of the cluster that will be reused.<br>`reuse_cluster: 7dc6db84-eb01-4b61-a946-b5c72e0f6d71` | N/A | SCT_REUSE_CLUSTER
+| **<a href="#user-content-test_id" name="test_id">test_id</a>**  | test id to filter by | N/A | SCT_TEST_ID
+| **<a href="#user-content-seeds_selector" name="seeds_selector">seeds_selector</a>**  | How to select the seeds. Expected values: reflector/random/first | first | SCT_SEEDS_SELECTOR
+| **<a href="#user-content-seeds_num" name="seeds_num">seeds_num</a>**  | Number of seeds to select | 1 | SCT_SEEDS_NUM
+| **<a href="#user-content-send_email" name="send_email">send_email</a>**  | If true would send email out of the performance regression test | N/A | SCT_SEND_EMAIL
+| **<a href="#user-content-email_recipients" name="email_recipients">email_recipients</a>**  | list of email of send the performance regression test to | ['qa@scylladb.com'] | SCT_EMAIL_RECIPIENTS
+| **<a href="#user-content-email_subject_postfix" name="email_subject_postfix">email_subject_postfix</a>**  | Email subject postfix | N/A | SCT_EMAIL_SUBJECT_POSTFIX
+| **<a href="#user-content-enable_test_profiling" name="enable_test_profiling">enable_test_profiling</a>**  | Turn on sct profiling | N/A | SCT_ENABLE_TEST_PROFILING
+| **<a href="#user-content-ssh_transport" name="ssh_transport">ssh_transport</a>**  | Set type of ssh library to use. Could be 'fabric' (default) or 'libssh2' | fabric | SSH_TRANSPORT
+| **<a href="#user-content-bench_run" name="bench_run">bench_run</a>**  | If true would kill the scylla-bench thread in the test teardown | N/A | SCT_BENCH_RUN
+| **<a href="#user-content-fullscan" name="fullscan">fullscan</a>**  | If true would kill the fullscan thread in the test teardown | N/A | SCT_FULLSCAN
+| **<a href="#user-content-experimental" name="experimental">experimental</a>**  | when enabled scylla will use it's experimental features | True | SCT_EXPERIMENTAL
+| **<a href="#user-content-server_encrypt" name="server_encrypt">server_encrypt</a>**  | when enable scylla will use encryption on the server side | N/A | SCT_SERVER_ENCRYPT
+| **<a href="#user-content-client_encrypt" name="client_encrypt">client_encrypt</a>**  | when enable scylla will use encryption on the client side | N/A | SCT_CLIENT_ENCRYPT
+| **<a href="#user-content-hinted_handoff" name="hinted_handoff">hinted_handoff</a>**  | when enable or disable scylla hinted handoff (enabled/disabled) | N/A | SCT_HINTED_HANDOFF
+| **<a href="#user-content-authenticator" name="authenticator">authenticator</a>**  | which authenticator scylla will use AllowAllAuthenticator/PasswordAuthenticator | N/A | SCT_AUTHENTICATOR
+| **<a href="#user-content-authenticator_user" name="authenticator_user">authenticator_user</a>**  | the username if PasswordAuthenticator is used | N/A | SCT_AUTHENTICATOR_USER
+| **<a href="#user-content-authenticator_password" name="authenticator_password">authenticator_password</a>**  | the password if PasswordAuthenticator is used | N/A | SCT_AUTHENTICATOR_PASSWORD
+| **<a href="#user-content-authorizer" name="authorizer">authorizer</a>**  | which authorizer scylla will use AllowAllAuthorizer/CassandraAuthorizer | N/A | SCT_AUTHORIZER
+| **<a href="#user-content-system_auth_rf" name="system_auth_rf">system_auth_rf</a>**  | Replication factor will be set to system_auth | 3 | SCT_SYSTEM_AUTH_RF
+| **<a href="#user-content-alternator_port" name="alternator_port">alternator_port</a>**  | Port to configure for alternator in scylla.yaml | N/A | SCT_ALTERNATOR_PORT
+| **<a href="#user-content-dynamodb_primarykey_type" name="dynamodb_primarykey_type">dynamodb_primarykey_type</a>**  | Type of dynamodb table to create with range key or not, can be HASH or HASH_AND_RANGE | HASH | SCT_DYNAMODB_PRIMARYKEY_TYPE
+| **<a href="#user-content-alternator_write_isolation" name="alternator_write_isolation">alternator_write_isolation</a>**  | Set the write isolation for the alternator table, see https://github.com/scylladb/scylla/blob/master/docs/alternator/alternator.md#write-isolation-policies for more details | N/A | SCT_ALTERNATOR_WRITE_ISOLATION
+| **<a href="#user-content-alternator_use_dns_routing" name="alternator_use_dns_routing">alternator_use_dns_routing</a>**  | If true, spawn a docker with a dns server for the ycsb loader to point to | N/A | SCT_ALTERNATOR_USE_DNS_ROUTING
+| **<a href="#user-content-alternator_enforce_authorization" name="alternator_enforce_authorization">alternator_enforce_authorization</a>**  | If true, enable the authorization check in dynamodb api (alternator) | N/A | SCT_ALTERNATOR_ENFORCE_AUTHORIZATION
+| **<a href="#user-content-alternator_access_key_id" name="alternator_access_key_id">alternator_access_key_id</a>**  | the aws_access_key_id that would be used for alternator | N/A | SCT_ALTERNATOR_ACCESS_KEY_ID
+| **<a href="#user-content-alternator_secret_access_key" name="alternator_secret_access_key">alternator_secret_access_key</a>**  | the aws_secret_access_key that would be used for alternator | N/A | SCT_ALTERNATOR_SECRET_ACCESS_KEY
+| **<a href="#user-content-region_aware_loader" name="region_aware_loader">region_aware_loader</a>**  | When in multi region mode, run stress on loader that is located in the same region as db node | N/A | SCT_REGION_AWARE_LOADER
+| **<a href="#user-content-append_scylla_args" name="append_scylla_args">append_scylla_args</a>**  | More arguments to append to scylla command line | --blocked-reactor-notify-ms 500 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1 --enable-sstable-key-validation 1 | SCT_APPEND_SCYLLA_ARGS
+| **<a href="#user-content-append_scylla_args_oracle" name="append_scylla_args_oracle">append_scylla_args_oracle</a>**  | More arguments to append to oracle command line | N/A | SCT_APPEND_SCYLLA_ARGS_ORACLE
+| **<a href="#user-content-append_scylla_yaml" name="append_scylla_yaml">append_scylla_yaml</a>**  | More configuration to append to /etc/scylla/scylla.yaml | N/A | SCT_APPEND_SCYLLA_YAML
+| **<a href="#user-content-nemesis_class_name" name="nemesis_class_name">nemesis_class_name</a>**  | Nemesis class to use (possible types in sdcm.nemesis).<br>Next syntax supporting:<br>- nemesis_class_name: "NemesisName"  Run one nemesis in single thread<br>- nemesis_class_name: "<NemesisName>:<num>" Run <NemesisName> in <num><br>parallel threads on different nodes. Ex.: "ChaosMonkey:2"<br>- nemesis_class_name: "<NemesisName1>:<num1> <NemesisName2>:<num2>" Run<br><NemesisName1> in <num1> parallel threads and <NemesisName2> in <num2><br>parallel threads. Ex.: "DisruptiveMonkey:1 NonDisruptiveMonkey:2" | NoOpMonkey | SCT_NEMESIS_CLASS_NAME
+| **<a href="#user-content-nemesis_interval" name="nemesis_interval">nemesis_interval</a>**  | Nemesis sleep interval to use if None provided specifically in the test | 5 | SCT_NEMESIS_INTERVAL
+| **<a href="#user-content-nemesis_during_prepare" name="nemesis_during_prepare">nemesis_during_prepare</a>**  | Run nemesis during prepare stage of the test | True | SCT_NEMESIS_DURING_PREPARE
+| **<a href="#user-content-nemesis_seed" name="nemesis_seed">nemesis_seed</a>**  | A seed number in order to repeat nemesis sequence as part of SisyphusMonkey | N/A | SCT_NEMESIS_SEED
+| **<a href="#user-content-nemesis_add_node_cnt" name="nemesis_add_node_cnt">nemesis_add_node_cnt</a>**  | Add/remove nodes during GrowShrinkCluster nemesis | 1 | SCT_NEMESIS_ADD_NODE_CNT
+| **<a href="#user-content-cluster_target_size" name="cluster_target_size">cluster_target_size</a>**  | Used for scale test: max size of the cluster | N/A | SCT_CLUSTER_TARGET_SIZE
+| **<a href="#user-content-space_node_threshold" name="space_node_threshold">space_node_threshold</a>**  | Space node threshold before starting nemesis (bytes)<br>The default value is 6GB (6x1024^3 bytes)<br>This value is supposed to reproduce<br>https://github.com/scylladb/scylla/issues/1140 | N/A | SCT_SPACE_NODE_THRESHOLD
+| **<a href="#user-content-nemesis_filter_seeds" name="nemesis_filter_seeds">nemesis_filter_seeds</a>**  | If true runs the nemesis only on non seed nodes | True | SCT_NEMESIS_FILTER_SEEDS
+| **<a href="#user-content-stress_cmd" name="stress_cmd">stress_cmd</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD
+| **<a href="#user-content-gemini_version" name="gemini_version">gemini_version</a>**  | Version of download of the binaries of gemini tool | N/A | SCT_GEMINI_VERSION
+| **<a href="#user-content-gemini_schema_url" name="gemini_schema_url">gemini_schema_url</a>**  | Url of the schema/configuration the gemini tool would use | N/A | SCT_GEMINI_SCHEMA_URL
+| **<a href="#user-content-gemini_cmd" name="gemini_cmd">gemini_cmd</a>**  | gemini command to run (for now used only in GeminiTest) | N/A | SCT_GEMINI_CMD
+| **<a href="#user-content-gemini_seed" name="gemini_seed">gemini_seed</a>**  | Seed number for gemini command | N/A | SCT_GEMINI_SEED
+| **<a href="#user-content-gemini_table_options" name="gemini_table_options">gemini_table_options</a>**  | table options for created table. example:<br>["cdc={'enabled': true}"]<br>["cdc={'enabled': true}", "compaction={'class': 'IncrementalCompactionStrategy'}"] | N/A | SCT_GEMINI_TABLE_OPTIONS
+| **<a href="#user-content-instance_type_loader" name="instance_type_loader">instance_type_loader</a>**  | AWS image type of the loader node | N/A | SCT_INSTANCE_TYPE_LOADER
+| **<a href="#user-content-instance_type_monitor" name="instance_type_monitor">instance_type_monitor</a>**  | AWS image type of the monitor node | N/A | SCT_INSTANCE_TYPE_MONITOR
+| **<a href="#user-content-instance_type_db" name="instance_type_db">instance_type_db</a>**  | AWS image type of the db node | N/A | SCT_INSTANCE_TYPE_DB
+| **<a href="#user-content-instance_type_db_oracle" name="instance_type_db_oracle">instance_type_db_oracle</a>**  | AWS image type of the oracle node | N/A | SCT_INSTANCE_TYPE_DB_ORACLE
+| **<a href="#user-content-region_name" name="region_name">region_name</a>**  | AWS regions to use | N/A | SCT_REGION_NAME
+| **<a href="#user-content-security_group_ids" name="security_group_ids">security_group_ids</a>**  | AWS security groups ids to use | N/A | SCT_SECURITY_GROUP_IDS
+| **<a href="#user-content-subnet_id" name="subnet_id">subnet_id</a>**  | AWS subnet ids to use | N/A | SCT_SUBNET_ID
+| **<a href="#user-content-ami_id_db_scylla" name="ami_id_db_scylla">ami_id_db_scylla</a>**  | AMS AMI id to use for scylla db node | N/A | SCT_AMI_ID_DB_SCYLLA
+| **<a href="#user-content-ami_id_loader" name="ami_id_loader">ami_id_loader</a>**  | AMS AMI id to use for loader node | N/A | SCT_AMI_ID_LOADER
+| **<a href="#user-content-ami_id_monitor" name="ami_id_monitor">ami_id_monitor</a>**  | AMS AMI id to use for monitor node | N/A | SCT_AMI_ID_MONITOR
+| **<a href="#user-content-ami_id_db_cassandra" name="ami_id_db_cassandra">ami_id_db_cassandra</a>**  | AMS AMI id to use for cassandra node | N/A | SCT_AMI_ID_DB_CASSANDRA
+| **<a href="#user-content-ami_id_db_oracle" name="ami_id_db_oracle">ami_id_db_oracle</a>**  | AMS AMI id to use for oracle node | N/A | SCT_AMI_ID_DB_ORACLE
+| **<a href="#user-content-aws_root_disk_size_db" name="aws_root_disk_size_db">aws_root_disk_size_db</a>**  |  | N/A | SCT_AWS_ROOT_DISK_SIZE_DB
+| **<a href="#user-content-aws_root_disk_size_monitor" name="aws_root_disk_size_monitor">aws_root_disk_size_monitor</a>**  |  | N/A | SCT_AWS_ROOT_DISK_SIZE_MONITOR
+| **<a href="#user-content-aws_root_disk_size_loader" name="aws_root_disk_size_loader">aws_root_disk_size_loader</a>**  |  | N/A | SCT_AWS_ROOT_DISK_SIZE_LOADER
+| **<a href="#user-content-ami_db_scylla_user" name="ami_db_scylla_user">ami_db_scylla_user</a>**  |  | N/A | SCT_AMI_DB_SCYLLA_USER
+| **<a href="#user-content-ami_monitor_user" name="ami_monitor_user">ami_monitor_user</a>**  |  | N/A | SCT_AMI_MONITOR_USER
+| **<a href="#user-content-ami_loader_user" name="ami_loader_user">ami_loader_user</a>**  |  | N/A | SCT_AMI_LOADER_USER
+| **<a href="#user-content-ami_db_cassandra_user" name="ami_db_cassandra_user">ami_db_cassandra_user</a>**  |  | N/A | SCT_AMI_DB_CASSANDRA_USER
+| **<a href="#user-content-spot_max_price" name="spot_max_price">spot_max_price</a>**  | The max percentage of the on demand price we set for spot/fleet instances | 0.6 | SCT_SPOT_MAX_PRICE
+| **<a href="#user-content-extra_network_interface" name="extra_network_interface">extra_network_interface</a>**  | if true, create extra network interface on each node | N/A | SCT_EXTRA_NETWORK_INTERFACE
+| **<a href="#user-content-aws_instance_profile_name" name="aws_instance_profile_name">aws_instance_profile_name</a>**  | This is the name of the instance profile to set on all instances | N/A | SCT_AWS_INSTANCE_PROFILE_NAME
+| **<a href="#user-content-backup_bucket_location" name="backup_bucket_location">backup_bucket_location</a>**  | This is the bucket name to be used for backup with its region<br>(e.g. backup_bucket_location: 'manager-backup-tests') | N/A | SCT_BACKUP_BUCKET_LOCATION
+| **<a href="#user-content-tag_ami_with_result" name="tag_ami_with_result">tag_ami_with_result</a>**  | If True, would tag the ami with the test final result | N/A | SCT_TAG_AMI_WITH_RESULT
+| **<a href="#user-content-gce_datacenter" name="gce_datacenter">gce_datacenter</a>**  | Supported: us-east1 - means that the zone will be selected automatically or you can mention the zone explicitly, for example: us-east1-b | N/A | SCT_GCE_DATACENTER
+| **<a href="#user-content-gce_network" name="gce_network">gce_network</a>**  |  | N/A | SCT_GCE_NETWORK
+| **<a href="#user-content-gce_image" name="gce_image">gce_image</a>**  | GCE image to use for all node types: db, loader and monitor | N/A | SCT_GCE_IMAGE
+| **<a href="#user-content-gce_image_db" name="gce_image_db">gce_image_db</a>**  |  | N/A | SCT_GCE_IMAGE_DB
+| **<a href="#user-content-gce_image_monitor" name="gce_image_monitor">gce_image_monitor</a>**  |  | N/A | SCT_GCE_IMAGE_MONITOR
+| **<a href="#user-content-gce_image_loader" name="gce_image_loader">gce_image_loader</a>**  |  | N/A | SCT_GCE_IMAGE_LOADER
+| **<a href="#user-content-gce_image_username" name="gce_image_username">gce_image_username</a>**  |  | N/A | SCT_GCE_IMAGE_USERNAME
+| **<a href="#user-content-gce_instance_type_loader" name="gce_instance_type_loader">gce_instance_type_loader</a>**  |  | N/A | SCT_GCE_INSTANCE_TYPE_LOADER
+| **<a href="#user-content-gce_root_disk_type_loader" name="gce_root_disk_type_loader">gce_root_disk_type_loader</a>**  |  | N/A | SCT_GCE_ROOT_DISK_TYPE_LOADER
+| **<a href="#user-content-gce_n_local_ssd_disk_loader" name="gce_n_local_ssd_disk_loader">gce_n_local_ssd_disk_loader</a>**  |  | N/A | SCT_GCE_N_LOCAL_SSD_DISK_LOADER
+| **<a href="#user-content-gce_instance_type_monitor" name="gce_instance_type_monitor">gce_instance_type_monitor</a>**  |  | N/A | SCT_GCE_INSTANCE_TYPE_MONITOR
+| **<a href="#user-content-gce_root_disk_type_monitor" name="gce_root_disk_type_monitor">gce_root_disk_type_monitor</a>**  |  | N/A | SCT_GCE_ROOT_DISK_TYPE_MONITOR
+| **<a href="#user-content-gce_root_disk_size_monitor" name="gce_root_disk_size_monitor">gce_root_disk_size_monitor</a>**  |  | N/A | SCT_GCE_ROOT_DISK_SIZE_MONITOR
+| **<a href="#user-content-gce_n_local_ssd_disk_monitor" name="gce_n_local_ssd_disk_monitor">gce_n_local_ssd_disk_monitor</a>**  |  | N/A | SCT_GCE_N_LOCAL_SSD_DISK_MONITOR
+| **<a href="#user-content-gce_instance_type_db" name="gce_instance_type_db">gce_instance_type_db</a>**  |  | N/A | SCT_GCE_INSTANCE_TYPE_DB
+| **<a href="#user-content-gce_root_disk_type_db" name="gce_root_disk_type_db">gce_root_disk_type_db</a>**  |  | N/A | SCT_GCE_ROOT_DISK_TYPE_DB
+| **<a href="#user-content-gce_root_disk_size_db" name="gce_root_disk_size_db">gce_root_disk_size_db</a>**  |  | N/A | SCT_GCE_ROOT_DISK_SIZE_DB
+| **<a href="#user-content-gce_n_local_ssd_disk_db" name="gce_n_local_ssd_disk_db">gce_n_local_ssd_disk_db</a>**  |  | N/A | SCT_GCE_N_LOCAL_SSD_DISK_DB
+| **<a href="#user-content-gce_image_minikube" name="gce_image_minikube">gce_image_minikube</a>**  |  | N/A | SCT_GCE_IMAGE_MINIKUBE
+| **<a href="#user-content-gce_instance_type_minikube" name="gce_instance_type_minikube">gce_instance_type_minikube</a>**  |  | N/A | SCT_GCE_INSTANCE_TYPE_MINIKUBE
+| **<a href="#user-content-gce_root_disk_type_minikube" name="gce_root_disk_type_minikube">gce_root_disk_type_minikube</a>**  |  | N/A | SCT_GCE_ROOT_DISK_TYPE_MINIKUBE
+| **<a href="#user-content-gce_root_disk_size_minikube" name="gce_root_disk_size_minikube">gce_root_disk_size_minikube</a>**  |  | N/A | SCT_GCE_ROOT_DISK_SIZE_MINIKUBE
+| **<a href="#user-content-gke_cluster_version" name="gke_cluster_version">gke_cluster_version</a>**  |  | N/A | SCT_GKE_CLUSTER_VERSION
+| **<a href="#user-content-gke_cluster_n_nodes" name="gke_cluster_n_nodes">gke_cluster_n_nodes</a>**  |  | N/A | SCT_GKE_CLUSTER_N_NODES
+| **<a href="#user-content-k8s_scylla_operator_docker_image" name="k8s_scylla_operator_docker_image">k8s_scylla_operator_docker_image</a>**  |  | N/A | SCT_K8S_SCYLLA_OPERATOR_DOCKER_IMAGE
+| **<a href="#user-content-k8s_scylla_datacenter" name="k8s_scylla_datacenter">k8s_scylla_datacenter</a>**  |  | N/A | SCT_K8S_SCYLLA_DATACENTER
+| **<a href="#user-content-k8s_scylla_rack" name="k8s_scylla_rack">k8s_scylla_rack</a>**  |  | N/A | SCT_K8S_SCYLLA_RACK
+| **<a href="#user-content-k8s_scylla_cluster_name" name="k8s_scylla_cluster_name">k8s_scylla_cluster_name</a>**  |  | N/A | SCT_K8S_SCYLLA_CLUSTER_NAME
+| **<a href="#user-content-k8s_scylla_cpu_n" name="k8s_scylla_cpu_n">k8s_scylla_cpu_n</a>**  |  | N/A | SCT_K8S_SCYLLA_CPU_N
+| **<a href="#user-content-k8s_scylla_mem_gi" name="k8s_scylla_mem_gi">k8s_scylla_mem_gi</a>**  |  | N/A | SCT_K8S_SCYLLA_MEM_GI
+| **<a href="#user-content-k8s_scylla_disk_gi" name="k8s_scylla_disk_gi">k8s_scylla_disk_gi</a>**  |  | N/A | SCT_K8S_SCYLLA_DISK_GI
+| **<a href="#user-content-k8s_loader_cluster_name" name="k8s_loader_cluster_name">k8s_loader_cluster_name</a>**  |  | N/A | SCT_K8S_LOADER_CLUSTER_NAME
+| **<a href="#user-content-k8s_loader_cpu_n" name="k8s_loader_cpu_n">k8s_loader_cpu_n</a>**  |  | N/A | SCT_K8S_LOADER_CPU_N
+| **<a href="#user-content-k8s_loader_mem_gi" name="k8s_loader_mem_gi">k8s_loader_mem_gi</a>**  |  | N/A | SCT_K8S_LOADER_MEM_GI
+| **<a href="#user-content-minikube_version" name="minikube_version">minikube_version</a>**  |  | N/A | SCT_MINIKUBE_VERSION
+| **<a href="#user-content-k8s_cert_manager_version" name="k8s_cert_manager_version">k8s_cert_manager_version</a>**  |  | N/A | SCT_K8S_CERT_MANAGER_VERSION
+| **<a href="#user-content-docker_image" name="docker_image">docker_image</a>**  |  | N/A | SCT_DOCKER_IMAGE
+| **<a href="#user-content-db_nodes_private_ip" name="db_nodes_private_ip">db_nodes_private_ip</a>**  |  | N/A | SCT_DB_NODES_PRIVATE_IP
+| **<a href="#user-content-db_nodes_public_ip" name="db_nodes_public_ip">db_nodes_public_ip</a>**  |  | N/A | SCT_DB_NODES_PUBLIC_IP
+| **<a href="#user-content-loaders_private_ip" name="loaders_private_ip">loaders_private_ip</a>**  |  | N/A | SCT_LOADERS_PRIVATE_IP
+| **<a href="#user-content-loaders_public_ip" name="loaders_public_ip">loaders_public_ip</a>**  |  | N/A | SCT_LOADERS_PUBLIC_IP
+| **<a href="#user-content-monitor_nodes_private_ip" name="monitor_nodes_private_ip">monitor_nodes_private_ip</a>**  |  | N/A | SCT_MONITOR_NODES_PRIVATE_IP
+| **<a href="#user-content-monitor_nodes_public_ip" name="monitor_nodes_public_ip">monitor_nodes_public_ip</a>**  |  | N/A | SCT_MONITOR_NODES_PUBLIC_IP
+| **<a href="#user-content-cassandra_stress_population_size" name="cassandra_stress_population_size">cassandra_stress_population_size</a>**  |  | N/A | SCT_CASSANDRA_STRESS_POPULATION_SIZE
+| **<a href="#user-content-cassandra_stress_threads" name="cassandra_stress_threads">cassandra_stress_threads</a>**  |  | N/A | SCT_CASSANDRA_STRESS_THREADS
+| **<a href="#user-content-add_node_cnt" name="add_node_cnt">add_node_cnt</a>**  |  | N/A | SCT_ADD_NODE_CNT
+| **<a href="#user-content-stress_multiplier" name="stress_multiplier">stress_multiplier</a>**  |  | N/A | SCT_STRESS_MULTIPLIER
+| **<a href="#user-content-run_fullscan" name="run_fullscan">run_fullscan</a>**  |  | N/A | SCT_RUN_FULLSCAN
+| **<a href="#user-content-keyspace_num" name="keyspace_num">keyspace_num</a>**  |  | N/A | SCT_KEYSPACE_NUM
+| **<a href="#user-content-round_robin" name="round_robin">round_robin</a>**  |  | N/A | SCT_ROUND_ROBIN
+| **<a href="#user-content-batch_size" name="batch_size">batch_size</a>**  |  | N/A | SCT_BATCH_SIZE
+| **<a href="#user-content-pre_create_schema" name="pre_create_schema">pre_create_schema</a>**  |  | N/A | SCT_PRE_CREATE_SCHEMA
+| **<a href="#user-content-pre_create_keyspace" name="pre_create_keyspace">pre_create_keyspace</a>**  | Command to create keysapce to be pre-create before running workload | N/A | SCT_PRE_CREATE_KEYSPACE
+| **<a href="#user-content-post_prepare_cql_cmds" name="post_prepare_cql_cmds">post_prepare_cql_cmds</a>**  | CQL Commands to run after prepare stage finished (relevant only to longevity_test.py) | N/A | SCT_POST_PREPARE_CQL_CMDS
+| **<a href="#user-content-prepare_wait_no_compactions_timeout" name="prepare_wait_no_compactions_timeout">prepare_wait_no_compactions_timeout</a>**  | At the end of prepare stage, run major compaction and wait for this time (in minutes) for compaction to finish. (relevant only to longevity_test.py), Should be use only for when facing issue like compaction is affect the test or load | N/A | SCT_PREPARE_WAIT_NO_COMPACTIONS_TIMEOUT
+| **<a href="#user-content-compaction_strategy" name="compaction_strategy">compaction_strategy</a>**  | Choose a specific compaction strategy to pre-create schema with. | SizeTieredCompactionStrategy | SCT_COMPACTION_STRATEGY
+| **<a href="#user-content-sstable_size" name="sstable_size">sstable_size</a>**  | Configure sstable size for the usage of pre-create-schema mode | N/A | SSTABLE_SIZE
+| **<a href="#user-content-cluster_health_check" name="cluster_health_check">cluster_health_check</a>**  | When true, start cluster health checker for all nodes | True | SCT_CLUSTER_HEALTH_CHECK
+| **<a href="#user-content-validate_partitions" name="validate_partitions">validate_partitions</a>**  | when true, log of the partitions before and after the nemesis run is compacted | N/A | SCT_VALIDATE_PARTITIONS
+| **<a href="#user-content-table_name" name="table_name">table_name</a>**  | table name to check for the validate_partitions check | N/A | SCT_TABLE_NAME
+| **<a href="#user-content-primary_key_column" name="primary_key_column">primary_key_column</a>**  | primary key of the table to check for the validate_partitions check | N/A | SCT_PRIMARY_KEY_COLUMN
+| **<a href="#user-content-stress_read_cmd" name="stress_read_cmd">stress_read_cmd</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_READ_CMD
+| **<a href="#user-content-prepare_verify_cmd" name="prepare_verify_cmd">prepare_verify_cmd</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_PREPARE_VERIFY_CMD
+| **<a href="#user-content-user_profile_table_count" name="user_profile_table_count">user_profile_table_count</a>**  | number of tables to create for template user c-s | N/A | SCT_USER_PROFILE_TABLE_COUNT
+| **<a href="#user-content-scylla_mgmt_upgrade_to_repo" name="scylla_mgmt_upgrade_to_repo">scylla_mgmt_upgrade_to_repo</a>**  | Url to the repo of scylla manager version to upgrade to for management tests | N/A | SCT_SCYLLA_MGMT_UPGRADE_TO_REPO
+| **<a href="#user-content-partition_range_with_data_validation" name="partition_range_with_data_validation">partition_range_with_data_validation</a>**  | Relevant for scylla-bench. Hold range (min - max) of PKs values for partitions that data was<br>written with validate data and will be validate during the read.<br>Example: 0-250.<br>Optional parameter for DeleteByPartitionsMonkey and DeleteByRowsRangeMonkey | N/A | SCT_PARTITION_RANGE_WITH_DATA_VALIDATION
+| **<a href="#user-content-max_partitions_in_test_table" name="max_partitions_in_test_table">max_partitions_in_test_table</a>**  | Relevant for scylla-bench. MAX partition keys (partition-count) in the scylla_bench.test table.<br>Mandatory parameter for DeleteByPartitionsMonkey and DeleteByRowsRangeMonkey | N/A | SCT_MAX_PARTITIONS_IN_TEST_TABLE
+| **<a href="#user-content-stress_cmd_w" name="stress_cmd_w">stress_cmd_w</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_W
+| **<a href="#user-content-stress_cmd_r" name="stress_cmd_r">stress_cmd_r</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_R
+| **<a href="#user-content-stress_cmd_m" name="stress_cmd_m">stress_cmd_m</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_M
+| **<a href="#user-content-prepare_write_cmd" name="prepare_write_cmd">prepare_write_cmd</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_PREPARE_WRITE_CMD
+| **<a href="#user-content-stress_cmd_no_mv" name="stress_cmd_no_mv">stress_cmd_no_mv</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_NO_MV
+| **<a href="#user-content-stress_cmd_no_mv_profile" name="stress_cmd_no_mv_profile">stress_cmd_no_mv_profile</a>**  |  | N/A | SCT_STRESS_CMD_NO_MV_PROFILE
+| **<a href="#user-content-cs_user_profiles" name="cs_user_profiles">cs_user_profiles</a>**  |  | N/A | SCT_CS_USER_PROFILES
+| **<a href="#user-content-cs_duration" name="cs_duration">cs_duration</a>**  |  | N/A | SCT_CS_DURATION
+| **<a href="#user-content-stress_cmd_mv" name="stress_cmd_mv">stress_cmd_mv</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_MV
+| **<a href="#user-content-prepare_stress_cmd" name="prepare_stress_cmd">prepare_stress_cmd</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_PREPARE_STRESS_CMD
+| **<a href="#user-content-skip_download" name="skip_download">skip_download</a>**  |  | N/A | SCT_SKIP_DOWNLOAD
+| **<a href="#user-content-sstable_file" name="sstable_file">sstable_file</a>**  |  | N/A | SCT_SSTABLE_FILE
+| **<a href="#user-content-sstable_url" name="sstable_url">sstable_url</a>**  |  | N/A | SCT_SSTABLE_URL
+| **<a href="#user-content-sstable_md5" name="sstable_md5">sstable_md5</a>**  |  | N/A | SCT_SSTABLE_MD5
+| **<a href="#user-content-flush_times" name="flush_times">flush_times</a>**  |  | N/A | SCT_FLUSH_TIMES
+| **<a href="#user-content-flush_period" name="flush_period">flush_period</a>**  |  | N/A | SCT_FLUSH_PERIOD
+| **<a href="#user-content-new_scylla_repo" name="new_scylla_repo">new_scylla_repo</a>**  |  | N/A | SCT_NEW_SCYLLA_REPO
+| **<a href="#user-content-new_version" name="new_version">new_version</a>**  | Assign new upgrade version, use it to upgrade to specific minor release. eg: 3.0.1 | N/A | SCT_NEW_VERSION
+| **<a href="#user-content-target_upgrade_version" name="target_upgrade_version">target_upgrade_version</a>**  | Assign target upgrade version, use for decide if the truncate entries test should be run. This test should be performed in case the target upgrade version >= 3.1 | N/A | SCT_TAGRET_UPGRADE_VERSION
+| **<a href="#user-content-upgrade_node_packages" name="upgrade_node_packages">upgrade_node_packages</a>**  |  | N/A | SCT_UPGRADE_NODE_PACKAGES
+| **<a href="#user-content-test_sst3" name="test_sst3">test_sst3</a>**  |  | N/A | SCT_TEST_SST3
+| **<a href="#user-content-test_upgrade_from_installed_3_1_0" name="test_upgrade_from_installed_3_1_0">test_upgrade_from_installed_3_1_0</a>**  | Enable an option for installed 3.1.0 for work around a scylla issue if it's true | N/A | SCT_TEST_UPGRADE_FROM_INSTALLED_3_1_0
+| **<a href="#user-content-authorization_in_upgrade" name="authorization_in_upgrade">authorization_in_upgrade</a>**  | Which Authorization to enable after upgrade | N/A | SCT_AUTHORIZATION_IN_UPGRADE
+| **<a href="#user-content-remove_authorization_in_rollback" name="remove_authorization_in_rollback">remove_authorization_in_rollback</a>**  | Disable Authorization after rollback to old Scylla | N/A | SCT_REMOVE_AUTHORIZATION_IN_ROLLBACK
+| **<a href="#user-content-new_introduced_pkgs" name="new_introduced_pkgs">new_introduced_pkgs</a>**  |  | N/A | SCT_NEW_INTRODUCED_PKGS
+| **<a href="#user-content-recover_system_tables" name="recover_system_tables">recover_system_tables</a>**  |  | N/A | SCT_RECOVER_SYSTEM_TABLES
+| **<a href="#user-content-stress_cmd_1" name="stress_cmd_1">stress_cmd_1</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_1
+| **<a href="#user-content-stress_cmd_complex_prepare" name="stress_cmd_complex_prepare">stress_cmd_complex_prepare</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_COMPLEX_PREPARE
+| **<a href="#user-content-prepare_write_stress" name="prepare_write_stress">prepare_write_stress</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_PREPARE_WRITE_STRESS
+| **<a href="#user-content-stress_cmd_read_10m" name="stress_cmd_read_10m">stress_cmd_read_10m</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_READ_10M
+| **<a href="#user-content-stress_cmd_read_cl_one" name="stress_cmd_read_cl_one">stress_cmd_read_cl_one</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure. | N/A | SCT_STRESS_CMD_READ_CL_ONE
+| **<a href="#user-content-stress_cmd_read_60m" name="stress_cmd_read_60m">stress_cmd_read_60m</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_READ_60M
+| **<a href="#user-content-stress_cmd_complex_verify_read" name="stress_cmd_complex_verify_read">stress_cmd_complex_verify_read</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_COMPLEX_VERIFY_READ
+| **<a href="#user-content-stress_cmd_complex_verify_more" name="stress_cmd_complex_verify_more">stress_cmd_complex_verify_more</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_COMPLEX_VERIFY_MORE
+| **<a href="#user-content-write_stress_during_entire_test" name="write_stress_during_entire_test">write_stress_during_entire_test</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_WRITE_STRESS_DURING_ENTIRE_TEST
+| **<a href="#user-content-verify_data_after_entire_test" name="verify_data_after_entire_test">verify_data_after_entire_test</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure. | N/A | SCT_VERIFY_DATA_AFTER_ENTIRE_TEST
+| **<a href="#user-content-stress_cmd_read_cl_quorum" name="stress_cmd_read_cl_quorum">stress_cmd_read_cl_quorum</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_READ_CL_QUORUM
+| **<a href="#user-content-verify_stress_after_cluster_upgrade" name="verify_stress_after_cluster_upgrade">verify_stress_after_cluster_upgrade</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_VERIFY_STRESS_AFTER_CLUSTER_UPGRADE
+| **<a href="#user-content-stress_cmd_complex_verify_delete" name="stress_cmd_complex_verify_delete">stress_cmd_complex_verify_delete</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_COMPLEX_VERIFY_DELETE
+| **<a href="#user-content-scylla_encryption_options" name="scylla_encryption_options">scylla_encryption_options</a>**  | options will be used for enable encryption at-rest for tables | N/A | SCT_SCYLLA_ENCRYPTION_OPTIONS
+| **<a href="#user-content-logs_transport" name="logs_transport">logs_transport</a>**  | How to transport logs: rsyslog, ssh or docker | rsyslog | SCT_LOGS_TRANSPORT
+| **<a href="#user-content-collect_logs" name="collect_logs">collect_logs</a>**  | Collect logs from instances and sct runner | N/A | SCT_COLLECT_LOGS
+| **<a href="#user-content-execute_post_behavior" name="execute_post_behavior">execute_post_behavior</a>**  | Run post behavior actions in sct teardown step | N/A | SCT_EXECUTE_POST_BEHAVIOR
+| **<a href="#user-content-post_behavior_db_nodes" name="post_behavior_db_nodes">post_behavior_db_nodes</a>**  | Failure/post test behavior, i.e. what to do with the db cloud instances at the end of the test.<br><br>'destroy' - Destroy instances and credentials (default)<br>'keep' - Keep instances running and leave credentials alone<br>'keep-on-failure' - Keep instances if testrun failed | keep-on-failure | SCT_POST_BEHAVIOR_DB_NODES
+| **<a href="#user-content-post_behavior_loader_nodes" name="post_behavior_loader_nodes">post_behavior_loader_nodes</a>**  | Failure/post test behavior, i.e. what to do with the loader cloud instances at the end of the test.<br><br>'destroy' - Destroy instances and credentials (default)<br>'keep' - Keep instances running and leave credentials alone<br>'keep-on-failure' - Keep instances if testrun failed | destroy | SCT_POST_BEHAVIOR_LOADER_NODES
+| **<a href="#user-content-post_behavior_monitor_nodes" name="post_behavior_monitor_nodes">post_behavior_monitor_nodes</a>**  | Failure/post test behavior, i.e. what to do with the monitor cloud instances at the end of the test.<br><br>'destroy' - Destroy instances and credentials (default)<br>'keep' - Keep instances running and leave credentials alone<br>'keep-on-failure' - Keep instances if testrun failed | keep-on-failure | SCT_POST_BEHAVIOR_MONITOR_NODES
+| **<a href="#user-content-workaround_kernel_bug_for_iotune" name="workaround_kernel_bug_for_iotune">workaround_kernel_bug_for_iotune</a>**  | Workaround a known kernel bug which causes iotune to fail in scylla_io_setup, only effect GCE backend | N/A | SCT_WORKAROUND_KERNEL_BUG_FOR_IOTUNE
+| **<a href="#user-content-internode_compression" name="internode_compression">internode_compression</a>**  | scylla option: internode_compression | N/A | SCT_INTERNODE_COMPRESSION
+| **<a href="#user-content-internode_encryption" name="internode_encryption">internode_encryption</a>**  | scylla sub option of server_encryption_options: internode_encryption | all | SCT_INTERNODE_ENCRYPTION
+| **<a href="#user-content-loader_swap_size" name="loader_swap_size">loader_swap_size</a>**  | The size of the swap file for the loaders. Its size in bytes calculated by x * 1MB | 1024 | SCT_LOADER_SWAP_SIZE
+| **<a href="#user-content-monitor_swap_size" name="monitor_swap_size">monitor_swap_size</a>**  | The size of the swap file for the monitors. Its size in bytes calculated by x * 1MB | 8192 | SCT_MONITOR_SWAP_SIZE
+| **<a href="#user-content-store_perf_results" name="store_perf_results">store_perf_results</a>**  | A flag that indicates whether or not to gather the prometheus stats at the end of the run.<br>Intended to be used in performance testing | N/A | SCT_STORE_PERF_RESULTS
+| **<a href="#user-content-append_scylla_setup_args" name="append_scylla_setup_args">append_scylla_setup_args</a>**  | More arguments to append to scylla_setup command line | N/A | SCT_APPEND_SCYLLA_SETUP_ARGS
+| **<a href="#user-content-use_preinstalled_scylla" name="use_preinstalled_scylla">use_preinstalled_scylla</a>**  | Don't install/update ScyllaDB on DB nodes | N/A | SCT_USE_PREINSTALLED_SCYLLA
+| **<a href="#user-content-stress_cdclog_reader_cmd" name="stress_cdclog_reader_cmd">stress_cdclog_reader_cmd</a>**  | cdc-stressor command to read cdc_log table.<br>You can specify everything but the -node , -keyspace, -table, parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CDCLOG_READER_CMD
+| **<a href="#user-content-store_cdclog_reader_stats_in_es" name="store_cdclog_reader_stats_in_es">store_cdclog_reader_stats_in_es</a>**  | Add cdclog reader stats to ES for future performance result calculating | N/A | SCT_STORE_CDCLOG_READER_STATS_IN_ES
+| **<a href="#user-content-stop_test_on_stress_failure" name="stop_test_on_stress_failure">stop_test_on_stress_failure</a>**  | If set to True the test will be stopped immediately when stress command failed.<br>When set to False the test will continue to run even when there are errors in the<br>stress process | True | SCT_STOP_TEST_ON_STRESS_FAILURE
+| **<a href="#user-content-stress_cdc_log_reader_batching_enable" name="stress_cdc_log_reader_batching_enable">stress_cdc_log_reader_batching_enable</a>**  | retrieving data from multiple streams in one poll | True | SCT_STRESS_CDC_LOG_READER_BATCHING_ENABLE
+| **<a href="#user-content-use_legacy_cluster_init" name="use_legacy_cluster_init">use_legacy_cluster_init</a>**  | Use legacy cluster initialization with autobootsrap disabled and parallel node setup | N/A | SCT_USE_LEGACY_CLUSTER_INIT
+| **<a href="#user-content-availability_zone" name="availability_zone">availability_zone</a>**  | Availability zone to use. Same for multi-region scenario. | N/A | SCT_AVAILABILITY_ZONE
+| **<a href="#user-content-num_nodes_to_rollback" name="num_nodes_to_rollback">num_nodes_to_rollback</a>**  | Number of nodes to upgrade and rollback in test_generic_cluster_upgrade | N/A | SCT_NUM_NODES_TO_ROLLBACK
+| **<a href="#user-content-upgrade_sstables" name="upgrade_sstables">upgrade_sstables</a>**  | Whether to upgrade sstables as part of upgrade_node or not | N/A | SCT_UPGRADE_SSTABLES
+| **<a href="#user-content-stress_before_upgrade" name="stress_before_upgrade">stress_before_upgrade</a>**  | Stress command to be run before upgrade (preapre stage) | N/A | SCT_STRESS_BEFORE_UPGRADE
+| **<a href="#user-content-stress_during_entire_upgrade" name="stress_during_entire_upgrade">stress_during_entire_upgrade</a>**  | Stress command to be run during the upgrade - user should take care for suitable duration | N/A | SCT_STRESS_DURING_ENTIRE_UPGRADE
+| **<a href="#user-content-stress_after_cluster_upgrade" name="stress_after_cluster_upgrade">stress_after_cluster_upgrade</a>**  | Stress command to be run after full upgrade - usually used to read the dataset for verification | N/A | SCT_STRESS_AFTER_CLUSTER_UPGRADE

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1500,7 +1500,7 @@ class SCTConfiguration(dict):
 
             default = self.get_default_value(opt['name'])
             default_text = default if default else 'N/A'
-            ret += """| **<a name="{name}">{name}</a>**  | {help_text} | {default_text} | {env}\n""".format(
+            ret += """| **<a href="#user-content-{name}" name="{name}">{name}</a>**  | {help_text} | {default_text} | {env}\n""".format(
                 help_text=help_text, default_text=default_text, **opt)
 
         return ret


### PR DESCRIPTION
changed the config parameters to be linkable with anchors
so we can send link directly to the specific parameter in where we need it