### PR TITLE
improvement(jepsen): add test count and run policy options

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -147,6 +147,8 @@ jepsen_test_cmd:
   - 'test-all -w write-isolation --concurrency 10n'
   - 'test-all -w list-append --concurrency 10n'
   - 'test-all -w wr-register --concurrency 10n'
+jepsen_test_count: 1
+jepsen_test_run_policy: all
 
 max_events_severities: ""
 mgmt_docker_image: ''

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -265,5 +265,7 @@
 | **<a href="#user-content-stress_after_cluster_upgrade" name="stress_after_cluster_upgrade">stress_after_cluster_upgrade</a>**  | Stress command to be run after full upgrade - usually used to read the dataset for verification | N/A | SCT_STRESS_AFTER_CLUSTER_UPGRADE
 | **<a href="#user-content-jepsen_scylla_repo" name="jepsen_scylla_repo">jepsen_scylla_repo</a>**  | Link to the git repository with Jepsen Scylla tests | https://github.com/jepsen-io/scylla.git | SCT_JEPSEN_SCYLLA_REPO
 | **<a href="#user-content-jepsen_test_cmd" name="jepsen_test_cmd">jepsen_test_cmd</a>**  | Jepsen test command (e.g., 'test-all') | N/A | SCT_JEPSEN_TEST_CMD
+| **<a href="#user-content-jepsen_test_count" name="jepsen_test_count">jepsen_test_count</a>**  | possible number of reruns of single Jepsen test command | 1 | SCT_JEPSEN_TEST_COUNT
+| **<a href="#user-content-jepsen_test_run_policy" name="jepsen_test_run_policy">jepsen_test_run_policy</a>**  | Jepsen test run policy (i.e., what we want to consider as passed for a single test)<br><br>'most' - most test runs are passed<br>'any'  - one pass is enough<br>'all'  - all test runs should pass | all | SCT_JEPSEN_TEST_RUN_POLICY
 | **<a href="#user-content-max_events_severities" name="max_events_severities">max_events_severities</a>**  | Limit severity level for event types | N/A | SCT_MAX_EVENTS_SEVERITIES
 | **<a href="#user-content-scylla_rsyslog_setup" name="scylla_rsyslog_setup">scylla_rsyslog_setup</a>**  | Configure rsyslog on scylla nodes to send logs to monitoring nodes | False | SCT_SCYLLA_RSYSLOG_SETUP

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1096,6 +1096,17 @@ class SCTConfiguration(dict):
              help="Link to the git repository with Jepsen Scylla tests"),
         dict(name="jepsen_test_cmd", env="SCT_JEPSEN_TEST_CMD", type=str_or_list,
              help="Jepsen test command (e.g., 'test-all')"),
+        dict(name="jepsen_test_count", env="SCT_JEPSEN_TEST_COUNT", type=int,
+             help="possible number of reruns of single Jepsen test command"),
+        dict(name="jepsen_test_run_policy", env="SCT_JEPSEN_TEST_RUN_POLICY", type=str,
+             help="""
+                Jepsen test run policy (i.e., what we want to consider as passed for a single test)
+
+                'most' - most test runs are passed
+                'any'  - one pass is enough
+                'all'  - all test runs should pass
+             """,
+             choices=("most", "any", "all")),
 
         dict(name="max_events_severities", env="SCT_MAX_EVENTS_SEVERITIES", type=str_or_list,
              help="Limit severity level for event types"),

--- a/test-cases/jepsen/jepsen.yaml
+++ b/test-cases/jepsen/jepsen.yaml
@@ -1,4 +1,4 @@
-test_duration: 360
+test_duration: 720
 cluster_backend: 'gce'
 gce_image_username: 'sct'
 gce_image_db: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-10'
@@ -16,3 +16,5 @@ scylla_linux_distro: 'debian-buster'
 user_prefix: 'jepsen'
 use_legacy_cluster_init: true
 jepsen_scylla_repo: 'https://github.com/scylladb/jepsen.git'
+jepsen_test_count: 5
+jepsen_test_run_policy: any


### PR DESCRIPTION
Another attempt to stabilize Jepsen tests without modification of the Clojure code. 

I've added two parameters:

1. `jepsen_test_count`: possible number of single test (re)runs
2. `jepsen_test_run_policy`: what we want to consider as passed for a single test

Possible values for latter are `most` (i.e. > 50% passed), `any` (i.e., at least one pas), and `all` (all passed.)

And I want to use 5 runs with `any` policy for our regular Jepsen job. 

Also we need to merge https://github.com/scylladb/jepsen/pull/12 for better stability.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
