### PR TITLE
fix(AddRemoveRackNemesis): switch it to use plain values

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -47,7 +47,7 @@ from sdcm.coredump import CoredumpExportFileThread
 from sdcm.mgmt import AnyManagerCluster
 from sdcm.sct_events.health import ClusterHealthValidatorEvent
 from sdcm.sct_events.system import TestFrameworkEvent
-from sdcm.utils.common import download_from_github
+from sdcm.utils.common import download_from_github, walk_thru_data
 from sdcm.utils.k8s import KubernetesOps, ApiCallRateLimiter, JSON_PATCH_TYPE, KUBECTL_TIMEOUT
 from sdcm.utils.decorators import log_run_info, timeout
 from sdcm.utils.remote_logger import get_system_logging_thread, CertManagerLogger, ScyllaOperatorLogger, \
@@ -971,20 +971,20 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):
                                                   content_type=JSON_PATCH_TYPE)
 
     def get_scylla_cluster_value(self, path: str) -> Optional[ANY_KUBERNETES_RESOURCE]:
-        current = self._k8s_scylla_cluster_api.get(namespace=self.namespace, name=self.scylla_cluster_name)
-        for name in path.split('/'):
-            if current is None:
-                return None
-            if not name:
-                continue
-            if name.isalnum() and isinstance(current, (list, tuple, set)):
-                try:
-                    current = current[int(name)]
-                except Exception:
-                    current = None
-                continue
-            current = current.get(name, None)
-        return current
+        """
+        Get scylla cluster value from kubernetes API.
+        """
+        cluster_data = self._k8s_scylla_cluster_api.get(namespace=self.namespace, name=self.scylla_cluster_name)
+        return walk_thru_data(cluster_data, path)
+
+    def get_scylla_cluster_plain_value(self, path: str) -> Union[Dict, List, str, None]:
+        """
+        Get scylla cluster value from kubernetes API and converts result to basic python data types.
+        Use it if you are going to modify the data.
+        """
+        cluster_data = self._k8s_scylla_cluster_api.get(
+            namespace=self.namespace, name=self.scylla_cluster_name).to_dict()
+        return walk_thru_data(cluster_data, path)
 
     def add_scylla_cluster_value(self, path: str, element: Any):
         init = self.get_scylla_cluster_value(path) is None
@@ -1106,13 +1106,13 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):
         if self.get_scylla_cluster_value(f'/spec/datacenter/racks/{rack}') is not None:
             return
         # Create new rack of very first rack of the cluster
-        new_rack = self.get_scylla_cluster_value('/spec/datacenter/racks/0')
+        new_rack = self.get_scylla_cluster_plain_value('/spec/datacenter/racks/0')
         new_rack['members'] = 0
         new_rack['name'] = f'{new_rack["name"]}-{rack}'
         self.add_scylla_cluster_value('/spec/datacenter/racks', new_rack)
 
     def _delete_k8s_rack(self, rack: int):
-        racks = self.get_scylla_cluster_value(f'/spec/datacenter/racks/')
+        racks = self.get_scylla_cluster_plain_value(f'/spec/datacenter/racks/')
         if len(racks) == 1:
             return
         racks.pop(rack)

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -37,7 +37,7 @@ import re
 import requests
 import uuid
 import zipfile
-from typing import Iterable, List, Callable, Optional, Dict, Union, Literal, Tuple
+from typing import Iterable, List, Callable, Optional, Dict, Union, Literal, Tuple, Any
 from urllib.parse import urlparse
 from unittest.mock import Mock
 
@@ -2173,3 +2173,20 @@ def download_from_github(repo: str, tag: str, dst_dir: str):
         base_dir = os.path.join(tmpdir, os.listdir(tmpdir)[0])
         for file in os.listdir(base_dir):
             os.rename(os.path.join(base_dir, file), os.path.join(dst_dir, file))
