### PR TITLE
More improvements to the YCSB test examples and documentations

### DIFF
--- a/test-cases/longevity/longevity-ycsb-a-100M.yaml
+++ b/test-cases/longevity/longevity-ycsb-a-100M.yaml
@@ -50,7 +50,6 @@ prepare_write_cmd:
 #     -p scylla.maxconnections=280 -p scylla.username=cassandra -p scylla.password=cassandra -p scylla.tokenaware=true -p hosts=10.0.2.51,10.0.3.133,10.0.3.67 -p scylla.readconsistencylevel=ONE -p
 #      scylla.writeconsistencylevel=ONE
 stress_cmd: [
-    "bin/ycsb run cassandra-cql -P workloads/workloada -target 120000 -threads 840 -p recordcount=100000000 -p fieldcount=10 -p fieldlength=128 -p operationcount=300000000 -p cassandra.coreconnections=280 -p cassandra.maxconnections=280 -p cassandra.username=cassandra -p cassandra.password=cassandra"
 ]
 
 round_robin: true

--- a/test-cases/longevity/longevity-ycsb-a-100M.yaml
+++ b/test-cases/longevity/longevity-ycsb-a-100M.yaml
@@ -1,54 +1,66 @@
 # [Ivan]: I am currently testing CRDB vs ScyllaDB with YCSB workloads.
-#         This scenario shows how to run YCSB workload A against Scylla.
+#         This scenario shows how to load and run YCSB workload A against Scylla.
 #         It can be run with Jenkins BYO as in https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/ivan/job/ivan-byo-longevity/23/:
 #         test_name: longevity_test.LongevityTest.test_custom_time.
 #
-# avg load speed per 2*2*128 threads 44K ops/s each
-# 10M / 44K = ~3 minutes
+#         README about scylla native binding for YCSB and
+#         how to pick correct numbers for benchmark tests see at:
+#         https://github.com/brianfrankcooper/ycsb/tree/master/scylla#scylla-cql-binding
+#         or longevity-ycsb.txt.
 #
-# 240 = 4 hours * 60
-# 480 = 8 hours * 60
-# 10900 = 7 days * 24 hours a day * 60 minutes an hour
-test_duration: 480
+#         for --target 100K data load is:
+#
+#           - 10M  / 100K = ~100   seconds
+#           - 100M / 100K = ~1000  seconds = ~16  minutes
+#           - 1B   / 100K = ~10000 seconds = ~166 minutes = ~2.7 hours
+#
+#         on 3 nodes i3.4xlarge cluster with CL=QUORUM, RF=3 100K TPS is maximum.
+#         rather it will about around 80K.
+#
+#         16 vCPU loader instance (for example c5.4xlarge) would not be able to give
+#         away more than 150K target tps with 840 threads. It will cap loader CPU.
+#         even with 150K target the latency will struggle due to the overload.
+#         either split load between loaders or use at least c5.9xlarge to produce
+#         around 200K TPS for 3 nodes Scylla cluster.
+#
+#         10900 seconds = 7 days * 24 hours a day * 60 minutes an hour
+#         3600  seconds = 60 minutes
+test_duration: 3600
 
 pre_create_keyspace: [
   "CREATE KEYSPACE ycsb WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor': 3 };",
   "CREATE TABLE ycsb.usertable (y_id varchar primary key, field0 varchar, field1 varchar, field2 varchar, field3 varchar, field4 varchar, field5 varchar, field6 varchar, field7 varchar, field8 varchar, field9 varchar);"
 ]
 
-# number of core connections must match number of vCPU (16) on a db node - 2
-# it will take about 20 minutes : 10^6 records / 120K QPS
+# there is no sense to use more than 1 loader for 3 nodes cluster
 prepare_write_cmd:
   - >-
     bin/ycsb load cassandra-cql -P workloads/workloada -threads 84 -p recordcount=100000000
     -p cassandra.readconsistencylevel=ONE -p cassandra.writeconsistencylevel=ONE
     -p readproportion=0 -p updateproportion=0
     -p fieldcount=10 -p fieldlength=128
