### PR TITLE
improvement(cluster): wait for Scylla Machine Image setup to be done

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2648,6 +2648,15 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         else:
             self.remoter.run('sudo yum install -y epel-release', retry=3)
 
+    def is_machine_image_configured(self):
+        smi_configured_path = "/etc/scylla/machine_image_configured"
+        result = self.remoter.run(cmd=f"test -e {smi_configured_path}", ignore_status=True, verbose=False)
+        return result.ok
+
+    def wait_for_machine_image_configured(self):
+        self.log.info("Waiting for Scylla Machine Image setup to finish...")
+        wait.wait_for(self.is_machine_image_configured, step=10, timeout=300)
+
 
 class FlakyRetryPolicy(RetryPolicy):
 

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -467,6 +467,10 @@ class ScyllaGCECluster(cluster.BaseScyllaCluster, GCECluster):
                                                )
         self.version = '2.1'
 
+    @staticmethod
+    def _wait_for_preinstalled_scylla(node):
+        node.wait_for_machine_image_configured()
+
 
 class LoaderSetGCE(cluster.BaseLoaderSet, GCECluster):
 


### PR DESCRIPTION
when image setup is finished SMI touches /etc/scylla/machine_image_configured file.
So the the correct way to wait the image setup to be finished is to check if
the file exists.
Fixes: #2855

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
