### PR TITLE
Fix DecommissionStreamingErr nemesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2537,6 +2537,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         self.log.debug('Interrupt the task by hard reboot')
 
+        new_node = None
         with DbEventsFilter(db_event=DatabaseLogEvent.RUNTIME_ERROR,
                             line="This node was decommissioned and will not rejoin",
                             node=self.target_node), \
@@ -2546,9 +2547,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.target_node.reboot(hard=True, verify_ssh=True)
             streaming_thread.join(60)
 
-        new_node = None
-        if task == 'decommission':
-            new_node = decommission_post_action()
+            if task == 'decommission':
+                new_node = decommission_post_action()
 
         if self.task_used_streaming:
             err = list(streaming_error_logs_stream)

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2474,9 +2474,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         """
 
         def decommission_post_action():
-            decommission_done = list(self.target_node.follow_system_log(
-                patterns=['DECOMMISSIONING: done'], start_from_beginning=True))
-
             ips = []
             seed_nodes = [node for node in self.cluster.nodes if node.is_seed]
             status = self.cluster.get_nodetool_status(verification_node=seed_nodes[0])
@@ -2486,6 +2483,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                     ips.extend(dc_info.keys())
                 except Exception:  # pylint: disable=broad-except
                     self.log.debug(dc_info)
+
+            decommission_done = list(self.target_node.follow_system_log(
+                patterns=['DECOMMISSIONING: done'], start_from_beginning=True))
 
             if self.target_node.ip_address not in ips or decommission_done:
                 self.log.error(


### PR DESCRIPTION
The DecommissionStreamingErr nemesis in scylla-4.4/longevity/longevity-10gb-3h-test#20 failed for rejoin error.
This PR fixed the problem.

2021-02-25 09:19:06.000: (DatabaseLogEvent Severity.ERROR): type=RUNTIME_ERROR regex=std::runtime_error line_number=11363 node=Node longevity-10gb-3h-4-4-db-node-598fff6e-2 [13.49.57.113 | 10.0.0.164] (seed: False)
2021-02-25T09:19:06+00:00  longevity-10gb-3h-4-4-db-node-598fff6e-2 !ERR     | scylla: [shard 0] init - Startup failed: std::runtime_error (This node was decommissioned and will not rejoin the ring unless override_decommission=true has been set,or all existing data is removed and the node is bootstrapped again)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
