### PR TITLE
fix(vars/getJobTimeouts.groovy): Fix timeouts

### DIFF
--- a/vars/getJobTimeouts.groovy
+++ b/vars/getJobTimeouts.groovy
@@ -10,16 +10,18 @@ List<Integer> call(Map params, String region){
     ./docker/env/hydra.sh output-conf -b "${params.backend}" 2>/dev/null | grep test_duration | awk '{print \$2}'
     """
     def testDuration = sh(script: cmd, returnStdout: true).trim()
-    println("Test duration: $testDuration")
     testDuration = testDuration.toInteger()
+    Integer testStartupTimeout = 20
+    Integer testTeardownTimeout = 40
+    Integer collectLogsTimeout = 70
+    Integer resourceCleanupTimeout = 15
+    Integer sendEmailTimeout = 5
+    Integer testRunTimeout = testStartupTimeout + testDuration + testTeardownTimeout
+    Integer runnerTimeout = testRunTimeout + collectLogsTimeout + resourceCleanupTimeout + sendEmailTimeout
     println("Test duration: $testDuration")
-    Integer testRunTimeout = testDuration + Math.max( (int) (testDuration * 0.2), (int) 40)
     println("Test run timeout: $testRunTimeout")
-    Integer runnerTimeout = (int) (testRunTimeout * 1.2)
-    println("Runner timeout: $runnerTimeout")
-    Integer collectLogsTimeout = Math.max( (int) (testDuration * 0.2), (int) 40)
     println("Collect logs timeout: $collectLogsTimeout")
-    Integer resourceCleanupTimeout = Math.max( (int) (testDuration * 0.2), (int) 40)
     println("Resource cleanup timeout: $resourceCleanupTimeout")
+    println("Runner timeout: $runnerTimeout")
     return [testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCleanupTimeout]
 }


### PR DESCRIPTION
https://trello.com/c/VHHvfSqW/2499-incorrect-keep-alive-time-for-sct-runner

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
