### PR TITLE
fix(perf latency with nemesis): fix mixed workload metrics

### DIFF
--- a/sdcm/report_templates/results_latency_during_ops.html
+++ b/sdcm/report_templates/results_latency_during_ops.html
@@ -24,11 +24,8 @@
         {% endfor %}
         </ul>
     </div>
-
-    {% for workload_type, operations in stats.items() %}
-        <h1>Test {{ workload_type }}</h1>
         <div>
-            {% for operation, results in operations.items() %}
+            {% for operation, results in stats.items() %}
                 {% if operation != 'Steady State' %}
                     <h2>{{ operation }}</h2>
                     <table id="results_table">
@@ -55,7 +52,7 @@
                                     <td>{{ cycle[lat_type] }}</td>
                                 {% endfor %}
                                 <td>{{ results['Cycles Average'][lat_type] }}</td>
-                                <td>{{ operations['Steady State'][lat_type] }}</td>
+                                <td>{{ stats['Steady State'][lat_type] }}</td>
                                 <td>{{ results['Relative to Steady'][lat_type] }}</td>
                             </tr>
                         {% endfor %}
@@ -63,7 +60,6 @@
                 {% endif %}
             {% endfor %}
         </div>
-    {% endfor %}
 
     <h3>Links:</h3>
     <ul>

--- a/sdcm/utils/decorators.py
+++ b/sdcm/utils/decorators.py
@@ -167,27 +167,25 @@ def latency_calculator_decorator(func):
         test_name = args[0].tester.__repr__().split('testMethod=')[-1].split('>')[0]
         monitor = args[0].monitoring_set.nodes[0]
         if 'read' in test_name:
-            workload = ['read']
+            workload = 'read'
         elif 'write' in test_name:
-            workload = ['write']
+            workload = 'write'
         elif 'mixed' in test_name:
-            workload = ['read', 'write']
+            workload = 'mixed'
         else:
             return res
-        for workload_type in workload:
-            if workload_type not in args[0].cluster.latency_results:
-                args[0].cluster.latency_results[workload_type] = dict()
-            if "steady" not in func.__name__.lower():
-                if func.__name__ not in args[0].cluster.latency_results[workload_type]:
-                    args[0].cluster.latency_results[workload_type][func.__name__] = dict()
-                if 'cycles' not in args[0].cluster.latency_results[workload_type][func.__name__]:
-                    args[0].cluster.latency_results[workload_type][func.__name__]['cycles'] = list()
-            result = latency.collect_latency(monitor, start, end, workload_type, args[0].cluster, all_nodes_list)
-            if "steady" in func.__name__.lower() and \
-                    'Steady State' not in args[0].cluster.latency_results[workload_type]:
-                args[0].cluster.latency_results[workload_type]['Steady State'] = result
-            else:
-                args[0].cluster.latency_results[workload_type][func.__name__]['cycles'].append(result)
+
+        if "steady" not in func.__name__.lower():
+            if func.__name__ not in args[0].cluster.latency_results:
+                args[0].cluster.latency_results[func.__name__] = dict()
+            if 'cycles' not in args[0].cluster.latency_results[func.__name__]:
+                args[0].cluster.latency_results[func.__name__]['cycles'] = list()
+        result = latency.collect_latency(monitor, start, end, workload, args[0].cluster, all_nodes_list)
+        if "steady" in func.__name__.lower() and \
+                'Steady State' not in args[0].cluster.latency_results:
+            args[0].cluster.latency_results['Steady State'] = result
+        else:
+            args[0].cluster.latency_results[func.__name__]['cycles'].append(result)
         return res
 
     return wrapped


### PR DESCRIPTION
fix(perf latency with nemesis): fix mixed workload metrics

the original work considered taking read and write metrics
from both c-s and Scylla, where in c-s there is a 3rd
metric, "mixed" for mixed workloads.
changed a bit the format of the stored data, as there
is no more meaning to have the kind of workload that
was originally introduced to deal with mixed workloads,
so now the read and write metrics from Scylla will
appear one after the other in the result table, for mixed
workloads.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
