### PR TITLE
feature(pre-commit): show diff on failure

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     hooks:
     -   id: autopep8
         name: autopep8
-        entry: autopep8 -i -j 2 -v --max-line-length=120 --ignore=E226,E24,W50,W690,E402
+        entry: autopep8 -i -j 2 --max-line-length=120 --ignore=E226,E24,W50,W690,E402
         language: system
         types: [python]
 

--- a/sct.py
+++ b/sct.py
@@ -575,7 +575,7 @@ def pre_commit():
         'bash -c "git show -s --format=%B > /tmp/commit-msg; '
         'pre-commit run --hook-stage commit-msg --commit-msg-filename /tmp/commit-msg"'
     )
-    result += os.system('pre-commit run -a')
+    result += os.system('pre-commit run -a --show-diff-on-failure')
     result = 1 if result else 0
     sys.exit(result)
 

--- a/sdcm/utils/k8s.py
+++ b/sdcm/utils/k8s.py
@@ -171,8 +171,8 @@ class KubernetesOps:
 
     @classmethod
     def kubectl_multi_cmd(cls, kluster, *command, namespace: Optional[str] = None, timeout: int = KUBECTL_TIMEOUT,
-                         remoter: Optional['KubernetesCmdRunner'] = None, ignore_status: bool = False,
-                         verbose: bool = True):
+                          remoter: Optional['KubernetesCmdRunner'] = None, ignore_status: bool = False,
+                          verbose: bool = True):
         total_command = ' '.join(command)
         final_command = []
         for cmd in total_command.split(' '):

--- a/unit_tests/test_nemesis.py
+++ b/unit_tests/test_nemesis.py
@@ -28,6 +28,7 @@ def test_list_nemesis_of_added_disrupt_methods():
     assert 'disrupt_add_remove_dc' in nemesis.get_list_of_methods_by_flags(disruptive=False)
     assert nemesis.call_random_disrupt_method(disrupt_methods=['disrupt_add_remove_dc']) is None
 
+
 def test_is_it_on_kubernetes():
     class FakeMinikubeScyllaPodCluster(MinikubeScyllaPodCluster):
         def __init__(self, params: dict = None):
@@ -65,10 +66,14 @@ def test_is_it_on_kubernetes():
     assert not Nemesis(FakeTester(FakeScyllaDockerCluster()), None)._is_it_on_kubernetes()
 
 # pylint: disable=protected-access
+
+
 def test_categorical_monkey():
     runs = []
+
     def disrupt_m1(_):
         runs.append(1)
+
     def disrupt_m2(_):
         runs.append(2)
     setattr(CategoricalMonkey, 'disrupt_m1', disrupt_m1)


### PR DESCRIPTION
make sure we show the diff on case on failures in pre-commit in CI
this would be more helpful the verbose of autopep8, which is very
very hard to read and figure what was changed

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
