### PR TITLE
fix(logcollector): make loader-set pick up inactive nodes logs

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -872,6 +872,9 @@ class LoaderLogCollector(LogCollector):
                 search_locally=True)
     ]
 
+    def collect_logs(self, local_search_path=None):
+        self.collect_logs_for_inactive_nodes(local_search_path)
+        return super().collect_logs(local_search_path)
 
 class MonitorLogCollector(LogCollector):
     """SCT monitor set log collector


### PR DESCRIPTION
https://trello.com/c/sRWXFL3s/2625-sct-collect-logs-does-not-pick-up-loader-logs

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
