### PR TITLE
fix(cluster.py): reduce severity for empty nested_exception

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -420,6 +420,11 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             DatabaseLogEvent(type='BROKEN_PIPE', severity=Severity.WARNING,
                              regex='cql_server - exception while processing connection:.*Broken pipe'),
             DatabaseLogEvent(type='SEMAPHORE_TIME_OUT', regex='semaphore_timed_out', severity=Severity.WARNING),
+            DatabaseLogEvent(
+                type='EMPTY_NESTED_EXCEPTION',
+                regex='cql_server - exception while processing connection: seastar::nested_exception '
+                      '\(seastar::nested_exception\)$',
+                severity=Severity.WARNING),
             DatabaseLogEvent(type='DATABASE_ERROR', regex='Exception '),
             DatabaseLogEvent(type='BAD_ALLOC', regex='std::bad_alloc'),
             DatabaseLogEvent(type='SCHEMA_FAILURE', regex='Failed to load schema version'),


### PR DESCRIPTION
https://trello.com/c/swyZGuww/2651-k8s-reduce-severity-for-nestedexception
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
