### PR TITLE
K8s add rolling restart

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -878,6 +878,7 @@ class LoaderLogCollector(LogCollector):
         self.collect_logs_for_inactive_nodes(local_search_path)
         return super().collect_logs(local_search_path)
 
+
 class MonitorLogCollector(LogCollector):
     """SCT monitor set log collector
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -398,6 +398,12 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.target_node.wait_jmx_up()
         self.cluster.wait_for_nodes_up_and_normal(nodes=[self.target_node])
 
+    def disrupt_rolling_restart_cluster(self):
+        self._set_current_disruption('RollingRestartCluster %s' % self.target_node)
+        if not self._is_it_on_kubernetes():
+            raise UnsupportedNemesis('RollingRestartCluster is supported only for kubernetes backends')
+        self.cluster.rollout_restart()
+
     def disrupt_restart_with_resharding(self):
         self._set_current_disruption('RestartNodeWithResharding %s' % self.target_node)
         murmur3_partitioner_ignore_msb_bits = 15  # pylint: disable=invalid-name
@@ -3226,6 +3232,15 @@ class NodeRestartWithResharding(Nemesis):
     @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_restart_with_resharding()
+
+
+class ClusterRollingRestart(Nemesis):
+    disruptive = True
+    kubernetes = True
+
+    @log_time_elapsed_and_status
+    def disrupt(self):
+        self.disrupt_rolling_restart_cluster()
 
 
 class TopPartitions(Nemesis):


### PR DESCRIPTION
https://trello.com/c/9xfqhtZH/2589-rollingrestartcluster

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
