### PR TITLE
fix(k8s jenkins jobs): add +20 to testduration and +40 to pipeline timeout

### DIFF
--- a/jenkins-pipelines/longevity-scylla-operator-3h-gke-add-remove-rack.jenkinsfile
+++ b/jenkins-pipelines/longevity-scylla-operator-3h-gke-add-remove-rack.jenkinsfile
@@ -6,5 +6,5 @@ operatorPipeline(
     backend: 'k8s-gke',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-gke-add-remove-rack.yaml',
-    timeout: [time: 360, unit: 'MINUTES']
+    timeout: [time: 400, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-scylla-operator-3h-gke-backup.jenkinsfile
+++ b/jenkins-pipelines/longevity-scylla-operator-3h-gke-backup.jenkinsfile
@@ -6,5 +6,5 @@ operatorPipeline(
     backend: 'k8s-gke',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-gke-backup.yaml',
-    timeout: [time: 300, unit: 'MINUTES']
+    timeout: [time: 400, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-scylla-operator-3h-gke-cluster-rolling.jenkinsfile
+++ b/jenkins-pipelines/longevity-scylla-operator-3h-gke-cluster-rolling.jenkinsfile
@@ -6,5 +6,5 @@ operatorPipeline(
     backend: 'k8s-gke',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-gke-cluster-rolling.yaml',
-    timeout: [time: 360, unit: 'MINUTES']
+    timeout: [time: 400, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-scylla-operator-3h-gke-grow-shrink.jenkinsfile
+++ b/jenkins-pipelines/longevity-scylla-operator-3h-gke-grow-shrink.jenkinsfile
@@ -6,5 +6,5 @@ operatorPipeline(
     backend: 'k8s-gke',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-gke-grow-shrink.yaml',
-    timeout: [time: 360, unit: 'MINUTES']
+    timeout: [time: 400, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-scylla-operator-3h-gke-repair.jenkinsfile
+++ b/jenkins-pipelines/longevity-scylla-operator-3h-gke-repair.jenkinsfile
@@ -6,5 +6,5 @@ operatorPipeline(
     backend: 'k8s-gke',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-gke-repair.yaml',
-    timeout: [time: 360, unit: 'MINUTES']
+    timeout: [time: 400, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-scylla-operator-3h-gke-replace.jenkinsfile
+++ b/jenkins-pipelines/longevity-scylla-operator-3h-gke-replace.jenkinsfile
@@ -6,5 +6,5 @@ operatorPipeline(
     backend: 'k8s-gke',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-gke-replace.yaml',
-    timeout: [time: 360, unit: 'MINUTES']
+    timeout: [time: 400, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-scylla-operator-3h-gke-stop-start.jenkinsfile
+++ b/jenkins-pipelines/longevity-scylla-operator-3h-gke-stop-start.jenkinsfile
@@ -6,5 +6,5 @@ operatorPipeline(
     backend: 'k8s-gke',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-gke-stop-start.yaml',
-    timeout: [time: 360, unit: 'MINUTES']
+    timeout: [time: 400, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-scylla-operator-3h-gke-terminate-decommission-add.jenkinsfile
+++ b/jenkins-pipelines/longevity-scylla-operator-3h-gke-terminate-decommission-add.jenkinsfile
@@ -6,5 +6,5 @@ operatorPipeline(
     backend: 'k8s-gke',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-gke-terminate-decommission-add.yaml',
-    timeout: [time: 360, unit: 'MINUTES']
+    timeout: [time: 400, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-scylla-operator-3h-gke-terminate-recover.jenkinsfile
+++ b/jenkins-pipelines/longevity-scylla-operator-3h-gke-terminate-recover.jenkinsfile
@@ -6,5 +6,5 @@ operatorPipeline(
     backend: 'k8s-gke',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-gke-terminate-recover.yaml',
-    timeout: [time: 360, unit: 'MINUTES']
+    timeout: [time: 400, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-scylla-operator-3h-gke-terminate-replace.jenkinsfile
+++ b/jenkins-pipelines/longevity-scylla-operator-3h-gke-terminate-replace.jenkinsfile
@@ -6,5 +6,5 @@ operatorPipeline(
     backend: 'k8s-gke',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-gke-terminate-replace.yaml',
-    timeout: [time: 360, unit: 'MINUTES']
+    timeout: [time: 400, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-scylla-operator-3h-gke.jenkinsfile
+++ b/jenkins-pipelines/longevity-scylla-operator-3h-gke.jenkinsfile
@@ -6,5 +6,5 @@ operatorPipeline(
     backend: 'k8s-gke',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-gke.yaml',
-    timeout: [time: 360, unit: 'MINUTES']
+    timeout: [time: 400, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-scylla-operator-3h-minikube.jenkinsfile
+++ b/jenkins-pipelines/longevity-scylla-operator-3h-minikube.jenkinsfile
@@ -6,5 +6,5 @@ operatorPipeline(
     backend: 'k8s-gce-minikube',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-minikube.yaml',
-    timeout: [time: 360, unit: 'MINUTES']
+    timeout: [time: 400, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-scylla-operator-basic-3h-gke.jenkinsfile
+++ b/jenkins-pipelines/longevity-scylla-operator-basic-3h-gke.jenkinsfile
@@ -6,5 +6,5 @@ operatorPipeline(
     backend: 'k8s-gke',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-basic-3h-gke.yaml',
-    timeout: [time: 360, unit: 'MINUTES']
+    timeout: [time: 400, unit: 'MINUTES']
 )

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-add-remove-rack.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-add-remove-rack.yaml
@@ -1,4 +1,4 @@
-test_duration: 280
+test_duration: 300
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
              ]
 # Should be n_db_nodes + 1

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-backup.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-backup.yaml
@@ -1,4 +1,4 @@
-test_duration: 240
+test_duration: 300
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
              ]
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-cluster-rolling.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-cluster-rolling.yaml
@@ -1,4 +1,4 @@
-test_duration: 280
+test_duration: 300
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
              ]
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-grow-shrink.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-grow-shrink.yaml
@@ -1,4 +1,4 @@
-test_duration: 280
+test_duration: 300
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
              ]
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-repair.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-repair.yaml
@@ -1,4 +1,4 @@
-test_duration: 280
+test_duration: 300
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
              ]
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-replace.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-replace.yaml
@@ -1,4 +1,4 @@
-test_duration: 280
+test_duration: 300
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
              ]
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-stop-start.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-stop-start.yaml
@@ -1,4 +1,4 @@
-test_duration: 280
+test_duration: 300
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
              ]
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-terminate-decommission-add.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-terminate-decommission-add.yaml
@@ -1,4 +1,4 @@
-test_duration: 280
+test_duration: 300
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
              ]
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-terminate-recover.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-terminate-recover.yaml
@@ -1,4 +1,4 @@
-test_duration: 280
+test_duration: 300
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
              ]
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-terminate-replace.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-gke-terminate-replace.yaml
@@ -1,4 +1,4 @@
-test_duration: 280
+test_duration: 300
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
              ]
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-gke.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-gke.yaml
@@ -1,4 +1,4 @@
-test_duration: 280
+test_duration: 300
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
              ]
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-minikube.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-minikube.yaml
@@ -1,4 +1,4 @@
-test_duration: 240
+test_duration: 300
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=100 throttle=10000/s -pop seq=1..10000000 -log interval=5"
              ]
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-basic-3h-gke.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-basic-3h-gke.yaml
@@ -1,4 +1,4 @@
-test_duration: 280
+test_duration: 300
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
              ]
 


### PR DESCRIPTION
This is needed since after we added manager deployment test initialization time increased and started to ran over testduration limit

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
