### PR TITLE
feature(nemesis): New nemesis to work with cdc feature

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -134,3 +134,5 @@ scylla_version: ''
 remove_authorization_in_rollback: false
 test_upgrade_from_installed_3_1_0: false
 target_upgrade_version: ''
+
+stress_cdclog_reader_cmd: "cdc-stressor -stream-query-round-duration 30s"

--- a/sdcm/cdclog_reader_thread.py
+++ b/sdcm/cdclog_reader_thread.py
@@ -9,10 +9,10 @@ from sdcm.sct_events import CDCReaderStressEvent, Severity
 from sdcm.utils.common import get_docker_stress_image_name
 from sdcm.utils.docker_utils import RemoteDocker
 from sdcm.stress_thread import format_stress_cmd_error, DockerBasedStressThread
+from sdcm.utils.cdc.options import CDC_LOGTABLE_SUFFIX
 
 LOGGER = logging.getLogger(__name__)
 
-CDC_LOGTABLE_SUFFIX = "_scylla_cdc_log"
 CDCLOG_READER_IMAGE = get_docker_stress_image_name(tool_name="cdcstressor")
 PP = pprint.PrettyPrinter(indent=2)
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2431,10 +2431,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def disrupt_toggle_cdc_feature_properties_on_table(self):
         """Manipulate cdc feature settings
 
-        randomly choose table form list and toggle cdc feature settings
-        if cdc was disaled, wait settings applying and scylla_cdc_log table
-        removing and enable cdc back
-        if cdc was enabled, run cdc stressor tool for table for period [5-20] minutes
+        Find table with CDC enabled (skip nemesis if not found).
+        Randomly select on CDC parameter.
+        Toggle the selected parameter state (True/False) or select a random value for TTL
 
         """
         self._set_current_disruption("ToggleCDCProperties")

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -43,6 +43,7 @@ from sdcm.mgmt import TaskStatus
 from sdcm.utils.common import remote_get_file, get_db_tables, generate_random_string, \
     update_certificates, reach_enospc_on_node, clean_enospc_on_node, parse_nodetool_listsnapshots
 from sdcm.utils.decorators import retrying
+from sdcm.utils import cdc
 from sdcm.log import SDCMAdapter
 from sdcm.keystore import KeyStore
 from sdcm.prometheus import nemesis_metrics_obj
@@ -2427,6 +2428,104 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.target_node.remoter.run(
             "stress-ng --vm-bytes $(awk '/MemTotal/{printf \"%d\\n\", $2 * 0.9;}' < /proc/meminfo)k --vm-keep -m 1 -t 100")
 
