### PR TITLE
fix(cluster_init): Add recommended cluster initialization with bootst…

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -57,3 +57,5 @@ collect_logs: false
 
 loader_swap_size: 1024 # Size of swap file for loader node in bytes 1024 * 1MB
 monitor_swap_size: 8192 # Size of swap file for monitor node in bytes 8192 * 1MB
+
+use_legacy_cluster_init: true

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -188,3 +188,4 @@
 | **<a name="loader_swap_size">loader_swap_size</a>**  | The size of the swap file for the loaders. Its size in bytes calculated by x * 1MB | 1024 | SCT_LOADER_SWAP_SIZE
 | **<a name="monitor_swap_size">monitor_swap_size</a>**  | The size of the swap file for the monitors. Its size in bytes calculated by x * 1MB | 8192 | SCT_MONITOR_SWAP_SIZE
 | **<a name="store_perf_results">store_perf_results</a>**  | A flag that indicates whether or not to gather the prometheus stats at the end of the run.<br>Intended to be used in performance testing | N/A | SCT_STORE_PERF_RESULTS
+| **<a name="use_legacy_cluster_init">use_legacy_cluster_init</a>**  | Use legacy cluster initialization with autobootsrap disabled and parallel node setup | True | SCT_USE_LEGACY_CLUSTER_INIT

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -419,6 +419,10 @@ class ScyllaGCECluster(cluster.BaseScyllaCluster, GCECluster):
                                                )
         self.version = '2.1'
 
+    @staticmethod
+    def _wait_for_preinstalled_scylla(node):
+        node.wait_for_machine_image_configured()
+
 
 class LoaderSetGCE(cluster.BaseLoaderSet, GCECluster):
 

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -830,6 +830,8 @@ class SCTConfiguration(dict):
 
         dict(name="append_scylla_setup_args", env="SCT_APPEND_SCYLLA_SETUP_ARGS", type=str,
              help="More arguments to append to scylla_setup command line"),
+        dict(name="use_legacy_cluster_init", env="SCT_USE_LEGACY_CLUSTER_INIT", type=boolean,
+             help="""Use legacy cluster initialization with autobootsrap disabled and parallel node setup"""),
     ]
 
     required_params = ['cluster_backend', 'test_duration', 'n_db_nodes', 'n_loaders', 'user_credentials_path']

--- a/test-cases/performance/perf-regression.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys.yaml
@@ -21,3 +21,5 @@ backtrace_decoding: false
 store_perf_results: true
 send_email: true
 email_recipients: ['qa@scylladb.com']
+
+use_legacy_cluster_init: false


### PR DESCRIPTION
…rap enabled

According to scylla doc next schema of cluster initializtion should be used:
1. choose one node as seed.
2. update scylla.yaml on all other node with seed ip(only one)
3. start scylla on node as seed with auto bootstrap enabled
4. start next node with autobootstrap enabled.
5. wait node is UN
6. Repeat 4, 5 for all other node.
7. update scylla.yaml with required number of seeds ips. Reboot not required

docs:
https://docs.scylladb.com/operating-scylla/procedures/cluster-management/create_cluster/

Also was added code from commit:
https://github.com/scylladb/scylla-cluster-tests/pull/2856/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
