### PR TITLE
fix(cluster_k8s): check if cert-manager is actually operational

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -51,6 +51,7 @@ ANY_KUBERNETES_RESOURCE = Union[Resource, ResourceField, ResourceInstance, Resou
 
 SCYLLA_OPERATOR_CONFIG = sct_abs_path("sdcm/k8s_configs/operator.yaml")
 SCYLLA_MANAGER_CONFIG = sct_abs_path("sdcm/k8s_configs/manager.yaml")
+CERT_MANAGER_TEST_CONFIG = sct_abs_path("sdcm/k8s_configs/cert-manager-test.yaml")
 SCYLLA_API_VERSION = "scylla.scylladb.com/v1"
 SCYLLA_CLUSTER_RESOURCE_KIND = "ScyllaCluster"
 DEPLOY_SCYLLA_CLUSTER_DELAY = 15  # seconds
@@ -124,6 +125,12 @@ class KubernetesCluster:
                                namespace="cert-manager"))
         time.sleep(10)
         self.kubectl("wait --timeout=10m --all --for=condition=Ready pod", namespace="cert-manager")
+        wait_for(
+            self.check_if_cert_manager_fully_functional,
+            text='Waiting for cert-manager to become fully operational',
+            timeout=10 * 60,
+            step=10,
+            throw_exc=True)
         self.start_cert_manager_journal_thread()
 
     @log_run_info
@@ -133,6 +140,15 @@ class KubernetesCluster:
         time.sleep(10)
         self.kubectl("wait --timeout=10m --all --for=condition=Ready pod", namespace="scylla-manager-system")
         self.start_scylla_manager_journal_thread()
+
+    def check_if_cert_manager_fully_functional(self) -> bool:
+        # Cert-manager readiness status does not guarantee that it is fully operational
+        # This function checks it if is operational via deploying ca and issuing certificate
+        try:
+            self.apply_file(CERT_MANAGER_TEST_CONFIG)
+            return True
+        finally:
+            self.kubectl(f'delete -f {CERT_MANAGER_TEST_CONFIG}', ignore_status=True)
 
     @property
     def scylla_operator_log(self) -> str:

--- a/sdcm/k8s_configs/cert-manager-test.yaml
+++ b/sdcm/k8s_configs/cert-manager-test.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager-test
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: test-selfsigned
+  namespace: cert-manager-test
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: selfsigned-cert
+  namespace: cert-manager-test
+spec:
+  dnsNames:
+    - example.com
+  secretName: selfsigned-cert-tls
+  issuerRef:
+    name: test-selfsigned


### PR DESCRIPTION
https://trello.com/c/Hj70Xle2/2712-k8s-address-cert-manager-issue

https://cloudius-jenkins-test.s3.amazonaws.com/8e05f3e5-94a2-40e2-a318-3515c41ad4eb/20201214_090614/sct-runner-8e05f3e5.zip


Addressed issue when build fails due to the no operational cert-manager:

```
2020-12-14 09:05:56.914: (TestFrameworkEvent Severity.ERROR), source=LongevityTest.SetUp()
exception=Encountered a bad command exit code!
Command: 'kubectl apply -f <(envsubst</jenkins/slave/workspace/operator-master/longevity-scylla-operator-3h-gke-cluster-rolling/scylla-cluster-tests/sdcm/k8s_configs/operator.yaml)'
Exit code: 1
Stdout:
namespace/scylla-operator-system created
customresourcedefinition.apiextensions.k8s.io/scyllaclusters.scylla.scylladb.com created
mutatingwebhookconfiguration.admissionregistration.k8s.io/scylla-operator-mutating-webhook-configuration created
clusterrole.rbac.authorization.k8s.io/scylla-operator-manager-role created
clusterrolebinding.rbac.authorization.k8s.io/scylla-operator-manager-rolebinding created
service/scylla-operator-webhook-service created
statefulset.apps/scylla-operator-controller-manager created
issuer.cert-manager.io/scylla-operator-selfsigned-issuer created
validatingwebhookconfiguration.admissionregistration.k8s.io/scylla-operator-validating-webhook-configuration created
Stderr:
Error from server (InternalError): error when creating "/dev/fd/63": Internal error occurred: failed calling webhook "webhook.cert-manager.io": Post https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=30s: x509: certificate signed by unknown authority
```



## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
