### PR TITLE
test(cdc replication): Enable cdc replication tests in regular run

### DIFF
--- a/cdc_replication_test.py
+++ b/cdc_replication_test.py
@@ -167,10 +167,11 @@ class CDCReplicationTest(ClusterTester):
             }, default_weight=0))
         self.db_cluster.nemesis_count = 1
 
-        # 9 rounds, ~1h30 minutes each -> ~11h30m total
+        # 1 rounds, ~1h30 minutes each
         # The number of rounds is tuned according to the available disk space in an i3.large AWS instance.
         # One more round would cause the nodes to run out of disk space.
-        no_rounds = 9
+        # default value is 2. test duration is ~ 3h
+        no_rounds = self.params.get("cdc_replication_rounds_num")
         for rnd in range(no_rounds):
             self.log.info('Starting round {}'.format(rnd))
 

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -151,3 +151,5 @@ mgmt_docker_image: ''
 k8s_deploy_monitoring: false
 
 scylla_rsyslog_setup: false
+
+cdc_replication_rounds_num: 2

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -266,3 +266,4 @@
 | **<a href="#user-content-jepsen_test_cmd" name="jepsen_test_cmd">jepsen_test_cmd</a>**  | Jepsen test command (e.g., 'test-all') | N/A | SCT_JEPSEN_TEST_CMD
 | **<a href="#user-content-max_events_severities" name="max_events_severities">max_events_severities</a>**  | Limit severity level for event types | N/A | SCT_MAX_EVENTS_SEVERITIES
 | **<a href="#user-content-scylla_rsyslog_setup" name="scylla_rsyslog_setup">scylla_rsyslog_setup</a>**  | Configure rsyslog on scylla nodes to send logs to monitoring nodes | False | SCT_SCYLLA_RSYSLOG_SETUP
+| **<a href="#user-content-cdc_replication_rounds_num" name="cdc_replication_rounds_num">cdc_replication_rounds_num</a>**  | Number of rounds for cdc replication longevity tests | False | SCT_CDC_REPLICATION_ROUNDS_NUM

--- a/jenkins-pipelines/feature-cdc-replication-short-longevity-3h.jenkinsfile
+++ b/jenkins-pipelines/feature-cdc-replication-short-longevity-3h.jenkinsfile
@@ -1,0 +1,14 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+cdcReplicationPipeline(
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'cdc_replication_test.CDCReplicationTest.test_replication_longevity',
+    test_config: 'test-cases/cdc/cdc-replication-short-longevity-3h.yaml',
+
+    timeout: [time: 350, unit: 'MINUTES'],
+    email_recipients: 'qa@scylladb.com,kbraun@scylladb.com,piotr@scylladb.com,alex.bykov@scylladb.com'
+)

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1094,7 +1094,11 @@ class SCTConfiguration(dict):
              help="Limit severity level for event types"),
 
         dict(name="scylla_rsyslog_setup", env="SCT_SCYLLA_RSYSLOG_SETUP", type=boolean,
-             help="Configure rsyslog on Scylla nodes to send logs to monitoring nodes")
+             help="Configure rsyslog on Scylla nodes to send logs to monitoring nodes"),
+
+        dict(name="cdc_replication_rounds_num", env="SCT_CDC_REPLICATION_ROUNDS_NUM", type=int,
+             help="""Number of rounds for cdc replication longevity tests""")
+
     ]
 
     required_params = ['cluster_backend', 'test_duration', 'n_db_nodes', 'n_loaders', 'use_preinstalled_scylla',

--- a/test-cases/cdc/cdc-replication-short-longevity-3h.yaml
+++ b/test-cases/cdc/cdc-replication-short-longevity-3h.yaml
@@ -1,4 +1,4 @@
-test_duration: 900
+test_duration: 300
 
 user_prefix: 'cdc-replication-longevity'
 db_type: mixed_scylla
@@ -24,5 +24,3 @@ gemini_cmd: "gemini --duration 30m --warmup 0s -c 4 -m write --non-interactive -
 gemini_version: 'latest'
 # Required by SCT, although not used:
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json'
-
-cdc_replication_rounds_num: 9


### PR DESCRIPTION
Cdc replication tests added by Kamil are stable and there was a
decision to add them to regular sct jobs.
Added new parameter which configure number of replication rounds
Added 2 new jobs:
cdc-replication-short-longevity-3h - it has 2 rounds and run for ~3h.
cdc-replication-longevity - it has 9 rounds (defined by limit of disk
size for i3.large instance type)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
