### PR TITLE
fix(cluster_k8s): make scheme inline with current operator scheme

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -48,7 +48,7 @@ from sdcm.cluster_k8s.operator_monitoring import ScyllaOperatorLogMonitoring, Sc
 ANY_KUBERNETES_RESOURCE = Union[Resource, ResourceField, ResourceInstance, ResourceList, Subresource]
 
 SCYLLA_OPERATOR_CONFIG = sct_abs_path("sdcm/k8s_configs/operator.yaml")
-SCYLLA_API_VERSION = "scylla.scylladb.com/v1alpha1"
+SCYLLA_API_VERSION = "scylla.scylladb.com/v1"
 SCYLLA_CLUSTER_RESOURCE_KIND = "ScyllaCluster"
 DEPLOY_SCYLLA_CLUSTER_DELAY = 15  # seconds
 

--- a/sdcm/k8s_configs/cluster-gke.yaml
+++ b/sdcm/k8s_configs/cluster-gke.yaml
@@ -73,7 +73,7 @@ subjects:
 ---
 
 # Scylla Cluster
-apiVersion: scylla.scylladb.com/v1alpha1
+apiVersion: scylla.scylladb.com/v1
 kind: ScyllaCluster
 metadata:
   labels:

--- a/sdcm/k8s_configs/cluster-minikube.yaml
+++ b/sdcm/k8s_configs/cluster-minikube.yaml
@@ -73,7 +73,7 @@ subjects:
 ---
 
 # Simple Scylla Cluster
-apiVersion: scylla.scylladb.com/v1alpha1
+apiVersion: scylla.scylladb.com/v1
 kind: ScyllaCluster
 metadata:
   labels:

--- a/sdcm/k8s_configs/operator.yaml
+++ b/sdcm/k8s_configs/operator.yaml
@@ -158,6 +158,34 @@ spec:
                             description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                             type: object
                         type: object
+                      agentVolumeMounts:
+                        description: AgentVolumeMounts to be added to Agent container.
+                        items:
+                          description: VolumeMount describes a mounting of a Volume within a container.
+                          properties:
+                            mountPath:
+                              description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                              type: boolean
+                            subPath:
+                              description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                              type: string
+                            subPathExpr:
+                              description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                              type: string
+                          required:
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
                       members:
                         description: Members is the number of Scylla instances in this rack.
                         format: int32
@@ -597,7 +625,7 @@ spec:
                           type: object
                         type: array
                       volumes:
-                        description: Volumes added to Scylla container.
+                        description: Volumes added to Scylla Pod.
                         items:
                           description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
                           properties:
@@ -1422,10 +1450,7 @@ spec:
                   description: FailureStrategy specifies which logic is executed when upgrade failure happens. Currently only Retry is supported.
                   type: string
                 pollInterval:
-                  description: PollInterval specifies how often upgrade logic polls on state updates. Increasing this value should lower number of requests sent to apiserver, but it may affect overall time required spent during upgrade.
-                  type: string
-                validationTimeout:
-                  description: ValidationTimeout specifies how long it can take for Scylla to boot and enter ready state after upgrade until FailureStrategy is executed.
+                  description: PollInterval specifies how often upgrade logic polls on state updates. Increasing this value should lower number of requests sent to apiserver, but it may affect overall time spent during upgrade.
                   type: string
               type: object
             network:
@@ -1453,7 +1478,7 @@ spec:
                     description: Host to repair, by default all hosts are repaired
                     type: string
                   intensity:
-                    description: Intensity how many token ranges (per shard) to repair in a single Scylla repair job. By default this is 1. If you set it to 0 the number of token ranges is adjusted to the maximum supported by node (see max_repair_ranges_in_parallel in Scylla logs). Valid values are 0 and integers >= 1. Higher values will result in increased cluster load and slightly faster repairs. Changing the intensity impacts repair granularity if you need to resume it, the higher the value the more work on resume. For Scylla clusters that DO NOT SUPPORT ROW-LEVEL REPAIR, intensity can be a decimal between (0,1). In that case it specifies percent of shards that can be repaired in parallel on a repair master node. For Scylla clusters that are row-level repair enabled, setting intensity below 1 has the same effect as setting intensity 1.
+                    description: Intensity how many token ranges (per shard) to repair in a single Scylla repair job. By default this is 1. If you set it to 0 the number of token ranges is adjusted to the maximum supported by node (see max_repair_ranges_in_parallel in Scylla logs). Valid values are 0 and integers >= 1. Higher values will result in increased cluster load and slightly faster repairs. Changing the intensity impacts repair granularity if you need to resume it, the higher the value the more work on resume. For Scylla clusters that *do not support row-level repair*, intensity can be a decimal between (0,1). In that case it specifies percent of shards that can be repaired in parallel on a repair master node. For Scylla clusters that are row-level repair enabled, setting intensity below 1 has the same effect as setting intensity 1.
                     type: string
                   interval:
                     description: Interval task schedule interval e.g. 3d2h10m, valid units are d, h, m, s (default "0").
