### PR TITLE
fix(upgrade_test): use strict pattern for idx_token error

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -420,7 +420,8 @@ class UpgradeTest(FillDatabaseData):
     # @staticmethod
     def search_for_idx_token_error_after_upgrade(self, node, step):
         self.log.debug('Search for idx_token error. Step {}'.format(step))
-        idx_token_error = list(node.follow_system_log(patterns=['idx_token'], start_from_beginning=True))
+        idx_token_error = list(node.follow_system_log(
+            patterns=["Column idx_token doesn't exist"], start_from_beginning=True))
         if idx_token_error:
             IndexSpecialColumnErrorEvent('Node: %s. Step: %s. '
                                          'Found error: index special column "idx_token" is not recognized' %


### PR DESCRIPTION
follow_system_log() compiles string to regex with re.IGNORECASE flag,
the simple 'idx_token' pattern would wrongly match feature log (eg:
CORRECT_IDX_TOKEN_IN_SECONDARY_INDEX).

This patch changed to use strict pattern.

Signed-off-by: Amos Kong <amos@scylladb.com>

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/2868


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
