### PR TITLE
fix(sct_runner.py): use larger disk for long longevity

### DIFF
--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -52,11 +52,11 @@ class SctRunner:
 
     @staticmethod
     def instance_root_disk_size(test_duration):
-        INSTANCE_ROOT_DISK_SIZE = 35  # GB
+        disk_size = 35  # GB
         if test_duration and test_duration > 3 * 24 * 60:  # 3 days
             # add 20G more space for jobs which test_duration is longer than 3 days
-            return INSTANCE_ROOT_DISK_SIZE + 20
-        return INSTANCE_ROOT_DISK_SIZE
+            return disk_size + 20
+        return disk_size
 
     @staticmethod
     @lru_cache(maxsize=None)


### PR DESCRIPTION
My 1TB-longevity failed in collecting logs because of ENOSPC on sct
runner. I know it's not a common case, but when it occurs we might lost
the test logs.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
