### PR TITLE
fix(sct_events.py): default filter warning from DB log

### DIFF
--- a/sdcm/sct_events/setup.py
+++ b/sdcm/sct_events/setup.py
@@ -18,8 +18,9 @@ import logging
 from typing import Union, Optional
 from pathlib import Path
 
+from sdcm.sct_events import Severity
 from sdcm.sct_events.grafana import start_grafana_pipeline
-from sdcm.sct_events.filters import DbEventsFilter
+from sdcm.sct_events.filters import DbEventsFilter, EventsSeverityChangerFilter
 from sdcm.sct_events.database import DatabaseLogEvent
 from sdcm.sct_events.file_logger import start_events_logger
 from sdcm.sct_events.events_device import start_events_main_device
@@ -55,6 +56,10 @@ def start_events_device(log_dir: Optional[Union[str, Path]] = None,
     time.sleep(EVENTS_SUBSCRIBERS_START_DELAY)
 
     # Default filters.
+    EventsSeverityChangerFilter(new_severity=Severity.WARNING,
+                                event_class=DatabaseLogEvent.DATABASE_ERROR,
+                                regex='workload prioritization - update_service_levels_from_distributed_data: an error '
+                                      'occurred while retrieving configuration').publish()
     DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line='Rate-limit: supressed').publish()
     DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line='Rate-limit: suppressed').publish()
 


### PR DESCRIPTION
it is failing tests, but it shouldn't, so adding this
message to default_filter to not fail the test, when
it is not supposed to fail.

same as #3240 , but for master and future branches.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
