### PR TITLE
fix(sct-runner): workaround for OOM issue #2859

### DIFF
--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -48,7 +48,7 @@ class SctRunner:
     @staticmethod
     def instance_type(test_duration):
         if test_duration > 7 * 60:
-            return "m5.large"
+            return "r5.large"
         return "t3.large"  # has 7h 12m CPU burst
 
     @staticmethod


### PR DESCRIPTION
For long runs moving to r5.large since it has 32GB RAM.
Checked all regions, this instance type should be available there:

```
16:49 $ aws ec2 describe-instance-type-offerings --location-type availability-zone  --filters Name=instance-type,Values=r5.large --region eu-north-1 --output table
--------------------------------------------------------
|             DescribeInstanceTypeOfferings            |
+------------------------------------------------------+
||                InstanceTypeOfferings               ||
|+--------------+---------------+---------------------+|
|| InstanceType |   Location    |    LocationType     ||
|+--------------+---------------+---------------------+|
||  r5.large    |  eu-north-1c  |  availability-zone  ||
||  r5.large    |  eu-north-1b  |  availability-zone  ||
||  r5.large    |  eu-north-1a  |  availability-zone  ||
|+--------------+---------------+---------------------+|
(sct38) ✔ ~/devel/scylladb/scylla-cluster-tests [sct-runner-r5 L|…10⚑ 3] 
19:24 $ aws ec2 describe-instance-type-offerings --location-type availability-zone  --filters Name=instance-type,Values=r5.large --region eu-west-1 --output table
-------------------------------------------------------
|            DescribeInstanceTypeOfferings            |
+-----------------------------------------------------+
||               InstanceTypeOfferings               ||
|+--------------+--------------+---------------------+|
|| InstanceType |  Location    |    LocationType     ||
|+--------------+--------------+---------------------+|
||  r5.large    |  eu-west-1c  |  availability-zone  ||
||  r5.large    |  eu-west-1a  |  availability-zone  ||
||  r5.large    |  eu-west-1b  |  availability-zone  ||
|+--------------+--------------+---------------------+|
(sct38) ✔ ~/devel/scylladb/scylla-cluster-tests [sct-runner-r5 L|…10⚑ 3] 
19:24 $ aws ec2 describe-instance-type-offerings --location-type availability-zone  --filters Name=instance-type,Values=r5.large --region eu-west-2 --output table
-------------------------------------------------------
|            DescribeInstanceTypeOfferings            |
+-----------------------------------------------------+
||               InstanceTypeOfferings               ||
|+--------------+--------------+---------------------+|
|| InstanceType |  Location    |    LocationType     ||
|+--------------+--------------+---------------------+|
||  r5.large    |  eu-west-2c  |  availability-zone  ||
||  r5.large    |  eu-west-2a  |  availability-zone  ||
||  r5.large    |  eu-west-2b  |  availability-zone  ||
|+--------------+--------------+---------------------+|
(sct38) ✔ ~/devel/scylladb/scylla-cluster-tests [sct-runner-r5 L|…10⚑ 3] 
19:25 $ aws ec2 describe-instance-type-offerings --location-type availability-zone  --filters Name=instance-type,Values=r5.large --region eu-central-1 --output table
----------------------------------------------------------
|              DescribeInstanceTypeOfferings             |
+--------------------------------------------------------+
||                 InstanceTypeOfferings                ||
|+--------------+-----------------+---------------------+|
|| InstanceType |    Location     |    LocationType     ||
|+--------------+-----------------+---------------------+|
||  r5.large    |  eu-central-1b  |  availability-zone  ||
||  r5.large    |  eu-central-1c  |  availability-zone  ||
||  r5.large    |  eu-central-1a  |  availability-zone  ||
|+--------------+-----------------+---------------------+|
(sct38) ✔ ~/devel/scylladb/scylla-cluster-tests [sct-runner-r5 L|…10⚑ 3] 
19:25 $ aws ec2 describe-instance-type-offerings --location-type availability-zone  --filters Name=instance-type,Values=r5.large --region us-east-1 --output table
-------------------------------------------------------
|            DescribeInstanceTypeOfferings            |
+-----------------------------------------------------+
||               InstanceTypeOfferings               ||
|+--------------+--------------+---------------------+|
|| InstanceType |  Location    |    LocationType     ||
|+--------------+--------------+---------------------+|
||  r5.large    |  us-east-1c  |  availability-zone  ||
||  r5.large    |  us-east-1b  |  availability-zone  ||
||  r5.large    |  us-east-1a  |  availability-zone  ||
||  r5.large    |  us-east-1d  |  availability-zone  ||
||  r5.large    |  us-east-1f  |  availability-zone  ||
|+--------------+--------------+---------------------+|
(sct38) ✔ ~/devel/scylladb/scylla-cluster-tests [sct-runner-r5 L|…10⚑ 3] 
```



## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
