### PR TITLE
feature(jenkins-pipelines): add pipeline for nonroot_offline_install

### DIFF
--- a/jenkins-pipelines/nonroot-offline-install/artifacts-centos8.jenkinsfile
+++ b/jenkins-pipelines/nonroot-offline-install/artifacts-centos8.jenkinsfile
@@ -1,0 +1,15 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/centos8.yaml',
+    backend: 'gce',
+    nonroot_offline_install: true,
+    provision_type: 'spot',
+    scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/nonroot-offline-install/artifacts-debian10.jenkinsfile
+++ b/jenkins-pipelines/nonroot-offline-install/artifacts-debian10.jenkinsfile
@@ -1,0 +1,15 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/debian10.yaml',
+    backend: 'gce',
+    nonroot_offline_install: true,
+    provision_type: 'spot',
+    scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/buster/master/latest/scylladb-manager-master/scylla-manager.list',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/nonroot-offline-install/artifacts-debian9.jenkinsfile
+++ b/jenkins-pipelines/nonroot-offline-install/artifacts-debian9.jenkinsfile
@@ -1,0 +1,15 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/debian9.yaml',
+    backend: 'gce',
+    nonroot_offline_install: true,
+    provision_type: 'spot',
+    scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/stretch/master/latest/scylladb-manager-master/scylla-manager.list',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/nonroot-offline-install/artifacts-oel76.jenkinsfile
+++ b/jenkins-pipelines/nonroot-offline-install/artifacts-oel76.jenkinsfile
@@ -1,0 +1,16 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/oel76.yaml',
+    backend: 'aws',
+    nonroot_offline_install: true,
+    region_name: 'eu-west-1',
+    provision_type: 'spot_low_price',
+    scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+
+    timeout: [time: 60, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/nonroot-offline-install/artifacts-ubuntu1604.jenkinsfile
+++ b/jenkins-pipelines/nonroot-offline-install/artifacts-ubuntu1604.jenkinsfile
@@ -1,0 +1,15 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/ubuntu1604.yaml',
+    backend: 'gce',
+    nonroot_offline_install: true,
+    provision_type: 'spot',
+    scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/xenial/master/latest/scylla-manager-master/scylla-manager.list',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/nonroot-offline-install/artifacts-ubuntu1804.jenkinsfile
+++ b/jenkins-pipelines/nonroot-offline-install/artifacts-ubuntu1804.jenkinsfile
@@ -1,0 +1,15 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/ubuntu1804.yaml',
+    backend: 'gce',
+    nonroot_offline_install: true,
+    provision_type: 'spot',
+    scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/bionic/master/latest/scylladb-manager-master/scylla-manager.list',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/nonroot-offline-install/artifacts-ubuntu2004.jenkinsfile
+++ b/jenkins-pipelines/nonroot-offline-install/artifacts-ubuntu2004.jenkinsfile
@@ -1,0 +1,15 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/ubuntu2004.yaml',
+    backend: 'gce',
+    nonroot_offline_install: true,
+    provision_type: 'spot',
+    scylla_mgmt_repo: '',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)


### PR DESCRIPTION
This added pipeline files for nonroot offline install, they will be used
to create jobs.

CentOS7 doesn't support nonroot offline install.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
