### PR TITLE
fix(gemini): don't warn for unparsable log messages

### DIFF
--- a/sdcm/gemini_thread.py
+++ b/sdcm/gemini_thread.py
@@ -46,7 +46,11 @@ class GeminiEventsPublisher(FileFollowerThread):
                 time.sleep(0.5)
                 continue
             for line_number, line in enumerate(self.follow_file(self.gemini_log_filename), start=1):
-                GeminiLogEvent.geminievent(verbose=self.verbose).add_info(self.node, line, line_number).publish()
+                GeminiLogEvent.geminievent(verbose=self.verbose).add_info(
+                    node=self.node,
+                    line=line,
+                    line_number=line_number,
+                ).publish(warn_not_ready=False)
                 if self.stopped():
                     break
 

--- a/sdcm/sct_events/__init__.py
+++ b/sdcm/sct_events/__init__.py
@@ -53,10 +53,10 @@ class SctEventProtocol(Protocol):
     def formatted_timestamp(self) -> str:
         ...
 
-    def publish(self) -> None:
+    def publish(self, warn_not_ready: bool = True) -> None:
         ...
 
-    def publish_or_dump(self, default_logger: Optional[logging.Logger] = None) -> None:
+    def publish_or_dump(self, default_logger: Optional[logging.Logger] = None, warn_not_ready: bool = True) -> None:
         ...
 
     def to_json(self) -> str:

--- a/sdcm/sct_events/base.py
+++ b/sdcm/sct_events/base.py
@@ -144,22 +144,24 @@ class SctEvent:
             LOGGER.exception("Failed to format a timestamp: %r", self.timestamp)
             return "0000-00-00 <UnknownTimestamp>"
 
-    def publish(self) -> None:
+    def publish(self, warn_not_ready: bool = True) -> None:
         # pylint: disable=import-outside-toplevel; to avoid cyclic imports
         from sdcm.sct_events.events_device import get_events_main_device
 
         if not self._ready_to_publish:
-            LOGGER.warning("[SCT internal warning] %s is not ready to be published", self)
+            if warn_not_ready:
+                LOGGER.warning("[SCT internal warning] %s is not ready to be published", self)
             return
         get_events_main_device(_registry=self._events_processes_registry).publish_event(self)
         self._ready_to_publish = False
 
-    def publish_or_dump(self, default_logger: Optional[logging.Logger] = None) -> None:
+    def publish_or_dump(self, default_logger: Optional[logging.Logger] = None, warn_not_ready: bool = True) -> None:
         # pylint: disable=import-outside-toplevel; to avoid cyclic imports
         from sdcm.sct_events.events_device import get_events_main_device
 
         if not self._ready_to_publish:
-            LOGGER.warning("[SCT internal warning] %s is not ready to be published", self)
+            if warn_not_ready:
+                LOGGER.warning("[SCT internal warning] %s is not ready to be published", self)
             return
         if proc := get_events_main_device(_registry=self._events_processes_registry):
             if proc.is_alive():


### PR DESCRIPTION
To avoid warnings like 

```
...
< t:2020-12-24 04:31:26,798 f:base.py         l:152  c:sdcm.sct_events.base p:WARNING > [SCT internal warning] (GeminiLogEvent Severity.CRITICAL): type=geminievent line_number=0 node=None
< t:2020-12-24 04:31:26,798 f:base.py         l:152  c:sdcm.sct_events.base p:WARNING > None is not ready to be published
< t:2020-12-24 04:31:26,798 f:base.py         l:152  c:sdcm.sct_events.base p:WARNING > [SCT internal warning] (GeminiLogEvent Severity.CRITICAL): type=geminievent line_number=0 node=None
< t:2020-12-24 04:31:26,798 f:base.py         l:152  c:sdcm.sct_events.base p:WARNING > None is not ready to be published
...
```

These warnings are expected because gemini log contains some lines not in JSON format (e.g., at the beginning)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
