### PR TITLE
fix(gemini_cdc): Fix instance type for gemini_cdc tests

### DIFF
--- a/test-cases/gemini/gemini-3h-cdc-postimage-write.yaml
+++ b/test-cases/gemini/gemini-3h-cdc-postimage-write.yaml
@@ -2,10 +2,10 @@ test_duration: 300
 n_db_nodes: 3
 n_loaders: 1
 n_monitor_nodes: 1
-instance_type_db: 'i3.large'
+instance_type_db: 'i3.4xlarge'
 
 store_results_in_elasticsearch: False
-user_prefix: "gemini-cdc-preimage-write"
+user_prefix: "gemini-cdc-postimage-write"
 
 gemini_cmd: "gemini -d --duration 3h \
 -c 50 -m write -f --non-interactive --cql-features normal \
@@ -19,7 +19,3 @@ gemini_table_options:
   - "cdc={'enabled': true, 'postimage': true}"
 
 db_type: scylla
-
-append_scylla_yaml: |
-  experimental_features:
-    - cdc

--- a/test-cases/gemini/gemini-3h-cdc-preimage-write.yaml
+++ b/test-cases/gemini/gemini-3h-cdc-preimage-write.yaml
@@ -2,7 +2,7 @@ test_duration: 300
 n_db_nodes: 3
 n_loaders: 1
 n_monitor_nodes: 1
-instance_type_db: 'i3.large'
+instance_type_db: 'i3.4xlarge'
 
 store_results_in_elasticsearch: False
 user_prefix: "gemini-cdc-preimage-write"
@@ -19,7 +19,3 @@ gemini_table_options:
   - "cdc={'enabled': true, 'preimage': true}"
 
 db_type: scylla
-
-append_scylla_yaml: |
-  experimental_features:
-    - cdc

--- a/test-cases/gemini/gemini-3h-cdc-write.yaml
+++ b/test-cases/gemini/gemini-3h-cdc-write.yaml
@@ -2,7 +2,7 @@ test_duration: 300
 n_db_nodes: 3
 n_loaders: 1
 n_monitor_nodes: 1
-instance_type_db: 'i3.large'
+instance_type_db: 'i3.4xlarge'
 
 store_results_in_elasticsearch: False
 user_prefix: "gemini-cdc-write"
@@ -20,7 +20,3 @@ gemini_version: 'latest'
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 
 db_type: scylla
-
-append_scylla_yaml: |
-  experimental_features:
-    - cdc


### PR DESCRIPTION
During tests cdc_gemini_(preimage/postimage) gemini only use
write operations. Cdc enabled for test tables. And these could
trigger error: No space left on device

Type of instance increased from i3.large -> i3.4xlarge

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] ~I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)~
- [ ] ~I didn't leave commented-out/debugging code~
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (CI)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
