### PR TITLE
fix(lwt longevity): filter out mutation errors on system.paxos

### DIFF
--- a/longevity_lwt_test.py
+++ b/longevity_lwt_test.py
@@ -62,13 +62,14 @@ class LWTLongevityTest(LongevityTest):
         self.db_cluster.start_nemesis()
 
     def test_lwt_longevity(self):
-        self.test_custom_time()
+        with ignore_mutation_write_errors():
+            self.test_custom_time()
 
-        # Stop nemesis. Prefer all nodes will be run before collect data for validation
-        # Increase timeout to wait for nemesis finish
-        if self.db_cluster.nemesis_threads:
-            self.db_cluster.stop_nemesis(timeout=300)
-        self.validate_data()
+            # Stop nemesis. Prefer all nodes will be run before collect data for validation
+            # Increase timeout to wait for nemesis finish
+            if self.db_cluster.nemesis_threads:
+                self.db_cluster.stop_nemesis(timeout=300)
+            self.validate_data()
 
     def validate_data(self):
         node = self.db_cluster.nodes[0]


### PR DESCRIPTION
Filter system.paxos mutation errors in LWT test (Roy's request)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
