### PR TITLE
fix(monitoring): fix usage of mikefarah/yq

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4777,7 +4777,7 @@ class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-inst
 
             if not self.params.get('cluster_backend') == 'docker':
                 configure_self_node_exporter = dedent(f'''
-                    docker run --rm -v {self.monitoring_conf_dir}:/workdir mikefarah/yq yq w -i node_exporter_servers.yml '[0].targets[+]' ''[{node.private_ip_address}]:9100''
+                    docker run --rm -v {self.monitoring_conf_dir}:/workdir mikefarah/yq:3 yq w -i node_exporter_servers.yml '[0].targets[+]' ''[{node.private_ip_address}]:9100''
                 ''')
                 node.remoter.run("sudo bash -ce '%s'" % configure_self_node_exporter, verbose=True)
 


### PR DESCRIPTION
mikefarah/yq updated to v4 which is not backward compatible.

Example of failure: https://jenkins.scylladb.com/job/scylla-4.3/job/longevity/job/longevity-cdc-100gb-4h-test/25/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
