### PR TITLE
fix(DecommissionStreamingErr): ignore  "Startup failed" logs

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2347,10 +2347,16 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         time.sleep(random.randint(10, 600))
 
         self.log.debug('Interrupt the task by hard reboot')
-        self.target_node.reboot(hard=True, verify_ssh=True)
-        streaming_thread.join(60)
 
-        new_node = decommission_post_action()
+        with DbEventsFilter(db_event=DatabaseLogEvent.RUNTIME_ERROR,
+                            line="This node was decommissioned and will not rejoin",
+                            node=self.target_node):
+            self.target_node.reboot(hard=True, verify_ssh=True)
+            streaming_thread.join(60)
+
+        new_node = None
+        if task == 'decommission':
+            new_node = decommission_post_action()
 
         if self.task_used_streaming:
             err = list(streaming_error_logs_stream)


### PR DESCRIPTION
Ignore errors like this during this nemesis:
```
(DatabaseLogEvent Severity.ERROR): type=RUNTIME_ERROR
   regex=std::runtime_error line_number=54404
scylla: [shard 0] init - Startup failed: std::runtime_error (This node
   was decommissioned and will not rejoin the ring unless
   override_decommission=true has been set,or all existing data is
   removed and the node is bootstrapped again)
```

Fixes: #3015, #3016

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- ~~[ ] New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- ~~[ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- ~~[ ] I have updated the Readme/doc folder accordingly (if needed)~~
