### PR TITLE
Fix NonRoot offline install

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2036,20 +2036,17 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         # Offline install does't provide openjdk-8, it has to be installed in advance
         # https://github.com/scylladb/scylla-jmx/issues/127
         if self.is_rhel_like():
-            sysconfdir_option = ''
             self.remoter.run(f'sudo yum install -y java-1.8.0-openjdk {additional_pkgs}')
         elif self.distro.is_debian10:
-            sysconfdir_option = '--sysconfdir /etc/default'
             self.remoter.run(f'sudo apt-get install -y openjdk-11-jre-headless {additional_pkgs}')
         else:
-            sysconfdir_option = '--sysconfdir /etc/default'
             self.remoter.run(f'sudo apt-get install -y openjdk-8-jre-headless {additional_pkgs}')
             self.remoter.run('sudo update-java-alternatives --jre-headless -s java-1.8.0-openjdk-amd64')
 
         if nonroot:
             install_cmds = dedent(f"""
                 tar xvfz ./unified_package.tar.gz
-                ./install.sh --nonroot {sysconfdir_option}
+                ./install.sh --nonroot
                 sudo rm -f /tmp/scylla.yaml
             """)
             # Known issue: https://github.com/scylladb/scylla/issues/7071
@@ -2057,7 +2054,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         else:
             install_cmds = dedent(f"""
                 tar xvfz ./unified_package.tar.gz
-                ./install.sh --housekeeping {sysconfdir_option}
+                ./install.sh --housekeeping
                 rm -f /tmp/scylla.yaml
             """)
             self.remoter.run('sudo bash -cxe "%s"' % install_cmds)

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -929,8 +929,8 @@ class ScyllaAWSCluster(cluster.BaseScyllaCluster, AWSCluster):
     def _wait_for_preinstalled_scylla(node):
         node.wait_for_machine_image_configured()
 
-    def _scylla_post_install(self, node: AWSNode, new_scylla_installed: bool) -> None:
-        super()._scylla_post_install(node, new_scylla_installed)
+    def _scylla_post_install(self, node: AWSNode, new_scylla_installed: bool, devname: str) -> None:
+        super()._scylla_post_install(node, new_scylla_installed, devname)
         if self.params.get('ip_ssh_connections') == 'ipv6':
             node.set_web_listen_address()
 

--- a/sdcm/utils/remote_logger.py
+++ b/sdcm/utils/remote_logger.py
@@ -133,7 +133,7 @@ class SSHNonRootScyllaSystemdLogger(SSHLoggerBase):
     @property
     def _logger_cmd(self) -> str:
         scylla_log_file = '~/scylladb/scylla-server.log'
-        return f'test -e {scylla_log_file} && tail -f {scylla_log_file}'
+        return f'mkdir -p ~/scylladb && touch {scylla_log_file} && tail -f {scylla_log_file}'
 
 
 class SSHGeneralSystemdLogger(SSHLoggerBase):

--- a/sdcm/utils/remote_logger.py
+++ b/sdcm/utils/remote_logger.py
@@ -125,6 +125,17 @@ class SSHScyllaSystemdLogger(SSHLoggerBase):
                '-u scylla-jmx.service'
 
 
+class SSHNonRootScyllaSystemdLogger(SSHLoggerBase):
+    """
+    In NonRoot installation, scylla-server log is redirected a log file in install directory.
+    Related commit: https://github.com/scylladb/scylla/commit/0f786f05fed41be94b09e33aa34a767074a14ec1
+    """
+    @property
+    def _logger_cmd(self) -> str:
+        scylla_log_file = '~/scylladb/scylla-server.log'
+        return f'test -e {scylla_log_file} && tail -f {scylla_log_file}'
+
+
 class SSHGeneralSystemdLogger(SSHLoggerBase):
     @property
     def _logger_cmd(self) -> str:
@@ -282,6 +293,9 @@ def get_system_logging_thread(logs_transport, node, target_log_file):  # pylint:
         return KubectlGeneralLogger(node, target_log_file)
     if logs_transport == 'ssh':
         if node.init_system == 'systemd':
+            if 'db-node' in node.name and node.is_nonroot_install and node.remoter.run(
+                    'sudo test -e /var/log/journal', ignore_status=True).exit_status != 0:
+                return SSHNonRootScyllaSystemdLogger(node, target_log_file)
             if 'db-node' in node.name:
                 return SSHScyllaSystemdLogger(node, target_log_file)
             return SSHGeneralSystemdLogger(node, target_log_file)

--- a/sdcm/utils/remote_logger.py
+++ b/sdcm/utils/remote_logger.py
@@ -133,7 +133,7 @@ class SSHNonRootScyllaSystemdLogger(SSHLoggerBase):
     @property
     def _logger_cmd(self) -> str:
         scylla_log_file = '~/scylladb/scylla-server.log'
-        return f'mkdir -p ~/scylladb && touch {scylla_log_file} && tail -f {scylla_log_file}'
+        return f'mkdir -p ~/scylladb && touch {scylla_log_file} && tail -F {scylla_log_file}'
 
 
 class SSHGeneralSystemdLogger(SSHLoggerBase):


### PR DESCRIPTION
ticket: https://trello.com/c/B9Ld2Xdw/2741-address-track-offline-install-fails

Scylla-server log was redirected to ~/scylladb/scylla-server.log after
scylladb/scylla@0f786f0.

So current 'journalctl' cmdline can't fetch the scylla-server log, the 
log file in test result is empty.

This patch changed to fetch scylla-server log from different source for 
nonroot offline install.

Fixes https://github.com/scylladb/scylla-cluster-tests/issues/3066

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
