### PR TITLE
fix(yaml.loads): replace with yaml.safe_load

### DIFF
--- a/longevity_test.py
+++ b/longevity_test.py
@@ -487,7 +487,7 @@ class LongevityTest(ClusterTester):
         cs_user_profiles = self.params.get('cs_user_profiles', default=[])
         # read user-profile
         for profile_file in cs_user_profiles:
-            profile_yaml = yaml.load(open(profile_file), Loader=yaml.SafeLoader)
+            profile_yaml = yaml.safe_load(open(profile_file))
             keyspace_definition = profile_yaml['keyspace_definition']
             keyspace_name = profile_yaml['keyspace']
             table_template = string.Template(profile_yaml['table_definition'])

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -554,7 +554,7 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
 
             # Get materialized view name from user profile
 
-            user_profile_yaml = yaml.load(open(user_profile), Loader=yaml.SafeLoader)
+            user_profile_yaml = yaml.safe_load(open(user_profile))
             mv_name = ''
 
             for k in user_profile_yaml:

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3464,7 +3464,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         res = node.run_nodetool('info')
         # Removing unnecessary lines from the output
         proper_yaml_output = "\n".join([line for line in res.stdout.splitlines() if ":" in line])
-        info_res = yaml.load(proper_yaml_output)
+        info_res = yaml.safe_load(proper_yaml_output)
         return info_res
 
     def check_cluster_health(self):
@@ -4429,7 +4429,7 @@ class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-inst
             node.remoter.receive_files(src=prometheus_yaml_template,
                                        dst=local_template_tmp)
             with open(local_template_tmp) as output_file:
-                templ_yaml = yaml.load(output_file, Loader=yaml.SafeLoader)  # to override avocado
+                templ_yaml = yaml.safe_load(output_file)
                 self.log.debug("Configs %s" % templ_yaml)
             loader_targets_list = ["[%s]:9103" % n.ip_address for n in self.targets["loaders"].nodes]
 

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -944,7 +944,7 @@ class CassandraAWSCluster(ScyllaAWSCluster):
         node.remoter.receive_files(src='/etc/cassandra/cassandra.yaml',
                                    dst=yaml_dst_path)
         with open(yaml_dst_path, 'r') as yaml_stream:
-            conf_dict = yaml.load(yaml_stream, Loader=yaml.SafeLoader)
+            conf_dict = yaml.safe_load(yaml_stream)
             try:
                 return conf_dict['seed_provider'][0]['parameters'][0]['seeds'].split(',')
             except:

--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -110,7 +110,7 @@ def update_config_file(node, region, config_file=SCYLLA_MANAGER_AGENT_YAML_PATH)
     # 'us-east-1 us-west-2' and 'manager-backup-tests-us-east-1 manager-backup-tests-eu-west-2'
 
     node.remoter.run(f'sudo chmod o+w {config_file}')
-    configuration = yaml.load(node.remoter.run(f'cat {config_file}').stdout)
+    configuration = yaml.safe_load(node.remoter.run(f'cat {config_file}').stdout)
     if 's3' not in configuration:
         configuration['s3'] = {}
     configuration['s3']['region'] = region

--- a/test_lib/compaction.py
+++ b/test_lib/compaction.py
@@ -38,7 +38,7 @@ def get_compaction_strategy(node, keyspace, table):
             continue
         list_stripped_values = [val.strip() for val in row.split('|')]
         if list_stripped_values[0] == keyspace and list_stripped_values[1] == table:
-            dict_compaction_values = yaml.load(list_stripped_values[2])
+            dict_compaction_values = yaml.safe_load(list_stripped_values[2])
             compaction = CompactionStrategy.from_str(output_str=dict_compaction_values['class'])
             break
 


### PR DESCRIPTION
Get rid of those ugly warnings we have on the output:
```
YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
