### PR TITLE
fix(tester.py): Change cassandra-stress default timeout according to duration parameter

### DIFF
--- a/longevity_test.py
+++ b/longevity_test.py
@@ -372,7 +372,9 @@ class LongevityTest(ClusterTester):
         for batch, _, _, extra_tables_idx in list(chunks(stress_params_list, batch_size)):
 
             stress_queue = list()
-            batch_params = dict(round_robin=True, stress_cmd=[], timeout=self.params.get('cs_duration'))
+            cs_duration_in_min = self.params.get('cs_duration')
+            timeout = self.get_duration(duration=int(cs_duration_in_min[:-1]))
+            batch_params = dict(round_robin=True, stress_cmd=[], timeout=timeout)
 
             # add few stress threads with tables that weren't pre-created
             customer_profiles = self.params.get('cs_user_profiles')

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -372,7 +372,7 @@ class LongevityTest(ClusterTester):
         for batch, _, _, extra_tables_idx in list(chunks(stress_params_list, batch_size)):
 
             stress_queue = list()
-            batch_params = dict(round_robin=True, stress_cmd=[])
+            batch_params = dict(round_robin=True, stress_cmd=[], timeout=self.params.get('cs_duration'))
 
             # add few stress threads with tables that weren't pre-created
             customer_profiles = self.params.get('cs_user_profiles')

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1107,7 +1107,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
     def run_stress_thread(self, stress_cmd, duration=None, stress_num=1, keyspace_num=1, profile=None, prefix='',  # pylint: disable=too-many-arguments
                           round_robin=False, stats_aggregate_cmds=True, keyspace_name=None, use_single_loader=False,
-                          stop_test_on_failure=True):
+                          stop_test_on_failure=True, timeout=None):
 
         params = dict(stress_cmd=stress_cmd, duration=duration, stress_num=stress_num, keyspace_num=keyspace_num,
                       keyspace_name=keyspace_name, profile=profile, prefix=prefix, round_robin=round_robin,
@@ -1115,7 +1115,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
         if 'cassandra-stress' in stress_cmd:  # cs cmdline might started with JVM_OPTION
             params['stop_test_on_failure'] = stop_test_on_failure
-            return self.run_stress_cassandra_thread(**params)
+            return self.run_stress_cassandra_thread(**params, timeout=timeout)
         elif stress_cmd.startswith('scylla-bench'):
             params['stop_test_on_failure'] = stop_test_on_failure
             return self.run_stress_thread_bench(**params)
@@ -1132,9 +1132,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
     def run_stress_cassandra_thread(self, stress_cmd, duration=None, stress_num=1, keyspace_num=1, profile=None, prefix='',  # pylint: disable=too-many-arguments,unused-argument
                                     round_robin=False, stats_aggregate_cmds=True, keyspace_name=None, use_single_loader=False,  # pylint: disable=too-many-arguments,unused-argument
-                                    stop_test_on_failure=True):  # pylint: disable=too-many-arguments,unused-argument
+                                    stop_test_on_failure=True, timeout=None):  # pylint: disable=too-many-arguments,unused-argument
         # stress_cmd = self._cs_add_node_flag(stress_cmd)
-        timeout = self.get_duration(duration)
+        timeout = timeout or self.get_duration(duration)
         if self.create_stats:
             self.update_stress_cmd_details(stress_cmd, prefix, stresser="cassandra-stress",
                                            aggregate=stats_aggregate_cmds)


### PR DESCRIPTION
	in order for a cs stress not to get stuck for the whole test duration,
	blocking other test operation and batch stresses.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
