### PR TITLE
fix(get_peers_info): fix it to match only peers records

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -26,6 +26,7 @@ import traceback
 import uuid
 import itertools
 import json
+import ipaddress
 
 from collections import defaultdict
 from typing import List, Optional, Dict, Union
@@ -2527,18 +2528,28 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         cql_result = self.run_cqlsh('select peer, data_center, host_id, rack, release_version, '
                                     'rpc_address, schema_version, supported_features from system.peers',
                                     split=True, verbose=False)
+        # peer | data_center | host_id | rack | release_version | rpc_address | schema_version | supported_features
+        # ------+-------------+---------+------+-----------------+-------------+----------------+--------------------
+
         peers_details = {}
-        for line in cql_result[3:-2]:
+        for line in cql_result:
             line_splitted = line.split('|')
             if len(line_splitted) < 8:
                 continue
-            peers_details[line_splitted[0].strip()] = {'data_center': line_splitted[1].strip(),
-                                                       'host_id': line_splitted[2].strip(),
-                                                       'rack': line_splitted[3].strip(),
-                                                       'release_version': line_splitted[4].strip(),
-                                                       'rpc_address': line_splitted[5].strip(),
-                                                       'schema_version': line_splitted[6].strip(),
-                                                       'supported_features': line_splitted[7].strip()}
+            peer = line_splitted[0].strip()
+            try:
+                ipaddress.ip_address(peer)
+            except ValueError:
+                continue
+            peers_details[peer] = {
+                'data_center': line_splitted[1].strip(),
+                'host_id': line_splitted[2].strip(),
+                'rack': line_splitted[3].strip(),
+                'release_version': line_splitted[4].strip(),
+                'rpc_address': line_splitted[5].strip(),
+                'schema_version': line_splitted[6].strip(),
+                'supported_features': line_splitted[7].strip(),
+            }
 
         return peers_details
 


### PR DESCRIPTION
https://trello.com/c/ZAVuSCq7/2628-nodes-peer-exists-in-the-systempeers-but-missed-in-gossip-after-restartthenrepairnode

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
