### PR TITLE
fix(cluster.py): Increase timeouts of scylla start

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2322,7 +2322,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         }
         return checklist.get(abs_path, INSTALL_DIR + abs_path)
 
-    def start_scylla_server(self, verify_up=True, verify_down=False, timeout=300, verify_up_timeout=300):
+    def start_scylla_server(self, verify_up=True, verify_down=False, timeout=500, verify_up_timeout=300):
         if verify_down:
             self.wait_db_down(timeout=timeout)
         if self.is_ubuntu14():
@@ -2343,7 +2343,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             self.wait_jmx_up(timeout=verify_up_timeout)
 
     @log_run_info
-    def start_scylla(self, verify_up=True, verify_down=False, timeout=300):
+    def start_scylla(self, verify_up=True, verify_down=False, timeout=500):
         self.start_scylla_server(verify_up=verify_up, verify_down=verify_down, timeout=timeout)
         if verify_up:
             self.wait_jmx_up(timeout=timeout)
@@ -2377,7 +2377,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         if verify_down:
             self.wait_jmx_down(timeout=timeout)
 
-    def restart_scylla_server(self, verify_up_before=False, verify_up_after=True, timeout=300, ignore_status=False):
+    def restart_scylla_server(self, verify_up_before=False, verify_up_after=True, timeout=500, ignore_status=False):
         if verify_up_before:
             self.wait_db_up(timeout=timeout)
         if self.distro.is_ubuntu14:
@@ -2400,7 +2400,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             self.wait_jmx_up(timeout=timeout)
 
     @log_run_info
-    def restart_scylla(self, verify_up_before=False, verify_up_after=True, timeout=300):
+    def restart_scylla(self, verify_up_before=False, verify_up_after=True, timeout=500):
         self.restart_scylla_server(verify_up_before=verify_up_before, verify_up_after=verify_up_after, timeout=timeout)
         if verify_up_after:
             self.wait_jmx_up(timeout=timeout)


### PR DESCRIPTION
In some cases when trying to start scylla service, a timeout of 300s
isn't long enough for scylla to complete startup. It happens due to
the reshaping that happens every time node boots and detect work that
need to be done on the sstables.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
