### PR TITLE
fix(kubernetes): fix terminate_decommission_add_node_kubernetes nemesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -735,6 +735,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 'drain_k8s_node',
                 # NOTE: enable below methods when it's support fully implemented
                 # https://trello.com/c/LrAObHPC/3119-fix-gce-node-termination-nemesis-on-k8s
+                # https://github.com/scylladb/scylla-operator/issues/524
+                # https://github.com/scylladb/scylla-operator/issues/507
                 # 'terminate_k8s_host',
                 # 'terminate_k8s_node',
             ]
@@ -847,7 +849,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         node_terminate_method()
         self.log.info(f'Decommission %s', node)
         self.cluster.decommission(node)
-        self.add_new_node(rack=node.rack)
+        new_node = self.add_new_node(rack=node.rack)
+        self.unset_current_running_nemesis(new_node)
 
     def _disrupt_terminate_and_replace_node_kubernetes(self, node, node_terminate_method_name):  # pylint: disable=invalid-name
         old_uid = node.k8s_pod_uid


### PR DESCRIPTION
By doing 2 things:
- avoid remoter calls when decommissioned node already absent
- fix setting of current nemesis for k8s decommission node operation.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