-    -p insertstart=0 -p insertcount=50000000
-    -p cassandra.coreconnections=14 -p cassandra.maxconnections=14
-    -p cassandra.username=cassandra -p cassandra.password=cassandra
-
-  - >-
-    bin/ycsb load cassandra-cql -P workloads/workloada -threads 84 -p recordcount=100000000
-    -p cassandra.readconsistencylevel=ONE -p cassandra.writeconsistencylevel=ONE
-    -p readproportion=0 -p updateproportion=0
-    -p fieldcount=10 -p fieldlength=128
-    -p insertstart=50000000 -p insertcount=50000000
+    -p insertstart=0 -p insertcount=100000000
     -p cassandra.coreconnections=14 -p cassandra.maxconnections=14
     -p cassandra.username=cassandra -p cassandra.password=cassandra
 
 # --target must be set to have correct latency results for const throughput - see coordinated omission avoidance problem
-# 16 vCPU per node = 14 shards per node =>
+#
 # we need high concurrency per shard to at least somewhat load request queues
+# number of core connections must match number of vCPU (16) on a db node - 2
+#
+# 16 vCPU per node = 14 shards per node =>
 # 14 vCPUs * 20 parallelism factor = 280 connections per host
+#
 # 840 threads = 280 conns / host * 3 nodes = 840 total threads
 # ops count 300 * 10^6 * / 60 = 40 minutes for workload
+#
 # ycsb workloads use zipfian distribution so we will use a single loader with 32 vCPUs
-# fix framework to support custom CL: -p scylla.readconsistencylevel=ONE -p scylla.writeconsistencylevel=ONE
-# or at least-p scylla.readconsistencylevel=QUORUM -p scylla.writeconsistencylevel=ONE
-# $ $ bin/ycsb run scylla -P workloads/workloada -target 120000 -threads 840 -p recordcount=100000000 -p fieldcount=10 -p fieldlength=128 -p operationcount=300000000 -p scylla.coreconnections=280
-#     -p scylla.maxconnections=280 -p scylla.username=cassandra -p scylla.password=cassandra -p scylla.tokenaware=true -p hosts=10.0.2.51,10.0.3.133,10.0.3.67 -p scylla.readconsistencylevel=ONE -p
-#      scylla.writeconsistencylevel=ONE
+# fix framework to support custom CL:
+#   -p scylla.readconsistencylevel=ONE -p scylla.writeconsistencylevel=ONE
+# or at least
+#   -p scylla.readconsistencylevel=QUORUM -p scylla.writeconsistencylevel=ONE
+#
+# $ bin/ycsb run scylla -s -t -P workloads/workloada -target 120000 -threads 840 -p recordcount=100000000 -p fieldcount=10 -p fieldlength=128 -p operationcount=300000000 -p scylla.coreconnections=280 -p scylla.maxconnections=280 -p scylla.username=cassandra -p scylla.password=cassandra -p scylla.hosts=10.0.2.51,10.0.3.133,10.0.3.67 -p scylla.readconsistencylevel=ONE -p scylla.writeconsistencylevel=ONE -p scylla.tokenaware=true 
 stress_cmd: [
 ]
 

--- a/test-cases/longevity/longevity-ycsb-a-10M.yaml
+++ b/test-cases/longevity/longevity-ycsb-a-10M.yaml
@@ -1,54 +1,66 @@
 # [Ivan]: I am currently testing CRDB vs ScyllaDB with YCSB workloads.
-#         This scenario shows how to run YCSB workload A against Scylla.
+#         This scenario shows how to load and run YCSB workload A against Scylla.
 #         It can be run with Jenkins BYO as in https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/ivan/job/ivan-byo-longevity/23/:
 #         test_name: longevity_test.LongevityTest.test_custom_time.
 #
-# avg load speed per 2*2*128 threads 44K ops/s each
-# 10M / 44K = ~3 minutes
+#         README about scylla native binding for YCSB and
+#         how to pick correct numbers for benchmark tests see at:
+#         https://github.com/brianfrankcooper/ycsb/tree/master/scylla#scylla-cql-binding
+#         or longevity-ycsb.txt.
 #
-# 240 = 4 hours * 60
-# 480 = 8 hours * 60
-# 10900 = 7 days * 24 hours a day * 60 minutes an hour
-test_duration: 480
+#         for --target 100K data load is:
+#
+#           - 10M  / 100K = ~100   seconds
+#           - 100M / 100K = ~1000  seconds = ~16  minutes
+#           - 1B   / 100K = ~10000 seconds = ~166 minutes = ~2.7 hours
+#
+#         on 3 nodes i3.4xlarge cluster with CL=QUORUM, RF=3 100K TPS is maximum.
+#         rather it will about around 80K.
+#
+#         16 vCPU loader instance (for example c5.4xlarge) would not be able to give
+#         away more than 150K target tps with 840 threads. It will cap loader CPU.
+#         even with 150K target the latency will struggle due to the overload.
+#         either split load between loaders or use at least c5.9xlarge to produce
+#         around 200K TPS for 3 nodes Scylla cluster.
+#
+#         10900 seconds = 7 days * 24 hours a day * 60 minutes an hour
+#         3600  seconds = 60 minutes
+test_duration: 1800
 
 pre_create_keyspace: [
   "CREATE KEYSPACE ycsb WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor': 3 };",
   "CREATE TABLE ycsb.usertable (y_id varchar primary key, field0 varchar, field1 varchar, field2 varchar, field3 varchar, field4 varchar, field5 varchar, field6 varchar, field7 varchar, field8 varchar, field9 varchar);"
 ]
 
