### PR TITLE
fix(event_filters): change BROKEN_PIPE to CLIENT_DISCONNECT

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -12,7 +12,7 @@ FullScanEvent.start: NORMAL
 FullScanEvent.finish: ERROR
 DatabaseLogEvent.NO_SPACE_ERROR: ERROR
 DatabaseLogEvent.UNKNOWN_VERB: WARNING
-DatabaseLogEvent.BROKEN_PIPE: WARNING
+DatabaseLogEvent.CLIENT_DISCONNECT: WARNING
 DatabaseLogEvent.SEMAPHORE_TIME_OUT: WARNING
 DatabaseLogEvent.EMPTY_NESTED_EXCEPTION: WARNING
 DatabaseLogEvent.DATABASE_ERROR: ERROR

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -27,7 +27,7 @@ LOGGER = logging.getLogger(__name__)
 class DatabaseLogEvent(LogEvent, abstract=True):
     NO_SPACE_ERROR: Type[LogEventProtocol]
     UNKNOWN_VERB: Type[LogEventProtocol]
-    BROKEN_PIPE: Type[LogEventProtocol]
+    CLIENT_DISCONNECT: Type[LogEventProtocol]
     SEMAPHORE_TIME_OUT: Type[LogEventProtocol]
     EMPTY_NESTED_EXCEPTION: Type[LogEventProtocol]
     DATABASE_ERROR: Type[LogEventProtocol]
@@ -66,8 +66,8 @@ DatabaseLogEvent.add_subevent_type("NO_SPACE_ERROR", severity=Severity.ERROR,
                                    regex="No space left on device")
 DatabaseLogEvent.add_subevent_type("UNKNOWN_VERB", severity=Severity.WARNING,
                                    regex="unknown verb exception")
-DatabaseLogEvent.add_subevent_type("BROKEN_PIPE", severity=Severity.WARNING,
-                                   regex="cql_server - exception while processing connection:.*Broken pipe")
+DatabaseLogEvent.add_subevent_type("CLIENT_DISCONNECT", severity=Severity.WARNING,
+                                   regex=r"\!INFO.*cql_server - exception while processing connection:.*")
 DatabaseLogEvent.add_subevent_type("SEMAPHORE_TIME_OUT", severity=Severity.WARNING,
                                    regex="semaphore_timed_out")
 DatabaseLogEvent.add_subevent_type("EMPTY_NESTED_EXCEPTION", severity=Severity.WARNING,
@@ -106,7 +106,7 @@ DatabaseLogEvent.add_subevent_type("stream_exception", severity=Severity.ERROR,
 SYSTEM_ERROR_EVENTS = (
     DatabaseLogEvent.NO_SPACE_ERROR(),
     DatabaseLogEvent.UNKNOWN_VERB(),
-    DatabaseLogEvent.BROKEN_PIPE(),
+    DatabaseLogEvent.CLIENT_DISCONNECT(),
     DatabaseLogEvent.SEMAPHORE_TIME_OUT(),
     DatabaseLogEvent.EMPTY_NESTED_EXCEPTION(),
     DatabaseLogEvent.DATABASE_ERROR(),

--- a/unit_tests/test_sct_events_database.py
+++ b/unit_tests/test_sct_events_database.py
@@ -23,7 +23,7 @@ class TestDatabaseLogEvent(unittest.TestCase):
     def test_known_system_errors(self):
         self.assertTrue(issubclass(DatabaseLogEvent.NO_SPACE_ERROR, DatabaseLogEvent))
         self.assertTrue(issubclass(DatabaseLogEvent.UNKNOWN_VERB, DatabaseLogEvent)),
-        self.assertTrue(issubclass(DatabaseLogEvent.BROKEN_PIPE, DatabaseLogEvent)),
+        self.assertTrue(issubclass(DatabaseLogEvent.CLIENT_DISCONNECT, DatabaseLogEvent)),
         self.assertTrue(issubclass(DatabaseLogEvent.SEMAPHORE_TIME_OUT, DatabaseLogEvent)),
         self.assertTrue(issubclass(DatabaseLogEvent.EMPTY_NESTED_EXCEPTION, DatabaseLogEvent)),
         self.assertTrue(issubclass(DatabaseLogEvent.DATABASE_ERROR, DatabaseLogEvent)),


### PR DESCRIPTION
since scylladb/scylla@b8f7fb35e149ee6eb1bdbbc5cf9b4aa55772ac45, in scylla
there is a diffrent type of print being raised, we want to demote it to warning

Ref: https://github.com/scylladb/scylla/issues/5661

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
