### PR TITLE
fix(ycsb_thread): raise error on verification errors 

### DIFF
--- a/sdcm/remote/base.py
+++ b/sdcm/remote/base.py
@@ -254,19 +254,18 @@ class FailuresWatcher(Responder):
         self.callback = callback
         self.raise_exception = raise_exception
 
-    def first_matching_line(self, stream, index):
+    def process_all_matching_lines(self, stream, index):
         new_ = stream[index:]
         for line in new_.splitlines():
             if re.findall(self.sentinel, line, re.S):
-                return line
-        return None
+                self._process_line(line)
 
     def submit(self, stream):
         index = getattr(self, "failure_index")
         # Also check stream for our failure sentinel
         # Error out if we seem to have failed after a previous response.
         if self.pattern_matches(stream, self.sentinel, "failure_index"):
-            self._process_line(self.first_matching_line(stream, index))
+            self.process_all_matching_lines(stream, index)
         return []
 
     def submit_line(self, line: str):

--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -254,7 +254,7 @@ class YcsbStressThread(DockerBasedStressThread):  # pylint: disable=too-many-ins
                     log_file=log_file_name,
                     watchers=[
                         FailuresWatcher(
-                            r'\sERROR|=UNEXPECTED_STATE',
+                            r'\sERROR|=UNEXPECTED_STATE|=ERROR',
                             callback=raise_event_callback,
                             raise_exception=False
                         )

--- a/test-cases/longevity/longevity-ycsb.txt
+++ b/test-cases/longevity/longevity-ycsb.txt
@@ -241,7 +241,7 @@ of 3 nodes of i3.4xlarge (16 vCPU per node) and target of 120000 is:
 * `scylla.writeconsistencylevel`
 
   * Default value is `QUORUM`
-  - Consistency level for reads and writes, respectively. 
+  - Consistency level for reads and writes, respectively.
     See the [Scylla documentation](https://docs.scylladb.com/glossary/#term-consistency-level-any) for details.
 
 * `scylla.maxconnections`

--- a/unit_tests/lib/events_utils.py
+++ b/unit_tests/lib/events_utils.py
@@ -63,8 +63,8 @@ class EventsUtilsMixin:
 
         while time.perf_counter() < end_time and subscriber.events_counter < last_event_n:
             time.sleep(0.1)
-        self.assertLessEqual(last_event_n, subscriber.events_counter,
-                             f"Subscriber {subscriber} didn't receive {count} events in {timeout} seconds")
+        assert last_event_n <= subscriber.events_counter, \
+            f"Subscriber {subscriber} didn't receive {count} events in {timeout} seconds"
 
         # Give a chance to the subscriber to handle last event received.
         time.sleep(last_event_processing_delay)


### PR DESCRIPTION
Seem like we weren't raising error event when error verification was happening

for some reason the `FailuresWatcher` was raising only the first encountered
error (match for the regex), and not others, now it would raise any match as
error event

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
