### PR TITLE
fix(check_node_health): mark not published events

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2608,6 +2608,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                     event.publish()
                 break
 
+            event.dont_publish()
+
             LOGGER.debug("Wait for %d secs before next try to validate the health of the node `%s'",
                          CHECK_NODE_HEALTH_RETRY_DELAY, self.name)
             time.sleep(CHECK_NODE_HEALTH_RETRY_DELAY)


### PR DESCRIPTION
Addresses following WARNING:
```
SCT internal warning] (ClusterHealthValidatorEvent Severity.ERROR): type=NodeStatus subtype=ERROR node=sct-cluster-us-east1-b-us-east1-0 error=Current node 10.3.254.247. The node 10.3.254.97 exists in the gossip but doesn't exist in the nodetool.status has not been published or dumped, maybe you missed .publish()
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
