### PR TITLE
improvement(sct_config): resolve latest repo symlinks

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -69,6 +69,7 @@ StartupTestEvent: NORMAL
 TestTimeoutEvent: CRITICAL
 TestFrameworkEvent: ERROR
 SpotTerminationEvent: CRITICAL
+ScyllaRepoEvent: WARNING
 InfoEvent: NORMAL
 ThreadFailedEvent: ERROR
 CoreDumpEvent: ERROR

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -32,7 +32,7 @@ from sdcm.utils import alternator
 from sdcm.utils.common import find_scylla_repo, get_scylla_ami_versions, get_branched_ami, get_ami_tags, \
     ami_built_by_scylla, MAX_SPOT_DURATION_TIME
 from sdcm.utils.version_utils import get_branch_version, get_branch_version_for_multiple_repositories, \
-    get_scylla_docker_repo_from_version
+    get_scylla_docker_repo_from_version, resolve_latest_repo_symlink
 from sdcm.sct_events.base import add_severity_limit_rules, print_critical_events
 
 
@@ -1265,7 +1265,12 @@ class SCTConfiguration(dict):
             elif not self.get('new_scylla_repo'):
                 self['new_scylla_repo'] = find_scylla_repo(new_scylla_version, dist_type, dist_version)
 
-        # 8) append username or ami_id_db_scylla_desc to the user_prefix
+        # 8) resolve repo symlinks
+        for repo_key in ("scylla_repo", "scylla_repo_loader", "new_scylla_repo", ):
+            if self.get(repo_key):
+                self[repo_key] = resolve_latest_repo_symlink(self[repo_key])
+
+        # 9) append username or ami_id_db_scylla_desc to the user_prefix
         version_tag = self.get('ami_id_db_scylla_desc')
         user_prefix = self.get('user_prefix')
         if user_prefix:
@@ -1274,16 +1279,16 @@ class SCTConfiguration(dict):
 
             self['user_prefix'] = "{}-{}".format(user_prefix, version_tag)[:35]
 
-        # 9) update target_upgrade_version automatically
+        # 10) update target_upgrade_version automatically
         new_scylla_repo = self.get('new_scylla_repo')
         if new_scylla_repo and not self.get('target_upgrade_version'):
             self['target_upgrade_version'] = get_branch_version(new_scylla_repo)
 
-        # 10) validate that supported instance_provision selected
+        # 11) validate that supported instance_provision selected
         if self.get('instance_provision') not in ['spot', 'on_demand', 'spot_fleet', 'spot_low_price', 'spot_duration']:
             raise ValueError(f"Selected instance_provision type '{self.get('instance_provision')}' is not supported!")
 
-        # 11) spot_duration instance can be created for test duration
+        # 12) spot_duration instance can be created for test duration
         if self.get('instance_provision').lower() == "spot_duration":
             test_duration = self.get('test_duration')
             if test_duration:
@@ -1291,7 +1296,7 @@ class SCTConfiguration(dict):
                     f'Test duration too long for spot_duration instance type. ' \
                     f'Max possible test duration time for this instance type is {MAX_SPOT_DURATION_TIME} minutes'
 
-        # 12) validate authenticator parameters
+        # 13) validate authenticator parameters
         if self.get('authenticator') and self.get('authenticator') == "PasswordAuthenticator":
             authenticator_user = self.get("authenticator_user")
             authenticator_password = self.get("authenticator_password")

--- a/sdcm/sct_events/base.py
+++ b/sdcm/sct_events/base.py
@@ -161,7 +161,12 @@ class SctEvent:
         if not self._ready_to_publish:
             LOGGER.warning("[SCT internal warning] %s is not ready to be published", self)
             return
-        if proc := get_events_main_device(_registry=self._events_processes_registry):
+        try:
+            proc = get_events_main_device(_registry=self._events_processes_registry)
+        except RuntimeError:
+            LOGGER.exception("Unable to get events main device")
+            proc = None
+        if proc:
             if proc.is_alive():
                 self.publish()
             else:

--- a/sdcm/sct_events/system.py
+++ b/sdcm/sct_events/system.py
@@ -95,6 +95,18 @@ class SpotTerminationEvent(SctEvent):
         return super().msgfmt + ": node={0.node} message={0.message}"
 
 
