### PR TITLE
feature(rollout_restart): implement for all backends

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4063,11 +4063,13 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         if check_node_health:
             node_list[0].check_node_health()
 
-    def restart_scylla(self, nodes=None):
+    def restart_scylla(self, nodes=None, random=False):
         if nodes:
             nodes_to_restart = nodes
         else:
             nodes_to_restart = self.nodes
+        if random:
+            nodes_to_restart = random.sample(nodes_to_restart, len(nodes_to_restart))
         self.log.info("Going to restart Scylla on %s" % [n.name for n in nodes_to_restart])
         for node in nodes_to_restart:
             node.stop_scylla(verify_down=True)

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -459,11 +459,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.target_node.wait_jmx_up()
         self.cluster.wait_for_nodes_up_and_normal(nodes=[self.target_node])
 
-    def disrupt_rolling_restart_cluster(self):
+    def disrupt_rolling_restart_cluster(self, random=False):
         self._set_current_disruption('RollingRestartCluster %s' % self.target_node)
-        if not self._is_it_on_kubernetes():
-            raise UnsupportedNemesis('RollingRestartCluster is supported only for kubernetes backends')
-        self.cluster.rollout_restart()
+        self.cluster.restart_scylla(random=random)
 
     def disrupt_restart_with_resharding(self):
         self._set_current_disruption('RestartNodeWithResharding %s' % self.target_node)
@@ -3557,7 +3555,16 @@ class ClusterRollingRestart(Nemesis):
 
     @log_time_elapsed_and_status
     def disrupt(self):
-        self.disrupt_rolling_restart_cluster()
+        self.disrupt_rolling_restart_cluster(random=False)
+
+
+class ClusterRollingRestartRandomOrder(Nemesis):
+    disruptive = True
+    kubernetes = True
+
+    @log_time_elapsed_and_status
+    def disrupt(self):
+        self.disrupt_rolling_restart_cluster(random=True)
 
 
 class TopPartitions(Nemesis):


### PR DESCRIPTION
Add support of 'rollout_restart' method for all backend classes.
With this change it is now possible to run 'ClusterRollingRestart'
nemesis on any backend.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] ~~I added the relevant `backport` labels~~
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
