### PR TITLE
fix(update_scylla_packages): reinstall the packages even they are present

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3457,7 +3457,8 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             node.remoter.send_files(new_scylla_bin, '/tmp/scylla', verbose=True)
             # replace the packages
             node.remoter.run('yum list installed | grep scylla')
-            node.remoter.sudo('rpm -URvh --replacefiles /tmp/scylla/*.rpm', ignore_status=False, verbose=True)
+            node.remoter.sudo('rpm -URvh --replacepkgs --replacefiles /tmp/scylla/*.rpm',
+                              ignore_status=False, verbose=True)
             node.remoter.run('yum list installed | grep scylla')
             _queue.put(node)
             _queue.task_done()


### PR DESCRIPTION
Ticket: https://trello.com/c/nYm2F8c0/2191-debug-rpms-test-with-longevity

scylla-debug packages has same name with regular scylla package, it's
failed to replace the regular packages by `rpm -URvh --replacepkgs
--replacefiles /tmp/scylla/*.rpm`, because the packages are already
exist.

This patch added a `--replacepkgs' option to rpm cmdline, the packages
will be reinstalled even they are already present.

```
[scyllaadm@longevity-10gb-3h-master-db-node-f0321570-1 ~]$ ls /tmp/scylla/
scylla-4.4.dev-0.20201210.e4b55f40f.x86_64.rpm
scylla-conf-4.4.dev-0.20201210.e4b55f40f.x86_64.rpm
scylla-debuginfo-4.4.dev-0.20201210.e4b55f40f.x86_64.rpm
scylla-kernel-conf-4.4.dev-0.20201210.e4b55f40f.x86_64.rpm
scylla-server-4.4.dev-0.20201210.e4b55f40f.x86_64.rpm

[scyllaadm@longevity-10gb-3h-master-db-node-f0321570-1 ~]$ sudo rpm -URvh --replacefiles /tmp/scylla/*.rpm
Preparing...                          ################################# [100%]
	package scylla-conf-4.4.dev-0.20201210.e4b55f40f.x86_64 is already installed
	package scylla-server-4.4.dev-0.20201210.e4b55f40f.x86_64 is already installed
	package scylla-kernel-conf-4.4.dev-0.20201210.e4b55f40f.x86_64 is already installed
	package scylla-4.4.dev-0.20201210.e4b55f40f.x86_64 is already installed
	package scylla-debuginfo-4.4.dev-0.20201210.e4b55f40f.x86_64 is already installed
[scyllaadm@longevity-10gb-3h-master-db-node-f0321570-1 ~]$ echo $?
5

[scyllaadm@longevity-10gb-3h-master-db-node-f0321570-1 ~]$ sudo rpm -URvh --replacepkgs --replacefiles /tmp/scylla/*.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:scylla-conf-4.4.dev-0.20201210.e4################################# [ 20%]
scylla:x:1001:
scylla:x:997:1001::/var/lib/scylla:/sbin/nologin
   2:scylla-server-4.4.dev-0.20201210.################################# [ 40%]
   3:scylla-kernel-conf-4.4.dev-0.2020################################# [ 60%]
   4:scylla-4.4.dev-0.20201210.e4b55f4################################# [ 80%]
   5:scylla-debuginfo-4.4.dev-0.202012################################# [100%]
[scyllaadm@longevity-10gb-3h-master-db-node-f0321570-1 ~]$ echo $?
0
```

Signed-off-by: Amos Kong <amos@scylladb.com>

Failed job: https://jenkins.scylladb.com/job/scylla-master/job/longevity/job/scylla-debug-longevity-10gb-3h-test/3/console
Test id: test_id: f0321570-b8a6-463d-a29c-e52af82d7b32

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
