### PR TITLE
fix(data validator): fix wrong assert syntax

### DIFF
--- a/sdcm/utils/data_validator.py
+++ b/sdcm/utils/data_validator.py
@@ -442,8 +442,8 @@ class LongevityDataValidator:
                     'Actual dataset length: {}, Expected dataset length: {}'.format(len(actual_result),
                                                                                     len(expected_result))
 
-                assert (actual_result, expected_result,
-                        'One or more rows are not as expected, suspected LWT wrong update')
+                assert actual_result == expected_result, \
+                    'One or more rows are not as expected, suspected LWT wrong update'
 
                 # Raise info event at the end of the test only.
                 DataValidatorEvent.ImmutableRowsValidator(


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
