### PR TITLE
fix(issue_template): don't print events and screenshots in the result_issue_template

### DIFF
--- a/sdcm/report_templates/results_issue_template.html
+++ b/sdcm/report_templates/results_issue_template.html
@@ -96,3 +96,9 @@
         [Jenkins job URL]({{ job_url }})<br>
     {% endif %}
 {% endblock %}
+
+{%- block events -%}
+{%- endblock -%}
+
+{%- block links -%}
+{%- endblock -%}


### PR DESCRIPTION
Events and screenshouts were added to the results_base_custom template
by PR #3244 . Remove them from result_issue_template

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
