### PR TITLE
fix(create_metrix_gauge): Revert renaming of c-s latency metric label

### DIFF
--- a/sdcm/loader.py
+++ b/sdcm/loader.py
@@ -130,7 +130,7 @@ class CassandraStressExporter(StressExporter):
             self.METRICS_GAUGES[gauge_name] = self.metrics.create_gauge(
                 gauge_name,
                 'Gauge for cassandra stress metrics',
-                [f'cassandra_stress_{self.stress_operation}', 'instance', 'loader_idx', 'cpu_idx', 'type', '_keyspace'])
+                [f'cassandra_stress_{self.stress_operation}', 'instance', 'loader_idx', 'cpu_idx', 'type', 'keyspace'])
         return gauge_name
 
     def merics_position_in_log(self) -> MetricsPosition:
@@ -163,7 +163,7 @@ class ScyllaBenchStressExporter(StressExporter):
             self.METRICS_GAUGES[gauge_name] = self.metrics.create_gauge(
                 gauge_name,
                 'Gauge for scylla-bench stress metrics',
-                [f'scylla_bench_stress_{self.stress_operation}', 'instance', 'loader_idx', 'cpu_idx', 'type', '_keyspace'])
+                [f'scylla_bench_stress_{self.stress_operation}', 'instance', 'loader_idx', 'cpu_idx', 'type', 'keyspace'])
         return gauge_name
 
     def merics_position_in_log(self) -> MetricsPosition:


### PR DESCRIPTION
PR https://github.com/scylladb/scylla-cluster-tests/pull/3153/
brake the rolling upgrade by renaming label, which is used
in rolling upgrade tests to validate metrics.
Revert renaming because require functionality already
supported by Grafana

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
