### PR TITLE
fix(wait_for_init): Reverting the change to control wait for db_up

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3569,7 +3569,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                           alternator_enforce_authorization=self.params.get('alternator_enforce_authorization'),
                           ldap=self.params.get('use_ldap_authorization'))
 
-    def node_setup(self, node: BaseNode, verbose: bool = False, timeout: int = 3600, wait_db_up: bool = True):  # pylint: disable=too-many-branches
+    def node_setup(self, node: BaseNode, verbose: bool = False, timeout: int = 3600):  # pylint: disable=too-many-branches
         node.wait_ssh_up(verbose=verbose, timeout=timeout)
 
         install_scylla = True
@@ -3619,11 +3619,11 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         else:
             self._reuse_cluster_setup(node)
 
-        if wait_db_up:
-            node.wait_db_up(verbose=verbose, timeout=timeout)
-            # Wait the node is UN and then run "nodetool status"
-            self.wait_for_nodes_up_and_normal(nodes=[node], verification_node=node)
-            self.clean_replacement_node_ip(node)
+        node.wait_db_up(verbose=verbose, timeout=timeout)
+        nodes_status = node.get_nodes_status()
+        check_nodes_status(nodes_status=nodes_status, current_node=node)
+
+        self.clean_replacement_node_ip(node)
 
     def _scylla_install(self, node):
         node.update_repo_cache()
@@ -3676,13 +3676,12 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         return True
 
     @wait_for_init_wrap
-    def wait_for_init(self, node_list=None, verbose=False, timeout=None, wait_db_up=True, check_node_health=True):  # pylint: disable=unused-argument, too-many-arguments
+    def wait_for_init(self, node_list=None, verbose=False, timeout=None, check_node_health=True):  # pylint: disable=unused-argument, too-many-arguments
         """
         Scylla cluster setup.
         :param node_list: List of nodes to watch for init.
         :param verbose: Whether to print extra info while watching for init.
         :param timeout: timeout in minutes to wait for init to be finished
-        :param wait_db_up: select if wait for db to start up or not
         :param check_node_health: select if run node health check or not
         :return:
         """

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -932,7 +932,7 @@ class CassandraAWSCluster(ScyllaAWSCluster):
                                                                  dc_idx=dc_idx)
         return added_nodes
 
-    def node_setup(self, node, verbose=False, timeout=3600, wait_db_up=True):
+    def node_setup(self, node, verbose=False, timeout=3600):
         node.wait_ssh_up(verbose=verbose)
         node.wait_db_up(verbose=verbose)
 
@@ -947,7 +947,7 @@ class CassandraAWSCluster(ScyllaAWSCluster):
         node.remoter.run('sudo apt-get install -y openjdk-6-jdk')
 
     @cluster.wait_for_init_wrap
-    def wait_for_init(self, node_list=None, verbose=False, timeout=None, wait_db_up=True, check_node_health=True):  # pylint: disable=too-many-arguments
+    def wait_for_init(self, node_list=None, verbose=False, timeout=None, check_node_health=True):  # pylint: disable=too-many-arguments
         self.get_seed_nodes()
 
 

--- a/sdcm/cluster_baremetal.py
+++ b/sdcm/cluster_baremetal.py
@@ -111,7 +111,7 @@ class ScyllaPhysicalCluster(cluster.BaseScyllaCluster, PhysicalMachineCluster):
         ))
         super(ScyllaPhysicalCluster, self).__init__(**kwargs)
 
-    def node_setup(self, node, verbose=False, timeout=3600, wait_db_up=True):
+    def node_setup(self, node, verbose=False, timeout=3600):
         """
         Configure scylla.yaml on cluster nodes.
         We have to modify scylla.yaml on our own because we are not on AWS,

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -222,7 +222,7 @@ class ScyllaDockerCluster(cluster.BaseScyllaCluster, DockerCluster):  # pylint: 
                          n_nodes=n_nodes,
                          params=params)
 
-    def node_setup(self, node, verbose=False, timeout=3600, wait_db_up=True):
+    def node_setup(self, node, verbose=False, timeout=3600):
         endpoint_snitch = self.params.get('endpoint_snitch')
         seed_address = ','.join(self.seed_nodes_ips)
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -465,8 +465,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.set_current_running_nemesis(node=new_node)  # prevent to run nemesis on new node when running in parallel
         new_node.replacement_node_ip = old_node_ip
         try:
-            self.cluster.wait_for_init(node_list=[new_node], timeout=timeout, wait_db_up=False, check_node_health=False)
-            new_node.wait_db_up(timeout=timeout)
+            self.cluster.wait_for_init(node_list=[new_node], timeout=timeout, check_node_health=False)
             self.cluster.clean_replacement_node_ip(new_node)
         except (NodeSetupFailed, NodeSetupTimeout):
             self.log.warning("Setup of the '%s' failed, removing it from list of nodes" % new_node)


### PR DESCRIPTION
Reverting commit 7b58c4d3 that added a flag to control db_up waiting.
The change caused the nemesis to miss the new node addition because it
didn't wait for the node to complete the bootstrap.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
