### PR TITLE
fix(sct_events.py): default filter warning from DB log

### DIFF
--- a/sdcm/sct_events.py
+++ b/sdcm/sct_events.py
@@ -983,7 +983,12 @@ def start_events_device(log_dir, timeout=5):  # pylint: disable=redefined-outer-
         raise
 
     # default filters
+    workload_line = 'workload prioritization - update_service_levels_from_distributed_data: an error occurred while ' \
+                    'retrieving configuration'
     EVENTS_PROCESSES['default_filter'] = []
+    EVENTS_PROCESSES['default_filter'] += [EventsSeverityChangerFilter(event_class=DatabaseLogEvent,
+                                                                       regex=workload_line,
+                                                                       severity=Severity.WARNING)]
     EVENTS_PROCESSES['default_filter'] += [DbEventsFilter(type='BACKTRACE', line='Rate-limit: supressed')]
     EVENTS_PROCESSES['default_filter'] += [DbEventsFilter(type='BACKTRACE', line='Rate-limit: suppressed')]
 


### PR DESCRIPTION
it is failing tests, but it shouldn't, so adding this
message to default_filter to not fail the test, when
it is not supposed to fail.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
