### PR TITLE
fix(offline_install_scylla): reload env variables by SSH reconnect

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2047,6 +2047,11 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             self.remoter.run('sudo update-java-alternatives --jre-headless -s java-1.8.0-openjdk-amd64')
 
         if nonroot:
+            # Make sure env variable (XDG_RUNTIME_DIR) is set, which is necessary for systemd user
+            if not 'XDG_RUNTIME_DIR=' in self.remoter.run('env').stdout:
+                # Reload the env variables by ssh reconnect
+                self.remoter.run('env', verbose=True, change_context=True)
+                assert 'XDG_RUNTIME_DIR' in self.remoter.run('env', verbose=True).stdout
             install_cmds = dedent(f"""
                 tar xvfz ./unified_package.tar.gz
                 ./install.sh --nonroot {sysconfdir_option}


### PR DESCRIPTION
SSH session might establish before user-runtime-dir@1000.service is
ready. Nonroot offline install will fail if XDG_RUNTIME_DIR is empty.

This patch reconnect the ssh session before nonroot offline install,
then the latest env variables(includes XDG_RUNTIME_DIR) will be loaded.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
