### PR TITLE
fix(tester): publish critical exception instead of killing test

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -90,6 +90,7 @@ PrometheusAlertManagerEvent.end: WARNING
 ScyllaOperatorLogEvent: ERROR
 ScyllaOperatorRestartEvent: ERROR
 StartupTestEvent: NORMAL
+TestTimeoutEvent: CRITICAL
 TestFrameworkEvent: ERROR
 SpotTerminationEvent: CRITICAL
 InfoEvent: NORMAL

--- a/sdcm/sct_events/system.py
+++ b/sdcm/sct_events/system.py
@@ -11,6 +11,7 @@
 #
 # Copyright (c) 2020 ScyllaDB
 
+import time
 from typing import Any, Optional, Sequence
 from traceback import format_stack
 
@@ -21,6 +22,18 @@ from sdcm.sct_events.base import SctEvent, SystemEvent
 class StartupTestEvent(SystemEvent):
     def __init__(self):
         super().__init__(severity=Severity.NORMAL)
+
+
+class TestTimeoutEvent(SctEvent):
+    def __init__(self, start_time: float, duration: int):
+        super().__init__(severity=Severity.CRITICAL)
+        self.start_time = start_time
+        self.duration = duration
+
+    @property
+    def msgfmt(self) -> str:
+        start_time = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(self.start_time))
+        return f"{super().msgfmt}, Test started at {start_time}, reached it's timeout ({self.duration} minute)"
 
 
 class TestFrameworkEvent(SctEvent):  # pylint: disable=too-many-instance-attributes
@@ -170,7 +183,7 @@ class TestResultEvent(SctEvent, Exception):
         for event_group, events in self.events.items():
             if not events:
                 continue
-            result.append(f"""{f'{"":-<5} LAST {event_group} EVENT ':-<{self._marker_width-2}}""")
+            result.append(f"""{f'{"":-<5} LAST {event_group} EVENT ':-<{self._marker_width - 2}}""")
             result.extend(events)
         return "\n".join(result)
 


### PR DESCRIPTION
https://trello.com/c/jFgHDvv8/2396-some-times-timeout-message-does-not-appear-in-the-logs-and-it-takes-time-to-investigate-reason-of-the-test-got-stopped

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
