### PR TITLE
[ycsb/doc] scylla binding don't require stating connections count

### DIFF
--- a/test-cases/longevity/longevity-ycsb.txt
+++ b/test-cases/longevity/longevity-ycsb.txt
@@ -36,8 +36,7 @@ Create a keyspace, and a table as mentioned above. Load data with:
         -p readproportion=0 -p updateproportion=0 \
         -p fieldcount=10 -p fieldlength=128 \
         -p insertstart=0 -p insertcount=1000000000 \
-        -p cassandra.coreconnections=14 -p cassandra.maxconnections=14 \
-        -p cassandra.username=cassandra -p cassandra.password=cassandra \
+        -p scylla.username=cassandra -p scylla.password=cassandra \
         -p scylla.hosts=ip1,ip2,ip3,...
 
 Use as following:
@@ -46,7 +45,6 @@ Use as following:
         -target 120000 -threads 840 -p recordcount=1000000000 \
         -p fieldcount=10 -p fieldlength=128 \
         -p operationcount=50000000 \
-        -p scylla.coreconnections=280 -p scylla.maxconnections=280 \
         -p scylla.username=cassandra -p scylla.password=cassandra \
         -p scylla.hosts=ip1,ip2,ip3,... \
         -p scylla.tokenaware=true
@@ -55,18 +53,22 @@ Use as following:
 
 ### 1. Load target
 
-You want to test how a database handles load. To get the performance picture
-you would want to look at the latency distribution and utilization under the
-constant load. To select load use `-target` to state desired throughput level.
+Suppose, you want to test how a database handles an open-class system load.
+
+In this case, to get the performance picture you want to look at the latency
+distribution and utilization under the constant throughput. Use the `-target` flag
+to state desired throughput level.
 
 For example `-target 120000` means that we expect YCSB workers to generate
 120,000 requests per second (RPS, QPS or TPS) to the database.
 
 Why is this important? Because without setting target throughput you will be
-looking only on the system equilibrium point that in the face of constantly
-varying latency will not allow you to see either throughput, nor latency.
+looking at the system equilibrium point which in the face of constantly
+varying latency would show you neither throughput, nor latency. Your system
+in that case will converge to the closed-class queuing system and that is something
+not what you wanted.
 
