### PR TITLE
fix(nodes list in email): not print nodes list in the email if more then 20 nodes

### DIFF
--- a/sdcm/report_templates/results_issue_template.html
+++ b/sdcm/report_templates/results_issue_template.html
@@ -8,24 +8,20 @@
         {% if live_nodes_shards %}
             Scylla running with shards number (live nodes):<br>
             {% for shards_info in live_nodes_shards %}
+               &nbsp;&nbsp;&nbsp;{{ shards_info.name }} ({{ shards_info.ip }}): {{ shards_info.shards }} shards<br>
                 {% if loop.length > 10 %}
-                    &nbsp;&nbsp;&nbsp;There are {{ loop.length }} nodes in the cluster.
-                    The list is so long and won't be printed in the email<br><br>
+                    &nbsp;&nbsp;&nbsp;>> List of nodes is larger than 10. See sct log for a full list of nodes.<br><br>
                     {% break %}
-                {% else %}
-               &nbsp;&nbsp;   {{ shards_info.name }} ({{ shards_info.ip }}): {{ shards_info.shards }} shards<br><br>
                 {% endif %}
             {% endfor %}
         {% endif %}
         {% if dead_nodes_shards %}
             Scylla running with shards number (terminated nodes):<br>
             {% for shards_info in dead_nodes_shards %}
+                &nbsp;&nbsp;&nbsp;{{ shards_info.name }} ({{ shards_info.ip }}): {{ shards_info.shards }} shards<br>
                 {% if loop.length > 10 %}
-                    &nbsp;&nbsp;&nbsp;There are {{ loop.length }} nodes in the cluster.
-                    The list is so long and won't be printed in the email<br><br>
+                    &nbsp;&nbsp;&nbsp;>> List of nodes is larger than 10. See sct log for a full list of nodes.<br><br>
                     {% break %}
-                {% else %}
-               &nbsp;&nbsp;   {{ shards_info.name }} ({{ shards_info.ip }}): {{ shards_info.shards }} shards<br><br>
                 {% endif %}
             {% endfor %}
         {% endif %}

--- a/sdcm/report_templates/results_issue_template.html
+++ b/sdcm/report_templates/results_issue_template.html
@@ -8,13 +8,25 @@
         {% if live_nodes_shards %}
             Scylla running with shards number (live nodes):<br>
             {% for shards_info in live_nodes_shards %}
-               &nbsp;&nbsp;{{ shards_info.name }} ({{ shards_info.ip }}): {{ shards_info.shards }} shards<br>
+                {% if loop.length > 10 %}
+                    &nbsp;&nbsp;&nbsp;There are {{ loop.length }} nodes in the cluster.
+                    The list is so long and won't be printed in the email<br><br>
+                    {% break %}
+                {% else %}
+               &nbsp;&nbsp;   {{ shards_info.name }} ({{ shards_info.ip }}): {{ shards_info.shards }} shards<br><br>
+                {% endif %}
             {% endfor %}
         {% endif %}
         {% if dead_nodes_shards %}
             Scylla running with shards number (terminated nodes):<br>
             {% for shards_info in dead_nodes_shards %}
-               &nbsp;&nbsp;{{ shards_info.name }} ({{ shards_info.ip }}): {{ shards_info.shards }} shards<br>
+                {% if loop.length > 10 %}
+                    &nbsp;&nbsp;&nbsp;There are {{ loop.length }} nodes in the cluster.
+                    The list is so long and won't be printed in the email<br><br>
+                    {% break %}
+                {% else %}
+               &nbsp;&nbsp;   {{ shards_info.name }} ({{ shards_info.ip }}): {{ shards_info.shards }} shards<br><br>
+                {% endif %}
             {% endfor %}
         {% endif %}
         OS (RHEL/CentOS/Ubuntu/AWS AMI): {% if scylla_ami_id %} `{{ scylla_ami_id }}` {% endif %} {% if scylla_node_image %} `{{ scylla_node_image }}`{% endif %} ({{ backend }}{% if region_name %}: {{ region_name }}{% endif %})<br>

--- a/sdcm/report_templates/results_longevity.html
+++ b/sdcm/report_templates/results_longevity.html
@@ -20,11 +20,19 @@
                         <th>Scylla shards</th>
                     </tr>
                     {% for node in live_nodes_shards %}
-                    <tr>
-                        <td>{{ node.name }}</td>
-                        <td>{{ node.ip }}</td>
-                        <td>{{ node.shards }}</td>
-                    </tr>
+                        {% if loop.length > 10 %}
+                            <tr>
+                                <td colspan="3">There are {{ loop.length }} nodes in the cluster.
+                                    The list is so long and won't be printed in the email</td>
+                            </tr>
+                            {% break %}
+                        {% else %}
+                            <tr>
+                                <td>{{ node.name }}</td>
+                                <td>{{ node.ip }}</td>
+                                <td>{{ node.shards }}</td>
+                            </tr>
+                        {% endif %}
                 {% endfor %}
                 </table>
             </div>
@@ -42,14 +50,22 @@
                         <th>Terminated by nemesis</th>
                     </tr>
                     {% for node in dead_nodes_shards %}
