### PR TITLE
fix(upgrade): don't ignore CDC error in upgrade

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -88,10 +88,6 @@ def ignore_upgrade_schema_errors():
             db_event=DatabaseLogEvent.RUNTIME_ERROR,
             line="Failed to load schema",
         ))
-        stack.enter_context(DbEventsFilter(
-            db_event=DatabaseLogEvent.DATABASE_ERROR,
-            line="Could not retrieve CDC streams with timestamp",
-        ))
         # This error message occurs during version rating only for the Drain operating system.
         stack.enter_context(DbEventsFilter(
             db_event=DatabaseLogEvent.DATABASE_ERROR,

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -19,6 +19,7 @@ import logging
 import os.path
 import tempfile
 import unittest
+import time
 from weakref import proxy as weakproxy
 
 from invoke import Result
@@ -122,9 +123,10 @@ class TestBaseNode(unittest.TestCase, EventsUtilsMixin):
         with ignore_upgrade_schema_errors():
             self.node._read_system_log_and_publish_events(start_from_beginning=True)
 
+        time.sleep(0.1)
         with self.get_events_logger().events_logs_by_severity[Severity.ERROR].open() as events_file:
-            events = [json.loads(line) for line in events_file]
-            assert events == []
+            cdc_err_events = [line for line in events_file if 'cdc - Could not retrieve CDC streams' in line]
+            assert cdc_err_events != []
 
     def test_search_system_suppressed_messages(self):
         self.node.system_log = os.path.join(os.path.dirname(


### PR DESCRIPTION
The ignored CDC error only occurs in upgrading from old scylla with
experimental CDC to scylla with CDC (GA).

CDC is already GA from Scylla 4.3, this error should not occur in
upgrade test.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
