### PR TITLE
Make monitoring node have proper DB node endpoints installing on K8S

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -640,10 +640,10 @@ class BasePodContainer(cluster.BaseNode):
 
         if cluster_ip_service := self._cluster_ip_service:
             cluster_ip = cluster_ip_service.spec.cluster_ip
-            public_ips.append(cluster_ip)
             private_ips.append(cluster_ip)
 
         if pod_status := self._pod_status:
+            public_ips.append(pod_status.host_ip)
             private_ips.append(pod_status.pod_ip)
         return (public_ips or [None, ], private_ips or [None, ])
 

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -213,9 +213,8 @@ class KubernetesCluster:
         if scylla_operator_image_tag:
             set_options.append(f"controllerImage.tag={scylla_operator_image_tag}")
 
-        # Install and wait for initialization of the Scylla Operator chart
+        # Install and wait for initialization of the Scylla Manager chart
         LOGGER.info("Deploy scylla-manager")
-        self.kubectl(f'create namespace {SCYLLA_MANAGER_NAMESPACE}')
         LOGGER.debug(self.helm_install(
             target_chart_name="scylla-manager",
             source_chart_name="scylla-operator/scylla-manager",
@@ -315,7 +314,6 @@ class KubernetesCluster:
     @log_run_info
     def deploy_scylla_cluster(self, config: str, target_mgmt_agent_to_minio: bool = False) -> None:
         LOGGER.info("Create and initialize a Scylla cluster")
-        self.kubectl(f"create namespace {SCYLLA_NAMESPACE}")
         if target_mgmt_agent_to_minio:
             # Create kubernetes secret that holds scylla manager agent configuration
             self.update_secret_from_data('scylla-agent-config', 'scylla', {

--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -264,6 +264,10 @@ class GkeCluster(KubernetesCluster, cluster.BaseCluster):
         LOGGER.info("Wait for readiness of all pods in default namespace...")
         self.kubectl("wait --timeout=15m --all --for=condition=Ready pod", timeout=15*60+10)
 
+        # Create namespaces which are required in several different optional places
+        self.kubectl(f"create namespace {self._scylla_namespace}")
+        self.kubectl(f"create namespace {self._scylla_manager_namespace}")
+
     def destroy(self):
         self.api_call_rate_limiter.stop()
         if self._gcloud_token_thread:

--- a/sdcm/cluster_k8s/minikube.py
+++ b/sdcm/cluster_k8s/minikube.py
@@ -204,6 +204,10 @@ class GceMinikubeCluster(MinikubeCluster, cluster_gce.GCECluster):
         for node in self.nodes:
             node.remoter._reconnect()  # Reconnect to update user groups in main thread too.
 
+        # Create namespaces which are required in several different optional places
+        self.kubectl(f"create namespace {self._scylla_namespace}")
+        self.kubectl(f"create namespace {self._scylla_manager_namespace}")
+
     def get_node_ips_param(self, public_ip=True):
         raise NotImplementedError("Not implemented yet.")  # TODO: add implementation of this method
 

--- a/sdcm/k8s_configs/gke-cluster-chart-values.yaml
+++ b/sdcm/k8s_configs/gke-cluster-chart-values.yaml
@@ -27,7 +27,7 @@ sysctls: ["fs.aio-max-nr=2097152"]
 backups: []
 repairs: []
 serviceMonitor:
-  create: false
+  create: ${SCT_K8S_DEPLOY_MONITORING}
 
 datacenter: ${SCT_K8S_SCYLLA_DATACENTER}
 racks:

--- a/sdcm/k8s_configs/minikube-cluster-chart-values.yaml
+++ b/sdcm/k8s_configs/minikube-cluster-chart-values.yaml
@@ -27,7 +27,7 @@ sysctls: []
 backups: []
 repairs: []
 serviceMonitor:
-  create: false
+  create: ${SCT_K8S_DEPLOY_MONITORING}
 
 datacenter: ${SCT_K8S_SCYLLA_DATACENTER}
 racks:

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -921,6 +921,13 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                         params=self.params,
                                         gce_datacenter=gce_datacenter)
         self.k8s_cluster.wait_for_init()
+
+        if self.params.get('k8s_deploy_monitoring'):
+            self.k8s_cluster.deploy_monitoring_cluster(
+                self.params.get('k8s_scylla_operator_docker_image').split(':')[-1],
+                is_manager_deployed=self.params.get('use_mgmt')
+            )
+
         self.k8s_cluster.deploy_cert_manager()
         self.k8s_cluster.deploy_scylla_operator()
         if self.params.get('use_mgmt'):
@@ -937,12 +944,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                               user_prefix=self.params.get("user_prefix"),
                                               n_nodes=self.params.get("n_db_nodes"),
                                               params=self.params)
-
-        if self.params.get('k8s_deploy_monitoring'):
-            self.k8s_cluster.deploy_monitoring_cluster(
-                self.params.get('k8s_scylla_operator_docker_image').split(':')[-1],
-                is_manager_deployed=self.params.get('use_mgmt')
-            )
 
         self.log.debug("Update startup script with iptables rules")
         startup_script = "\n".join((Setup.get_startup_script(), *self.db_cluster.nodes_iptables_redirect_rules(), ))
@@ -1000,6 +1001,16 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                           params=self.params,
                                           gce_datacenter=gce_datacenter)
         self.k8s_cluster.wait_for_init()
+
+        if self.params.get('k8s_deploy_monitoring'):
+            self.k8s_cluster.add_gke_pool(name="monitoring",
+                                          num_nodes=1,
+                                          instance_type=self.params.get("gce_instance_type_monitor"))
+            self.k8s_cluster.deploy_monitoring_cluster(
+                self.params.get('k8s_scylla_operator_docker_image').split(':')[-1],
+                is_manager_deployed=self.params.get('use_mgmt')
+            )
+
         self.k8s_cluster.deploy_cert_manager()
         self.k8s_cluster.deploy_scylla_operator()
         if self.params.get('use_mgmt'):
@@ -1012,15 +1023,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                                   user_prefix=self.params.get("user_prefix"),
                                                   n_nodes=self.params.get("n_db_nodes"),
                                                   params=self.params)
-
-        if self.params.get('k8s_deploy_monitoring'):
-            self.k8s_cluster.add_gke_pool(name="monitoring",
-                                          num_nodes=1,
-                                          instance_type=self.params.get("gce_instance_type_monitor"))
-            self.k8s_cluster.deploy_monitoring_cluster(
-                self.params.get('k8s_scylla_operator_docker_image').split(':')[-1],
-                is_manager_deployed=self.params.get('use_mgmt')
-            )
 
         self.k8s_cluster.add_gke_pool(name=self.params.get("k8s_loader_cluster_name"),
                                       num_nodes=self.params.get("n_loaders"),


### PR DESCRIPTION
We use monitoring out of K8S cluster (but in the same VPC) and, for now, we have as endpoints IP addresses of "k8s services" dedicated for Scylla DB nodes, but it has K8S-only availability. So, switch to the node IPs which serve it too and available VPC-wide.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
