### PR TITLE
feature(cluster.py): support a new fuzzing tool: cassandra-harry

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -37,6 +37,11 @@ DatabaseLogEvent.SUPPRESSED_MESSAGES: WARNING
 DatabaseLogEvent.stream_exception: ERROR
 DatabaseLogEvent.POWER_OFF: CRITICAL
 IndexSpecialColumnErrorEvent: ERROR
+CassandraHarryEvent.failure: CRITICAL
+CassandraHarryEvent.error: ERROR
+CassandraHarryEvent.timeout: ERROR
+CassandraHarryEvent.start: NORMAL
+CassandraHarryEvent.finish: NORMAL
 YcsbStressEvent.failure: CRITICAL
 YcsbStressEvent.error: ERROR
 YcsbStressEvent.start: NORMAL

--- a/jenkins-pipelines/longevity-harry-2h.jenkinsfile
+++ b/jenkins-pipelines/longevity-harry-2h.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/longevity/longevity-harry-2h.yaml',
+
+    timeout: [time: 240, unit: 'MINUTES']
+)

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -51,6 +51,8 @@ class LongevityTest(ClusterTester):
                 stress_queue.append(self.run_stress_thread(stress_cmd=stress_cmd,
                                                            stats_aggregate_cmds=False,
                                                            round_robin=self.params.get('round_robin')))
+            elif stress_cmd.startswith('cassandra-harry'):
+                stress_queue.append(self.run_stress_thread(**params))
             else:
                 stress_queue.append(self.run_stress_thread(**params))
 

