### PR TITLE
feature(hydra_kcl): Use alternator client load balancer

### DIFF
--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -119,7 +119,7 @@ class YcsbStressThread(DockerBasedStressThread):  # pylint: disable=too-many-ins
         if self.params.get('alternator_use_dns_routing'):
             target_address = 'alternator'
         else:
-            if getattr(self.node_list[0], 'parent_cluster'):
+            if hasattr(self.node_list[0], 'parent_cluster'):
                 target_address = self.node_list[0].parent_cluster.get_node().ip_address
             else:
                 target_address = self.node_list[0].ip_address


### PR DESCRIPTION
Now that Nadav figure out how older AWS code can be used
with a client load balancing code, we are moving to use
that for the `hydra-kcl` stress tool

Ref: https://github.com/scylladb/alternator-load-balancing/pull/6
Ref: https://github.com/fruch/hydra-kcl/pull/3

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
