### PR TITLE
fix(test-cases): Use proper nemesis in longevity-scylla-operator-3h-gke

### DIFF
--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-gke.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-gke.yaml
@@ -10,7 +10,7 @@ n_db_nodes: 3
 n_loaders: 2
 n_monitor_nodes: 1
 
-nemesis_class_name: 'OperatorMgmtBackup'
+nemesis_class_name: 'KubernetesScyllaOperatorMonkey'
 nemesis_interval: 5
 use_mgmt: true
 


### PR DESCRIPTION
Use 'KubernetesScyllaOperatorMonkey' nemesis in the
'test-cases/scylla-operator/longevity-scylla-operator-3h-gke.yaml' file
instead of inexistent 'OperatorMgmtBackup' one.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