--- a/sdcm/cassandra_harry_thread.py
+++ b/sdcm/cassandra_harry_thread.py
@@ -1,0 +1,199 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2021 ScyllaDB
+
+import os
+import uuid
+import time
+import logging
+import concurrent.futures
+
+from sdcm.loader import CassandraHarryStressExporter
+from sdcm.prometheus import nemesis_metrics_obj
+from sdcm.sct_events.loaders import CassandraHarryEvent, CASSANDRA_HARRY_ERROR_EVENTS_PATTERNS
+from sdcm.utils.common import FileFollowerThread, generate_random_string
+from sdcm.stress_thread import format_stress_cmd_error
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class CassandraHarryStressEventsPublisher(FileFollowerThread):
+    def __init__(self, node, harry_log_filename):
+        super().__init__()
+        self.harry_log_filename = harry_log_filename
+        self.node = str(node)
+
+    def run(self):
+        while not self.stopped():
+            exists = os.path.isfile(self.harry_log_filename)
+            if not exists:
+                time.sleep(0.5)
+                continue
+
+            for line_number, line in enumerate(self.follow_file(self.harry_log_filename)):
+                if self.stopped():
+                    break
+
+                for pattern, event in CASSANDRA_HARRY_ERROR_EVENTS_PATTERNS:
+                    if pattern.search(line):
+                        event.add_info(node=self.node, line=line, line_number=line_number).publish()
+
+
+#  pylint: disable=too-many-instance-attributes
+class CassandraHarryThread:
+    #  pylint: disable=too-many-arguments
+    def __init__(self, stress_cmd, loader_set, timeout, node_list=None, round_robin=False, use_single_loader=False,
+                 stop_test_on_failure=False, stress_num=1, credentials=None):
+        if not node_list:
+            node_list = []
+        self.loader_set = loader_set
+        self.stress_cmd = stress_cmd
+        self.timeout = timeout
+        self.use_single_loader = use_single_loader
+        self.round_robin = round_robin
+        self.node_list = node_list
+        self.stress_num = stress_num
+        if credentials and 'username=' not in self.stress_cmd:
+            self.stress_cmd += " -username {} -password {}".format(*credentials)
+        self.stop_test_on_failure = stop_test_on_failure
+
+        self.executor = None
+        self.results_futures = []
+        self.shell_marker = generate_random_string(20)
+        self.max_workers = 0
+
+    def get_stress_results_bench(self):
+        ret = []
+        results = []
+
+        LOGGER.debug('Wait for stress threads results')
+        for future in concurrent.futures.as_completed(self.results_futures, timeout=self.timeout):
+            results.append(future.result())
+
+        for _, result in results:
+            if not result:
+                # Silently skip if stress command throwed error, since it was already reported in _run_stress
+                continue
+            output = result.stdout + result.stderr
+            try:
+                lines = output.splitlines()
+                node_cs_res = self._parse_harry_summary(lines)  # pylint: disable=protected-access
+                if node_cs_res:
+                    ret.append(node_cs_res)
+            except Exception as exc:  # pylint: disable=broad-except
+                CassandraHarryEvent.error(node="",
+                                          stress_cmd=self.stress_cmd,
+                                          errors=[f"Failed to proccess stress summary due to {exc}"]).publish()
+
+        return ret
+
+    def verify_results(self):
+        harry_summary = []
+        results = []
+        errors = []
+
+        LOGGER.debug('Wait for stress threads results')
+        for future in concurrent.futures.as_completed(self.results_futures, timeout=self.timeout):
+            results.append(future.result())
+
+        for node, result in results:
+            if not result:
+                # Silently skip if stress command throwed error, since it was already reported in _run_stress
+                continue
+            output = result.stdout + result.stderr
+
+            lines = output.splitlines()
+            node_cs_res = self._parse_harry_summary(lines)  # pylint: disable=protected-access
+
+            if node_cs_res:
+                harry_summary.append(node_cs_res)
+
+            for line in lines:
+                if 'java.io.IOException' in line:
+                    errors += ['%s: %s' % (node, line.strip())]
+
+        return harry_summary, errors
+
+    def _run_stress_harry(self, node, loader_idx, stress_cmd, node_list):
+
+        CassandraHarryEvent.start(node=node, stress_cmd=stress_cmd).publish()
+        os.makedirs(node.logdir, exist_ok=True)
+
+        log_file_name = os.path.join(node.logdir, f'cassandra-harry-l{loader_idx}-{uuid.uuid4()}.log')
+        # Select first seed node to send the scylla-harry cmds
+        ip = node_list[0].private_ip_address
+
+        with CassandraHarryStressExporter(instance_name=node.ip_address,
+                                          metrics=nemesis_metrics_obj(),
+                                          stress_operation='write',
+                                          stress_log_filename=log_file_name,
+                                          loader_idx=loader_idx), \
+                CassandraHarryStressEventsPublisher(node=node, harry_log_filename=log_file_name):
+            result = None
+            try:
+                result = node.remoter.run(
+                    cmd=f"{stress_cmd} -node {ip}",
+                    timeout=self.timeout,
+                    log_file=log_file_name)
+            except Exception as exc:  # pylint: disable=broad-except
+                errors_str = format_stress_cmd_error(exc)
+                if "timeout" in errors_str:
+                    event_type = CassandraHarryEvent.timeout
+                elif self.stop_test_on_failure:
+                    event_type = CassandraHarryEvent.failure
+                else:
+                    event_type = CassandraHarryEvent.error
+                event_type(
+                    node=node,
+                    stress_cmd=stress_cmd,
+                    log_file_name=log_file_name,
+                    errors=[errors_str, ],
+                ).publish()
+            else:
+                CassandraHarryEvent.finish(node=node, stress_cmd=stress_cmd, log_file_name=log_file_name).publish()
+
+        return node, result
+
+    def run(self):
+        if self.round_robin:
+            loaders = [self.loader_set.get_loader()]
+        else:
+            loaders = self.loader_set.nodes if not self.use_single_loader else [self.loader_set.nodes[0]]
+        LOGGER.debug("Round-Robin through loaders, Selected loader is {} ".format(loaders))
+
+        self.max_workers = (os.cpu_count() or 1) * 5
+        LOGGER.debug("Starting %d cassandra-harry Worker threads", self.max_workers)
+        # pylint: disable=consider-using-with
+        self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.max_workers)
+
+        for loader_idx, loader in enumerate(loaders):
+            self.results_futures += [self.executor.submit(self._run_stress_harry,
+                                                          *(loader, loader_idx, self.stress_cmd, self.node_list))]
+            time.sleep(60)
+
+        return self
+
+    @staticmethod
+    def _parse_harry_summary(lines):  # pylint: disable=too-many-branches
+        """
+        Currently we only check if it succeeds or not.
+        A succeed sample:
+
+        INFO  [pool-6-thread-1] instance_id_IS_UNDEFINED 2021-01-19 13:46:49,835 Runner.java:255 - Completed
+        """
+        results = {}
+        if any(['Runner.java:255 - Completed' in line for line in lines]):  # pylint: disable=use-a-generator
+            results['status'] = 'completed'
+        else:
+            results['status'] = 'failed'
+        return results

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -210,6 +210,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
         self.remoter = None
         self.is_scylla_bench_installed = False
+        self.is_cassandra_harry_installed = False
 
         self._spot_monitoring_thread = None
         self._journal_thread = None
