### PR TITLE
fix(cluster_k8s): add timeout on reboots

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -363,11 +363,17 @@ class BasePodContainer(cluster.BaseNode):
         raise NotImplementedError("Not implemented yet")  # TODO: implement this method.
 
     def hard_reboot(self):
-        self.parent_cluster.k8s_cluster.kubectl(f'delete pod {self.name} --now', namespace='scylla')
+        self.parent_cluster.k8s_cluster.kubectl(
+            f'delete pod {self.name} --now',
+            namespace='scylla',
+            timeout=SCYLLA_POD_TERMINATE_TIMEOUT * 60 + 10)
 
     def soft_reboot(self):
         # Kubernetes brings pods back to live right after it is deleted
-        self.parent_cluster.k8s_cluster.kubectl(f'delete pod {self.name} --grace-period=300', namespace='scylla')
+        self.parent_cluster.k8s_cluster.kubectl(
+            f'delete pod {self.name} --grace-period={SCYLLA_POD_TERMINATE_TIMEOUT * 60}',
+            namespace='scylla',
+            timeout=SCYLLA_POD_TERMINATE_TIMEOUT * 60 + 10)
 
     # On kubernetes there is no stop/start, closest analog of node restart would be soft_restart
     restart = soft_reboot
@@ -414,7 +420,9 @@ class BasePodContainer(cluster.BaseNode):
         return self.node_name
 
     def terminate_k8s_node(self):
-        self.parent_cluster.k8s_cluster.kubectl(f'delete node {self.node_name} --now')
+        self.parent_cluster.k8s_cluster.kubectl(
+            f'delete node {self.node_name} --now',
+            timeout=SCYLLA_POD_TERMINATE_TIMEOUT * 60 + 10)
 
     def terminate_k8s_host(self):
         raise NotImplementedError("To be overridden in child class")
@@ -656,7 +664,7 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):
         super().terminate_node(node)
         self.k8s_cluster.kubectl(f"wait --timeout={SCYLLA_POD_TERMINATE_TIMEOUT}m --for=delete pod {node.name}",
                                  namespace=self.namespace,
-                                 timeout=SCYLLA_POD_TERMINATE_TIMEOUT*60+10)
+                                 timeout=SCYLLA_POD_TERMINATE_TIMEOUT * 60 + 10)
 
     def terminate_k8s_node(self, node: BasePodContainer):
         assert self.nodes[-1] == node, "Can withdraw the last node only"
@@ -665,7 +673,7 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):
         self.replace_scylla_cluster_value("/spec/datacenter/racks/0/members", current_members - 1)
         self.k8s_cluster.kubectl(f"wait --timeout={SCYLLA_POD_TERMINATE_TIMEOUT}m --for=delete pod {node.name}",
                                  namespace=self.namespace,
-                                 timeout=SCYLLA_POD_TERMINATE_TIMEOUT*60+10)
+                                 timeout=SCYLLA_POD_TERMINATE_TIMEOUT * 60 + 10)
 
     def terminate_k8s_host(self, node: BasePodContainer):
         assert self.nodes[-1] == node, "Can withdraw the last node only"
@@ -674,7 +682,7 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):
         self.replace_scylla_cluster_value("/spec/datacenter/racks/0/members", current_members - 1)
         self.k8s_cluster.kubectl(f"wait --timeout={SCYLLA_POD_TERMINATE_TIMEOUT}m --for=delete pod {node.name}",
                                  namespace=self.namespace,
-                                 timeout=SCYLLA_POD_TERMINATE_TIMEOUT*60+10)
+                                 timeout=SCYLLA_POD_TERMINATE_TIMEOUT * 60 + 10)
 
     def decommission(self, node):
         self.terminate_node(node)


### PR DESCRIPTION
https://trello.com/c/6aC89cwT/2652-k8s-add-timeouts-to-reboot-method

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
