### PR TITLE
fix(longevity-encryption-at-rest-200GB-6h.yaml): remove unstable KMIP config

### DIFF
--- a/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
+++ b/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
@@ -37,11 +37,3 @@ append_scylla_yaml: |
       enabled: True  # system_info_encryption
       key_provider: LocalFileSystemKeyProviderFactory  # system_info_encryption
       secret_key_file: '/etc/scylla/encrypt_conf/system_info_encryption_keyfile'
-
-  kmip_hosts:
-       kmip_test:
-           hosts: kmip-interop1.cryptsoft.com
-           certificate: /etc/encrypt_conf/SCYLLADB.pem
-           keyfile: /etc/encrypt_conf/SCYLLADB.pem
-           truststore: /etc/encrypt_conf/CA.pem
-           priority_string: 'SECURE128:+RSA:-VERS-TLS1.0:-ECDHE-ECDSA'


### PR DESCRIPTION
The KMIP server of cryptsoft isn't stable, we have our hytrust KMIP
server for testing. The unstable KMIP config won't be overwrote in
EaR-longevity-local-200gb-6h-test, and scylla will fail to start.

The encryption configure will be loaded from additional configure files.
This patch removed the unstable & unused KMIP config from
longevity-encryption-at-rest-200GB-6h.yaml.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
