### PR TITLE
Changed scylla BE of manager to 2020, and added (disabled) config files for buster and focal

### DIFF
--- a/configurations/manager/debian10.yaml
+++ b/configurations/manager/debian10.yaml
@@ -1,0 +1,4 @@
+ami_id_monitor: 'ami-07d02ee1eeb0c996c'  # Debian buster image - debian-10-amd64-20210208-542
+ami_monitor_user: 'admin'
+
+scylla_repo_m: null # no 2020 build for debian 10, no testing for it so far

--- a/configurations/manager/debian9.yaml
+++ b/configurations/manager/debian9.yaml
@@ -1,4 +1,4 @@
 ami_id_monitor: 'ami-0cfac3931b2a799d1'  # Debian stretch image
 ami_monitor_user: 'admin'
 
-scylla_repo_m: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/debian/scylla-2019.1-stretch.list'
+scylla_repo_m: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/debian/scylla-2020.1-stretch.list'

--- a/configurations/manager/ubuntu16.yaml
+++ b/configurations/manager/ubuntu16.yaml
@@ -1,4 +1,4 @@
 ami_id_monitor: 'ami-092d0d014b7b31a08'  # Canonical, Ubuntu, 16.04 LTS, amd64 xenial image build on 2019-02-12
 ami_monitor_user: 'ubuntu'
 
-scylla_repo_m: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-2019.1-xenial.list'
+scylla_repo_m: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-2020.1-xenial.list'

--- a/configurations/manager/ubuntu18.yaml
+++ b/configurations/manager/ubuntu18.yaml
@@ -1,4 +1,4 @@
 ami_id_monitor: 'ami-08b314ce48a790a19'  # Canonical, Ubuntu, 18.04 LTS, amd64 bionic image build on 2019-07-22
 ami_monitor_user: 'ubuntu'
 
-scylla_repo_m: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-2019.1-bionic.list'
+scylla_repo_m: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-2020.1-bionic.list'

--- a/configurations/manager/ubuntu20.yaml
+++ b/configurations/manager/ubuntu20.yaml
@@ -1,0 +1,4 @@
+ami_id_monitor: 'ami-042e8287309f5df03'  # Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2021-02-23
+ami_monitor_user: 'ubuntu'
+
+scylla_repo_m: null  # no 2020 build for ubuntu 20, no testing for it so far

--- a/jenkins-pipelines/manager/debian10-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/debian10-manager-sanity.jenkinsfile
@@ -1,0 +1,21 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+managerPipeline(
+    backend: 'aws',
+    ip_ssh_connections: 'public',
+    aws_region: '''["us-east-1", "us-west-2"]''',
+    test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
+    test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/debian10.yaml"]''',
+
+    scylla_mgmt_repo: 'http://downloads.scylladb.com/manager/deb/unstable/buster/master/latest/scylladb-manager-master/scylla-manager.list',
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+    scylla_version: 'master:latest',
+
+    timeout: [time: 120, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy'
+)

--- a/jenkins-pipelines/manager/debian10-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian10-manager-upgrade.jenkinsfile
@@ -1,0 +1,22 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+managerPipeline(
+    manager: true,
+    backend: 'aws',
+    aws_region: 'us-east-1',
+
+    target_scylla_mgmt_server_repo: 'http://downloads.scylladb.com/manager/deb/unstable/buster/master/latest/scylladb-manager-master/scylla-manager.list',
+    target_scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+
+    scylla_mgmt_repo: Null,  // no debian 10 build of branch 2.2, nothing to upgrade from
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.2.repo',
+    scylla_version: 'master:latest',
+
+    test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
+    test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/debian10.yaml"]''',
+
+    timeout: [time: 360, unit: 'MINUTES']
+)

--- a/jenkins-pipelines/manager/ubuntu20-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu20-manager-sanity.jenkinsfile
@@ -1,0 +1,20 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+managerPipeline(
+    backend: 'aws',
+    ip_ssh_connections: 'public',
+    aws_region: '''["us-east-1", "us-west-2"]''',
+    test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
+    test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/ubuntu20.yaml"]''',
+    scylla_mgmt_repo: 'http://downloads.scylladb.com/manager/deb/unstable/focal/master/latest/scylla-manager-master/scylla-manager.list',
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+    scylla_version: 'master:latest',
+
+    timeout: [time: 120, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy'
+)

--- a/jenkins-pipelines/manager/ubuntu20-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu20-manager-upgrade.jenkinsfile
@@ -1,0 +1,22 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+managerPipeline(
+    manager: true,
+    backend: 'aws',
+    aws_region: 'us-east-1',
+
+    target_scylla_mgmt_server_repo: 'http://downloads.scylladb.com/manager/deb/unstable/focal/master/latest/scylla-manager-master/scylla-manager.list',
+    target_scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+
+    scylla_mgmt_repo: Null,  // no ubuntu 20 build of branch 2.2, nothing to upgrade from
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.2.repo',
+    scylla_version: 'master:latest',
+
+    test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
+    test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/ubuntu20.yaml"]''',
+
+    timeout: [time: 360, unit: 'MINUTES']
+)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -662,6 +662,10 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         deprecation("consider to use node.distro.is_ubuntu18 property instead")
         return self.distro.is_ubuntu18
 
+    def is_ubuntu20(self):
+        deprecation("consider to use node.distro.is_ubuntu20 property instead")
+        return self.distro.is_ubuntu20
+
     def is_ubuntu(self):
         deprecation("consider to use node.distro.is_ubuntu property instead")
         return self.distro.is_ubuntu
@@ -673,6 +677,10 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
     def is_debian9(self):
         deprecation("consider to use node.distro.is_debian9 property instead")
         return self.distro.is_debian9
+
+    def is_debian10(self):
+        deprecation("consider to use node.distro.is_debian10 property instead")
+        return self.distro.is_debian10
 
     def is_debian(self):
         deprecation("consider to use node.distro.is_debian property instead")
@@ -4715,7 +4723,7 @@ class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-inst
                 pip3 install -I -U psutil
                 systemctl start docker
             """)
-        elif node.is_debian9():
+        elif node.is_debian9() or node.is_debian10():
             node.remoter.run(
                 cmd="sudo apt install -y apt-transport-https ca-certificates curl software-properties-common gnupg2")
             node.remoter.run('curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -', retry=3)

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -760,7 +760,8 @@ class ScyllaManagerTool(ScyllaManagerBase):
         ScyllaManagerBase.__init__(self, id="MANAGER", manager_node=manager_node)
         self._initial_wait(20)
         LOGGER.info("Initiating Scylla-Manager, version: {}".format(self.version))
-        list_supported_distros = [Distro.CENTOS7, Distro.DEBIAN8, Distro.DEBIAN9, Distro.UBUNTU16, Distro.UBUNTU18]
+        list_supported_distros = [Distro.CENTOS7, Distro.DEBIAN8, Distro.DEBIAN9, Distro.DEBIAN10,
+                                  Distro.UBUNTU16, Distro.UBUNTU18, Distro.UBUNTU20]
         self.default_user = "centos"
         if manager_node.distro not in list_supported_distros:
             raise ScyllaManagerError(


### PR DESCRIPTION
Also: alligned scylla_repo_m to be 2021.1 accross the board,
since there's no earlier version for focal

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
