### PR TITLE
improvement(tester): don't fail on ES errors

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -69,6 +69,7 @@ ScyllaOperatorRestartEvent: ERROR
 StartupTestEvent: NORMAL
 TestTimeoutEvent: CRITICAL
 TestFrameworkEvent: ERROR
+ElasticsearchEvent: ERROR
 SpotTerminationEvent: CRITICAL
 ScyllaRepoEvent: WARNING
 InfoEvent: NORMAL

--- a/sdcm/sct_events/system.py
+++ b/sdcm/sct_events/system.py
@@ -83,6 +83,18 @@ class TestFrameworkEvent(SctEvent):  # pylint: disable=too-many-instance-attribu
         return fmt
 
 
+class ElasticsearchEvent(SctEvent):
+    def __init__(self, doc_id: str, error: str):
+        super().__init__(severity=Severity.ERROR)
+
+        self.doc_id = doc_id
+        self.error = error
+
+    @property
+    def msgfmt(self) -> str:
+        return super().msgfmt + ": doc_id={0.doc_id} error={0.error}"
+
+
 class SpotTerminationEvent(SctEvent):
     def __init__(self, node: Any, message: str):
         super().__init__(severity=Severity.CRITICAL)

--- a/unit_tests/test_sct_events_system.py
+++ b/unit_tests/test_sct_events_system.py
@@ -16,7 +16,7 @@ import unittest
 from textwrap import dedent
 
 from sdcm.sct_events.system import \
-    StartupTestEvent, TestFrameworkEvent, SpotTerminationEvent, ScyllaRepoEvent, InfoEvent, \
+    StartupTestEvent, TestFrameworkEvent, ElasticsearchEvent, SpotTerminationEvent, ScyllaRepoEvent, InfoEvent, \
     ThreadFailedEvent, CoreDumpEvent, TestResultEvent
 
 
@@ -38,6 +38,11 @@ class TestSystemEvents(unittest.TestCase):
             "(TestFrameworkEvent Severity.ERROR), source=s1.m1(args=('a1', 'a2'), kwargs={'k1': 'v1', 'k2': 'v2'})"
             " message=msg1\nexception=e1",
         )
+        self.assertEqual(event, pickle.loads(pickle.dumps(event)))
+
+    def test_elasticsearch_event(self):
+        event = ElasticsearchEvent(doc_id="d1", error="e1")
+        self.assertEqual(str(event), "(ElasticsearchEvent Severity.ERROR): doc_id=d1 error=e1")
         self.assertEqual(event, pickle.loads(pickle.dumps(event)))
 
     def test_spot_termination_event(self):

--- a/unit_tests/test_tester.py
+++ b/unit_tests/test_tester.py
@@ -79,8 +79,8 @@ class ClusterTesterForTests(ClusterTester):
     def update_certificates():
         pass
 
-    @staticmethod
-    def _create_es_connection():
+    @property
+    def elasticsearch(self):
         return None
 
     @silence()


### PR DESCRIPTION
Trello: https://trello.com/c/Jq3MTbWh/2409-sct-should-be-tolerant-to-elasticsearch-errors

Fixed #2759

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
