### PR TITLE
fix(event_filters): change BROKEN_PIPE to CLIENT_DISCONNECT

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -399,8 +399,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         self._system_error_events = [
             DatabaseLogEvent(type='NO_SPACE_ERROR', regex='No space left on device'),
             DatabaseLogEvent(type='UNKNOWN_VERB', regex='unknown verb exception', severity=Severity.WARNING),
-            DatabaseLogEvent(type='BROKEN_PIPE', severity=Severity.WARNING,
-                             regex='cql_server - exception while processing connection:.*Broken pipe'),
+            DatabaseLogEvent(type='CLIENT_DISCONNECT', severity=Severity.WARNING,
+                             regex=r'\!INFO.*cql_server - exception while processing connection:.*'),
             DatabaseLogEvent(type='SEMAPHORE_TIME_OUT', regex='semaphore_timed_out', severity=Severity.WARNING),
             DatabaseLogEvent(type='DATABASE_ERROR', regex='Exception '),
             DatabaseLogEvent(type='BAD_ALLOC', regex='std::bad_alloc'),


### PR DESCRIPTION
since scylladb/scylla@b8f7fb35e149ee6eb1bdbbc5cf9b4aa55772ac45, in scylla
there is a diffrent type of print being raised, we want to demote it to warning

Ref: https://github.com/scylladb/scylla/issues/5661

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
