### PR TITLE
fix(snapshot nemesis): nemesis looks into wrong list

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1706,6 +1706,12 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                     keyspaces = list(set([ks.split('.')[0] for ks in ks_cf]))
                 keyspace = ','.join(keyspaces)
 
+            if not keyspace:
+                # it's unexpected situation. We have system keyspaces, so the keyspace(s) should be found always.
+                # If not - raise exception to investigate the issue
+                raise Exception(f'Something wrong happened, not empty keyspace(s) was not'
+                                f'found in the list:\n{ks_cf}')
+
             return f'snapshot -kc {keyspace}'
 
         def _few_tables():
@@ -1724,8 +1730,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
             ks_with_few_tables = get_ks_with_few_tables(ks_cf)
             if not ks_with_few_tables:
-                any_ks_cf = self.cluster.get_any_ks_cf_list(db_node=self.target_node)
-                ks_with_few_tables = get_ks_with_few_tables(any_ks_cf)
+                # If non-system keyspace with few tables wasn't found - take system table snapshot
+                ks_cf = self.cluster.get_any_ks_cf_list(db_node=self.target_node)
+                ks_with_few_tables = get_ks_with_few_tables(ks_cf)
 
             if not ks_with_few_tables:
                 self.log.warning('Keyspace with few tables has not been found')
@@ -1733,6 +1740,12 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
             selected_keyspace = random.choice(ks_with_few_tables)
             tables = ','.join([k_c.split('.')[1] for k_c in ks_cf if k_c.startswith(f"{selected_keyspace}.")])
+
+            if not tables:
+                # it's unexpected situation. We have system keyspaces with few tables, so the keyspaces should be found.
+                # If not - raise exception to investigate the issue
+                raise Exception(f'Something wrong happened, tables for "{selected_keyspace}" keyspace were not'
+                                f'found in the list:\n{ks_cf}')
 
             return f'snapshot {selected_keyspace} -cf {tables}'
 


### PR DESCRIPTION
Issue [#2874](https://github.com/scylladb/scylla-cluster-tests/issues/2874)

Snapshot nemesis for few tables failed because of table parameter was empty:
`nodetool snapshot system -cf `

It happened because tables were searched in the wrong list with keyspaces

Bug in PR #2620 

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
