### PR TITLE
improvement(.gitignore): ignore linux swap files (tmp of vim)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ fabric.properties
 # Virtualenv & direnv files
 .venv*
 .env*
+
+# Linux swap files range from .saa to .swp (used by vim and some other apps)
+*.s[a-w][a-p]


### PR DESCRIPTION
vim text editor creates 'linux swap'-kind of temporary files.
So, add it to the '.gitignore' to avoid mistaken merge of these files.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
