### PR TITLE
Ldap SaslauthdAuthenticator test

### DIFF
--- a/configurations/ldap-authenticator.yaml
+++ b/configurations/ldap-authenticator.yaml
@@ -1,0 +1,5 @@
+authenticator: 'com.scylladb.auth.SaslauthdAuthenticator'
+authenticator_user: 'cassandra'
+authenticator_password: 'cassandra'
+authorizer: 'CassandraAuthorizer'
+prepare_saslauthd: true

--- a/configurations/ldap-authorization-and-authentication.yaml
+++ b/configurations/ldap-authorization-and-authentication.yaml
@@ -5,3 +5,4 @@ authenticator_user: 'cassandra'
 authenticator_password: 'cassandra'
 
 authorizer: 'CassandraAuthorizer'
+use_ldap_authorization: true

--- a/jenkins-pipelines/longevity-100gb-4h-ldap-auth.jenkinsfile
+++ b/jenkins-pipelines/longevity-100gb-4h-ldap-auth.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/ldap-authorization-and-authentication.yaml"]''',
+
+    timeout: [time: 360, unit: 'MINUTES']
+)

--- a/jenkins-pipelines/longevity-10gb-3h-ldap-auth.jenkinsfile
+++ b/jenkins-pipelines/longevity-10gb-3h-ldap-auth.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-10gb-3h.yaml", "configurations/ldap-authenticator.yaml"]''',
+
+    timeout: [time: 300, unit: 'MINUTES']
+)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1803,7 +1803,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 if 'auto_bootstrap' in scylla_yml:
                     scylla_yml['auto_bootstrap'] = False
 
-            if authenticator in ['AllowAllAuthenticator', 'PasswordAuthenticator']:
+            if authenticator in ['AllowAllAuthenticator', 'PasswordAuthenticator', 'com.scylladb.auth.SaslauthdAuthenticator']:
                 scylla_yml['authenticator'] = authenticator
 
             if authorizer in ['AllowAllAuthorizer', 'CassandraAuthorizer']:
@@ -3032,6 +3032,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
         self.params = params
         self.datacenter = region_names or []
         self.dead_nodes_list = []
+        self.use_saslauthd_authenticator = self.params.get('use_saslauthd_authenticator')
 
         if Setup.REUSE_CLUSTER:
             # get_node_ips_param should be defined in child
@@ -3164,7 +3165,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
         node.destroy()
 
     def get_db_auth(self):
-        if self.params.get('use_ldap_authorization') and self.params.get('are_ldap_users_on_scylla'):
+        if (self.params.get('use_ldap_authorization') or self.use_saslauthd_authenticator) and self.params.get('are_ldap_users_on_scylla'):
             user = LDAP_USERS[0]
             password = LDAP_PASSWORD
         else:

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1711,6 +1711,10 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
     def create_ldap_users_on_scylla(self):
         self.run_cqlsh(f'CREATE ROLE \'{LDAP_ROLE}\' WITH SUPERUSER=true')
         for user in LDAP_USERS:
+            if user == 'cassandra':
+                # User `cassandra' has been created by default
+                continue
+        for user in LDAP_USERS:
             self.run_cqlsh(f'CREATE ROLE \'{user}\' WITH login=true AND password=\'{LDAP_PASSWORD}\'')
 
     # pylint: disable=invalid-name,too-many-arguments,too-many-locals,too-many-branches,too-many-statements

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -489,22 +489,33 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         using SaslauthdAuthenticator. We have same account (cassandra) for SaslauthdAuthenticator
         and PasswordAuthenticator, so it can be toggled smoothly without effect to c-s workloads.
 
