### PR TITLE
test(rolling_upgrade with ldap): added a new test

### DIFF
--- a/jenkins-pipelines/rolling-upgrade-centos7-ldap-authorization.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-centos7-ldap-authorization.jenkinsfile
@@ -1,0 +1,17 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+rollingUpgradePipeline(
+    backend: 'gce',
+    base_versions: ['2020.1'],
+    linux_distro: 'centos',
+    gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7',
+
+    test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
+    test_config: '''["test-cases/upgrades/rolling-upgrade.yaml", "configurations/ldap-authorization.yaml"]''',
+    workaround_kernel_bug_for_iotune: false,
+
+    timeout: [time: 360, unit: 'MINUTES']
+)


### PR DESCRIPTION
rolling upgrade when there is LDAP authorization enabled
in the base_version.
This is to be used for enterprise, as this feature
is not available for OSS.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
