### PR TITLE
Introduce CategoricalMonkey

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2839,6 +2839,9 @@ class CategoricalMonkey(Nemesis):
 
     @log_time_elapsed_and_status
     def disrupt(self):
+        self._random_disrupt()
+
+    def _random_disrupt(self):
         population, weights = self.disruption_distribution
         assert len(population) == len(weights) and population
 

--- a/unit_tests/test_nemesis.py
+++ b/unit_tests/test_nemesis.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 import sdcm.utils.cloud_monitor  # pylint: disable=unused-import # import only to avoid cyclic dependency
-from sdcm.nemesis import Nemesis, ChaosMonkey
+from sdcm.nemesis import Nemesis, ChaosMonkey, CategoricalMonkey
 from sdcm.cluster_k8s.minikube import MinikubeScyllaPodCluster
 from sdcm.cluster_k8s.gke import GkeScyllaPodCluster
 from sdcm.cluster_gce import ScyllaGCECluster
@@ -27,7 +27,6 @@ def test_list_nemesis_of_added_disrupt_methods():
     nemesis = ChaosMonkey(FakeTester(), None)
     assert 'disrupt_add_remove_dc' in nemesis.get_list_of_methods_by_flags(disruptive=False)
     assert nemesis.call_random_disrupt_method(disrupt_methods=['disrupt_add_remove_dc']) is None
-
 
 def test_is_it_on_kubernetes():
     class FakeMinikubeScyllaPodCluster(MinikubeScyllaPodCluster):
@@ -64,3 +63,28 @@ def test_is_it_on_kubernetes():
     assert not Nemesis(FakeTester(FakeScyllaGCECluster()), None)._is_it_on_kubernetes()
     assert not Nemesis(FakeTester(FakeScyllaAWSCluster()), None)._is_it_on_kubernetes()
     assert not Nemesis(FakeTester(FakeScyllaDockerCluster()), None)._is_it_on_kubernetes()
+
+# pylint: disable=protected-access
+def test_categorical_monkey():
+    runs = []
+    def disrupt_m1(_):
+        runs.append(1)
+    def disrupt_m2(_):
+        runs.append(2)
+    setattr(CategoricalMonkey, 'disrupt_m1', disrupt_m1)
+    setattr(CategoricalMonkey, 'disrupt_m2', disrupt_m2)
+
+    tester = FakeTester()
+
+    nemesis = CategoricalMonkey(tester, None, {'m1': 1}, 0)
+    nemesis._random_disrupt()
+
+    nemesis = CategoricalMonkey(tester, None, {'m2': 1}, 0)
+    nemesis._random_disrupt()
+
+    assert runs == [1, 2]
+
+    nemesis = CategoricalMonkey(tester, None, {'m1': 1, 'm2': 1}, 0)
+    nemesis._random_disrupt()
+
+    assert runs in ([1, 2, 1], [1, 2, 2])


### PR DESCRIPTION
A monkey that executes disruptions according to the provided categorical
distribution (https://en.wikipedia.org/wiki/Categorical_distribution):

    """Randomly picks disruptions to execute using the given categorical distribution.

    Each disruption is assigned a weight. The probability that a disruption D with weight W
    will be executed is W / T, where T is the sum of weights of all disruptions.

    The distribution is passed into the monkey's constructor as a dictionary.
    Keys in the dictionary are names of the disruption methods (from the `Nemesis` class)
    e.g. `disrupt_hard_reboot_node`. The value for each key is the weight of this disruption.
    You can omit the ``disrupt_'' prefix from the key, e.g. `hard_reboot_node`.

    A default weight can be passed; it will be assigned to each disruption that is not listed.
    In particular if the default weight is 0 then the unlisted disruptions won't be executed.
    """


Fixes https://github.com/scylladb/scylla-cluster-tests/issues/2732.



## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
