### PR TITLE
improvement(test_default): Decreasing the stall detector to 100ms

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -13,7 +13,7 @@ scylla_repo_loader: ''
 experimental: true
 round_robin: false
 
-append_scylla_args: '--blocked-reactor-notify-ms 500 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1 --enable-sstable-key-validation 1'
+append_scylla_args: '--blocked-reactor-notify-ms 100 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1 --enable-sstable-key-validation 1'
 append_scylla_setup_args: ''
 
 db_nodes_shards_selection: 'default'

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -19,7 +19,7 @@ from sdcm.sct_events import Severity, SctEventProtocol
 from sdcm.sct_events.base import SctEvent, LogEvent, LogEventProtocol, T_log_event
 
 
-TOLERABLE_REACTOR_STALL: int = 2000  # ms
+TOLERABLE_REACTOR_STALL: int = 1000  # ms
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
Since we changed the stall detector backtraces to one-liner and we
have much better tooling around grepping all these backtraces and
build them in a tree graph, it's about time to decrease the stall
detector to 100ms for all test runs.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
