### PR TITLE
fix(restart_then_repair): filter out 'Can't find a column family with UUID' backtrace

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -414,7 +414,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         # Task https://trello.com/c/llRuLIOJ/2110-add-dbeventfilter-for-nosuchcolumnfamily-error
         # If this error happens during the first boot with the missing disk this issue is expected and it's not an issue
         with DbEventsFilter(db_event=DatabaseLogEvent.DATABASE_ERROR,
-                            line="Can't find a column family with UUID", node=self.target_node):
+                            line="Can't find a column family with UUID", node=self.target_node), \
+            DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE,
+                           line="Can't find a column family with UUID", node=self.target_node):
             self.target_node.restart()
 
         self.log.info('Waiting scylla services to start after node restart')


### PR DESCRIPTION
In the nemesis RestartThenRepairNode the DATABASE_ERROR 'Can't find a column
family with UUID' is filtered out, but not backtrace of this error. So the
test fails on this error. Added filter on DatabaseLogEvent.BACKTRACE

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
