### PR TITLE
refactor(scylla_bench_thread.py) _run_stress_bench

### DIFF
--- a/sdcm/scylla_bench_thread.py
+++ b/sdcm/scylla_bench_thread.py
@@ -124,7 +124,8 @@ class ScyllaBenchThread:
         return sb_summary, errors
 
     def _run_stress_bench(self, node, loader_idx, stress_cmd, node_list):
-        stress_cmd = re.sub(r"SCT_TIME", f"{int(time.time())-480}", stress_cmd)
+        read_gap = 480 # reads starts after write, read can look before start read time to current time using several sstables
+        stress_cmd = re.sub(r"SCT_TIME", f"{int(time.time()) - read_gap}", stress_cmd)
         LOGGER.debug(f"replaced stress command {stress_cmd}")
 
         ScyllaBenchEvent.start(node=node, stress_cmd=stress_cmd).publish()


### PR DESCRIPTION
add veriable and comment for read gap

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] ~~I added the relevant `backport` labels~~
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
