### PR TITLE
fix(c-s testbed failing): if c-s fails inside a nemesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -966,9 +966,13 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if ks not in test_keyspaces or not table_exist:
             stress_cmd = "cassandra-stress write n=400000 cl=QUORUM -port jmx=6868 -mode native cql3 " \
                          f"-schema 'replication(factor={self.tester.reliable_replication_factor})' -log interval=5"
-            cs_thread = self.tester.run_stress_thread(
-                stress_cmd=stress_cmd, keyspace_name=ks, stop_test_on_failure=False)
-            cs_thread.verify_results()
+            try:
+                cs_thread = self.tester.run_stress_thread(
+                    stress_cmd=stress_cmd, keyspace_name=ks, stop_test_on_failure=False)
+                cs_thread.verify_results()
+            except Exception as exc:  # pylint: disable=broad-except
+                self.log.error(exc)
+                raise UnsupportedNemesis("c-s failed to create test bed for this nemesis")
 
     def disrupt_truncate(self):
         self._set_current_disruption('TruncateMonkey {}'.format(self.target_node))


### PR DESCRIPTION
raise Unsupported exception (as nemesis will not be able
to run without specific table.
this fixes #3028

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
