### PR TITLE
fix(cdc_perf): Fix wrong sub test for cdc latency performance

### DIFF
--- a/jenkins-pipelines/perf-regression-cdc-mixed-latency-60min.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-cdc-mixed-latency-60min.jenkinsfile
@@ -8,7 +8,7 @@ perfRegressionParallelPipeline(
     aws_region: "us-east-1",
     test_name: "performance_regression_cdc_test.PerformanceRegressionCDCTest",
     test_config: "test-cases/performance/perf-regression-latency-cdc-mixed-poll-batching.yaml",
-    sub_tests: ["test_mixed_throughput"],
+    sub_tests: ["test_mixed_latency"],
 
     timeout: [time: 550, unit: "MINUTES"]
 )


### PR DESCRIPTION
Fix sub test for cdc latency performance test.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] ~I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)~
- [ ] ~I didn't leave commented-out/debugging code~
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (CI)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
