### PR TITLE
fix(rollingOperatorUpgradePipeline.groovy): fix eks code to make pipeline succeeded

### DIFF
--- a/jenkins-pipelines/upgrade-major-scylla-k8s-eks.jenkinsfile
+++ b/jenkins-pipelines/upgrade-major-scylla-k8s-eks.jenkinsfile
@@ -4,6 +4,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingOperatorUpgradePipeline(
     backend: 'k8s-eks',
+    aws_region: 'eu-north-1',
     base_versions: '["4.1.5"]',
     new_version: '4.2.1',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_scylla_upgrade',

--- a/jenkins-pipelines/upgrade-scylla-k8s-eks.jenkinsfile
+++ b/jenkins-pipelines/upgrade-scylla-k8s-eks.jenkinsfile
@@ -4,6 +4,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingOperatorUpgradePipeline(
     backend: 'k8s-eks',
+    aws_region: 'eu-north-1',
     base_versions: '["4.2.0"]',
     new_version: '4.2.1',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_scylla_upgrade',

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1066,7 +1066,6 @@ class ClusterTester(db_stats.TestStatsMixin,
                 # It should have at least 3 vCPU to be able to hold all the pods
                 disk_size=40,
                 role_arn=self.k8s_cluster.nodegroup_role_arn,
-                provision_type=self.params.get('instance_provision'),
                 k8s_cluster=self.k8s_cluster),
             wait_till_ready=False)
 
@@ -1075,7 +1074,6 @@ class ClusterTester(db_stats.TestStatsMixin,
             num_nodes=self.params.get("n_db_nodes") + 1,
             instance_type=self.params.get('instance_type_db'),
             role_arn=self.params.get('eks_nodegroup_role_arn'),
-            provision_type=self.params.get('instance_provision'),
             disk_size=self.params.get('aws_root_disk_size_db'),
             k8s_cluster=self.k8s_cluster
         )
@@ -1086,7 +1084,6 @@ class ClusterTester(db_stats.TestStatsMixin,
             num_nodes=self.params.get("n_loaders"),
             instance_type=self.params.get("instance_type_monitor"),
             role_arn=self.params.get('eks_nodegroup_role_arn'),
-            provision_type=self.params.get('instance_provision'),
             disk_size=self.params.get('aws_root_disk_size_monitor'),
             k8s_cluster=self.k8s_cluster)
         self.k8s_cluster.deploy_node_pool(loader_pool, wait_till_ready=False)
@@ -1098,7 +1095,6 @@ class ClusterTester(db_stats.TestStatsMixin,
                 num_nodes=1,
                 instance_type=self.params.get("instance_type_monitor"),
                 role_arn=self.params.get('eks_nodegroup_role_arn'),
-                provision_type=self.params.get('instance_provision'),
                 disk_size=self.params.get('aws_root_disk_size_monitor'),
                 k8s_cluster=self.k8s_cluster
             )

--- a/vars/rollingOperatorUpgradePipeline.groovy
+++ b/vars/rollingOperatorUpgradePipeline.groovy
@@ -16,6 +16,8 @@ def call(Map pipelineParams) {
         parameters {
             choice(choices: ["${pipelineParams.get('backend', 'k8s-gke')}", 'k8s-gke', 'k8s-gce-minikube'],
                    name: 'backend')
+            choice(choices: ["${pipelineParams.get('aws_region', '')}", 'eu-north-1', 'eu-west-1', 'eu-central-1', 'us-east-1'],
+                   name: 'aws_region')
             string(defaultValue: "${pipelineParams.get('base_versions', '')}",
                    name: 'base_versions')
             string(defaultValue: "${pipelineParams.get('new_version', '')}",


### PR DESCRIPTION
https://trello.com/c/6QLhDfY7/3102-eks-fix-upgrade-pipelines

Fix node group provision to ignore provision type from pipeline and use "on demand" instead.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
