### PR TITLE
cleanup apt install options

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2026,8 +2026,6 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             self.remoter.run('sudo apt-get update')
             self.remoter.run(
                 'sudo apt-get install -y '
-                '-o Dpkg::Options::="--force-confdef" '
-                '-o Dpkg::Options::="--force-confold" '
                 ' {} '.format(self.scylla_pkg()))
 
     def offline_install_scylla(self, unified_package, nonroot):
@@ -2081,7 +2079,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             self.remoter.run(
                 r'sudo yum install -y {0}-debuginfo-{1}\*'.format(self.scylla_pkg(), self.scylla_version), ignore_status=True)
         else:
-            self.remoter.run(r'sudo apt-get install -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" {0}-server-dbg={1}\*'
+            self.remoter.run(r'sudo apt-get install -y {0}-server-dbg={1}\*'
                              .format(self.scylla_pkg(), self.scylla_version), ignore_status=True)
 
     def is_scylla_installed(self):
@@ -2211,9 +2209,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             # 1) scylla-manager
             # 2) scylla-manager-client
             # 3) scylla-manager-server
-            self.remoter.run('sudo apt-get dist-upgrade scylla-manager-server scylla-manager-client -y '
-                             '-o Dpkg::Options::="--force-confdef" '
-                             '-o Dpkg::Options::="--force-confold" ')
+            self.remoter.run('sudo apt-get dist-upgrade scylla-manager-server scylla-manager-client -y ')
         time.sleep(3)
         if start_manager_after_upgrade:
             if self.is_docker():
@@ -4325,8 +4321,6 @@ class BaseLoaderSet():
         else:
             node.remoter.run('sudo apt-get update')
             node.remoter.run('sudo apt-get install -y '
-                             '-o Dpkg::Options::="--force-confdef" '
-                             '-o Dpkg::Options::="--force-confold" '
                              ' {}-tools '.format(node.scylla_pkg()))
 
         if db_node_address is not None:

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1930,8 +1930,10 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 self.remoter.run('sudo yum update -y --skip-broken', retry=3)
         else:
             self.remoter.run(
-                'sudo DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confold" '
-                '-o Dpkg::Options::="--force-confdef" upgrade -y', retry=3)
+                'sudo DEBIAN_FRONTEND=noninteractive apt-get '
+                '-o Dpkg::Options::="--force-confold" '
+                '-o Dpkg::Options::="--force-confdef" '
+                'upgrade -y ', retry=3)
         # update repo cache after upgrade
         self.update_repo_cache()
 
