### PR TITLE
fix(scylla_encryption_options): fix condition in create_table

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1404,7 +1404,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                      (query, speculative_retry))
         if in_memory:
             query += " AND in_memory=true AND compaction={'class': 'InMemoryCompactionStrategy'}"
-        if not scylla_encryption_options:
+        if scylla_encryption_options:
             query = '%s AND scylla_encryption_options=%s' % (query, scylla_encryption_options)
         if compact_storage:
             query += ' AND COMPACT STORAGE'


### PR DESCRIPTION
If scylla_encryption_options is None ot '', ignore it, don't add to table
creation command

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
