### PR TITLE
fix(rollingOperatorUpgradePipeline): remove withEnv and make it use routines

### DIFF
--- a/jenkins-pipelines/upgrade-scylla-k8s-gke.jenkinsfile
+++ b/jenkins-pipelines/upgrade-scylla-k8s-gke.jenkinsfile
@@ -6,5 +6,4 @@ rollingOperatorUpgradePipeline(
     backend: 'k8s-gke',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_scylla_upgrade',
     test_config: 'test-cases/scylla-operator/kubernetes-scylla-upgrade-gke.yaml',
-    timeout: [time: 300, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/upgrade-scylla-k8s-minikube.jenkinsfile
+++ b/jenkins-pipelines/upgrade-scylla-k8s-minikube.jenkinsfile
@@ -6,5 +6,4 @@ rollingOperatorUpgradePipeline(
     backend: 'k8s-gce-minikube',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_scylla_upgrade',
     test_config: 'test-cases/scylla-operator/kubernetes-scylla-upgrade-minikube.yaml',
-    timeout: [time: 300, unit: 'MINUTES']
 )

--- a/vars/rollingOperatorUpgradePipeline.groovy
+++ b/vars/rollingOperatorUpgradePipeline.groovy
@@ -11,9 +11,10 @@ def call(Map pipelineParams) {
         environment {
             AWS_ACCESS_KEY_ID     = credentials('qa-aws-secret-key-id')
             AWS_SECRET_ACCESS_KEY = credentials('qa-aws-secret-access-key')
+            SCT_TEST_ID = UUID.randomUUID().toString()
         }
         parameters {
-            choice(choices: ["${pipelineParams.get('backend', 'k8s-gce-minikube')}", 'k8s-gke'],
+            choice(choices: ["${pipelineParams.get('backend', 'k8s-gke')}", 'k8s-gke', 'k8s-gce-minikube'],
                    name: 'backend')
             string(defaultValue: "${pipelineParams.get('base_versions', '')}",
                    name: 'base_versions')
@@ -32,99 +33,83 @@ def call(Map pipelineParams) {
                    name: 'post_behavior_loader_nodes')
             choice(choices: ["${pipelineParams.get('post_behavior_monitor_nodes', 'destroy')}", 'keep', 'keep-on-failure'],
                    name: 'post_behavior_monitor_nodes')
-            string(defaultValue: "${pipelineParams.get('email_recipients', 'qa@scylladb.com')}",
+            string(defaultValue: "${pipelineParams.get('email_recipients', 'qa@scylladb.com,scylla-operator@scylladb.com')}",
                    description: 'email recipients of email report',
                    name: 'email_recipients')
+            string(defaultValue: "${pipelineParams.get('test_config', '')}",
+                   description: 'Test configuration file',
+                   name: 'test_config')
+            string(defaultValue: "${pipelineParams.get('test_name', '')}",
+                   description: 'Name of the test to run',
+                   name: 'test_name')
         }
         options {
             timestamps()
             disableConcurrentBuilds()
-            timeout(pipelineParams.timeout)
             buildDiscarder(logRotator(numToKeepStr: '20'))
         }
         stages {
+            stage('Get test duration') {
+                steps {
+                    catchError(stageResult: 'FAILURE') {
+                        timeout(time: 1, unit: 'MINUTES') {
+                            script {
+                                wrap([$class: 'BuildUser']) {
+                                    dir('scylla-cluster-tests') {
+                                        checkout scm
+                                        (testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCleanupTimeout) = getJobTimeouts(params, builder.region)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
             stage('Run SCT stages') {
                 steps {
                     script {
                         def tasks = [:]
-                        def base_version2 = readJSON text: params.base_versions
-                        for (version in base_version2) {
-                            def base_version = version
+                        def base_versions_list = readJSON text: params.base_versions
+                        for (base_version in base_versions_list) {
+                            run_params =  readJSON text: groovy.json.JsonOutput.toJson(params)
+                            run_params.scylla_version = base_version
                             tasks["Scylla Operator upgrade from ${base_version} to ${new_version}"] = {
-                                withEnv(["AWS_ACCESS_KEY_ID=${env.AWS_ACCESS_KEY_ID}",
-                                         "AWS_SECRET_ACCESS_KEY=${env.AWS_SECRET_ACCESS_KEY}",]) {
-                                    stage("${base_version} -> ${new_version} - Running test") {
-                                        catchError(stageResult: 'FAILURE') {
+
+                                stage("${base_version} -> ${new_version} - Running test") {
+                                    catchError(stageResult: 'FAILURE') {
+                                        script {
                                             wrap([$class: 'BuildUser']) {
                                                 dir('scylla-cluster-tests') {
-                                                    checkout scm
-                                                    def test_config = groovy.json.JsonOutput.toJson(pipelineParams.test_config)
-                                                    sh """
-                                                    #!/bin/bash
-                                                    set -xe
-                                                    env
-
-                                                    rm -fv ./latest
-
-                                                    export SCT_CLUSTER_BACKEND=gce
-
-                                                    export SCT_CONFIG_FILES=${test_config}
-                                                    export SCT_SCYLLA_VERSION=${base_version}
-                                                    export SCT_NEW_VERSION=${new_version}
-
-                                                    export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
-                                                    export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
-                                                    export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"
-                                                    export SCT_INSTANCE_PROVISION="${params.provision_type}"
-
-                                                    echo "start test ......."
-                                                    ./docker/env/hydra.sh run-test ${pipelineParams.test_name} --backend ${params.backend}  --logdir "`pwd`"
-                                                    echo "end test ....."
-                                                    """
+                                                    timeout(time: testRunTimeout, unit: 'MINUTES') {
+                                                        checkout scm
+                                                        runSctTest(run_params, builder.region)
+                                                    }
                                                 }
                                             }
                                         }
                                     }
-                                    stage("${base_version} -> ${new_version} - Collect logs") {
-                                        catchError(stageResult: 'FAILURE') {
+                                }
+                                stage("${base_version} -> ${new_version} - Collect logs") {
+                                    catchError(stageResult: 'FAILURE') {
+                                        script {
                                             wrap([$class: 'BuildUser']) {
                                                 dir('scylla-cluster-tests') {
-                                                    def test_config = groovy.json.JsonOutput.toJson(pipelineParams.test_config)
-                                                    sh """
-                                                    #!/bin/bash
-
-                                                    set -xe
-                                                    env
-
-                                                    export SCT_CLUSTER_BACKEND=gce
-                                                    export SCT_CONFIG_FILES=${test_config}
-
-                                                    echo "start collect logs ..."
-                                                    ./docker/env/hydra.sh collect-logs --logdir "`pwd`" --backend gce
-                                                    echo "end collect logs"
-                                                    """
+                                                    timeout(time: collectLogsTimeout, unit: 'MINUTES') {
+                                                        runCollectLogs(run_params, builder.region)
+                                                    }
                                                 }
                                             }
                                         }
                                     }
-                                    stage("${base_version} -> ${new_version} - Clean resources") {
-                                        catchError(stageResult: 'FAILURE') {
+                                }
+                                stage("${base_version} -> ${new_version} - Clean resources") {
+                                    catchError(stageResult: 'FAILURE') {
+                                        script {
                                             wrap([$class: 'BuildUser']) {
                                                 dir('scylla-cluster-tests') {
-                                                    sh """
-                                                    #!/bin/bash
-
-                                                    set -xe
-                                                    env
-
-                                                    export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
-                                                    export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
-                                                    export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"
-
-                                                    echo "start clean resources ..."
-                                                    ./docker/env/hydra.sh clean-resources --post-behavior --logdir "`pwd`"
-                                                    echo "end clean resources"
-                                                    """
+                                                    timeout(time: resourceCleanupTimeout, unit: 'MINUTES') {
+                                                        runCleanupResource(run_params, builder.region)
+                                                    }
                                                 }
                                             }
                                         }

--- a/vars/runCleanupResource.groovy
+++ b/vars/runCleanupResource.groovy
@@ -13,7 +13,11 @@ def call(Map params, String region){
 
     export SCT_CONFIG_FILES=${test_config}
     export SCT_CLUSTER_BACKEND="${params.backend}"
-    export SCT_REGION_NAME=${aws_region}
+
+    if [[ -n "${params.aws_region ? params.aws_region : ''}" ]] ; then
+        export SCT_REGION_NAME=${aws_region}
+    fi
+
     export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
     export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
     export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"
@@ -21,7 +25,7 @@ def call(Map params, String region){
     echo "Starting to clean resources ..."
     if [[ "$cloud_provider" == "aws" ]]; then
         SCT_RUNNER_IP=\$(cat sct_runner_ip||echo "")
-        if [[ ! -z "\${SCT_RUNNER_IP}" ]] ; then
+        if [[ -n "\${SCT_RUNNER_IP}" ]] ; then
             ./docker/env/hydra.sh --execute-on-runner \${SCT_RUNNER_IP} clean-resources --post-behavior --test-id \$SCT_TEST_ID
         else
             echo "SCT runner IP file is empty. Probably SCT Runner was not created."

--- a/vars/runCollectLogs.groovy
+++ b/vars/runCollectLogs.groovy
@@ -19,7 +19,7 @@ def call(Map params, String region){
     echo "start collect logs ..."
     if [[ "$cloud_provider" == "aws" ]]; then
         SCT_RUNNER_IP=\$(cat sct_runner_ip||echo "")
-        if [[ ! -z "\${SCT_RUNNER_IP}" ]] ; then
+        if [[ -n "\${SCT_RUNNER_IP}" ]] ; then
             ./docker/env/hydra.sh --execute-on-runner \${SCT_RUNNER_IP} collect-logs
         else
             echo "SCT runner IP file is empty. Probably SCT Runner was not created."

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -14,15 +14,30 @@ def call(Map params, String region){
     rm -fv ./latest
 
     export SCT_CLUSTER_BACKEND="${params.backend}"
-    export SCT_REGION_NAME=${aws_region}
     export SCT_CONFIG_FILES=${test_config}
     export SCT_COLLECT_LOGS=false
 
-    if [[ ! -z "${params.scylla_ami_id}" ]] ; then
+    if [[ -n "${params.aws_region ? params.aws_region : ''}" ]] ; then
+        export SCT_REGION_NAME=${aws_region}
+    fi
+
+    if [[ -n "${params.new_version ? params.new_version : ''}" ]] ; then
+        export SCT_NEW_VERSION="${params.new_version}"
+    fi
+
+    if [[ -n "${params.k8s_scylla_operator_docker_image ? params.k8s_scylla_operator_docker_image : ''}" ]] ; then
+        export SCT_K8S_SCYLLA_OPERATOR_DOCKER_IMAGE=${params.k8s_scylla_operator_docker_image}
+    fi
+
+    if [[ -n "${params.scylla_mgmt_agent_version ? params.scylla_mgmt_agent_version : ''}" ]] ; then
+        export SCT_SCYLLA_MGMT_AGENT_VERSION=${params.scylla_mgmt_agent_version}
+    fi
+
+    if [[ -n "${params.scylla_ami_id ? params.scylla_ami_id : ''}" ]] ; then
         export SCT_AMI_ID_DB_SCYLLA="${params.scylla_ami_id}"
-    elif [[ ! -z "${params.scylla_version}" ]] ; then
+    elif [[ -n "${params.scylla_version ? params.scylla_version : ''}" ]] ; then
         export SCT_SCYLLA_VERSION="${params.scylla_version}"
-    elif [[ ! -z "${params.scylla_repo}" ]] ; then
+    elif [[ -n "${params.scylla_repo ? params.scylla_repo : ''}" ]] ; then
         export SCT_SCYLLA_REPO="${params.scylla_repo}"
     else
         echo "need to choose one of SCT_AMI_ID_DB_SCYLLA | SCT_SCYLLA_VERSION | SCT_SCYLLA_REPO"
@@ -32,25 +47,36 @@ def call(Map params, String region){
     export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
     export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
     export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"
-    export SCT_INSTANCE_PROVISION="${params.provision_type}"
-    export SCT_INSTANCE_PROVISION_FALLBACK_ON_DEMAND="${params.instance_provision_fallback_on_demand ? params.instance_provision_fallback_on_demand : ''}"
+
+    if [[ -n "${params.provision_type ? params.provision_type : ''}" ]] ; then
+        export SCT_INSTANCE_PROVISION="${params.provision_type}"
+    fi
+
+    if [[ -n "${params.instance_provision_fallback_on_demand ? params.instance_provision_fallback_on_demand : ''}" ]] ; then
+        export SCT_INSTANCE_PROVISION_FALLBACK_ON_DEMAND="${params.instance_provision_fallback_on_demand}"
+    fi
     export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$GIT_BRANCH | sed -E 's+(origin/|origin/branch-)++')
     export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$SCT_AMI_ID_DB_SCYLLA_DESC | tr ._ - | cut -c1-8 )
     if [[ "${params.update_db_packages || false}" == "true" ]] ; then
         export SCT_UPDATE_DB_PACKAGES="${params.update_db_packages}"
     fi
 
-    export SCT_TAG_AMI_WITH_RESULT="${params.tag_ami_with_result}"
-    export SCT_IP_SSH_CONNECTIONS="${params.ip_ssh_connections}"
+    if [[ -n "${params.tag_ami_with_result ? params.tag_ami_with_result : ''}" ]] ; then
+        export SCT_TAG_AMI_WITH_RESULT="${params.tag_ami_with_result}"
+    fi
 
-    if [[ ! -z "${params.scylla_mgmt_repo}" ]] ; then
+    if [[ -n "${params.ip_ssh_connections ? params.ip_ssh_connections : ''}" ]] ; then
+        export SCT_IP_SSH_CONNECTIONS="${params.ip_ssh_connections}"
+    fi
+
+    if [[ -n "${params.scylla_mgmt_repo ? params.scylla_mgmt_repo : ''}" ]] ; then
         export SCT_SCYLLA_MGMT_REPO="${params.scylla_mgmt_repo}"
     fi
 
     echo "start test ......."
     if [[ "$cloud_provider" == "aws" ]]; then
         SCT_RUNNER_IP=\$(cat sct_runner_ip||echo "")
-        if [[ ! -z "\${SCT_RUNNER_IP}" ]] ; then
+        if [[ -n "\${SCT_RUNNER_IP}" ]] ; then
             ./docker/env/hydra.sh --execute-on-runner \${SCT_RUNNER_IP} run-test ${params.test_name} --backend ${params.backend}
         else
             echo "SCT runner IP file is empty. Probably SCT Runner was not created."

--- a/vars/runSendEmail.groovy
+++ b/vars/runSendEmail.groovy
@@ -22,7 +22,7 @@ def call(Map params, RunWrapper currentBuild){
     echo "Start send email ..."
     if [[ "$cloud_provider" == "aws" ]]; then
         SCT_RUNNER_IP=\$(cat sct_runner_ip||echo "")
-        if [[ ! -z "\${SCT_RUNNER_IP}" ]] ; then
+        if [[ -n "\${SCT_RUNNER_IP}" ]] ; then
             ./docker/env/hydra.sh --execute-on-runner \${SCT_RUNNER_IP} send-email ${test_status} ${start_time} --email-recipients "${email_recipients}"
         else
             echo "SCT runner IP file is empty. Probably SCT Runner was not created."


### PR DESCRIPTION
https://trello.com/c/SPcGhigl/2670-deprecate-withenv-in-the-upgrade-pipeline
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
