### PR TITLE
fix(perf_query): Filter performance tests for last year

### DIFF
--- a/sdcm/results_analyze/__init__.py
+++ b/sdcm/results_analyze/__init__.py
@@ -436,7 +436,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
                     param, src[param], dst[param], version_dst))
         return cmp_res
 
-    def check_regression(self, test_id, is_gce=False, email_subject_postfix=None):
+    def check_regression(self, test_id, is_gce=False, email_subject_postfix=None, use_wide_query=False, lastyear=False):
         """
         Get test results by id, filter similar results and calculate max values for each version,
         then compare with max in the test version and all the found versions.
@@ -459,7 +459,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
             return False
 
         # filter tests
-        query = query_filter(doc, is_gce)
+        query = query_filter(doc, is_gce, use_wide_query, lastyear)
         if not query:
             return False
         self.log.debug("Query to ES: %s", query)
@@ -506,9 +506,9 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
                 self.log.error('Skip non-valid test: %s', row['_id'])
                 continue
             version_info = self._test_version(row)
-            version = version_info['version']
-            if not version:
+            if not version_info:
                 continue
+            version = version_info['version']
             curr_test_stats = self._test_stats(row)
             if not curr_test_stats:
                 continue

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2267,7 +2267,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         is_gce = bool(self.params.get('cluster_backend') == 'gce')
         try:
             results_analyzer.check_regression(self._test_id, is_gce,
-                                              email_subject_postfix=self.params.get('email_subject_postfix'))
+                                              email_subject_postfix=self.params.get('email_subject_postfix'),
+                                              use_wide_query=True)
         except Exception as ex:  # pylint: disable=broad-except
             self.log.exception('Failed to check regression: %s', ex)
 

--- a/sdcm/utils/es_queries.py
+++ b/sdcm/utils/es_queries.py
@@ -1,5 +1,7 @@
 import logging
 
+from datetime import datetime, timedelta
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -35,12 +37,16 @@ class QueryFilter():
         test_details += ' AND test_details.test_name: {}'.format(self.test_name.replace(":", r"\:"))
         return test_details
 
+    def filter_test_for_lastyear(self):
+        year_ago = (datetime.today() - timedelta(days=365)).date().strftime("%Y%m%d")
+        return f"versions.scylla-server.date:{{{year_ago} TO *}}"
+
     def test_cmd_details(self):
         raise NotImplementedError('Derived classes must implement this method.')
 
     def __call__(self, *args, **kwargs):
         try:
-            return '{} AND {}'.format(self.filter_test_details(), self.filter_setup_details())
+            return '{} AND {} AND {}'.format(self.filter_test_details(), self.filter_setup_details(), self.filter_test_for_lastyear())
         except KeyError:
             LOGGER.exception('Expected parameters for filtering are not found , test {}'.format(self.test_doc['_id']))
         return None


### PR DESCRIPTION
Add parameter to query for filtering result
for last year from current performance run

Trello: https://trello.com/c/XIHDxPL8

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (CI)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
