### PR TITLE
improvement(perf pipeline): use now SCT runner

### DIFF
--- a/vars/createSctRunner.groovy
+++ b/vars/createSctRunner.groovy
@@ -4,6 +4,13 @@ def call(Map params, Integer test_duration, String region) {
 
     def cloud_provider = params.backend.trim().toLowerCase()
     println(params)
+    def test_id
+    if (params.test_id) {
+        test_id = params.test_id
+    } else {
+        test_id = env.SCT_TEST_ID
+    }
+
     sh """
     #!/bin/bash
     set -xe
@@ -11,7 +18,7 @@ def call(Map params, Integer test_duration, String region) {
 
     if [[ "$cloud_provider" == "aws" ]]; then
         rm -fv sct_runner_ip
-        ./docker/env/hydra.sh create-runner-instance --cloud-provider ${cloud_provider} --region ${region} --availability-zone ${params.availability_zone} --test-id \${SCT_TEST_ID} --duration ${test_duration}
+        ./docker/env/hydra.sh create-runner-instance --cloud-provider ${cloud_provider} --region ${region} --availability-zone ${params.availability_zone} --test-id ${test_id} --duration ${test_duration}
     else
         echo "Currently, <$cloud_provider> not supported to. Will run on regular builder."
     fi

--- a/vars/runCleanupResource.groovy
+++ b/vars/runCleanupResource.groovy
@@ -5,6 +5,13 @@ def call(Map params, String region){
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)
     def cloud_provider = params.backend.trim().toLowerCase()
 
+    def test_id
+    if (params.test_id) {
+        test_id = params.test_id
+    } else {
+        test_id = env.SCT_TEST_ID
+    }
+
     sh """
     #!/bin/bash
 
@@ -26,7 +33,7 @@ def call(Map params, String region){
     if [[ "$cloud_provider" == "aws" ]]; then
         SCT_RUNNER_IP=\$(cat sct_runner_ip||echo "")
         if [[ -n "\${SCT_RUNNER_IP}" ]] ; then
-            ./docker/env/hydra.sh --execute-on-runner \${SCT_RUNNER_IP} clean-resources --post-behavior --test-id \$SCT_TEST_ID
+            ./docker/env/hydra.sh --execute-on-runner \${SCT_RUNNER_IP} clean-resources --post-behavior --test-id ${test_id}
         else
             echo "SCT runner IP file is empty. Probably SCT Runner was not created."
             exit 1


### PR DESCRIPTION
moving the old format perf pipeline to use
all the capabilities of the SCT runner.

send email stage was also removed, as the
perf tests send the email from inside the
specific test.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
