### PR TITLE
fix(issue template): fix config file link

### DIFF
--- a/sdcm/report_templates/results_issue_template.html
+++ b/sdcm/report_templates/results_issue_template.html
@@ -30,15 +30,15 @@
     <br>
     <div>
         {% if job_name %}
-        Test: {{ job_name }}<br>
+        Test: `{{ job_name }}`<br>
         {% endif %}
         {% if test_name %}
-        Test name: {{ test_name }}<br>
+        Test name: `{{ test_name }}`<br>
         {% endif %}
         {% if config_files %}
         Test config file(s):<br>
             {% for config_file_link in config_files_link %}
-                - [{{ config_file_link.file }}]({{ config_file_link.link }})<br>
+                - {{ config_file_link.file }} ({{ config_file_link.link }})<br>
             {% endfor %}
         {% endif %}
     </div>
@@ -69,7 +69,9 @@
     <div>
         Logs:<br>
         {% for logs_link in logs_links %}
-            {{ logs_link.type }} - [{{ logs_link.link }}]({{ logs_link.link }})<br>
+            {% if logs_link.type != "prometheus" %}
+                {{ logs_link.type }} - [{{ logs_link.link }}]({{ logs_link.link }})<br>
+            {% endif %}
         {% endfor %}
     </div>
     {% endif %}

--- a/sdcm/send_email.py
+++ b/sdcm/send_email.py
@@ -404,12 +404,25 @@ class LongevityEmailReporter(BaseEmailReporter):
 
     def get_config_file_link(self, attachments_data):
         config_files = []
-        for config_file in attachments_data["config_files"]:
 
-            last_commit = subprocess.run(['git', 'rev-list', 'HEAD', '-1', config_file], capture_output=True, text=True)
-            config_files.append({"file": config_file.split("/")[-1],
+        if "N/A" in attachments_data["config_files"]:
+            return config_files
+
+        for config_file in attachments_data["config_files"]:
+            if not config_file:
+                continue
+
+            if 'cloud' in config_file or 'cloud' in attachments_data["job_name"]:
+                config_files.append({"file": f"{config_file.split('/')[-1]} ",
+                                     "link": "Siren repo"})
+                continue
+
+            last_commit = subprocess.run(['git', 'rev-list', 'HEAD', '-1', config_file], capture_output=True,
+                                         text=True)
+            config_files.append({"file": f"[{config_file.split('/')[-1]}]",
                                  "link": f"https://github.com/scylladb/scylla-cluster-tests/blob"
                                  f"/{last_commit.stdout.strip()}/{config_file}"})
+
         return config_files
 
 


### PR DESCRIPTION
1. Does not show config file link for Siren tests
2. Ignore value 'N/A' in the config files

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
