### PR TITLE
fix(show-monitor): monitor missing dashboards on master

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4194,7 +4194,7 @@ class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-inst
         self.log.debug("Using %s ScyllaDB version to derive monitoring version" %
                        self.scylla_version)
         version = re.match(r"(\d+\.\d+)", self.scylla_version)
-        if not version:
+        if not version or 'dev' in self.scylla_version:
             return 'master'
         else:
             return version.group(1)
@@ -4281,7 +4281,7 @@ class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-inst
 
     def set_local_sct_ip(self):
 
-        ngrok_name = self.params.get('sct_ngrok_name', default=None)
+        ngrok_name = self.params.get('sct_ngrok_name')
         if ngrok_name:
             return self.configure_ngrok()
 


### PR DESCRIPTION
since master version are now `4.4-dev` and such,
seems like we are looking for 4.4 version on monitoring when
using `hydra invesigate show-monitor`, which doesn't yet exists.

we should default to 'master' in those cases.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
