### PR TITLE
Fix gke deployment

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -593,11 +593,6 @@ class KubernetesCluster(metaclass=abc.ABCMeta):
             LOGGER.info("Install local volume provisioner")
             self.helm(f"install local-provisioner {LOCAL_PROVISIONER_DIR}", values=node_pool.helm_affinity_values)
 
-            self.deploy_node_pool(node_pool, wait_till_ready=False)
-            time.sleep(10)
-
-            self.wait_till_cluster_is_operational()
-
             # Calculate cpu and memory limits to occupy all available amounts by scylla pods
             cpu_limit, memory_limit = node_pool.cpu_and_memory_capacity
             # TBD: Remove reduction logic after https://github.com/scylladb/scylla-operator/issues/384 is fixed


### PR DESCRIPTION
When all GKE node pools are created in a row then GKE cluster goes into "repair" state for about 5 minutes.
And during this time range API server is not available.

So, to avoid such problem, install apps specific to default-pool between cluster creation and additional node pools creation to win about 3 minutes which is enough to avoid "cluster repair".

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
