### PR TITLE
WIP: K8s enable terminate

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -662,19 +662,21 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):
         assert self.nodes[-1] == node, "Can withdraw the last node only"
         current_members = self.scylla_cluster_spec.datacenter.racks[0].members
         node.terminate_k8s_node()
+        timeout_in_minutes = SCYLLA_POD_TERMINATE_TIMEOUT + SCYLLA_POD_READINESS_TIMEOUT
         self.replace_scylla_cluster_value("/spec/datacenter/racks/0/members", current_members - 1)
-        self.k8s_cluster.kubectl(f"wait --timeout={SCYLLA_POD_TERMINATE_TIMEOUT}m --for=delete pod {node.name}",
+        self.k8s_cluster.kubectl(f"wait --timeout={timeout_in_minutes}m --for=ready pod {node.name}",
                                  namespace=self.namespace,
-                                 timeout=SCYLLA_POD_TERMINATE_TIMEOUT*60+10)
+                                 timeout=timeout_in_minutes*60+10)
 
     def terminate_k8s_host(self, node: BasePodContainer):
         assert self.nodes[-1] == node, "Can withdraw the last node only"
         current_members = self.scylla_cluster_spec.datacenter.racks[0].members
         node.terminate_k8s_host()
         self.replace_scylla_cluster_value("/spec/datacenter/racks/0/members", current_members - 1)
-        self.k8s_cluster.kubectl(f"wait --timeout={SCYLLA_POD_TERMINATE_TIMEOUT}m --for=delete pod {node.name}",
+        timeout_in_minutes = SCYLLA_POD_TERMINATE_TIMEOUT + SCYLLA_POD_READINESS_TIMEOUT
+        self.k8s_cluster.kubectl(f"wait --timeout={timeout_in_minutes}m --for=ready pod {node.name}",
                                  namespace=self.namespace,
-                                 timeout=SCYLLA_POD_TERMINATE_TIMEOUT*60+10)
+                                 timeout=timeout_in_minutes*60+10)
 
     def decommission(self, node):
         self.terminate_node(node)

--- a/sdcm/k8s_configs/cluster-gke.yaml
+++ b/sdcm/k8s_configs/cluster-gke.yaml
@@ -85,6 +85,7 @@ spec:
   repository: ${SCT_DOCKER_IMAGE}
   agentVersion: ${SCT_SCYLLA_MGMT_AGENT_VERSION}
   cpuset: true
+  automaticOrphanedNodeCleanup: true
   sysctls:
     - "fs.aio-max-nr=2097152"
   network:

--- a/sdcm/k8s_configs/operator.yaml
+++ b/sdcm/k8s_configs/operator.yaml
@@ -61,6 +61,9 @@ spec:
                   format: int32
                   type: integer
               type: object
+            automaticOrphanedNodeCleanup:
+              description: AutomaticOrphanedNodeCleanup controls if automatic orphan node cleanup should be performed.
+              type: boolean
             backups:
               description: Backups specifies backup task in Scylla Manager. When Scylla Manager is not installed, these will be ignored.
               items:
@@ -1564,6 +1567,11 @@ spec:
                     description: ReadyMembers is the number of ready members in the specific Rack
                     format: int32
                     type: integer
+                  replace_address_first_boot:
+                    additionalProperties:
+                      type: string
+                    description: Pool of addresses which should be replaced by new nodes.
+                    type: object
                   version:
                     description: Version is the current version of Scylla in use.
                     type: string
@@ -1681,9 +1689,25 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
   - get
   - list
   - watch

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -556,14 +556,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def _terminate_cluster_node(self, node):
         if isinstance(self.cluster, GkeScyllaPodCluster):
-            # Scylla-operator can't recover when k8s node is gone, so we disable terminate_k8s_host and terminate_k8s_node
-            # termination_methods = ('terminate_k8s_host', 'terminate_k8s_node', 'terminate_node')
-            # TBD: enable terminate_k8s_node when https://github.com/scylladb/scylla-operator/issues/215 is fixed
-            termination_methods = ('terminate_node',)
+            termination_methods = ('terminate_k8s_host', 'terminate_k8s_node', 'terminate_node')
         elif isinstance(self.cluster, MinikubeScyllaPodCluster):
-            # Scylla-operator can't recover when k8s node is gone, so we disable terminate_k8s_node
-            # termination_methods = ('terminate_k8s_node', 'terminate_node')
-            # TBD: enable terminate_k8s_node when https://github.com/scylladb/scylla-operator/issues/215 is fixed
+            # Minikube is deployed with only one node setup, it can't be deleted
             termination_methods = ('terminate_node',)
         else:
             termination_methods = ('terminate_node',)

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-gke.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-gke.yaml
@@ -6,8 +6,8 @@ n_db_nodes: 3
 n_loaders: 2
 n_monitor_nodes: 1
 
-nemesis_class_name: 'KubernetesScyllaOperatorMonkey'
-nemesis_interval: 5
+nemesis_class_name: 'NodeTerminateAndReplace'
+nemesis_interval: 15
 
 # Need to keep rendered name less than 40 chars because of GKE restrictions. Note, that backend name included automatically.
 user_prefix: 'longevity-scylla-operator-3h-gke'


### PR DESCRIPTION
https://trello.com/c/jyPdrRef/2593-test-replace-dead-node-procedure-enable-terminatek8snode

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
