### PR TITLE
backport rolling upgrade ami to 2020.1

### DIFF
--- a/jenkins-pipelines/rolling-upgrade-ami.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-ami.jenkinsfile
@@ -1,0 +1,16 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+rollingUpgradePipeline(
+    backend: 'aws',
+    base_versions: ['2019.1', '4.0'],
+    linux_distro: 'centos',
+
+    test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
+    test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
+    workaround_kernel_bug_for_iotune: false,
+
+    timeout: [time: 360, unit: 'MINUTES']
+)

--- a/test-cases/upgrades/rolling-upgrade.yaml
+++ b/test-cases/upgrades/rolling-upgrade.yaml
@@ -18,6 +18,8 @@ n_db_nodes: 4
 n_loaders: 1
 n_monitor_nodes: 1
 
+instance_type_db: 'i3.2xlarge'
+
 user_prefix: 'rolling-upgrade'
 
 server_encrypt: true

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -16,6 +16,14 @@ def call(Map pipelineParams) {
                description: 'aws|gce',
                name: 'backend')
 
+            string(defaultValue: "${pipelineParams.get('aws_region', 'eu-west-1')}",
+               description: 'Supported: us-east-1|eu-west-1|eu-west-2|eu-north-1|random (randomly select region)',
+               name: 'aws_region')
+            string(defaultValue: "a",
+               description: 'Availability zone',
+               name: 'availability_zone')
+
+            string(defaultValue: '', description: '', name: 'scylla_ami_id')
             string(defaultValue: '', description: '', name: 'new_scylla_repo')
 
             string(defaultValue: "${pipelineParams.get('provision_type', 'spot_low_price')}",
@@ -69,7 +77,7 @@ def call(Map pipelineParams) {
 
                                                         rm -fv ./latest
 
-                                                        export SCT_CLUSTER_BACKEND=gce
+                                                        export SCT_CLUSTER_BACKEND=${params.backend}
 
                                                         export SCT_CONFIG_FILES=${pipelineParams.test_config}
                                                         export SCT_SCYLLA_VERSION=${base_version}
@@ -107,11 +115,11 @@ def call(Map pipelineParams) {
                                                         set -xe
                                                         env
 
-                                                        export SCT_CLUSTER_BACKEND=gce
+                                                        export SCT_CLUSTER_BACKEND=${params.backend}
                                                         export SCT_CONFIG_FILES=${pipelineParams.test_config}
 
                                                         echo "start collect logs ..."
-                                                        ./docker/env/hydra.sh collect-logs --logdir "`pwd`" --backend gce
+                                                        ./docker/env/hydra.sh collect-logs --logdir "`pwd`" --backend ${params.backend}
                                                         echo "end collect logs"
                                                         """
                                                     }


### PR DESCRIPTION
The trigger rolling-upgrade-ami-test failed for lacking of jenkins pipeline.
- https://jenkins.scylladb.com/job/enterprise-2020.1/job/rolling-upgrade/job/rolling-upgrade-ami-test/3/console

Currently we pend https://github.com/scylladb/scylla-cluster-tests/pull/3086, because it enabled internode_compression for some rolling upgrade tests, we want to backport it to 2020.1 after 2020.1.6 release.

This PR only backport commits to support rolling upgrade ami to 2020.1, (internode compression isn't enabled).


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
