### PR TITLE
fix(configure_ldap): there is a race condition between

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -80,6 +80,10 @@ class LogContentNotFound(Exception):
     pass
 
 
+class LdapNotRunning(Exception):
+    pass
+
+
 class UnsupportedNemesis(Exception):
     """ raised from within a nemesis execution to skip this nemesis"""
 
@@ -647,6 +651,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                     ldap_config[key] = scylla_yaml.pop(key)
             node.restart_scylla_server()
 
+        if not ContainerManager.is_running(self.tester.localhost, 'ldap'):
+            raise LdapNotRunning("LDAP server was supposed to be running, but it is not")
+
         InfoEvent(message='Disable LDAP Authorization Configuration').publish()
         for node in self.cluster.nodes:
             remove_ldap_configuration_from_node(node)
@@ -668,6 +675,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         create_ldap_container()
         for node in self.cluster.nodes:
             add_ldap_configuration_to_node(node)
+
+        if not ContainerManager.is_running(self.tester.localhost, 'ldap'):
+            raise LdapNotRunning("LDAP server was supposed to be running, but it is not")
 
     @retrying(n=3, sleep_time=60, allowed_exceptions=(NodeSetupFailed, NodeSetupTimeout))
     def _add_and_init_new_cluster_node(self, old_node_ip=None, timeout=HOUR_IN_SEC * 6, rack=0):

--- a/sdcm/utils/ldap.py
+++ b/sdcm/utils/ldap.py
@@ -11,8 +11,11 @@
 #
 # Copyright (c) 2020 ScyllaDB
 
+from sdcm.utils.decorators import retrying
+
 from time import sleep
 from ldap3 import Server, Connection, ALL, ALL_ATTRIBUTES
+from ldap3.core.exceptions import LDAPSocketOpenError
 
 
 LDAP_IMAGE = "osixia/openldap:1.4.0"
@@ -26,6 +29,10 @@ LDAP_PASSWORD = 'scylla'
 LDAP_ROLE = 'scylla_ldap'
 LDAP_USERS = ['scylla-qa', 'dummy-user']
 LDAP_BASE_OBJECT = (lambda l: ','.join([f'dc={part}' for part in l.split('.')]))(LDAP_DOMAIN)
+
+
+class LdapServerNotReady(Exception):
+    pass
 
 
 class LdapContainerMixin:  # pylint: disable=too-few-public-methods
@@ -44,6 +51,7 @@ class LdapContainerMixin:  # pylint: disable=too-few-public-methods
                     )
 
     @staticmethod
+    @retrying(n=10, sleep_time=6, allowed_exceptions=(LdapServerNotReady, LDAPSocketOpenError))
     def create_ldap_connection(ip, ldap_port, user, password):
         LdapContainerMixin.ldap_server = Server(host=f'ldap://{ip}:{ldap_port}', get_info=ALL)
         LdapContainerMixin.ldap_conn = Connection(server=LdapContainerMixin.ldap_server, user=user, password=password)


### PR DESCRIPTION
creating a new LDAP docker container and running
commands against it. Adding here a command that will
wait for the container `wait-process`, giving us time
to start adding entries to it when the LDAP server is
ready to get it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
