### PR TITLE
fix(lwt_24h data validator): didn't have data to compare

### DIFF
--- a/data_dir/c-s_lwt_big_data.yaml
+++ b/data_dir/c-s_lwt_big_data.yaml
@@ -73,7 +73,7 @@ columnspec:
     cluster: uniform(1..2000)         #under each domain we will have max 2000 posts
 
   - name: lwt_indicator
-    population: seq(1..1001000)
+    population: seq(1..100100)
 
   - name: url
     size: fixed(200)

--- a/data_dir/c-s_lwt_big_data_multidc.yaml
+++ b/data_dir/c-s_lwt_big_data_multidc.yaml
@@ -58,10 +58,10 @@ table_definition: |
 extra_definitions:
   - create MATERIALIZED VIEW blogposts_update_one_column_lwt_indicator as select domain, lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator >=-2000 and lwt_indicator < 0 PRIMARY KEY(lwt_indicator, domain, published_date);
   - create MATERIALIZED VIEW blogposts_update_one_column_lwt_indicator_after_update as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator = 30000000 PRIMARY KEY(lwt_indicator, domain, published_date);
-  - create MATERIALIZED VIEW blogposts_update_2_columns_lwt_indicator as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator > 0 and lwt_indicator <= 2000 PRIMARY KEY(lwt_indicator, domain, published_date);
+  - create MATERIALIZED VIEW blogposts_update_2_columns_lwt_indicator as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator > 0 and lwt_indicator <= 100000 PRIMARY KEY(lwt_indicator, domain, published_date);
   - create MATERIALIZED VIEW blogposts_update_2_columns_lwt_indicator_after_update as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator = 20000000 PRIMARY KEY(lwt_indicator, domain, published_date);
   - create MATERIALIZED VIEW blogposts_not_updated_lwt_indicator as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator > 1000000 and lwt_indicator < 20000000 PRIMARY KEY(lwt_indicator, domain, published_date);
-  - create MATERIALIZED VIEW blogposts_deletions as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator > 10000 and lwt_indicator < 100000 PRIMARY KEY(lwt_indicator, domain, published_date);
+  - create MATERIALIZED VIEW blogposts_deletions as select lwt_indicator, author from blogposts where domain is not null and published_date is not null and lwt_indicator > 100000 and lwt_indicator < 900000 PRIMARY KEY(lwt_indicator, domain, published_date);
 
 ### Column Distribution Specifications ###
 
@@ -120,8 +120,8 @@ queries:
       cql: update blogposts set lwt_indicator = 30000000 where domain = ? and published_date = ? if lwt_indicator >=-2000 and lwt_indicator < 0
       fields: samerow
    lwt_update_two_columns:
-      cql: update blogposts set lwt_indicator = 20000000, author = 'text' where domain = ? and published_date = ? if lwt_indicator > 0 and lwt_indicator <= 2000 and author != 'text'
+      cql: update blogposts set lwt_indicator = 20000000, author = 'text' where domain = ? and published_date = ? if lwt_indicator > 0 and lwt_indicator <= 100000 and author != 'text'
       fields: samerow
    lwt_deletes:
-     cql: delete from blogposts where domain = ? and published_date = ? if lwt_indicator > 10000 and lwt_indicator < 100000
+     cql: delete from blogposts where domain = ? and published_date = ? if lwt_indicator > 100000 and lwt_indicator < 900000
      fields: samerow


### PR DESCRIPTION
increased the range of the MVs used for the data validator
as in one case it didn't have data, and failed.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
