### PR TITLE
fix(update_scylla_config): Make it flush changes before feeding yaml file to kubectl

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -498,7 +498,11 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):
     def wait_for_init(self, node_list=None, verbose=False, timeout=None, *_, **__):
         node_list = node_list if node_list else self.nodes
         self.wait_for_nodes_up_and_normal(nodes=node_list)
-        if self.update_scylla_config():
+        if self.scylla_yaml_update_required:
+            self.update_scylla_config()
+            time.sleep(30)
+            self.rollout_restart()
+            self.scylla_yaml_update_required = False
             self.wait_for_nodes_up_and_normal(nodes=node_list)
 
     @cached_property
@@ -616,19 +620,19 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):
         self.replace_scylla_cluster_value("/spec/version", new_version)
         self.rollout_restart()
 
-    def update_scylla_config(self) -> bool:
+    def update_scylla_config(self):
         with self.scylla_yaml_lock:
-            if not self.scylla_yaml_update_required:
-                return False
             with NamedTemporaryFile("w", delete=False) as tmp:
                 tmp.write(yaml.safe_dump(self.scylla_yaml))
-            self.k8s_cluster.kubectl(f"create configmap scylla-config --from-file=scylla.yaml={tmp.name}",
-                                     namespace=self.namespace)
-            time.sleep(30)
-            self.rollout_restart()
+                tmp.flush()
+                KubernetesOps.kubectl_multi_cmd(
+                    self.k8s_cluster,
+                    f'kubectl create configmap scylla-config --from-file=scylla.yaml={tmp.name} ||'
+                    f'kubectl create configmap scylla-config --from-file=scylla.yaml={tmp.name} -o yaml '
+                    '--dry-run=client | kubectl replace -f -',
+                    namespace=self.namespace
+                )
             os.remove(tmp.name)
-            self.scylla_yaml_update_required = False
-        return True
 
     def rollout_restart(self):
         self.k8s_cluster.kubectl("rollout restart statefulset", namespace=self.namespace)


### PR DESCRIPTION
https://trello.com/c/TeU2BT76/2576-k8s-make-updatescyllaconfig-tolerate-when-config-is-already-there

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
