### PR TITLE
fix(health_checker.py): increase retry sleep time

### DIFF
--- a/sdcm/utils/health_checker.py
+++ b/sdcm/utils/health_checker.py
@@ -20,7 +20,7 @@ from sdcm.sct_events.health import ClusterHealthValidatorEvent
 
 
 CHECK_NODE_HEALTH_RETRIES = 3
-CHECK_NODE_HEALTH_RETRY_DELAY = 5
+CHECK_NODE_HEALTH_RETRY_DELAY = 45
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
during latest master CDC 4h job, after nemesis
DecommissionStreamingErr one of the nodes continued
to see the new node as UJ for a while, as it was
most likely busy with background tasks, and the 5
seconds sleep might be not enough.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
