### PR TITLE
feature(byo-job): Run gemini test with specific seed number

### DIFF
--- a/vars/byoLongevityPipeline.groovy
+++ b/vars/byoLongevityPipeline.groovy
@@ -51,6 +51,13 @@ def call() {
             string(defaultValue: '', description: '', name: 'scylla_repo')
 
             string(defaultValue: '',
+                   description: "Which version to use for oracle cluster during gemini test",
+                   name: "oracle_scylla_version")
+
+            string(defaultValue: '', description: 'run gemini with specific seed number',
+                   name: "gemini_seed")
+
+            string(defaultValue: '',
                    description: 'If empty - the default manager version will be taken',
                    name: 'scylla_mgmt_repo')
 

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -44,6 +44,14 @@ def call(Map params, String region){
         exit 1
     fi
 
+    if [[ -n "${params.oracle_scylla_version ? params.oracle_scylla_version : ''}" ]] ; then
+        export SCT_ORACLE_SCYLLA_VERSION="${params.oracle_scylla_version}"
+    fi
+
+    if [[ -n "${params.gemini_seed ? params.genini_seed : ''}" ]] ; then
+        export SCT_GEMINI_SEED="${params.gemini_seed}"
+    fi
+
     export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
     export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
     export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"


### PR DESCRIPTION
Add to BYO longevity job 2 new parameters ORACLE VERSION and GEMINI SEED
which allow to run BYO job for gemini test with specific seed number
for reproduce purposes

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] ~I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)~
- [ ] ~I didn't leave commented-out/debugging code~
- [ ] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (CI)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
