### PR TITLE
test(12h with asymmetric cluster): Add new longevity-50gb-asymmetric-cluster-12h test

### DIFF
--- a/jenkins-pipelines/longevity-50gb-asymmetric-cluster-12h.jenkinsfile
+++ b/jenkins-pipelines/longevity-50gb-asymmetric-cluster-12h.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-50GB-12h-verifier-LimitedMonkey-tls.yaml", "configurations/db-nodes-shards-random.yaml"]'''
+)

--- a/test-cases/longevity/longevity-50GB-12h-verifier-LimitedMonkey-tls.yaml
+++ b/test-cases/longevity/longevity-50GB-12h-verifier-LimitedMonkey-tls.yaml
@@ -1,0 +1,31 @@
+test_duration: 750
+prepare_write_cmd: "cassandra-stress write cl=ALL n=50050075  -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=1000 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..50050075 -log interval=15"
+
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=360m  -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=250  -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=400200300..600200300 -log interval=15"]
+stress_read_cmd: ["cassandra-stress read cl=ONE duration=360m -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=250  -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..50050075 -log interval=5"]
+run_fullscan: 'keyspace1.standard1, 5' # 'ks.cf|random, interval(min)''
+
+n_db_nodes: 4
+n_loaders: 1
+n_monitor_nodes: 1
+
+instance_type_db: 'i3.4xlarge'
+
+nemesis_class_name: 'LimitedChaosMonkey'
+nemesis_interval: 30
+nemesis_during_prepare: false
+
+user_prefix: 'longevity-50gb-12h'
+
+space_node_threshold: 644245094
+
+use_mgmt: true
+
+server_encrypt: true
+client_encrypt: true
+authenticator: 'PasswordAuthenticator'
+authenticator_user: cassandra
+authenticator_password: cassandra
+authorizer: 'CassandraAuthorizer'
+
+scylla_rsyslog_setup: true


### PR DESCRIPTION
This test based on longevity-200gb-48h. New test will run 12h on cluster where
Scylla starts with random SMP on every node

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
