### PR TITLE
fix(k8s-gke): make cleanup of GKE clusters work

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -955,7 +955,10 @@ def list_clusters_gke(tags_dict: Optional[dict] = None, verbose: bool = False) -
     clusters = GkeCleaner().list_gke_clusters()
 
     if tags_dict:
-        clusters = filter_gce_by_tags(tags_dict=tags_dict, instances=clusters)
+        clusters = filter_gce_by_tags(
+            tags_dict={k: v for k, v in tags_dict.items() if k != 'NodeType'},
+            instances=clusters,
+        )
 
     if verbose:
         LOGGER.info("Done. Found total of %s GKE clusters.", len(clusters))


### PR DESCRIPTION
Cleanup of GKE clusters doesn't work now because
filtering tags we provide include "NodeType" tag which is node
specific and must not be provided for clean up of k8s clusters.
So, remove that tag from filtering to allow k8s clsuters be deleted
only based on the "test_id" tag.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
