### PR TITLE
fix(nemesis): Skipping few nemesis for Sirenada run

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4336,6 +4336,10 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             host_ip = self.nodes[0].ip_address
         return manager_tool.add_cluster(name=cluster_name, host=host_ip, auth_token=self.scylla_manager_auth_token)
 
+    @cached_property
+    def is_enterprise(self):
+        return self.nodes[0].is_enterprise
+
 
 class BaseLoaderSet():
 


### PR DESCRIPTION
* Skip on `RefreshMonkey` and `RefreshBigMonkey`, because the run is failed with following error:
```
validate_resharding_after_refresh(resharding_done)
File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 898, in
   validate_resharding_after_refresh
assert resharding_done, "Resharding wasn't run"
AssertionError: Resharding wasn't run
```
* Skipping on nemesis `TerminateAndRemoveNodeMonkey` because is not work for Scylla version `2020`

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
