### PR TITLE
test(200gb_48h): timeout too close to the stress size

### DIFF
--- a/test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
+++ b/test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
@@ -1,4 +1,4 @@
-test_duration: 2880
+test_duration: 2940
 prepare_write_cmd: "cassandra-stress write cl=ALL n=200200300  -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=1000 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..200200300 -log interval=15"
 # prepare_verify_cmd: "cassandra-stress read cl=ALL n=200200300  -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=2000 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..200200300 -log interval=15"
 


### PR DESCRIPTION
the time between the main stress to the timeout was
only 20min, this doesn't cover the time it take for
the prepare stress, I've added 1h for the timeout of
the test

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