@@ -382,6 +383,25 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             GO111MODULE=on go get -v github.com/scylladb/scylla-bench@{self.parent_cluster.params.get('scylla_bench_version')}
         """))
         self.is_scylla_bench_installed = True
+
+    @retrying(n=3)
+    def install_cassandra_harry(self):
+        if self.distro.is_rhel_like:
+            self.remoter.sudo("yum install -y git make maven")
+        else:
+            self.remoter.sudo(shell_script_cmd("""\
+                apt-get update
+                apt-get install -y git make maven
+            """))
+        self.remoter.run(shell_script_cmd("""\
+            rm -rf cassandra-harry
+            git clone -b scylla-branch https://github.com/amoskong/cassandra-harry
+            cd cassandra-harry
+            make mvn
+        """))
+        result = self.remoter.run('realpath ~/cassandra-harry/scripts/cassandra-harry')
+        self.remoter.sudo(f"ln -s {result.stdout.strip()} /usr/bin/cassandra-harry", ignore_status=True)
+        self.is_cassandra_harry_installed = True
 
     @property
     def cassandra_stress_version(self):
@@ -4620,6 +4640,9 @@ class BaseLoaderSet():
             # Update existing scylla-bench to latest
             if not node.is_scylla_bench_installed:
                 node.install_scylla_bench()
+        if 'cassandra-harry' in self.params.list_of_stress_tools:
+            if not node.is_cassandra_harry_installed:
+                node.install_cassandra_harry()
 
         result = node.remoter.run('test -e ~/PREPARED-LOADER', ignore_status=True)
         node.remoter.sudo("bash -cxe \"echo '*\t\thard\tcore\t\tunlimited\n*\t\tsoft\tcore\t\tunlimited' "
@@ -4681,6 +4704,9 @@ class BaseLoaderSet():
         if 'scylla-bench' in self.params.list_of_stress_tools:
             if not node.is_scylla_bench_installed:
                 node.install_scylla_bench()
+        if 'cassandra-harry' in self.params.list_of_stress_tools:
+            if not node.is_cassandra_harry_installed:
+                node.install_cassandra_harry(node)
 
         # install docker
         docker_install = dedent("""

--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -136,6 +136,21 @@ def get_stress_bench_cmd_params(cmd):
     return cmd_params
 
 
