### PR TITLE
fix(unit_tests): mocks for clean_cloud_resources

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -595,7 +595,7 @@ def clean_resources_docker(tags_dict: dict, builder_name: Optional[str] = None, 
             image.client.images.remove(image=image.id, force=True)
             LOGGER.debug("Done.")
 
-    resources_to_clean = list_resources_docker(tags_dict, builder_name=builder_name, group_as_builder=False)
+    resources_to_clean = list_resources_docker(tags_dict=tags_dict, builder_name=builder_name, group_as_builder=False)
     containers = resources_to_clean.get("containers", [])
     images = resources_to_clean.get("images", [])
 

--- a/unit_tests/test_clean_cloud_resources_func.py
+++ b/unit_tests/test_clean_cloud_resources_func.py
@@ -12,13 +12,134 @@
 # Copyright (c) 2020 ScyllaDB
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from sdcm.utils.common import clean_cloud_resources
+from sdcm.utils.common import \
+    clean_cloud_resources, \
+    clean_instances_aws, clean_elastic_ips_aws, clean_clusters_gke, clean_instances_gce, clean_resources_docker
 
 
-@patch("sdcm.utils.common.clean_clusters_gke", lambda *_, **__: None)  # TODO: fix our builders and remove this patch
+SCT_RUNNER_AWS = {
+    "Tags": [{"Key": "NodeType", "Value": "sct-runner"}],
+    "InstanceId": "i-1111",
+}
+
+
+@patch("boto3.client")
+class CleanInstanceAwsTest(unittest.TestCase):
+    def test_empty_tags_dict(self, _):
+        self.assertRaisesRegex(AssertionError, "not provided", clean_instances_aws, {})
+
+    def test_empty_list(self, ec2_client):
+        with patch("sdcm.utils.common.list_instances_aws", return_value={}) as list_instances_aws:
+            clean_instances_aws({"TestId": 1111, })
+        list_instances_aws.assert_called_with(tags_dict={"TestId": 1111, }, group_as_region=True)
+        ec2_client().terminate_instances.assert_not_called()
+
+    def test_sct_runner(self, ec2_client):
+        with patch("sdcm.utils.common.list_instances_aws",
+                   return_value={"eu-north-1": [SCT_RUNNER_AWS, ]}) as list_instances_aws:
+            clean_instances_aws({"TestId": 1111, })
+        list_instances_aws.assert_called_with(tags_dict={"TestId": 1111, }, group_as_region=True)
+        ec2_client().terminate_instances.assert_not_called()
+
+    def test_terminate(self, ec2_client):
+        with patch("sdcm.utils.common.list_instances_aws",
+                   return_value={"eu-north-1": [{"InstanceId": "i-1111", }, ]}) as list_instances_aws:
+            clean_instances_aws({"TestId": 1111, })
+        list_instances_aws.assert_called_with(tags_dict={"TestId": 1111, }, group_as_region=True)
+        ec2_client().terminate_instances.assert_called_once_with(InstanceIds=["i-1111"])
+
+
+@patch("boto3.client")
+class CleanElasticIpsAws(unittest.TestCase):
+    def test_empty_tags_dict(self, _):
+        self.assertRaisesRegex(AssertionError, "not provided", clean_elastic_ips_aws, {})
+
+    def test_empty_list(self, ec2_client):
+        with patch("sdcm.utils.common.list_elastic_ips_aws", return_value={}) as list_elastic_ips_aws:
+            clean_elastic_ips_aws({"TestId": 1111, })
+        list_elastic_ips_aws.assert_called_with(tags_dict={"TestId": 1111, }, group_as_region=True)
+        ec2_client().disassociate_address.assert_not_called()
+        ec2_client().release_address.assert_not_called()
+
+    def test_release(self, ec2_client):
+        with patch("sdcm.utils.common.list_elastic_ips_aws",
+                   return_value={"eu-north-1": [{
+                       "AssociationId": 2222,
+                       "AllocationId": 3333,
+                       "PublicIp": '127.0.0.1',
+                   }]}) as list_elastic_ips_aws:
+            clean_elastic_ips_aws({"TestId": 1111, })
+        list_elastic_ips_aws.assert_called_with(tags_dict={"TestId": 1111, }, group_as_region=True)
+        ec2_client().disassociate_address.assert_called_once_with(AssociationId=2222)
+        ec2_client().release_address.assert_called_once_with(AllocationId=3333)
+
+
+class CleanClustersGkeTest(unittest.TestCase):
+    def test_empty_tags_dict(self):
+        self.assertRaisesRegex(AssertionError, "not provided", clean_clusters_gke, {})
+
+    def test_destroy(self):
+        cluster = MagicMock()
+        with patch("sdcm.utils.common.list_clusters_gke", return_value=[cluster, ]) as list_clusters_gke:
+            clean_clusters_gke({"TestId": 1111, })
+        list_clusters_gke.assert_called_with(tags_dict={"TestId": 1111, })
+        cluster.destroy.assert_called_once_with()
+
+
+class CleanInstancesGceTest(unittest.TestCase):
+    def test_empty_tags_dict(self):
+        self.assertRaisesRegex(AssertionError, "not provided", clean_instances_gce, {})
+
+    def test_destroy(self):
+        instance = MagicMock()
+        with patch("sdcm.utils.common.list_instances_gce", return_value=[instance, ]) as list_instances_gce:
+            clean_instances_gce({"TestId": 1111, })
+        list_instances_gce.assert_called_with(tags_dict={"TestId": 1111, })
+        instance.destroy.assert_called_once_with()
+
+
+class CleanResourcesDockerTest(unittest.TestCase):
+    def test_empty_tags_dict(self):
+        self.assertRaisesRegex(AssertionError, "not provided", clean_resources_docker, {})
+
+    @staticmethod
+    def test_destroy():
+        image = MagicMock()
+        container = MagicMock()
+        with patch("sdcm.utils.common.list_resources_docker",
+                   return_value={"images": [image, ], "containers": [container, ], }) as list_resources_docker:
+            clean_resources_docker({"TestId": 1111, })
+        list_resources_docker.assert_called_with(
+            tags_dict={"TestId": 1111, },
+            builder_name=None,
+            group_as_builder=False,
+        )
+        container.remove.assert_called_once_with(v=True, force=True)
+        image.client.images.remove.assert_called_once_with(image=image.id, force=True)
+
+
 class CleanCloudResourcesTest(unittest.TestCase):
+    integration = False  # set it to True if you want to run test with actual cloud operations.
+    functions_to_patch = (
+        "sdcm.utils.common.clean_instances_aws",
+        "sdcm.utils.common.clean_elastic_ips_aws",
+        "sdcm.utils.common.clean_clusters_gke",
+        "sdcm.utils.common.clean_instances_gce",
+        "sdcm.utils.common.clean_resources_docker",
+    )
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not cls.integration:
+            for func in cls.functions_to_patch:
+                patch(func).start()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        patch.stopall()
+
     def test_no_tag_testid_and_runbyuser(self):
         params = {}
         res = clean_cloud_resources(params)


### PR DESCRIPTION
Trello: https://trello.com/c/CaKm3eja/1785-make-testcleancloudresourcesfuncpy-less-dangerous

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
