### PR TITLE
fix(ipv6 config): add IPV6_AUTOCONF and IPV6_DEFROUTE to sysconfig

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -351,6 +351,21 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
             IPv6_CIDR=`curl -s ${BASE_EC2_NETWORK_URL}${MAC}/subnet-ipv6-cidr-blocks`
 
             grep -qi "amazon linux" /etc/os-release || sudo ip route add $IPv6_CIDR dev eth0
+
+            grep -q IPV6_AUTOCONF /etc/sysconfig/network-scripts/ifcfg-eth0
+            if [[ $? -eq 0 ]]; then
+                sudo sed -i 's/^IPV6_AUTOCONF=[^ ]*/IPV6_AUTOCONF=yes/' /etc/sysconfig/network-scripts/ifcfg-eth0
+            else
+                sudo echo "IPV6_AUTOCONF=yes" >> /etc/sysconfig/network-scripts/ifcfg-eth0
+            fi
+
+            grep -q IPV6_DEFROUTE /etc/sysconfig/network-scripts/ifcfg-eth0
+            if [[ $? -eq 0 ]]; then
+                sudo sed -i 's/^IPV6_DEFROUTE=[^ ]*/IPV6_DEFROUTE=yes/' /etc/sysconfig/network-scripts/ifcfg-eth0
+            else
+                sudo echo "IPV6_DEFROUTE=yes" >> /etc/sysconfig/network-scripts/ifcfg-eth0
+            fi
+            sudo systemctl restart network
         """)
 
     @staticmethod


### PR DESCRIPTION
After revert of Amazon Linux 2 node configuration was changed and
IPV6_AUTOCONF and IPV6_DEFROUTE parameters is not set to 'yes' that cause to failure
of multiDC test with IPv6.

Relevant issue [#5179](https://github.com/scylladb/scylla/issues/5179)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
