### PR TITLE
fix(fill_db_data.py): correct the support version with rc suffix

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -42,8 +42,8 @@ class FillDatabaseData(ClusterTester):
     """
     NON_FROZEN_SUPPORT_OS_MIN_VERSION = '4.1'  # open source version with non-frozen user_types support
     NON_FROZEN_SUPPORT_ENTERPRISE_MIN_VERSION = '2020'  # enterprise version with non-frozen user_types support
-    NULL_VALUES_SUPPORT_OS_MIN_VERSION = "4.4"
-    NEW_SORTING_ORDER_WITH_SECONDARY_INDEXES_OS_MIN_VERSION = "4.4"
+    NULL_VALUES_SUPPORT_OS_MIN_VERSION = "4.4.rc0"
+    NEW_SORTING_ORDER_WITH_SECONDARY_INDEXES_OS_MIN_VERSION = "4.4.rc0"
 
     # List of dictionaries for all items tables and their data
     all_verification_items = [
@@ -769,7 +769,7 @@ class FillDatabaseData(ClusterTester):
             'invalid_queries': [
                 "INSERT INTO null_support_test (k, c, v2) VALUES (0, 2, {1, null})",
                 "INSERT INTO null_support_test (k, c, v2) VALUES (0, 0, { 'foo', 'bar', null })"],
-            'min_version': '4.4',
+            'min_version': '4.4.rc0',
             'max_version': '',
             'skip_condition': 'self.version_null_values_support()',
             'skip': ''},
@@ -824,7 +824,7 @@ class FillDatabaseData(ClusterTester):
             # Due the issue https://github.com/scylladb/scylla/issues/7443, the result of the query changed
             # from "[['Bob'], ['Tom']]" to "[['Tom'], ['Bob']]" from versions Scylla 4.4 and above
             'results': [[['Tom'], ['Bob']]],
-            'min_version': '4.4',
+            'min_version': '4.4.rc0',
             'max_version': '',
             'skip_condition': 'self.version_new_sorting_order_with_secondary_indexes()',
             'skip': ''},


### PR DESCRIPTION
4.4.rc0 is smaller than 4.4 (4.4.0) in parse_version(), actually the feature
had been supported from 4.4.rc0

So null_support_test_old_version will be executed with 4.4.rc4
unexpectedly, but null_support_test won't be executed with 4.4.rc4
unexpectedly.

* Currently
>>> parse_version('4.4.rc4') >= parse_version('4.4')
False
>>> parse_version('4.4.0') >= parse_version('4.4')
True

* Correct
>>> parse_version('4.4.0') >= parse_version('4.4.rc0')
True
>>> parse_version('4.4.rc4') >= parse_version('4.4.rc0')
True

This patch corrected the version to correct point (rc0).

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
