### PR TITLE
fix(restart_then_repair_node): change event in filter

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -414,7 +414,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self._set_current_disruption('RestartThenRepairNode %s' % self.target_node)
         # Task https://trello.com/c/llRuLIOJ/2110-add-dbeventfilter-for-nosuchcolumnfamily-error
         # If this error happens during the first boot with the missing disk this issue is expected and it's not an issue
-        with DbEventsFilter(db_event=LogEvent, line="Can't find a column family with UUID", node=self.target_node):
+        with DbEventsFilter(db_event=DatabaseLogEvent.DATABASE_ERROR,
+                            line="Can't find a column family with UUID", node=self.target_node):
             self.target_node.restart()
 
         self.log.info('Waiting scylla services to start after node restart')


### PR DESCRIPTION
Error "Can't find a column family with UUID" is DatabaseLogEvent.DATABASE_ERROR,
not LogEvent. Due this the error was not filtered and fails the test.

This error appears in the https://jenkins.scylladb.com/job/scylla-master/job/longevity/job/longevity-50gb-3days/54/ and reported as error

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
