### PR TITLE
fix(jepsen): increase default concurrency

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -137,7 +137,7 @@ target_upgrade_version: ''
 stress_cdclog_reader_cmd: "cdc-stressor -stream-query-round-duration 30s"
 
 jepsen_scylla_repo: 'https://github.com/jepsen-io/scylla.git'
-jepsen_test_cmd: 'test-all'
+jepsen_test_cmd: 'test-all --concurrency 10n'
 
 max_events_severities: ""
 mgmt_docker_image: ''


### PR DESCRIPTION
Some of Jepsen tests are not fine with default concurrency (5). Set it to 10 x {num_of_nodes}.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
