### PR TITLE
fix(install_scylla_bench): reinstall scylla-bench if it exists

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4240,6 +4240,8 @@ class BaseLoaderSet():
         node.remoter.sudo("bash -cxe \"echo '*\t\thard\tcore\t\tunlimited\n*\t\tsoft\tcore\t\tunlimited' "
                           ">> /etc/security/limits.d/20-coredump.conf\"")
         if result.exit_status == 0:
+            # Update existing scylla-bench to latest
+            node.remoter.run('go get -u github.com/scylladb/scylla-bench')
             self.log.debug('Skip loader setup for using a prepared AMI')
             return
 

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4477,7 +4477,7 @@ class BaseLoaderSet():
             echo 'export GOPATH=$HOME/go' >> $HOME/.bash_profile
             echo 'export PATH=$PATH:/usr/local/go/bin' >> $HOME/.bash_profile
             source $HOME/.bash_profile
-            go get github.com/scylladb/scylla-bench
+            go get -u github.com/scylladb/scylla-bench
         """))
 
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1146,6 +1146,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         timeout = self.get_duration(duration)
         stop_test_on_failure = False if not self.params.get("stop_test_on_stress_failure") else stop_test_on_failure
 
+        if self.params.get("client_encrypt") and ' -tls' not in stress_cmd:
+            stress_cmd += ' -tls '
+
         if self.create_stats:
             self.update_stress_cmd_details(stress_cmd, stresser="scylla-bench", aggregate=stats_aggregate_cmds)
         bench_thread = ScyllaBenchThread(


### PR DESCRIPTION
Currently we are still using very old scylla-bench for testing, so
scylla-bench failed in tls jobs. Because tls support of scylla-bench was
added recently.

When we prepare the new loader image, scylla-bench won't be updated by
`go get github.com/scylladb/scylla-bench'.

[centos@longevity-tls-1tb-7d-4-4-loader-node-223f91b5-1 ~]$ ls -lh go/bin/
total 6.3M
-rwxrwxr-x. 1 centos centos 6.3M Jan 24  2019 scylla-bench
[centos@longevity-tls-1tb-7d-4-4-loader-node-223f91b5-1 ~]$ md5sum go/bin/scylla-bench
5cbd2c3e9faff3feab171f89d87d1da8  go/bin/scylla-bench

This patch added a `-u' option to go cmdline, it will upgrade existing
scylla-bench to latest.

Related SCT issue: https://github.com/scylladb/scylla-cluster-tests/issues/2850

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
