### PR TITLE
fix(save_email_data): no IPv6 address for Docker

### DIFF
--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -88,6 +88,10 @@ class DockerNode(cluster.BaseNode, NodeContainerMixin):  # pylint: disable=abstr
     def _get_private_ip_address(self) -> Optional[str]:
         return self.public_ip_address
 
+    def _get_ipv6_ip_address(self):
+        self.log.warning("We don't support IPv6 for Docker backend")
+        return ""
+
     def is_running(self):
         return ContainerManager.is_running(self, "node")
 

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1197,7 +1197,8 @@ class BasePodContainer(cluster.BaseNode):
         return self._container_status.image
 
     def _get_ipv6_ip_address(self):
-        raise NotImplementedError()
+        self.log.warning("We don't support IPv6 for k8s-* backends")
+        return ""
 
     def restart(self):
         raise NotImplementedError("Not implemented yet")  # TODO: implement this method.


### PR DESCRIPTION
Fixes problem with `save_email_data()` on docker backend introduced by https://github.com/scylladb/scylla-cluster-tests/pull/3280

Example of failed test run: https://jenkins.scylladb.com/job/scylla-master/job/artifacts/job/artifacts-docker-test/256/

Successful run with the fix: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/evgeniy/job/artifacts-docker/13/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
