### PR TITLE
fix(k8s-gke): Fix deployment of minio storage for scylla-manager

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -962,7 +962,6 @@ class ClusterTester(db_stats.TestStatsMixin,
         self.k8s_cluster.deploy_cert_manager()
         self.k8s_cluster.deploy_scylla_operator()
         if self.params.get('use_mgmt'):
-            self.k8s_cluster.deploy_minio_s3_backend(minio_bucket_name=self.params.get('backup_bucket_location'))
             self.k8s_cluster.deploy_scylla_manager()
 
         loader_pool = gke.GkeNodePool(


### PR DESCRIPTION
Remove explicit call of 'deploy_minio_s3_backend' method because
it is called implicitely as part of the recently updated
'deploy_scylla_manager' method.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
