### PR TITLE
feature(nemesis_publisher): report each nemesis result into elastic

### DIFF
--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -347,6 +347,9 @@ class Stats():
     def get_doc_id(self):
         return self._test_id
 
+    def get_stats(self):
+        return self._stats
+
     def create(self):
         self.elasticsearch.create_doc(index=self._test_index, doc_type=self._es_doc_type,
                                       doc_id=self._test_id, body=self._stats)

--- a/sdcm/nemesis_publisher.py
+++ b/sdcm/nemesis_publisher.py
@@ -1,0 +1,73 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2020 ScyllaDB
+
+import logging
+from datetime import datetime
+
+from elasticsearch import Elasticsearch
+
+from sdcm.keystore import KeyStore
+
+LOGGER = logging.getLogger(__name__)
+
+
+class NemesisElasticSearchPublisher:
+    index_name = 'nemesis_data'
+    es: Elasticsearch
+
+    def __init__(self, tester):
+        self.tester = tester
+
+    def create_es_connection(self):
+        ks = KeyStore()
+        es_conf = ks.get_elasticsearch_credentials()
+        self.es = Elasticsearch(hosts=[es_conf["es_url"]], verify_certs=False,
+                                http_auth=(es_conf["es_user"], es_conf["es_password"]))
+
+    def publish(self, disrupt_name, status=True, data=None):
+        test_data = self.tester.get_stats()
+        assert test_data, "without _stats data we can't publish nemesis ES"
+
+        new_nemesis_data = dict(
+            test_id=test_data['test_details']['test_id'],
+            job_name=test_data['test_details']['job_name'],
+            test_name=test_data['test_details']['test_name'],
+            scylla_version=test_data['versions']['scylla-server']['version'],
+            scylla_git_sha=test_data['versions']['scylla-server']['commit_id'],
+        )
+        if status:
+            new_nemesis_data.update(
+                nemesis_name=disrupt_name,
+                nemesis_duration=data['duration'],
+                start_time=datetime.utcfromtimestamp(data['start']),
+                end_time=datetime.utcfromtimestamp(data['end']),
+                target_node=data['node'],
+                outcome="passed"
+            )
+            if 'skip_reason' in data:
+                new_nemesis_data['outcome'] = 'skipped'
+                new_nemesis_data['skip_reason'] = data['skip_reason']
+
+        else:
+            new_nemesis_data.update(dict(
+                nemesis_name=disrupt_name,
+                nemesis_duration=data['duration'],
+                start_time=datetime.utcfromtimestamp(data['start']),
+                end_time=datetime.utcfromtimestamp(data['end']),
+                target_node=data['node'],
+                outcome="failure",
+                failure_message=data['error']
+            ))
+
+        res = self.es.index(index=self.index_name, doc_type='nemesis', body=new_nemesis_data)
+        LOGGER.debug(res)