+class ScyllaRepoEvent(SctEvent):
+    def __init__(self, url: str, error: str):
+        super().__init__(severity=Severity.WARNING)
+
+        self.url = url
+        self.error = error
+
+    @property
+    def msgfmt(self) -> str:
+        return super().msgfmt + ": url={0.url} error={0.error}"
+
+
 class InfoEvent(SctEvent):
     def __init__(self, message: str):
         super().__init__(severity=Severity.NORMAL)

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -17,6 +17,7 @@ import itertools
 import unittest
 
 from sdcm.sct_config import SCTConfiguration
+from sdcm.utils.version_utils import resolve_latest_repo_symlink
 
 
 RPM_URL = 'https://s3.amazonaws.com/downloads.scylladb.com/enterprise/rpm/unstable/centos/' \
@@ -359,8 +360,11 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
 
         conf = SCTConfiguration()
         conf.verify_configuration()
-        self.assertEqual(conf.get('scylla_repo'),
-                         "https://s3.amazonaws.com/downloads.scylladb.com/rpm/unstable/centos/branch-4.2/latest/scylla.repo")
+
+        resolved_repo_link = resolve_latest_repo_symlink(
+            "https://s3.amazonaws.com/downloads.scylladb.com/rpm/unstable/centos/branch-4.2/latest/scylla.repo"
+        )
+        self.assertEqual(conf.get('scylla_repo'), resolved_repo_link)
         target_upgrade_version = conf.get('target_upgrade_version')
         self.assertTrue(target_upgrade_version == '666.development' or target_upgrade_version.endswith(".dev"))
 
@@ -374,8 +378,11 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
 
         conf = SCTConfiguration()
         conf.verify_configuration()
-        self.assertEqual(conf.get('scylla_repo'),
-                         "https://s3.amazonaws.com/downloads.scylladb.com/deb/unstable/unified/master/latest/scylladb-master/scylla.list")
+
+        resovled_repo_link = resolve_latest_repo_symlink(
+            "https://s3.amazonaws.com/downloads.scylladb.com/deb/unstable/unified/master/latest/scylladb-master/scylla.list"
+        )
+        self.assertEqual(conf.get('scylla_repo'), resovled_repo_link)
         target_upgrade_version = conf.get('target_upgrade_version')
         self.assertTrue(target_upgrade_version == '666.development' or target_upgrade_version.endswith(".dev"))
 

--- a/unit_tests/test_sct_events_system.py
+++ b/unit_tests/test_sct_events_system.py
@@ -16,7 +16,7 @@ import unittest
 from textwrap import dedent
 
 from sdcm.sct_events.system import \
-    StartupTestEvent, TestFrameworkEvent, SpotTerminationEvent, InfoEvent, \
+    StartupTestEvent, TestFrameworkEvent, SpotTerminationEvent, ScyllaRepoEvent, InfoEvent, \
     ThreadFailedEvent, CoreDumpEvent, TestResultEvent
 
 
@@ -43,6 +43,11 @@ class TestSystemEvents(unittest.TestCase):
     def test_spot_termination_event(self):
         event = SpotTerminationEvent(node="node1", message="m1")
         self.assertEqual(str(event), "(SpotTerminationEvent Severity.CRITICAL): node=node1 message=m1")
+        self.assertEqual(event, pickle.loads(pickle.dumps(event)))
+
+    def test_scylla_repo_event(self):
+        event = ScyllaRepoEvent(url="u1", error="e1")
+        self.assertEqual(str(event), "(ScyllaRepoEvent Severity.WARNING): url=u1 error=e1")
         self.assertEqual(event, pickle.loads(pickle.dumps(event)))
 
     def test_info_event(self):


### PR DESCRIPTION
Trello: https://trello.com/c/71kw0Fy9/2412-check-that-latest-symlink-points-to-the-latest-deb-in-the-repo

There is a behavior change: ScyllaDB repo links (`scylla_repo`, `scylla_repo_loader`, and `new_scylla_repo`) are resolving to actual builds to be consistent during the test run (imagine if there is a new build published during the test run, especially cluster setup)

I.e., ` https://s3.amazonaws.com/downloads.scylladb.com/rpm/unstable/centos/branch-4.2/latest/scylla.repo` will be resolved to something like `https://s3.amazonaws.com/downloads.scylladb.com/rpm/unstable/centos/branch-4.2/2020-12-17T01:20:51Z/scylla.repo`

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
