### PR TITLE
test(nemesis.py): add test that will toggle LDAP configuration

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -600,7 +600,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.target_node.start_scylla_server(verify_up=True, verify_down=False)
 
     def disrupt_ldap_connection_toggle(self):
-        self._set_current_disruption('Disconnect and Reconnect LDAP connection')
+        self._set_current_disruption('LDAP_Disconnect_and_Reconnect_connection')
         if not self.cluster.params.get('use_ldap_authorization'):
             raise UnsupportedNemesis('Cluster is not configured to run with LDAP authorization, hence skipping')
 
@@ -611,6 +611,47 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.log.info('Will now resume the LDAP container')
         ContainerManager.unpause_container(self.tester.localhost, 'ldap')
         self.log.info('finished with nemesis')
+
+    def disrupt_disable_enable_ldap_authorization(self):
+        self._set_current_disruption('LDAP_Toggle_authorization_configuration')
+        if not self.cluster.params.get('use_ldap_authorization'):
+            raise UnsupportedNemesis('Cluster is not configured to run with LDAP authorization, hence skipping')
+        ldap_config = {'role_manager': '',
+                       'ldap_url_template': '',
+                       'ldap_attr_role': '',
+                       'ldap_bind_dn': '',
+                       'ldap_bind_passwd': ''}
+
+        def destroy_ldap_container():
+            ContainerManager.destroy_container(self.tester.localhost, 'ldap')
+
+        def remove_ldap_configuration_from_node(node):
+            with node.remote_scylla_yaml() as scylla_yaml:
+                for key in ldap_config.keys():
+                    ldap_config[key] = scylla_yaml.pop(key)
+            node.restart_scylla_server()
+
+        InfoEvent(message='Disable LDAP Authorization Configuration').publish()
+        for node in self.cluster.nodes:
+            remove_ldap_configuration_from_node(node)
+        destroy_ldap_container()
+
+        self.log.debug('Will wait few minutes with LDAP disabled, before re-enabling it')
+        time.sleep(600)
+
+        def create_ldap_container():
+            self.tester.configure_ldap(self.tester.localhost)
+
+        def add_ldap_configuration_to_node(node):
+            node.refresh_ip_address()
+            with node.remote_scylla_yaml() as scylla_yaml:
+                scylla_yaml.update(ldap_config)
+            node.restart_scylla_server()
+
+        InfoEvent(message='Re-enable LDAP Authorization Configuration').publish()
+        create_ldap_container()
+        for node in self.cluster.nodes:
+            add_ldap_configuration_to_node(node)
 
     @retrying(n=3, sleep_time=60, allowed_exceptions=(NodeSetupFailed, NodeSetupTimeout))
     def _add_and_init_new_cluster_node(self, old_node_ip=None, timeout=HOUR_IN_SEC * 6, rack=0):
@@ -2896,6 +2937,14 @@ class PauseLdapNemesis(Nemesis):
     @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_ldap_connection_toggle()
+
+
+class ToggleLdapConfiguration(Nemesis):
+    disruptive = True
+
+    @log_time_elapsed_and_status
+    def disrupt(self):
+        self.disrupt_disable_enable_ldap_authorization()
 
 
 class NoOpMonkey(Nemesis):

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -286,7 +286,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
         self.alternator: alternator.api.Alternator = alternator.api.Alternator(sct_params=self.params)
         if self.params.get("use_ldap_authorization"):
-            Setup.configure_ldap(self.localhost, use_ssl=False)
+            self.configure_ldap(node=self.localhost, use_ssl=False)
             ldap_role = LDAP_ROLE
             ldap_users = LDAP_USERS.copy()
             ldap_address = list(Setup.LDAP_ADDRESS).copy()
@@ -302,6 +302,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         start_events_device(log_dir=self.logdir, _registry=self.events_processes_registry)
         time.sleep(0.5)
         InfoEvent(message=f"TEST_START test_id={Setup.test_id()}").publish()
+
+    @staticmethod
+    def configure_ldap(node, use_ssl=False):
+        Setup.configure_ldap(node=node, use_ssl=use_ssl)
 
     def _init_test_timeout_thread(self) -> threading.Timer:
         start_time = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(self.start_time))


### PR DESCRIPTION
this is for enterprise only, and the idea is to
disable the LDAP configuration on the go, and
then re-enable it.
Nothing should stop, and although all nodes must
be restarted, it shouldn't affect workload.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
