### PR TITLE
fix(k8s-gke): reduce number of used k8s terminate methods

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -693,7 +693,13 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def _get_kubernetes_node_break_methods(self):
         if isinstance(self.cluster, GkeScyllaPodCluster):
-            return ['drain_k8s_node', 'terminate_k8s_host', 'terminate_k8s_node']
+            return [
+                'drain_k8s_node',
+                # NOTE: enable below methods when it's support fully implemented
+                # https://trello.com/c/LrAObHPC/3119-fix-gce-node-termination-nemesis-on-k8s
+                # 'terminate_k8s_host',
+                # 'terminate_k8s_node',
+            ]
         raise UnsupportedNemesis("Only GkeScyllaPodCluster is supported")
 
     def _terminate_cluster_node(self, node):


### PR DESCRIPTION
As of now we don't have complete support for running
'terminate k8s host' and 'terminate k8s node' disruptions.
So, do not run these while full support is not added.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
