### PR TITLE
fix(sdcm/sct_events.py): regex pattern missed .*

### DIFF
--- a/sdcm/sct_events/setup.py
+++ b/sdcm/sct_events/setup.py
@@ -58,8 +58,8 @@ def start_events_device(log_dir: Optional[Union[str, Path]] = None,
     # Default filters.
     EventsSeverityChangerFilter(new_severity=Severity.WARNING,
                                 event_class=DatabaseLogEvent.DATABASE_ERROR,
-                                regex='workload prioritization - update_service_levels_from_distributed_data: an error '
-                                      'occurred while retrieving configuration').publish()
+                                regex=r'.*workload prioritization - update_service_levels_from_distributed_data: an '
+                                      r'error occurred while retrieving configuration').publish()
     DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line='Rate-limit: supressed').publish()
     DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line='Rate-limit: suppressed').publish()
 


### PR DESCRIPTION
the code was sent, but was not functioning as
expected, because it was supposed to have .* in
the beginning of the regex pattern (as it is
using match() and not search() regex function).

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
