### PR TITLE
fix(jepsen): add a check for empty nodes list for log collector

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -992,14 +992,15 @@ class JepsenLogCollector(LogCollector):
 
     def collect_logs(self, local_search_path: Optional[str] = None) -> Optional[str]:
         s3_link = None
-        jepsen_node = self.nodes[0]
-        if jepsen_archive := self.archive_log_remotely(jepsen_node, "./jepsen-scylla", "jepsen-data"):
-            self.receive_log(jepsen_node, jepsen_archive, self.local_dir)
-            s3_link = upload_archive_to_s3(
-                archive_path=os.path.join(self.local_dir, os.path.basename(jepsen_archive)),
-                storing_path=f"{self.test_id}/{self.current_run}",
-            )
-        remove_files(self.local_dir)
+        if self.nodes:
+            jepsen_node = self.nodes[0]
+            if jepsen_archive := self.archive_log_remotely(jepsen_node, "./jepsen-scylla", "jepsen-data"):
+                self.receive_log(jepsen_node, jepsen_archive, self.local_dir)
+                s3_link = upload_archive_to_s3(
+                    archive_path=os.path.join(self.local_dir, os.path.basename(jepsen_archive)),
+                    storing_path=f"{self.test_id}/{self.current_run}",
+                )
+            remove_files(self.local_dir)
         return s3_link
 
 


### PR DESCRIPTION
Example of failure: https://jenkins.scylladb.com/view/master/job/scylla-master/job/artifacts/job/artifacts-centos7-test/306/console

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
