### PR TITLE
fix(unit_tests/test_seed_selector.py): add a is_nonroot_install() to DummyNode

### DIFF
--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -54,6 +54,10 @@ class DummyNode(BaseNode):  # pylint: disable=abstract-method
     def wait_ssh_up(self, verbose=True, timeout=500):
         pass
 
+    @property
+    def is_nonroot_install(self):
+        return False
+
 
 class DummyDbCluster(BaseCluster):
     def __init__(self, nodes):
@@ -170,7 +174,7 @@ class TestBaseNodeGetScyllaVersion(unittest.TestCase):
 
     def test_no_scylla_binary_rhel_like(self):
         self.node.remoter = VersionDummyRemote(self, (
-            ("scylla --version", (127, "", "bash: scylla: command not found\n")),
+            ("/usr/bin/scylla --version", (127, "", "bash: scylla: command not found\n")),
             ("rpm --query --queryformat '%{VERSION}' scylla", (0, "3.3.rc1", "")),
         ))
         self.assertEqual(self.node.get_scylla_version(), "3.3.rc1")
@@ -179,7 +183,7 @@ class TestBaseNodeGetScyllaVersion(unittest.TestCase):
     def test_no_scylla_binary_other(self):
         self.node.distro = Distro.DEBIAN9
         self.node.remoter = VersionDummyRemote(self, (
-            ("scylla --version", (127, "", "bash: scylla: command not found\n")),
+            ("/usr/bin/scylla --version", (127, "", "bash: scylla: command not found\n")),
             ("dpkg-query --show --showformat '${Version}' scylla", (0, "3.3~rc1-0.20200209.0d0c1d43188-1", "")),
         ))
         self.assertEqual(self.node.get_scylla_version(), "3.3.rc1")
@@ -187,7 +191,7 @@ class TestBaseNodeGetScyllaVersion(unittest.TestCase):
 
     def test_scylla(self):
         self.node.remoter = VersionDummyRemote(self, (
-            ("scylla --version", (0, "3.3.rc1-0.20200209.0d0c1d43188\n", "")),
+            ("/usr/bin/scylla --version", (0, "3.3.rc1-0.20200209.0d0c1d43188\n", "")),
             ("readelf -n /usr/bin/scylla", (0, "Build ID: xxx", "")),
         ))
         self.assertEqual(self.node.get_scylla_version(), "3.3.rc1")
@@ -196,7 +200,7 @@ class TestBaseNodeGetScyllaVersion(unittest.TestCase):
 
     def test_scylla_master(self):
         self.node.remoter = VersionDummyRemote(self, (
-            ("scylla --version", (0, "666.development-0.20200205.2816404f575\n", "")),
+            ("/usr/bin/scylla --version", (0, "666.development-0.20200205.2816404f575\n", "")),
             ("readelf -n /usr/bin/scylla", (0, "Build ID: xxx", "")),
         ))
         self.assertEqual(self.node.get_scylla_version(), "666.development")
@@ -204,7 +208,7 @@ class TestBaseNodeGetScyllaVersion(unittest.TestCase):
 
     def test_scylla_master_new_format(self):
         self.node.remoter = VersionDummyRemote(self, (
-            ("scylla --version", (0, "4.4.dev-0.20200205.2816404f575\n", "")),
+            ("/usr/bin/scylla --version", (0, "4.4.dev-0.20200205.2816404f575\n", "")),
             ("readelf -n /usr/bin/scylla", (0, "Build ID: xxx", "")),
         ))
         self.assertEqual(self.node.get_scylla_version(), "4.4.dev")
@@ -213,7 +217,7 @@ class TestBaseNodeGetScyllaVersion(unittest.TestCase):
     def test_scylla_enterprise(self):
         self.node.is_enterprise = True
         self.node.remoter = VersionDummyRemote(self, (
-            ("scylla --version", (0, "2019.1.4-0.20191217.b59e92dbd\n", "")),
+            ("/usr/bin/scylla --version", (0, "2019.1.4-0.20191217.b59e92dbd\n", "")),
             ("readelf -n /usr/bin/scylla", (0, "Build ID: xxx", "")),
         ))
         self.assertEqual(self.node.get_scylla_version(), "2019.1.4")
@@ -222,7 +226,7 @@ class TestBaseNodeGetScyllaVersion(unittest.TestCase):
     def test_scylla_enterprise_no_scylla_binary(self):
         self.node.is_enterprise = True
         self.node.remoter = VersionDummyRemote(self, (
-            ("scylla --version", (127, "", "bash: scylla: command not found\n")),
+            ("/usr/bin/scylla --version", (127, "", "bash: scylla: command not found\n")),
             ("rpm --query --queryformat '%{VERSION}' scylla-enterprise", (0, "2019.1.4", "")),
         ))
         self.assertEqual(self.node.get_scylla_version(), "2019.1.4")

--- a/unit_tests/test_seed_selector.py
+++ b/unit_tests/test_seed_selector.py
@@ -28,6 +28,10 @@ class DummyNode(sdcm.cluster.BaseNode):  # pylint: disable=abstract-method
         # Expected node name like : node1, node2, node3 ...
         return '127.0.0.%s' % self.name.replace('node', '')
 
+    @property
+    def is_nonroot_install(self):
+        return False
+
 
 class DummyCluster(sdcm.cluster.BaseScyllaCluster):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
This unittest uses a scylla.yaml inside ./test_data directory, it's fine
to access it by the given path.

If is_nonroot_install() returns False, the config path won't be changed.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
