### PR TITLE
feature(longevityPipeline): add update_db_packages parameter for test…

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -878,6 +878,7 @@ class LoaderLogCollector(LogCollector):
         self.collect_logs_for_inactive_nodes(local_search_path)
         return super().collect_logs(local_search_path)
 
+
 class MonitorLogCollector(LogCollector):
     """SCT monitor set log collector
 

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -31,6 +31,9 @@ def call(Map pipelineParams) {
                name: 'availability_zone')
 
             string(defaultValue: '', description: '', name: 'scylla_ami_id')
+            string(defaultValue: '',
+                   description: 'cloud path for RPMs, s3:// or gs://',
+                   name: 'update_db_packages')
             string(defaultValue: '', description: '', name: 'scylla_version')
             string(defaultValue: '', description: '', name: 'scylla_repo')
             string(defaultValue: "${pipelineParams.get('provision_type', 'spot')}",


### PR DESCRIPTION
…ing scylla-debug package

scylla-debug package(rpm/deb) is promoted to relocatable directory on
S3, there is no dependent repo for it.

We have to use update_db_pacakges interface in longevity to replace
installed scylla in AMI.

New job:
https://jenkins.scylladb.com/job/scylla-master/job/longevity/job/scylla-debug-longevity-10gb-3h-test/

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
