### PR TITLE
fix(get_all_tables_with_cdc): Fix removing cdc_log_suffix

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3197,9 +3197,9 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
                                             filter_out_system=True,
                                             filter_out_mv=True)
         self.log.debug(all_ks_cf)
-        ks_tables_with_cdc = [ks_cf_cdc.strip(cdc.options.CDC_LOGTABLE_SUFFIX)
+        ks_tables_with_cdc = [ks_cf_cdc[:-len(cdc.options.CDC_LOGTABLE_SUFFIX)]
                               for ks_cf_cdc in all_ks_cf if ks_cf_cdc.endswith(cdc.options.CDC_LOGTABLE_SUFFIX)]
-        self.log.info(ks_tables_with_cdc)
+        self.log.debug(ks_tables_with_cdc)
 
         return ks_tables_with_cdc
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2583,7 +2583,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         self.log.info(f"Apply new cdc settigs for table {ks}.{table}: {cdc_settings}")
         self._alter_table_with_cdc_properties(ks, table, cdc_settings)
+        self.log.debug(f"Verify new cdc settings on table {ks}.{table}")
         self._verify_cdc_feature_status(ks, table, cdc_settings)
+        InfoEvent(f"{ks}.{table} have new cdc settings {cdc_settings}").publish()
 
     def disrupt_run_cdcstressor_tool(self):
         self._set_current_disruption(label="RunCDCStressorTool")
@@ -2632,19 +2634,22 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         with self.cluster.cql_connection_patient(self.target_node) as session:
             session.execute(cmd)
         # wait applying cdc configuration
-        time.sleep(15)
+        time.sleep(30)
 
     def _verify_cdc_feature_status(self, keyspace: str, table: str, cdc_settings: dict) -> None:
 
-        self.log.debug("Wait for cdc enabled and cdc log tables will be populated")
-        time.sleep(60)
         output = self.target_node.run_cqlsh(f"desc keyspace {keyspace}")
         self.log.debug(output.stdout)
 
         with self.cluster.cql_connection_patient(node=self.target_node) as session:
             actual_cdc_settings = cdc.options.get_table_cdc_properties(session, keyspace, table)
 
-        assert actual_cdc_settings == cdc_settings, f"CDC extension settings are differs"
+        if not cdc_settings["enabled"]:
+            assert (actual_cdc_settings["enabled"] is False,
+                    f"CDC options was not disabled. Current: {actual_cdc_settings} expected: {cdc_settings}")
+        else:
+            assert (actual_cdc_settings == cdc_settings,
+                    f"CDC extension settings are differs. Current: {actual_cdc_settings} expected: {cdc_settings}")
 
 
 def log_time_elapsed_and_status(method):  # pylint: disable=too-many-statements


### PR DESCRIPTION
On step removing cdc_log_suffix to get base table name
incorrectly used function strip(). if keyspace or
table starts or finished with chars from cdc_log_suffix
such chars removed and list contains wrong name of keyspace.table

Instead that, using the slicing

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (CI)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
