### PR TITLE
fix(multidc test): configure remoter with new public IP after reboot

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -488,8 +488,11 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         raise AssertionError(f"Could not find the requested node {self.ip_address} in nodetool status")
 
     def refresh_ip_address(self):
+        if self.ssh_login_info["hostname"] == self.external_address:
+            return
         self.ssh_login_info["hostname"] = self.external_address
-        self.remoter.hostname = self.external_address
+        self.remoter.stop()
+        self._init_remoter(self.ssh_login_info)
         self._init_port_mapping()
 
     @cached_property


### PR DESCRIPTION
Issue https://github.com/scylladb/scylla-cluster-tests/issues/2854
RestartThenRepairNode failed after machine restarted with new public IP.
SCT does not handle this IP change and node fail to restart.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
