### PR TITLE
fix(fullscan): pass credentials for cql connection

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1369,7 +1369,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         cmd_bypass_cache = 'select * from {} bypass cache'
         cmd = random.choice([cmd_select_all, cmd_bypass_cache]).format(ks_cf)
         try:
-            with self.db_cluster.cql_connection_patient(db_node) as session:
+            credentials = self.db_cluster.get_db_auth()
+            username, password = credentials if credentials else (None, None)
+            with self.db_cluster.cql_connection_patient(db_node, user=username, password=password) as session:
                 self.log.info('Will run command "{}"'.format(cmd))
                 result = session.execute(SimpleStatement(cmd, fetch_size=page_size,
                                                          consistency_level=ConsistencyLevel.ONE))


### PR DESCRIPTION
scylla: [shard 2] cql_server - exception while processing connection:
        std::system_error (error GnuTLS:-10, The specified session has
        been invalidated for some reason.)

Fixes https://github.com/scylladb/scylla-cluster-tests/issues/3219

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
