### PR TITLE
refactor(perf-regression): Change email recipents for performance tes…

### DIFF
--- a/test-cases/performance/perf-regression-2mv.yaml
+++ b/test-cases/performance/perf-regression-2mv.yaml
@@ -21,5 +21,5 @@ user_prefix: 'perf-regression-mv'
 
 store_perf_results: true
 send_email: true
-email_recipients: ['roy@scylladb.com', 'bentsi@scylladb.com']
+email_recipients: ['scylla-perf-results@scylladb.com']
 backtrace_decoding: false

--- a/test-cases/performance/perf-regression-alternator-latency-500gb-30min.yaml
+++ b/test-cases/performance/perf-regression-alternator-latency-500gb-30min.yaml
@@ -52,4 +52,4 @@ backtrace_decoding: false
 
 store_perf_results: true
 send_email: true
-email_recipients: ['qa@scylladb.com', 'alternator@scylladb.com']
+email_recipients: ['scylla-perf-results@scylladb.com', 'alternator@scylladb.com']

--- a/test-cases/performance/perf-regression-alternator.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression-alternator.100threads.30M-keys.yaml
@@ -54,4 +54,4 @@ space_node_threshold: 644245094
 
 store_perf_results: true
 send_email: true
-email_recipients: ['qa@scylladb.com', 'alternator@scylladb.com']
+email_recipients: ['scylla-perf-results@scylladb.com', 'alternator@scylladb.com']

--- a/test-cases/performance/perf-regression-latency-1TB.yaml
+++ b/test-cases/performance/perf-regression-latency-1TB.yaml
@@ -25,5 +25,5 @@ append_scylla_args: '--blocked-reactor-notify-ms 4'
 
 store_perf_results: true
 send_email: true
-email_recipients: ['qa@scylladb.com', 'rnd-internal@scylladb.com']
+email_recipients: ['scylla-perf-results@scylladb.com']
 backtrace_decoding: false

--- a/test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml
+++ b/test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml
@@ -32,4 +32,4 @@ use_mgmt: true
 
 store_perf_results: true
 send_email: true
-email_recipients: ['qa@scylladb.com']
+email_recipients: ['scylla-perf-results@scylladb.com']

--- a/test-cases/performance/perf-regression-latency-500gb-30min.yaml
+++ b/test-cases/performance/perf-regression-latency-500gb-30min.yaml
@@ -26,4 +26,4 @@ append_scylla_args: '--blocked-reactor-notify-ms 4'
 
 store_perf_results: true
 send_email: true
-email_recipients: ['qa@scylladb.com']
+email_recipients: ['scylla-perf-results@scylladb.com']

--- a/test-cases/performance/perf-regression-latency-cdc-mixed-poll-batching.yaml
+++ b/test-cases/performance/perf-regression-latency-cdc-mixed-poll-batching.yaml
@@ -25,5 +25,5 @@ store_perf_results: true
 append_scylla_args: '--blocked-reactor-notify-ms 50'
 
 send_email: true
-email_recipients: ['qa@scylladb.com', 'piotr@scylladb.com ', 'piodul@scylladb.com', 'shlomi@scylladb.com ']
+email_recipients: ['scylla-perf-results@scylladb.com', 'cdc@scylladb.com']
 backtrace_decoding: false

--- a/test-cases/performance/perf-regression-latency-in-memory.yaml
+++ b/test-cases/performance/perf-regression-latency-in-memory.yaml
@@ -27,5 +27,5 @@ append_scylla_args: "--in-memory-storage-size-mb 80000 --blocked-reactor-notify-
 
 store_perf_results: true
 send_email: true
-email_recipients: ['qa@scylladb.com', 'rnd-internal@scylladb.com']
+email_recipients: ['scylla-perf-results@scylladb.com']
 backtrace_decoding: false

--- a/test-cases/performance/perf-regression-latency-lwt-big.yaml
+++ b/test-cases/performance/perf-regression-latency-lwt-big.yaml
@@ -61,5 +61,5 @@ append_scylla_args: '--blocked-reactor-notify-ms 400 --memory 4G --experimental 
 backtrace_decoding: false
 store_perf_results: true
 send_email: true
-email_recipients: ['qa@scylladb.com', 'lwt@scylladb.com']
+email_recipients: ['scylla-perf-results@scylladb.com', 'lwt@scylladb.com']
 email_subject_postfix: 'disk-wise(big dataset)'

