### PR TITLE
fix(sdcm/utils/k8s.py): make _k8s_core_v1_api cached on KubernetesCluster

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -168,6 +168,14 @@ class KubernetesCluster:
         pods = KubernetesOps.list_pods(self, namespace='scylla-operator-system')
         return pods[0].status if pods else None
 
+    @cached_property
+    def k8s_core_v1_api(self):
+        return KubernetesOps.core_v1_api(self)
+
+    @cached_property
+    def k8s_apps_v1_api(self):
+        return KubernetesOps.apps_v1_api(self)
+
 
 class BasePodContainer(cluster.BaseNode):
     parent_cluster: PodCluster
@@ -413,12 +421,12 @@ class PodCluster(cluster.BaseCluster):
         return f"{type(self).__name__} {self.name} | Namespace: {self.namespace}"
 
     @cached_property
-    def _k8s_apps_v1_api(self):
-        return KubernetesOps.apps_v1_api(self.k8s_cluster)
+    def k8s_apps_v1_api(self):
+        return self.k8s_cluster.k8s_apps_v1_api
 
     @cached_property
-    def _k8s_core_v1_api(self):
-        return KubernetesOps.core_v1_api(self.k8s_cluster)
+    def k8s_core_v1_api(self):
+        return self.k8s_cluster.k8s_core_v1_api
 
     def _create_node(self, node_index: int, pod_name: str) -> BasePodContainer:
         node = self.PodContainerClass(parent_cluster=self,

--- a/sdcm/remote/kubernetes_cmd_runner.py
+++ b/sdcm/remote/kubernetes_cmd_runner.py
@@ -33,7 +33,7 @@ class KubernetesRunner(Runner):
         super().__init__(context)
 
         self.process = None
-        self._k8s_core_v1_api = KubernetesOps.core_v1_api(context.k8s_kluster)
+        self._k8s_core_v1_api = context.k8s_kluster.k8s_core_v1_api
         self._ws_lock = threading.RLock()
 
     def should_use_pty(self, pty: bool, fallback: bool) -> bool:

--- a/sdcm/utils/k8s.py
+++ b/sdcm/utils/k8s.py
@@ -126,29 +126,29 @@ class KubernetesOps:
 
     @classmethod
     def apps_v1_api(cls, kluster):
-        return getattr(kluster, "_k8s_apps_v1_api", None) or k8s.client.AppsV1Api(cls.api_client(kluster))
+        return k8s.client.AppsV1Api(cls.api_client(kluster))
 
     @classmethod
     def core_v1_api(cls, kluster):
-        return getattr(kluster, "_k8s_core_v1_api", None) or k8s.client.CoreV1Api(cls.api_client(kluster))
+        return k8s.client.CoreV1Api(cls.api_client(kluster))
 
     @classmethod
     def list_statefulsets(cls, kluster, namespace=None, **kwargs):
         if namespace is None:
-            return cls.apps_v1_api(kluster).list_stateful_set_for_all_namespaces(watch=False, **kwargs).items
-        return cls.apps_v1_api(kluster).list_namespaced_stateful_set(namespace=namespace, watch=False, **kwargs).items
+            return kluster.k8s_apps_v1_api.list_stateful_set_for_all_namespaces(watch=False, **kwargs).items
+        return kluster.k8s_apps_v1_api.list_namespaced_stateful_set(namespace=namespace, watch=False, **kwargs).items
 
     @classmethod
     def list_pods(cls, kluster, namespace=None, **kwargs):
         if namespace is None:
-            return cls.core_v1_api(kluster).list_pod_for_all_namespaces(watch=False, **kwargs).items
-        return cls.core_v1_api(kluster).list_namespaced_pod(namespace=namespace, watch=False, **kwargs).items
+            return kluster.k8s_core_v1_api.list_pod_for_all_namespaces(watch=False, **kwargs).items
+        return kluster.k8s_core_v1_api.list_namespaced_pod(namespace=namespace, watch=False, **kwargs).items
 
     @classmethod
     def list_services(cls, kluster, namespace=None, **kwargs):
         if namespace is None:
-            return cls.core_v1_api(kluster).list_service_all_namespaces(watch=False, **kwargs).items
-        return cls.core_v1_api(kluster).list_namespaced_service(namespace=namespace, watch=False, **kwargs).items
+            return kluster.k8s_core_v1_api.list_service_all_namespaces(watch=False, **kwargs).items
+        return kluster.k8s_core_v1_api.list_namespaced_service(namespace=namespace, watch=False, **kwargs).items
 
     @staticmethod
     def kubectl_cmd(kluster, *command, namespace=None, ignore_k8s_server_url=False):


### PR DESCRIPTION
https://trello.com/c/RrOCzny0/2578-k8s-make-k8scorev1api-cached-on-kubernetescluster

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
