### PR TITLE
fix(cluster_k8s): fix timeout routines

### DIFF
--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -225,6 +225,10 @@ class GkeCluster(KubernetesCluster, cluster.BaseCluster):
 class GkeScyllaPodContainer(BasePodContainer, IptablesPodIpRedirectMixin):
     parent_cluster: 'GkeScyllaPodCluster'
 
+    pod_readiness_delay = 30  # seconds
+    pod_readiness_timeout = 30  # minutes
+    pod_terminate_timeout = 30  # minutes
+
     def __init__(self, *args, **kwargs):
         BasePodContainer.__init__(self, *args, **kwargs)
 

--- a/sdcm/cluster_k8s/minikube.py
+++ b/sdcm/cluster_k8s/minikube.py
@@ -212,6 +212,11 @@ class GceMinikubeCluster(MinikubeCluster, cluster_gce.GCECluster):
 
 
 class MinikubeScyllaPodContainer(BasePodContainer, IptablesPodPortsRedirectMixin):
+
+    pod_readiness_delay = 30  # seconds
+    pod_readiness_timeout = 30  # minutes
+    pod_terminate_timeout = 30  # minutes
+
     @cached_property
     def host_remoter(self):
         return self.parent_cluster.k8s_cluster.remoter


### PR DESCRIPTION
https://trello.com/c/PC8hgmFb/2677-k8s-fix-timeout-issues

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
