### PR TITLE
feature(sct.py): add support for creating offline install

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -757,7 +757,8 @@ def create_test_release_jobs(branch, username, password, sct_branch, sct_repo):
                                    ('features-', 'SCT Feature Tests'),
                                    ('artifacts', 'SCT Artifacts Tests'),
                                    ('load-test', 'SCT Load Tests'),
-                                   ('k8s', 'SCT Kubernetes Tests'), ]:
+                                   ('k8s', 'SCT Kubernetes Tests'),
+                                   ]:
         server.create_directory(name=group_name, display_name=group_desc)
 
         for jenkins_file in glob.glob(f'{server.base_sct_dir}/jenkins-pipelines/{group_name}*.jenkinsfile'):
@@ -766,6 +767,12 @@ def create_test_release_jobs(branch, username, password, sct_branch, sct_repo):
         if group_name == 'load-test':
             for jenkins_file in glob.glob(f'{server.base_sct_dir}/jenkins-pipelines/admission_control_overload*'):
                 server.create_pipeline_job(jenkins_file, group_name)
+
+    server.create_directory(name='artifacts-offline-install', display_name='SCT Artifacts Offline Install Tests')
+    for jenkins_file in glob.glob(f'{server.base_sct_dir}/jenkins-pipelines/nonroot-offline-install/*.jenkinsfile'):
+        server.create_pipeline_job(jenkins_file, 'artifacts-offline-install')
+        server.create_pipeline_job(jenkins_file, 'artifacts-offline-install',
+                                   job_name=str(Path(jenkins_file).stem) + '-nonroot')
 
 
 @cli.command('create-test-release-jobs-enterprise', help="Create pipeline jobs for a new branch")

--- a/sct.py
+++ b/sct.py
@@ -769,8 +769,11 @@ def create_test_release_jobs(branch, username, password, sct_branch, sct_repo):
                 server.create_pipeline_job(jenkins_file, group_name)
 
     server.create_directory(name='artifacts-offline-install', display_name='SCT Artifacts Offline Install Tests')
-    for jenkins_file in glob.glob(f'{server.base_sct_dir}/jenkins-pipelines/nonroot-offline-install/*.jenkinsfile'):
+    for jenkins_file in glob.glob(f'{server.base_sct_dir}/jenkins-pipelines/artifacts-*.jenkinsfile'):
+        if any([f'-{i}.jenkinsfile' in jenkins_file for i in ['ami', 'amazon2', 'docker', 'gce-image']]):
+            continue
         server.create_pipeline_job(jenkins_file, 'artifacts-offline-install')
+    for jenkins_file in glob.glob(f'{server.base_sct_dir}/jenkins-pipelines/nonroot-offline-install/*.jenkinsfile'):
         server.create_pipeline_job(jenkins_file, 'artifacts-offline-install',
                                    job_name=str(Path(jenkins_file).stem) + '-nonroot')
 

--- a/utils/build_system/create_test_release_jobs.py
+++ b/utils/build_system/create_test_release_jobs.py
@@ -20,8 +20,8 @@ class JenkinsPipelines:
         except jenkins.JenkinsException as ex:
             print(ex)
 
-    def create_pipeline_job(self, jenkins_file, group_name):
-        base_name = Path(jenkins_file).stem
+    def create_pipeline_job(self, jenkins_file, group_name, job_name=None):
+        base_name = job_name or Path(jenkins_file).stem
         sct_jenkinsfile = 'jenkins-pipelines/{}'.format(Path(jenkins_file).name)
         print(sct_jenkinsfile)
         xml_data = JOB_TEMPLATE % dict(sct_display_name=f"{base_name}-test",


### PR DESCRIPTION
new that we have offline installer job and directory we
should add them to the command that create the jobs for new
releases

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
