### PR TITLE
fix(EventsAnalyzer): don't stop test on cassandra-stress/scylla-bench…

### DIFF
--- a/sdcm/sct_events_analyzer.py
+++ b/sdcm/sct_events_analyzer.py
@@ -25,8 +25,8 @@ class EventsAnalyzer(threading.Thread):
                 if event_class == 'TestResultEvent':
                     # don't send kill test cause of those event, test is already done when those are sent out
                     continue
-
-                if event_class in ['CassandraStressEvent', 'ScyllaBenchEvent', 'YcsbStressEvent', 'NdbenchStressEvent'] \
+                # TODO: add support for `stop_test_on_failure` for those too
+                if event_class in ['YcsbStressEvent', 'NdbenchStressEvent'] \
                         and message_data.type == 'failure':
                     raise TestFailure(f"Stress Command failed: {message_data}")
 


### PR DESCRIPTION
… errors

Now that we have `stop_test_on_failure` option, a critical event would be
raise for those cases

TODO: we still need to handle `YcsbStressEvent` and `NdbenchStressEvent`

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
