### PR TITLE
fix(disrupt_add_drop_column) add missing _set_current_disruption

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1255,6 +1255,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self._add_drop_column_target_table)
         if self._add_drop_column_target_table is None:
             raise UnsupportedNemesis("AddDropColumnMonkey: can't find table to run on")
+        self._set_current_disruption(f'AddDropColumnMonkey table {".".join(self._add_drop_column_target_table)}')
         self._add_drop_column_run_in_cycle()
 
     def modify_table_comment(self):


### PR DESCRIPTION
fix for logs description of disrupt_add_drop_column
disrupt_add_drop_column not having correct description

Signed-off-by: Shoshan Dagany <shoshan.dagany@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