-        It's only support to switch from PasswordAuthenticator, the authenticator will be reset
-        back in the end of nemesis.
+        It's only support to switch between PasswordAuthenticator and SaslauthdAuthenticator,
+        the authenticator will be reset back in the end of nemesis.
         """
         self._set_current_disruption('ToggleAuthenticatorType %s' % self.target_node)
-        # Switch to com.scylladb.auth.SaslauthdAuthenticator
-        if self.cluster.params.get('prepare_saslauthd') and 'PasswordAuthenticator' in self.cluster.params.get('authenticator'):
-            update_authenticator(self.cluster.nodes, 'com.scylladb.auth.SaslauthdAuthenticator')
+        result = self.target_node.remoter.run("grep -o '^authenticator: .*' /etc/scylla/scylla.yaml")
+        if 'com.scylladb.auth.SaslauthdAuthenticator' in result.stdout:
+            orig_auth = 'com.scylladb.auth.SaslauthdAuthenticator'
+            opposite_auth = 'PasswordAuthenticator'
+        elif 'PasswordAuthenticator' in result.stdout:
+            orig_auth = 'PasswordAuthenticator'
+            opposite_auth = 'com.scylladb.auth.SaslauthdAuthenticator'
+        else:
+            raise UnsupportedNemesis(
+                'This nemesis only supports to switch between SaslauthdAuthenticator and PasswordAuthenticator')
+        if self.cluster.params.get('prepare_saslauthd'):
+            update_authenticator(self.cluster.nodes, opposite_auth)
             try:
                 # Run connect a new session after authenticator switch, and run a short workload
                 self._prepare_test_table(ks='keyspace_for_authenticator_switch', table='standard1')
             finally:
-                update_authenticator(self.cluster.nodes, 'PasswordAuthenticator')
+                update_authenticator(self.cluster.nodes, orig_auth)
 
             # Run connect a new session after authenticator switch, drop the test keyspace
             with self.cluster.cql_connection_patient(self.target_node) as session:
                 session.execute(f'DROP KEYSPACE keyspace_for_authenticator_switch')
+        else:
+            raise UnsupportedNemesis("SaslauthdAuthenticator can't work without saslauthd environment")
 
     def disrupt_restart_with_resharding(self):
         self._set_current_disruption('RestartNodeWithResharding %s' % self.target_node)

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -38,7 +38,8 @@ from sdcm.cluster import SCYLLA_YAML_PATH, NodeSetupTimeout, NodeSetupFailed, Cl
 from sdcm.cluster import NodeStayInClusterAfterDecommission
 from sdcm.mgmt import TaskStatus
 from sdcm.utils.common import remote_get_file, get_db_tables, generate_random_string, \
-    update_certificates, reach_enospc_on_node, clean_enospc_on_node, parse_nodetool_listsnapshots
+    update_certificates, reach_enospc_on_node, clean_enospc_on_node, parse_nodetool_listsnapshots, \
+    update_authenticator
 from sdcm.utils import cdc
 from sdcm.utils.decorators import retrying, latency_calculator_decorator, timeout
 from sdcm.utils.docker_utils import ContainerManager
@@ -481,6 +482,29 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def disrupt_rolling_restart_cluster(self, random=False):
         self._set_current_disruption('RollingRestartCluster %s' % self.target_node)
         self.cluster.restart_scylla(random=random)
+
+    def disrupt_toggle_authenticator_type(self):
+        """
+        If prepare_saslauthd is enabled, saslauthd and ldap environment will be prepared for
+        using SaslauthdAuthenticator. We have same account (cassandra) for SaslauthdAuthenticator
+        and PasswordAuthenticator, so it can be toggled smoothly without effect to c-s workloads.
+
+        It's only support to switch from PasswordAuthenticator, the authenticator will be reset
+        back in the end of nemesis.
+        """
+        self._set_current_disruption('ToggleAuthenticatorType %s' % self.target_node)
+        # Switch to com.scylladb.auth.SaslauthdAuthenticator
+        if self.cluster.params.get('prepare_saslauthd') and 'PasswordAuthenticator' in self.cluster.params.get('authenticator'):
+            update_authenticator(self.cluster.nodes, 'com.scylladb.auth.SaslauthdAuthenticator')
+            try:
+                # Run connect a new session after authenticator switch, and run a short workload
+                self._prepare_test_table(ks='keyspace_for_authenticator_switch', table='standard1')
+            finally:
+                update_authenticator(self.cluster.nodes, 'PasswordAuthenticator')
+
+            # Run connect a new session after authenticator switch, drop the test keyspace
+            with self.cluster.cql_connection_patient(self.target_node) as session:
+                session.execute(f'DROP KEYSPACE keyspace_for_authenticator_switch')
 
     def disrupt_restart_with_resharding(self):
         self._set_current_disruption('RestartNodeWithResharding %s' % self.target_node)
@@ -3638,6 +3662,14 @@ class ClusterRollingRestartRandomOrder(Nemesis):
     @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_rolling_restart_cluster(random=True)
+
+
+class ToggleAuthenticatorType(Nemesis):
+    disruptive = True  # the nemesis has rolling restart
+
+    @log_time_elapsed_and_status
+    def disrupt(self):
+        self.disrupt_toggle_authenticator_type()
 
 
 class TopPartitions(Nemesis):

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -483,7 +483,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self._set_current_disruption('RollingRestartCluster %s' % self.target_node)
         self.cluster.restart_scylla(random=random)
 
-    def disrupt_toggle_authenticator_type(self):
+    def disrupt_switch_between_PasswordAuthenticator_and_SaslauthdAuthenticator_and_back(self):
         """
         If prepare_saslauthd is enabled, saslauthd and ldap environment will be prepared for
         using SaslauthdAuthenticator. We have same account (cassandra) for SaslauthdAuthenticator
