### PR TITLE
fix(group_common_events.py): Ignoring "seastar::nested_exception" error

### DIFF
--- a/sdcm/group_common_events.py
+++ b/sdcm/group_common_events.py
@@ -42,6 +42,9 @@ def ignore_upgrade_schema_errors():
         stack.enter_context(DbEventsFilter(type='DATABASE_ERROR', line='Failed to pull schema'))
         stack.enter_context(DbEventsFilter(type='RUNTIME_ERROR', line='Failed to load schema'))
         stack.enter_context(DbEventsFilter(type='RUNTIME_ERROR', line='Could not retrieve CDC streams with timestamp'))
+        stack.enter_context(DbEventsFilter(type='DATABASE_ERROR',
+                                           line="cql_server - exception while processing connection:"
+                                                " seastar::nested_exception (seastar::nested_exception)"))
         yield
 
 


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
