### PR TITLE
fix(restart): supply a random node as provider when restarting a seed

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -1,6 +1,7 @@
 # pylint: disable=too-many-lines, too-many-public-methods
 
 import re
+import random
 import logging
 import time
 import uuid
@@ -643,6 +644,22 @@ class AWSNode(cluster.BaseNode):
             return
 
         event_filters = ()
+        if self.is_seed:
+            # Due to https://github.com/scylladb/scylla/issues/7588, when we restart a node that is defined as "seed",
+            # we must state a different, living node as the seed provider in the scylla yaml of the restarted node
+            other_nodes = list(set(self.parent_cluster.nodes) - {self})
+            free_nodes = [node for node in other_nodes if not node.running_nemesis]
+            random_node = random.choice(free_nodes)
+
+            seed_provider = [{
+                "class_name": "org.apache.cassandra.locator.SimpleSeedProvider",
+                "parameters": [{
+                    "seeds": f"{random_node.ip_address}"
+                }, ],
+            }, ]
+
+            with self.remote_scylla_yaml() as scylla_yml:
+                scylla_yml["seed_provider"] = seed_provider
         if any(ss in self._instance.instance_type for ss in ['i3', 'i2']):
             # since there's no disk yet in those type, lots of the errors here are acceptable, and we'll ignore them
             event_filters = DbEventsFilter(type="DATABASE_ERROR", node=self), \

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2429,26 +2429,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             "stress-ng --vm-bytes $(awk '/MemTotal/{printf \"%d\\n\", $2 * 0.9;}' < /proc/meminfo)k --vm-keep -m 1 -t 100")
 
 
-class NotSpotNemesis(Nemesis):
-    def set_target_node(self):
-
-        if isinstance(self.cluster, ScyllaAWSCluster):
-            non_seed_nodes = [node for node in self.cluster.nodes
-                              if not node.is_seed and
-                              not node.is_spot and
-                              not node.running_nemesis]
-            if non_seed_nodes:
-                self.target_node = random.choice(non_seed_nodes)
-
-        else:
-            super(NotSpotNemesis, self).set_target_node()
-
-        self.log.info('Current Target: %s', self.target_node)
-
-    def disrupt(self):
-        raise NotImplementedError()
-
-
 def log_time_elapsed_and_status(method):  # pylint: disable=too-many-statements
     """
     Log time elapsed for method to run
@@ -2577,7 +2557,7 @@ class StopStartMonkey(Nemesis):
         self.disrupt_stop_start_scylla_server()
 
 
-class RestartThenRepairNodeMonkey(NotSpotNemesis):
+class RestartThenRepairNodeMonkey(Nemesis):
     disruptive = True
     kubernetes = True
 


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
