### PR TITLE
fix(fill_db_data): null as condition

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -804,7 +804,6 @@ class FillDatabaseData(ClusterTester):
             'invalid_queries': [
                 "INSERT INTO null_support_test_old_version (k, c, v2) VALUES (0, 2, {1, null})",
                 "INSERT INTO null_support_test_old_version (k, c, v2) VALUES (0, 0, { 'foo', 'bar', null })",
-                "SELECT * FROM null_support_test_old_version WHERE k = null",
             ],
             'min_version': '',
             'max_version': '4.3',


### PR DESCRIPTION
removing it as "invalid query" because from
4.5 it is valid, hence master jobs (upgrading
from 4.5) are now able to run this query without
any issues.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
