### PR TITLE
fix(gemini): Fix missing gemini command, screenshots in report

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1285,7 +1285,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     def verify_gemini_results(self, queue):
         results = queue.get_gemini_results()
 
-        stats = {'status': None, 'results': [], 'errors': {}, 'cmd': queue.gemini_commands}
+        stats = {'results': [], 'errors': {}}
         if not results:
             self.log.error('Gemini results are not found')
             stats['status'] = 'FAILED'


### PR DESCRIPTION
If gemini exits with exit code != 0, then executed gemini
command is not displayed in report. Fix by adding the
executing gemini command to gemini result before gemini start

Also fixed the missing screenshots and snapshots for gemini jobs

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] ~I didn't leave commented-out/debugging code~
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (CI)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
