### PR TITLE
fix(disrupt_no_corrupt_repair): put test tables in multiple keyspaces

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -687,7 +687,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         # prepare test tables and fill test data
         for i in range(10):
             self.log.debug('Prepare test tables if they do not exist')
-            self._prepare_test_table(ks='drop_table_during_repair_ks', table=f'drop_table_during_repair_{i}')
+            self._prepare_test_table(ks=f'drop_table_during_repair_ks_{i}', table='standard1')
 
         self.log.debug("Start repair target_node in background")
         thread1 = threading.Thread(target=self.repair_nodetool_repair, name='NodeToolRepairThread', daemon=True)
@@ -697,7 +697,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         for i in range(10):
             time.sleep(random.randint(0, 300))
             with self.cluster.cql_connection_patient(self.target_node) as session:
-                session.execute(f'DROP TABLE drop_table_during_repair_ks.drop_table_during_repair_{i}')
+                session.execute(f'DROP TABLE drop_table_during_repair_ks_{i}.standard1')
         thread1.join(timeout=120)
 
     def disrupt_major_compaction(self):


### PR DESCRIPTION
_prepare_test_table() uses cassandra-stress to create the table and fill
data, the table name isn't configurable, it's always `standard1'.

This patch changed to use multiple keyspaces for test tables.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