+    def disrupt_toggle_cdc_feature_properties_on_table(self):
+        """Manipulate cdc feature settings
+
+        randomly choose table form list and toggle cdc feature settings
+        if cdc was disaled, wait settings applying and scylla_cdc_log table
+        removing and enable cdc back
+        if cdc was enabled, run cdc stressor tool for table for period [5-20] minutes
+
+        """
+        self._set_current_disruption("ToggleCDCProperties")
+
+        ks_tables_with_cdc = self.cluster.get_all_tables_with_cdc(self.target_node)
+        self.log.debug(f"Found next tables with enabled cdc feature: {ks_tables_with_cdc}")
+
+        if not ks_tables_with_cdc:
+            self.log.warning("CDC is not enabled on any table. Skipping")
+            UnsupportedNemesis("CDC is not enabled on any table. Skipping")
+            return
+
+        ks, table = random.choice(ks_tables_with_cdc).split(".")
+
+        self.log.debug(f"Get table {ks}.{table} cdc extension state")
+        with self.cluster.cql_connection_patient(node=self.target_node) as session:
+            cdc_settings = cdc.options.get_table_cdc_properties(session, ks, table)
+        self.log.debug(f"table {ks}.{table} cdc extension state: {cdc_settings}")
+
+        self.log.debug("Choose random cdc property to toggle")
+        cdc_property = random.choice(cdc.options.get_cdc_settings_names())
+        self.log.debug(f"Next cdc property will be changed {cdc_property}")
+
+        cdc_settings[cdc_property] = cdc.options.toggle_cdc_property(cdc_property, cdc_settings[cdc_property])
+        self.log.debug(f"New table cdc extension state: {cdc_settings}")
+
+        self.log.info(f"Apply new cdc settigs for table {ks}.{table}: {cdc_settings}")
+        self._alter_table_with_cdc_properties(ks, table, cdc_settings)
+        self._verify_cdc_feature_status(ks, table, cdc_settings)
+
+    def disrupt_run_cdcstressor_tool(self):
+        self._set_current_disruption(label="RunCDCStressorTool")
+
+        ks_tables_with_cdc = self.cluster.get_all_tables_with_cdc(self.target_node)
+        if not ks_tables_with_cdc:
+            self.log.warning("CDC is not enabled on any table. Skipping")
+            UnsupportedNemesis("CDC is not enabled on any table. Skipping")
+            return
+        ks, table = random.choice(ks_tables_with_cdc).split(".")
+        self._run_cdc_stressor_tool(ks, table)
+
+    def _run_cdc_stressor_tool(self, ks, table):
+        cdc_stressor_cmd = self.tester.params.get("stress_cdclog_reader_cmd")
+
+        if " -duration" not in cdc_stressor_cmd:
+            read_time = random.randint(5, 20)
+            cdc_stressor_cmd += f" -duration {read_time}m "
+
+        cdc_reader_thread = self.tester.run_cdclog_reader_thread(stress_cmd=cdc_stressor_cmd,
+                                                                 stress_num=1,
+                                                                 keyspace_name=ks,
+                                                                 base_table_name=table)
+
+        self.tester.verify_cdclog_reader_results(cdc_reader_thread, update_es=False)
+
+    def _alter_table_with_cdc_properties(self, keyspace: str, table: str, cdc_settings: dict) -> None:
+        """Alter base table with cdc properties
+
+        Build valid query and alter table with cdc properties
+        :param keyspace: keyspace name
+        :type keyspace: str
+        :param table: base table name
+        :type table: str
+        :param cdc_enabled: is cdc enabled for base table, defaults to True
+        :type cdc_enabled: bool, optional
+        :param preimage: is preimage enabled for base table, defaults to False
+        :type preimage: bool, optional
+        :param postimage: is postimage enabled for base table, defaults to False
+        :type postimage: bool, optional
+        :param ttl: set ttl for scylla_cdc_log table, defaults to None
+        :type ttl: Optional[int], optional
+        """
+        cmd = f"ALTER TABLE {keyspace}.{table} WITH cdc = {cdc_settings};"
+        self.log.debug(f"Alter command: {cmd}")
+        with self.cluster.cql_connection_patient(self.target_node) as session:
+            session.execute(cmd)
+        # wait applying cdc configuration
+        time.sleep(15)
+
+    def _verify_cdc_feature_status(self, keyspace: str, table: str, cdc_settings: dict) -> None:
+
+        self.log.debug("Wait for cdc enabled and cdc log tables will be populated")
+        time.sleep(60)
+        output = self.target_node.run_cqlsh(f"desc keyspace {keyspace}")
+        self.log.debug(output.stdout)
+
+        with self.cluster.cql_connection_patient(node=self.target_node) as session:
+            actual_cdc_settings = cdc.options.get_table_cdc_properties(session, keyspace, table)
+
+        assert actual_cdc_settings == cdc_settings, f"CDC extension settings are differs"
+
 
 class NotSpotNemesis(Nemesis):
     def set_target_node(self):
@@ -3343,6 +3442,20 @@ class SisyphusMonkey(Nemesis):
         self.call_next_nemesis()
 
 
+class ToggleCDCMonkey(Nemesis):
+    disruptive = False
+
+    def disrupt(self):
+        self.disrupt_toggle_cdc_feature_properties_on_table()
+
+
+class CDCStressorMonkey(Nemesis):
+    disruptive = False
+
+    def disrupt(self):
+        self.disrupt_run_cdcstressor_tool()
+
+
 # Disable unstable streaming err nemesises
 #
 # class DecommissionStreamingErrMonkey(Nemesis):
@@ -3370,7 +3483,6 @@ class SisyphusMonkey(Nemesis):
 #     @log_time_elapsed_and_status
 #     def disrupt(self):
 #         self.disrupt_repair_streaming_err()