-For more information check out these resources on the coordinated omission problem:
+For more information check out these resources on the coordinated omission problem.
 
 See
 [[1]](http://highscalability.com/blog/2015/10/5/your-load-generator-is-probably-lying-to-you-take-the-red-pi.html)
@@ -75,7 +77,41 @@ See
 and [[this]](https://www.youtube.com/watch?v=lJ8ydIuPFeU)
 great talk by Gil Tene.
 
-### 2. Parallelism factor and threads
+### 2. Latency correction
+
+To measure latency correctly, it is not enough to just set a target.
+The latencies must be measured according to the running schedule.
+This is what YCSB calls an Intended operation.
+
+This fair measurement consists of the operation latency and its correction
+to the point of its intended execution. Even if you don’t want to have
+a completely fair measurement, use “both”:
+
+    --measurement.interval=both
+
+Other options are “op” and “intended”. “op” is the default.
+
+Another flag that affects measurement quality is the type of histogram
+“--measurementtype” but for a long time, it uses “hdrhistogram” that
+must be fine for most use cases.
+
+### 3. Latency percentiles and multiple loaders
+
+Latencies percentiles can't be averaged. Don't fall into this trap.
+Neither averages nor p99 averages do not make any sense.
+
+If you run a single loader (ycsb) instance look for P99 - 99
+percentile. If you run multiple loaders dump result histograms with:
+
+    --measurement.histogram.verbose=true
+
+merge them manually and extract required percentiles out of the
+joined result.
+
+Remember that running multiple workloads may distort original
+workloads distributions they were intended to produce.
+
+### 4. Parallelism factor and threads
 
 Scylla utilizes [thread-per-core](https://www.scylladb.com/product/technology/) architecture design.
 That means that a Node consists of shards that are mapped to the CPU cores 1-per-core.
@@ -116,7 +152,17 @@ Another concern is that for high throughput scenarios you would probably
 want to keep shards incoming queues non-empty. For that your parallelism factor
 must be at least 2.
 
-### 3. Number of connections
+### 5. Number of connections
+
+If you use original Cassandra drivers you need to pick the proper number
+of connections per host. Scylla drivers do not require this to be configured
+and by default create a connection per shard. For example if your node has
+16 vCPU and thus 14 shards Scylla drivers will pick to create 14 connections
+per host. An excess of connections may result in degraded latency.
+
+Database client protocol is asynchronous and allows queueing requests in
+a single connection. The default queue limit for local keys is 1024 and 256
+for remote ones. Current binding implementation do not require this.
 
 Both `scylla.coreconnections` and `scylla.maxconnections` define limits
 per node. When you see `-p scylla.coreconnections=280 -p scylla.maxconnections=280`
@@ -130,7 +176,7 @@ Number of connections must be a multiple of:
 For example, for `i3.4xlarge` that has 14 shards per node and `K = 20`
 it makes sense to pick `connections = shards * K = 14 * 20 = 280`.
 
-### 4. Other considerations
+### 6. Other considerations
 
 Consistency levels do not change consistency model or its strongness.
 Even with `-p scylla.writeconsistencylevel=ONE` the data will be written
@@ -142,12 +188,9 @@ latency picture a bit but would not affect utilization.
 Remember that you can't measure CPU utilization with Scylla by normal
 Unix tools. Check out Scylla own metrics to see real reactors utilization.
 
-Always use [token aware](https://www.scylladb.com/2019/03/27/best-practices-for-scylla-applications/)
-load balancing `-p scylla.tokenaware=true`.
-
 For best performance it is crucial to evenly load all available shards.
 
-### 5. Expected performance target
+### 7. Expected performance target
 
 You can expect about 12500 uOPS / core (shard), where uOPS are basic
 reads and writes operations post replication. Don't forget that usually
@@ -170,3 +213,54 @@ of 3 nodes of i3.4xlarge (16 vCPU per node) and target of 120000 is:
 
     [ 120K * 0.5 * 3 + 120K * 0.5 * 2 (QUORUM) ] / [ (16 - 2) * 3 nodes ] =
     = 7142 uOPS / vCPU ~ 14000 uOPS / Core.
+
+## Scylla configuration parameters
+
+- `scylla.hosts` (**required**)
+  - A list of Scylla nodes to connect to.
+  - No default. Usage: `-p scylla.hosts=ip1,ip2,ip3,...`
+
+* `scylla.port`
+
+  - CQL port for communicating with Scylla cluster.
+    This port must be the same on all cluster nodes.
+  - Default is `9042`.
+
+- `scylla.keyspace`
+
+  - keyspace name - must match the keyspace for the table created (see above).
+    See https://docs.scylladb.com/getting-started/ddl/#create-keyspace-statement for details.
+  - Default value is `ycsb`
+
+- `scylla.username` and `scylla.password`
+
+  - Optional user name and password for authentication.
+  - See https://docs.scylladb.com/operating-scylla/security/enable-authorization/ for details.
+
+* `scylla.readconsistencylevel`
+* `scylla.writeconsistencylevel`
+
+  * Default value is `QUORUM`
+  - Consistency level for reads and writes, respectively. 
+    See the [Scylla documentation](https://docs.scylladb.com/glossary/#term-consistency-level-any) for details.
+
+* `scylla.maxconnections`
+* `scylla.coreconnections`
+
+  * Defaults for max and core connections can be found here:
+    https://github.com/scylladb/java-driver/tree/latest/manual/pooling.
+
+* `scylla.connecttimeoutmillis`
+* `scylla.readtimeoutmillis`
+* `scylla.useSSL`
+
+  * Default value is false.
+  - To connect with SSL set this value to true.
+
+* `scylla.tracing`
+  * Default is false
+  * https://docs.scylladb.com/using-scylla/tracing/
+
+- `scylla.lwt`
+  - Use LWT for operations
+  - Default is false.


### PR DESCRIPTION
Scylla-native Token Aware driver is capable of automatically pick the
right amount of connectionts per shard.