### PR TITLE
improvement(k8s-monitoring): make MonitoringStatus event be warning

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -1,5 +1,5 @@
 ClusterHealthValidatorEvent.NodeStatus: CRITICAL
-ClusterHealthValidatorEvent.MonitoringStatus: ERROR
+ClusterHealthValidatorEvent.MonitoringStatus: WARNING
 ClusterHealthValidatorEvent.NodePeersNulls: ERROR
 ClusterHealthValidatorEvent.NodeSchemaVersion: ERROR
 ClusterHealthValidatorEvent.NodesNemesis: WARNING


### PR DESCRIPTION
Make MonitoringStatus event have warning (not "error") type of severity.
As of now it is the cause for failures in lots of K8S runs where
it fails just because of having too big diff between standalone
monitoring and k8s-based one.
It is not critical now, so, make it be "warning" as of now.
It can be changed to "error" back when approach for checking monitoring
health is stabilized.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
