### PR TITLE
fix(get_rate_limit_for_network_disruption): metric is not working

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2135,9 +2135,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.target_node.traffic_control(None)
             self._wait_all_nodes_un()
 
-    @retrying(n=15, sleep_time=10, allowed_exceptions=ClusterNodesNotReady)
+    @retrying(n=15, sleep_time=5, allowed_exceptions=ClusterNodesNotReady)
     def _wait_all_nodes_un(self):
-        self.cluster.check_nodes_up_and_normal()
+        for node in self.cluster.nodes:
+            self.cluster.check_nodes_up_and_normal(verification_node=node)
 
     def disrupt_remove_node_then_add_node(self):
         """

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1760,6 +1760,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     # Temporary disable due to https://trello.com/c/Ru0T9Nmu/1239-fix-validatehintedhandoff-nemesis
     # TODO: Bentsi to fix this nemesis or investigate if it's a real scylla issue.
     # TODO: Bentsi to fix this nemesis or investigate if it's a real scylla issue.
+
     def disable_disrupt_validate_hh_short_downtime(self):  # pylint: disable=invalid-name
         """
             Validates that hinted handoff mechanism works: there were no drops and errors
@@ -2048,7 +2049,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         # get the last 10min avg network bandwidth used, and limit  30% to 70% of it
         prometheus_stats = PrometheusDBStats(host=self.monitoring_set.nodes[0].external_address)
-        query = 'avg(irate(node_network_receive_bytes_total{instance=~".*?%s.*?", device="eth0"}[60s]))' % \
+        query = 'avg(node_network_receive_bytes_total{instance=~".*?%s.*?", device="eth0"})' % \
                 self.target_node.ip_address
         now = time.time()
         results = prometheus_stats.query(query=query, start=now - 600, end=now)
@@ -2079,7 +2080,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         rate_limit: Optional[str] = self.get_rate_limit_for_network_disruption()
         if not rate_limit:
-            self.log.warn("NetworkRandomInterruption won't limit network bandwith due to lack of monitoring nodes.")
+            self.log.warning("NetworkRandomInterruption won't limit network bandwidth due to lack of monitoring nodes.")
 
         # random packet loss - between 1% - 15%
         loss_percentage = random.randrange(1, 15)
@@ -2112,6 +2113,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             time.sleep(wait_time)
         finally:
             self.target_node.traffic_control(None)
+            self._wait_all_nodes_un()
 
     def disrupt_network_block(self):
         self._set_current_disruption('BlockNetwork')
@@ -2394,6 +2396,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             time.sleep(wait_time)
         finally:
             self.target_node.remoter.run("sudo /sbin/ifup eth1")
+            self._wait_all_nodes_un()
 
     def break_streaming_task_and_rebuild(self, task='decommission'):  # pylint: disable=too-many-statements
         """


### PR DESCRIPTION
on current running jobs (4.3.rc's) this function is always
returning empty.
Checked on a monitor stack recreated from latest test with
network nemesis, and this changes are now properly working.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
