### PR TITLE
feature(hydra): Support running with podman

### DIFF
--- a/sdcm/utils/monitorstack.py
+++ b/sdcm/utils/monitorstack.py
@@ -35,8 +35,8 @@ class ErrorUploadAnnotations(Exception):
 
 
 def restore_monitoring_stack(test_id, date_time=None):  # pylint: disable=too-many-return-statements
-    if not is_docker_available():
-        return False
+    # if not is_docker_available():
+    #    return False
 
     arch = get_monitoring_stack_archive(test_id, date_time)
     if not arch:


### PR DESCRIPTION
this now is working with podman
```bash
HYDRA_TOOL=podman bash -x ./docker/env/hydra.sh list-ami-versions
```

Anything that run docker inside the hydra image, is failing with premission error
that I'm not sure how to solve:

```bash
0 fruch@SCT-CONTAINER ~/Projects/scylla-cluster-tests (support_podman)# docker ps
Got permission denied while trying to connect to the Docker daemon
  socket at unix:///var/run/docker.sock: Get http://%2Fvar%2Frun%2Fdocker.sock/v1.40/
  containers/json: dial unix /var/run/docker.sock: connect: permission denied

0 fruch@SCT-CONTAINER ~/Projects/scylla-cluster-tests (support_podman)# ls -all /var/run/docker.sock
srw-rw---- 1 65534 nogroup 0 Dec  6 13:28 /var/run/docker.sock
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
