### PR TITLE
Longevity twcs tests 3h, 48h.

### DIFF
--- a/jenkins-pipelines/longevity-twcs-3h.jenkinsfile
+++ b/jenkins-pipelines/longevity-twcs-3h.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_twcs_test.TWCSLongevityTest.test_custom_time',
+    test_config: 'test-cases/longevity/longevity-twcs-3h.yaml',
+
+    timeout: [time: 300, unit: 'MINUTES']
+)

--- a/jenkins-pipelines/longevity-twcs-48h.jenkinsfile
+++ b/jenkins-pipelines/longevity-twcs-48h.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_twcs_test.TWCSLongevityTest.test_custom_time',
+    test_config: 'test-cases/longevity/longevity-twcs-48h.yaml',
+
+    timeout: [time: 3060, unit: 'MINUTES']
+)

--- a/longevity_twcs_test.py
+++ b/longevity_twcs_test.py
@@ -1,0 +1,48 @@
+#
+# This is stress longevity test that runs scylla-benchtime window load  with different node operations:
+# disruptive and not disruptive
+
+import time
+
+from longevity_test import LongevityTest
+from sdcm.sct_events.group_common_events import ignore_mutation_write_errors
+
+
+class TWCSLongevityTest(LongevityTest):
+    def __init__(self, *args):
+        super(TWCSLongevityTest, self).__init__(*args)
+
+    def create_tables_for_scylla_bench(self, window_size=1, ttl=900):
+        with self.db_cluster.cql_connection_patient(self.db_cluster.nodes[0]) as session:
+            session.execute("""
+                        CREATE KEYSPACE scylla_bench WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}
+                        AND durable_writes = true;
+                    """)
+            session.execute(f"""
+                        CREATE TABLE scylla_bench.test (
+                            pk bigint,
+                            ck bigint,
+                            v blob,
+                            PRIMARY KEY (pk, ck)
+                        ) WITH CLUSTERING ORDER BY (ck ASC)
+                            AND default_time_to_live = {ttl}
+                            AND compaction = {{'class': 'TimeWindowCompactionStrategy', 'compaction_window_size': '{window_size}',
+                            'compaction_window_unit': 'MINUTES'}}
+                    """)
+
+    def run_prepare_write_cmd(self):
+        self.create_tables_for_scylla_bench()
+        with ignore_mutation_write_errors():
+            super(TWCSLongevityTest, self).run_prepare_write_cmd()
+
+        # Run nemesis during stress as it was stopped before copy expected data
+        if self.params.get('nemesis_during_prepare'):
+            self.db_cluster.start_nemesis()
+
+    def test_twcs_longevity(self):
+        self.test_custom_time()
+
+        # Stop nemesis. Prefer all nodes will be run before collect data for validation
+        # Increase timeout to wait for nemesis finish
+        if self.db_cluster.nemesis_threads:
+            self.db_cluster.stop_nemesis(timeout=300)

--- a/sdcm/scylla_bench_thread.py
+++ b/sdcm/scylla_bench_thread.py
@@ -124,6 +124,8 @@ class ScyllaBenchThread:
         return sb_summary, errors
 
     def _run_stress_bench(self, node, loader_idx, stress_cmd, node_list):
+        stress_cmd = re.sub(r"SCT_TIME", f"{int(time.time())-480}", stress_cmd)
+        LOGGER.debug(f"replaced stress command {stress_cmd}")
 
         ScyllaBenchEvent.start(node=node, stress_cmd=stress_cmd).publish()
         os.makedirs(node.logdir, exist_ok=True)

--- a/test-cases/longevity/longevity-twcs-3h.yaml
+++ b/test-cases/longevity/longevity-twcs-3h.yaml
@@ -1,0 +1,19 @@
+test_duration: 210
+bench_run: true
+
+
+stress_cmd: ["scylla-bench -workload=timeseries -mode=write -replication-factor=3 -partition-count=20000 -clustering-row-count=9999999000000 -clustering-row-size=200 -concurrency=30 -max-rate=60000 -rows-per-request=5000 -duration=170m"]
+stress_read_cmd: ["scylla-bench -workload=timeseries -mode=read -partition-count=20000 -concurrency=48 -replication-factor=3 -write-rate=3 -clustering-row-count=9999999000000 -clustering-row-size=200  -rows-per-request=300 -provide-upper-bound -start-timestamp=SCT_TIME -duration=170m"]
+
+n_db_nodes: 3
+n_loaders: 1
+n_monitor_nodes: 1
+
+instance_type_db: 'i3.2xlarge'
+
+nemesis_class_name: 'ChaosMonkey'
+nemesis_interval: 5
+nemesis_during_prepare: false
+space_node_threshold: 64424
+
+user_prefix: 'longevity-twcs-3h'

--- a/test-cases/longevity/longevity-twcs-48h.yaml
+++ b/test-cases/longevity/longevity-twcs-48h.yaml
@@ -1,0 +1,18 @@
+test_duration: 3000
+bench_run: true
+
+stress_cmd: ["scylla-bench -workload=timeseries -mode=write -replication-factor=3 -partition-count=20000 -clustering-row-count=9999999000000 -clustering-row-size=200 -concurrency=30 -max-rate=60000 -rows-per-request=5000 -duration=2880m"]
+stress_read_cmd: ["scylla-bench -workload=timeseries -mode=read -partition-count=20000 -concurrency=48 -replication-factor=3 -write-rate=3 -clustering-row-count=9999999000000 -clustering-row-size=200  -rows-per-request=300 -provide-upper-bound -start-timestamp=SCT_TIME -duration=2880m"]
+
+n_db_nodes: 3
+n_loaders: 1
+n_monitor_nodes: 1
+
+instance_type_db: 'i3.2xlarge'
+
+nemesis_class_name: 'ChaosMonkey'
+nemesis_interval: 15
+nemesis_during_prepare: false
+space_node_threshold: 64424
+
+user_prefix: 'longevity-twcs-48h'


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] ~~I added the relevant `backport` labels~~
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~

Add two new tests longevity-twcs-bench-3h.yaml, longevity-twcs-bench-48h.yaml
longevity-twcs-bench-3h.yaml revealed https://github.com/scylladb/scylla/issues/8030
IO drop after adding node to cluster with TWCS strategy.

other run ended with no errors but had IO drop too with nemesis DestroyDataThenRebuild,
![twcs#17_passed](https://user-images.githubusercontent.com/99000/107144568-ad3bc480-6944-11eb-803c-dc3dc3d8a431.png)



