### PR TITLE
fix(longevity-lwt-500G-3d): fix prepare stage

### DIFF
--- a/test-cases/longevity/longevity-lwt-500G-3d.yaml
+++ b/test-cases/longevity/longevity-lwt-500G-3d.yaml
@@ -1,5 +1,8 @@
 test_duration: 4450
-prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml n=400000000 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=1000" ]
+prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml n=133333333 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=100 -pop seq=1..133333333",
+                    "cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml n=133333333 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=100 -pop seq=133333334..266666666",
+                    "cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml n=133333333 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=100 -pop seq=266666667..400000000"
+                   ]
 stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1,lwt_deletes=1)' cl=QUORUM duration=3600m -mode native cql3 -rate threads=10" ,
              "cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1,lwt_deletes=1)' cl=QUORUM duration=3600m -mode native cql3 -rate threads=10"
             ]


### PR DESCRIPTION
Test runs with round-robin. Prepare stage start just one c-s command with 1000
threads. After 6 hours the load was interrupted. I found 'zombie' c-s
processes that do nothing.
Separate prepare command to 3 and decrease threads amount

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
