### PR TITLE
install-hydra.sh: Fix install when the /usr/local/bin/hydra exists

### DIFF
--- a/install-hydra.sh
+++ b/install-hydra.sh
@@ -13,10 +13,7 @@ if ! docker --version ; then
     echo "==================================================================================================="
 fi
 echo "Docker is installed."
-if [ ! -L "${HYDRA_LINK_PATH}" ]; then
-    echo "Installing  Hydra"
-    ln -s $(pwd)/docker/env/hydra.sh ${HYDRA_LINK_PATH}
-fi
+ln -vsf $(pwd)/docker/env/hydra.sh ${HYDRA_LINK_PATH}
 echo "Hydra installed."
 if ! aws --version; then
     echo "Installing AWS CLI..."


### PR DESCRIPTION
Step1:

user1 installs hydra
/usr/local/bin/hydra -> /home/user1//scylla-cluster-tests/docker/env/hydra.sh

Step2:

user2 installs hydra
/usr/local/bin/hydra -> /home/user1/scylla-cluster-tests/docker/env/hydra.sh

user2 will use the install from user1.

To fix create the link with -f option and unconditionally.

To make it even better, we'd better create the link under ~/.local/bin not /usr/local/bin.

