### PR TITLE
fix(kubernetes): fix usage of custom operator image

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -472,12 +472,12 @@ class KubernetesCluster(metaclass=abc.ABCMeta):
         scylla_operator_repo_base = self.params.get(
             'k8s_scylla_operator_docker_image').split('/')[0]
         if scylla_operator_repo_base:
-            values.set('controllerImage.repository', scylla_operator_repo_base)
+            values.set('image.repository', scylla_operator_repo_base)
 
         scylla_operator_image_tag = self.params.get(
             'k8s_scylla_operator_docker_image').split(':')[-1]
         if scylla_operator_image_tag:
-            values.set('controllerImage.tag', scylla_operator_image_tag)
+            values.set('image.tag', scylla_operator_image_tag)
 
         # Install and wait for initialization of the Scylla Operator chart
         LOGGER.info("Deploy Scylla Operator")
@@ -692,7 +692,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):
         helm_values.set('server.resources.limits.memory', memory_limit)
         helm_values.set('nodeExporter.enabled', False)
 
-        if scylla_operator_tag == 'nightly':
+        if scylla_operator_tag in ('nightly', 'latest'):
             scylla_operator_tag = 'master'
         elif scylla_operator_tag == '':
             scylla_operator_tag = get_git_tag_from_helm_chart_version(


### PR DESCRIPTION
It was broken in 2 places:
- incorrect chart config options were used for setting custom operator image
- usage of "latest" image was incorrectly mapped to the operator git branches

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
