### PR TITLE
fix(lwt multidc): decrease prepare stage time

### DIFF
--- a/test-cases/longevity/longevity-lwt-24h-multidc.yaml
+++ b/test-cases/longevity/longevity-lwt-24h-multidc.yaml
@@ -1,13 +1,13 @@
 test_duration: 1560
-prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data_multidc.yaml n=10000000 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=100" ]
-stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data_multidc.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1,lwt_deletes=1)' cl=QUORUM duration=1440m -mode native cql3 -rate threads=30" ]
-stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data_multidc.yaml ops'(select=1)' cl=SERIAL duration=1440m -mode native cql3 -rate threads=30" ]
+prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data_multidc.yaml n=10000000 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=1000" ]
+stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data_multidc.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1,lwt_deletes=1)' cl=QUORUM duration=1440m -mode native cql3 -rate threads=800" ]
+stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data_multidc.yaml ops'(select=1)' cl=SERIAL duration=1440m -mode native cql3 -rate threads=800" ]
 
 n_db_nodes: '4 3 2'
 n_loaders: 3
 n_monitor_nodes: 1
 
-instance_type_db: 'i3.xlarge'
+instance_type_db: 'i3.4xlarge'
 
 nemesis_class_name: 'ChaosMonkey'
 nemesis_interval: 5


### PR DESCRIPTION
Now prepare stage time takes about 12 hours. It's too long.
Change db node instance type to stronger and increase threads for the
c-s command

Prepare stage - 1.5 hour:
![Screenshot from 2021-01-20 12-09-09](https://user-images.githubusercontent.com/34435448/105180088-c7973500-5b32-11eb-9de1-fc2c4e8d6699.png)

select/update c-s runs - CPU  is 65-85, ops almost 20K:
![Screenshot from 2021-01-20 12-33-25](https://user-images.githubusercontent.com/34435448/105180090-c8c86200-5b32-11eb-8a02-ab741cfa567e.png)


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
