### PR TITLE
fix(sdcm/cluster): rename random library to librandom

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -17,7 +17,7 @@ import queue
 import getpass
 import logging
 import os
-import random
+import random as librandom
 import re
 import tempfile
 import threading
@@ -3413,7 +3413,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                                            timeout=wait_for_timeout, throw_exc=True)
         else:
             if seeds_selector == 'random':
-                selected_nodes = random.sample(self.nodes, seeds_num)
+                selected_nodes = librandom.sample(self.nodes, seeds_num)
             # seeds_selector == 'first'
             else:
                 selected_nodes = self.nodes[:seeds_num]
@@ -3645,7 +3645,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         :return: dict
         """
         if not verification_node:
-            verification_node = random.choice(self.nodes)
+            verification_node = librandom.choice(self.nodes)
         status = {}
         res = verification_node.run_nodetool('status')
         data_centers = res.stdout.strip().split("Datacenter: ")
@@ -4066,7 +4066,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         else:
             nodes_to_restart = self.nodes
         if random:
-            nodes_to_restart = random.sample(nodes_to_restart, len(nodes_to_restart))
+            nodes_to_restart = librandom.sample(nodes_to_restart, len(nodes_to_restart))
         self.log.info("Going to restart Scylla on %s" % [n.name for n in nodes_to_restart])
         for node in nodes_to_restart:
             node.stop_scylla(verify_down=True)
@@ -4138,10 +4138,10 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
 
         target_node_ip = node.ip_address
         node.run_nodetool("decommission")
-        verification_node = random.choice(self.nodes)
+        verification_node = librandom.choice(self.nodes)
         node_ip_list = get_node_ip_list(verification_node)
         while verification_node == node or node_ip_list is None:
-            verification_node = random.choice(self.nodes)
+            verification_node = librandom.choice(self.nodes)
             node_ip_list = get_node_ip_list(verification_node)
 
         if target_node_ip in node_ip_list:

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import os
-import random
+import random as librandom
 import requests
 import time
 import base64
@@ -1319,7 +1319,7 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):
         readiness_timeout = self.get_nodes_reboot_timeout(len(self.nodes))
         statefulsets = KubernetesOps.list_statefulsets(self.k8s_cluster, namespace=self.namespace)
         if random:
-            statefulsets = random.sample(statefulsets, len(statefulsets))
+            statefulsets = librandom.sample(statefulsets, len(statefulsets))
         for statefulset in statefulsets:
             self.k8s_cluster.kubectl(
                 f"rollout status statefulset/{statefulset.metadata.name} "


### PR DESCRIPTION
random is common variable name and often it is very convinient to use it as argument name.
in such case it overrides library name that can't be used inside such functions

Also if fixes two bugs in restart_scylla implementation done here:
https://github.com/scylladb/scylla-cluster-tests/commit/11d34603aa336e88d0609dadedff84df83f12e39


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
