### PR TITLE
fix(scylla bench): run scylla-bench wuth correct ssh connection type

### DIFF
--- a/sdcm/scylla_bench_thread.py
+++ b/sdcm/scylla_bench_thread.py
@@ -130,7 +130,7 @@ class ScyllaBenchThread:
 
         log_file_name = os.path.join(node.logdir, f'scylla-bench-l{loader_idx}-{uuid.uuid4()}.log')
         # Select first seed node to send the scylla-bench cmds
-        ips = node_list[0].private_ip_address
+        ips = node_list[0].ip_address
 
         # Find stress mode:
         #    "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=100"


### PR DESCRIPTION
Use node IP according to test ip_ssh_connections in scylla-bench command
Support IPv6 as well: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/yulia/job/staging-10gb-3h/116/


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
