### PR TITLE
fix(cs_thread): set stress_operation to next word after c-s

### DIFF
--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -153,7 +153,9 @@ class CassandraStressThread:  # pylint: disable=too-many-instance-attributes
                 LOGGER.info('Profile content:\n%s', profile_file.read())
             node.remoter.send_files(self.profile, os.path.join('/tmp', os.path.basename(self.profile)), delete_dst=True)
 
-        stress_cmd_opt = stress_cmd.split()[1]
+        # Get next word after `cassandra-stress' in stress_cmd.
+        # Do it this way because stress_cmd can contain env variables before `cassandra-stress'.
+        stress_cmd_opt = stress_cmd.split("cassandra-stress", 1)[1].split(None, 1)[0]
 
         LOGGER.info('Stress command:\n%s', stress_cmd)
 


### PR DESCRIPTION
This thing prevent to collect stats for c-s in longevity-large-collections-12h-test because of:

```
...
Cannot create metrics gauge: Invalid label metric name: cassandra_stress_-Xmx8033M
...
```

https://jenkins.scylladb.com/view/scylla-4.3/job/scylla-4.3/job/longevity/job/longevity-large-collections-12h-test/3/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
