### PR TITLE
Manager 2.3 suspend and resume tests

### DIFF
--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -730,6 +730,16 @@ class ManagerCluster(ScyllaManagerBase):
             return value_list[0]
         return default_value
 
+    def suspend(self):
+        cmd = f"suspend -c {self.id}"
+        self.sctool.run(cmd=cmd)
+
+    def resume(self, start_tasks=True):
+        cmd = f"resume -c {self.id}"
+        if start_tasks:
+            cmd += " --start-tasks"
+        self.sctool.run(cmd=cmd)
+
 
 def verify_errorless_result(cmd, res):
     if res.exited != 0:


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
