### PR TITLE
fix(operator_monitoring.py): operator_pod_status can be None

### DIFF
--- a/sdcm/cluster_k8s/operator_monitoring.py
+++ b/sdcm/cluster_k8s/operator_monitoring.py
@@ -110,6 +110,8 @@ class ScyllaOperatorStatusMonitoring(threading.Thread):
         restart_happened = False
         try:
             status = self.kluster.operator_pod_status
+            if status is None:
+                return
             current_restart_count = status.container_statuses[0].restart_count
             if self.last_restart_count != current_restart_count:
                 restart_happened = True


### PR DESCRIPTION
https://trello.com/c/qU4Hn5Bc/2554-k8s-address-nonetype-object-has-no-attribute-containerstatuses

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
