### PR TITLE
Fix seed flag in log prefix and decommission bug

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3399,7 +3399,6 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         if first_only:
             node = self.nodes[0]
             node.wait_ssh_up()
-            node.is_seed = True
             seed_nodes_ips = [node.ip_address]
 
         elif seeds_selector == 'reflector' or Setup.REUSE_CLUSTER or cluster_backend == 'aws-siren':

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2861,6 +2861,11 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
         return properties
 
+    def set_seed_flag(self, is_seed):
+        self.is_seed = is_seed
+        if hasattr(self.log, 'extra'):
+            self.log.extra['prefix'] = str(self)
+
 
 class FlakyRetryPolicy(RetryPolicy):
 
@@ -3420,7 +3425,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
 
         for node in self.nodes:
             if node.ip_address in seed_nodes_ips:
-                node.is_seed = True
+                node.set_seed_flag(True)
 
         assert seed_nodes_ips, "We should have at least one selected seed by now"
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -657,12 +657,12 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         if not self.target_node.is_seed:
             self.target_node = random.choice(self.cluster.seed_nodes)
-        self.target_node.is_seed = False
+        self.target_node.set_seed_flag(False)
         self.cluster.update_seed_provider()
 
         new_seed_node = self.disrupt_nodetool_decommission(add_node=add_node, disruption_name="SeedDecommission")
         if new_seed_node and not new_seed_node.is_seed:
-            new_seed_node.is_seed = True
+            new_seed_node.set_seed_flag(True)
             self.cluster.update_seed_provider()
 
     @latency_calculator_decorator
@@ -2211,7 +2211,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         new_node = self._add_and_init_new_cluster_node(rack=self.target_node.rack)
         # in case the removed node was a seed
         if node_to_remove.is_seed:
-            new_node.is_seed = True
+            new_node.set_seed_flag(True)
             self.cluster.update_seed_provider()
         # after add_node, the left nodes have data that isn't part of their tokens anymore.
         # In order to eliminate cases that we miss a "data loss" bug because of it, we cleanup this data.


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
