### PR TITLE
fix(upgrade): ignore both runtime_err and exception of cdc

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -88,16 +88,27 @@ def ignore_upgrade_schema_errors():
             db_event=DatabaseLogEvent.RUNTIME_ERROR,
             line="Failed to load schema",
         ))
-        stack.enter_context(DbEventsFilter(
-            db_event=DatabaseLogEvent.DATABASE_ERROR,
-            line="Could not retrieve CDC streams with timestamp",
-        ))
         # This error message occurs during version rating only for the Drain operating system.
         stack.enter_context(DbEventsFilter(
             db_event=DatabaseLogEvent.DATABASE_ERROR,
             line="cql_server - exception while processing connection: seastar::nested_exception "
                  "(seastar::nested_exception)",
         ))
+        yield
+
+
+@contextmanager
+def ignore_upgrade_cdc_errors(version=None):
+    with ExitStack() as stack:
+        if version and '2020.1' in version:
+            stack.enter_context(DbEventsFilter(
+                db_event=DatabaseLogEvent.DATABASE_ERROR,
+                line="Could not retrieve CDC streams with timestamp",
+            ))
+            stack.enter_context(DbEventsFilter(
+                db_event=DatabaseLogEvent.RUNTIME_ERROR,
+                line="Could not retrieve CDC streams with timestamp",
+            ))
         yield
 
 

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -26,6 +26,7 @@ from sdcm.utils.version_utils import is_enterprise, get_node_supported_sstable_v
 from sdcm.sct_events.system import InfoEvent
 from sdcm.sct_events.database import IndexSpecialColumnErrorEvent
 from sdcm.sct_events.group_common_events import ignore_upgrade_schema_errors, ignore_ycsb_connection_refused
+from sdcm.sct_events.group_common_events import ignore_upgrade_cdc_errors
 
 
 def truncate_entries(func):
@@ -207,7 +208,8 @@ class UpgradeTest(FillDatabaseData):
         check_reload_systemd_config(node)
         # Current default 300s aren't enough for upgrade test of Debian 9.
         # Related issue: https://github.com/scylladb/scylla-cluster-tests/issues/1726
-        node.start_scylla_server(verify_up_timeout=500)
+        with ignore_upgrade_cdc_errors(self.orig_ver):
+            node.start_scylla_server(verify_up_timeout=500)
         result = node.remoter.run('scylla --version')
         new_ver = result.stdout
         assert self.orig_ver != self.new_ver, "scylla-server version isn't changed"


### PR DESCRIPTION
There are two kinds of event need to be ignored, it's only needed in
upgrade test from 2020.1(cdc experimental) to 2021.1 (cdc GA)

Ignored by Oren:
!ERR     | scylla: [shard 0] cdc - Could not retrieve CDC streams with
timestamp {2021/04/06 04:41:50} upon gossip event. Reason: "std::runtime_error
(Could not find CDC generation with timestamp 2021/04/06 04:41:50 in
distributed system tables (current time: 2021/04/06 05:27:30), even though
some node gossiped about it.)". Action: not retrying.

Replied by Dmitry:
!ERR     | scylla:  [shard 0] cdc - Could not retrieve CDC streams with
timestamp {2021/01/01 04:31:29} upon gossip event. Reason:
"exceptions::invalid_request_exception (unconfigured table
cdc_generation_descriptions)". Action: not retrying.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
