### PR TITLE
fix(ignore_ycsb_connection_refused): wrong regex caused evalutaion error

### DIFF
--- a/sdcm/sct_events/filters.py
+++ b/sdcm/sct_events/filters.py
@@ -75,7 +75,10 @@ class EventsFilter(BaseFilter):
 
     @cached_property
     def _regex(self):
-        return self.regex and re.compile(self.regex, self.regex_flags)
+        try:
+            return self.regex and re.compile(self.regex, self.regex_flags)
+        except Exception as exc:
+            raise ValueError(f'Compilation of the regexp "{self.regex}" failed with error: {exc}') from None
 
     def cancel_filter(self) -> None:
         if self.extra_time_to_expiration:

--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -152,5 +152,5 @@ def ignore_mutation_write_errors():
 
 @contextmanager
 def ignore_ycsb_connection_refused():
-    with EventsFilter(event_class=YcsbStressEvent, regex='*Unable to execute HTTP request: Connection refused.*'):
+    with EventsFilter(event_class=YcsbStressEvent, regex='.*Unable to execute HTTP request: Connection refused.*'):
         yield


### PR DESCRIPTION
https://trello.com/c/V9Vm043V/2762-rolling-upgrade-failed-with-reerror-nothing-to-repeat-at-position-0

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~

