### PR TITLE
fix(webdriver container): prevent unnecessary printouts in the log

### DIFF
--- a/sdcm/utils/docker_utils.py
+++ b/sdcm/utils/docker_utils.py
@@ -200,9 +200,11 @@ class ContainerManager:
                 container = docker_client.containers.run(**run_args)
             instance._containers[name.full] = container
             LOGGER.info("Container %s started.", container)
-        else:
+        elif container.status != 'running':
             LOGGER.warning("Re-run container %s", container)
             container.start()
+        else:
+            LOGGER.debug("Container %s is running already.", container)
         return container
 
     @staticmethod


### PR DESCRIPTION
Add verification that webdriver container is not started before start it
for prevention of 'Re-run container' log message in case the container
is running. Now we print it always even when the container is running
and start shouldn't be run ('start' command nothing performs in case the
container is running)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
