### PR TITLE
fix(raid-daemonset.yaml): make it deploy raid same way we do that in scylla_raid_setup

### DIFF
--- a/sdcm/k8s_configs/raid-daemonset.yaml
+++ b/sdcm/k8s_configs/raid-daemonset.yaml
@@ -66,18 +66,25 @@ spec:
             # Unmount disks from host filesystem
             for i in `seq 0 $((NUM_DISKS-1))`;
             do
-                umount "${DISK_MNT_DIR_PREFIX}${i}" &> /dev/null || echo "Disk ${DISK_MNT_DIR_PREFIX}${i} already unmounted."
+                CURR_DISK=${DISKS[$i]}
+                DISCARD_FLAG_PATH="/sys/block/${CURR_DISK#'/dev/'}/queue/discard_granularity"
+                umount $CURR_DISK &> /dev/null || echo "Disk $CURR_DISK already unmounted."
+                if [ "`cat $DISCARD_FLAG_PATH`" != "0" ]; then
+                    blkdiscard $CURR_DISK || true
+                fi
             done
-
+            # Waits till udev reread device data
+            udevadm settle
             # Create a raid array
-            yes | mdadm --create /dev/md0 --force --level=0 --raid-devices="$NUM_DISKS" "${DISKS[@]}"
-
+            yes | mdadm --create /dev/md0 --force --level=0 -c1024 --raid-devices="$NUM_DISKS" "${DISKS[@]}"
+            # Waits till udev reread md0 device data
+            udevadm settle
             # Format the raid array as xfs
             mkfs.xfs /dev/md0
 
             # Mount the raid array in a predefined location
             mkdir -p $RAID_DIR
-            mount /dev/md0 $RAID_DIR
+            mount -o noatime /dev/md0 $RAID_DIR
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
https://trello.com/c/su8VWLSI/2626-gke-fix-raid-daemonsetyaml-to-setup-raid-same-way-as-we-do-that-in-scyllasetup

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
