### PR TITLE
fix(perfRegressionParallelPipeline): send no email from pipeline

### DIFF
--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -177,28 +177,6 @@ def call(Map pipelineParams) {
                                                 }
                                             }
                                         }
-                                        stage("Send email with result for ${sub_test}") {
-                                            catchError(stageResult: 'FAILURE') {
-                                                script {
-                                                    wrap([$class: 'BuildUser']) {
-                                                        dir('scylla-cluster-tests') {
-                                                            def email_recipients = groovy.json.JsonOutput.toJson(params.email_recipients)
-
-                                                            sh """
-                                                            #!/bin/bash
-
-                                                            set -xe
-                                                            env
-
-                                                            echo "Start send email ..."
-                                                            ./docker/env/hydra.sh send-email --logdir "`pwd`" --email-recipients "${email_recipients}"
-                                                            echo "Email sent"
-                                                            """
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
Performance tests are sending email from the test.
While sending email step from the pipeline generates misleading "ABORTED: ..." email

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
