### PR TITLE
Add note for "disable_disrupt_validate_hh_short_downtime" method

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1817,10 +1817,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         self.log.debug("Execute a complete repair for target node")
         self.repair_nodetool_repair()
-    # Temporary disable due to https://trello.com/c/Ru0T9Nmu/1239-fix-validatehintedhandoff-nemesis
-    # TODO: Bentsi to fix this nemesis or investigate if it's a real scylla issue.
-    # TODO: Bentsi to fix this nemesis or investigate if it's a real scylla issue.
 
+    # NOTE: enable back when 'https://github.com/scylladb/scylla/issues/8136' issue is fixed
     def disable_disrupt_validate_hh_short_downtime(self):  # pylint: disable=invalid-name
         """
             Validates that hinted handoff mechanism works: there were no drops and errors

--- a/sdcm/report_templates/results_issue_template.html
+++ b/sdcm/report_templates/results_issue_template.html
@@ -39,7 +39,7 @@
         {% if config_files %}
         Test config file(s):<br>
             {% for config_file_link in config_files_link %}
-                - {{ config_file_link.file }} ({{ config_file_link.link }})<br>
+                - {{ config_file_link.file }}({{ config_file_link.link }})<br>
             {% endfor %}
         {% endif %}
     </div>


### PR DESCRIPTION
Add note for the "disable_disrupt_validate_hh_short_downtime" nemesis method
describing the reason it is disabled.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
