### PR TITLE
test(upgrade_test.py): adding paged query to complex

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -487,6 +487,10 @@ class UpgradeTest(FillDatabaseData):
         # wait for the complex workload to finish
         self.verify_stress_thread(complex_cs_thread_pool)
 
+        self.log.info('Will check paged query before upgrading nodes')
+        self.paged_query()
+        self.log.info('Done checking paged query before upgrading nodes')
+
         # prepare write workload
         self.log.info('Starting c-s prepare write workload (n=10000000)')
         prepare_write_stress = self.params.get('prepare_write_stress')
@@ -619,6 +623,10 @@ class UpgradeTest(FillDatabaseData):
             stress_cmd=stress_cmd_complex_verify_read, profile='data_dir/complex_schema.yaml')
         # wait for the read complex workload to finish
         self.verify_stress_thread(complex_cs_thread_pool)
+
+        self.log.info('Will check paged query after upgrading all nodes')
+        self.paged_query()
+        self.log.info('Done checking paged query after upgrading nodes')
 
         # After adjusted the workloads, there is a entire write workload, and it uses a fixed duration for catching
         # the data lose.


### PR DESCRIPTION
schema workload.
Added a new test to be performed during rolling upgrade
tests, that will execute paged queries before and after
upgrading the cluster.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
