### PR TITLE
fix(perf regression): add steady state info events

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2616,7 +2616,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def steady_state_latency(self, sleep_time=None):
         if not sleep_time:
             sleep_time = self.cluster.params.get('nemesis_interval') * 60
+        InfoEvent(message=f'StartEvent - start a sleep of {sleep_time} as Steady State').publish()
         time.sleep(sleep_time)
+        InfoEvent(message='FinishEvent - Steady State sleep has been finished').publish()
 
     def disrupt_run_unique_sequence(self):
         sleep_time_between_ops = self.cluster.params.get('nemesis_sequence_sleep_between_ops')


### PR DESCRIPTION
these events went missing, probably during conflict
solving before the original PR was merged.
This is about `disrupt_run_unique_sequence` steady state
sleep time for compare latency during management
operations.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
