### PR TITLE
fix(_read_system_log_and_publish_events): stop matching json-encoded logs to the patterns

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -25,6 +25,7 @@ import time
 import traceback
 import uuid
 import itertools
+import json
 
 from collections import defaultdict
 from typing import List, Optional, Dict, Union
@@ -1331,6 +1332,12 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             if start_search_from_byte:
                 db_file.seek(start_search_from_byte)
             for index, line in enumerate(db_file, start=last_line_no):
+                json_log = None
+                if line[0] == '{':
+                    try:
+                        json_log = json.loads(line)
+                    except Exception:
+                        pass
                 if not start_from_beginning and Setup.RSYSLOG_ADDRESS:
                     line = line.strip()
                     if not exclude_from_logging:
@@ -1343,6 +1350,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                                 break
                         if not exclude:
                             LOGGER.debug(line)
+                if json_log:
+                    continue
                 match = backtrace_regex.search(line)
                 one_line_backtrace = []
                 if match and backtraces:


### PR DESCRIPTION
https://trello.com/c/Fcf0SWEe/2483-k8s-stop-matching-json-encoded-logs-to-general-regex

Messages that come from sidecar are in json format and are getting mixed with textual logs from scylla.

Some patterns we have, like 'std::runtime_error', 'stream_exception' are comes from seastar, and are generated by both scylla and api server.
Those that generated by api servers are getting leaked thrue sidecar framework and endup in sidecar logs.

Since api server errors are not critical we should avoid them to be matched by same patterns we have for textual scylla logs.

PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
