### PR TITLE
feature(asymmertic cluster): add support of asymmetric cluster

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -16,6 +16,8 @@ round_robin: false
 append_scylla_args: '--blocked-reactor-notify-ms 500 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1 --enable-sstable-key-validation 1'
 append_scylla_setup_args: ''
 
+db_nodes_shards_selection: 'default'
+
 # for for version selection
 scylla_linux_distro: 'centos'
 scylla_linux_distro_loader: 'centos'

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -58,6 +58,7 @@
 | **<a href="#user-content-instance_provision_fallback_on_demand" name="instance_provision_fallback_on_demand">instance_provision_fallback_on_demand</a>**  | instance_provision_fallback_on_demand: create instance on_demand provision type if instance with selected 'instance_provision' type creation failed. Expected values: true|false (default - false | N/A | SCT_INSTANCE_PROVISION_FALLBACK_ON_DEMAND
 | **<a href="#user-content-reuse_cluster" name="reuse_cluster">reuse_cluster</a>**  | If reuse_cluster is set it should hold test_id of the cluster that will be reused.<br>`reuse_cluster: 7dc6db84-eb01-4b61-a946-b5c72e0f6d71` | N/A | SCT_REUSE_CLUSTER
 | **<a href="#user-content-test_id" name="test_id">test_id</a>**  | test id to filter by | N/A | SCT_TEST_ID
+| **<a href="#user-content-db_nodes_shards_selection" name="db_nodes_shards_selection">db_nodes_shards_selection</a>**  | How to select number of shards of Scylla. Expected values: default/random | default | SCT_NODES_SHARDS_SELECTION
 | **<a href="#user-content-seeds_selector" name="seeds_selector">seeds_selector</a>**  | How to select the seeds. Expected values: reflector/random/first | first | SCT_SEEDS_SELECTOR
 | **<a href="#user-content-seeds_num" name="seeds_num">seeds_num</a>**  | Number of seeds to select | 1 | SCT_SEEDS_NUM
 | **<a href="#user-content-send_email" name="send_email">send_email</a>**  | If true would send email out of the performance regression test | N/A | SCT_SEND_EMAIL

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -702,8 +702,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             ]
         raise UnsupportedNemesis("Only GkeScyllaPodCluster is supported")
 
-    def _terminate_cluster_node(self, node):
-        self.cluster.terminate_node(node)
+    def _terminate_cluster_node(self, node, by_nemesis=""):
+        self.cluster.terminate_node(node, by_nemesis=by_nemesis)
         self.monitoring_set.reconfigure_scylla_monitoring()
 
     def disrupt_nodetool_decommission(self, add_node=True, disruption_name=None):
@@ -747,8 +747,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.cluster.update_seed_provider()
 
     @latency_calculator_decorator
-    def _terminate_and_wait(self, target_node, sleep_time=300):
-        self._terminate_cluster_node(target_node)
+    def _terminate_and_wait(self, target_node, sleep_time=300, by_nemesis=""):
+        self._terminate_cluster_node(target_node, by_nemesis=by_nemesis)
         time.sleep(sleep_time)  # Sleeping for 5 mins to let the cluster live with a missing node for a while
 
     @latency_calculator_decorator
@@ -836,7 +836,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self._set_current_disruption('TerminateAndReplaceNode %s' % self.target_node)
         old_node_ip = self.target_node.ip_address
         InfoEvent(message='StartEvent - Terminate node and wait 5 minutes').publish()
-        self._terminate_and_wait(target_node=self.target_node)
+        self._terminate_and_wait(target_node=self.target_node, by_nemesis='TerminateAndReplaceNode')
         InfoEvent(message='FinishEvent - target_node was terminated').publish()
         new_node = self._add_and_init_new_cluster_node(old_node_ip, rack=self.target_node.rack)
         try:
@@ -2255,7 +2255,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         node_to_remove.stop_scylla_server(verify_up=True, verify_down=True)
 
         # terminate node
-        self._terminate_cluster_node(node_to_remove)
+        self._terminate_cluster_node(node_to_remove, by_nemesis='TerminateAndRemoveNodeMonkey')
 
         # full cluster repair
         up_normal_nodes.remove(node_to_remove)
@@ -2496,7 +2496,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             if self.target_node.ip_address not in ips or decommission_done:
                 self.log.error(
                     'The target node is decommission unexpectedly, decommission might complete before stopping it. Re-add a new node')
-                self._terminate_cluster_node(self.target_node)
+                self._terminate_cluster_node(self.target_node, by_nemesis='DecommissionStreamingErr')
                 new_node = self._add_and_init_new_cluster_node(rack=self.target_node.rack)
                 self.unset_current_running_nemesis(new_node)
                 return new_node

