### PR TITLE
feature(configurations): add audit.yaml

### DIFF
--- a/configurations/audit.yaml
+++ b/configurations/audit.yaml
@@ -1,0 +1,5 @@
+append_scylla_yaml: |
+  audit: "table"
+  audit_categories: "DCL,DDL,AUTH,ADMIN"
+  audit_tables: "keyspace1.standard1,scylla_bench.test"
+  audit_keyspaces: "keyspace1,scylla_bench"


### PR DESCRIPTION
This patch added a config file of audit, it will only be used for
scylla-enterprise.

The audit is only enabled for the default keyspaces and tables of
cassandra-stress and scylla-bench.

I will backport this commit to enterprise and use this config file
for some longevity jobs.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
