### PR TITLE
fix(upgrade_tests): wait until stress is starting

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -453,12 +453,15 @@ class UpgradeTest(FillDatabaseData):
         entire_write_cs_thread_pool = self.run_stress_thread(stress_cmd=write_stress_during_entire_test)
 
         # Let to write_stress_during_entire_test complete the schema changes
-        time.sleep(300)
+        self.metric_has_data(
+            metric_query='collectd_cassandra_stress_write_gauge{type="ops", keyspace="keyspace_entire_test"}', n=10)
 
         # Prepare keyspace and tables for truncate test
         if self.truncate_entries_flag:
             self.insert_rows = 10
             self.fill_db_data_for_truncate_test(insert_rows=self.insert_rows)
+            # Let to ks_truncate complete the schema changes
+            time.sleep(120)
 
         # generate random order to upgrade
         nodes_num = len(self.db_cluster.nodes)
@@ -482,7 +485,8 @@ class UpgradeTest(FillDatabaseData):
         prepare_write_stress = self.params.get('prepare_write_stress')
         prepare_write_cs_thread_pool = self.run_stress_thread(stress_cmd=prepare_write_stress)
         self.log.info('Sleeping for 60s to let cassandra-stress start before the upgrade...')
-        time.sleep(60)
+        self.metric_has_data(
+            metric_query='collectd_cassandra_stress_write_gauge{type="ops", keyspace="keyspace1"}', n=5)
 
         with ignore_upgrade_schema_errors():
 


### PR DESCRIPTION
seem like in some cases the `time.sleep(60)` wasn't enoguh
for the stress command to start, and then upgrade would start
during the init of the stress casuing it to fail on
schema agreement

Ref: https://github.com/scylladb/scylla/issues/6867

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
