### PR TITLE
Backport debug typo fix to 2020.1

### DIFF
--- a/sdcm/remote/remote_base.py
+++ b/sdcm/remote/remote_base.py
@@ -239,7 +239,7 @@ class RemoteCmdRunnerBase(CommandRunner):  # pylint: disable=too-many-instance-a
                     files_received = False
                 # Avoid "already printed" message without real error
                 if result.stderr:
-                    self.log.deubg("Stderr: %s", result.stderr)
+                    self.log.debug("Stderr: %s", result.stderr)
                     files_received = False
 
         if not preserve_perm:


### PR DESCRIPTION
The typo had been fixed in master by commit 88b45ff9f,
the commit contains many changes, this patch only backport
the typo fix.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