+
+
+def walk_thru_data(data, path: str) -> Any:
+    current = data
+    for name in path.split('/'):
+        if current is None:
+            return None
+        if not name:
+            continue
+        if name.isalnum() and isinstance(current, (list, tuple, set)):
+            try:
+                current = current[int(name)]
+            except Exception:
+                current = None
+            continue
+        current = current.get(name, None)
+    return current


### PR DESCRIPTION
https://trello.com/c/VxbvobTi/2996-k8s-address-addremoverack-nemesis-failure

Nemesis fails with following error:

```
2021-02-07 09:10:40.549: (DisruptionEvent Severity.ERROR): type=GrowCluster subtype=end node=Node sct-cluster-us-east1-b-us-east1-2 [10.11.241.54 | 10.11.241.54] (seed: False) duration=25 error='ResourceField' object does not support item assignment
Traceback (most recent call last):
  File "/jenkins/slave/workspace/scylla-operator/operator-master/longevity-scylla-operator-3h-gke-add-remove-rack/scylla-cluster-tests/sdcm/nemesis.py", line 2831, in wrapper
    result = method(*args, **kwargs)
  File "/jenkins/slave/workspace/scylla-operator/operator-master/longevity-scylla-operator-3h-gke-add-remove-rack/scylla-cluster-tests/sdcm/nemesis.py", line 2905, in disrupt
    self.disrupt_grow_shrink_new_rack()
  File "/jenkins/slave/workspace/scylla-operator/operator-master/longevity-scylla-operator-3h-gke-add-remove-rack/scylla-cluster-tests/sdcm/nemesis.py", line 2573, in disrupt_grow_shrink_new_rack
    self._disrupt_grow_shrink_cluster(rack=max(self.cluster.racks) + 1)
  File "/jenkins/slave/workspace/scylla-operator/operator-master/longevity-scylla-operator-3h-gke-add-remove-rack/scylla-cluster-tests/sdcm/nemesis.py", line 2587, in _disrupt_grow_shrink_cluster
    added_node = self.add_new_node(rack=rack)
  File "/jenkins/slave/workspace/scylla-operator/operator-master/longevity-scylla-operator-3h-gke-add-remove-rack/scylla-cluster-tests/sdcm/utils/decorators.py", line 163, in wrapped
    res = func(*args, **kwargs)
  File "/jenkins/slave/workspace/scylla-operator/operator-master/longevity-scylla-operator-3h-gke-add-remove-rack/scylla-cluster-tests/sdcm/nemesis.py", line 2550, in add_new_node
    return self._add_and_init_new_cluster_node(rack=rack)
  File "/jenkins/slave/workspace/scylla-operator/operator-master/longevity-scylla-operator-3h-gke-add-remove-rack/scylla-cluster-tests/sdcm/utils/decorators.py", line 61, in inner
    return func(*args, **kwargs)
  File "/jenkins/slave/workspace/scylla-operator/operator-master/longevity-scylla-operator-3h-gke-add-remove-rack/scylla-cluster-tests/sdcm/nemesis.py", line 606, in _add_and_init_new_cluster_node
    new_node = self.cluster.add_nodes(
  File "/jenkins/slave/workspace/scylla-operator/operator-master/longevity-scylla-operator-3h-gke-add-remove-rack/scylla-cluster-tests/sdcm/cluster_k8s/gke.py", line 381, in add_nodes
    new_nodes = super().add_nodes(count=count,
  File "/jenkins/slave/workspace/scylla-operator/operator-master/longevity-scylla-operator-3h-gke-add-remove-rack/scylla-cluster-tests/sdcm/cluster_k8s/__init__.py", line 1093, in add_nodes
    self._create_k8s_rack_if_not_exists(rack)
  File "/jenkins/slave/workspace/scylla-operator/operator-master/longevity-scylla-operator-3h-gke-add-remove-rack/scylla-cluster-tests/sdcm/cluster_k8s/__init__.py", line 1110, in _create_k8s_rack_if_not_exists
    new_rack['members'] = 0
TypeError: 'ResourceField' object does not support item assignment
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
