### PR TITLE
fix(lwt-24h-multidc-test): reduce stress

### DIFF
--- a/test-cases/longevity/longevity-lwt-24h-multidc.yaml
+++ b/test-cases/longevity/longevity-lwt-24h-multidc.yaml
@@ -1,5 +1,5 @@
 test_duration: 1560
-prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data_multidc.yaml n=10000000 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=1000" ]
+prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data_multidc.yaml n=10000000 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=100" ]
 stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data_multidc.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1,lwt_deletes=1)' cl=QUORUM duration=1440m -mode native cql3 -rate threads=30" ]
 stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data_multidc.yaml ops'(select=1)' cl=SERIAL duration=1440m -mode native cql3 -rate threads=30" ]
 


### PR DESCRIPTION
during prepare, there were 1000 threads,
exhausting the nodes memory and running
the load avg very high.
reducing it to try to make the test to
pass.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
