### PR TITLE
fix(monitoring_prereqs): specifing python3.6 in installation

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4677,8 +4677,8 @@ class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-inst
                 apt-get install -y python3.6 python3.6-dev
                 apt-get install -y python-setuptools unzip wget
                 apt install -y python3-pip
-                python3 -m pip install --upgrade pip
-                python3 -m pip install pyyaml
+                python3.6 -m pip install --upgrade pip
+                python3.6 -m pip install pyyaml
                 pip3 install -I -U psutil
                 systemctl start docker
             """)


### PR DESCRIPTION
Fixes: #3174 

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
