### PR TITLE
fix(node-setup): disable daily triggered services for Ubuntu

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2978,6 +2978,14 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         if hasattr(self.log, 'extra'):
             self.log.extra['prefix'] = str(self)
 
+    def disable_daily_triggered_services(self):
+        if self.distro.uses_systemd == 'systemd' and (self.is_ubuntu() or self.is_debian()):
+            LOGGER.info("Disabling 'apt-daily' and 'apt-daily-upgrade' services...")
+            self.remoter.sudo('systemctl disable apt-daily.timer')
+            self.remoter.sudo('systemctl disable apt-daily-upgrade.timer')
+            self.remoter.sudo('systemctl stop apt-daily.timer', ignore_status=True)
+            self.remoter.sudo('systemctl stop apt-daily-upgrade.timer', ignore_status=True)
+
 
 class FlakyRetryPolicy(RetryPolicy):
 
@@ -4062,6 +4070,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                 raise Exception("There is no pre-installed ScyllaDB")
 
         if not Setup.REUSE_CLUSTER:
+            node.disable_daily_triggered_services()
             # prepare and start saslauthd service
             setup_script = dedent(f"""
                 sudo yum install -y cyrus-sasl
@@ -4160,11 +4169,6 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
 
     def _scylla_install(self, node):
         node.update_repo_cache()
-        if node.init_system == 'systemd' and (node.is_ubuntu() or node.is_debian()):
-            node.remoter.sudo('systemctl disable apt-daily.timer')
-            node.remoter.sudo('systemctl disable apt-daily-upgrade.timer')
-            node.remoter.sudo('systemctl stop apt-daily.timer', ignore_status=True)
-            node.remoter.sudo('systemctl stop apt-daily-upgrade.timer', ignore_status=True)
         node.clean_scylla()
         if self.params.get('unified_package'):
             node.offline_install_scylla(unified_package=self.params.get('unified_package'),


### PR DESCRIPTION
The code was part of _scylla_install method that was
called only when Scylla is installed but we need to disable
the daily triggered services in any case (when we use
Scylla image like AMI or GCE Image Scylla is preinstalled)

```
invoke.exceptions.UnexpectedExit: Encountered a bad command exit code!
Command: 'sudo bash -cxe "\napt-get install -y scylla-manager-agent\nsed -i \'s/# auth_token:.*$/auth_token: 4ea94ed9-708e-4317-8789-01306a70a611/\' /etc/scylla-manager-agent/scylla-manager-agent.yaml\nscyllamgr_ssl_cert_gen\nsed -i \'s/#tls_cert_file/tls_cert_file/\' /etc/scylla-manager-agent/scylla-manager-agent.yaml\nsed -i \'s/#tls_key_file/tls_key_file/\' /etc/scylla-manager-agent/scylla-manager-agent.yaml\nsed -i \'s/#prometheus: .*/prometheus: :5090/\' /etc/scylla-manager-agent/scylla-manager-agent.yaml\nsystemctl restart scylla-manager-agent\nsystemctl enable scylla-manager-agent\n"'
Exit code: 100
Stdout:
Stderr:
+ apt-get install -y scylla-manager-agent
E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 14408 (unattended-upgr)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?

```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
