### PR TITLE
fix(rolling upgrade ami): fix getting 'provision_type' parameter

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -26,7 +26,7 @@ regions_data:
 
 
 aws_root_disk_size_monitor: 50  # GB, remove this field if default disk size should be used
-aws_root_disk_size_db: 15
+aws_root_disk_size_db: 30
 aws_root_disk_size_loader: 30  # GB, Increase loader disk in order to have extra space for a larger swap
 loader_swap_size: 10240  #10GB SWAP space
 ami_db_scylla_user: 'centos'

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -87,7 +87,7 @@ def call(Map pipelineParams) {
                                                         export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
                                                         export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
                                                         export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"
-                                                        export SCT_INSTANCE_PROVISION="${pipelineParams.params.get('provision_type', '')}"
+                                                        export SCT_INSTANCE_PROVISION="${params.get('provision_type', '')}"
                                                         export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$GIT_BRANCH | sed -E 's+(origin/|origin/branch-)++')
                                                         export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$SCT_AMI_ID_DB_SCYLLA_DESC | tr ._ - | cut -c1-8 )
 


### PR DESCRIPTION
Rolling upgrade ami test consistently fails in the branch-2020.1 with
error at rollingUpgradePipeline.call(rollingUpgradePipeline.groovy:90):
`java.lang.NullPointerException: Cannot invoke method get() on null object`

Fix getting this parameter.
This issue fixed in master/branch-2021.1

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
