### PR TITLE
fix(stop/restart): increase stop/restart timeout

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2465,8 +2465,10 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         if self.is_ubuntu14():
             self.remoter.run('sudo service scylla-server stop', timeout=timeout, ignore_status=ignore_status)
         else:
+            # systemd stop timeout of scylla-server is 900 seconds, the addition 100 seconds
+            # is used for killing scylla and finishing the stop.
             self.remoter.run(f'{self.systemctl} stop scylla-server.service',
-                             timeout=timeout, ignore_status=ignore_status)
+                             timeout=timeout * 3 + 100, ignore_status=ignore_status)
         if verify_down:
             self.wait_db_down(timeout=timeout)
 
@@ -2493,8 +2495,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             self.remoter.run("sudo service scylla-server restart",
                              timeout=timeout, ignore_status=ignore_status)
         else:
+            # systemd stop timeout of scylla-server is 900 seconds, the resest time is for starting
             self.remoter.run(f"{self.systemctl} restart scylla-server.service",
-                             timeout=timeout, ignore_status=ignore_status)
+                             timeout=timeout * 3, ignore_status=ignore_status)
         if verify_up_after:
             self.wait_db_up(timeout=timeout)
 


### PR DESCRIPTION
Systemd stop timeout of scylla-server is 900 seconds, it also required
some seconds to kill scylla. Current 300 timeout isn't enough.

The timeout exception will interrupt the nemesis, and the final stopped
db node will fail in health check, then the job will fail.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
