### PR TITLE
fix(cluster_k8s): make it work with enterprise scylla

### DIFF
--- a/defaults/docker_config.yaml
+++ b/defaults/docker_config.yaml
@@ -1,4 +1,4 @@
-docker_image: 'scylladb/scylla'
 user_credentials_path: '~/.ssh/scylla-test'
 logs_transport: docker
 use_preinstalled_scylla: true
+docker_image: ''

--- a/defaults/k8s_gce_minikube_config.yaml
+++ b/defaults/k8s_gce_minikube_config.yaml
@@ -41,3 +41,4 @@ use_preinstalled_scylla: true
 backtrace_decoding: false
 
 append_scylla_args: ''
+docker_image: ''

--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -44,3 +44,4 @@ use_preinstalled_scylla: true
 backtrace_decoding: false
 
 append_scylla_args: ''
+docker_image: ''

--- a/sdcm/cluster_k8s/minikube.py
+++ b/sdcm/cluster_k8s/minikube.py
@@ -270,7 +270,7 @@ class MinikubeScyllaPodCluster(ScyllaPodCluster, IptablesClusterOpsMixin):
         super().terminate_node(node)
 
     def upgrade_scylla_cluster(self, new_version: str) -> None:
-        self.k8s_cluster.docker_pull(f"scylladb/scylla:{new_version}")
+        self.k8s_cluster.docker_pull(f"{self.params.get('docker_image')}:{new_version}")
         return super().upgrade_scylla_cluster(new_version)
 
     @retrying(n=20, sleep_time=60, allowed_exceptions=(cluster.ClusterNodesNotReady, UnexpectedExit),

--- a/sdcm/k8s_configs/cluster-gke.yaml
+++ b/sdcm/k8s_configs/cluster-gke.yaml
@@ -82,6 +82,7 @@ metadata:
   namespace: scylla
 spec:
   version: ${SCT_SCYLLA_VERSION}
+  repository: ${SCT_DOCKER_IMAGE}
   agentVersion: ${SCT_SCYLLA_MGMT_AGENT_VERSION}
   cpuset: true
   sysctls:

--- a/sdcm/k8s_configs/cluster-minikube.yaml
+++ b/sdcm/k8s_configs/cluster-minikube.yaml
@@ -82,6 +82,7 @@ metadata:
   namespace: scylla
 spec:
   version: ${SCT_SCYLLA_VERSION}
+  repository: ${SCT_DOCKER_IMAGE}
   agentVersion: ${SCT_SCYLLA_MGMT_AGENT_VERSION}
   developerMode: true
   datacenter:

--- a/sdcm/k8s_configs/gke-loaders.yaml
+++ b/sdcm/k8s_configs/gke-loaders.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: cassandra-stress
-          image: scylladb/scylla:${SCT_SCYLLA_VERSION}
+          image: ${SCT_DOCKER_IMAGE}:${SCT_SCYLLA_VERSION}
           command:
             - "/bin/cat"
           tty: true

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1071,7 +1071,7 @@ class SCTConfiguration(dict):
                 'gce_instance_type_monitor', 'gce_root_disk_type_monitor', 'gce_root_disk_size_monitor',
                 'gce_n_local_ssd_disk_monitor', 'gce_datacenter'],
 
-        'docker': ['user_credentials_path'],
+        'docker': ['user_credentials_path', 'scylla_version'],
 
         'baremetal': ['db_nodes_private_ip', 'db_nodes_public_ip', 'user_credentials_path'],
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -76,6 +76,7 @@ from sdcm.remote import RemoteCmdRunnerBase
 from sdcm.utils.gce_utils import get_gce_services
 from sdcm.keystore import KeyStore
 
+
 try:
     import cluster_cloud
 except ImportError:
@@ -891,7 +892,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         self.k8s_cluster.deploy_scylla_operator()
 
         # This should remove some of the unpredictability of pods startup time.
-        self.k8s_cluster.docker_pull(f'scylladb/scylla:{self.params.get("scylla_version")}')
+        self.k8s_cluster.docker_pull(f"{self.params.get('docker_image')}:{self.params.get('scylla_version')}")
 
         self.db_cluster = \
             minikube.MinikubeScyllaPodCluster(k8s_cluster=self.k8s_cluster,

--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -189,3 +189,11 @@ def get_systemd_version(output: str) -> int:
         except ValueError:
             pass
     return 0
+
+
+def get_scylla_docker_repo_from_version(version: str):
+    if version == 'latest':
+        return 'scylladb/scylla-nightly'
+    if is_enterprise(version):
+        return 'scylladb/scylla-enterprise'
+    return 'scylladb/scylla'


### PR DESCRIPTION
https://trello.com/c/wBYJibpu/2641-k8s-make-it-possible-to-run-on-enterprise

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
