### PR TITLE
fix(test_remoter): stop running long running tests

### DIFF
--- a/unit_tests/test_remoter.py
+++ b/unit_tests/test_remoter.py
@@ -173,8 +173,8 @@ class TestRemoteCmdRunners(unittest.TestCase):
         for future in threads:
             future.join()
 
-    @parameterized.expand(ALL_COMMANDS_WITH_ALL_OPTIONS)
-    # @unittest.skip('To be ran manually')
+    # @parameterized.expand(ALL_COMMANDS_WITH_ALL_OPTIONS)
+    @unittest.skip('To be ran manually')
     def test_run_in_mainthread(  # pylint: disable=too-many-arguments
             self, remoter_type, host: str, stmt: str, verbose: bool, ignore_status: bool, new_session: bool, retry: int,
             timeout: Union[float, None]):


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
