### PR TITLE
fix(aws-siren): remove multi-region verification

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1416,7 +1416,7 @@ class SCTConfiguration(dict):
             raise ValueError("Unsupported backend [{}]".format(backend))
 
         # verify multi-region aws params
-        if backend in ['aws', 'aws-siren']:
+        if backend in ['aws']:
             region_count = {}
             for opt in self.multi_region_params:
                 val = self.get(opt)

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -307,7 +307,6 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         os.environ['SCT_REGION_NAME'] = 'us-east-1'
         os.environ['SCT_N_DB_NODES'] = '2'
         os.environ['SCT_INSTANCE_TYPE_DB'] = 'i3.large'
-        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-eae4f795'
         os.environ['SCT_AUTHENTICATOR_USER'] = "user"
         os.environ['SCT_AUTHENTICATOR_PASSWORD'] = "pass"
         os.environ['SCT_CLOUD_CLUSTER_ID'] = "193712947904378"


### PR DESCRIPTION
since we are not passing down AMI or a version for SCT in this case
we can't pass this verification anyhow, so let skip it

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
