### PR TITLE
fix(cluster.py): unsupported python3.9 feature

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2810,7 +2810,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         self.log.info("Waiting for Scylla Machine Image setup to finish...")
         wait.wait_for(self.is_machine_image_configured, step=10, timeout=300)
 
-    def get_sysctl_output(self) -> dict[str, str]:
+    def get_sysctl_output(self):
         properties = {}
         result = self.remoter.sudo("sysctl -a", ignore_status=True)
 


### PR DESCRIPTION
it was added, and backported to branch-perf-v10
but it is still using hydra image with python
3.8, so the tests are failing because of it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
