### PR TITLE
Nemesis dashboard: wrong units in materialized view FC delay graph

### DIFF
--- a/data_dir/scylla-dash-per-server-nemesis.3.1.json
+++ b/data_dir/scylla-dash-per-server-nemesis.3.1.json
@@ -2798,7 +2798,7 @@
                         },
                         "yaxes": [
                             {
-                                "format": "ops",
+                                "format": "ns",
                                 "logBase": 1,
                                 "max": null,
                                 "min": 0,

--- a/data_dir/scylla-dash-per-server-nemesis.3.2.json
+++ b/data_dir/scylla-dash-per-server-nemesis.3.2.json
@@ -2798,7 +2798,7 @@
                         },
                         "yaxes": [
                             {
-                                "format": "ops",
+                                "format": "ns",
                                 "logBase": 1,
                                 "max": null,
                                 "min": 0,

--- a/data_dir/scylla-dash-per-server-nemesis.3.3.json
+++ b/data_dir/scylla-dash-per-server-nemesis.3.3.json
@@ -2798,7 +2798,7 @@
                         },
                         "yaxes": [
                             {
-                                "format": "ops",
+                                "format": "ns",
                                 "logBase": 1,
                                 "max": null,
                                 "min": 0,

--- a/data_dir/scylla-dash-per-server-nemesis.4.0.json
+++ b/data_dir/scylla-dash-per-server-nemesis.4.0.json
@@ -2786,7 +2786,7 @@
                         },
                         "yaxes": [
                             {
-                                "format": "ops",
+                                "format": "ns",
                                 "logBase": 1,
                                 "max": null,
                                 "min": 0,

--- a/data_dir/scylla-dash-per-server-nemesis.master.json
+++ b/data_dir/scylla-dash-per-server-nemesis.master.json
@@ -2820,7 +2820,7 @@
                         },
                         "yaxes": [
                             {
-                                "format": "ops",
+                                "format": "ns",
                                 "logBase": 1,
                                 "max": null,
                                 "min": 0,


### PR DESCRIPTION
The units in this graph should be nano-seconds and not ops.

Fixes #3277