--- a/test-cases/performance/perf-regression-latency-lwt-small.yaml
+++ b/test-cases/performance/perf-regression-latency-lwt-small.yaml
@@ -62,5 +62,5 @@ append_scylla_args: '--blocked-reactor-notify-ms 400 --memory 4G --experimental 
 backtrace_decoding: false
 store_perf_results: true
 send_email: true
-email_recipients: ['qa@scylladb.com', 'lwt@scylladb.com']
+email_recipients: ['scylla-perf-results@scylladb.com', 'lwt@scylladb.com']
 email_subject_postfix: 'memory-wise(small dataset)'

--- a/test-cases/performance/perf-regression-throughput-cdc-mixed-poll-batching.yaml
+++ b/test-cases/performance/perf-regression-throughput-cdc-mixed-poll-batching.yaml
@@ -29,5 +29,5 @@ append_scylla_yaml: |
     - cdc
 
 send_email: true
-email_recipients: ['qa@scylladb.com']
+email_recipients: ['scylla-perf-results@scylladb.com', 'cdc@scylladb.com']
 backtrace_decoding: false

--- a/test-cases/performance/perf-regression-throughput-lwt-big.yaml
+++ b/test-cases/performance/perf-regression-throughput-lwt-big.yaml
@@ -64,5 +64,5 @@ append_scylla_args: '--blocked-reactor-notify-ms 1000 --memory 4G --experimental
 backtrace_decoding: false
 store_perf_results: true
 send_email: true
-email_recipients: ['qa@scylladb.com', 'lwt@scylladb.com']
+email_recipients: ['scylla-perf-results@scylladb.com', 'lwt@scylladb.com']
 email_subject_postfix: 'disk-wise(big dataset)'

--- a/test-cases/performance/perf-regression-throughput-lwt-small.yaml
+++ b/test-cases/performance/perf-regression-throughput-lwt-small.yaml
@@ -63,5 +63,5 @@ append_scylla_args: '--blocked-reactor-notify-ms 1000 --memory 4G --experimental
 backtrace_decoding: false
 store_perf_results: true
 send_email: true
-email_recipients: ['qa@scylladb.com', 'lwt@scylladb.com']
+email_recipients: ['scylla-perf-results@scylladb.com', 'lwt@scylladb.com']
 email_subject_postfix: 'memory-wise(small dataset)'

--- a/test-cases/performance/perf-regression-user-profiles.yaml
+++ b/test-cases/performance/perf-regression-user-profiles.yaml
@@ -36,3 +36,5 @@ store_perf_results: true
 append_scylla_args: '--blocked-reactor-notify-ms 4'
 
 backtrace_decoding: false
+
+email_recipients: ['scylla-perf-results@scylladb.com']

--- a/test-cases/performance/perf-regression-write-latency-cdc.yaml
+++ b/test-cases/performance/perf-regression-write-latency-cdc.yaml
@@ -18,5 +18,5 @@ append_scylla_args: '--blocked-reactor-notify-ms 50'
 
 
 send_email: true
-email_recipients: ['qa@scylladb.com', 'piotr@scylladb.com ', 'piodul@scylladb.com', 'shlomi@scylladb.com ']
+email_recipients: ['scylla-perf-results@scylladb.com', 'cdc@scylladb.com ']
 backtrace_decoding: false

--- a/test-cases/performance/perf-regression-write-throughput-cdc.yaml
+++ b/test-cases/performance/perf-regression-write-throughput-cdc.yaml
@@ -22,5 +22,5 @@ append_scylla_yaml: |
     - cdc
 
 send_email: true
-email_recipients: ['qa@scylladb.com', 'piotr@scylladb.com ', 'piodul@scylladb.com', 'shlomi@scylladb.com ']
+email_recipients: ['scylla-perf-results@scylladb.com', 'cdc@scylladb.com ']
 backtrace_decoding: false

--- a/test-cases/performance/perf-regression.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys.yaml
@@ -20,4 +20,4 @@ backtrace_decoding: false
 
 store_perf_results: true
 send_email: true
-email_recipients: ['qa@scylladb.com']
+email_recipients: ['scylla-perf-results@scylladb.com']

--- a/test-cases/performance/perf-row-level-repair-1TB.yaml
+++ b/test-cases/performance/perf-row-level-repair-1TB.yaml
@@ -26,3 +26,5 @@ store_perf_results: true
 send_email: 'true'
 
 backtrace_decoding: false
+
+email_recipients: ['scylla-perf-results@scylladb.com']


### PR DESCRIPTION
…ts reports

New group called scylla-perf-results@scylladb.com is now the default recipient for performance reports.
Some reports has an addiitonal group like lwt, cdc and alternator.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
