### PR TITLE
fix(fill_db_data.py): correct the support version of enterprise

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -43,7 +43,9 @@ class FillDatabaseData(ClusterTester):
     NON_FROZEN_SUPPORT_OS_MIN_VERSION = '4.1'  # open source version with non-frozen user_types support
     NON_FROZEN_SUPPORT_ENTERPRISE_MIN_VERSION = '2020'  # enterprise version with non-frozen user_types support
     NULL_VALUES_SUPPORT_OS_MIN_VERSION = "4.4.rc0"
+    NULL_VALUES_SUPPORT_ENTERPRISE_MIN_VERSION = "2021.2.dev"
     NEW_SORTING_ORDER_WITH_SECONDARY_INDEXES_OS_MIN_VERSION = "4.4.rc0"
+    NEW_SORTING_ORDER_WITH_SECONDARY_INDEXES_ENTERPRISE_MIN_VERSION = "2021.2.dev"
 
     # List of dictionaries for all items tables and their data
     all_verification_items = [
@@ -3037,13 +3039,19 @@ class FillDatabaseData(ClusterTester):
 
     def version_null_values_support(self):
         scylla_version, is_enterprise = self.get_scylla_version()
-        return is_enterprise or parse_version(scylla_version) >= parse_version(
-            self.NULL_VALUES_SUPPORT_OS_MIN_VERSION)
+        if is_enterprise:
+            version_with_support = self.NULL_VALUES_SUPPORT_ENTERPRISE_MIN_VERSION
+        else:
+            version_with_support = self.NULL_VALUES_SUPPORT_OS_MIN_VERSION
+        return parse_version(scylla_version) >= parse_version(version_with_support)
 
     def version_new_sorting_order_with_secondary_indexes(self):
         scylla_version, is_enterprise = self.get_scylla_version()
-        return is_enterprise or parse_version(scylla_version) >= parse_version(
-            self.NEW_SORTING_ORDER_WITH_SECONDARY_INDEXES_OS_MIN_VERSION)
+        if is_enterprise:
+            version_with_support = self.NEW_SORTING_ORDER_WITH_SECONDARY_INDEXES_ENTERPRISE_MIN_VERSION
+        else:
+            version_with_support = self.NEW_SORTING_ORDER_WITH_SECONDARY_INDEXES_OS_MIN_VERSION
+        return parse_version(scylla_version) >= parse_version(version_with_support)
 
     def version_non_frozen_udt_support(self):
         """
@@ -3056,10 +3064,7 @@ class FillDatabaseData(ClusterTester):
         else:
             version_with_support = self.NON_FROZEN_SUPPORT_OS_MIN_VERSION
 
-        if parse_version(scylla_version) < parse_version(version_with_support):
-            return False  # current version doesn't support non-frozen UDT
-        else:
-            return True  # current version supports non-frozen UDT
+        return parse_version(scylla_version) >= parse_version(version_with_support)
 
     @retrying(n=3, sleep_time=20, allowed_exceptions=ProtocolException)
     def truncate_table(self, session, truncate):  # pylint: disable=no-self-use


### PR DESCRIPTION
Currently we assume the two features are supported by all enterprise,
actually they aren't support in 2021.1 unstable, two tests will fail the
upgrade jobs.

The two commits only exist in enterprise branch (2021.2 prepare), but
not branch-2021.1

- https://github.com/scylladb/scylla/commit/2342b386f467770b93238239332ccf45c9c33021
  Fix for #7443, adjusted SI result order
- https://github.com/scylladb/scylla/commit/4bb11076525df443d155e45331c82a3f34e2e649
  Add support of null query

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
