### PR TITLE
improvement(jepsen): allow multiple test commands

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -137,7 +137,15 @@ target_upgrade_version: ''
 stress_cdclog_reader_cmd: "cdc-stressor -stream-query-round-duration 30s"
 
 jepsen_scylla_repo: 'https://github.com/jepsen-io/scylla.git'
-jepsen_test_cmd: 'test-all --concurrency 10n'
+jepsen_test_cmd:
+  - 'test-all -w cas-register --concurrency 10n'
+  - 'test-all -w counter --concurrency 10n'
+  - 'test-all -w cmap --concurrency 10n'
+  - 'test-all -w cset --concurrency 10n'
+#  - 'test-all -w mv --concurrency 10n'
+  - 'test-all -w write-isolation --concurrency 10n'
+  - 'test-all -w list-append --concurrency 10n'
+  - 'test-all -w wr-register --concurrency 10n'
 
 max_events_severities: ""
 mgmt_docker_image: ''

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -267,6 +267,6 @@
 | **<a href="#user-content-stress_during_entire_upgrade" name="stress_during_entire_upgrade">stress_during_entire_upgrade</a>**  | Stress command to be run during the upgrade - user should take care for suitable duration | N/A | SCT_STRESS_DURING_ENTIRE_UPGRADE
 | **<a href="#user-content-stress_after_cluster_upgrade" name="stress_after_cluster_upgrade">stress_after_cluster_upgrade</a>**  | Stress command to be run after full upgrade - usually used to read the dataset for verification | N/A | SCT_STRESS_AFTER_CLUSTER_UPGRADE
 | **<a href="#user-content-jepsen_scylla_repo" name="jepsen_scylla_repo">jepsen_scylla_repo</a>**  | Link to the git repository with Jepsen Scylla tests | https://github.com/jepsen-io/scylla.git | SCT_JEPSEN_SCYLLA_REPO
-| **<a href="#user-content-jepsen_test_cmd" name="jepsen_test_cmd">jepsen_test_cmd</a>**  | Jepsen test command (e.g., 'test-all') | test-all | SCT_JEPSEN_TEST_CMD
+| **<a href="#user-content-jepsen_test_cmd" name="jepsen_test_cmd">jepsen_test_cmd</a>**  | Jepsen test command (e.g., 'test-all') | N/A | SCT_JEPSEN_TEST_CMD
 | **<a href="#user-content-max_events_severities" name="max_events_severities">max_events_severities</a>**  | Limit severity level for event types | N/A | SCT_MAX_EVENTS_SEVERITIES
 | **<a href="#user-content-scylla_rsyslog_setup" name="scylla_rsyslog_setup">scylla_rsyslog_setup</a>**  | Configure rsyslog on scylla nodes to send logs to monitoring nodes | False | SCT_SCYLLA_RSYSLOG_SETUP

--- a/sdcm/report_templates/results_jepsen.html
+++ b/sdcm/report_templates/results_jepsen.html
@@ -6,7 +6,13 @@
     <div>
         <ul>
             <li>Jepsen repo: {{ jepsen_scylla_repo }}</li>
-            <li>Jepsen test command: {{ jepsen_test_cmd }}</li>
+            <li>Jepsen test commands:
+                <ul>
+                    {% for test in jepsen_test_cmd %}
+                    <li>- {{ test }}</li>
+                    {% endfor %}
+                </ul>
+            </li>
         </ul>
     </div>
     <h3>

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1073,7 +1073,7 @@ class SCTConfiguration(dict):
         # Jepsen test.
         dict(name="jepsen_scylla_repo", env="SCT_JEPSEN_SCYLLA_REPO", type=str,
              help="Link to the git repository with Jepsen Scylla tests"),
-        dict(name="jepsen_test_cmd", env="SCT_JEPSEN_TEST_CMD", type=str,
+        dict(name="jepsen_test_cmd", env="SCT_JEPSEN_TEST_CMD", type=str_or_list,
              help="Jepsen test command (e.g., 'test-all')"),
 
         dict(name="max_events_severities", env="SCT_MAX_EVENTS_SEVERITIES", type=str_or_list,

--- a/vars/jepsenPipeline.groovy
+++ b/vars/jepsenPipeline.groovy
@@ -33,7 +33,7 @@ def call(Map pipelineParams) {
                    description: 'a link to the git repository with Jepsen Scylla tests',
                    name: 'jepsen_scylla_repo')
             string(defaultValue: '',
-                   description: "Jepsen test command (e.g., 'test-all')",
+                   description: "Jepsen test command(s) (e.g., 'test-all')",
                    name: 'jepsen_test_cmd')
 
             string(defaultValue: "${pipelineParams.get('post_behavior_db_nodes', 'destroy')}",


### PR DESCRIPTION
Trello: https://trello.com/c/WtMjbApE/3055-exclude-mv-workload-from-jepsen-regular-runs

Run all workloads except `mv` as separate `test-all` commands.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
