### PR TITLE
don't interpret Gemini's stderr as CRITICAL failure

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -31,6 +31,7 @@ DatabaseLogEvent.SUPPRESSED_MESSAGES: WARNING
 DatabaseLogEvent.stream_exception: ERROR
 IndexSpecialColumnErrorEvent: ERROR
 GeminiEvent.error: CRITICAL
+GeminiEvent.warning: WARNING
 GeminiEvent.start: NORMAL
 GeminiEvent.finish: NORMAL
 CassandraStressEvent.failure: CRITICAL

--- a/sdcm/gemini_thread.py
+++ b/sdcm/gemini_thread.py
@@ -122,9 +122,11 @@ class GeminiStressThread():  # pylint: disable=too-many-instance-attributes
             LOGGER.error(details)
             result = getattr(details, "result", NotGeminiErrorResult(details))
 
-        if result.exited or result.stderr:
+        if result.exited:
             GeminiEvent.error(cmd=gemini_cmd, result=result).publish()
         else:
+            if result.stderr:
+                GeminiEvent.warning(cmd=gemini_cmd, result=result).publish()
             GeminiEvent.finish(cmd=gemini_cmd, result=result).publish()
 
         return node, result, self.gemini_result_file

--- a/sdcm/sct_events/base.py
+++ b/sdcm/sct_events/base.py
@@ -336,11 +336,14 @@ class BaseStressEvent(SctEvent, abstract=True):
                              error: Optional[Severity] = None,
                              timeout: Optional[Severity] = None,
                              start: Optional[Severity] = Severity.NORMAL,
-                             finish: Optional[Severity] = Severity.NORMAL) -> None:
+                             finish: Optional[Severity] = Severity.NORMAL,
+                             warning: Optional[Severity] = None) -> None:
         if failure is not None:
             cls.add_subevent_type("failure", severity=failure)
         if error is not None:
             cls.add_subevent_type("error", severity=error)
+        if warning is not None:
+            cls.add_subevent_type("warning", severity=warning)
         if timeout is not None:
             cls.add_subevent_type("timeout", severity=timeout)
         if start is not None:

--- a/sdcm/sct_events/loaders.py
+++ b/sdcm/sct_events/loaders.py
@@ -31,6 +31,7 @@ LOGGER = logging.getLogger(__name__)
 
 class GeminiEvent(BaseStressEvent, abstract=True):
     error: Type[SctEventProtocol]
+    warning: Type[SctEventProtocol]
     start: Type[SctEventProtocol]
     finish: Type[SctEventProtocol]
 
@@ -55,7 +56,7 @@ class GeminiEvent(BaseStressEvent, abstract=True):
         return fmt
 
 
-GeminiEvent.add_stress_subevents(error=Severity.CRITICAL)
+GeminiEvent.add_stress_subevents(error=Severity.CRITICAL, warning=Severity.WARNING)
 
 
 class CassandraStressEvent(StressEvent, abstract=True):


### PR DESCRIPTION
If Gemini only prints some output to stderr but otherwise finishes
(with exit code != 0), we report this fact as a WARNING event instead of
CRITICAL which resulted in stopping the test.

For example, during the reboot nemesis Gemini would report (to stderr)
that it cannot connect to the rebooted node but it would still continue
running workload by sending its requests to the other nodes.

Fixes #2748.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
