### PR TITLE
feature(nemesis): add OperatorNodeTerminateAndReplace

### DIFF
--- a/jenkins-pipelines/longevity-scylla-operator-3h-gke-replace.jenkinsfile
+++ b/jenkins-pipelines/longevity-scylla-operator-3h-gke-replace.jenkinsfile
@@ -1,0 +1,10 @@
+#!groovy
+
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+operatorPipeline(
+    backend: 'k8s-gke',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-gke-replace.yaml',
+    timeout: [time: 300, unit: 'MINUTES']
+)

--- a/jenkins-pipelines/longevity-scylla-operator-3h-gke-terminate-decommission-add.jenkinsfile
+++ b/jenkins-pipelines/longevity-scylla-operator-3h-gke-terminate-decommission-add.jenkinsfile
@@ -1,0 +1,10 @@
+#!groovy
+
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+operatorPipeline(
+    backend: 'k8s-gke',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-gke-terminate-decommission-add.yaml',
+    timeout: [time: 300, unit: 'MINUTES']
+)

--- a/jenkins-pipelines/longevity-scylla-operator-3h-gke-terminate-recover.jenkinsfile
+++ b/jenkins-pipelines/longevity-scylla-operator-3h-gke-terminate-recover.jenkinsfile
@@ -1,0 +1,10 @@
+#!groovy
+
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+operatorPipeline(
+    backend: 'k8s-gke',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-gke-terminate-recover.yaml',
+    timeout: [time: 300, unit: 'MINUTES']
+)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1042,9 +1042,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             return
         self.log.info('Set termination_event')
         self.termination_event.set()
-        if self._coredump_thread:
+        if self._coredump_thread and self._coredump_thread.is_alive():
             self._coredump_thread.stop()
-        if self._alert_manager:
+        if self._alert_manager and self._alert_manager.is_alive():
             self._alert_manager.stop()
 
     @log_run_info
@@ -2995,8 +2995,10 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
             node.destroy()
 
     def terminate_node(self, node):
-        self.dead_nodes_ip_address_list.add(node.ip_address)
-        self.nodes.remove(node)
+        if node.ip_address not in self.dead_nodes_ip_address_list:
+            self.dead_nodes_ip_address_list.add(node.ip_address)
+        if node in self.nodes:
+            self.nodes.remove(node)
         node.destroy()
 
     def get_db_auth(self):

--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -14,6 +14,7 @@
 import os
 import logging
 import time
+from textwrap import dedent
 from typing import List
 from functools import cached_property
 
@@ -258,6 +259,13 @@ class GkeScyllaPodContainer(BasePodContainer, IptablesPodIpRedirectMixin):
         return self.parent_cluster.k8s_cluster.gce_services[0].ex_get_node(name=self.node_name)
 
     def terminate_k8s_host(self):
+        self.log.info('terminate_k8s_host: GCE instance of kubernetes node will be terminated, '
+                      'the following is affected :\n' + dedent('''
+            GCE instance  X  <-
+            K8s node      X
+            Scylla Pod    X
+            Scylla node   X
+            '''))
         self._instance_wait_safe(self._destroy)
         self.destroy()
 

--- a/sdcm/k8s_configs/operator.yaml
+++ b/sdcm/k8s_configs/operator.yaml
@@ -1782,6 +1782,7 @@ rules:
   - delete
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - ""

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-replace.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-replace.yaml
@@ -10,7 +10,7 @@ n_db_nodes: 3
 n_loaders: 2
 n_monitor_nodes: 1
 
-nemesis_class_name: 'OperatorNodeTerminateAndReplace'
+nemesis_class_name: 'OperatorNodeReplace'
 nemesis_interval: 5
 
 # Need to keep rendered name less than 40 chars because of GKE restrictions. Note, that backend name included automatically.

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-terminate-decommission-add.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-terminate-decommission-add.yaml
@@ -10,7 +10,7 @@ n_db_nodes: 3
 n_loaders: 2
 n_monitor_nodes: 1
 
-nemesis_class_name: 'OperatorNodeTerminateAndReplace'
+nemesis_class_name: 'OperatorNodeTerminateDecommissionAdd'
 nemesis_interval: 5
 
 # Need to keep rendered name less than 40 chars because of GKE restrictions. Note, that backend name included automatically.

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-terminate-recover.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-terminate-recover.yaml
@@ -10,7 +10,7 @@ n_db_nodes: 3
 n_loaders: 2
 n_monitor_nodes: 1
 
-nemesis_class_name: 'OperatorNodeTerminateAndReplace'
+nemesis_class_name: 'OperatorNodeTerminateAndRecover'
 nemesis_interval: 5
 
 # Need to keep rendered name less than 40 chars because of GKE restrictions. Note, that backend name included automatically.


### PR DESCRIPTION
https://trello.com/c/00UvGVne/2691-k8s-operatornodeterminateandreplace

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