+def get_stress_harry_cmd_params(cmd):
+    """
+    Parsing cassandra-harry stress command
+    :param cmd: stress cmd
+    :return: dict with params
+    """
+    cmd = cmd.split('cassandra-harry')[1].strip()
+    cmd_params = {}
+    for key in ['run-time', 'run-time-unit']:
+        match = re.search(fr'(-{key}\s+([^-| ]+))', cmd)
+        if match:
+            cmd_params[key] = match.group(2).strip()
+    return cmd_params
+
+
 def get_ycsb_cmd_params(cmd):
     """
     Parsing ycsb command
@@ -559,6 +574,8 @@ class TestStatsMixin(Stats):
             cmd_params = get_stress_cmd_params(cmd)
         elif stresser == "scylla-bench":
             cmd_params = get_stress_bench_cmd_params(cmd)
+        elif stresser == "cassandra-harry":
+            cmd_params = get_stress_harry_cmd_params(cmd)
         elif stresser == 'ycsb':
             cmd_params = get_ycsb_cmd_params(cmd)
         elif stresser in ['gemini', 'ndbench']:

--- a/sdcm/loader.py
+++ b/sdcm/loader.py
@@ -161,6 +161,7 @@ class ScyllaBenchStressExporter(StressExporter):
                 [f'scylla_bench_stress_{self.stress_operation}', 'instance', 'loader_idx', 'cpu_idx', 'type', 'keyspace'])
         return gauge_name
 
+    # pylint: disable=line-too-long
     def merics_position_in_log(self) -> MetricsPosition:
         # Enumerate stress metric position in the log. Example:
         # time  operations/s    rows/s   errors  max   99.9th   99th      95th     90th       median        mean
@@ -169,6 +170,7 @@ class ScyllaBenchStressExporter(StressExporter):
         return MetricsPosition(ops=1, lat_mean=10, lat_med=9, lat_perc_95=7, lat_perc_99=6, lat_perc_999=5,
                                lat_max=4, errors=3)
 
+    # pylint: disable=line-too-long
     def skip_line(self, line) -> bool:
         # If line is not starts with numeric ended by "s" - skip this line.
         # Example:
@@ -188,3 +190,32 @@ class ScyllaBenchStressExporter(StressExporter):
     @staticmethod
     def split_line(line: str) -> list:
         return [element.strip() for element in line.split()]
+
+
+class CassandraHarryStressExporter(StressExporter):
+
+    # pylint: disable=too-many-arguments,useless-super-delegation
+    def __init__(self, instance_name: str, metrics: NemesisMetrics, stress_operation: str, stress_log_filename: str,
+                 loader_idx: int, cpu_idx: int = 1):
+
+        super().__init__(instance_name, metrics, stress_operation, stress_log_filename,
+                         loader_idx, cpu_idx)
+
+    def create_metrix_gauge(self) -> str:
+        gauge_name = f'collectd_cassandra_harry_stress_{self.stress_operation}_gauge'
+        if gauge_name not in self.METRICS_GAUGES:
+            self.METRICS_GAUGES[gauge_name] = self.metrics.create_gauge(
+                gauge_name,
+                'Gauge for scylla-bench stress metrics',
+                [f'scylla_bench_stress_{self.stress_operation}', 'instance', 'loader_idx', 'cpu_idx', 'type', 'keyspace'])
+        return gauge_name
+
+    def merics_position_in_log(self) -> MetricsPosition:
+        pass
+
+    def skip_line(self, line) -> bool:
+        return not 'Reorder buffer size has grown up to' in line
+
+    @staticmethod
+    def split_line(line: str) -> list:
+        return line.split()

--- a/sdcm/sct_events/base.py
+++ b/sdcm/sct_events/base.py
@@ -59,6 +59,7 @@ class SctEventTypesRegistry(Dict[str, Type["SctEvent"]]):  # pylint: disable=too
         self[owner.__name__] = owner  # add owner class to the registry.
 
 
+# pylint: disable=invalid-name
 class EventPeriod(Enum):
     BEGIN = "begin"
     END = "end"

--- a/sdcm/sct_events/loaders.py
+++ b/sdcm/sct_events/loaders.py
@@ -20,7 +20,7 @@ from typing import Type, Optional, List, Tuple, Any
 import dateutil.parser
 from invoke.runners import Result
 
-from sdcm.sct_events import Severity
+from sdcm.sct_events import Severity, SctEventProtocol
 from sdcm.sct_events.base import SctEvent, LogEvent, LogEventProtocol, T_log_event
 from sdcm.sct_events.stress_events import BaseStressEvent, StressEvent, StressEventProtocol
 
@@ -73,6 +73,24 @@ class CassandraStressEvent(StressEvent):
 
 class ScyllaBenchEvent(StressEvent):
     ...
+
+
+class CassandraHarryEvent(StressEvent, abstract=True):
+    failure: Type[StressEventProtocol]
+    error: Type[SctEventProtocol]
+    timeout: Type[StressEventProtocol]
+    start: Type[StressEventProtocol]
+    finish: Type[StressEventProtocol]
+
+    @property
+    def msgfmt(self):
+        fmt = super(StressEvent, self).msgfmt + ": type={0.type} node={0.node} stress_cmd={0.stress_cmd}"
+        if self.errors:
+            return fmt + " error={0.errors_formatted}"
+        return fmt
+
+
+CassandraHarryEvent.add_stress_subevents(failure=Severity.CRITICAL, error=Severity.ERROR, timeout=Severity.ERROR)
 
 
 class BaseYcsbStressEvent(StressEvent, abstract=True):
@@ -185,6 +203,11 @@ SCYLLA_BENCH_ERROR_EVENTS = (
 )
 SCYLLA_BENCH_ERROR_EVENTS_PATTERNS: List[Tuple[re.Pattern, LogEventProtocol]] = \
     [(re.compile(event.regex), event) for event in SCYLLA_BENCH_ERROR_EVENTS]
+
+CASSANDRA_HARRY_ERROR_EVENTS = (
+)
+CASSANDRA_HARRY_ERROR_EVENTS_PATTERNS: List[Tuple[re.Pattern, LogEventProtocol]] = \
+    [(re.compile(event.regex), event) for event in CASSANDRA_HARRY_ERROR_EVENTS]
 
 
 class GeminiStressLogEvent(LogEvent[T_log_event], abstract=True):  # pylint: disable=too-many-instance-attributes

--- a/test-cases/longevity/longevity-harry-2h.yaml
+++ b/test-cases/longevity/longevity-harry-2h.yaml
@@ -1,0 +1,17 @@
+test_duration: 240
+stress_cmd: ["/usr/bin/cassandra-harry -run-time 2 -run-time-unit HOURS"]
+
+n_db_nodes: 6
+n_loaders: 2
+n_monitor_nodes: 1
+
+instance_type_db: 'i3.large'
+
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_seed: '111'
+nemesis_interval: 2
+ssh_transport: 'libssh2'
+
+user_prefix: 'longevity-10gb-3h'
+space_node_threshold: 64424
+use_mgmt: false

--- a/test-cases/longevity/longevity-harry-2h.yaml
+++ b/test-cases/longevity/longevity-harry-2h.yaml
@@ -12,6 +12,6 @@ nemesis_seed: '111'
 nemesis_interval: 2
 ssh_transport: 'libssh2'
 
-user_prefix: 'longevity-10gb-3h'
+user_prefix: 'longevity-harry-2h'
 space_node_threshold: 64424
 use_mgmt: false


### PR DESCRIPTION
Ticket: https://trello.com/c/tFSmBovn/2395-explore-cassandra-harry-new-fuzzing-tool-from-cassandra

    This patchset added a new kind of workload.
    
    /usr/bin/cassandra-harry on loader points a wrapper script CLI, it accepts
    `-node` and `-run-time` arguments.


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
