### PR TITLE
fix(upgrade cluster): Remove apt-get install deprecated option of --force-yes

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1930,7 +1930,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 self.remoter.run('sudo yum update -y --skip-broken', retry=3)
         else:
             self.remoter.run(
-                'sudo DEBIAN_FRONTEND=noninteractive apt-get --force-yes -o Dpkg::Options::="--force-confold" -o Dpkg::Options::="--force-confdef" upgrade -y', retry=3)
+                'sudo DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confold" '
+                '-o Dpkg::Options::="--force-confdef" upgrade -y', retry=3)
         # update repo cache after upgrade
         self.update_repo_cache()
 
@@ -2204,7 +2205,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             # 2) scylla-manager-client
             # 3) scylla-manager-server
             self.remoter.run('sudo apt-get dist-upgrade scylla-manager-server scylla-manager-client -y -o '
-                             'Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --force-yes'
+                             'Dpkg::Options::="--force-overwrite" -o Dpkg::Options::="--force-confdef" -o '
+                             'Dpkg::Options::="--force-confold" '
                              ' --allow-unauthenticated')
         time.sleep(3)
         if start_manager_after_upgrade:
@@ -2247,7 +2249,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         else:
             self.remoter.run(cmd="sudo apt-get update", ignore_status=True)
             self.remoter.run(
-                'sudo apt-get install -y {}{}'.format(package_names, ' --force-yes' if not self.is_debian9() else ''))
+                'sudo apt-get install -y {}'.format(package_names))
 
         if self.is_docker():
             try:

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -182,7 +182,9 @@ class UpgradeTest(FillDatabaseData):
                     node.remoter.run(r'sudo apt-get remove scylla\* -y')
                     # fixme: add publick key
                     node.remoter.run(
-                        r'sudo apt-get install {}{} -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --force-yes --allow-unauthenticated'.format(scylla_pkg, ver_suffix))
+                        r'sudo apt-get install {}{} -y -o Dpkg::Options::="--force-overwrite" -o '
+                        r'Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" '
+                        r'--allow-unauthenticated'.format(scylla_pkg, ver_suffix))
                     node.remoter.run(r'for conf in $(cat /var/lib/dpkg/info/scylla-*server.conffiles /var/lib/dpkg/info/scylla-*conf.conffiles /var/lib/dpkg/info/scylla-*jmx.conffiles'
                                      r' | grep -v init ); do sudo cp -v $conf $conf.backup-2.1; done')
             else:
@@ -191,7 +193,9 @@ class UpgradeTest(FillDatabaseData):
                 else:
                     node.remoter.run('sudo apt-get update')
                     node.remoter.run(
-                        r'sudo apt-get dist-upgrade {} -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --force-yes --allow-unauthenticated'.format(scylla_pkg))
+                        r'sudo apt-get dist-upgrade {} -y -o Dpkg::Options::="--force-overwrite" -o '
+                        r'Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" '
+                        r'--allow-unauthenticated'.format(scylla_pkg))
         if self.params.get('test_sst3'):
             node.remoter.run("echo 'enable_sstables_mc_format: true' |sudo tee --append /etc/scylla/scylla.yaml")
         if self.params.get('test_upgrade_from_installed_3_1_0'):
@@ -245,11 +249,14 @@ class UpgradeTest(FillDatabaseData):
                 node.remoter.run(r'sudo yum remove scylla\* -y')
                 node.remoter.run(r'sudo yum install %s -y' % node.scylla_pkg())
                 node.remoter.run(
-                    r'for conf in $( rpm -qc $(rpm -qa | grep scylla) | grep -v contains ); do sudo cp -v $conf.autobackup $conf; done')
+                    r'for conf in $( rpm -qc $(rpm -qa | grep scylla) | grep -v contains ); do sudo cp -v '
+                    r'$conf.autobackup $conf; done')
             else:
                 node.remoter.run(r'sudo apt-get remove scylla\* -y')
                 node.remoter.run(
-                    r'sudo apt-get install %s -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --force-yes --allow-unauthenticated' % node.scylla_pkg())
+                    r'sudo apt-get install %s -y -o Dpkg::Options::="--force-overwrite" -o '
+                    r'Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" '
+                    r'--allow-unauthenticated' % node.scylla_pkg())
                 node.remoter.run(
                     r'for conf in $(cat /var/lib/dpkg/info/scylla-*server.conffiles /var/lib/dpkg/info/scylla-*conf.conffiles /var/lib/dpkg/info/scylla-*jmx.conffiles | grep -v init ); do sudo cp -v $conf.backup $conf; done')
 


### PR DESCRIPTION
Fixes: https://github.com/scylladb/scylla-pkg/issues/1922
Same fix was done for install: https://github.com/scylladb/scylla-cluster-tests/pull/3247

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
