### PR TITLE
fix(rollout_restart): Make it wait till rollout is completed

### DIFF
--- a/sdcm/utils/k8s.py
+++ b/sdcm/utils/k8s.py
@@ -125,8 +125,18 @@ class KubernetesOps:
         return cls.dynamic_client(kluster).resources.get(api_version=api_version, kind=kind)
 
     @classmethod
+    def apps_v1_api(cls, kluster):
+        return getattr(kluster, "_k8s_apps_v1_api", None) or k8s.client.AppsV1Api(cls.api_client(kluster))
+
+    @classmethod
     def core_v1_api(cls, kluster):
         return getattr(kluster, "_k8s_core_v1_api", None) or k8s.client.CoreV1Api(cls.api_client(kluster))
+
+    @classmethod
+    def list_statefulsets(cls, kluster, namespace=None, **kwargs):
+        if namespace is None:
+            return cls.apps_v1_api(kluster).list_stateful_set_for_all_namespaces(watch=False, **kwargs).items
+        return cls.apps_v1_api(kluster).list_namespaced_stateful_set(namespace=namespace, watch=False, **kwargs).items
 
     @classmethod
     def list_pods(cls, kluster, namespace=None, **kwargs):


### PR DESCRIPTION
https://trello.com/c/2DELCtof/2561-investigate-test-failure-on-nodetool-repair-when-cluster-was-just-started


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