--- a/sdcm/report_templates/results_base.html
+++ b/sdcm/report_templates/results_base.html
@@ -43,6 +43,25 @@
             padding: 8px;
         }
 
+        .nodes_info_table {
+            font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;
+            border-collapse: collapse;
+            vertical-align: top;
+            width: 90%;
+        }
+
+        .nodes_info_table td, .nodes_info_table th {
+            border: 1px solid #ddd;
+            text-align: center;
+        }
+
+        .nodes_info_table th {
+            padding: 8px;
+            text-align: center;
+            background-color: #85C1E9;
+            color: white;
+        }
+
         .longevity_result_table {
             font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;
             border-collapse: collapse;

--- a/sdcm/report_templates/results_issue_template.html
+++ b/sdcm/report_templates/results_issue_template.html
@@ -5,6 +5,18 @@
         Kernel version: `{{ kernel_version }}`<br>
         Scylla version (or git commit hash): `{{ scylla_version }}`<br>
         Cluster size: {{ number_of_db_nodes }} nodes ({{ scylla_instance_type }})<br>
+        {% if live_nodes_shards %}
+            Scylla running with shards number (live nodes):<br>
+            {% for shards_info in live_nodes_shards %}
+               &nbsp;&nbsp;{{ shards_info.name }} ({{ shards_info.ip }}): {{ shards_info.shards }} shards<br>
+            {% endfor %}
+        {% endif %}
+        {% if dead_nodes_shards %}
+            Scylla running with shards number (terminated nodes):<br>
+            {% for shards_info in dead_nodes_shards %}
+               &nbsp;&nbsp;{{ shards_info.name }} ({{ shards_info.ip }}): {{ shards_info.shards }} shards<br>
+            {% endfor %}
+        {% endif %}
         OS (RHEL/CentOS/Ubuntu/AWS AMI): {% if scylla_ami_id %} `{{ scylla_ami_id }}` {% endif %} {% if scylla_node_image %} `{{ scylla_node_image }}`{% endif %} ({{ backend }}{% if region_name %}: {{ region_name }}{% endif %})<br>
         {% if scylla_repo %}
         Private repo: `{{ scylla_repo }}`<br>

--- a/sdcm/report_templates/results_longevity.html
+++ b/sdcm/report_templates/results_longevity.html
@@ -8,6 +8,52 @@
             <li>Scylla version: {{ scylla_version }} ({{ scylla_ami_id }})</li>
             <li>Instance type: {{ scylla_instance_type }}</li>
             <li>Number of scylladb nodes: {{ number_of_db_nodes }}</li>
+
+
+            {% if live_nodes_shards %}
+            <h4>Live nodes (at the end of the test)</h4>
+            <div>
+                <table class='nodes_info_table'>
+                    <tr>
+                        <th>Name</th>
+                        <th>IP address</th>
+                        <th>Scylla shards</th>
+                    </tr>
+                    {% for node in live_nodes_shards %}
+                    <tr>
+                        <td>{{ node.name }}</td>
+                        <td>{{ node.ip }}</td>
+                        <td>{{ node.shards }}</td>
+                    </tr>
+                {% endfor %}
+                </table>
+            </div>
+            {% endif %}
+
+            {% if dead_nodes_shards %}
+            <h4>Terminated nodes</h4>
+            <div>
+                <table class='nodes_info_table'>
+                    <tr>
+                        <th>Name</th>
+                        <th>IP address</th>
+                        <th>Scylla shards</th>
+                        <th>Termination time</th>
+                        <th>Terminated by nemesis</th>
+                    </tr>
+                    {% for node in dead_nodes_shards %}
+                    <tr>
+                        <td>{{ node.name }}</td>
+                        <td>{{ node.ip }}</td>
+                        <td>{{ node.shards }}</td>
+                        <td>{{ node.termination_time }}</td>
+                        <td>{{ node.terminated_by_nemesis }}</td>
+                    </tr>
+                {% endfor %}
+                </table>
+            </div>
+            {% endif %}
+
         </ul>
     </div>
 {% include "results_nemesis_stats.html" %}

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -315,6 +315,13 @@ class SCTConfiguration(dict):
         dict(name="test_id", env="SCT_TEST_ID", type=str,
              help="""Set the test_id of the run manually. Use only from the env before running Hydra"""),
 
+        dict(name="db_nodes_shards_selection", env="SCT_NODES_SHARDS_SELECTION", type=str,
+             choices=['default', 'random'],
+             help="""How to select number of shards of Scylla. Expected values: default/random.
+             Default value: 'default'.
+             In case of random option - Scylla will start with different (random) shards on every node of the cluster
+             """),
+
         dict(name="seeds_selector", env="SCT_SEEDS_SELECTOR", type=str,
              choices=['reflector', 'random', 'first'],
              help="""How to select the seeds. Expected values: reflector/random/first"""),

--- a/sdcm/send_email.py
+++ b/sdcm/send_email.py
@@ -135,6 +135,8 @@ class BaseEmailReporter:
         "logs_links",
         "nodes",
         "number_of_db_nodes",
+        "live_nodes_shards",
+        "dead_nodes_shards",
         "region_name",
         "scylla_instance_type",
         "scylla_version",

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -11,6 +11,8 @@
 #
 # Copyright (c) 2016 ScyllaDB
 # pylint: disable=too-many-lines
+from collections import defaultdict
+from dataclasses import asdict
 
 import logging
 import os
@@ -29,7 +31,7 @@ import signal
 import sys
 import traceback
 
-from invoke.exceptions import UnexpectedExit, Failure
+from invoke.exceptions import UnexpectedExit, Failure  # pylint: disable=import-error
 
 from cassandra.concurrent import execute_concurrent_with_args  # pylint: disable=no-name-in-module
 from cassandra import ConsistencyLevel
@@ -2747,6 +2749,19 @@ class ClusterTester(db_stats.TestStatsMixin,
         """
         return {}
 
+    def all_nodes_scylla_shards(self):
+        all_nodes_shards = defaultdict(list)
+        for node in self.db_cluster.nodes:
+            ipv6 = node.ipv6_ip_address if node.ip_address == node.ipv6_ip_address else ''
+            all_nodes_shards['live_nodes'].append({'name': node.name,
+                                                   'ip': f"{node.public_ip_address} | {node.private_ip_address}"
+                                                         f"{f' | {ipv6}' if ipv6 else ''}",
+                                                   'shards': node.scylla_shards})
+
+        all_nodes_shards['dead_nodes'] = [asdict(node) for node in self.db_cluster.dead_nodes_list]
+
+        return all_nodes_shards
+
     def _get_common_email_data(self) -> dict:
         """Helper for subclasses which extracts common data for email."""
 
@@ -2766,6 +2781,8 @@ class ClusterTester(db_stats.TestStatsMixin,
             self.log.error(f"Can't discover instance type for {backend}!")
             scylla_instance_type = "N/A"
         job_name = os.environ.get('JOB_NAME').split("/")[-1] if os.environ.get('JOB_NAME') else config_file_name
+        nodes_shards = self.all_nodes_scylla_shards()
+
         return {"backend": backend,
                 "build_id": os.environ.get('BUILD_NUMBER', ''),
                 "job_url": os.environ.get("BUILD_URL"),
@@ -2777,6 +2794,8 @@ class ClusterTester(db_stats.TestStatsMixin,
                 "region_name": region_name,
                 "scylla_instance_type": scylla_instance_type,
                 "scylla_version": scylla_version,
+                "live_nodes_shards": nodes_shards['live_nodes'],
+                "dead_nodes_shards": nodes_shards['dead_nodes'],
                 "kernel_version": kernel_version,
                 "start_time": start_time,
                 "subject": f"{test_status}: {os.environ.get('JOB_NAME') or config_file_name}{build_id}: {start_time}",


### PR DESCRIPTION
Test Asymmetric clusters:
- bootstrapping an asymmetric cluster
- adding asymmetric nodes to cluster

SMP selection:
- minimum SMP should be calculated as 50% of max SMP
- max SMP as it is calculated now by default
- new parameter: db_nodes_shards_selection (default | random)

Add 2 new longevities to use it:
1. That will be based on the large-paritions-8h but to be shortened to 3 hours and will be run
daily (like all others).
2. another longevity that will be based on 200gb-48h but to be shorten to 12h.

Task:
https://trello.com/c/WYdqMLgp/2672-test-asymmetric-clusters-bootstrapping-an-asymmetric-cluster-adding-asymmetric-nodes-to-cluster-customer-issue

Email body changes:
![Screenshot from 2021-03-16 14-46-33](https://user-images.githubusercontent.com/34435448/111311702-32fb1000-8667-11eb-91ec-b8a11abb02d6.png)

Issue template changes:

![Screenshot from 2021-03-16 14-47-23](https://user-images.githubusercontent.com/34435448/111311735-3d1d0e80-8667-11eb-85a5-2bf1380a0ae6.png)


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
