### PR TITLE
fix(cluster.py): Fixing remote typo error

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4879,7 +4879,7 @@ class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-inst
                                   f" '[0].targets[+]' ''[{node.private_ip_address}]:9100''", verbose=True)
 
             if self.params.get("cloud_prom_bearer_token"):
-                node.remote.sudo(shell_script_cmd(f"""\
+                node.remoter.sudo(shell_script_cmd(f"""\
                     echo "targets: [] " > {self.monitoring_conf_dir}/scylla_servers.yml
                     echo "targets: [] " > {self.monitoring_conf_dir}/node_exporter_servers.yml
                 """), verbose=True)


### PR DESCRIPTION
Fix type issue and replace `node.remote` to `node.remoter`

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
