### PR TITLE
feature(grafana): wait grafana page loading by panels

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -41,8 +41,8 @@ from sdcm.utils.common import (list_instances_aws, list_instances_gce, list_reso
                                search_test_id_in_latest, get_testrun_dir, format_timestamp, list_clusters_gke,
                                list_clusters_eks)
 from sdcm.utils.jepsen import JepsenResults
-from sdcm.utils.monitorstack import (restore_monitoring_stack, get_monitoring_stack_services,
-                                     kill_running_monitoring_stack_services)
+from sdcm.monitorstack import (restore_monitoring_stack, get_monitoring_stack_services,
+                               kill_running_monitoring_stack_services)
 from sdcm.cluster import Setup
 from sdcm.utils.log import setup_stdout_logger
 from sdcm.utils.prepare_region import AwsRegion

--- a/sdcm/monitorstack/__init__.py
+++ b/sdcm/monitorstack/__init__.py
@@ -355,12 +355,12 @@ def verify_dockers_are_running():
     return False
 
 
-def verify_grafana_is_available(version):
+def verify_grafana_is_available(version):  # pylint: disable=no-member
     from sdcm.logcollector import GrafanaEntity
     grafana_statuses = []
-    for entity in GrafanaEntity.base_grafana_entity_names:
-        path = entity['path'].format(version=version.replace('.', '-'),
-                                     dashboard_name=entity['name'])
+    for dashboard in GrafanaEntity.base_grafana_dashboards:
+        path = dashboard.path.format(version=version.replace('.', '-'),  # pylint: disable=no-member
+                                     dashboard_name=dashboard.name)  # pylint: disable=no-member
         url = f"http://localhost:{GRAFANA_DOCKER_PORT}/{path}"
         try:
             LOGGER.info("Test url {}".format(url))

