### PR TITLE
fix(group_common_events.py): Ignoring "Could not retrieve CDC streams" error

### DIFF
--- a/sdcm/group_common_events.py
+++ b/sdcm/group_common_events.py
@@ -41,6 +41,7 @@ def ignore_upgrade_schema_errors():
         stack.enter_context(DbEventsFilter(type='SCHEMA_FAILURE', line='Failed to load schema'))
         stack.enter_context(DbEventsFilter(type='DATABASE_ERROR', line='Failed to pull schema'))
         stack.enter_context(DbEventsFilter(type='RUNTIME_ERROR', line='Failed to load schema'))
+        stack.enter_context(DbEventsFilter(type='RUNTIME_ERROR', line='Could not retrieve CDC streams with timestamp'))
         yield
 
 


### PR DESCRIPTION
* https://github.com/scylladb/scylla/issues/7817

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