Fixed test failing with following error:
```
12:09:30  Exception in thread Thread-2:
12:09:30  Traceback (most recent call last):
12:09:30    File "/usr/local/lib/python3.9/threading.py", line 954, in _bootstrap_inner
12:09:30      self.run()
12:09:30    File "/jenkins/slave/workspace/scylla-master/rolling-upgrade/rolling-upgrade-alternator-test/scylla-cluster-tests/sdcm/sct_events/grafana.py", line 44, in run
12:09:30      for event_tuple in self.inbound_events():  # pylint: disable=no-member; pylint doesn't understand generics
12:09:30    File "/jenkins/slave/workspace/scylla-master/rolling-upgrade/rolling-upgrade-alternator-test/scylla-cluster-tests/sdcm/sct_events/events_processes.py", line 81, in inbound_events
12:09:30      yield from cast(OutboundEventsProtocol[T_inbound_event],
12:09:30    File "/jenkins/slave/workspace/scylla-master/rolling-upgrade/rolling-upgrade-alternator-test/scylla-cluster-tests/sdcm/sct_events/events_device.py", line 160, in outbound_events
12:09:30      obj_filtered = any([f.eval_filter(obj) for f in filters.values()])
12:09:30    File "/jenkins/slave/workspace/scylla-master/rolling-upgrade/rolling-upgrade-alternator-test/scylla-cluster-tests/sdcm/sct_events/events_device.py", line 160, in <listcomp>
12:09:30      obj_filtered = any([f.eval_filter(obj) for f in filters.values()])
12:09:30    File "/jenkins/slave/workspace/scylla-master/rolling-upgrade/rolling-upgrade-alternator-test/scylla-cluster-tests/sdcm/sct_events/filters.py", line 88, in eval_filter
12:09:30      if self._regex:
12:09:30    File "/usr/local/lib/python3.9/functools.py", line 969, in __get__
12:09:30  Process EventsFileLogger-2:
12:09:30      val = self.func(instance)
12:09:30    File "/jenkins/slave/workspace/scylla-master/rolling-upgrade/rolling-upgrade-alternator-test/scylla-cluster-tests/sdcm/sct_events/filters.py", line 78, in _regex
12:09:30      return self.regex and re.compile(self.regex, self.regex_flags)
12:09:30    File "/usr/local/lib/python3.9/re.py", line 252, in compile
12:09:30      return _compile(pattern, flags)
12:09:30    File "/usr/local/lib/python3.9/re.py", line 304, in _compile
12:09:30      p = sre_compile.compile(pattern, flags)
12:09:30    File "/usr/local/lib/python3.9/sre_compile.py", line 764, in compile
12:09:30      p = sre_parse.parse(p, flags)
12:09:30    File "/usr/local/lib/python3.9/sre_parse.py", line 948, in parse
12:09:30      p = _parse_sub(source, state, flags & SRE_FLAG_VERBOSE, 0)
12:09:30    File "/usr/local/lib/python3.9/sre_parse.py", line 443, in _parse_sub
12:09:30      itemsappend(_parse(source, state, verbose, nested + 1,
12:09:30    File "/usr/local/lib/python3.9/sre_parse.py", line 668, in _parse
12:09:30  Exception in thread Thread-5:
12:09:30  Traceback (most recent call last):
12:09:30    File "/usr/local/lib/python3.9/threading.py", line 954, in _bootstrap_inner
12:09:30      self.run()
12:09:30    File "/jenkins/slave/workspace/scylla-master/rolling-upgrade/rolling-upgrade-alternator-test/scylla-cluster-tests/sdcm/sct_events/events_analyzer.py", line 39, in run
12:09:30      for event_tuple in self.inbound_events():
12:09:30    File "/jenkins/slave/workspace/scylla-master/rolling-upgrade/rolling-upgrade-alternator-test/scylla-cluster-tests/sdcm/sct_events/events_processes.py", line 81, in inbound_events
12:09:30      yield from cast(OutboundEventsProtocol[T_inbound_event],
12:09:30    File "/jenkins/slave/workspace/scylla-master/rolling-upgrade/rolling-upgrade-alternator-test/scylla-cluster-tests/sdcm/sct_events/events_device.py", line 160, in outbound_events
12:09:30      obj_filtered = any([f.eval_filter(obj) for f in filters.values()])
12:09:30    File "/jenkins/slave/workspace/scylla-master/rolling-upgrade/rolling-upgrade-alternator-test/scylla-cluster-tests/sdcm/sct_events/events_device.py", line 160, in <listcomp>
12:09:30      obj_filtered = any([f.eval_filter(obj) for f in filters.values()])
12:09:30    File "/jenkins/slave/workspace/scylla-master/rolling-upgrade/rolling-upgrade-alternator-test/scylla-cluster-tests/sdcm/sct_events/filters.py", line 88, in eval_filter
12:09:30      if self._regex:
12:09:30    File "/usr/local/lib/python3.9/functools.py", line 969, in __get__
12:09:30      val = self.func(instance)
12:09:30    File "/jenkins/slave/workspace/scylla-master/rolling-upgrade/rolling-upgrade-alternator-test/scylla-cluster-tests/sdcm/sct_events/filters.py", line 78, in _regex
12:09:30      return self.regex and re.compile(self.regex, self.regex_flags)
12:09:30    File "/usr/local/lib/python3.9/re.py", line 252, in compile
12:09:30      return _compile(pattern, flags)
12:09:30    File "/usr/local/lib/python3.9/re.py", line 304, in _compile
12:09:30      p = sre_compile.compile(pattern, flags)
12:09:30    File "/usr/local/lib/python3.9/sre_compile.py", line 764, in compile
12:09:30      p = sre_parse.parse(p, flags)
12:09:30    File "/usr/local/lib/python3.9/sre_parse.py", line 948, in parse
12:09:30      p = _parse_sub(source, state, flags & SRE_FLAG_VERBOSE, 0)
12:09:30    File "/usr/local/lib/python3.9/sre_parse.py", line 443, in _parse_sub
12:09:30      itemsappend(_parse(source, state, verbose, nested + 1,
12:09:30    File "/usr/local/lib/python3.9/sre_parse.py", line 668, in _parse
12:09:30      raise source.error("nothing to repeat",
12:09:30  re.error: nothing to repeat at position 0
12:09:30      raise source.error("nothing to repeat",
12:09:30  re.error: nothing to repeat at position 0
12:09:30  Traceback (most recent call last):
12:09:30    File "/usr/local/lib/python3.9/multiprocessing/process.py", line 315, in _bootstrap
12:09:30      self.run()
12:09:30    File "/jenkins/slave/workspace/scylla-master/rolling-upgrade/rolling-upgrade-alternator-test/scylla-cluster-tests/sdcm/sct_events/file_logger.py", line 69, in run
12:09:30      for event_tuple in self.inbound_events():
12:09:30    File "/jenkins/slave/workspace/scylla-master/rolling-upgrade/rolling-upgrade-alternator-test/scylla-cluster-tests/sdcm/sct_events/events_processes.py", line 81, in inbound_events
12:09:30      yield from cast(OutboundEventsProtocol[T_inbound_event],
12:09:30    File "/jenkins/slave/workspace/scylla-master/rolling-upgrade/rolling-upgrade-alternator-test/scylla-cluster-tests/sdcm/sct_events/events_device.py", line 160, in outbound_events
12:09:30      obj_filtered = any([f.eval_filter(obj) for f in filters.values()])
12:09:30    File "/jenkins/slave/workspace/scylla-master/rolling-upgrade/rolling-upgrade-alternator-test/scylla-cluster-tests/sdcm/sct_events/events_device.py", line 160, in <listcomp>
12:09:30      obj_filtered = any([f.eval_filter(obj) for f in filters.values()])
12:09:30    File "/jenkins/slave/workspace/scylla-master/rolling-upgrade/rolling-upgrade-alternator-test/scylla-cluster-tests/sdcm/sct_events/filters.py", line 88, in eval_filter
12:09:30      if self._regex:
12:09:30    File "/usr/local/lib/python3.9/functools.py", line 969, in __get__
12:09:30      val = self.func(instance)
12:09:30    File "/jenkins/slave/workspace/scylla-master/rolling-upgrade/rolling-upgrade-alternator-test/scylla-cluster-tests/sdcm/sct_events/filters.py", line 78, in _regex
12:09:30      return self.regex and re.compile(self.regex, self.regex_flags)
12:09:30    File "/usr/local/lib/python3.9/re.py", line 252, in compile
12:09:30      return _compile(pattern, flags)
12:09:30    File "/usr/local/lib/python3.9/re.py", line 304, in _compile
12:09:30      p = sre_compile.compile(pattern, flags)
12:09:30    File "/usr/local/lib/python3.9/sre_compile.py", line 764, in compile
12:09:30      p = sre_parse.parse(p, flags)
12:09:30    File "/usr/local/lib/python3.9/sre_parse.py", line 948, in parse
12:09:30      p = _parse_sub(source, state, flags & SRE_FLAG_VERBOSE, 0)
12:09:30    File "/usr/local/lib/python3.9/sre_parse.py", line 443, in _parse_sub
12:09:30      itemsappend(_parse(source, state, verbose, nested + 1,
12:09:30    File "/usr/local/lib/python3.9/sre_parse.py", line 668, in _parse
12:09:30      raise source.error("nothing to repeat",
12:09:30  re.error: nothing to repeat at position 0
```

