### PR TITLE
feature(rolling-upgrade): enable internode_compression for more tests

### DIFF
--- a/jenkins-pipelines/rolling-upgrade-ami.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-ami.jenkinsfile
@@ -11,6 +11,7 @@ rollingUpgradePipeline(
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
     test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
     workaround_kernel_bug_for_iotune: false,
+    internode_compression: 'all',
 
     timeout: [time: 360, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/rolling-upgrade-centos7.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-centos7.jenkinsfile
@@ -12,6 +12,7 @@ rollingUpgradePipeline(
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
     test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
     workaround_kernel_bug_for_iotune: false,
+    internode_compression: 'all',
 
     timeout: [time: 360, unit: 'MINUTES']
 )


### PR DESCRIPTION
Currently we only enabled internode_compression for rolling upgrade test
of CentOS8, Ubuntu18 and Ubuntu20.

This patch enabled internode_compression for rolling upgrade test of
CentOS7 and AMI as required by Roy.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
