### PR TITLE
fix(shrink cluster): transfer nemesis name in 'decommission' method

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3145,7 +3145,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
         for node in self.nodes:
             node.destroy()
 
-    def terminate_node(self, node, by_nemesis=""):
+    def terminate_node(self, node):
         if node.ip_address not in self.dead_nodes_ip_address_list:
             self.dead_nodes_list.append(DeadNode(name=node.name,
                                                  public_ip=node.public_ip_address,
@@ -3154,7 +3154,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
                                                  ip_address=node.ip_address,
                                                  shards=node.scylla_shards,
                                                  termination_time=datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f"),
-                                                 terminated_by_nemesis=by_nemesis))
+                                                 terminated_by_nemesis=node.running_nemesis))
         if node in self.nodes:
             self.nodes.remove(node)
         node.destroy()


### PR DESCRIPTION
Transfer nemesis name in 'decommission' method that called by ShrinkCluster
nemesis. This info will be printed in the email for terminated nodes list
in the column 'Terminated by nemesis'"

![Screenshot from 2021-03-25 14-23-21](https://user-images.githubusercontent.com/34435448/112472342-ae4e7700-8d75-11eb-8e20-6524935beb56.png)


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
