### PR TITLE
[branch-2020.1] test(nemesis.py): added nemesis that will toggle LDAP connection

### DIFF
--- a/sdcm/utils/docker_utils.py
+++ b/sdcm/utils/docker_utils.py
@@ -378,6 +378,14 @@ class ContainerManager:
         docker_client = docker_client or cls.default_docker_client
         return docker_client.containers.get(c_id).name
 
+    @classmethod
+    def pause_container(cls, instance: object, name: str) -> None:
+        cls.get_container(instance, name).pause()
+
+    @classmethod
+    def unpause_container(cls, instance: object, name: str) -> None:
+        cls.get_container(instance, name).unpause()
+
 
 class RemoteDocker:
     def __init__(self, node, image_name, ports=None, command_line="tail -f /dev/null", extra_docker_opts=""):  # pylint: disable=too-many-arguments


### PR DESCRIPTION
this is for enterprise only, and the idea is to
see how Scylla behaves when it loses its connection
to the LDAP server.

this is a backport only, as #3230 had conflicts.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
