### PR TITLE
test(performance): Change number of threads for perf cdc latency test

### DIFF
--- a/jenkins-pipelines/perf-regression-cdc-mixed-latency-60min.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-cdc-mixed-latency-60min.jenkinsfile
@@ -7,8 +7,8 @@ perfRegressionParallelPipeline(
     backend: "aws",
     aws_region: "us-east-1",
     test_name: "performance_regression_cdc_test.PerformanceRegressionCDCTest",
-    test_config: "test-cases/performance/perf-regression-write-latency-cdc.yaml",
-    sub_tests: ["test_write_latency"],
+    test_config: "test-cases/performance/perf-regression-latency-cdc-mixed-poll-batching.yaml",
+    sub_tests: ["test_mixed_throughput"],
 
     timeout: [time: 550, unit: "MINUTES"]
 )

--- a/performance_regression_cdc_test.py
+++ b/performance_regression_cdc_test.py
@@ -12,6 +12,8 @@ class PerformanceRegressionCDCTest(PerformanceRegressionTest):
     keyspace = None
     table = None
     cdclog_reader_cmd = None
+    enable_batching = False
+    update_es = False
 
     def test_write_with_cdc(self):
         write_cmd = self.params.get("stress_cmd_w")
@@ -80,6 +82,7 @@ class PerformanceRegressionCDCTest(PerformanceRegressionTest):
 
     def test_write_latency(self):
         self.cdc_workflow()
+        self.update_test_details()
 
     def test_mixed_throughput(self):
         self.cdc_workflow(use_cdclog_reader=True)
@@ -91,12 +94,11 @@ class PerformanceRegressionCDCTest(PerformanceRegressionTest):
         self.keyspace = "keyspace1"
         self.table = "standard1"
         write_cmd = self.params.get("stress_cmd_w")
-        update_es = None
 
         if use_cdclog_reader:
             self.cdclog_reader_cmd = self.params.get('stress_cdclog_reader_cmd')
-            update_es = self.params.get('store_cdclog_reader_stats_in_es')
-            enable_batching = self.params.get('stress_cdc_log_reader_batching_enable')
+            self.update_es = self.params.get('store_cdclog_reader_stats_in_es')
+            self.enable_batching = self.params.get('stress_cdc_log_reader_batching_enable')
 
         self._workload_cdc(write_cmd,
                            stress_num=2,
@@ -115,8 +117,8 @@ class PerformanceRegressionCDCTest(PerformanceRegressionTest):
                            test_name="test_write",
                            sub_type="cdc_enabled",
                            read_cdclog_cmd=self.cdclog_reader_cmd,
-                           update_cdclog_stats=update_es,
-                           enable_batching=enable_batching)
+                           update_cdclog_stats=self.update_es,
+                           enable_batching=self.enable_batching)
 
         self.wait_no_compactions_running()
         self.run_fstrim_on_all_db_nodes()
@@ -129,8 +131,8 @@ class PerformanceRegressionCDCTest(PerformanceRegressionTest):
                            test_name="test_write",
                            sub_type="cdc_preimage_enabled",
                            read_cdclog_cmd=self.cdclog_reader_cmd,
-                           update_cdclog_stats=update_es,
-                           enable_batching=enable_batching)
+                           update_cdclog_stats=self.update_es,
+                           enable_batching=self.enable_batching)
 
         self.wait_no_compactions_running()
         self.run_fstrim_on_all_db_nodes()
@@ -143,8 +145,8 @@ class PerformanceRegressionCDCTest(PerformanceRegressionTest):
                            test_name="test_write",
                            sub_type="cdc_postimage_enabled",
                            read_cdclog_cmd=self.cdclog_reader_cmd,
-                           update_cdclog_stats=update_es,
-                           enable_batching=enable_batching)
+                           update_cdclog_stats=self.update_es,
+                           enable_batching=self.enable_batching)
 
         self.wait_no_compactions_running()
 

--- a/test-cases/performance/perf-regression-latency-cdc-mixed-poll-batching.yaml
+++ b/test-cases/performance/perf-regression-latency-cdc-mixed-poll-batching.yaml
@@ -1,6 +1,14 @@
+# test runs 4 subtest with duration 60 min
+# and time for clear table between subtest
 test_duration: 500
 
 stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=60m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=10 throttle=2500/s' -col 'size=FIXED(1024) n=FIXED(1)' -pop 'dist=gauss(1..500000000,250000000,25000000)' "
+
+stress_cdclog_reader_cmd: "cdc-stressor -duration 70m -stream-query-round-duration 30s"
+store_cdclog_reader_stats_in_es: false
+stress_cdc_log_reader_batching_enable: true
+
+
 n_db_nodes: 3
 n_loaders: 4
 n_monitor_nodes: 1
@@ -9,13 +17,12 @@ instance_type_loader: 'c4.2xlarge'
 instance_type_monitor: 't3.small'
 instance_type_db: 'i3.2xlarge'
 
-user_prefix: 'perf-cdc-latency-write'
+user_prefix: 'perf-cdc-latency-mixed'
 space_node_threshold: 644245094
 
 
 store_perf_results: true
 append_scylla_args: '--blocked-reactor-notify-ms 50'
-
 
 send_email: true
 email_recipients: ['qa@scylladb.com', 'piotr@scylladb.com ', 'piodul@scylladb.com', 'shlomi@scylladb.com ']

--- a/test-cases/performance/perf-regression-write-latency-cdc.yaml
+++ b/test-cases/performance/perf-regression-write-latency-cdc.yaml
@@ -5,7 +5,7 @@ n_db_nodes: 3
 n_loaders: 4
 n_monitor_nodes: 1
 
-instance_type_loader: 'c4.2xlarge'
+instance_type_loader: 'c5.2xlarge'
 instance_type_monitor: 't3.small'
 instance_type_db: 'i3.2xlarge'
 


### PR DESCRIPTION
Performance test for latency for cdc feature generate too large cpu payload.
Decrease number of threads to reach constant cpu load during load

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] ~I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)~
- [ ] ~I didn't leave commented-out/debugging code~
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (CI)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
