### PR TITLE
fix(nemesis): Don't publish es_event if results are not stored in es

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -141,7 +141,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             # TODO: issue https://github.com/scylladb/scylla/issues/6074. Waiting for dev conclusions
             'cqlstress_lwt_example': '*'  # Ignore LWT user-profile tables
         }
-        self.es_publisher = NemesisElasticSearchPublisher(self.tester)
+        self.es_publisher = NemesisElasticSearchPublisher(self.tester) if self.tester.create_stats else None
 
     @classmethod
     def add_disrupt_method(cls, func=None):
@@ -265,7 +265,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     @raise_event_on_failure
     def run(self, interval=None):
-        self.es_publisher.create_es_connection()
+        if self.es_publisher:
+            self.es_publisher.create_es_connection()
         if interval:
             self.interval = interval * 60
         self.log.info('Interval: %s s', self.interval)
@@ -1760,6 +1761,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     # Temporary disable due to https://trello.com/c/Ru0T9Nmu/1239-fix-validatehintedhandoff-nemesis
     # TODO: Bentsi to fix this nemesis or investigate if it's a real scylla issue.
     # TODO: Bentsi to fix this nemesis or investigate if it's a real scylla issue.
+
     def disable_disrupt_validate_hh_short_downtime(self):  # pylint: disable=invalid-name
         """
             Validates that hinted handoff mechanism works: there were no drops and errors


### PR DESCRIPTION
If test configured with don't store results in es, es_puslisher
failed. 
https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/abykov/job/BYO-abykov-staging/55
```
01:32:02  < t:2021-01-16 18:31:54,355 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  > 
01:32:02  < t:2021-01-16 18:31:54,355 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  > During handling of the above exception, another exception occurred:
01:32:02  < t:2021-01-16 18:31:54,355 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  > 
01:32:02  < t:2021-01-16 18:31:54,355 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  > Traceback (most recent call last):
01:32:02  < t:2021-01-16 18:31:54,355 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/home/ubuntu/scylla-cluster-tests/sdcm/sct_events/decorators.py", line 26, in wrapper
01:32:02  < t:2021-01-16 18:31:54,355 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     return func(*args, **kwargs)
01:32:02  < t:2021-01-16 18:31:54,355 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 277, in run
01:32:02  < t:2021-01-16 18:31:54,355 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     self.disrupt()
01:32:02  < t:2021-01-16 18:31:54,355 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 2856, in wrapper
01:32:02  < t:2021-01-16 18:31:54,355 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     args[0].update_stats(disrupt, status, log_info)
01:32:02  < t:2021-01-16 18:31:54,355 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 187, in update_stats
01:32:02  < t:2021-01-16 18:31:54,355 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     self.es_publisher.publish(disrupt_name=disrupt, status=status, data=data)
01:32:02  < t:2021-01-16 18:31:54,355 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis_publisher.py", line 39, in publish
01:32:02  < t:2021-01-16 18:31:54,355 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     assert test_data, "without _stats data we can't publish nemesis ES"
```
This error terminate nemesis thread and no any other nemesis are not started.

Fix by checking the create_stats property and depend on state create or not create the EsPublisher object.
Success run: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/abykov/job/BYO-abykov-staging/58


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
