### PR TITLE
fix(manager): Added 'Aborted' task status

### DIFF
--- a/sdcm/mgmt.py
+++ b/sdcm/mgmt.py
@@ -94,6 +94,7 @@ class TaskStatus:
     ERROR = "ERROR"
     STOPPED = "STOPPED"
     STARTING = "STARTING"
+    ABORTED = "ABORTED"
 
     @classmethod
     def from_str(cls, output_str):
@@ -375,7 +376,7 @@ class ManagerTask(ScyllaManagerBase):
         2) return the final status.
         :return:
         """
-        list_final_status = [TaskStatus.ERROR, TaskStatus.STOPPED, TaskStatus.DONE]
+        list_final_status = [TaskStatus.ERROR, TaskStatus.STOPPED, TaskStatus.DONE, TaskStatus.ABORTED]
         LOGGER.debug("Waiting for task: {} getting to a final status ({})..".format(self.id, str(list_final_status)))
         res = self.wait_for_status(list_status=list_final_status, timeout=timeout, step=step)
         if not res:


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
