### PR TITLE
fix(get_peers_info): cover case when run_cqlsh returns malformed output

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2493,6 +2493,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         peers_details = {}
         for line in cql_result[3:-2]:
             line_splitted = line.split('|')
+            if len(line_splitted) < 8:
+                continue
             peers_details[line_splitted[0].strip()] = {'data_center': line_splitted[1].strip(),
                                                        'host_id': line_splitted[2].strip(),
                                                        'rack': line_splitted[3].strip(),


### PR DESCRIPTION
https://trello.com/c/cqXGCeM8/2559-k8s-fix-getpeersinfo-issue

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
