### PR TITLE
fix(amazon2 check): not check cluster name during amazon2 artifact test

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -81,8 +81,9 @@ class ArtifactsTest(ClusterTester):
         if self.params["cluster_backend"] == "gce":
             self.verify_users()
 
-        with self.subTest("check the cluster name"):
-            self.check_cluster_name()
+        if self.params["use_preinstalled_scylla"] and "docker" not in self.params["cluster_backend"]:
+            with self.subTest("check the cluster name"):
+                self.check_cluster_name()
 
         with self.subTest("check Scylla server after installation"):
             self.check_scylla()


### PR DESCRIPTION
amazon2 artifact test doesn't use prepared ami that set cluster name in user-data.
Cluster name validation checks that cluster is named according to the user data, so
this check can't be performed for amazon2 artifact test

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