-                    <tr>
-                        <td>{{ node.name }}</td>
-                        <td>{{ node.ip }}</td>
-                        <td>{{ node.shards }}</td>
-                        <td>{{ node.termination_time }}</td>
-                        <td>{{ node.terminated_by_nemesis }}</td>
-                    </tr>
-                {% endfor %}
+                        {% if loop.length > 10 %}
+                            <tr>
+                                <td colspan="5">There are {{ loop.length }} nodes in the cluster.
+                                    The list is so long and won't be printed in the email</td>
+                            </tr>
+                            {% break %}
+                        {% else %}
+                            <tr>
+                                <td>{{ node.name }}</td>
+                                <td>{{ node.ip }}</td>
+                                <td>{{ node.shards }}</td>
+                                <td>{{ node.termination_time }}</td>
+                                <td>{{ node.terminated_by_nemesis }}</td>
+                            </tr>
+                        {% endif %}
+                    {% endfor %}
                 </table>
             </div>
             {% endif %}

--- a/sdcm/report_templates/results_longevity.html
+++ b/sdcm/report_templates/results_longevity.html
@@ -20,20 +20,20 @@
                         <th>Scylla shards</th>
                     </tr>
                     {% for node in live_nodes_shards %}
+                        <tr>
+                            <td>{{ node.name }}</td>
+                            <td>{{ node.ip }}</td>
+                            <td>{{ node.shards }}</td>
+                        </tr>
                         {% if loop.length > 10 %}
                             <tr>
-                                <td colspan="3">There are {{ loop.length }} nodes in the cluster.
-                                    The list is so long and won't be printed in the email</td>
+                                <td colspan="3">
+                                    List of nodes is larger than 10. See sct log for a full list of nodes.
+                                </td>
                             </tr>
                             {% break %}
-                        {% else %}
-                            <tr>
-                                <td>{{ node.name }}</td>
-                                <td>{{ node.ip }}</td>
-                                <td>{{ node.shards }}</td>
-                            </tr>
                         {% endif %}
-                {% endfor %}
+                    {% endfor %}
                 </table>
             </div>
             {% endif %}
@@ -50,20 +50,20 @@
                         <th>Terminated by nemesis</th>
                     </tr>
                     {% for node in dead_nodes_shards %}
+                        <tr>
+                            <td>{{ node.name }}</td>
+                            <td>{{ node.ip }}</td>
+                            <td>{{ node.shards }}</td>
+                            <td>{{ node.termination_time }}</td>
+                            <td>{{ node.terminated_by_nemesis }}</td>
+                        </tr>
                         {% if loop.length > 10 %}
                             <tr>
-                                <td colspan="5">There are {{ loop.length }} nodes in the cluster.
-                                    The list is so long and won't be printed in the email</td>
+                                <td colspan="5">
+                                    List of nodes is larger than 10. See sct log for a full list of nodes.
+                                </td>
                             </tr>
                             {% break %}
-                        {% else %}
-                            <tr>
-                                <td>{{ node.name }}</td>
-                                <td>{{ node.ip }}</td>
-                                <td>{{ node.shards }}</td>
-                                <td>{{ node.termination_time }}</td>
-                                <td>{{ node.terminated_by_nemesis }}</td>
-                            </tr>
                         {% endif %}
                     {% endfor %}
                 </table>

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2750,12 +2750,7 @@ class ClusterTester(db_stats.TestStatsMixin,
         return {}
 
     def all_nodes_scylla_shards(self):
-        all_nodes_shards = defaultdict(list, {'live_nodes': [], 'dead_nodes': []})
-
-        # There are scale tests with a lot of nodes. It will be so big list of nodes to print it in the email
-        if len(self.db_cluster.dead_nodes_list) + len(self.db_cluster.nodes) > 20:
-            return all_nodes_shards
-
+        all_nodes_shards = defaultdict(list)
         for node in self.db_cluster.nodes:
             ipv6 = node.ipv6_ip_address if node.ip_address == node.ipv6_ip_address else ''
             all_nodes_shards['live_nodes'].append({'name': node.name,

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2750,7 +2750,12 @@ class ClusterTester(db_stats.TestStatsMixin,
         return {}
 
     def all_nodes_scylla_shards(self):
-        all_nodes_shards = defaultdict(list)
+        all_nodes_shards = defaultdict(list, {'live_nodes': [], 'dead_nodes': []})
+
+        # There are scale tests with a lot of nodes. It will be so big list of nodes to print it in the email
+        if len(self.db_cluster.dead_nodes_list) + len(self.db_cluster.nodes) > 20:
+            return all_nodes_shards
+
         for node in self.db_cluster.nodes:
             ipv6 = node.ipv6_ip_address if node.ip_address == node.ipv6_ip_address else ''
             all_nodes_shards['live_nodes'].append({'name': node.name,


### PR DESCRIPTION
There are scale tests with a lot of nodes. It will be so big list of nodes to print it in the
email. Don't print nodes info if test cluster has more then 20 nodes (live and terminated)

issue template:

![Screenshot from 2021-03-30 17-04-28](https://user-images.githubusercontent.com/34435448/113003008-fd801780-917a-11eb-8ba1-7d966a0c6128.png)

email body:
![Screenshot from 2021-03-30 15-56-15](https://user-images.githubusercontent.com/34435448/113003012-feb14480-917a-11eb-9f57-35bf8ef72f5e.png)


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
