### PR TITLE
fix(longevity-200GB-48h): Extend test timeout to 3100 minutes

### DIFF
--- a/test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
+++ b/test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
@@ -1,4 +1,4 @@
-test_duration: 2940
+test_duration: 3100
 prepare_write_cmd: "cassandra-stress write cl=ALL n=200200300  -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=1000 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..200200300 -log interval=15"
 # prepare_verify_cmd: "cassandra-stress read cl=ALL n=200200300  -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=2000 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..200200300 -log interval=15"
 


### PR DESCRIPTION
In recent runs the timeout of 2940 wasn't enough, extending to 3100.
If it's still not enoguh one will need to dig into it and check why.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
