### PR TITLE
fix(GcloudTokenUpdateThread): recalc --min-expiry= as seconds

### DIFF
--- a/sdcm/utils/gce_utils.py
+++ b/sdcm/utils/gce_utils.py
@@ -158,7 +158,7 @@ class GcloudTokenUpdateThread(threading.Thread):
         while not self._termination_event.wait(wait_time):
             try:
                 gcloud_config = self._gcloud.run(
-                    f'config config-helper --min-expiry={self._token_min_duration} --format=json')
+                    f'config config-helper --min-expiry={self._token_min_duration * 60} --format=json')
                 with open(self._config_path, 'w') as gcloud_config_file:
                     gcloud_config_file.write(gcloud_config)
                     gcloud_config_file.flush()


### PR DESCRIPTION
 --min-expiry= is in seconds, while we assume that it is in minutes

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
