### PR TITLE
fix(fill_db_data.py): paged query test did insert before table schema

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -3122,6 +3122,7 @@ class FillDatabaseData(ClusterTester):
         node = self.db_cluster.nodes[-1]
         with self.db_cluster.cql_connection_patient(node, keyspace=keyspace) as session:
             create_table()
+            self.db_cluster.wait_for_schema_agreement()  # WORKAROUND TO SCHEMA PROPAGATION TAKING TOO LONG
             fill_table()
             statement = f'select * from {keyspace}.paged_query_test;'
             self.log.info('running now session.execute')


### PR DESCRIPTION
was fully propagated.
very clear in the logs that insert started, but the schema is
not fully sync'ed. Adding `wait_for_schema_agreement()` should
ensure we will have the schemas fully sync'ed before we start
inserting data into that new table.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