-
 DEPRECATED_LIST_OF_NEMESISES = [UpgradeNemesis, UpgradeNemesisOneNode, RollbackNemesis]
 
 COMPLEX_NEMESIS = [NoOpMonkey, ChaosMonkey,

--- a/sdcm/utils/cdc/__init__.py
+++ b/sdcm/utils/cdc/__init__.py
@@ -1,0 +1,1 @@
+from sdcm.utils.cdc import options

--- a/sdcm/utils/cdc/options.py
+++ b/sdcm/utils/cdc/options.py
@@ -1,0 +1,113 @@
+import re
+import time
+import logging
+
+from typing import Dict, Union, List
+from random import choice, randint
+
+LOGGER = logging.getLogger(__name__)
+
+CDC_LOGTABLE_SUFFIX = "_scylla_cdc_log"
+CDC_SETTINGS_NAMES_VALUES = {
+    "enabled": [True, False],
+    "delta": ["full", "keys"],
+    "preimage": ["full", "on", "off"],
+    "postimage": [True, False],
+    "ttl": "86400"
+}
+
+CDC_DELTA_REGEXP = r"delta.*?(?P<delta>(full|keys))"
+CDC_ENABLED_REGEXP = r"enabled.*?(?P<enabled>(true|false))"
+CDC_PREIMAGE_REGEXP = r"preimage.*?(?P<preimage>(full|on|off))"
+CDC_POSTIMAGE_REGEXP = r"postimage.*?(?P<postimage>(true|false))"
+CDC_TTL_REGEXP = r"ttl.*?(?P<ttl>\d+)"
+
+CDC_SETTINGS_REGEXP = [CDC_ENABLED_REGEXP,
+                       CDC_DELTA_REGEXP,
+                       CDC_PREIMAGE_REGEXP,
+                       CDC_POSTIMAGE_REGEXP,
+                       CDC_TTL_REGEXP]
+
+
+def parse_cdc_blob_settings(blob: bytes) -> Dict[str, Union[bool, str]]:
+    """parse blob object with cdc setttings
+
+    cdc settings stored in MetaTableData as blob.
+    b'\x05\x00\x00\x00\x05\x00\x00\x00delta\x04\x00\x00\x00full
+      \x07\x00\x00\x00enabled\x04\x00\x00\x00true
+      \t\x00\x00\x00postimage\x05\x00\x00\x00true
+      \x08\x00\x00\x00preimage\x05\x00\x00\x00false
+      \x03\x00\x00\x00ttl\x05\x00\x00\x00860'
+
+    using regexp the bytes string parsed to dict
+        cdc_settings = {"delta": "full",
+                    "enabled": "true",
+                    "preimage": "false",
+                    "postimage": "true",
+                    "ttl": "860"}
+
+    :param blob: blob object containing cdc settings
+    :type blob: bytes
+    :returns: dict with cdc settings
+    :rtype: {dict}
+    """
+    cdc_settings = {"delta": "full",
+                    "enabled": False,
+                    "preimage": False,
+                    "postimage": False,
+                    "ttl": "86400"}
+
+    for regexp in CDC_SETTINGS_REGEXP:
+        res = re.search(regexp, blob.decode())
+        if res:
+            for key, value in res.groupdict().items():
+                if value == 'false':
+                    value = False
+                elif value == 'true':
+                    value = True
+
+                cdc_settings[key] = value
+
+    return cdc_settings
+
+
+def get_table_cdc_properties(session, ks_name: str, table_name: str) -> Dict[str, Union[bool, str]]:
+    """Return cdc settings for table
+
+    Get cdc settings from table meta data and return dict
+    cdc_settings = {"delta": "full",
+                    "enabled": "true",
+                    "preimage": "false",
+                    "postimage": "true",
+                    "ttl": "860"}
+
+    :param ks_name: [description]
+    :type ks_name: str
+    :param table_name: [description]
+    :type table_name: str
+    :returns: [description]
+    :rtype: {Dict[str, str]}
+    """
+
+    session.cluster.refresh_schema_metadata()
+    # For some reason, `refresh_schema_metadata` doesn't refresh immediatelly...
+    time.sleep(10)
+    ks = session.cluster.metadata.keyspaces[ks_name]
+    raw_cdc_extention = ks.tables[table_name].extensions['cdc']
+    LOGGER.debug(f"Blob object with cdc settings: {raw_cdc_extention}")
+    cdc_settings = parse_cdc_blob_settings(raw_cdc_extention)
+    LOGGER.debug(f"CDC settings as dict: {cdc_settings}")
+
+    return cdc_settings
+
+
+def toggle_cdc_property(name: str, value: Union[str, bool]) -> Union[bool, str]:
+    if name in ["ttl"]:
+        return str(randint(300, 3600))
+    else:
+        variants = set(CDC_SETTINGS_NAMES_VALUES[name]) - set([value])
+        return choice(list(variants))
+
+
+def get_cdc_settings_names() -> List[str]:
+    return list(CDC_SETTINGS_NAMES_VALUES.keys())


### PR DESCRIPTION
CDC feature is moved to GA status on v4.3.
Added 2 new nemesis which allow to check the functionality
of cdc feature during longevity jobs:

- ToggleCDCMonkey: nemesis can enable/disable the cdc for user created tables and enable/disable additional cdc options
- CDCStressorMonkey: nemesis run cdc stressor tool, which read cdc log table during random time

Trello: https://trello.com/c/dkPmTBSe

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