--- a/utils/migrate_nemesis_data.py
+++ b/utils/migrate_nemesis_data.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+import sys
+import os.path
+import datetime
+import logging
+import logging.config
+
+import click
+from elasticsearch import Elasticsearch
+from elasticsearch.helpers import scan
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from sdcm.keystore import KeyStore
+
+LOGGER = logging.getLogger(__name__)
+
+
+@click.command(help="Migrate nemesis data from old indexes into the new one")
+@click.option('--dry-run/--no-dry-run', default=False)
+@click.option('--new-index', default='nemesis_data', help='name of the target index')
+@click.option('--days', default=10, type=int, help="how many days backwards to migrate")
+@click.argument('old_index_name', type=str, default='longevitytest')
+def migrate(old_index_name, dry_run, new_index, days):
+
+    logging.basicConfig(level=logging.DEBUG)
+    logging.config.dictConfig({
+        'version': 1,
+        'disable_existing_loggers': True,
+        'formatters': {
+            'standard': {
+                'format': '%(asctime)s [%(levelname)s] %(name)s: %(message)s'
+            },
+        },
+        'handlers': {
+            'default': {
+                'level': 'INFO',
+                'formatter': 'standard',
+                'class': 'logging.StreamHandler',
+                'stream': 'ext://sys.stdout',  # Default is stderr
+            },
+        },
+        'loggers': {
+            '': {  # root logger
+                'handlers': ['default'],
+                'level': 'WARNING',
+                'propagate': False
+            },
+            '__main__': {  # if __name__ == '__main__'
+                'handlers': ['default'],
+                'level': 'DEBUG',
+                'propagate': False
+            },
+        }
+    }
+    )
+    ks = KeyStore()
+    es_conf = ks.get_elasticsearch_credentials()
+    es = Elasticsearch(hosts=[es_conf["es_url"]], verify_certs=True,
+                       http_auth=(es_conf["es_user"], es_conf["es_password"]))
+
+    if not es.indices.exists(index=new_index):
+        es.indices.create(index=new_index)
+
+    def post_to_new(doc):
+        if dry_run:
+            return
+        es.index(index=new_index, doc_type='nemesis', body=doc)
+
+    res = scan(es, index=old_index_name, query={"query": {"range": {
+        "test_details.start_time": {
+            "gte": (datetime.datetime.utcnow() - datetime.timedelta(days=days)).timestamp(),
+            "lte": datetime.datetime.utcnow().timestamp(),
+            "boost": 2.0
+        }
+    }}}, size=300, scroll='3h')
+
+    for num, hit in enumerate(res):
+        nemesis_list = hit["_source"]["nemesis"]
+        test_data = hit["_source"]
+        LOGGER.info(f"{num}: {test_data['test_details']['test_id']}")
+        if 'scylla-server' not in test_data['versions']:
+            LOGGER.debug(
+                f"{num}: No version for {test_data['test_details']['test_id']} - {test_data['test_details']['job_name']}")
+            if not test_data['test_details']['job_name']:
+                LOGGER.debug(test_data)
+            continue
+
+        for nemesis_class, data in nemesis_list.items():
+            for failure in data['failures']:
+                new_nemesis_data = dict(
+                    test_id=test_data['test_details']['test_id'],
+                    job_name=test_data['test_details']['job_name'],
+                    test_name=test_data['test_details']['test_name'],
+                    scylla_version=test_data['versions']['scylla-server']['version'],
+                    scylla_git_sha=test_data['versions']['scylla-server']['commit_id'],
+                )
+
+                new_nemesis_data.update(dict(
+                    nemesis_name=nemesis_class,
+                    nemesis_duration=failure['duration'],
+                    start_time=datetime.datetime.utcfromtimestamp(failure['start']),
+                    end_time=datetime.datetime.utcfromtimestamp(failure['end']),
+                    target_node=failure['node'],
+                    outcome="failure",
+                    failure_message=failure['error']
+                ))
+                post_to_new(new_nemesis_data)
+
+            for run in data['runs']:
+                new_nemesis_data = dict(
+                    test_id=test_data['test_details']['test_id'],
+                    job_name=test_data['test_details']['job_name'],
+                    test_name=test_data['test_details']['test_name'],
+                    scylla_version=test_data['versions']['scylla-server']['version'],
+                    scylla_git_sha=test_data['versions']['scylla-server']['commit_id'],
+                )
+                new_nemesis_data.update(dict(
+                    nemesis_name=nemesis_class,
+                    nemesis_duration=run['duration'],
+                    start_time=datetime.datetime.utcfromtimestamp(run['start']),
+                    end_time=datetime.datetime.utcfromtimestamp(run['end']),
+                    target_node=run['node'],
+                    outcome="passed"
+                ))
+                if run.get('type', '') == 'skipped':
+                    new_nemesis_data['outcome'] = 'skipped'
+                    new_nemesis_data['skip_reason'] = run['skip_reason']
+                post_to_new(new_nemesis_data)
+
+
+if __name__ == '__main__':
+    migrate()  # pylint: disable=no-value-for-parameter


### PR DESCRIPTION
since we want to track better which nemesis code has been run/failed
using elasticsearch and kiband dashboard.
we are sending each nemesis result, stright away in a flatter data structure

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
