### PR TITLE
fix(k8s.py): retry on api calls

### DIFF
--- a/sdcm/utils/k8s.py
+++ b/sdcm/utils/k8s.py
@@ -26,6 +26,7 @@ from urllib3.util.retry import Retry
 
 from sdcm.remote import LOCALRUNNER
 from sdcm.sct_config import sct_abs_path
+from sdcm.utils.decorators import timeout as timeout_decor
 from sdcm.utils.docker_utils import ContainerManager, DockerException, Container
 
 
@@ -152,18 +153,21 @@ class KubernetesOps:
         return k8s.client.CoreV1Api(api_client)
 
     @classmethod
+    @timeout_decor(timeout=600)
     def list_statefulsets(cls, kluster, namespace=None, **kwargs):
         if namespace is None:
             return kluster.k8s_apps_v1_api.list_stateful_set_for_all_namespaces(watch=False, **kwargs).items
         return kluster.k8s_apps_v1_api.list_namespaced_stateful_set(namespace=namespace, watch=False, **kwargs).items
 
     @classmethod
+    @timeout_decor(timeout=600)
     def list_pods(cls, kluster, namespace=None, **kwargs):
         if namespace is None:
             return kluster.k8s_core_v1_api.list_pod_for_all_namespaces(watch=False, **kwargs).items
         return kluster.k8s_core_v1_api.list_namespaced_pod(namespace=namespace, watch=False, **kwargs).items
 
     @classmethod
+    @timeout_decor(timeout=600)
     def list_services(cls, kluster, namespace=None, **kwargs):
         if namespace is None:
             return kluster.k8s_core_v1_api.list_service_all_namespaces(watch=False, **kwargs).items


### PR DESCRIPTION
https://trello.com/c/48ubKQPz/2648-k8s-add-timeout-for-api-calls

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
