### PR TITLE
fix(parallel nemesis test): rename the pipeline

### DIFF
--- a/jenkins-pipelines/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.jenkinsfile
+++ b/jenkins-pipelines/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.jenkinsfile
@@ -9,5 +9,5 @@ longevityPipeline(
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml',
 
-    timeout: [time: 3120, unit: 'MINUTES']
+    timeout: [time: 3180, unit: 'MINUTES']
 )


### PR DESCRIPTION
the yaml for this test was updated, but the pipeline file
wasn't.
Also, increasing the pipeline timeout with an extra 60 minutes
to allow the extra stages of the pipeline to work without
reaching the timeout incorrectly (stress should finish graceful
before reaching the pipeline timeout).

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
