### PR TITLE
fix(rolling upgrade centos 7): make fit to branch-2020.1

### DIFF
--- a/jenkins-pipelines/rolling-upgrade-centos7-ldap-authorization.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-centos7-ldap-authorization.jenkinsfile
@@ -4,6 +4,8 @@
 def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
+    params: params,
+
     backend: 'gce',
     base_versions: ['2020.1'],
     linux_distro: 'centos',


### PR DESCRIPTION
it was backported from master, but did not work, as
it needs few changes to adapt to branch-2020.1

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
