### PR TITLE
fix(corrupt_then_scrub): set current disruption event

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2606,6 +2606,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         Try to rebuild the sstables of all test keyspaces by scrub, the corrupted partitions
         will be skipped.
         """
+        self._set_current_disruption('CorruptThenScrub')
         self.log.debug("Rebuild sstables by scrub with `--skip-corrupted`, corrupted partitions will be skipped.")
         with ignore_scrub_invalid_errors():
             for ks in self.cluster.get_test_keyspaces():

--- a/sdcm/scylla_bench_thread.py
+++ b/sdcm/scylla_bench_thread.py
@@ -124,7 +124,7 @@ class ScyllaBenchThread:
         return sb_summary, errors
 
     def _run_stress_bench(self, node, loader_idx, stress_cmd, node_list):
-        read_gap = 480 # reads starts after write, read can look before start read time to current time using several sstables
+        read_gap = 480  # reads starts after write, read can look before start read time to current time using several sstables
         stress_cmd = re.sub(r"SCT_TIME", f"{int(time.time()) - read_gap}", stress_cmd)
         LOGGER.debug(f"replaced stress command {stress_cmd}")
 


### PR DESCRIPTION
Current disruption event is missed for `CorruptThenScrubMonkey`. As result
`ChaosMonkey` is printed in the log instead of real nemesis name

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