-# number of core connections must match number of vCPU (16) on a db node - 2
+# there is no sense to use more than 1 loader for 3 nodes cluster
 prepare_write_cmd:
   - >-
     bin/ycsb load cassandra-cql -P workloads/workloada -threads 84 -p recordcount=10000000
     -p cassandra.readconsistencylevel=ONE -p cassandra.writeconsistencylevel=ONE
     -p readproportion=0 -p updateproportion=0
     -p fieldcount=10 -p fieldlength=128
-    -p insertstart=0 -p insertcount=5000000
-    -p cassandra.coreconnections=14 -p cassandra.maxconnections=14
-    -p cassandra.username=cassandra -p cassandra.password=cassandra
-
-  - >-
-    bin/ycsb load cassandra-cql -P workloads/workloada -threads 84 -p recordcount=10000000
-    -p cassandra.readconsistencylevel=ONE -p cassandra.writeconsistencylevel=ONE
-    -p readproportion=0 -p updateproportion=0
-    -p fieldcount=10 -p fieldlength=128
-    -p insertstart=5000000 -p insertcount=5000000
+    -p insertstart=0 -p insertcount=10000000
     -p cassandra.coreconnections=14 -p cassandra.maxconnections=14
     -p cassandra.username=cassandra -p cassandra.password=cassandra
 
 # --target must be set to have correct latency results for const throughput - see coordinated omission avoidance problem
-# 16 vCPU per node = 14 shards per node =>
+#
 # we need high concurrency per shard to at least somewhat load request queues
+# number of core connections must match number of vCPU (16) on a db node - 2
+#
+# 16 vCPU per node = 14 shards per node =>
 # 14 vCPUs * 20 parallelism factor = 280 connections per host
+#
 # 840 threads = 280 conns / host * 3 nodes = 840 total threads
 # ops count 300 * 10^6 * / 60 = 40 minutes for workload
+#
 # ycsb workloads use zipfian distribution so we will use a single loader with 32 vCPUs
-# fix framework to support custom CL: -p scylla.readconsistencylevel=ONE -p scylla.writeconsistencylevel=ONE
-# or at least-p scylla.readconsistencylevel=QUORUM -p scylla.writeconsistencylevel=ONE
-# to use scylla-cql with token awareness use:
-# $ $ bin/ycsb run scylla -P workloads/workloada -target 120000 -threads 840 -p recordcount=10000000 -p fieldcount=10 -p fieldlength=128 -p operationcount=300000000 -p scylla.coreconnections=280
-#     -p scylla.maxconnections=280 -p scylla.username=cassandra -p scylla.password=cassandra -p scylla.tokenaware=true -p hosts=10.0.2.51,10.0.3.133,10.0.3.67 -p scylla.readconsistencylevel=ONE -p
-#      scylla.writeconsistencylevel=ONE
+# fix framework to support custom CL:
+#   -p scylla.readconsistencylevel=ONE -p scylla.writeconsistencylevel=ONE
+# or at least
+#   -p scylla.readconsistencylevel=QUORUM -p scylla.writeconsistencylevel=ONE
+#
+# $ bin/ycsb run scylla -s -t -P workloads/workloada -target 120000 -threads 840 -p recordcount=10000000 -p fieldcount=10 -p fieldlength=128 -p operationcount=300000000 -p scylla.coreconnections=280 -p scylla.maxconnections=280 -p scylla.username=cassandra -p scylla.password=cassandra -p scylla.hosts=10.0.2.51,10.0.3.133,10.0.3.67 -p scylla.readconsistencylevel=ONE -p scylla.writeconsistencylevel=ONE -p scylla.tokenaware=true 
 stress_cmd: [
 ]
 

