### PR TITLE
fix(group_common_events.py): Ignoring "seastar::nested_exception" error

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -495,7 +495,9 @@ class UpgradeTest(FillDatabaseData):
                 DbEventsFilter(type='SCHEMA_FAILURE', line='Failed to load schema'), \
                 DbEventsFilter(type='DATABASE_ERROR', line='Failed to pull schema'), \
                 DbEventsFilter(type='RUNTIME_ERROR', line='Failed to load schema'), \
-                DbEventsFilter(type='RUNTIME_ERROR', line='Could not retrieve CDC streams with timestamp'):
+                DbEventsFilter(type='RUNTIME_ERROR', line='Could not retrieve CDC streams with timestamp'), \
+                DbEventsFilter(type='DATABASE_ERROR', line="cql_server - exception while processing connection: "
+                                                           "seastar::nested_exception (seastar::nested_exception)"):
 
             step = 'Step1 - Upgrade First Node '
             self.log.info(step)
@@ -568,7 +570,10 @@ class UpgradeTest(FillDatabaseData):
                 DbEventsFilter(type='SCHEMA_FAILURE', line='Failed to load schema'), \
                 DbEventsFilter(type='DATABASE_ERROR', line='Failed to pull schema'), \
                 DbEventsFilter(type='RUNTIME_ERROR', line='Failed to load schema'), \
-                DbEventsFilter(type='RUNTIME_ERROR', line='Could not retrieve CDC streams with timestamp'):
+                DbEventsFilter(type='RUNTIME_ERROR', line='Could not retrieve CDC streams with timestamp'), \
+                DbEventsFilter(type='DATABASE_ERROR', line="cql_server - exception while processing connection: "
+                                                           "seastar::nested_exception (seastar::nested_exception)"):
+
             step = 'Step5 - Upgrade rest of the Nodes '
             self.log.info(step)
             for i in indexes[1:]:


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
