### PR TITLE
fix(fill_db_data): don't run filter by NULL query for now

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -755,13 +755,17 @@ class FillDatabaseData(ClusterTester):
                         "INSERT INTO null_support_test (k, c, v1) VALUES (0, 1, null)",
                         "INSERT INTO null_support_test (k, c, v2) VALUES(0, 0, null)",
                         "SELECT * FROM null_support_test",
-                        "SELECT * FROM null_support_test WHERE k = null"],
+                        # TODO: uncomment when run tests on 4.5
+                        # "SELECT * FROM null_support_test WHERE k = null"
+                        ],
             'results': [
                 [[0, 0, None, set(['1', '2'])], [0, 1, 1, None]],
                 [],
                 [],
                 [[0, 0, None, None], [0, 1, None, None]],
-                []],
+                # TODO: uncomment when run tests on 4.5
+                # []
+            ],
             'invalid_queries': [
                 "INSERT INTO null_support_test (k, c, v2) VALUES (0, 2, {1, null})",
                 "INSERT INTO null_support_test (k, c, v2) VALUES (0, 0, { 'foo', 'bar', null })"],


### PR DESCRIPTION
This query is supported in 4.4 only meanwhile and fails on 4.2.
So all rolling upgrade tests fail.
We will run this query when will test 4.5

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
