### PR TITLE
fix(cluster_k8s): increase scylla readiness timeout

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -434,7 +434,7 @@ class PodCluster(cluster.BaseCluster):
     def wait_for_init(self):
         raise NotImplementedError("Derived class must implement 'wait_for_init' method!")
 
-    @timeout(message="Wait for pod(s) to be ready...", timeout=600)
+    @timeout(message="Wait for pod(s) to be ready...", timeout=900)
     def wait_for_pods_readiness(self, count: Optional[int] = None):
         if count is None:
             count = len(self.nodes)


### PR DESCRIPTION
https://trello.com/c/ZIYbDtLJ/2555-k8s-adding-pod-can-fail-due-to-the-timeout

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
