### PR TITLE
fix(version): add support for x.y.dev

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -17,8 +17,9 @@ import os
 import time
 import re
 from random import randint
+
 from invoke import exceptions
-from distutils.version import LooseVersion
+from pkg_resources import parse_version
 
 from sdcm import mgmt
 from sdcm.sct_events.group_common_events import ignore_no_space_errors
@@ -218,7 +219,7 @@ class BackupFunctionsMixIn:
         number_of_loaders = self.params.get("n_loaders")
 
         scylla_version = self.db_cluster.nodes[0].scylla_version
-        if LooseVersion(scylla_version).version[0] == 2019:
+        if parse_version(scylla_version).release[0] == 2019:
             # Making sure scylla version is 2019.1.x
             throttle_per_node = 10666
         else:

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -32,10 +32,10 @@ from contextlib import ExitStack
 import yaml
 import boto3
 from mypy_boto3_ec2 import EC2Client
+from pkg_resources import parse_version
 from botocore.exceptions import WaiterError
-from distutils.version import LooseVersion  # pylint: disable=no-name-in-module,import-error
 
-from sdcm import wait, ec2_client, cluster
+from sdcm import ec2_client, cluster
 from sdcm.remote import LocalCmdRunner, shell_script_cmd, NETWORK_EXCEPTIONS
 from sdcm.cluster import INSTANCE_PROVISION_ON_DEMAND
 from sdcm.ec2_client import CreateSpotInstancesError
@@ -825,7 +825,7 @@ class ScyllaAWSCluster(cluster.BaseScyllaCluster, AWSCluster):
         user_data_format_version = ami_tags.get('sci_version', '2')
         user_data_format_version = ami_tags.get('user_data_format_version', user_data_format_version)
 
-        if LooseVersion(user_data_format_version) >= LooseVersion('2'):
+        if parse_version(user_data_format_version) >= parse_version('2'):
             user_data = dict(scylla_yaml=dict(cluster_name=name), start_scylla_on_first_boot=False)
         else:
             user_data = ('--clustername %s '

--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -21,12 +21,12 @@ import random
 import time
 from collections import OrderedDict
 from uuid import UUID
-from distutils.version import LooseVersion
 
 from cassandra import InvalidRequest
 from cassandra.util import sortedset, SortedSet  # pylint: disable=no-name-in-module
 from cassandra import ConsistencyLevel
 from cassandra.protocol import ProtocolException  # pylint: disable=no-name-in-module
+from pkg_resources import parse_version
 
 from sdcm.tester import ClusterTester
 from sdcm.utils.decorators import retrying
@@ -2975,7 +2975,7 @@ class FillDatabaseData(ClusterTester):
         else:
             version_with_support = self.NON_FROZEN_SUPPORT_OS_MIN_VERSION
 
-        if LooseVersion(scylla_version) < LooseVersion(version_with_support):
+        if parse_version(scylla_version) < parse_version(version_with_support):
             return False  # current version doesn't support non-frozen UDT
         else:
             return True  # current version supports non-frozen UDT

--- a/sdcm/results_analyze/test.py
+++ b/sdcm/results_analyze/test.py
@@ -113,7 +113,7 @@ class SoftwareVersion(ClassBase):
 
     @property
     def as_int(self):
-        if self.as_string == '666.development':
+        if self.as_string == '666.development' or self.as_string.endswith('.dev'):
             return (100 ** 5) * 10
         version_parts = self.as_string.split('.')
         idx = 100**5
@@ -130,7 +130,7 @@ class SoftwareVersion(ClassBase):
 
     @property
     def major_as_int(self):
-        if self.as_string == '666.development':
+        if self.as_string == '666.development' or self.as_string.endswith('.dev'):
             return (100 ** 5) * 10
         version_parts = self.as_string.split('.')
         idx = 100**5


### PR DESCRIPTION
Trello: https://trello.com/c/oBLoE6ak/2466-versionutilspy-add-support-for-xydev

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
