### PR TITLE
fix(longevity-alternator-3h-multidc.yaml): Increase the running time to 8H

### DIFF
--- a/jenkins-pipelines/longevity-alternator-3h-multidc.jenkinsfile
+++ b/jenkins-pipelines/longevity-alternator-3h-multidc.jenkinsfile
@@ -9,6 +9,5 @@ longevityPipeline(
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-alternator-3h-multidc.yaml',
 
-    timeout: [time: 400, unit: 'MINUTES'],
     email_recipients: 'qa@scylladb.com'
 )

--- a/test-cases/longevity/longevity-alternator-3h-multidc.yaml
+++ b/test-cases/longevity/longevity-alternator-3h-multidc.yaml
@@ -1,4 +1,4 @@
-test_duration: 300
+test_duration: 480
 prepare_write_cmd:
   - >-
     bin/ycsb load dynamodb -P workloads/workloadc -threads 80 -p recordcount=6990500


### PR DESCRIPTION
* Increases the running time of the JOB, because it lasts more than 3 hours
   and failed because of timeout.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