--- a/test-cases/longevity/longevity-ycsb-a-10M.yaml
+++ b/test-cases/longevity/longevity-ycsb-a-10M.yaml
@@ -50,7 +50,6 @@ prepare_write_cmd:
 #     -p scylla.maxconnections=280 -p scylla.username=cassandra -p scylla.password=cassandra -p scylla.tokenaware=true -p hosts=10.0.2.51,10.0.3.133,10.0.3.67 -p scylla.readconsistencylevel=ONE -p
 #      scylla.writeconsistencylevel=ONE
 stress_cmd: [
-    "bin/ycsb run cassandra-cql -P workloads/workloada -target 120000 -threads 840 -p recordcount=10000000 -p fieldcount=10 -p fieldlength=128 -p operationcount=300000000 -p cassandra.coreconnections=280 -p cassandra.maxconnections=280 -p cassandra.username=cassandra -p cassandra.password=cassandra"
 ]
 
 round_robin: true

--- a/test-cases/longevity/longevity-ycsb-a-1B.yaml
+++ b/test-cases/longevity/longevity-ycsb-a-1B.yaml
@@ -66,7 +66,6 @@ prepare_write_cmd:
 #     -p scylla.maxconnections=280 -p scylla.username=cassandra -p scylla.password=cassandra -p scylla.tokenaware=true -p hosts=10.0.2.51,10.0.3.133,10.0.3.67 -p scylla.readconsistencylevel=ONE -p
 #      scylla.writeconsistencylevel=ONE
 stress_cmd: [
-    "bin/ycsb run cassandra-cql -P workloads/workloada -target 120000 -threads 840 -p recordcount=1000000000 -p fieldcount=10 -p fieldlength=128 -p operationcount=300000000 -p cassandra.coreconnections=280 -p cassandra.maxconnections=280 -p cassandra.username=cassandra -p cassandra.password=cassandra"
 ]
 
 round_robin: true

--- a/test-cases/longevity/longevity-ycsb-a-1B.yaml
+++ b/test-cases/longevity/longevity-ycsb-a-1B.yaml
@@ -3,11 +3,27 @@
 #         It can be run with Jenkins BYO as in https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/ivan/job/ivan-byo-longevity/23/:
 #         test_name: longevity_test.LongevityTest.test_custom_time.
 #
-# avg load speed per 2*2*128 threads 44K ops/s each
-# 10M / 44K = ~3 minutes
-# 1B / 44K = ~63 hours
+#         README about Scylla native binding for YCSB and
+#         how to pick correct numbers for benchmark tests see at:
+#         https://github.com/brianfrankcooper/YCSB/tree/master/scylla#scylla-cql-binding
+#         or longevity-ycsb.txt.
 #
