### PR TITLE
fix(rolling-upgrade): increase the test_duration to 360

### DIFF
--- a/test-cases/upgrades/rolling-upgrade.yaml
+++ b/test-cases/upgrades/rolling-upgrade.yaml
@@ -1,6 +1,6 @@
 # TODO: need to qualify on GCE and AWS
 
-test_duration: 250
+test_duration: 360
 
 # workloads
 write_stress_during_entire_test: cassandra-stress write no-warmup cl=QUORUM n=20100200 -schema 'keyspace=keyspace_entire_test replication(factor=3) compression=LZ4Compressor' -port jmx=6868 -mode cql3 native compression=lz4 -rate threads=100 -pop seq=1..20100200 -log interval=5


### PR DESCRIPTION
Current test_duration (250 mins) isn't enough, some upgrade job was
interrupt for timeout.

> Test started at 2021-02-25 13:37:40, reached it's timeout (250 minute)

The jenkins pipeline timeout is 360, let's set the test_duration to be
same.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
