### PR TITLE
fix(longevity-2tb-48h): Fixing timeout issue and stress duration

### DIFF
--- a/jenkins-pipelines/longevity-2tb-4days-1Dis-2NonDis-Nemesises.jenkinsfile
+++ b/jenkins-pipelines/longevity-2tb-4days-1Dis-2NonDis-Nemesises.jenkinsfile
@@ -9,5 +9,5 @@ longevityPipeline(
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml',
 
-    timeout: [time: 3100, unit: 'MINUTES']
+    timeout: [time: 3120, unit: 'MINUTES']
 )

--- a/test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
+++ b/test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
@@ -1,13 +1,13 @@
-test_duration: 3000
+test_duration: 3120 # 7h (preapre) + 41h for stress + 4h spare.
 prepare_write_cmd: ["cassandra-stress write cl=QUORUM n=536870912 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..536870912",
                     "cassandra-stress write cl=QUORUM n=536870912 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=536870913..1073741824",
                     "cassandra-stress write cl=QUORUM n=536870912 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1073741825..1610612736",
                     "cassandra-stress write cl=QUORUM n=536870912 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native  -rate threads=50 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1610612737..2147483648"]
 
-stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=2640m -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=50 -pop seq=1..2147483648  -log interval=5 -col 'size=FIXED(64) n=FIXED(16)' ",
-             "cassandra-stress user profile=/tmp/cs_mv_profile.yaml ops'(insert=3,read1=1,read2=1,read3=1)' cl=QUORUM duration=5760m -port jmx=6868 -mode cql3 native -rate threads=10"]
+stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=2460m -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=50 -pop seq=1..2147483648  -log interval=5 -col 'size=FIXED(64) n=FIXED(16)' ",
+             "cassandra-stress user profile=/tmp/cs_mv_profile.yaml ops'(insert=3,read1=1,read2=1,read3=1)' cl=QUORUM duration=2460m -port jmx=6868 -mode cql3 native -rate threads=10"]
 
-stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=2640m -port jmx=6868 -mode cql3 native  -rate threads=10 -pop seq=1..2147483648  -log interval=5 -col 'size=FIXED(64) n=FIXED(16)'"]
+stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=2460m -port jmx=6868 -mode cql3 native  -rate threads=10 -pop seq=1..2147483648  -log interval=5 -col 'size=FIXED(64) n=FIXED(16)'"]
 
 run_fullscan: 'random, 240'  # 'ks.cf|random, interval(min)''
 


### PR DESCRIPTION
The test has been aborted because the preapre time now takes a bit
longer than previosuly due to known write throughput degradation.
Also, the user profile stress duration wasn't configured correctly
(longer than the timout).

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
