### PR TITLE
improvement(cluster.py): Supporting update_db_packages that are supplied as tar.gz

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3649,7 +3649,11 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             node.remoter.send_files(new_scylla_bin, '/tmp/scylla', verbose=True)
 
             self._wait_for_preinstalled_scylla(node)
+            logging.info("unzipping any tar.gz rpms")
+            node.remoter.run('tar -xvf /tmp/scylla/*.tar.gz -C /tmp/scylla/', ignore_status=True, verbose=True)
+
             # replace the packages
+            logging.info("Installing rpms")
             node.remoter.run('yum list installed | grep scylla')
             node.remoter.sudo('rpm -URvh --replacepkgs --replacefiles /tmp/scylla/*.rpm',
                               ignore_status=False, verbose=True)


### PR DESCRIPTION

In case the update_db_packages url contains rpms that are tar.gz,
this command will untar them before trying to install them.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
