### PR TITLE
fix(monitoringstack): Add Error messages if data dir is empty

### DIFF
--- a/sdcm/utils/monitorstack.py
+++ b/sdcm/utils/monitorstack.py
@@ -198,12 +198,18 @@ def extract_file_from_zip_archive(pattern, archive, extract_dir):
 def get_monitoring_data_dir(base_dir):
     monitoring_data_dirs = [d for d in os.listdir(base_dir)
                             if os.path.isdir(os.path.join(base_dir, d))]
+    if not monitoring_data_dirs:
+        LOGGER.error("%s is empty. No data found", base_dir)
+        return False
     return os.path.join(base_dir, monitoring_data_dirs[0])
 
 
 def get_monitoring_stack_dir(base_dir):
-    monitoring_stack_dir = [d for d in os.listdir(base_dir) if 'scylla-monitoring' in d][0]
-    return os.path.join(base_dir, monitoring_stack_dir)
+    monitoring_stack_dir = [d for d in os.listdir(base_dir) if 'scylla-monitoring' in d]
+    if not monitoring_stack_dir:
+        LOGGER.error("%s is empty. No data found", base_dir)
+        return False
+    return os.path.join(base_dir, monitoring_stack_dir[0])
 
 
 def get_monitoring_stack_scylla_version(monitoring_stack_dir):


### PR DESCRIPTION
Print log error message if after extracting the archive with
monitoringstack data stays empty.

Trello: https://trello.com/c/WW44d4Up

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (CI)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
