### PR TITLE
fix(fill_db_data.py): Fixing "Tom Bob" query result

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -783,7 +783,9 @@ class FillDatabaseData(ClusterTester):
                 "INSERT INTO nameless_index_test (id, birth_year) VALUES ('Paul', 24)",
                 "INSERT INTO nameless_index_test (id, birth_year) VALUES ('Bob', 42)"],
             'queries': ["SELECT id FROM nameless_index_test WHERE birth_year = 42"],
-            'results': [[['Bob'], ['Tom']]],
+            # Due the issue https://github.com/scylladb/scylla/issues/7443, the result of the query changed
+            # from "[['Bob'], ['Tom']]" to "[['Tom'], ['Bob']]" from versions Scylla 4.4 and above
+            'results': [[['Tom'], ['Bob']]],
             'min_version': '3.0',
             'max_version': '',
             'skip': ''},


### PR DESCRIPTION
* According to `Cassandra` version 4.0, the order of the "result" variable should be `[['Tom'], ['Bob']]`.
* Github issue https://github.com/scylladb/scylla/issues/8207

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
