### PR TITLE
fix(StopWaitStartMonkey): on k8s it should not start scylla, but wait till s-o bring it up

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -335,6 +335,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.target_node.stop_scylla_server(verify_up=False, verify_down=True)
         self.log.info("Sleep for %s seconds", sleep_time)
         time.sleep(sleep_time)
+        if self._is_it_on_kubernetes():
+            # Kubernetes brings node up automatically, no need to start it up
+            self.target_node.wait_db_up(timeout=sleep_time)
+            return
         self.target_node.start_scylla_server(verify_up=True, verify_down=False)
 
     def disrupt_stop_start_scylla_server(self):  # pylint: disable=invalid-name


### PR DESCRIPTION
https://trello.com/c/qLfZOweU/2551-k8s-stopwaitstartmonkey-make-it-wait-scylla-instead-of-starting-it-up

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