@@ -492,7 +492,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         It's only support to switch between PasswordAuthenticator and SaslauthdAuthenticator,
         the authenticator will be reset back in the end of nemesis.
         """
-        self._set_current_disruption('ToggleAuthenticatorType %s' % self.target_node)
+        self._set_current_disruption('SwitchBetweenPasswordAuthAndSaslauthdAuth %s' % self.target_node)
         result = self.target_node.remoter.run("grep -o '^authenticator: .*' /etc/scylla/scylla.yaml")
         if 'com.scylladb.auth.SaslauthdAuthenticator' in result.stdout:
             orig_auth = 'com.scylladb.auth.SaslauthdAuthenticator'
@@ -509,11 +509,13 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 # Run connect a new session after authenticator switch, and run a short workload
                 self._prepare_test_table(ks='keyspace_for_authenticator_switch', table='standard1')
             finally:
+                # Wait 2 mins to let the workloads run with new Authenticator,
+                # then switch Authenticator back to original
+                time.sleep(120)
                 update_authenticator(self.cluster.nodes, orig_auth)
-
-            # Run connect a new session after authenticator switch, drop the test keyspace
-            with self.cluster.cql_connection_patient(self.target_node) as session:
-                session.execute(f'DROP KEYSPACE keyspace_for_authenticator_switch')
+                # Run connect a new session after authenticator switch, drop the test keyspace
+                with self.cluster.cql_connection_patient(self.target_node) as session:
+                    session.execute(f'DROP KEYSPACE keyspace_for_authenticator_switch')
         else:
             raise UnsupportedNemesis("SaslauthdAuthenticator can't work without saslauthd environment")
 
@@ -3675,12 +3677,12 @@ class ClusterRollingRestartRandomOrder(Nemesis):
         self.disrupt_rolling_restart_cluster(random=True)
 
 
-class ToggleAuthenticatorType(Nemesis):
+class SwitchBetweenPasswordAuthAndSaslauthdAuth(Nemesis):
     disruptive = True  # the nemesis has rolling restart
 
     @log_time_elapsed_and_status
     def disrupt(self):
-        self.disrupt_toggle_authenticator_type()
+        self.disrupt_switch_between_PasswordAuthenticator_and_SaslauthdAuthenticator_and_back()
 
 
 class TopPartitions(Nemesis):

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -254,6 +254,12 @@ class SCTConfiguration(dict):
         dict(name="use_ldap_authorization", env="SCT_USE_LDAP_AUTHORIZATION", type=boolean,
              help="When defined true, will create a docker container with LDAP and configure scylla.yaml to use it"),
 
+        dict(name="use_saslauthd_authenticator", env="SCT_USE_LDAP_AUTHENTICATOR", type=boolean,
+             help="When defined true, will create a docker container with LDAP and configure scylla.yaml to use it"),
+
+        dict(name="prepare_saslauthd", env="SCT_PREPARE_SASLAUTHD", type=boolean,
+             help="When defined true, will install and start saslauthd service"),
+
         dict(name="use_mgmt", env="SCT_USE_MGMT", type=boolean,
              help="When define true, will install scylla management"),
 

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -365,7 +365,7 @@ class SCTConfiguration(dict):
 
         dict(name="authenticator", env="SCT_AUTHENTICATOR", type=str,
              help="which authenticator scylla will use AllowAllAuthenticator/PasswordAuthenticator",
-             choices=("PasswordAuthenticator", "AllowAllAuthenticator"),
+             choices=("PasswordAuthenticator", "AllowAllAuthenticator", "com.scylladb.auth.SaslauthdAuthenticator"),
              ),
 
         dict(name="authenticator_user", env="SCT_AUTHENTICATOR_USER", type=str,

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -305,6 +305,11 @@ class ClusterTester(db_stats.TestStatsMixin,
                           {'uniqueMember': unique_members_list, 'userPassword': user_password}]
             self.localhost.add_ldap_entry(ip=ldap_address[0], ldap_port=ldap_address[1],
                                           user=ldap_username, password=LDAP_PASSWORD, ldap_entry=ldap_entry)
+        if self.params.get("prepare_saslauthd"):
+            ldap_entry = [f'uid=cassandra,ou=Person,{self.test_ldap_docker.ldap_base_object}',
+                ['uidObject', 'organizationalPerson', 'top'],
+                {'userPassword': LDAP_PASSWORD, 'sn': 'PersonSn', 'cn': 'PersonCn'}]
+            self.localhost.add_ldap_entry(ldap_entry)
         self.alternator = alternator.api.Alternator(sct_params=self.params)
         start_events_device(log_dir=self.logdir, _registry=self.events_processes_registry)
         time.sleep(0.5)

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -317,9 +317,10 @@ class ClusterTester(db_stats.TestStatsMixin,
                                           user=ldap_username, password=LDAP_PASSWORD, ldap_entry=ldap_entry)
             # Buildin user also need to be added in ldap server, otherwise it can't login to create LDAP_USERS
             for user in [self.params.get('authenticator_user')] + LDAP_USERS:
+                password = LDAP_PASSWORD if user in LDAP_USERS else self.params.get("authenticator_password")
                 ldap_entry = [f'uid={user},ou=Person,{LDAP_BASE_OBJECT}',
                               ['uidObject', 'organizationalPerson', 'top'],
-                              {'userPassword': LDAP_PASSWORD, 'sn': 'PersonSn', 'cn': 'PersonCn'}]
+                              {'userPassword': password, 'sn': 'PersonSn', 'cn': 'PersonCn'}]
                 self.localhost.add_ldap_entry(ip=ldap_address[0], ldap_port=ldap_address[1],
                                               user=ldap_username, password=LDAP_PASSWORD, ldap_entry=ldap_entry)
         self.alternator = alternator.api.Alternator(sct_params=self.params)

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -478,7 +478,7 @@ class ClusterTester(db_stats.TestStatsMixin,
                 self.legacy_init_nodes(db_cluster=self.db_cluster)
             else:
                 self.init_nodes(db_cluster=self.db_cluster)
-            if self.params.get('use_ldap_authorization') and not self.params.get('are_ldap_users_on_scylla'):
+            if (self.params.get('use_ldap_authorization') and not self.params.get('are_ldap_users_on_scylla')) or self.params.get('prepare_saslauthd'):
                 self.db_cluster.nodes[0].create_ldap_users_on_scylla()
                 self.params['are_ldap_users_on_scylla'] = True
             self.set_system_auth_rf()

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -57,7 +57,7 @@ from sdcm.utils.common import format_timestamp, wait_ami_available, tag_ami, upd
     rows_to_list
 from sdcm.utils.get_username import get_username
 from sdcm.utils.decorators import log_run_info, retrying
-from sdcm.utils.ldap import LDAP_USERS, LDAP_PASSWORD, LDAP_ROLE, LDAP_BASE_OBJECT, BUILDIN_USERS
+from sdcm.utils.ldap import LDAP_USERS, LDAP_PASSWORD, LDAP_ROLE, LDAP_BASE_OBJECT
 from sdcm.utils.log import configure_logging, handle_exception
 from sdcm.db_stats import PrometheusDBStats
 from sdcm.results_analyze import PerformanceResultsAnalyzer, SpecifiedStatsPerformanceAnalyzer, \
@@ -316,7 +316,7 @@ class ClusterTester(db_stats.TestStatsMixin,
             self.localhost.add_ldap_entry(ip=ldap_address[0], ldap_port=ldap_address[1],
                                           user=ldap_username, password=LDAP_PASSWORD, ldap_entry=ldap_entry)
             # Buildin user also need to be added in ldap server, otherwise it can't login to create LDAP_USERS
-            for user in BUILDIN_USERS + LDAP_USERS:
+            for user in [self.params.get('authenticator_user')] + LDAP_USERS:
                 ldap_entry = [f'uid={user},ou=Person,{LDAP_BASE_OBJECT}',
                               ['uidObject', 'organizationalPerson', 'top'],
                               {'userPassword': LDAP_PASSWORD, 'sn': 'PersonSn', 'cn': 'PersonCn'}]

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -2257,5 +2257,6 @@ def update_authenticator(nodes, authenticator='AllowAllAuthenticator', restart=T
         node.remoter.run(
             f"sed -ie 's/^authenticator:.*/authenticator: {authenticator}/g' /etc/scylla/scylla.yaml")
         if restart:
+            node.use_saslauthd_authenticator = authenticator == 'com.scylladb.auth.SaslauthdAuthenticator'
             node.restart_scylla_server()
             node.wait_db_up()

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -2254,7 +2254,7 @@ def update_authenticator(nodes, authenticator='AllowAllAuthenticator', restart=T
     Update the authenticator of nodes, restart the nodes to make the change effective
     """
     for node in nodes:
