### PR TITLE
fix(gce-byo-longevity): fix gce_image_db option handling

### DIFF
--- a/vars/byoLongevityPipeline.groovy
+++ b/vars/byoLongevityPipeline.groovy
@@ -47,6 +47,7 @@ def call() {
 
             string(defaultValue: '', description: '', name: 'loader_ami_id')
             string(defaultValue: '', description: '', name: 'scylla_ami_id')
+            string(defaultValue: '', description: '', name: 'gce_image_db')
             string(defaultValue: '', description: '', name: 'scylla_version')
             string(defaultValue: '', description: '', name: 'scylla_repo')
 

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -35,7 +35,7 @@ def call(Map params, String region){
 
     if [[ -n "${params.scylla_ami_id ? params.scylla_ami_id : ''}" ]] ; then
         export SCT_AMI_ID_DB_SCYLLA="${params.scylla_ami_id}"
-    elif [[ ! -z "${params.gce_image_db}" ]] ; then
+    elif [[ -n "${params.gce_image_db ? params.gce_image_db : ''}" ]] ; then
         export SCT_GCE_IMAGE_DB="${params.gce_image_db}"
 
     elif [[ -n "${params.scylla_version ? params.scylla_version : ''}" ]] ; then


### PR DESCRIPTION
Current handling of 'gce_image_db' option is broken.
In case it is not set groovy code sets it as empty value.
And then test runner fails on consequent problem not having
image set. But we expect explicit failure when it is not set.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] ~~I added the relevant `backport` labels~~
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
