### PR TITLE
fix(fill_db_data): fix query that filter by null

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -755,7 +755,7 @@ class FillDatabaseData(ClusterTester):
                         "INSERT INTO null_support_test (k, c, v1) VALUES (0, 1, null)",
                         "INSERT INTO null_support_test (k, c, v2) VALUES(0, 0, null)",
                         "SELECT * FROM null_support_test",
-                        "SELECT * FROM null_support_test WHERE k = null"],
+                        "SELECT * FROM null_support_test WHERE k = 0 and c = 1 and v1 = null ALLOW FILTERING"],
             'results': [
                 [[0, 0, None, set(['1', '2'])], [0, 1, 1, None]],
                 [],


### PR DESCRIPTION
Scylla is not allow a NULL value in the partition key columns and
not allow to filter with NULL by partition keys columns

Fix for [PR](https://github.com/scylladb/scylla-cluster-tests/pull/3079)
Failed test with this error: https://jenkins.scylladb.com/job/scylla-master/job/rolling-upgrade/job/rolling-upgrade-ubuntu16.04-test/87/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
