### PR TITLE
fix(gce-ipv6-property): return empty string for IPv6 address in GCE

### DIFF
--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -189,8 +189,9 @@ class GCENode(cluster.BaseNode):
         return b''
 
     def _get_ipv6_ip_address(self):
-        raise NotImplementedError('On GCE, VPC networks only support IPv4 unicast traffic. '
-                                  'They do not support IPv6 traffic within the network.')
+        self.log.warning('On GCE, VPC networks only support IPv4 unicast traffic. '
+                         'They do not support IPv6 traffic within the network.')
+        return ""
 
     @property
     def image(self):


### PR DESCRIPTION
Fixes following error that was introduce in #3280 :
```
02:52:43  < t:2021-03-22 23:52:42,332 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  > 2021-03-22 23:52:42.327: (TestFrameworkEvent Severity.ERROR), source=ArtifactsTest.save_email_data() message=save_email_data (silenced) failed with:
02:52:43  < t:2021-03-22 23:52:42,332 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  > exception=On GCE, VPC networks only support IPv4 unicast traffic. They do not support IPv6 traffic within the network.
02:52:43  < t:2021-03-22 23:52:42,332 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  > Traceback (most recent call last):
02:52:43  < t:2021-03-22 23:52:42,332 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/jenkins/slave/workspace/scylla-master/artifacts/artifacts-debian10-test/scylla-cluster-tests/./sct.py", line 924, in <module>
02:52:43  < t:2021-03-22 23:52:42,332 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     cli()
02:52:43  < t:2021-03-22 23:52:42,332 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/usr/local/lib/python3.9/site-packages/click/core.py", line 764, in __call__
02:52:43  < t:2021-03-22 23:52:42,332 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     return self.main(*args, **kwargs)
02:52:43  < t:2021-03-22 23:52:42,332 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/usr/local/lib/python3.9/site-packages/click/core.py", line 717, in main
02:52:43  < t:2021-03-22 23:52:42,332 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     rv = self.invoke(ctx)
02:52:43  < t:2021-03-22 23:52:42,332 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1137, in invoke
02:52:43  < t:2021-03-22 23:52:42,332 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     return _process_result(sub_ctx.command.invoke(sub_ctx))
02:52:43  < t:2021-03-22 23:52:42,332 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/usr/local/lib/python3.9/site-packages/click/core.py", line 956, in invoke
02:52:43  < t:2021-03-22 23:52:42,332 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     return ctx.invoke(self.callback, **ctx.params)
02:52:43  < t:2021-03-22 23:52:42,332 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/usr/local/lib/python3.9/site-packages/click/core.py", line 555, in invoke
02:52:43  < t:2021-03-22 23:52:42,332 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >     return callback(*args, **kwargs)
02:52:43  < t:2021-03-22 23:52:42,332 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  >   File "/jenkins/slave/workspace/scylla-master/artifacts/artifacts-debian10-test/scylla-cluster-tests/./sct.py", line 676, in run_test
```
@juliayakovlev FYI

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
