### PR TITLE
fix(sct_events): publish events w/o backtrace when backtrace decoding is enabled

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1455,14 +1455,16 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             backtraces = list(filter(filter_backtraces, backtraces))
 
         for backtrace in backtraces:
-            if Setup.BACKTRACE_DECODING:
-                if backtrace['event'].raw_backtrace:
-                    scylla_debug_info = self.get_scylla_debuginfo_file()
-                    self.log.debug('Debug info file %s', scylla_debug_info)
-                    Setup.DECODING_QUEUE.put({"node": self, "debug_file": scylla_debug_info,
-                                              "event": backtrace['event']})
+            if Setup.BACKTRACE_DECODING and backtrace["event"].raw_backtrace:
+                scylla_debug_info = self.get_scylla_debuginfo_file()
+                self.log.debug("Debug info file %s", scylla_debug_info)
+                Setup.DECODING_QUEUE.put({
+                    "node": self,
+                    "debug_file": scylla_debug_info,
+                    "event": backtrace["event"],
+                })
             else:
-                backtrace['event'].publish()
+                backtrace["event"].publish()
 
     def start_decode_on_monitor_node_thread(self):
         self._decoding_backtraces_thread = threading.Thread(

--- a/sdcm/sct_events/base.py
+++ b/sdcm/sct_events/base.py
@@ -173,6 +173,7 @@ class SctEvent:
 
     def dont_publish(self):
         self._ready_to_publish = False
+        LOGGER.debug("%s marked to not publish", self)
 
     def to_json(self) -> str:
         return json.dumps({


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
