### PR TITLE
fix(increase jmx memory): on 5k tables test jmx was crashing

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2133,6 +2133,14 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             self.log.info("Found kernel version: {}".format(self._kernel_version))
         return self._kernel_version
 
+    def increase_jmx_heap_memory(self, jmx_memory):
+        jmx_file = '/opt/scylladb/jmx/scylla-jmx'
+        self.log.info('changing scylla-jmx heap memory to avoid 5k crashing jmx')
+        self.remoter.run(f"sudo sed -i 's/Xmx256m/Xmx{jmx_memory}m/' {jmx_file}")
+        self.log.info('changed scylla-jmx heap memory')
+        self.remoter.run(f"sudo grep Xmx {jmx_file}")
+        self.log.info('result after changing scylla-jmx heap above')
+
     @log_run_info
     def scylla_setup(self, disks):
         """
@@ -3873,6 +3881,12 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                 node.stop_scylla_server(verify_down=False)
                 node.clean_scylla_data()
                 node.start_scylla_server(verify_up=False)
+
+            # code to increase java heap memory to scylla-jmx (because of #7609)
+            jmx_memory = self.params.get("jmx_heap_memory")
+            if jmx_memory:
+                node.increase_jmx_heap_memory(jmx_memory)
+                node.restart_scylla_jmx()
 
             self.log.info('io.conf right after reboot')
             node.remoter.sudo('cat /etc/scylla.d/io.conf')

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1005,6 +1005,9 @@ class SCTConfiguration(dict):
         dict(name="internode_encryption", env="SCT_INTERNODE_ENCRYPTION", type=str,
              help="scylla sub option of server_encryption_options: internode_encryption"),
 
+        dict(name="jmx_heap_memory", env="SCT_JMX_HEAP_MEMORY", type=int,
+             help="The total size of the memory allocated to JMX. Values in MB, so for 1GB enter 1024(MB)"),
+
         dict(name="loader_swap_size", env="SCT_LOADER_SWAP_SIZE", type=int,
              help="The size of the swap file for the loaders. Its size in bytes calculated by x * 1MB"),
 

--- a/test-cases/longevity/longevity-5000-tables.yaml
+++ b/test-cases/longevity/longevity-5000-tables.yaml
@@ -14,6 +14,8 @@ n_monitor_nodes: 1
 n_db_nodes: 1
 add_node_cnt: 5
 
+jmx_heap_memory: 1024 # this is a fix/workaround for https://github.com/scylladb/scylla/issues/7609
+
 instance_type_db: 'i3.8xlarge'
 instance_type_loader: 'c5.4xlarge'
 user_prefix: 'longevity-5000-tables'


### PR DESCRIPTION
due to scylladb/scylla#7609 i added more memory to the
jmx java process, and it solved the issue.
now, do we want to do this to every run, or try to
do it only for the 5000 tables (or other tests that might
be failing with the same error)?

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
