### PR TITLE
fix(sdcm/cluster_k8s/gke.py): Make it automatically truncate cluster name

### DIFF
--- a/ics_space_amplification_goal_test.py
+++ b/ics_space_amplification_goal_test.py
@@ -194,7 +194,7 @@ class IcsSpaceAmplificationTest(LongevityTest):
         InfoEvent(message="Wait for compactions to finish after write is done.")
         self.wait_no_compactions_running()
 
-        stress_cmd = self.params.get('stress_cmd', default=None)
+        stress_cmd = self.params.get('stress_cmd')
         sag_testing_values = [None, '1.5', '1.2', '1.5', None]
         column_size = 205
         num_of_columns = 5

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -2076,3 +2076,64 @@ def convert_metric_to_ms(metric: str) -> float:
         metric_converted = metric
         LOGGER.error("Value %s can't be converted to float. Exception: %s", metric, ve)
     return metric_converted
+
+
+def _shorten_alpha_sequences(value: str, max_alpha_chunk_size: int) -> str:
+    if not value:
+        return value
+    is_alpha = value[0].isalpha()
+    num = 0
+    output = ''
+    for char in value:
+        if is_alpha == char.isalpha():
+            if is_alpha and num >= max_alpha_chunk_size:
+                continue
+            num += 1
+            output += char
+            continue
+        output += char
+        num = 1
+    return output
+
+
+def _shorten_sequences_in_string(value: Union[str, List[str]], max_alpha_chunk_size: int) -> str:
+    chunks = []
+    if isinstance(value, str):
+        tmp = value.split('-')
+    else:
+        tmp = value
+    for chunk in tmp:
+        chunks.append(_shorten_alpha_sequences(chunk, max_alpha_chunk_size))
+    return '-'.join(chunks)
+
+
+def _string_max_chunk_size(value):
+    return max([len(chunk) for chunk in value.split('-')])
+
+
+def shorten_cluster_name(name: str, max_string_len: int):
+    """
+    Make an attempt to shorten cluster/any name so that it would fit into max_string_len limit
+    If it can't make it that short, it will return original name
+    Shortening is done in following manner:
+    1. It split string by '-' and take out and preserve last chunk (supposedly short test id there)
+    2. Array of chunks that is left it splits into sequences of digits and non-digits
+    3. Next it goes over non-digit chunks and trims them from right side by 1 char
+    4. On each trimming round it recombine name back in exact same order
+    5. Check if resulted string has len less than max_string_len and return it if it does
+    6. If trimming is not possible anymore it return original name
+
+    Example:
+        original name - longevity-scylla-operator-3h-gke-je-k8s-gke-cd86ad2b
+        shorten name - lon-scy-ope-3h-gke-je-k8s-gke-cd86ad2b
+    """
+    max_alpha_chunk_size = _string_max_chunk_size(name)
+    last_chunk = name.split('-')[-1]
+    current = '-'.join(name.split('-')[0:-1])
+    last_chunk_len = len(last_chunk)
+    while len(current) + last_chunk_len + 1 > max_string_len and max_alpha_chunk_size > 0:
+        current = _shorten_sequences_in_string(name.split('-')[0:-1], max_alpha_chunk_size)
+        max_alpha_chunk_size -= 1
+    if max_alpha_chunk_size == 0:
+        return name
+    return '-'.join([current, last_chunk])

--- a/test-cases/scylla-operator/kubernetes-scylla-upgrade-gke.yaml
+++ b/test-cases/scylla-operator/kubernetes-scylla-upgrade-gke.yaml
@@ -9,7 +9,7 @@ n_loaders: 1
 n_monitor_nodes: 1
 
 # Need to keep rendered name less than 40 chars because of GKE restrictions. Note, that backend name included automatically.
-user_prefix: 'upgrade'
+user_prefix: 'kubernetes-scylla-upgrade-gke'
 
 new_version: '4.1.7'
 

--- a/test-cases/scylla-operator/kubernetes-scylla-upgrade-minikube.yaml
+++ b/test-cases/scylla-operator/kubernetes-scylla-upgrade-minikube.yaml
@@ -16,7 +16,7 @@ n_db_nodes: 3
 n_loaders: 1
 n_monitor_nodes: 1
 
-user_prefix: 'k8s-scylla-upgrade'
+user_prefix: 'kubernetes-scylla-upgrade-minikube'
 
 new_version: '4.1.7'
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-gke.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-gke.yaml
@@ -10,6 +10,6 @@ nemesis_class_name: 'KubernetesScyllaOperatorMonkey'
 nemesis_interval: 5
 
 # Need to keep rendered name less than 40 chars because of GKE restrictions. Note, that backend name included automatically.
-user_prefix: 'long-10gb-3h'
+user_prefix: 'longevity-scylla-operator-3h-gke'
 
 space_node_threshold: 64424

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-minikube.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-minikube.yaml
@@ -16,5 +16,5 @@ n_monitor_nodes: 1
 nemesis_class_name: 'KubernetesScyllaOperatorMonkey'
 nemesis_interval: 5
 
-user_prefix: 'k8s-longevity-10gb-3h'
+user_prefix: 'longevity-scylla-operator-3h-minikube'
 space_node_threshold: 64424


### PR DESCRIPTION
https://trello.com/c/9FM9iwmr/2581-gke-make-it-truncate-name-automatically

GKE does not allow to deploy cluster with name more than 40 chars long. 
Currently we solve it by squashing prefix in test-case yaml file
Let's Implement automated cluster name truncation for GKE so that any test could be ran on GKE backend.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