-        node.remoter.run(
+        node.remoter.sudo(
             f"sed -ie 's/^authenticator:.*/authenticator: {authenticator}/g' /etc/scylla/scylla.yaml")
         if restart:
             node.use_saslauthd_authenticator = authenticator == 'com.scylladb.auth.SaslauthdAuthenticator'

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -62,6 +62,7 @@ from sdcm.utils.aws_utils import EksClusterCleanupMixin
 from sdcm.utils.ssh_agent import SSHAgent
 from sdcm.utils.decorators import retrying
 from sdcm import wait
+from sdcm.utils.ldap import LDAP_PASSWORD, LDAP_USERS
 
 LOGGER = logging.getLogger('utils')
 DEFAULT_AWS_REGION = "eu-west-1"
@@ -2254,9 +2255,12 @@ def update_authenticator(nodes, authenticator='AllowAllAuthenticator', restart=T
     Update the authenticator of nodes, restart the nodes to make the change effective
     """
     for node in nodes:
-        node.remoter.sudo(
-            f"sed -ie 's/^authenticator:.*/authenticator: {authenticator}/g' /etc/scylla/scylla.yaml")
+        with node.remote_scylla_yaml() as scylla_yml:
+            scylla_yml['authenticator'] = authenticator
         if restart:
+            if authenticator == 'com.scylladb.auth.SaslauthdAuthenticator':
+                node.run_cqlsh(f'ALTER ROLE \'{LDAP_USERS[0]}\' with password=\'{LDAP_PASSWORD}\'')
             node.use_saslauthd_authenticator = authenticator == 'com.scylladb.auth.SaslauthdAuthenticator'
+            node.parent_cluster.params['are_ldap_users_on_scylla'] = node.use_saslauthd_authenticator
             node.restart_scylla_server()
             node.wait_db_up()

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -2247,3 +2247,15 @@ def walk_thru_data(data, path: str) -> Any:
             continue
         current = current.get(name, None)
     return current
+
+
+def update_authenticator(nodes, authenticator='AllowAllAuthenticator', restart=True):
+    """
+    Update the authenticator of nodes, restart the nodes to make the change effective
+    """
+    for node in nodes:
+        node.remoter.run(
+            f"sed -ie 's/^authenticator:.*/authenticator: {authenticator}/g' /etc/scylla/scylla.yaml")
+        if restart:
+            node.restart_scylla_server()
+            node.wait_db_up()

--- a/sdcm/utils/ldap.py
+++ b/sdcm/utils/ldap.py
@@ -24,7 +24,8 @@ ORGANISATION = 'ScyllaDB'
 LDAP_DOMAIN = 'scylladb.com'
 LDAP_PASSWORD = 'scylla'
 LDAP_ROLE = 'scylla_ldap'
-LDAP_USERS = ['cassandra', 'scylla-qa', 'dummy-user']
+LDAP_USERS = ['scylla-qa', 'dummy-user']
+BUILDIN_USERS = ['cassandra']
 LDAP_BASE_OBJECT = (lambda l: ','.join([f'dc={part}' for part in l.split('.')]))(LDAP_DOMAIN)
 
 

--- a/sdcm/utils/ldap.py
+++ b/sdcm/utils/ldap.py
@@ -25,7 +25,6 @@ LDAP_DOMAIN = 'scylladb.com'
 LDAP_PASSWORD = 'scylla'
 LDAP_ROLE = 'scylla_ldap'
 LDAP_USERS = ['scylla-qa', 'dummy-user']
-BUILDIN_USERS = ['cassandra']
 LDAP_BASE_OBJECT = (lambda l: ','.join([f'dc={part}' for part in l.split('.')]))(LDAP_DOMAIN)
 
 

--- a/sdcm/utils/ldap.py
+++ b/sdcm/utils/ldap.py
@@ -24,7 +24,7 @@ ORGANISATION = 'ScyllaDB'
 LDAP_DOMAIN = 'scylladb.com'
 LDAP_PASSWORD = 'scylla'
 LDAP_ROLE = 'scylla_ldap'
-LDAP_USERS = ['scylla-qa', 'dummy-user']
+LDAP_USERS = ['cassandra', 'scylla-qa', 'dummy-user']
 LDAP_BASE_OBJECT = (lambda l: ','.join([f'dc={part}' for part in l.split('.')]))(LDAP_DOMAIN)
 
 


### PR DESCRIPTION
Ticket: https://trello.com/c/qr1W8k1A/2292-ldap-sasl-authentication

This PR added support of running SaslauthdAuthenticator test, and extended an existing nemesis to switch Authenticator.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
