### PR TITLE
improvement(artifacts test cases): enable fallback as 'on demand'

### DIFF
--- a/test-cases/artifacts/amazon2.yaml
+++ b/test-cases/artifacts/amazon2.yaml
@@ -5,6 +5,7 @@ backtrace_decoding: false
 cluster_backend: 'aws'
 instance_type_db: 'i3.large'
 instance_provision: "spot"
+instance_provision_fallback_on_demand: true
 logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0

--- a/test-cases/artifacts/ami.yaml
+++ b/test-cases/artifacts/ami.yaml
@@ -4,6 +4,7 @@ backtrace_decoding: false
 cluster_backend: 'aws'
 instance_type_db: 'i3.large'
 instance_provision: "spot"
+instance_provision_fallback_on_demand: true
 logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0

--- a/test-cases/artifacts/centos7.yaml
+++ b/test-cases/artifacts/centos7.yaml
@@ -6,6 +6,7 @@ gce_root_disk_type_db: 'pd-ssd'
 gce_root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
+instance_provision_fallback_on_demand: true
 logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0

--- a/test-cases/artifacts/centos8.yaml
+++ b/test-cases/artifacts/centos8.yaml
@@ -6,6 +6,7 @@ gce_root_disk_type_db: 'pd-ssd'
 gce_root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
+instance_provision_fallback_on_demand: true
 logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0

--- a/test-cases/artifacts/debian10.yaml
+++ b/test-cases/artifacts/debian10.yaml
@@ -6,6 +6,7 @@ gce_root_disk_type_db: 'pd-ssd'
 gce_root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
+instance_provision_fallback_on_demand: true
 logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0

--- a/test-cases/artifacts/debian9.yaml
+++ b/test-cases/artifacts/debian9.yaml
@@ -6,6 +6,7 @@ gce_root_disk_type_db: 'pd-ssd'
 gce_root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
+instance_provision_fallback_on_demand: true
 logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0

--- a/test-cases/artifacts/gce-image.yaml
+++ b/test-cases/artifacts/gce-image.yaml
@@ -7,6 +7,7 @@ gce_root_disk_type_db: 'pd-ssd'
 gce_root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
+instance_provision_fallback_on_demand: true
 logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0

--- a/test-cases/artifacts/oel76.yaml
+++ b/test-cases/artifacts/oel76.yaml
@@ -5,6 +5,7 @@ backtrace_decoding: false
 cluster_backend: 'aws'
 instance_type_db: 'i3.large'
 instance_provision: "spot"
+instance_provision_fallback_on_demand: true
 logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0

--- a/test-cases/artifacts/oel81.yaml
+++ b/test-cases/artifacts/oel81.yaml
@@ -5,6 +5,7 @@ backtrace_decoding: false
 cluster_backend: 'aws'
 instance_type_db: 'i3.large'
 instance_provision: "spot"
+instance_provision_fallback_on_demand: true
 logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0

--- a/test-cases/artifacts/rhel7.yaml
+++ b/test-cases/artifacts/rhel7.yaml
@@ -6,6 +6,7 @@ gce_root_disk_type_db: 'pd-ssd'
 gce_root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
+instance_provision_fallback_on_demand: true
 logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0

--- a/test-cases/artifacts/rhel8.yaml
+++ b/test-cases/artifacts/rhel8.yaml
@@ -6,6 +6,7 @@ gce_root_disk_type_db: 'pd-ssd'
 gce_root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
+instance_provision_fallback_on_demand: true
 logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0

--- a/test-cases/artifacts/ubuntu1604.yaml
+++ b/test-cases/artifacts/ubuntu1604.yaml
@@ -6,6 +6,7 @@ gce_root_disk_type_db: 'pd-ssd'
 gce_root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
+instance_provision_fallback_on_demand: true
 logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0

--- a/test-cases/artifacts/ubuntu1804.yaml
+++ b/test-cases/artifacts/ubuntu1804.yaml
@@ -6,6 +6,7 @@ gce_root_disk_type_db: 'pd-ssd'
 gce_root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
+instance_provision_fallback_on_demand: true
 logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0

--- a/test-cases/artifacts/ubuntu2004.yaml
+++ b/test-cases/artifacts/ubuntu2004.yaml
@@ -6,6 +6,7 @@ gce_root_disk_type_db: 'pd-ssd'
 gce_root_disk_size_db: 50
 gce_n_local_ssd_disk_db: 1
 instance_provision: "spot"
+instance_provision_fallback_on_demand: true
 logs_transport: 'ssh'
 n_db_nodes: 1
 n_loaders: 0


### PR DESCRIPTION
when 'spot' instances are not available.

https://trello.com/c/7yxsmuZd/2979-set-fallback-to-on-demand-when-spot-failed-for-all-artifact-tests

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
