### PR TITLE
test(nemesis.py): added nemesis that will toggle LDAP connection

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -40,6 +40,7 @@ from sdcm.utils.common import remote_get_file, get_db_tables, generate_random_st
     update_certificates, reach_enospc_on_node, clean_enospc_on_node, parse_nodetool_listsnapshots
 from sdcm.utils import cdc
 from sdcm.utils.decorators import retrying, latency_calculator_decorator, timeout
+from sdcm.utils.docker_utils import ContainerManager
 from sdcm.log import SDCMAdapter
 from sdcm.keystore import KeyStore
 from sdcm.prometheus import nemesis_metrics_obj
@@ -597,6 +598,19 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             # or scylla-server was stopped gracefully.
             self.target_node.stop_scylla_server(verify_up=False, verify_down=True, ignore_status=True)
             self.target_node.start_scylla_server(verify_up=True, verify_down=False)
+
+    def disrupt_ldap_connection_toggle(self):
+        self._set_current_disruption('Disconnect and Reconnect LDAP connection')
+        if not self.cluster.params.get('use_ldap_authorization'):
+            raise UnsupportedNemesis('Cluster is not configured to run with LDAP authorization, hence skipping')
+
+        self.log.info('Will now pause the LDAP container')
+        ContainerManager.pause_container(self.tester.localhost, 'ldap')
+        self.log.info('Will now sleep 180 seconds')
+        time.sleep(180)
+        self.log.info('Will now resume the LDAP container')
+        ContainerManager.unpause_container(self.tester.localhost, 'ldap')
+        self.log.info('finished with nemesis')
 
     @retrying(n=3, sleep_time=60, allowed_exceptions=(NodeSetupFailed, NodeSetupTimeout))
     def _add_and_init_new_cluster_node(self, old_node_ip=None, timeout=HOUR_IN_SEC * 6, rack=0):
@@ -2874,6 +2888,14 @@ class SslHotReloadingNemesis(Nemesis):
     @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_hot_reloading_internode_certificate()
+
+
+class PauseLdapNemesis(Nemesis):
+    disruptive = False
+
+    @log_time_elapsed_and_status
+    def disrupt(self):
+        self.disrupt_ldap_connection_toggle()
 
 
 class NoOpMonkey(Nemesis):

--- a/sdcm/utils/docker_utils.py
+++ b/sdcm/utils/docker_utils.py
@@ -384,6 +384,14 @@ class ContainerManager:
         docker_client = docker_client or cls.default_docker_client
         return docker_client.containers.get(c_id).name
 
+    @classmethod
+    def pause_container(cls, instance: object, name: str) -> None:
+        cls.get_container(instance, name).pause()
+
+    @classmethod
+    def unpause_container(cls, instance: object, name: str) -> None:
+        cls.get_container(instance, name).unpause()
+
 
 def running_in_docker():
     path = '/proc/self/cgroup'


### PR DESCRIPTION
this is for enterprise only, and the idea is to
see how Scylla behaves when it loses its connection
to the LDAP server.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
