### PR TITLE
fix(nemesis): unset node nemesis before getting list of nodes

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -231,11 +231,11 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if is_seed is DefaultValue - if self.filter_seed is True it act as if is_seed=False,
           otherwise it will act as if is_seed is None
         """
+        self.unset_current_running_nemesis(self.target_node)
         nodes = self._get_target_nodes(is_seed=is_seed, dc_idx=dc_idx, rack=rack)
         if not nodes:
             raise UnsupportedNemesis("Can't allocate node to run nemesis on")
         # Set name of nemesis, which is going to run on target node
-        self.unset_current_running_nemesis(self.target_node)
         self.target_node = random.choice(nodes)
         self.set_current_running_nemesis(node=self.target_node)
         self.log.info('Current Target: %s with running nemesis: %s', self.target_node, self.target_node.running_nemesis)
@@ -249,12 +249,12 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if is_seed is DefaultValue - if self.filter_seed is True it act as if is_seed=False,
           otherwise it will act as if is_seed is None
         """
+        self.unset_current_running_nemesis(self.target_node)
         target_nodes = self._get_target_nodes(is_seed=is_seed, dc_idx=dc_idx, rack=rack)
         if not target_nodes:
             dc_str = '' if dc_idx is None else f'dc {dc_idx} '
             rack_str = '' if rack is None else f'rack {rack} '
             raise UnsupportedNemesis(f"Can't allocate node from {dc_str}{rack_str}to run nemesis on")
-        self.unset_current_running_nemesis(self.target_node)
         self.target_node = target_nodes[-1]
         self.set_current_running_nemesis(node=self.target_node)
         self.log.info('Current Target: %s with running nemesis: %s', self.target_node, self.target_node.running_nemesis)


### PR DESCRIPTION
In setup of three nodes cluster it does not allow to pick any node if node is already occupied

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
