### PR TITLE
fix(kubernetes_cmd_runner): add threadexception to the list of retryable exceptions

### DIFF
--- a/sdcm/remote/kubernetes_cmd_runner.py
+++ b/sdcm/remote/kubernetes_cmd_runner.py
@@ -17,6 +17,7 @@ from typing import Optional, Callable, Iterator, List
 
 import kubernetes as k8s
 from invoke import Runner, Context, Config
+from invoke.exceptions import ThreadException
 from urllib3.exceptions import MaxRetryError
 
 from sdcm.utils.k8s import KubernetesOps
@@ -102,7 +103,7 @@ class KubernetesRunner(Runner):
 
 
 class KubernetesCmdRunner(RemoteCmdRunnerBase):
-    exception_retryable = (ConnectionError, MaxRetryError, )
+    exception_retryable = (ConnectionError, MaxRetryError, ThreadException)
 
     def __init__(self, kluster, pod: str, container: Optional[str] = None, namespace: str = "default") -> None:
         self.kluster = kluster


### PR DESCRIPTION
https://trello.com/c/2WA4yd3k/2654-k8s-add-threadexception-to-retryable-exception-list-of-the-remoter

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
