### PR TITLE
fix(autossh): pin down to jnovack/autossh:1.2.2

### DIFF
--- a/sdcm/utils/auto_ssh.py
+++ b/sdcm/utils/auto_ssh.py
@@ -15,7 +15,7 @@ import os
 from functools import cached_property
 
 
-AUTO_SSH_IMAGE = "jnovack/autossh:latest"
+AUTO_SSH_IMAGE = "jnovack/autossh:1.2.2"
 AUTO_SSH_LOGFILE = "autossh.log"
 
 


### PR DESCRIPTION
the docker autossh docker we were using had a new release (v2.0)
https://github.com/jnovack/autossh/commit/1cb6609c60eca7ed22467cb0c1361a762f69ae2b

this release changed all the envirment variable names, breaking all the places
we are using autossh for streaming rsyslog (i.e. multi dc test cases)

all manager sanity test failed like that:
```
2020-11-25 21:48:48.772: (TestFrameworkEvent Severity.ERROR), source=MgmtCliTest.SetUp()
exception=No db log from node [Node manager-regression-master-db-node-fe9672c2-1 ...
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
