### PR TITLE
[branch-2020.1] fix(check_nodes_status): check if remove nodes list is None

### DIFF
--- a/sdcm/utils/health_checker.py
+++ b/sdcm/utils/health_checker.py
@@ -13,6 +13,9 @@ def check_nodes_status(nodes_status, current_node, removed_nodes_list=None):
 
     LOGGER.info(f'Status for {node_type} node {current_node.name}')
 
+    if removed_nodes_list is None:
+        removed_nodes_list = []
+
     for node_ip, node_properties in nodes_status.items():
         if node_properties['status'] != "UN":
             is_target = current_node.print_node_running_nemesis(node_ip)


### PR DESCRIPTION
Prevent failure 'TypeError: argument of type 'NoneType' is not iterable'
Found in branch-2020.1:
https://jenkins.scylladb.com/job/enterprise-2020.1/job/rolling-upgrade/job/rolling-upgrade-debian9-test/23
```
13:52:14  < t:2021-04-09 10:52:08,649 f:sct_events.py   l:906  c:sdcm.sct_events      p:INFO  > exception=[Node rolling-upgrade-2020-1-debian-stret-db-node-c438bee6-0-3 [34.73.110.226 | 10.142.0.141] (seed: False)] NodeSetupFailed: argument of type 'NoneType' is not iterable
13:52:14  < t:2021-04-09 10:52:08,649 f:sct_events.py   l:906  c:sdcm.sct_events      p:INFO  > Traceback (most recent call last):
13:52:14  < t:2021-04-09 10:52:08,649 f:sct_events.py   l:906  c:sdcm.sct_events      p:INFO  >   File "/jenkins/slave/workspace/enterprise-2020.1/rolling-upgrade/rolling-upgrade-debian9-test@2/scylla-cluster-tests/sdcm/cluster.py", line 3043, in node_setup
13:52:14  < t:2021-04-09 10:52:08,649 f:sct_events.py   l:906  c:sdcm.sct_events      p:INFO  >     cl_inst.node_setup(_node, **setup_kwargs)
13:52:14  < t:2021-04-09 10:52:08,649 f:sct_events.py   l:906  c:sdcm.sct_events      p:INFO  >   File "/jenkins/slave/workspace/enterprise-2020.1/rolling-upgrade/rolling-upgrade-debian9-test@2/scylla-cluster-tests/sdcm/cluster.py", line 3622, in node_setup
13:52:14  < t:2021-04-09 10:52:08,649 f:sct_events.py   l:906  c:sdcm.sct_events      p:INFO  >     check_nodes_status(nodes_status=nodes_status, current_node=node)
13:52:14  < t:2021-04-09 10:52:08,649 f:sct_events.py   l:906  c:sdcm.sct_events      p:INFO  >   File "/jenkins/slave/workspace/enterprise-2020.1/rolling-upgrade/rolling-upgrade-debian9-test@2/scylla-cluster-tests/sdcm/utils/health_checker.py", line 20, in check_nodes_status
13:52:14  < t:2021-04-09 10:52:08,649 f:sct_events.py   l:906  c:sdcm.sct_events      p:INFO  >     if node_ip in removed_nodes_list:
13:52:14  < t:2021-04-09 10:52:08,649 f:sct_events.py   l:906  c:sdcm.sct_events      p:INFO  > TypeError: argument of type 'NoneType' is not iterable
```

Fixed in master/branch-2021.1

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
