### PR TITLE
fix(sdcm/cluster_k8s/__init__.py): Make ip_address properties cached

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -8,7 +8,7 @@ import os
 import tempfile
 import json
 import base64
-from typing import List, Dict
+from typing import List, Dict, Optional
 from textwrap import dedent
 from datetime import datetime
 from distutils.version import LooseVersion  # pylint: disable=no-name-in-module,import-error
@@ -545,19 +545,15 @@ class AWSNode(cluster.BaseNode):
         else:
             return self._instance.private_ip_address
 
-    @property
-    def public_ip_address(self):
+    def _get_public_ip_address(self) -> Optional[str]:
         return self._instance.public_ip_address
 
-    @property
-    def private_ip_address(self):
+    def _get_private_ip_address(self) -> Optional[str]:
         if self._eth1_private_ip_address:
             return self._eth1_private_ip_address
-
         return self._instance.private_ip_address
 
-    @property
-    def ipv6_ip_address(self):
+    def _get_ipv6_ip_address(self) -> Optional[str]:
         return self._instance.network_interfaces[0].ipv6_addresses[0]["Ipv6Address"]
 
     def _refresh_instance_state(self):

--- a/sdcm/cluster_baremetal.py
+++ b/sdcm/cluster_baremetal.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 from sdcm import cluster
 
@@ -33,12 +34,10 @@ class PhysicalMachineNode(cluster.BaseNode):
         self.set_hostname()
         self.run_startup_script()
 
-    @property
-    def public_ip_address(self):
+    def _get_public_ip_address(self) -> Optional[str]:
         return self._public_ip
 
-    @property
-    def private_ip_address(self):
+    def _get_private_ip_address(self) -> Optional[str]:
         return self._private_ip
 
     def set_hostname(self):

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -82,12 +82,10 @@ class DockerNode(cluster.BaseNode, NodeContainerMixin):  # pylint: disable=abstr
         return {**super().tags,
                 "NodeIndex": str(self.node_index), }
 
-    @cached_property
-    def public_ip_address(self):
+    def _get_public_ip_address(self) -> Optional[str]:
         return ContainerManager.get_ip_address(self, "node")
 
-    @cached_property
-    def private_ip_address(self):
+    def _get_private_ip_address(self) -> Optional[str]:
         return self.public_ip_address
 
     def is_running(self):

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -187,8 +187,7 @@ class GCENode(cluster.BaseNode):
         self.log.warning('Method is not implemented for GCENode')
         return b''
 
-    @property
-    def ipv6_ip_address(self):
+    def _get_ipv6_ip_address(self):
         raise NotImplementedError('On GCE, VPC networks only support IPv4 unicast traffic. '
                                   'They do not support IPv6 traffic within the network.')
 

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -316,8 +316,7 @@ class BasePodContainer(cluster.BaseNode):
     def image(self) -> str:
         return self._container_status.image
 
-    @property
-    def ipv6_ip_address(self):
+    def _get_ipv6_ip_address(self):
         raise NotImplementedError()
 
     def restart(self):

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -30,12 +30,10 @@ class DummyNode(BaseNode):  # pylint: disable=abstract-method
         super().init()
         self.remoter.stop()
 
-    @property
-    def private_ip_address(self):
+    def _get_private_ip_address(self):
         return '127.0.0.1'
 
-    @property
-    def public_ip_address(self):
+    def _get_public_ip_address(self):
         return '127.0.0.1'
 
     def start_task_threads(self):

--- a/unit_tests/test_seed_selector.py
+++ b/unit_tests/test_seed_selector.py
@@ -15,13 +15,11 @@ class DummyNode(sdcm.cluster.BaseNode):  # pylint: disable=abstract-method
         super().init()
         self.remoter.stop()
 
-    @property
-    def private_ip_address(self):
+    def _get_private_ip_address(self):
         # Expected node name like : node1, node2, node3 ...
         return '127.0.0.%s' % self.name.replace('node', '')
 
-    @property
-    def public_ip_address(self):
+    def _get_public_ip_address(self):
         # Expected node name like : node1, node2, node3 ...
         return '127.0.0.%s' % self.name.replace('node', '')
 


### PR DESCRIPTION
https://trello.com/c/sTYOxsGO/2582-k8s-make-ip-address

Whenever node name is printed we are making two api calls to get private and public ip addresses.
To avoid hitting api rate limit we need to make these ip's cached.  

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
