### PR TITLE
fix(scrub nemesis): disable scrub nemesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2607,6 +2607,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         will be skipped.
         """
         self.log.debug("Rebuild sstables by scrub with `--skip-corrupted`, corrupted partitions will be skipped.")
+        if '2021.1' in self.cluster.nodes[0].get_scylla_version():
+            raise UnsupportedNemesis("Disabled in branch 2021.1 due issue "
+                                     "https://github.com/scylladb/scylla-enterprise/issues/1688")
+
         with ignore_scrub_invalid_errors():
             for ks in self.cluster.get_test_keyspaces():
                 self.target_node.run_nodetool("scrub", args=f"--skip-corrupted {ks}")


### PR DESCRIPTION
Disable disrupt_corrupt_then_scrub nemesis in 2021.1 version due the issue
https://github.com/scylladb/scylla-enterprise/issues/1688 (Roy's request)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
