### PR TITLE
fix(scylla-operator-tests): increase test_duration to avoid test failures

### DIFF
--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-add-remove-rack.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-add-remove-rack.yaml
@@ -1,4 +1,4 @@
-test_duration: 240
+test_duration: 280
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
              ]
 # Should be n_db_nodes + 1

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-cluster-rolling.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-cluster-rolling.yaml
@@ -1,4 +1,4 @@
-test_duration: 240
+test_duration: 280
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
              ]
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-grow-shrink.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-grow-shrink.yaml
@@ -1,4 +1,4 @@
-test_duration: 240
+test_duration: 280
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
              ]
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-replace.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-replace.yaml
@@ -1,4 +1,4 @@
-test_duration: 240
+test_duration: 280
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
              ]
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-stop-start.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-stop-start.yaml
@@ -1,4 +1,4 @@
-test_duration: 240
+test_duration: 280
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
              ]
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-terminate-decommission-add.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-terminate-decommission-add.yaml
@@ -1,4 +1,4 @@
-test_duration: 240
+test_duration: 280
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
              ]
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-terminate-recover.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-terminate-recover.yaml
@@ -1,4 +1,4 @@
-test_duration: 240
+test_duration: 280
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
              ]
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-terminate-replace.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-terminate-replace.yaml
@@ -1,4 +1,4 @@
-test_duration: 240
+test_duration: 280
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
              ]
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-gke.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-gke.yaml
@@ -1,4 +1,4 @@
-test_duration: 240
+test_duration: 280
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
              ]
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-basic-3h-gke.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-basic-3h-gke.yaml
@@ -1,4 +1,4 @@
-test_duration: 240
+test_duration: 280
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
              ]
 


### PR DESCRIPTION
After recent changes test initialization started taking approximately 1 hour, which makes tests been stopped by timeout.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
