### PR TITLE
fix(versions): latest released to version under test

### DIFF
--- a/jenkins-pipelines/rolling-upgrade-ami.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-ami.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'aws',
-    base_versions: ['2019.1', '4.0'],
+    base_versions: ['2019.1', '4.0', '2020.1'],
     linux_distro: 'centos',
 
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',

--- a/jenkins-pipelines/rolling-upgrade-centos7.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-centos7.jenkinsfile
@@ -7,7 +7,7 @@ rollingUpgradePipeline(
     params: params,
 
     backend: 'gce',
-    base_versions: ['2019.1', '4.0'],
+    base_versions: ['2019.1', '4.0', '2020.1'],
     linux_distro: 'centos',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7',
 

--- a/jenkins-pipelines/rolling-upgrade-debian9.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-debian9.jenkinsfile
@@ -7,7 +7,7 @@ rollingUpgradePipeline(
     params: params,
 
     backend: 'gce',
-    base_versions: ['2019.1', '4.0'],
+    base_versions: ['2019.1', '4.0', '2020.1'],
     linux_distro: 'debian-stretch',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-9',
 

--- a/jenkins-pipelines/rolling-upgrade-ubuntu16.04.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-ubuntu16.04.jenkinsfile
@@ -7,7 +7,7 @@ rollingUpgradePipeline(
     params: params,
 
     backend: 'gce',
-    base_versions: ['2019.1', '4.0'],
+    base_versions: ['2019.1', '4.0', '2020.1'],
     linux_distro: 'ubuntu-xenial',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts',
 

--- a/jenkins-pipelines/rolling-upgrade-ubuntu18.04.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-ubuntu18.04.jenkinsfile
@@ -7,7 +7,7 @@ rollingUpgradePipeline(
     params: params,
 
     backend: 'gce',
-    base_versions: ['2019.1', '4.0'],
+    base_versions: ['2019.1', '4.0', '2020.1'],
     linux_distro: 'ubuntu-bionic',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-1804-lts',
 


### PR DESCRIPTION
we are not currently testing the current version
under test to be upgraded from latest released.
adding what should be `2020.1:latest`.

THIS IS TO BE MERGED TO `branch-2020.1`


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
