### PR TITLE
DataValidator - take unique MV names from user profile

### DIFF
--- a/sdcm/utils/data_validator.py
+++ b/sdcm/utils/data_validator.py
@@ -286,7 +286,9 @@ class LongevityDataValidator:
                     if not all_entries:
                         break
 
-        return mv_names
+        # If same user profile is called in parallel, the same MVs will be included few time in the list and test data
+        # will be copied a few times. Return list of unique MVs to prevent to duplicate of copying test data
+        return list(set(mv_names))
 
     @staticmethod
     def get_view_cmd_from_profile(profile_content, name_substr, all_entries=False):


### PR DESCRIPTION
If same user profile is called in parallel, the same MVs will be included few time in the list and
test data will be copied a few times. Return list of unique MVs to prevent to duplicate
of copying test data

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
