### PR TITLE
fix(operator_monitoring): mask out some operator events to reduce severity

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -64,6 +64,7 @@ GeminiLogEvent.geminievent: CRITICAL
 PrometheusAlertManagerEvent.start: WARNING
 PrometheusAlertManagerEvent.end: WARNING
 ScyllaOperatorLogEvent: ERROR
+ScyllaOperatorLogEvent.REAPPLY: WARNING
 ScyllaOperatorRestartEvent: ERROR
 StartupTestEvent: NORMAL
 TestTimeoutEvent: CRITICAL

--- a/sdcm/sct_events/base.py
+++ b/sdcm/sct_events/base.py
@@ -320,8 +320,17 @@ class LogEvent(Generic[T_log_event], SctEvent, abstract=True):
 
     @property
     def msgfmt(self):
-        fmt = super().msgfmt + ": " + "type={0.type} regex={0.regex} line_number={0.line_number} node={0.node}\n" \
-                                      "{0.line}"
+        fmt = super().msgfmt + ":"
+        if self.type is not None:
+            fmt += " type={0.type}"
+        if self.regex is not None:
+            fmt += " regex={0.regex}"
+        if self.line_number is not None:
+            fmt += " line_number={0.line_number}"
+        if self.node is not None:
+            fmt += " node={0.node}"
+        if self.line is not None:
+            fmt += "\n{0.line}"
         if self.backtrace:
             fmt += "\n{0.backtrace}"
         elif self.raw_backtrace:

--- a/sdcm/sct_events/operator.py
+++ b/sdcm/sct_events/operator.py
@@ -11,14 +11,49 @@
 #
 # Copyright (c) 2020 ScyllaDB
 
+import re
+import json
+import logging
+from datetime import datetime
+from typing import List, Tuple, Type, Optional
+
 from sdcm.sct_events import Severity
-from sdcm.sct_events.base import SctEvent
+from sdcm.sct_events.base import SctEvent, LogEvent, LogEventProtocol, T_log_event
 
 
-class ScyllaOperatorLogEvent(SctEvent):
-    def __init__(self, timestamp=None, namespace=None, cluster=None, message=None, error=None, trace_id=None):
-        super().__init__(severity=Severity.ERROR)
+LOGGER = logging.getLogger(__name__)
 
+
+class ScyllaOperatorLogEvent(LogEvent):
+    REAPPLY: Type[LogEventProtocol]
+    timestamp: str
+    namespace: str
+    cluster: str
+    message: str
+    error: str
+    trace_id: str
+
+    event_data_mapping = {
+        'T': 'timestamp',
+        'N': 'namespace',
+        'M': 'message',
+        'cluster': 'cluster',
+        'error': 'error',
+        '_trace_id': 'trace_id'
+    }
+
+    def __init__(self, timestamp=None, namespace=None, cluster=None, message=None, error=None, trace_id=None,
+                 regex=None, severity=Severity.ERROR):
+        super().__init__(regex, severity=severity)
+        self.set_params(timestamp=timestamp, namespace=namespace, cluster=cluster, message=message, error=error,
+                        trace_id=trace_id)
+
+    @property
+    def msgfmt(self):
+        cluster = f"/{self.cluster}" if self.cluster else ""
+        return super().msgfmt + " {0.trace_id} {0.namespace}" + cluster + ": {0.message}, {0.error}"
+
+    def set_params(self, timestamp=None, namespace=None, cluster=None, message=None, error=None, trace_id=None):
         self.namespace = namespace
         self.cluster = cluster
         self.message = message
@@ -26,10 +61,26 @@ class ScyllaOperatorLogEvent(SctEvent):
         self.error = error
         self.trace_id = trace_id
 
