### PR TITLE
fix(_init_test_timeout_thread): make it raise critical event, not killing the test

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -858,7 +858,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.log.info('Nemesis stack is empty - setting termination_event')
             self.termination_event.set()
 
-
     def repair_nodetool_repair(self, node=None):
         node = node if node else self.target_node
         node.run_nodetool("repair")

--- a/sdcm/sct_events.py
+++ b/sdcm/sct_events.py
@@ -272,6 +272,18 @@ class StartupTestEvent(SystemEvent):
         self.severity = Severity.NORMAL
 
 
+class TestTimeoutEvent(SctEvent):
+    def __init__(self, start_time: float, duration: int):
+        super().__init__()
+        self.severity = Severity.CRITICAL
+        self.start_time = start_time
+        self.duration = duration
+
+    def __str__(self):
+        start_time = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(self.start_time))
+        return f"{super().__str__()}, Test started at {start_time}, reached it's timeout ({self.duration} minutes)"
+
+
 class TestFrameworkEvent(SctEvent):  # pylint: disable=too-many-instance-attributes
     __test__ = False  # Mark this class to be not collected by pytest.
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -57,7 +57,7 @@ from sdcm.results_analyze import PerformanceResultsAnalyzer, SpecifiedStatsPerfo
 from sdcm.sct_config import SCTConfiguration
 from sdcm.sct_events import start_events_device, stop_events_device, InfoEvent, FullScanEvent, Severity, \
     TestFrameworkEvent, TestResultEvent, get_logger_event_summary, EVENTS_PROCESSES, stop_events_analyzer, \
-    ScyllaBenchEvent
+    TestTimeoutEvent
 from sdcm.stress_thread import CassandraStressThread
 from sdcm.gemini_thread import GeminiStressThread
 from sdcm.utils.prepare_region import AwsRegion
@@ -280,14 +280,12 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
     def _init_test_timeout_thread(self) -> threading.Timer:
         start_time = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(self.start_time))
+        end_time = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(self.start_time + int(self.test_duration) * 60))
+        self.log.info(f'Test start time {start_time}, duration is {self.test_duration} and timeout set to {end_time}')
 
         def kill_the_test():
-            try:
-                raise RuntimeError(
-                    f"Test started at {start_time} has reached timeout ({self.test_duration} minutes)"
-                )
-            except:  # pylint: disable=bare-except
-                self.kill_test(sys.exc_info())
+            TestTimeoutEvent(start_time=self.start_time, duration=self.test_duration).publish()
+
         th = threading.Timer(60 * int(self.test_duration), kill_the_test)
         th.daemon = True
         th.start()


### PR DESCRIPTION
https://trello.com/c/jFgHDvv8/2396-some-times-timeout-message-does-not-appear-in-the-logs-and-it-takes-time-to-investigate-reason-of-the-test-got-stopped

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
