### PR TITLE
improvement(k8s-gke): create loader nodes before scylla-operator installation

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1010,6 +1010,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 self.params.get('k8s_scylla_operator_docker_image').split(':')[-1],
                 is_manager_deployed=self.params.get('use_mgmt')
             )
+        self.k8s_cluster.add_gke_pool(name=self.params.get("k8s_loader_cluster_name"),
+                                      num_nodes=self.params.get("n_loaders"),
+                                      instance_type=self.params.get("gce_instance_type_loader"))
 
         self.k8s_cluster.deploy_cert_manager()
         self.k8s_cluster.deploy_scylla_operator()
@@ -1023,10 +1026,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                                   user_prefix=self.params.get("user_prefix"),
                                                   n_nodes=self.params.get("n_db_nodes"),
                                                   params=self.params)
-
-        self.k8s_cluster.add_gke_pool(name=self.params.get("k8s_loader_cluster_name"),
-                                      num_nodes=self.params.get("n_loaders"),
-                                      instance_type=self.params.get("gce_instance_type_loader"))
 
         self.loaders = cluster_k8s.LoaderPodCluster(k8s_cluster=self.k8s_cluster,
                                                     loader_cluster_config=gke.LOADER_CLUSTER_CONFIG,


### PR DESCRIPTION
It happens that we get failures creating loader node pool in GKE
without any error messages, just non-zero return code.
So, try to create it earlier than scylla-operator because of 2 reasons:
- catch failure earlier
- avoid possible side effect of preceding scylla-operator installation

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] ~~I added the relevant `backport` labels~~
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
