### PR TITLE
fix(performance): Fix performance job pipeline

### DIFF
--- a/jenkins-pipelines/perf-regression-throughput-30min.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-throughput-30min.jenkinsfile
@@ -10,5 +10,5 @@ perfRegressionParallelPipeline(
     test_config: "test-cases/performance/perf-regression.100threads.30M-keys.yaml",
     sub_tests: ["test_write", "test_read", "test_mixed"],
 
-    timeout: [time: 350, unit: "MINUTES"]
+    timeout: [time: 550, unit: "MINUTES"]
 )

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1044,7 +1044,7 @@ class SCTConfiguration(dict):
              type=boolean,
              help="""retrieving data from multiple streams in one poll"""),
 
-        dict(name="use_legacy_cluster_init", env="SCT_USE_LEGACY_CLUSTER_INIT", type=bool,
+        dict(name="use_legacy_cluster_init", env="SCT_USE_LEGACY_CLUSTER_INIT", type=boolean,
              help="""Use legacy cluster initialization with autobootsrap disabled and parallel node setup"""),
         dict(name="availability_zone", env="SCT_AVAILABILITY_ZONE",
              type=str,

--- a/test-cases/performance/perf-regression.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys.yaml
@@ -1,4 +1,4 @@
-test_duration: 70
+test_duration: 150
 
 stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=60m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=1..30000000"
 prepare_write_cmd: "cassandra-stress write no-warmup cl=QUORUM n=30000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=1..30000000"

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -48,6 +48,10 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('email_recipients', 'scylla-perf-results@scylladb.com')}",
                    description: 'email recipients of email report',
                    name: 'email_recipients')
+
+            string(defaultValue: "false",
+                   description: 'Initialize cluster in parallel (false) or sequentially(true)',
+                   name: 'use_legacy_cluster_init')
         }
         options {
             timestamps()
@@ -94,7 +98,7 @@ def call(Map pipelineParams) {
                                                         rm -fv ./latest
 
                                                         export SCT_CLUSTER_BACKEND=${params.backend}
-                                                        export SCT_REGION_NAME=${pipelineParams.aws_region}
+                                                        export SCT_REGION_NAME=${params.aws_region}
                                                         export SCT_CONFIG_FILES=${pipelineParams.test_config}
                                                         export SCT_EMAIL_RECIPIENTS="${email_recipients}"
                                                         if [[ ! -z "${params.scylla_ami_id}" ]] ; then
@@ -108,7 +112,7 @@ def call(Map pipelineParams) {
                                                             exit 1
                                                         fi
 
-
+                                                        export SCT_USE_LEGACY_CLUSTER_INIT=${params.use_legacy_cluster_init}
                                                         export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
                                                         export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
                                                         export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"
@@ -128,6 +132,7 @@ def call(Map pipelineParams) {
                                             catchError(stageResult: 'FAILURE') {
                                                 wrap([$class: 'BuildUser']) {
                                                     dir('scylla-cluster-tests') {
+                                                        def aws_region = groovy.json.JsonOutput.toJson(params.aws_region)
                                                         def test_config = groovy.json.JsonOutput.toJson(pipelineParams.test_config)
                                                         sh """
                                                         #!/bin/bash


### PR DESCRIPTION
Add new config param to  jenkins file for performance job to allow run with parallel and sequentiall
cluster initialization

After cdc moved to GA, cluster should be initialized sequentially.
otherwise, performance job for scylla version > 4.3 couldn't start.

fix correct type for config parameter

Fix to use aws_region

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