--- a/sdcm/monitorstack/ui.py
+++ b/sdcm/monitorstack/ui.py
@@ -1,0 +1,145 @@
+import logging
+
+from typing import Tuple, List
+
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.webelement import WebElement
+from selenium.common import exceptions
+
+from sdcm.utils.common import get_test_name
+
+
+LOGGER = logging.getLogger(__name__)
+UI_ELEMENT_LOAD_TIMEOUT = 180
+
+
+class Panel:
+    xpath_tmpl = """//div[contains(@aria-label,'{name}') and contains(@class, 'panel-title-container')]"""
+
+    def __init__(self, name):
+        self.name = name
+
+    @property
+    def xpath_locator(self):
+        return (By.XPATH, self.xpath_tmpl.format(name=self.name))
+
+    def wait_loading(self, remote_browser):
+        LOGGER.info(f"Waiting panel {self.name} loading")
+        WebDriverWait(remote_browser, UI_ELEMENT_LOAD_TIMEOUT).until(
+            EC.visibility_of_element_located(self.xpath_locator))
+        el: WebElement = remote_browser.find_element(*self.xpath_locator)
+        parent_el: WebElement = el.find_element_by_xpath("parent::*//parent::*")
+        remote_browser.execute_script("arguments[0].style.border='10px solid red'", parent_el)
+        try:
+            loading = parent_el.find_element_by_xpath("div[contains(@class, 'panel-loading')]")
+            WebDriverWait(remote_browser, UI_ELEMENT_LOAD_TIMEOUT).until(EC.invisibility_of_element(loading))
+        except exceptions.NoSuchElementException:
+            LOGGER.debug(f"Check panel is loaded")
+        list_of_childs = parent_el.find_elements_by_xpath("child::*")
+        assert len(list_of_childs) == 2, f"num of elements {len(list_of_childs)}"
+        LOGGER.info(f"Panel {self.name} loaded")
+
+
+class Snapshot:
+    locators_sequence = [
+        (By.XPATH, """//div[contains(@class, "navbar-buttons--actions")]"""),
+        (By.XPATH, """//ul/li[contains(text(), "Snapshot")]"""),
+        (By.XPATH, """//button//span[contains(text(), "Publish to snapshot.raintank.io")]"""),
+        (By.XPATH, """//a[contains(@href, "https://snapshot.raintank.io")]""")
+    ]
+
+    def get_shared_link(self, remote_browser):
+        """Get link from page to remote snapshot on https://snapshot.raintank.io
+
+        using selenium remote web driver remote_browser find sequentially web_element by locators
+        in self.snapshot_locators_sequence run actiom WebElement.click() and
+        get value from result link found by latest element in snapshot_locators_sequence
+
+        :param remote_browser: remote webdirver instance
+        :type remote_browser: selenium.webdriver.Remote
+        :returns: return value of link to remote snapshot on https://snapshot.raintank.io
+        :rtype: {str}
+        """
+        for element in self.locators_sequence[:-1]:
+            WebDriverWait(remote_browser, UI_ELEMENT_LOAD_TIMEOUT).until(EC.visibility_of_element_located(element))
+            found_element = remote_browser.find_element(*element)
+            found_element.click()
+        snapshot_link_locator = self.locators_sequence[-1]
+        WebDriverWait(remote_browser, UI_ELEMENT_LOAD_TIMEOUT).until(
+            EC.visibility_of_element_located(snapshot_link_locator))
+        snapshot_link_element = remote_browser.find_element(*snapshot_link_locator)
+
+        LOGGER.debug(snapshot_link_element.text)
+        return snapshot_link_element.text
+
+
+class Dashboard:
+    name: str
+    path: str
+    resolution: str
+    scroll_ready_locator: Tuple[By, str]
+    panels: List[Panel]
+    scroll_step: int = 1000
+
+    def scroll_to_bottom(self, remote_browser):
+        WebDriverWait(remote_browser, UI_ELEMENT_LOAD_TIMEOUT).until(
+            EC.visibility_of_element_located(self.scroll_ready_locator))
+        scroll_element = remote_browser.find_element(*self.scroll_ready_locator)
+        scroll_height = remote_browser.execute_script("return arguments[0].scrollHeight", scroll_element)
+
+        for scroll_size in range(0, scroll_height, self.scroll_step):
+            LOGGER.debug(f"Scrolling next {self.scroll_step}")
+            remote_browser.execute_script(f'arguments[0].scrollTop = {scroll_size}', scroll_element)
+
+    def wait_panels_loading(self, remote_browser):
+        LOGGER.info("Waiting panels load data")
+        for panel in self.panels:
+            panel.wait_loading(remote_browser)
+        LOGGER.info("All panels have loaded data")
+
+    def get_snapshot(self, remote_browser):
+        return Snapshot().get_shared_link(remote_browser)
+
+
+class OverviewDashboard(Dashboard):
+    name = 'overview'
+    path = 'd/overview-{version}/scylla-{dashboard_name}'
+    resolution = '1920px*4000px'
+    scroll_ready_locator = (By.XPATH, "//div[@class='view']")
+    panels = [Panel("Writes"),
+              Panel("Write Latencies"),
+              Panel("Read/Write Timeouts by DC")]
+
+
+class ServerMetricsNemesisDashboard(Dashboard):
+    if test_name := get_test_name():
+        test_name = f"{test_name.lower()}-"
+
+    name = f'{test_name}scylla-per-server-metrics-nemesis'
+    path = 'dashboard/db/{dashboard_name}-{version}'
+    resolution = '1920px*7000px'
+    scroll_ready_locator = (By.XPATH, "//div[@class='view']")
+    panels = [Panel("Total Requests"),
+              Panel("Load per Instance"),
+              Panel("Requests Served per Instance"),
+              Panel("Reads with no misses"),
+              Panel("Total Bytes"),
+              Panel("Running Compactions"),
+              Panel("Gemini metrics")
+              ]
+
+
+class AlternatorDashboard(Dashboard):
+    name = 'alternator'
+    path = 'd/alternator-{version}/{dashboard_name}'
+    resolution = '1920px*4000px'
+    scroll_ready_locator = (By.XPATH, "//div[@class='view']")
+    panels = [Panel("Total Actions"),
+              Panel("Scan by Instance"),
+              Panel("Completed GetItem"),
+              Panel("95th percentile DeleteItem latency by Instance"),
+              Panel("Cache Hits"),
+              Panel("Your Graph here")
+              ]

--- a/sdcm/utils/remotewebbrowser.py
+++ b/sdcm/utils/remotewebbrowser.py
@@ -97,17 +97,15 @@ class RemoteBrowser:
 
         return Remote(command_executor=f"http://{host}:{port}/wd/hub", options=ChromeOptions())
 
-    def get_screenshot(self, url, screenshot_path, resolution="1920px*1280px", load_page_screenshot_delay=30):
-        LOGGER.info("Get a screenshot of %s", url)
-
+    def open(self, url, resolution="1920px*1280px"):
+        LOGGER.info(f"Set resoltion {resolution}")
         self.browser.set_window_size(*resolution.replace("px", "").split("*", 1))
-
-        LOGGER.debug("Goto %s", url)
+        LOGGER.info(f"Get url {url}")
         self.browser.get(url)
 
-        LOGGER.debug("Wait for %s seconds and write a screenshot of %s to %s",
-                     load_page_screenshot_delay, url, screenshot_path)
-        time.sleep(load_page_screenshot_delay)
+    def get_screenshot(self, url, screenshot_path):
+        LOGGER.info(f"Save a screenshot of {url} to {screenshot_path}")
+
         self.browser.get_screenshot_as_file(screenshot_path)
 
     def quit(self):


### PR DESCRIPTION
Add panels locator and functionality to wait
while defined panels on grafana page will be
loaded and after that get screenshot and snapshot

Trello: https://trello.com/c/OMPRDfd4

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
