### PR TITLE
fix(nemesis): Uncommenting nemesis classes that were wrongly commented out

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3394,15 +3394,14 @@ class BlockNetworkMonkey(Nemesis):
         self.disrupt_network_block()
 
 
-# Temporary disable due to  https://github.com/scylladb/scylla/issues/6522
-# class RejectInterNodeNetworkMonkey(Nemesis):
-#     disruptive = True
-#     networking = True
-#     run_with_gemini = False
-#
-#     @log_time_elapsed_and_status
-#     def disrupt(self):
-#         self.disrupt_network_reject_inter_node_communication()
+class RejectInterNodeNetworkMonkey(Nemesis):
+    disruptive = True
+    networking = True
+    run_with_gemini = False
+
+    @log_time_elapsed_and_status
+    def disrupt(self):
+        self.disrupt_network_reject_inter_node_communication()
 
 
 class RejectNodeExporterNetworkMonkey(Nemesis):
@@ -3596,33 +3595,33 @@ class CDCStressorMonkey(Nemesis):
         self.disrupt_run_cdcstressor_tool()
 
 
-# Disable unstable streaming err nemesises
-#
-# class DecommissionStreamingErrMonkey(Nemesis):
-#
-#     disruptive = True
-#
-#     @log_time_elapsed_and_status
-#     def disrupt(self):
-#         self.disrupt_decommission_streaming_err()
-#
-#
-# class RebuildStreamingErrMonkey(Nemesis):
-#
-#     disruptive = True
-#
-#     @log_time_elapsed_and_status
-#     def disrupt(self):
-#         self.disrupt_rebuild_streaming_err()
-#
-#
-# class RepairStreamingErrMonkey(Nemesis):
-#
-#     disruptive = True
-#
-#     @log_time_elapsed_and_status
-#     def disrupt(self):
-#         self.disrupt_repair_streaming_err()
+class DecommissionStreamingErrMonkey(Nemesis):
+
+    disruptive = True
+
+    @log_time_elapsed_and_status
+    def disrupt(self):
+        self.disrupt_decommission_streaming_err()
+
+
+class RebuildStreamingErrMonkey(Nemesis):
+
+    disruptive = True
+
+    @log_time_elapsed_and_status
+    def disrupt(self):
+        self.disrupt_rebuild_streaming_err()
+
+
+class RepairStreamingErrMonkey(Nemesis):
+
+    disruptive = True
+
+    @log_time_elapsed_and_status
+    def disrupt(self):
+        self.disrupt_repair_streaming_err()
+
+
 DEPRECATED_LIST_OF_NEMESISES = [UpgradeNemesis, UpgradeNemesisOneNode, RollbackNemesis]
 
 COMPLEX_NEMESIS = [NoOpMonkey, ChaosMonkey,


### PR DESCRIPTION
Commenting a nemesis class does NOT disables it as one may have think.
The ChaosMonkey collects all the nemesis that starts with "disrupt_".
It means that these nemesis weren't disabled.
Moreover we know they work.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
