### PR TITLE
fix(manager): Changed the order of the sanity tests

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -320,17 +320,18 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         4) test_client_encryption
         :return:
         """
-        with self.subTest('STEP 1: Basic Backup Test'):
+        with self.subTest('Basic Backup Test'):
             self.test_basic_backup()
-        with self.subTest('STEP 2: Repair Multiple Keyspace Types'):
+        with self.subTest('Repair Multiple Keyspace Types'):
             self.test_repair_multiple_keyspace_types()
-        with self.subTest('STEP 3: Mgmt Cluster CRUD'):
+        with self.subTest('Mgmt Cluster CRUD'):
             self.test_mgmt_cluster_crud()
-        with self.subTest('STEP 4: Mgmt cluster Health Check'):
+        with self.subTest('Mgmt cluster Health Check'):
             self.test_mgmt_cluster_healthcheck()
-        with self.subTest('STEP 5: Client Encryption'):
-            self.test_client_encryption()
         self.test_suspend_and_resume()
+        with self.subTest('Client Encryption'):
+            # Since this test activates encryption, it has to be the last test in the sanity
+            self.test_client_encryption()
 
     def test_repair_intensity_feature_on_multiple_node(self):
         self._repair_intensity_feature(fault_multiple_nodes=True)


### PR DESCRIPTION
Since test_client_encryption activates ssl in the cluster and manager, I rearanged
the test order and made it the last test in the sanity

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
