### PR TITLE
Manager sanity: ignoring repair errors and removing clusters at the end of each test

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -518,9 +518,13 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         with DbEventsFilter(db_event=DatabaseLogEvent.DATABASE_ERROR, line="failed to do checksum for"), \
                 DbEventsFilter(db_event=DatabaseLogEvent.RUNTIME_ERROR, line="failed to do checksum for"), \
                 DbEventsFilter(db_event=DatabaseLogEvent.DATABASE_ERROR, line="Reactor stalled"), \
+                DbEventsFilter(db_event=DatabaseLogEvent.RUNTIME_ERROR, line="failed to repair"), \
+                DbEventsFilter(db_event=DatabaseLogEvent.RUNTIME_ERROR, line="repair id "), \
                 DbEventsFilter(db_event=DatabaseLogEvent.RUNTIME_ERROR, line="get_repair_meta: repair_meta_id"):
 
             self.db_cluster.enable_client_encrypt()
+
+            repair_task.wait_for_status(list_status=[TaskStatus.ERROR], step=5, timeout=240)
 
         mgr_cluster.update(client_encrypt=True)
         repair_task.start()

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -285,7 +285,10 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         mgr_cluster.update(name="{}_renamed".format(cluster_orig_name))
         assert mgr_cluster.name == cluster_orig_name+"_renamed", "Cluster name wasn't changed after update command"
         mgr_cluster.delete()
-        manager_tool.add_cluster(name=cluster_name, host=selected_host, auth_token=self.monitors.mgmt_auth_token)
+        mgr_cluster = manager_tool.add_cluster(name=cluster_name, host=selected_host,
+                                               auth_token=self.monitors.mgmt_auth_token)
+
+        mgr_cluster.delete()  # remove cluster at the end of the test
         self.log.info('finishing test_mgmt_cluster_crud')
 
     def get_cluster_hosts_ip(self):
@@ -446,6 +449,8 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         backup_task = mgr_cluster.create_backup_task(location_list=location_list)
         backup_task.wait_for_status(list_status=[TaskStatus.DONE])
         self.verify_backup_success(mgr_cluster=mgr_cluster, backup_task=backup_task)
+
+        mgr_cluster.delete()  # remove cluster at the end of the test
         self.log.info('finishing test_basic_backup')
 
     def test_backup_multiple_ks_tables(self):
@@ -528,6 +533,8 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         for host_health in dict_host_health.values():
             assert host_health.ssl == HostSsl.ON, "Not all hosts ssl is 'ON'"
             assert host_health.status == HostStatus.UP, "Not all hosts status is 'UP'"
+
+        mgr_cluster.delete()  # remove cluster at the end of the test
         self.log.info('finishing test_client_encryption')
 
     def test_mgmt_cluster_healthcheck(self):
@@ -559,6 +566,8 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         assert dict_host_health[other_host_ip].rest_status == HostRestStatus.DOWN, "Host: {} REST status is not 'DOWN'".format(
             other_host_ip)
         other_host.start_scylla_server()
+
+        mgr_cluster.delete()  # remove cluster at the end of the test
         self.log.info('finishing test_mgmt_cluster_healthcheck')
 
     def test_ssh_setup_script(self):
@@ -673,6 +682,8 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         assert localstrategy_keyspace_percentage is None, \
             "The keyspace with the replication strategy of localstrategy was included in repair, when it shouldn't"
         self.log.info("the sctool repair command was completed successfully")
+
+        mgr_cluster.delete()  # remove cluster at the end of the test
         self.log.info('finishing test_repair_multiple_keyspace_types')
 
     def test_enospc_during_backup(self):


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
