### PR TITLE
fix(kubernetes_cmd_runner): increase default retry

### DIFF
--- a/sdcm/remote/kubernetes_cmd_runner.py
+++ b/sdcm/remote/kubernetes_cmd_runner.py
@@ -104,6 +104,7 @@ class KubernetesRunner(Runner):
 
 class KubernetesCmdRunner(RemoteCmdRunnerBase):
     exception_retryable = (ConnectionError, MaxRetryError, ThreadException)
+    default_run_retry = 8
 
     def __init__(self, kluster, pod: str, container: Optional[str] = None, namespace: str = "default") -> None:
         self.kluster = kluster


### PR DESCRIPTION
Kubernetes retries only 3 times and fails, which is pretty low, given that GKE has API rate limit issue.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
