### PR TITLE
fix(RestarThenRepair): strictly check the valid replace_address_first_boot option

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -698,7 +698,7 @@ class AWSNode(cluster.BaseNode):
                 self.remoter.sudo(shell_script_cmd(f"""\
                     sed -e '/.*scylla/s/^/#/g' -i /etc/fstab
                     sed -e '/auto_bootstrap:.*/s/false/true/g' -i /etc/scylla/scylla.yaml
-                    if ! grep replace_address_first_boot: /etc/scylla/scylla.yaml; then
+                    if ! grep ^replace_address_first_boot: /etc/scylla/scylla.yaml; then
                         echo 'replace_address_first_boot: {self.ip_address}' | tee --append /etc/scylla/scylla.yaml
                     fi
                 """))


### PR DESCRIPTION

After the RestartThenRepair nemesis, we only comment the
replace_address_first_boot option, so the next RestartThenRepair won't
add replace_address_first_boot option for the wrong grep.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