-# 10900 = 7 days * 24 hours a day * 60 minutes an hour
+#         For --target 100K data load is:
+#
+#           - 10M  / 100K = ~100   seconds
+#           - 100M / 100K = ~1000  seconds = ~16  minutes
+#           - 1B   / 100K = ~10000 seconds = ~166 minutes = ~2.7hours
+#
+#         On 3 nodes i3.x4large cluster with CL=QUORUM, RF=3 100K TPS is maximum.
+#         Rather it will about around 80K.
+#
+#         16 vCPU loader instance (for example c5.4xlarge) would not be able to give
+#         away more than 150K target TPS with 840 threads. It will cap loader CPU.
+#         Even with 150K target the latency will struggle due to the overload.
+#         Either split load between loaders or use at least c5.9xlarge to produce
+#         around 200K TPS for 3 nodes Scylla cluster.
+#
+#         10900 seconds = 7 days * 24 hours a day * 60 minutes an hour
 test_duration: 10900
 
 pre_create_keyspace: [
@@ -15,56 +31,35 @@ pre_create_keyspace: [
   "CREATE TABLE ycsb.usertable (y_id varchar primary key, field0 varchar, field1 varchar, field2 varchar, field3 varchar, field4 varchar, field5 varchar, field6 varchar, field7 varchar, field8 varchar, field9 varchar);"
 ]
 
-# number of core connections must match number of vCPU (16) on a db node - 2
+# there is no sense to use more than 1 loader for 3 nodes cluster
 prepare_write_cmd:
   - >-
-    bin/ycsb load cassandra-cql -P workloads/workloada -threads 84 -p recordcount=1000000000
+    bin/ycsb load cassandra-cql -P workloads/workloada -threads 840 -p recordcount=1000000000
     -p cassandra.readconsistencylevel=ONE -p cassandra.writeconsistencylevel=ONE
     -p readproportion=0 -p updateproportion=0
     -p fieldcount=10 -p fieldlength=128
-    -p insertstart=0 -p insertcount=250000000
-    -p cassandra.coreconnections=14 -p cassandra.maxconnections=14
-    -p cassandra.username=cassandra -p cassandra.password=cassandra
-
-  - >-
-    bin/ycsb load cassandra-cql -P workloads/workloada -threads 84 -p recordcount=1000000000
-    -p cassandra.readconsistencylevel=ONE -p cassandra.writeconsistencylevel=ONE
-    -p readproportion=0 -p updateproportion=0
-    -p fieldcount=10 -p fieldlength=128
-    -p insertstart=250000000 -p insertcount=250000000
-    -p cassandra.coreconnections=14 -p cassandra.maxconnections=14
-    -p cassandra.username=cassandra -p cassandra.password=cassandra
-
-  - >-
-    bin/ycsb load cassandra-cql -P workloads/workloada -threads 84 -p recordcount=1000000000
-    -p cassandra.readconsistencylevel=ONE -p cassandra.writeconsistencylevel=ONE
-    -p readproportion=0 -p updateproportion=0
-    -p fieldcount=10 -p fieldlength=128
-    -p insertstart=500000000 -p insertcount=250000000
-    -p cassandra.coreconnections=14 -p cassandra.maxconnections=14
-    -p cassandra.username=cassandra -p cassandra.password=cassandra
-
-  - >-
-    bin/ycsb load cassandra-cql -P workloads/workloada -threads 84 -p recordcount=1000000000
-    -p cassandra.readconsistencylevel=ONE -p cassandra.writeconsistencylevel=ONE
-    -p readproportion=0 -p updateproportion=0
-    -p fieldcount=10 -p fieldlength=128
-    -p insertstart=750000000 -p insertcount=250000000
-    -p cassandra.coreconnections=14 -p cassandra.maxconnections=14
+    -p insertstart=0 -p insertcount=1000000000
+    -p cassandra.coreconnections=240 -p cassandra.maxconnections=240
     -p cassandra.username=cassandra -p cassandra.password=cassandra
 
 # --target must be set to have correct latency results for const throughput - see coordinated omission avoidance problem
-# 16 vCPU per node = 14 shards per node =>
+#
 # we need high concurrency per shard to at least somewhat load request queues
+# number of core connections must match number of vCPU (16) on a db node - 2
+#
+# 16 vCPU per node = 14 shards per node =>
 # 14 vCPUs * 20 parallelism factor = 280 connections per host
+#
 # 840 threads = 280 conns / host * 3 nodes = 840 total threads
 # ops count 300 * 10^6 * / 60 = 40 minutes for workload
+#
 # ycsb workloads use zipfian distribution so we will use a single loader with 32 vCPUs
-# fix framework to support custom CL: -p scylla.readconsistencylevel=ONE -p scylla.writeconsistencylevel=ONE
-# or at least-p scylla.readconsistencylevel=QUORUM -p scylla.writeconsistencylevel=ONE
-# $ $ bin/ycsb run scylla -P workloads/workloada -target 120000 -threads 840 -p recordcount=1000000000 -p fieldcount=10 -p fieldlength=128 -p operationcount=300000000 -p scylla.coreconnections=280
-#     -p scylla.maxconnections=280 -p scylla.username=cassandra -p scylla.password=cassandra -p scylla.tokenaware=true -p hosts=10.0.2.51,10.0.3.133,10.0.3.67 -p scylla.readconsistencylevel=ONE -p
-#      scylla.writeconsistencylevel=ONE
+# fix framework to support custom CL:
+#   -p scylla.readconsistencylevel=ONE -p scylla.writeconsistencylevel=ONE
+# or at least
+#   -p scylla.readconsistencylevel=QUORUM -p scylla.writeconsistencylevel=ONE
+#
+# $ bin/ycsb run scylla -s -t -P workloads/workloada -target 120000 -threads 840 -p recordcount=1000000000 -p fieldcount=10 -p fieldlength=128 -p operationcount=300000000 -p scylla.coreconnections=280 -p scylla.maxconnections=280 -p scylla.username=cassandra -p scylla.password=cassandra -p scylla.hosts=10.0.2.51,10.0.3.133,10.0.3.67 -p scylla.readconsistencylevel=ONE -p scylla.writeconsistencylevel=ONE -p scylla.tokenaware=true
 stress_cmd: [
 ]
 

--- a/test-cases/longevity/longevity-ycsb-a-1M.yaml
+++ b/test-cases/longevity/longevity-ycsb-a-1M.yaml
@@ -1,18 +1,39 @@
 # [Ivan]: I am currently testing CRDB vs ScyllaDB with YCSB workloads.
-#         This scenario shows how to run YCSB workload A against Scylla.
+#         This scenario shows how to load and run YCSB workload A against Scylla.
 #         It can be run with Jenkins BYO as in https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/ivan/job/ivan-byo-longevity/23/:
 #         test_name: longevity_test.LongevityTest.test_custom_time.
 #
-# 240 = 4 hours * 60
-# 10900 = 7 days * 24 hours a day * 60 minutes an hour
-test_duration: 240
+#         README about scylla native binding for YCSB and
+#         how to pick correct numbers for benchmark tests see at:
+#         https://github.com/brianfrankcooper/ycsb/tree/master/scylla#scylla-cql-binding
+#         or longevity-ycsb.txt.
+#
+#         for --target 100K data load is:
+#
+#           - 10M  / 100K = ~100   seconds
+#           - 100M / 100K = ~1000  seconds = ~16  minutes
+#           - 1B   / 100K = ~10000 seconds = ~166 minutes = ~2.7 hours
+#
+#         on 3 nodes i3.4xlarge cluster with CL=QUORUM, RF=3 100K TPS is maximum.
+#         rather it will about around 80K.
+#
+#         16 vCPU loader instance (for example c5.4xlarge) would not be able to give
+#         away more than 150K target tps with 840 threads. It will cap loader CPU.
+#         even with 150K target the latency will struggle due to the overload.
+#         either split load between loaders or use at least c5.9xlarge to produce
+#         around 200K TPS for 3 nodes Scylla cluster.
+#
+#         10900 seconds = 7 days * 24 hours a day * 60 minutes an hour
+#         3600  seconds = 60 minutes
+test_duration: 1800
 
 pre_create_keyspace: [
   "CREATE KEYSPACE ycsb WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor': 3 };",
   "CREATE TABLE ycsb.usertable (y_id varchar primary key, field0 varchar, field1 varchar, field2 varchar, field3 varchar, field4 varchar, field5 varchar, field6 varchar, field7 varchar, field8 varchar, field9 varchar);"
 ]
 
-# number of core connections must match number of vCPU (16) on a db node - 2
+# there is no sense to use more than 1 loader for 3 nodes cluster,
+# but this is just for example
 prepare_write_cmd:
   - >-
     bin/ycsb load cassandra-cql -P workloads/workloada -threads 84 -p recordcount=500000
@@ -33,17 +54,23 @@ prepare_write_cmd:
     -p cassandra.username=cassandra -p cassandra.password=cassandra
 
 # --target must be set to have correct latency results for const throughput - see coordinated omission avoidance problem
-# 16 vCPU per node = 14 shards per node =>
+#
 # we need high concurrency per shard to at least somewhat load request queues
+# number of core connections must match number of vCPU (16) on a db node - 2
+#
+# 16 vCPU per node = 14 shards per node =>
 # 14 vCPUs * 20 parallelism factor = 280 connections per host
+#
 # 840 threads = 280 conns / host * 3 nodes = 840 total threads
 # ops count 300 * 10^6 * / 60 = 40 minutes for workload
+#
 # ycsb workloads use zipfian distribution so we will use a single loader with 32 vCPUs
-# fix framework to support custom CL: -p scylla.readconsistencylevel=ONE -p scylla.writeconsistencylevel=ONE
-# or at least-p scylla.readconsistencylevel=QUORUM -p scylla.writeconsistencylevel=ONE
-# $ $ bin/ycsb run scylla -P workloads/workloada -target 120000 -threads 840 -p recordcount=1000000 -p fieldcount=10 -p fieldlength=128 -p operationcount=300000000 -p scylla.coreconnections=280
-#     -p scylla.maxconnections=280 -p scylla.username=cassandra -p scylla.password=cassandra -p scylla.tokenaware=true -p hosts=10.0.2.51,10.0.3.133,10.0.3.67 -p scylla.readconsistencylevel=ONE -p
-#      scylla.writeconsistencylevel=ONE
+# fix framework to support custom CL:
+#   -p scylla.readconsistencylevel=ONE -p scylla.writeconsistencylevel=ONE
+# or at least
+#   -p scylla.readconsistencylevel=QUORUM -p scylla.writeconsistencylevel=ONE
+#
+# $ bin/ycsb run scylla -s -t -P workloads/workloada -target 120000 -threads 840 -p recordcount=1000000 -p fieldcount=10 -p fieldlength=128 -p operationcount=300000000 -p scylla.coreconnections=280 -p scylla.maxconnections=280 -p scylla.username=cassandra -p scylla.password=cassandra -p scylla.hosts=10.0.2.51,10.0.3.133,10.0.3.67 -p scylla.readconsistencylevel=ONE -p scylla.writeconsistencylevel=ONE -p scylla.tokenaware=true 
 stress_cmd: [
 ]
 

--- a/test-cases/longevity/longevity-ycsb-a-1M.yaml
+++ b/test-cases/longevity/longevity-ycsb-a-1M.yaml
@@ -45,7 +45,6 @@ prepare_write_cmd:
 #     -p scylla.maxconnections=280 -p scylla.username=cassandra -p scylla.password=cassandra -p scylla.tokenaware=true -p hosts=10.0.2.51,10.0.3.133,10.0.3.67 -p scylla.readconsistencylevel=ONE -p
 #      scylla.writeconsistencylevel=ONE
 stress_cmd: [
-    "bin/ycsb run cassandra-cql -P workloads/workloada -target 120000 -threads 840 -p recordcount=1000000 -p fieldcount=10 -p fieldlength=128 -p operationcount=300000000 -p cassandra.coreconnections=280 -p cassandra.maxconnections=280 -p cassandra.username=cassandra -p cassandra.password=cassandra"
 ]
 
 round_robin: true

--- a/test-cases/longevity/longevity-ycsb.txt
+++ b/test-cases/longevity/longevity-ycsb.txt
@@ -1,0 +1,172 @@
+# Scylla CQL binding
+
+Binding for [Scylla](https://www.scylladb.com/), using the CQL API
+via the [Scylla driver](https://github.com/scylladb/java-driver/).
+
+Requires JDK8.
+
+## Creating a table for use with YCSB
+
+For keyspace `ycsb`, table `usertable`:
+
+    cqlsh> create keyspace ycsb
+        WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor': 3 };
+    cqlsh> USE ycsb;
+    cqlsh> create table usertable (
+        y_id varchar primary key,
+        field0 varchar,
+        field1 varchar,
+        field2 varchar,
+        field3 varchar,
+        field4 varchar,
+        field5 varchar,
+        field6 varchar,
+        field7 varchar,
+        field8 varchar,
+        field9 varchar);
+
+**Note that `replication_factor` and consistency levels (below) will affect performance.**
+
+## Quick start
+
+Create a keyspace, and a table as mentioned above. Load data with:
+
+    $ bin/ycsb load scylla -s -P workloads/workloada \
+        -threads 84 -p recordcount=1000000000 \
+        -p readproportion=0 -p updateproportion=0 \
+        -p fieldcount=10 -p fieldlength=128 \
+        -p insertstart=0 -p insertcount=1000000000 \
+        -p cassandra.coreconnections=14 -p cassandra.maxconnections=14 \
+        -p cassandra.username=cassandra -p cassandra.password=cassandra \
+        -p scylla.hosts=ip1,ip2,ip3,...
+
+Use as following:
+
+    $ bin/ycsb run scylla -s -P workloads/workloada \
+        -target 120000 -threads 840 -p recordcount=1000000000 \
+        -p fieldcount=10 -p fieldlength=128 \
+        -p operationcount=50000000 \
+        -p scylla.coreconnections=280 -p scylla.maxconnections=280 \
+        -p scylla.username=cassandra -p scylla.password=cassandra \
+        -p scylla.hosts=ip1,ip2,ip3,... \
+        -p scylla.tokenaware=true
+
+## On choosing meaningful configuration
+
+### 1. Load target
+
+You want to test how a database handles load. To get the performance picture
+you would want to look at the latency distribution and utilization under the
+constant load. To select load use `-target` to state desired throughput level.
+
+For example `-target 120000` means that we expect YCSB workers to generate
+120,000 requests per second (RPS, QPS or TPS) to the database.
+
+Why is this important? Because without setting target throughput you will be
+looking only on the system equilibrium point that in the face of constantly
+varying latency will not allow you to see either throughput, nor latency.
+
+For more information check out these resources on the coordinated omission problem:
+
+See
+[[1]](http://highscalability.com/blog/2015/10/5/your-load-generator-is-probably-lying-to-you-take-the-red-pi.html)
+[[2]](https://medium.com/@siddontang/the-coordinated-omission-problem-in-the-benchmark-tools-5d9abef79279)
+[[3]](https://bravenewgeek.com/tag/coordinated-omission/)
+and [[this]](https://www.youtube.com/watch?v=lJ8ydIuPFeU)
+great talk by Gil Tene.
+
+### 2. Parallelism factor and threads
+
+Scylla utilizes [thread-per-core](https://www.scylladb.com/product/technology/) architecture design.
+That means that a Node consists of shards that are mapped to the CPU cores 1-per-core.
+
+In production setup, Scylla reserves 1 core to the interrupts handling and other system stuff.
+For the system with hyper threading (HT) it means 2 virtual cores. From that follows that the number
+of _Shards_ per _Node_ typically is `Number Of Cores - 2` for HT machine and
+`Number Of Cores - 1` for a machine without HT.
+
+It makes sense to select number of YCSB worker _threads_ to be multiple of the number
+of shards, and the number of nodes in the cluster. For example:
+
+    AWS Amazon i3.4xlarge has 16 vCPU (8 physical cores with HT).
+
+    =>
+
+    scylla node shards = vCPUs - 2 = 16 - 2 = 14
+
+    =>
+
+    threads = K * shards * nodes = K * 14 * nodes
+
+    for i3.4xlarge where
+
+        - K is parallelism factor >= 1,
+        - Nodes is number of nodes in the cluster.
+
+For example for 3 nodes `i3.4xlarge` and `-threads 840` means
+`K = 20`, `shards = 14`, and `threads = 14 * 20 * 3`.
+
+Thus, the `K` - the parallelism factor must be selected in the first order. If you
+don't know what you want out of it start with 1.
+
+For picking desired parallelism factor it is useful to come from desired `target`
+parameter. It is better if the `target` is a multiple of `threads`.
+
+Another concern is that for high throughput scenarios you would probably
+want to keep shards incoming queues non-empty. For that your parallelism factor
+must be at least 2.
+
+### 3. Number of connections
+
+Both `scylla.coreconnections` and `scylla.maxconnections` define limits
+per node. When you see `-p scylla.coreconnections=280 -p scylla.maxconnections=280`
+that means 280 connections per node.
+
+Number of connections must be a multiple of:
+
+- number of _shards_
+- parallelism factor `K`
+
+For example, for `i3.4xlarge` that has 14 shards per node and `K = 20`
+it makes sense to pick `connections = shards * K = 14 * 20 = 280`.
+
+### 4. Other considerations
+
+Consistency levels do not change consistency model or its strongness.
+Even with `-p scylla.writeconsistencylevel=ONE` the data will be written
+according to the number of a table replication factor (RF). Usually,
+by default RF = 3. By using `-p scylla.writeconsistencylevel=ONE` you
+can omit waiting all replicas to write the value. It will improve your
+latency picture a bit but would not affect utilization.
+
+Remember that you can't measure CPU utilization with Scylla by normal
+Unix tools. Check out Scylla own metrics to see real reactors utilization.
+
+Always use [token aware](https://www.scylladb.com/2019/03/27/best-practices-for-scylla-applications/)
+load balancing `-p scylla.tokenaware=true`.
+
+For best performance it is crucial to evenly load all available shards.
+
+### 5. Expected performance target
+
+You can expect about 12500 uOPS / core (shard), where uOPS are basic
+reads and writes operations post replication. Don't forget that usually
+`Core = 2 * vCPU` for HT systems.
+
+For example if we insert a row with RF = 3 we can count at least 3 writes -
+1 write per each replica. That is 1 Transaction = 3 u operations.
+
+Formula for evaluating performance with respect to workloads is:
+
+    uOPS / vCPU = [
+        Transactions * Writes_Ratio * Replication_Factor +
+        Transactions * Read_Ratio   * Read_Consistency_level
+        ] / [ (vCPU_per_node - 2) * (nodes) ]
+
+    where Transactions == `-target` parameter (target throughput).
+
+For example for _workloada_ that is 50/50 reads and writes for a cluster
+of 3 nodes of i3.4xlarge (16 vCPU per node) and target of 120000 is:
+
+    [ 120K * 0.5 * 3 + 120K * 0.5 * 2 (QUORUM) ] / [ (16 - 2) * 3 nodes ] =
+    = 7142 uOPS / vCPU ~ 14000 uOPS / Core.


### PR DESCRIPTION
I have added new header description.
I have added guide on selecting benchmark numbers: test-cases/longevity/longevity-ycsb.txt
I have rewrote loaders to match 3 nodes cluster.
I have wrote a comment about loader sizes.
I have removed stress cmds into comments because they always manual in my case.