### PR TITLE
improvement(db_stats): Store in ES output sysctl -a

### DIFF
--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -501,6 +501,7 @@ class TestStatsMixin(Stats):
                 'cpuPlatform', 'UNKNOWN')
 
         setup_details['db_cluster_node_details'] = {}
+        setup_details['sysctl_output'] = []
         return setup_details
 
     def get_test_details(self):
@@ -715,6 +716,10 @@ class TestStatsMixin(Stats):
                 setup_details.update({"scylla_args": output(f"grep ^SCYLLA_ARGS {scylla_server_conf}"),
                                       "io_conf": output("grep -v ^# /etc/scylla.d/io.conf"),
                                       "cpuset_conf": output("grep -v ^# /etc/scylla.d/cpuset.conf"), })
+            for node in self.db_cluster.nodes:
+                result = node.get_sysctl_output()
+                if result:
+                    setup_details["sysctl_output"].append(result)
 
         self.update(update_data)
 


### PR DESCRIPTION
Store in ES in setup_details output of sysctl -a
Trello: https://trello.com/c/FbpVauDC

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (CI)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
