### PR TITLE
fix(gce failing spot): Instance failed to start due to preemption

### DIFF
--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -347,7 +347,7 @@ class GCECluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
             # May happen that spot instance was preempted during instance creating. This instance won't be
             # destroyed but stopped and stays with the name in the instances pool. In this case we should destroy this
             # instance before creating new one
-            if details.value["reason"] == "alreadyExists" and \
+            if "Instance failed to start due to preemption" in str(details) and \
                     (failed_instance := self._get_instances_by_name(dc_idx=dc_idx, name=name)):
                 self._gce_services[dc_idx].destroy_node(node=failed_instance, destroy_boot_disk=True)
 


### PR DESCRIPTION
Previous fix (#2840 ) was wrong.
If spot creation fails with message 'Instance failed to start due to preemption',
check if preempted instance still exists and destroy it if needed.
Then create on_demand

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
