### PR TITLE
fix(TerminateAndRemoveNodeMonkey): filter error on

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2180,8 +2180,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         # and as a result requires ignoring repair errors
         first_node_to_repair = up_normal_nodes[0]
         with DbEventsFilter(db_event=DatabaseLogEvent.RUNTIME_ERROR,
-                            line="failed to repair",
-                            node=first_node_to_repair):
+                            line="failed to repair"):
             try:
                 self.repair_nodetool_repair(node=first_node_to_repair)
             except Exception as details:  # pylint: disable=broad-except


### PR DESCRIPTION
all nodes now. Previously filter was ononly the 1st
node to run repair, but the same error was seen on
several (if not all) nodes.
Hence removing the filter on specific node, and now
having this "warning" message filtered out for all
nodes.
It is kind of enhancement for #3109.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
