### PR TITLE
fix DecommissionStreamingErr nemesis

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4143,7 +4143,10 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             verification_node = librandom.choice(self.nodes)
             node_ip_list = get_node_ip_list(verification_node)
 
-        if target_node_ip in node_ip_list:
+        decommission_done = list(node.follow_system_log(
+            patterns=['DECOMMISSIONING: done'], start_from_beginning=True))
+
+        if target_node_ip in node_ip_list and not decommission_done:
             cluster_status = self.get_nodetool_status(verification_node)
             error_msg = ('Node that was decommissioned %s still in the cluster. '
                          'Cluster status info: %s' % (node,

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4137,10 +4137,12 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                 return None
 
         target_node_ip = node.ip_address
-        verification_node = librandom.choice(self.nodes)
+        undecommission_nodes = [n for n in self.nodes if n != node]
+
+        verification_node = librandom.choice(undecommission_nodes)
         node_ip_list = get_node_ip_list(verification_node)
         while verification_node == node or node_ip_list is None:
-            verification_node = librandom.choice(self.nodes)
+            verification_node = librandom.choice(undecommission_nodes)
             node_ip_list = get_node_ip_list(verification_node)
 
         decommission_done = list(node.follow_system_log(

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4124,7 +4124,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         for node in self.nodes:
             node.run_nodetool('repair')
 
-    def decommission(self, node):
+    def verify_decommission(self, node):
         def get_node_ip_list(verification_node):
             try:
                 ip_node_list = []
@@ -4137,7 +4137,6 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                 return None
 
         target_node_ip = node.ip_address
-        node.run_nodetool("decommission")
         verification_node = librandom.choice(self.nodes)
         node_ip_list = get_node_ip_list(verification_node)
         while verification_node == node or node_ip_list is None:
@@ -4157,6 +4156,10 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         LOGGER.info('Decommission %s PASS', node)
         self.terminate_node(node)  # pylint: disable=no-member
         Setup.tester_obj().monitors.reconfigure_scylla_monitoring()
+
+    def decommission(self, node):
+        node.run_nodetool("decommission")
+        self.verify_decommission(node)
 
     @property
     def scylla_manager_node(self) -> BaseNode:

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -35,6 +35,7 @@ from invoke import UnexpectedExit
 from cassandra import ConsistencyLevel
 
 from sdcm.cluster import SCYLLA_YAML_PATH, NodeSetupTimeout, NodeSetupFailed, ClusterNodesNotReady
+from sdcm.cluster import NodeStayInClusterAfterDecommission
 from sdcm.mgmt import TaskStatus
 from sdcm.utils.common import remote_get_file, get_db_tables, generate_random_string, \
     update_certificates, reach_enospc_on_node, clean_enospc_on_node, parse_nodetool_listsnapshots
@@ -2480,27 +2481,22 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         """
 
         def decommission_post_action():
-            ips = []
-            seed_nodes = [node for node in self.cluster.nodes if node.is_seed]
-            status = self.cluster.get_nodetool_status(verification_node=seed_nodes[0])
-            self.log.debug(status)
-            for dc_info in status.values():
-                try:
-                    ips.extend(dc_info.keys())
-                except Exception:  # pylint: disable=broad-except
-                    self.log.debug(dc_info)
+            target_is_seed = self.target_node.is_seed
+            try:
+                self.cluster.verify_decommission(self.target_node)
+            except NodeStayInClusterAfterDecommission:
+                self.log.debug('The decommission of target node is successfully interrupted')
+                return None
+            except:
+                self.log.error('Unexpected exception raised in checking decommission status')
 
-            decommission_done = list(self.target_node.follow_system_log(
-                patterns=['DECOMMISSIONING: done'], start_from_beginning=True))
-
-            if self.target_node.ip_address not in ips or decommission_done:
-                self.log.error(
-                    'The target node is decommission unexpectedly, decommission might complete before stopping it. Re-add a new node')
-                self._terminate_cluster_node(self.target_node)
-                new_node = self._add_and_init_new_cluster_node(rack=self.target_node.rack)
-                self.unset_current_running_nemesis(new_node)
-                return new_node
-            return None
+            self.log.info('Decommission might complete before stopping it. Re-add a new node')
+            new_node = self._add_and_init_new_cluster_node(rack=self.target_node.rack)
+            if new_node.is_seed != target_is_seed:
+                new_node.set_seed_flag(target_is_seed)
+                self.cluster.update_seed_provider()
+            self.unset_current_running_nemesis(new_node)
+            return new_node
 
         def streaming_task_thread(nodetool_task='rebuild'):
             """


### PR DESCRIPTION
If the first node is seed and it's decommissioned, the nemesis DecommissionStreamingErr will fail in checking nodetool status.
The problem was caused by that we started to allow seed to be decommissioned, the solution is avoiding to check nodetool status from decommissioned node.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