@@ -1631,7 +1656,7 @@ spec:
                   id:
                     type: string
                   intensity:
-                    description: Intensity how many token ranges (per shard) to repair in a single Scylla repair job. By default this is 1. If you set it to 0 the number of token ranges is adjusted to the maximum supported by node (see max_repair_ranges_in_parallel in Scylla logs). Valid values are 0 and integers >= 1. Higher values will result in increased cluster load and slightly faster repairs. Changing the intensity impacts repair granularity if you need to resume it, the higher the value the more work on resume. For Scylla clusters that DO NOT SUPPORT ROW-LEVEL REPAIR, intensity can be a decimal between (0,1). In that case it specifies percent of shards that can be repaired in parallel on a repair master node. For Scylla clusters that are row-level repair enabled, setting intensity below 1 has the same effect as setting intensity 1.
+                    description: Intensity how many token ranges (per shard) to repair in a single Scylla repair job. By default this is 1. If you set it to 0 the number of token ranges is adjusted to the maximum supported by node (see max_repair_ranges_in_parallel in Scylla logs). Valid values are 0 and integers >= 1. Higher values will result in increased cluster load and slightly faster repairs. Changing the intensity impacts repair granularity if you need to resume it, the higher the value the more work on resume. For Scylla clusters that *do not support row-level repair*, intensity can be a decimal between (0,1). In that case it specifies percent of shards that can be repaired in parallel on a repair master node. For Scylla clusters that are row-level repair enabled, setting intensity below 1 has the same effect as setting intensity 1.
                     type: string
                   interval:
                     description: Interval task schedule interval e.g. 3d2h10m, valid units are d, h, m, s (default "0").
@@ -1695,9 +1720,9 @@ spec:
               type: object
           type: object
       type: object
-  version: v1alpha1
+  version: v1
   versions:
-  - name: v1alpha1
+  - name: v1
     served: true
     storage: true
 status:
@@ -1720,14 +1745,14 @@ webhooks:
     service:
       name: scylla-operator-webhook-service
       namespace: scylla-operator-system
-      path: /mutate-scylla-scylladb-com-v1alpha1-scyllacluster
+      path: /mutate-scylla-scylladb-com-v1-scyllacluster
   failurePolicy: Fail
   name: webhook.scylla.scylladb.com
   rules:
   - apiGroups:
     - scylla.scylladb.com
     apiVersions:
-    - v1alpha1
+    - v1
     operations:
     - CREATE
     - UPDATE
@@ -1782,7 +1807,6 @@ rules:
   - delete
   - get
   - list
-  - update
   - watch
 - apiGroups:
   - ""
@@ -1966,14 +1990,14 @@ webhooks:
     service:
       name: scylla-operator-webhook-service
       namespace: scylla-operator-system
-      path: /validate-scylla-scylladb-com-v1alpha1-scyllacluster
+      path: /validate-scylla-scylladb-com-v1-scyllacluster
   failurePolicy: Fail
   name: webhook.scylla.scylladb.com
   rules:
   - apiGroups:
     - scylla.scylladb.com
     apiVersions:
-    - v1alpha1
+    - v1
     operations:
     - CREATE
     - UPDATE

--- a/sdcm/k8s_configs/provisioner/values.yaml
+++ b/sdcm/k8s_configs/provisioner/values.yaml
@@ -83,7 +83,7 @@ daemonset:
   #
   # Defines Provisioner's image name including container registry.
   #
-  image: quay.io/external_storage/local-volume-provisioner:v2.2.0
+  image: quay.io/external_storage/local-volume-provisioner:v2.3.4
   #
   # Defines Image download policy, see kubernetes documentation for available values.
   #


### PR DESCRIPTION
https://trello.com/c/BBFkfUHO/2787-k8s-update-operator-scheme

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
