### PR TITLE
fix(cluster): AWS or GCE runs with public connectivity and use_mgmt=true are failing

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1244,7 +1244,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
     def is_manager_agent_up(self, port=None):
         port = port if port else self.MANAGER_AGENT_PORT
         # When the agent is IP, it should answer an https request of https://NODE_IP:10001/ping with status code 204
-        response = requests.get(f"https://{normalize_ipv6_url(self.ip_address)}:{port}/ping", verify=False)
+        response = requests.get(f"https://{normalize_ipv6_url(self.external_address)}:{port}/ping", verify=False)
         return response.status_code == 204
 
     def wait_manager_agent_up(self, verbose=True, timeout=180):


### PR DESCRIPTION
run with:
use_mgmt=true
ip_ssh_connections=public

Are failing with becaise ip_address use intra_node_comm_public to decide on using public or private:
```
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR > Traceback (most recent call last):
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/mnt/linux-drive-1/java/scylla/scylla-cluster-tests/sdcm/tester.py", line 121, in wrapper
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     return method(*args, **kwargs)
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/mnt/linux-drive-1/java/scylla/scylla-cluster-tests/sdcm/utils/decorators.py", line 110, in inner
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     res = func(*args, **kwargs)
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/mnt/linux-drive-1/java/scylla/scylla-cluster-tests/sdcm/tester.py", line 453, in setUp
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     self.init_nodes(db_cluster=self.db_cluster)
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/mnt/linux-drive-1/java/scylla/scylla-cluster-tests/sdcm/tester.py", line 404, in init_nodes
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     db_cluster.wait_for_init(node_list=db_cluster.nodes)
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/mnt/linux-drive-1/java/scylla/scylla-cluster-tests/sdcm/cluster.py", line 3300, in wrapper
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     verify_node_setup(start_time)
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/mnt/linux-drive-1/java/scylla/scylla-cluster-tests/sdcm/cluster.py", line 3279, in verify_node_setup
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     raise NodeSetupFailed(node=node, error_msg=setup_exception[0], traceback_str=setup_exception[1])
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR > sdcm.cluster.NodeSetupFailed: [Node PR-provision-test-pveentjer-db-node-1b15e6aa-1 [54.246.77.64 | 10.0.3.239] (seed: True)] NodeSetupFailed: HTTPSConnectionPool(host='10.0.3.239', port=10001): Max retries exceeded with url: /ping (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x7f29075692b0>: Failed to establish a new connection: [Errno 110] Connection timed out'))
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR > Traceback (most recent call last):
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/usr/local/lib/python3.9/site-packages/urllib3/connection.py", line 158, in _new_conn
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     conn = connection.create_connection(
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/usr/local/lib/python3.9/site-packages/urllib3/util/connection.py", line 80, in create_connection
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     raise err
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/usr/local/lib/python3.9/site-packages/urllib3/util/connection.py", line 70, in create_connection
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     sock.connect(sa)
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR > TimeoutError: [Errno 110] Connection timed out
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR > 
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR > During handling of the above exception, another exception occurred:
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR > 
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR > Traceback (most recent call last):
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/usr/local/lib/python3.9/site-packages/urllib3/connectionpool.py", line 597, in urlopen
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     httplib_response = self._make_request(conn, method, url,
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/usr/local/lib/python3.9/site-packages/urllib3/connectionpool.py", line 343, in _make_request
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     self._validate_conn(conn)
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/usr/local/lib/python3.9/site-packages/urllib3/connectionpool.py", line 839, in _validate_conn
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     conn.connect()
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/usr/local/lib/python3.9/site-packages/urllib3/connection.py", line 301, in connect
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     conn = self._new_conn()
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/usr/local/lib/python3.9/site-packages/urllib3/connection.py", line 167, in _new_conn
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     raise NewConnectionError(
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR > urllib3.exceptions.NewConnectionError: <urllib3.connection.VerifiedHTTPSConnection object at 0x7f29075692b0>: Failed to establish a new connection: [Errno 110] Connection timed out
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR > 
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR > During handling of the above exception, another exception occurred:
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR > 
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR > Traceback (most recent call last):
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/usr/local/lib/python3.9/site-packages/requests/adapters.py", line 439, in send
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     resp = conn.urlopen(
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/usr/local/lib/python3.9/site-packages/urllib3/connectionpool.py", line 637, in urlopen
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     retries = retries.increment(method, url, error=e, _pool=self,
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/usr/local/lib/python3.9/site-packages/urllib3/util/retry.py", line 399, in increment
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     raise MaxRetryError(_pool, url, error or ResponseError(cause))
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR > urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='10.0.3.239', port=10001): Max retries exceeded with url: /ping (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x7f29075692b0>: Failed to establish a new connection: [Errno 110] Connection timed out'))
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR > 
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR > During handling of the above exception, another exception occurred:
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR > 
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR > Traceback (most recent call last):
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/mnt/linux-drive-1/java/scylla/scylla-cluster-tests/sdcm/cluster.py", line 3268, in node_setup
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     cl_inst.node_setup(_node, **setup_kwargs)
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/mnt/linux-drive-1/java/scylla/scylla-cluster-tests/sdcm/cluster.py", line 3921, in node_setup
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     update_config_file(node=node, region=region[0])
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/mnt/linux-drive-1/java/scylla/scylla-cluster-tests/sdcm/mgmt.py", line 120, in update_config_file
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     node.wait_manager_agent_up()
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/mnt/linux-drive-1/java/scylla/scylla-cluster-tests/sdcm/cluster.py", line 1254, in wait_manager_agent_up
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     wait.wait_for(func=self.is_manager_agent_up, step=10, text=text, timeout=timeout, throw_exc=True)
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/mnt/linux-drive-1/java/scylla/scylla-cluster-tests/sdcm/wait.py", line 58, in wait_for
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     res = retry.call(func, **kwargs)
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/usr/local/lib/python3.9/site-packages/tenacity/__init__.py", line 358, in call
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     do = self.iter(retry_state=retry_state)
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/usr/local/lib/python3.9/site-packages/tenacity/__init__.py", line 331, in iter
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     raise retry_exc.reraise()
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/usr/local/lib/python3.9/site-packages/tenacity/__init__.py", line 167, in reraise
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     raise self.last_attempt.result()
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/usr/local/lib/python3.9/concurrent/futures/_base.py", line 433, in result
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     return self.__get_result()
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/usr/local/lib/python3.9/concurrent/futures/_base.py", line 389, in __get_result
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     raise self._exception
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/usr/local/lib/python3.9/site-packages/tenacity/__init__.py", line 361, in call
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     result = fn(*args, **kwargs)
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/mnt/linux-drive-1/java/scylla/scylla-cluster-tests/sdcm/cluster.py", line 1247, in is_manager_agent_up
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     response = requests.get(f"https://{normalize_ipv6_url(self.ip_address)}:{port}/ping", verify=False)
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/usr/local/lib/python3.9/site-packages/requests/api.py", line 75, in get
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     return request('get', url, params=params, **kwargs)
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/usr/local/lib/python3.9/site-packages/requests/api.py", line 60, in request
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     return session.request(method=method, url=url, **kwargs)
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/usr/local/lib/python3.9/site-packages/requests/sessions.py", line 524, in request
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     resp = self.send(prep, **send_kwargs)
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/usr/local/lib/python3.9/site-packages/requests/sessions.py", line 637, in send
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     r = adapter.send(request, **kwargs)
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >   File "/usr/local/lib/python3.9/site-packages/requests/adapters.py", line 516, in send
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR >     raise ConnectionError(e, request=request)
< t:2021-01-12 07:53:27,378 f:tester.py       l:128  c:sdcm.tester          p:ERROR > requests.exceptions.ConnectionError: HTTPSConnectionPool(host='10.0.3.239', port=10001): Max retries exceeded with url: /ping (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x7f29075692b0>: Failed to establish a new connection: [Errno 110] Connection timed out'))
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  > 2021-01-12 07:53:27.378: (TestFrameworkEvent Severity.ERROR), source=LongevityTest.SetUp()
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  > exception=[Node PR-provision-test-pveentjer-db-node-1b15e6aa-1 [54.246.77.64 | 10.0.3.239] (seed: True)] NodeSetupFailed: HTTPSConnectionPool(host='10.0.3.239', port=10001): Max retries exceeded with url: /ping (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x7f29075692b0>: Failed to establish a new connection: [Errno 110] Connection timed out'))
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  > Traceback (most recent call last):
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/usr/local/lib/python3.9/site-packages/urllib3/connection.py", line 158, in _new_conn
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     conn = connection.create_connection(
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/usr/local/lib/python3.9/site-packages/urllib3/util/connection.py", line 80, in create_connection
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     raise err
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/usr/local/lib/python3.9/site-packages/urllib3/util/connection.py", line 70, in create_connection
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     sock.connect(sa)
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  > TimeoutError: [Errno 110] Connection timed out
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  > 
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  > During handling of the above exception, another exception occurred:
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  > 
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  > Traceback (most recent call last):
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/usr/local/lib/python3.9/site-packages/urllib3/connectionpool.py", line 597, in urlopen
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     httplib_response = self._make_request(conn, method, url,
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/usr/local/lib/python3.9/site-packages/urllib3/connectionpool.py", line 343, in _make_request
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     self._validate_conn(conn)
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/usr/local/lib/python3.9/site-packages/urllib3/connectionpool.py", line 839, in _validate_conn
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     conn.connect()
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/usr/local/lib/python3.9/site-packages/urllib3/connection.py", line 301, in connect
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     conn = self._new_conn()
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/usr/local/lib/python3.9/site-packages/urllib3/connection.py", line 167, in _new_conn
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     raise NewConnectionError(
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  > urllib3.exceptions.NewConnectionError: <urllib3.connection.VerifiedHTTPSConnection object at 0x7f29075692b0>: Failed to establish a new connection: [Errno 110] Connection timed out
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  > 
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  > During handling of the above exception, another exception occurred:
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  > 
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  > Traceback (most recent call last):
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/usr/local/lib/python3.9/site-packages/requests/adapters.py", line 439, in send
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     resp = conn.urlopen(
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/usr/local/lib/python3.9/site-packages/urllib3/connectionpool.py", line 637, in urlopen
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     retries = retries.increment(method, url, error=e, _pool=self,
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/usr/local/lib/python3.9/site-packages/urllib3/util/retry.py", line 399, in increment
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     raise MaxRetryError(_pool, url, error or ResponseError(cause))
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  > urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='10.0.3.239', port=10001): Max retries exceeded with url: /ping (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x7f29075692b0>: Failed to establish a new connection: [Errno 110] Connection timed out'))
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  > 
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  > During handling of the above exception, another exception occurred:
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  > 
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  > Traceback (most recent call last):
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/mnt/linux-drive-1/java/scylla/scylla-cluster-tests/sdcm/cluster.py", line 3268, in node_setup
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     cl_inst.node_setup(_node, **setup_kwargs)
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/mnt/linux-drive-1/java/scylla/scylla-cluster-tests/sdcm/cluster.py", line 3921, in node_setup
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     update_config_file(node=node, region=region[0])
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/mnt/linux-drive-1/java/scylla/scylla-cluster-tests/sdcm/mgmt.py", line 120, in update_config_file
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     node.wait_manager_agent_up()
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/mnt/linux-drive-1/java/scylla/scylla-cluster-tests/sdcm/cluster.py", line 1254, in wait_manager_agent_up
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     wait.wait_for(func=self.is_manager_agent_up, step=10, text=text, timeout=timeout, throw_exc=True)
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/mnt/linux-drive-1/java/scylla/scylla-cluster-tests/sdcm/wait.py", line 58, in wait_for
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     res = retry.call(func, **kwargs)
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/usr/local/lib/python3.9/site-packages/tenacity/__init__.py", line 358, in call
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     do = self.iter(retry_state=retry_state)
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/usr/local/lib/python3.9/site-packages/tenacity/__init__.py", line 331, in iter
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     raise retry_exc.reraise()
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/usr/local/lib/python3.9/site-packages/tenacity/__init__.py", line 167, in reraise
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     raise self.last_attempt.result()
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/usr/local/lib/python3.9/concurrent/futures/_base.py", line 433, in result
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     return self.__get_result()
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/usr/local/lib/python3.9/concurrent/futures/_base.py", line 389, in __get_result
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     raise self._exception
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/usr/local/lib/python3.9/site-packages/tenacity/__init__.py", line 361, in call
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     result = fn(*args, **kwargs)
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/mnt/linux-drive-1/java/scylla/scylla-cluster-tests/sdcm/cluster.py", line 1247, in is_manager_agent_up
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     response = requests.get(f"https://{normalize_ipv6_url(self.ip_address)}:{port}/ping", verify=False)
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/usr/local/lib/python3.9/site-packages/requests/api.py", line 75, in get
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     return request('get', url, params=params, **kwargs)
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/usr/local/lib/python3.9/site-packages/requests/api.py", line 60, in request
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     return session.request(method=method, url=url, **kwargs)
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/usr/local/lib/python3.9/site-packages/requests/sessions.py", line 524, in request
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     resp = self.send(prep, **send_kwargs)
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/usr/local/lib/python3.9/site-packages/requests/sessions.py", line 637, in send
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     r = adapter.send(request, **kwargs)
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/usr/local/lib/python3.9/site-packages/requests/adapters.py", line 516, in send
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     raise ConnectionError(e, request=request)
< t:2021-01-12 07:53:27,380 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  > requests.exceptions.ConnectionError: HTTPSConnectionPool(host='10.0.3.239', port=10001): Max retries exceeded with url: /ping (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x7f29075692b0>: Failed to establish a new connection: [Errno 110] Connection timed out'))
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
