### PR TITLE
fix(CorruptThenScrubMonkey): fix and renable scrub nemesis

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -154,3 +154,17 @@ def ignore_mutation_write_errors():
 def ignore_ycsb_connection_refused():
     with EventsFilter(event_class=YcsbStressEvent, regex='.*Unable to execute HTTP request: Connection refused.*'):
         yield
+
+
+@contextmanager
+def ignore_scrub_invalid_errors():
+    with ExitStack() as stack:
+        stack.enter_context(DbEventsFilter(
+            db_event=DatabaseLogEvent.DATABASE_ERROR,
+            line="Skipping invalid clustering row fragment",
+        ))
+        stack.enter_context(DbEventsFilter(
+            db_event=DatabaseLogEvent.DATABASE_ERROR,
+            line="Skipping invalid partition",
+        ))
+        yield


### PR DESCRIPTION
ticket: https://trello.com/c/JTlE1RYu/1687-nodetool-scrub-implement-validation-and-the-skip-corrupted-flag

### V1:

Load sstables with invalid fragment by refresh, the sstables were generated by
scylla unittest (test/boost/sstable_datafile_test.cc:sstable_scrub_test).
Then try rebuild the sstables by scrub, the invalid sstable will be skipped if
`--skip-corrupted` option is used.

### V2:

fix(CorruptThenScrubMonkey): fix and renable scrub nemesis
    
The updated nemesis tries to rebuild sstables of all test keyspaces by
scrub, the corrupted partitions will be skipped.
    


Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
