### PR TITLE
fix(monitoring): make monitoring DB targets be in proper IP format

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4876,7 +4876,7 @@ class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-inst
             for db_node in self.targets["db_cluster"].nodes:
                 monitoring_targets.append(f"[{getattr(db_node, attr_name)}]:9180")
             monitoring_targets = " ".join(monitoring_targets)
-            if self.params.get("ip_ssh_connections") == "ipv6":
+            if self.params.get("ip_ssh_connections") != "ipv6":
                 monitoring_targets = monitoring_targets.replace("[", "").replace("]", "")
 
             node.remoter.sudo(shell_script_cmd(f"""\


### PR DESCRIPTION
Bug was introduced here: 
commit: https://github.com/scylladb/scylla-cluster-tests/commit/e60144ee
PR: https://github.com/scylladb/scylla-cluster-tests/pull/3293
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] ~~I added the relevant `backport` labels~~
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
