### PR TITLE
fix(kubernetes): workaround wrong scheduling of scylla-manager

### DIFF
--- a/sdcm/utils/k8s.py
+++ b/sdcm/utils/k8s.py
@@ -319,6 +319,18 @@ class ApiCallRateLimiter(threading.Thread):
         return output
 
 
+class CordonNodes:
+    def __init__(self, kubectl_method, selector):
+        self.kubectl = kubectl_method
+        self.cordon_cmd = f"cordon -l '{selector}'"
+
+    def __enter__(self):
+        return self.kubectl(self.cordon_cmd)
+
+    def __exit__(self, *exc):
+        self.kubectl(f"un{self.cordon_cmd}")
+
+
 class KubernetesOps:
 
     @staticmethod


### PR DESCRIPTION
Due to existing bug in the scylla operator: https://github.com/scylladb/scylla-operator/issues/496
we can face situation where 2 from 3 scylla-manager related pods may get scheduled anywhere taking valueable node resources.
It may cause situation where 1 or 2 loader pod(s) may not be scheduled at all just because scylla manager may take resources dedicated for it on loader nodes.


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
