### PR TITLE
fix(db_fill_data): Add timeout after simple table creation

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -2904,6 +2904,8 @@ class FillDatabaseData(ClusterTester):
         create_query = "CREATE TABLE IF NOT EXISTS truncate_table%d (my_id int PRIMARY KEY, col1 int, value int)"
         for i in range(rows):
             session.execute(create_query % i)
+            # Added sleep after each created table
+            time.sleep(15)
 
     @staticmethod
     def cql_insert_data_to_simple_tables(session, rows):  # pylint: disable=invalid-name


### PR DESCRIPTION
On master branch for centos7 upgrade tests failed during creating
truncate_table. Added timeout after each cql command execution
to allow sync schema between nodes

Failed job: https://jenkins.scylladb.com/view/master/job/scylla-master/view/master-test/job/rolling-upgrade/job/rolling-upgrade-centos7-test/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
