### PR TITLE
fix(gemini_test): Fix updating gemini_result dict

### DIFF
--- a/gemini_test.py
+++ b/gemini_test.py
@@ -40,7 +40,7 @@ class GeminiTest(ClusterTester):
         self.log.debug('Start gemini benchmark')
         gemini_thread = self.run_gemini(cmd=cmd)
         self.gemini_results["cmd"] = gemini_thread.gemini_commands
-        self.gemini_results = self.verify_gemini_results(queue=gemini_thread)
+        self.gemini_results.update(self.verify_gemini_results(queue=gemini_thread))
 
         self.verify_results()
 
@@ -82,7 +82,7 @@ class GeminiTest(ClusterTester):
                                                          keyspace_name="ks1",
                                                          base_table_name="table1")
 
-        self.gemini_results = self.verify_gemini_results(queue=gemini_thread)
+        self.gemini_results.update(self.verify_gemini_results(queue=gemini_thread))
 
         cdc_stress_results = self.verify_cdclog_reader_results(cdc_stress_queue, update_es)
 


### PR DESCRIPTION
gemini_result dict should be correctly updated. Overwise,
Exception happened during generating the email report:
 (TestFrameworkEvent Severity.ERROR), source=GeminiTest.save_email_data()
 message=save_email_data (silenced) failed with: exception='cmd'

Job example:

https://jenkins.scylladb.com/view/master/job/scylla-master/view/master-test/job/gemini-/job/gemini-1tb-10h/79/console

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (CI)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
