### PR TITLE
feature(housekeeping stats): add housekeeping stats test to artifact tests

### DIFF
--- a/sdcm/utils/housekeeping.py
+++ b/sdcm/utils/housekeeping.py
@@ -53,7 +53,7 @@ class HousekeepingDB:
         self._cursor = self._connection.cursor()
 
     def execute(self, query: str, args: Optional[Sequence[Any]] = None) -> Sequence[Row]:
-        LOGGER.info("Query: `%s', Args: %s", query, args)
+        LOGGER.debug("Query: `%s', Args: %s", query, args)
         self._cursor.execute(query, args)
         result = self._cursor.fetchall()
         self._connection.commit()

--- a/sdcm/utils/net.py
+++ b/sdcm/utils/net.py
@@ -1,8 +1,11 @@
 """
 Utility functions related to network information
 """
+import ipaddress
+
 import os
 import socket
+import requests
 
 
 def get_sct_runner_ip() -> str:
@@ -15,3 +18,19 @@ def get_my_ip():
     ip = sock.getsockname()[0]
     sock.close()
     return ip
+
+
+def get_my_public_ip() -> str:
+    hostnames = ['https://api4.my-ip.io/ip', "https://api.ipify.org", 'https://ip4.seeip.org/ip',
+                 'http://ipv4.icanhazip.com']
+
+    for hostname in hostnames:
+        result = requests.get(hostname, timeout=10)
+        if result.ok:
+            try:
+                ip_address = result.text.strip()
+                ipaddress.ip_address(ip_address)  # validating that we got IP address
+                return ip_address
+            except ValueError:
+                continue
+    return ""


### PR DESCRIPTION
Add housekeeping stats test to artifact tests

Tested on configurations:
- ami
- amazon2
- ubuntu2004
- docker

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
