### PR TITLE
fix(fill_db_data.py): list ordering make upgrade test to fail

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -3047,7 +3047,7 @@ class FillDatabaseData(ClusterTester):
                             self.assertEqual(str([list(row) for row in res]), item['results'][i])
                         else:
                             res = session.execute(item['queries'][i])
-                            self.assertEqual([list(row) for row in res], item['results'][i])
+                            self.assertEqual(sorted([list(row) for row in res]), sorted(item['results'][i]))
                     except Exception as ex:
                         LOGGER.exception(item['queries'][i])
                         raise ex


### PR DESCRIPTION
using `sorted()` function in both lists, will ensure we will
have the same results (including its order).

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
