### PR TITLE
fix(cluster_k8s): make it wait till API is not operational first

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -74,6 +74,9 @@ class KubernetesCluster:
     kubectl_cmd = partialmethod(KubernetesOps.kubectl_cmd)
     apply_file = partialmethod(KubernetesOps.apply_file)
 
+    def kubectl_no_wait(self, *command, namespace=None, timeout=KUBECTL_TIMEOUT, remoter=None):
+        return KubernetesOps.kubectl(self, *command, namespace=namespace, timeout=timeout, remoter=remoter)
+
     def kubectl(self, *command, namespace=None, timeout=KUBECTL_TIMEOUT, remoter=None):
         if self.api_call_rate_limiter:
             self.api_call_rate_limiter.wait()

--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -168,7 +168,9 @@ class GkeCluster(KubernetesCluster, cluster.BaseCluster):
                             f" --node-taints role=sct-loaders:NoSchedule"
                             f" --no-enable-autoupgrade"
                             f" --no-enable-autorepair")
-            self.kubectl('wait --timeout=15m --all --for=condition=Ready node')
+            self.api_call_rate_limiter.wait_till_api_become_not_operational(self)
+            self.api_call_rate_limiter.wait_till_api_become_stable(self)
+            self.kubectl_no_wait('wait --timeout=15m --all --for=condition=Ready node')
 
     def get_kubectl_config_for_user(self, config, username):
         for user in config["users"]:


### PR DESCRIPTION
https://trello.com/c/Tx1cYWWM/2924-gke-mark-api-unstable-when-node-is-added
Idea to reduce time on starting cluster up:

```
Without fix:
13:54:21  Started by user Dmitry Kropachev
15:08:03  < t:2021-01-18 08:08:01,383 f:tester.py       l:492  c:LongevityTest        p:INFO  > change RF of system_auth to 3
Initialization done in 72 minutes

With fix:
17:29:50  Started by user Dmitry Kropachev
18:16:23  < t:2021-01-18 11:16:16,225 f:tester.py       l:492  c:LongevityTest        p:INFO  > change RF of system_auth to 3
Initialization done in 47 minutes
```

Tested on:
https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/dmitry/job/dmitry-operator-byo-4/7/console

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