@@ -2015,13 +2017,18 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 self.remoter.run('sudo bash -cxe "%s"' % install_debian_10_prereqs)
 
             self.remoter.run(
-                'sudo DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confold" -o Dpkg::Options::="--force-confdef" upgrade -y')
+                'sudo DEBIAN_FRONTEND=noninteractive apt-get '
+                '-o Dpkg::Options::="--force-confold" '
+                '-o Dpkg::Options::="--force-confdef" '
+                'upgrade -y ')
             self.remoter.run('sudo apt-get install -y rsync tcpdump screen')
             self.download_scylla_repo(scylla_repo)
             self.remoter.run('sudo apt-get update')
             self.remoter.run(
-                'sudo apt-get install -y -o Dpkg::Options::="--force-overwrite" -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" '
-                '--allow-unauthenticated {}'.format(self.scylla_pkg()))
+                'sudo apt-get install -y '
+                '-o Dpkg::Options::="--force-confdef" '
+                '-o Dpkg::Options::="--force-confold" '
+                '--allow-unauthenticated {} '.format(self.scylla_pkg()))
 
     def offline_install_scylla(self, unified_package, nonroot):
         """
@@ -2204,10 +2211,10 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             # 1) scylla-manager
             # 2) scylla-manager-client
             # 3) scylla-manager-server
-            self.remoter.run('sudo apt-get dist-upgrade scylla-manager-server scylla-manager-client -y -o '
-                             'Dpkg::Options::="--force-overwrite" -o Dpkg::Options::="--force-confdef" -o '
-                             'Dpkg::Options::="--force-confold" '
-                             ' --allow-unauthenticated')
+            self.remoter.run('sudo apt-get dist-upgrade scylla-manager-server scylla-manager-client -y '
+                             '-o Dpkg::Options::="--force-confdef" '
+                             '-o Dpkg::Options::="--force-confold" '
+                             '--allow-unauthenticated ')
         time.sleep(3)
         if start_manager_after_upgrade:
             if self.is_docker():
@@ -4318,9 +4325,10 @@ class BaseLoaderSet():
             node.remoter.run('sudo yum install -y {}-tools'.format(node.scylla_pkg()))
         else:
             node.remoter.run('sudo apt-get update')
-            node.remoter.run('sudo apt-get install -y -o Dpkg::Options::="--force-confdef"'
-                             ' -o Dpkg::Options::="--force-confold" -o Dpkg::Options::="--force-overwrite"'
-                             ' --allow-unauthenticated {}-tools'.format(node.scylla_pkg()))
+            node.remoter.run('sudo apt-get install -y '
+                             '-o Dpkg::Options::="--force-confdef" '
+                             '-o Dpkg::Options::="--force-confold" '
+                             '--allow-unauthenticated {}-tools '.format(node.scylla_pkg()))
 
         if db_node_address is not None:
             node.remoter.run("echo 'export DB_ADDRESS=%s' >> $HOME/.bashrc" % db_node_address)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2028,7 +2028,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 'sudo apt-get install -y '
                 '-o Dpkg::Options::="--force-confdef" '
                 '-o Dpkg::Options::="--force-confold" '
-                '--allow-unauthenticated {} '.format(self.scylla_pkg()))
+                ' {} '.format(self.scylla_pkg()))
 
     def offline_install_scylla(self, unified_package, nonroot):
         """
@@ -2081,7 +2081,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             self.remoter.run(
                 r'sudo yum install -y {0}-debuginfo-{1}\*'.format(self.scylla_pkg(), self.scylla_version), ignore_status=True)
         else:
-            self.remoter.run(r'sudo apt-get install -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --allow-unauthenticated {0}-server-dbg={1}\*'
+            self.remoter.run(r'sudo apt-get install -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" {0}-server-dbg={1}\*'
                              .format(self.scylla_pkg(), self.scylla_version), ignore_status=True)
 
     def is_scylla_installed(self):
@@ -2213,8 +2213,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             # 3) scylla-manager-server
             self.remoter.run('sudo apt-get dist-upgrade scylla-manager-server scylla-manager-client -y '
                              '-o Dpkg::Options::="--force-confdef" '
-                             '-o Dpkg::Options::="--force-confold" '
-                             '--allow-unauthenticated ')
+                             '-o Dpkg::Options::="--force-confold" ')
         time.sleep(3)
         if start_manager_after_upgrade:
             if self.is_docker():
@@ -4328,7 +4327,7 @@ class BaseLoaderSet():
             node.remoter.run('sudo apt-get install -y '
                              '-o Dpkg::Options::="--force-confdef" '
                              '-o Dpkg::Options::="--force-confold" '
-                             '--allow-unauthenticated {}-tools '.format(node.scylla_pkg()))
+                             ' {}-tools '.format(node.scylla_pkg()))
 
         if db_node_address is not None:
             node.remoter.run("echo 'export DB_ADDRESS=%s' >> $HOME/.bashrc" % db_node_address)

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -182,8 +182,8 @@ class UpgradeTest(FillDatabaseData):
                     node.remoter.run(r'sudo apt-get remove scylla\* -y')
                     # fixme: add publick key
                     node.remoter.run(
-                        r'sudo apt-get install {}{} -y -o Dpkg::Options::="--force-overwrite" -o '
-                        r'Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" '
+                        r'sudo apt-get install {}{} -y '
+                        r'-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" '
                         r'--allow-unauthenticated'.format(scylla_pkg, ver_suffix))
                     node.remoter.run(r'for conf in $(cat /var/lib/dpkg/info/scylla-*server.conffiles /var/lib/dpkg/info/scylla-*conf.conffiles /var/lib/dpkg/info/scylla-*jmx.conffiles'
                                      r' | grep -v init ); do sudo cp -v $conf $conf.backup-2.1; done')
