### PR TITLE
fix(remove_node_then_add_node): filter repair error for all normal nodes

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2176,22 +2176,16 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         # full cluster repair
         up_normal_nodes.remove(node_to_remove)
-        # Repairing the first node will result in a best effort repair due to the terminated node,
+        # Repairing will result in a best effort repair due to the terminated node,
         # and as a result requires ignoring repair errors
-        first_node_to_repair = up_normal_nodes[0]
         with DbEventsFilter(db_event=DatabaseLogEvent.RUNTIME_ERROR,
                             line="failed to repair"):
-            try:
-                self.repair_nodetool_repair(node=first_node_to_repair)
-            except Exception as details:  # pylint: disable=broad-except
-                self.log.error(f"failed to execute repair command "
-                               f"on node {first_node_to_repair} due to the following error: {str(details)}")
-        for node in up_normal_nodes[1:]:
-            try:
-                self.repair_nodetool_repair(node=node)
-            except Exception as details:  # pylint: disable=broad-except
-                self.log.error(f"failed to execute repair command "
-                               f"on node {node} due to the following error: {str(details)}")
+            for node in up_normal_nodes:
+                try:
+                    self.repair_nodetool_repair(node=node)
+                except Exception as details:  # pylint: disable=broad-except
+                    self.log.error(f"failed to execute repair command "
+                                   f"on node {node} due to the following error: {str(details)}")
 
         def remove_node():
             # nodetool removenode 'host_id'


### PR DESCRIPTION
Filter repair error for all normal nodes for repair during remove_node_then_add_node
nemesis

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
