### PR TITLE
fix(TerminateAndRemoveNodeMonkey): added event filter for repair errors

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2165,13 +2165,24 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self._terminate_cluster_node(node_to_remove)
 
         # full cluster repair
-        for node in up_normal_nodes:
-            if node is not node_to_remove:
-                try:
-                    self.repair_nodetool_repair(node=node)
-                except Exception as details:  # pylint: disable=broad-except
-                    self.log.error(f"failed to execute repair command "
-                                   f"on node {node} due to the following error: {str(details)}")
+        up_normal_nodes.remove(node_to_remove)
+        # Repairing the first node will result in a best effort repair due to the terminated node,
+        # and as a result requires ignoring repair errors
+        first_node_to_repair = up_normal_nodes[0]
+        with DbEventsFilter(db_event=DatabaseLogEvent.RUNTIME_ERROR,
+                            line="failed to repair",
+                            node=first_node_to_repair):
+            try:
+                self.repair_nodetool_repair(node=first_node_to_repair)
+            except Exception as details:  # pylint: disable=broad-except
+                self.log.error(f"failed to execute repair command "
+                               f"on node {first_node_to_repair} due to the following error: {str(details)}")
+        for node in up_normal_nodes[1:]:
+            try:
+                self.repair_nodetool_repair(node=node)
+            except Exception as details:  # pylint: disable=broad-except
+                self.log.error(f"failed to execute repair command "
+                               f"on node {node} due to the following error: {str(details)}")
 
         def remove_node():
             # nodetool removenode 'host_id'


### PR DESCRIPTION
Due to the terminated node, the first repair after the termination is a 'best effort repair'.
Because of that, the first repair will cause repair error events to rise, and as such I ignored such
events in this pr.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
