### PR TITLE
fix(SslHotReloadingNemesis): make it less pron to fail

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -38,7 +38,7 @@ from sdcm.cluster import SCYLLA_YAML_PATH, NodeSetupTimeout, NodeSetupFailed
 from sdcm.mgmt import TaskStatus
 from sdcm.utils.common import remote_get_file, get_db_tables, generate_random_string, \
     update_certificates, reach_enospc_on_node, clean_enospc_on_node, parse_nodetool_listsnapshots
-from sdcm.utils.decorators import retrying
+from sdcm.utils.decorators import retrying, timeout
 from sdcm.utils import cdc
 from sdcm.log import SDCMAdapter
 from sdcm.keystore import KeyStore
@@ -2390,42 +2390,39 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.log.info("Finish cluster shrink. Current number of nodes %s", len(self.cluster.nodes))
 
     def disrupt_hot_reloading_internode_certificate(self):
-        '''
+        """
         https://github.com/scylladb/scylla/issues/6067
         Scylla has the ability to hot reload SSL certificates.
         This test will create and reload new certificates for the inter node communication.
-        '''
+        """
         self._set_current_disruption('ServerSslHotReloadingNemesis')
         if not self.cluster.params.get('server_encrypt'):
             raise UnsupportedNemesis('Server Encryption is not enabled, hence skipping')
 
-        @retrying(n=30, allowed_exceptions=(LogContentNotFound, ))
-        def check_ssl_reload_log(target_node, since_time):
-            msg = target_node.remoter.run(f'journalctl -u scylla-server --since="{since_time}" | grep '
-                                          f'messaging_service - Reloaded {{{ssl_files_location}}}', ignore_status=True)
-            if not msg.stdout:
+        @timeout(timeout=20, allowed_exceptions=(LogContentNotFound, ))
+        def check_ssl_reload_log(node_system_log):
+            if not list(node_system_log):
                 raise LogContentNotFound('Reload SSL message not found in node log')
-            return msg.stdout
+            return True
 
         ssl_files_location = json.loads(
             self.target_node.get_scylla_config_param("server_encryption_options"))["certificate"]
         in_place_crt = self.target_node.remoter.run(f"cat {ssl_files_location}",
                                                     ignore_status=True).stdout
         update_certificates()
-        time_now = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+        node_system_logs = {}
         for node in self.cluster.nodes:
+            node_system_logs[node] = node.follow_system_log(
+                patterns=f'messaging_service - Reloaded {{{ssl_files_location}}}')
             node.remoter.send_files(src='data_dir/ssl_conf/db.crt', dst='/tmp')
-        for node in self.cluster.nodes:
             node.remoter.run(f"sudo cp -f /tmp/db.crt {ssl_files_location}")
-        for node in self.cluster.nodes:
             new_crt = node.remoter.run(f"cat {ssl_files_location}").stdout
             if in_place_crt == new_crt:
-                raise Exception('The CRT file was not replaced with the new one')
-            reload = check_ssl_reload_log(target_node=node, since_time=time_now)
-            if not reload:
-                raise Exception('SSL auto Reload did not happen')
+                raise Exception('The CRT file was not replaced')
 
-        self.log.info('hot reloading internode ssl nemesis finished')
+        for node in self.cluster.nodes:
+            if not check_ssl_reload_log(node_system_logs[node]):
+                raise Exception('SSL auto Reload did not happen')
 
     def disrupt_run_unique_sequence(self):
         InfoEvent(message="StarEvent - start a repair by ScyllaManager").publish()


### PR DESCRIPTION
https://trello.com/c/boz1ia28/2655-ssl-server-certificate-hot-reload-messages-missed-by-sct-nemesis-mechanism-2962

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
