### PR TITLE
fix(gemini-1tb): Run test gemini 1tb with nemesis

### DIFF
--- a/jenkins-pipelines/gemini-1tb-10h.jenkinsfile
+++ b/jenkins-pipelines/gemini-1tb-10h.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 longevityPipeline(
     backend: 'aws',
     aws_region: 'eu-west-1',
-    test_name: 'gemini_test.GeminiTest.test_random_load',
+    test_name: 'gemini_test.GeminiTest.test_load_random_with_nemesis',
     test_config: 'test-cases/gemini/gemini-1tb-10h.yaml',
 
     timeout: [time: 1000, unit: 'MINUTES'],

--- a/test-cases/gemini/gemini-1tb-10h.yaml
+++ b/test-cases/gemini/gemini-1tb-10h.yaml
@@ -6,9 +6,10 @@ n_monitor_nodes: 1
 instance_type_db: 'i3.4xlarge'
 
 user_prefix: 'gemini-1tb-10h'
-# gemini
-# cmd: gemini -d -n [NUM_OF_TEST_ITERATIONS] -c [NUM_OF_THREADS] -m mixed -f
-# the below cmd runs about 10 hours
+
+nemesis_class_name: 'GeminiChaosMonkey'
+nemesis_interval: 5
+
 gemini_cmd: "gemini -d --duration 36000s --warmup 7200s -c 100 \
 -m mixed -f --non-interactive --cql-features normal \
 --max-mutation-retries 5 --max-mutation-retries-backoff 500ms \


### PR DESCRIPTION
Switch gemini 1tb test to run with nemesises for
test complexity increasing

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
