### PR TITLE
fix(ldap_toggle_config): the entries in LDAP were not

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -306,25 +306,23 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             aws_secret_access_key=self.params.get("alternator_secret_access_key"))
         if self.params.get("use_ldap_authorization"):
             self.configure_ldap(node=self.localhost, use_ssl=False)
-            ldap_role = LDAP_ROLE
-            ldap_users = LDAP_USERS.copy()
-            ldap_address = list(Setup.LDAP_ADDRESS).copy()
-            unique_members_list = [f'uid={user},ou=Person,{LDAP_BASE_OBJECT}' for user in ldap_users]
-            ldap_username = f'cn=admin,{LDAP_BASE_OBJECT}'
-            user_password = LDAP_PASSWORD  # not in use not for authorization, but must be in the config
-            ldap_entry = [f'cn={ldap_role},{LDAP_BASE_OBJECT}',
-                          ['groupOfUniqueNames', 'simpleSecurityObject', 'top'],
-                          {'uniqueMember': unique_members_list, 'userPassword': user_password}]
-            self.log.info('LDAP info {}'.format(ldap_address))
-            self.localhost.add_ldap_entry(ip=ldap_address[0], ldap_port=ldap_address[1],
-                                          user=ldap_username, password=LDAP_PASSWORD, ldap_entry=ldap_entry)
-        start_events_device(self.logdir)
+        start_events_device(log_dir=self.logdir)
         time.sleep(0.5)
         InfoEvent('TEST_START test_id=%s' % Setup.test_id())
 
-    @staticmethod
-    def configure_ldap(node, use_ssl=False):
+    def configure_ldap(self, node, use_ssl=False):
         Setup.configure_ldap(node=node, use_ssl=use_ssl)
+        ldap_role = LDAP_ROLE
+        ldap_users = LDAP_USERS.copy()
+        ldap_address = list(Setup.LDAP_ADDRESS).copy()
+        unique_members_list = [f'uid={user},ou=Person,{LDAP_BASE_OBJECT}' for user in ldap_users]
+        ldap_username = f'cn=admin,{LDAP_BASE_OBJECT}'
+        user_password = LDAP_PASSWORD  # not in use not for authorization, but must be in the config
+        ldap_entry = [f'cn={ldap_role},{LDAP_BASE_OBJECT}',
+                      ['groupOfUniqueNames', 'simpleSecurityObject', 'top'],
+                      {'uniqueMember': unique_members_list, 'userPassword': user_password}]
+        self.localhost.add_ldap_entry(ip=ldap_address[0], ldap_port=ldap_address[1],
+                                      user=ldap_username, password=LDAP_PASSWORD, ldap_entry=ldap_entry)
 
     def _init_localhost(self):
         return LocalHost(user_prefix=self.params.get("user_prefix", None), test_id=Setup.test_id())


### PR DESCRIPTION
created after the nemesis destroyed the original LDAP
cluster, and created a new LDAP container.
This fix is to include all the `add_ldap_entry()` to
the tester.py function that will configure LDAP.

this current PR is a backport PR of #3294 (as i'm running on top of branch-2020.1 and the backport didn't happen cleanly, here is already the backport PR).


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
