### PR TITLE
test(nemesis.py): add LDAP nemesis to limited chaos monkey

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3298,7 +3298,8 @@ class LimitedChaosMonkey(Nemesis):
                                                          'disrupt_snapshot_operations', 'disrupt_abort_repair',
                                                          'disrupt_mgmt_backup',
                                                          'disrupt_mgmt_backup_specific_keyspaces',
-                                                         'disrupt_add_drop_column'])
+                                                         'disrupt_add_drop_column', 'disrupt_ldap_connection_toggle',
+                                                         'disrupt_disable_enable_ldap_authorization'])
 
 
 class ScyllaCloudLimitedChaosMonkey(Nemesis):


### PR DESCRIPTION
while testing enterprise-2020.1 job (that uses
limited chaos monkey) we were not able to test
these new LDAP nemesis, hence adding it to this
class, and in any case, they will not be executed
on non-enterprise jobs, as LDAP will not be able
to be configured.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