-    @property
-    def msgfmt(self):
-        cluster = f"/{self.cluster}" if self.cluster else ""
-        return super().msgfmt + " {0.trace_id} {0.namespace}" + cluster + ": {0.message}, {0.error}"
+    def load_from_json_string(self: T_log_event, data: str) -> Optional[T_log_event]:
+        try:
+            log_data = json.loads(data)
+        except Exception as exc:  # pylint: disable=broad-except
+            LOGGER.error('Failed to interpret following log line:\n%s\n, due to the: %s', data, exc)
+            return None
+        event_data = {}
+        for log_en_name, attr_name in self.event_data_mapping.items():
+            log_en_data = log_data.get(log_en_name, None)
+            if log_en_data is None:
+                continue
+            if attr_name == 'timestamp':
+                log_en_data = datetime.strptime(log_en_data, "%Y-%m-%dT%H:%M:%S.%fZ").timestamp()
+            event_data[attr_name] = log_en_data
+        try:
+            self.set_params(**event_data)
+        except Exception as exc:  # pylint: disable=broad-except
+            LOGGER.error('Failed to set event parameters %s\n, due to the: %s', data, exc)
+            return None
+        return self
 
 
 class ScyllaOperatorRestartEvent(SctEvent):
@@ -43,4 +94,17 @@ class ScyllaOperatorRestartEvent(SctEvent):
         return super().msgfmt + ": Scylla Operator has been restarted, restart_count={0.restart_count}"
 
 
-__all__ = ("ScyllaOperatorLogEvent", "ScyllaOperatorRestartEvent", )
+ScyllaOperatorLogEvent.add_subevent_type(
+    "REAPPLY", severity=Severity.WARNING, regex="please apply your changes to the latest version and try again")
+
+
+SCYLLA_OPERATOR_EVENTS = [
+    ScyllaOperatorLogEvent.REAPPLY(),
+]
+
+
+SCYLLA_OPERATOR_EVENT_PATTERNS: List[Tuple[re.Pattern, LogEventProtocol]] = \
+    [(re.compile(event.regex, re.IGNORECASE), event) for event in SCYLLA_OPERATOR_EVENTS]
+
+
+__all__ = ("ScyllaOperatorLogEvent", "ScyllaOperatorRestartEvent", "SCYLLA_OPERATOR_EVENT_PATTERNS")

--- a/unit_tests/test_sct_events_base.py
+++ b/unit_tests/test_sct_events_base.py
@@ -549,7 +549,7 @@ class TestLogEvent(SctEventTestCase):
         Y.add_subevent_type("T", regex="r1")
 
         y = Y.T()
-        self.assertEqual(str(y), "(Y Severity.ERROR): type=T regex=r1 line_number=0 node=None\nNone")
+        self.assertEqual(str(y), "(Y Severity.ERROR): type=T regex=r1 line_number=0")
 
         y.add_info(node="n1", line="l1", line_number=1)
         self.assertEqual(str(y), "(Y Severity.ERROR): type=T regex=r1 line_number=1 node=n1\nl1")

--- a/unit_tests/test_sct_events_operator.py
+++ b/unit_tests/test_sct_events_operator.py
@@ -22,7 +22,7 @@ class TestOperatorEvents(unittest.TestCase):
         event = ScyllaOperatorLogEvent(namespace="scylla", cluster="c1", message="m1", error="e1", trace_id="tid1")
         self.assertEqual(
             str(event),
-            "(ScyllaOperatorLogEvent Severity.ERROR) tid1 scylla/c1: m1, e1",
+            "(ScyllaOperatorLogEvent Severity.ERROR): line_number=0 tid1 scylla/c1: m1, e1",
         )
         self.assertEqual(event, pickle.loads(pickle.dumps(event)))
 


### PR DESCRIPTION
https://trello.com/c/WhqWzw7S/2925-k8s-reduce-severity-for-s-o-mutation-errors

Errors example:

```
20:41:03  < t:2021-01-18 13:41:02,967 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  > 2021-01-18 13:41:02.937: (ScyllaOperatorLogEvent Severity.ERROR) Zje4sRB9TQya1MS68UYjZQ cluster-controller/scylla/sct-cluster: An error occurred during cluster reconciliation, wait pvc deletion: failed to update pvc: Operation cannot be fulfilled on persistentvolumeclaims "data-sct-cluster-us-east1-b-us-east1-2": the object has been modified; please apply your changes to the latest version and try again
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~`
