### PR TITLE
improvement(stress_latency_panel_name): Change name of panel for c-s latency on sct dashboard

### DIFF
--- a/data_dir/scylla-dash-per-server-nemesis.master.json
+++ b/data_dir/scylla-dash-per-server-nemesis.master.json
@@ -677,7 +677,7 @@
                 "panels": [
                     {
                         "class": "text_panel",
-                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Cassandra Stress latency</h1>",
+                        "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Stress tools latency</h1>",
                         "editable": true,
                         "error": false,
                         "id": 63,
@@ -694,7 +694,7 @@
                 "repeatIteration": null,
                 "repeatRowId": null,
                 "showTitle": false,
-                "title": "Cassandra stress latency",
+                "title": "Stress tools latency",
                 "titleSize": "h6"
             },
             {
@@ -821,7 +821,7 @@
                         "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
-                        "title": "cassandra-stress latency 95%",
+                        "title": "Stress tools latency 95%",
                         "tooltip": {
                             "msResolution": false,
                             "shared": true,
@@ -973,7 +973,7 @@
                         "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
-                        "title": "cassandra-stress latency 99%",
+                        "title": "Stress tools latency 99%",
                         "tooltip": {
                             "msResolution": false,
                             "shared": true,


### PR DESCRIPTION
Since the section and panels "Cassandra-Stress latency"  on sct dashboard
display latency result of c-s, scylla-bench, ycsb tools name should be
changed

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] ~I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)~
- [ ] ~I didn't leave commented-out/debugging code~
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (CI)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
