### PR TITLE
fix(ldap credentials): everything gets right credentials

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1756,11 +1756,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 'ldap_bind_passwd': LDAP_PASSWORD}
 
     def create_ldap_users_on_scylla(self):
-        if not self.parent_cluster.ldap_configured:
-            self.run_cqlsh(f'CREATE ROLE \'{LDAP_ROLE}\' WITH SUPERUSER=true')
-            for user in LDAP_USERS:
-                self.run_cqlsh(f'CREATE ROLE \'{user}\' WITH login=true AND password=\'{LDAP_PASSWORD}\'')
-            self.parent_cluster.ldap_configured = True
+        self.run_cqlsh(f'CREATE ROLE \'{LDAP_ROLE}\' WITH SUPERUSER=true')
+        for user in LDAP_USERS:
+            self.run_cqlsh(f'CREATE ROLE \'{user}\' WITH login=true AND password=\'{LDAP_PASSWORD}\'')
 
     # pylint: disable=invalid-name,too-many-arguments,too-many-locals,too-many-branches,too-many-statements
     def config_setup(self, seed_address=None, cluster_name=None, enable_exp=True, endpoint_snitch=None,
@@ -2863,7 +2861,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
         else:
             raise ValueError('Unsupported type: {}'.format(type(n_nodes)))
         self.coredumps = dict()
-        self.ldap_configured = False
+        self.latency_results = dict()
         super(BaseCluster, self).__init__()
 
     @cached_property
@@ -2968,7 +2966,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
         node.destroy()
 
     def get_db_auth(self):
-        if self.params.get('use_ldap_authorization') and self.ldap_configured:
+        if self.params.get('use_ldap_authorization') and self.params.get('are_ldap_users_on_scylla'):
             user = LDAP_USERS[0]
             password = LDAP_PASSWORD
         else:

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -306,6 +306,19 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             aws_secret_access_key=self.params.get("alternator_secret_access_key"))
         if self.params.get("use_ldap_authorization"):
             self.configure_ldap(node=self.localhost, use_ssl=False)
+            self.params['are_ldap_users_on_scylla'] = False
+            ldap_role = LDAP_ROLE
+            ldap_users = LDAP_USERS.copy()
+            ldap_address = list(Setup.LDAP_ADDRESS).copy()
+            unique_members_list = [f'uid={user},ou=Person,{LDAP_BASE_OBJECT}' for user in ldap_users]
+            ldap_username = f'cn=admin,{LDAP_BASE_OBJECT}'
+            user_password = LDAP_PASSWORD  # not in use not for authorization, but must be in the config
+            ldap_entry = [f'cn={ldap_role},{LDAP_BASE_OBJECT}',
+                          ['groupOfUniqueNames', 'simpleSecurityObject', 'top'],
+                          {'uniqueMember': unique_members_list, 'userPassword': user_password}]
+            self.log.info('LDAP info {}'.format(ldap_address))
+            self.localhost.add_ldap_entry(ip=ldap_address[0], ldap_port=ldap_address[1],
+                                          user=ldap_username, password=LDAP_PASSWORD, ldap_entry=ldap_entry)
         start_events_device(log_dir=self.logdir)
         time.sleep(0.5)
         InfoEvent('TEST_START test_id=%s' % Setup.test_id())
@@ -430,8 +443,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 self.legacy_init_nodes(db_cluster=self.db_cluster)
             else:
                 self.init_nodes(db_cluster=self.db_cluster)
-            if self.params.get('use_ldap_authorization'):
+            if self.params.get('use_ldap_authorization') and not self.params.get('are_ldap_users_on_scylla'):
                 self.db_cluster.nodes[0].create_ldap_users_on_scylla()
+                self.params['are_ldap_users_on_scylla'] = True
             self.set_system_auth_rf()
 
             db_node_address = self.db_cluster.nodes[0].ip_address


### PR DESCRIPTION
the credentials for stress tools were not taken correctly
because the flag set when LDAP is finally configured did
not exist in the load_set, so it was using the "superuser"
credentials instead (that works, but wasn't the intention
of the feature).

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
