### PR TITLE
fix(s3_paths): fix the paths to look from latest repo/list files

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1308,10 +1308,10 @@ def get_branched_repo(scylla_version: str,
         raise ValueError(f"{scylla_version=} should be in `branch-x.y:<date>' or `branch-x.y:latest' format") from None
 
     if dist_type == "centos":
-        prefix = f"rpm/unstable/centos/{branch}/{branch_version}/"
+        prefix = f"unstable/scylla/{branch}/rpm/centos/{branch_version}/"
         filename = "scylla.repo"
     elif dist_type in ("ubuntu", "debian", ):
-        prefix = f"deb/unstable/unified/{branch}/{branch_version}/scylladb-master/"
+        prefix = f"unstable/scylla/{branch}/deb/unified/{branch_version}/scylladb-master/"
         filename = "scylla.list"
     else:
         raise ValueError(f"Unsupported {dist_type=}")

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -354,7 +354,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
 
     def test_15a_new_scylla_repo_by_scylla_version(self):
         os.environ['SCT_CLUSTER_BACKEND'] = 'gce'
-        os.environ['SCT_SCYLLA_VERSION'] = 'branch-4.2:latest'
+        os.environ['SCT_SCYLLA_VERSION'] = 'master:latest'
         os.environ['SCT_NEW_VERSION'] = 'master:latest'
         os.environ['SCT_USER_PREFIX'] = 'testing'
 
@@ -362,7 +362,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         conf.verify_configuration()
 
         resolved_repo_link = resolve_latest_repo_symlink(
-            "https://s3.amazonaws.com/downloads.scylladb.com/rpm/unstable/centos/branch-4.2/latest/scylla.repo"
+            "https://s3.amazonaws.com/downloads.scylladb.com/unstable/scylla/master/rpm/centos/latest/scylla.repo"
         )
         self.assertEqual(conf.get('scylla_repo'), resolved_repo_link)
         target_upgrade_version = conf.get('target_upgrade_version')
@@ -380,7 +380,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         conf.verify_configuration()
 
         resovled_repo_link = resolve_latest_repo_symlink(
-            "https://s3.amazonaws.com/downloads.scylladb.com/deb/unstable/unified/master/latest/scylladb-master/scylla.list"
+            "https://s3.amazonaws.com/downloads.scylladb.com/unstable/scylla/master/deb/unified/latest/scylladb-master/scylla.list"
         )
         self.assertEqual(conf.get('scylla_repo'), resovled_repo_link)
         target_upgrade_version = conf.get('target_upgrade_version')


### PR DESCRIPTION
about a month ago the paths were change by scylla-pkg, and we
were testing the same version in rolling upgrades since than.

Ref: scylladb/scylla-pkg#1871

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
