### PR TITLE
feature(perf_query): Use wide queries to get results from ES

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1572,7 +1572,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                                       email_recipients=self.params.get('email_recipients', default=None))
         is_gce = bool(self.params.get('cluster_backend') == 'gce')
         try:
-            results_analyzer.check_regression(self._test_id, is_gce)
+            results_analyzer.check_regression(self._test_id, is_gce, use_wide_query=True)
         except Exception as ex:  # pylint: disable=broad-except
             self.log.exception('Failed to check regression: %s', ex)
 


### PR DESCRIPTION
Backport pr: 2e717baa feature(es_queries): Filter perf
result by dashboard query

use queries link in es dashboards to filter performance results

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
