### PR TITLE
fix(supportedUpgradeFromVersions): don't estimate enterprise from branch suffix

### DIFF
--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -62,7 +62,7 @@ def call(Map pipelineParams) {
                     script {
                         def tasks = [:]
 
-                        for (version in supportedUpgradeFromVersions(env.GIT_BRANCH, pipelineParams.base_versions)) {
+                        for (version in supportedUpgradeFromVersions(pipelineParams.base_versions, pipelineParams.new_scylla_repo)) {
                             def base_version = version
                             tasks["${base_version}"] = {
                                 node(builder.label) {

--- a/vars/supportedUpgradeFromVersions.groovy
+++ b/vars/supportedUpgradeFromVersions.groovy
@@ -1,8 +1,7 @@
 #!groovy
 
-def call(String git_branch, List base_versions_list) {
-    def clean_branch_name = git_branch.tokenize('-')[-1]
-    if (is_enterprise_version(clean_branch_name)) {
+def call(List base_versions_list, String new_scylla_repo) {
+    if (new_scylla_repo.contains('enterprise')) {
         return base_versions_list
     } else {
         return base_versions_list.findAll{ ! is_enterprise_version(it) }


### PR DESCRIPTION
Currently we estimate if the new scylla is enterprise or not by
parsing the git branch suffix. It doesn't work if we test with a
private branch in BYO job.

This patch changed to estimate it by checking 'enterprise' word
in the new_scylla_repo url.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
