### PR TITLE
fix(SslHotReloadingNemesis): mask out 'error GnuTLS:-34, Base64 decoding error' error

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2604,18 +2604,22 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                                                     ignore_status=True).stdout
         update_certificates()
         node_system_logs = {}
-        for node in self.cluster.nodes:
-            node_system_logs[node] = node.follow_system_log(
-                patterns=f'messaging_service - Reloaded {{{ssl_files_location}}}')
-            node.remoter.send_files(src='data_dir/ssl_conf/db.crt', dst='/tmp')
-            node.remoter.run(f"sudo cp -f /tmp/db.crt {ssl_files_location}")
-            new_crt = node.remoter.run(f"cat {ssl_files_location}").stdout
-            if in_place_crt == new_crt:
-                raise Exception('The CRT file was not replaced')
+        with DbEventsFilter(
+                db_event=DatabaseLogEvent.DATABASE_ERROR,
+                line="error GnuTLS:-34, Base64 decoding error"):
+            # TBD: To be removed after https://github.com/scylladb/scylla/issues/7909#issuecomment-758062545 is resolved
+            for node in self.cluster.nodes:
+                node_system_logs[node] = node.follow_system_log(
+                    patterns=f'messaging_service - Reloaded {{{ssl_files_location}}}')
+                node.remoter.send_files(src='data_dir/ssl_conf/db.crt', dst='/tmp')
+                node.remoter.run(f"sudo cp -f /tmp/db.crt {ssl_files_location}")
+                new_crt = node.remoter.run(f"cat {ssl_files_location}").stdout
+                if in_place_crt == new_crt:
+                    raise Exception('The CRT file was not replaced')
 
-        for node in self.cluster.nodes:
-            if not check_ssl_reload_log(node_system_logs[node]):
-                raise Exception('SSL auto Reload did not happen')
+            for node in self.cluster.nodes:
+                if not check_ssl_reload_log(node_system_logs[node]):
+                    raise Exception('SSL auto Reload did not happen')
 
     @latency_calculator_decorator
     def steady_state_latency(self, sleep_time=None):


### PR DESCRIPTION
https://trello.com/c/v5T6rj46/2788-serversslhotreloadingnemesis-investigate-why-it-can-trigger-error-gnutls-34-base64-decoding-error

Fixes https://github.com/scylladb/scylla-cluster-tests/issues/3119

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
