### PR TITLE
fix(manager): fix prometheus config

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2277,7 +2277,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             scyllamgr_ssl_cert_gen
             sed -i 's/#tls_cert_file/tls_cert_file/' /etc/scylla-manager/scylla-manager.yaml
             sed -i 's/#tls_key_file/tls_key_file/' /etc/scylla-manager/scylla-manager.yaml
-            sed -i 's/#prometheus: .*/prometheus: :{}/' /etc/scylla-manager/scylla-manager.yaml
+            sed -i "s/#prometheus: .*/prometheus: ':{}'/" /etc/scylla-manager/scylla-manager.yaml
             systemctl restart scylla-manager
             """.format(manager_prometheus_port))  # pylint: disable=too-many-format-args
             self.remoter.run('sudo bash -cxe "%s"' % configuring_manager_command)


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)

I have an odd failure with this pr. Even though the commands raises no issue when executes manually, I receive the following error:
```
Command: 'sudo bash -cxe "\nscyllamgr_ssl_cert_gen\nsed -i \'s/#tls_cert_file/tls_cert_file/\' /etc/scylla-manager/scylla-manager.yaml\nsed -i \'s/#tls_key_file/tls_key_file/\' /etc/scylla-manager/scylla-manager.yaml\nsed -i "s/#prometheus: .*/prometheus: \':5090\'/" /etc/scylla-manager/scylla-manager.yaml\nsystemctl restart scylla-manager\n"'

Exit code: 1

Stdout:



Stderr:

+ scyllamgr_ssl_cert_gen
Generating RSA private key, 4096 bit long modulus
..........................................................................................................................................................................................................................................................................++
.............++
e is 65537 (0x10001)
+ sed -i s/#tls_cert_file/tls_cert_file/ /etc/scylla-manager/scylla-manager.yaml
+ sed -i s/#tls_key_file/tls_key_file/ /etc/scylla-manager/scylla-manager.yaml
+ sed -i s/#prometheus:
sed: -e expression #1, char 14: unterminated `s' command
```
(https://jenkins.scylladb.com/job/manager-master/job/staging/job/centos-sanity-test-staging/19/artifact/logs/sct-results/latest/events_log/error.log/*view*/)

I tried two other solutions:
Attempting to write the line like so: `echo "prometheus: ':{}'" >> /etc/scylla-manager/scylla-manager.yaml` caused no effect (permission denied)

I tried to edit the config using _remote_yaml:
```
            with self.remote_manager_yaml() as scylla_manager_yaml:
                scylla_manager_yaml["prometheus"] = f"':{manager_prometheus_port}'"
```
However, it seems that this function deleted the entirety of the file except of the prometheus setting. Was it not only suppose to edit it?