@@ -193,8 +193,8 @@ class UpgradeTest(FillDatabaseData):
                 else:
                     node.remoter.run('sudo apt-get update')
                     node.remoter.run(
-                        r'sudo apt-get dist-upgrade {} -y -o Dpkg::Options::="--force-overwrite" -o '
-                        r'Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" '
+                        r'sudo apt-get dist-upgrade {} -y '
+                        r'-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" '
                         r'--allow-unauthenticated'.format(scylla_pkg))
         if self.params.get('test_sst3'):
             node.remoter.run("echo 'enable_sstables_mc_format: true' |sudo tee --append /etc/scylla/scylla.yaml")
@@ -254,8 +254,8 @@ class UpgradeTest(FillDatabaseData):
             else:
                 node.remoter.run(r'sudo apt-get remove scylla\* -y')
                 node.remoter.run(
-                    r'sudo apt-get install %s -y -o Dpkg::Options::="--force-overwrite" -o '
-                    r'Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" '
+                    r'sudo apt-get install %s -y '
+                    r'-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" '
                     r'--allow-unauthenticated' % node.scylla_pkg())
                 node.remoter.run(
                     r'for conf in $(cat /var/lib/dpkg/info/scylla-*server.conffiles /var/lib/dpkg/info/scylla-*conf.conffiles /var/lib/dpkg/info/scylla-*jmx.conffiles | grep -v init ); do sudo cp -v $conf.backup $conf; done')

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -183,8 +183,7 @@ class UpgradeTest(FillDatabaseData):
                     # fixme: add publick key
                     node.remoter.run(
                         r'sudo apt-get install {}{} -y '
-                        r'-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" '
-                        r'--allow-unauthenticated'.format(scylla_pkg, ver_suffix))
+                        r'-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" '.format(scylla_pkg, ver_suffix))
                     node.remoter.run(r'for conf in $(cat /var/lib/dpkg/info/scylla-*server.conffiles /var/lib/dpkg/info/scylla-*conf.conffiles /var/lib/dpkg/info/scylla-*jmx.conffiles'
                                      r' | grep -v init ); do sudo cp -v $conf $conf.backup-2.1; done')
             else:
@@ -194,8 +193,7 @@ class UpgradeTest(FillDatabaseData):
                     node.remoter.run('sudo apt-get update')
                     node.remoter.run(
                         r'sudo apt-get dist-upgrade {} -y '
-                        r'-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" '
-                        r'--allow-unauthenticated'.format(scylla_pkg))
+                        r'-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" '.format(scylla_pkg))
         if self.params.get('test_sst3'):
             node.remoter.run("echo 'enable_sstables_mc_format: true' |sudo tee --append /etc/scylla/scylla.yaml")
         if self.params.get('test_upgrade_from_installed_3_1_0'):
@@ -255,8 +253,7 @@ class UpgradeTest(FillDatabaseData):
                 node.remoter.run(r'sudo apt-get remove scylla\* -y')
                 node.remoter.run(
                     r'sudo apt-get install %s -y '
-                    r'-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" '
-                    r'--allow-unauthenticated' % node.scylla_pkg())
+                    r'-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" ' % node.scylla_pkg())
                 node.remoter.run(
                     r'for conf in $(cat /var/lib/dpkg/info/scylla-*server.conffiles /var/lib/dpkg/info/scylla-*conf.conffiles /var/lib/dpkg/info/scylla-*jmx.conffiles | grep -v init ); do sudo cp -v $conf.backup $conf; done')
 


### PR DESCRIPTION
* [PATCH] fix(apt install): remove unused --force-confdef/--force-confold
    The test instances are always clean, the force options aren't necessary.

* [PATCH] fix(apt install): remove unused --allow-unauthenticated
    Latest scylla packages are all signed, we don't need `--allow-unauthenticated'.

* [PATCH] fix(apt install): remove harmful --allow-overwrite option
    This option might ignore the real scylla install bug.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
