### PR TITLE
feature(hydra_kcl): Adding time based checkpoints, and retries

### DIFF
--- a/sdcm/kcl_thread.py
+++ b/sdcm/kcl_thread.py
@@ -45,7 +45,7 @@ class KclStressThread(DockerBasedStressThread):  # pylint: disable=too-many-inst
         return stress_cmd
 
     def _run_stress(self, loader, loader_idx, cpu_idx):
-        docker = RemoteDocker(loader, "scylladb/hydra-loaders:kcl-jdk8-20201229",
+        docker = RemoteDocker(loader, "scylladb/hydra-loaders:kcl-jdk8-20210215",
                               extra_docker_opts=f'--label shell_marker={self.shell_marker}')
         stress_cmd = self.build_stress_cmd()
 


### PR DESCRIPTION
Update of the hydra_kcl trying to test if it's the root cause of
scylladb/scylla#8012

Ref: https://github.com/scylladb/scylla/issues/8012
Ref: https://github.com/fruch/hydra-kcl/pull/4

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
