### PR TITLE
fix(restart_node_with_resharding): make it work on k8s all the time

### DIFF
--- a/sdcm/utils/k8s.py
+++ b/sdcm/utils/k8s.py
@@ -171,8 +171,8 @@ class KubernetesOps:
 
     @classmethod
     def kubectl_multi_cmd(cls, kluster, *command, namespace: Optional[str] = None, timeout: int = KUBECTL_TIMEOUT,
-                         remoter: Optional['KubernetesCmdRunner'] = None, ignore_status: bool = False,
-                         verbose: bool = True):
+                          remoter: Optional['KubernetesCmdRunner'] = None, ignore_status: bool = False,
+                          verbose: bool = True):
         total_command = ' '.join(command)
         final_command = []
         for cmd in total_command.split(' '):


### PR DESCRIPTION
https://trello.com/c/KaqlGBoV/2552-k8s-fix-restartnodewithresharding

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
