### PR TITLE
Saslauthd fix: optionally prepare saslauthd and add support of Ubuntu

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4072,21 +4072,6 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         if not Setup.REUSE_CLUSTER:
             node.disable_daily_triggered_services()
 
-            # prepare and start saslauthd service
-            if self.params.get('prepare_saslauthd'):
-                setup_script = dedent(f"""
-                    sudo yum install -y cyrus-sasl
-                    sudo systemctl enable saslauthd
-                    echo 'MECH=ldap' | sudo tee -a /etc/sysconfig/saslauthd
-                    sudo touch /etc/saslauthd.conf
-                    echo 'saslauthd_socket_path: /run/saslauthd/mux' | sudo tee -a /etc/scylla/scylla.yaml
-                """)
-                node.remoter.run('bash -cxe "%s"' % setup_script)
-                conf = node.get_saslauthd_config()
-                for key in conf.keys():
-                    node.remoter.run(f'echo "{key}: {conf[key]}" | sudo tee -a /etc/saslauthd.conf')
-                node.remoter.sudo('systemctl restart saslauthd')
-
             result = node.remoter.run('/sbin/ip -o link show |grep ether |awk -F": " \'{print $2}\'', verbose=True)
             devname = result.stdout.strip()
             if install_scylla:
@@ -4127,6 +4112,31 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             self.node_config_setup(node, ','.join(self.seed_nodes_ips), self.get_endpoint_snitch())
 
             self._scylla_post_install(node, install_scylla, devname)
+
+            # prepare and start saslauthd service
+            if self.params.get('prepare_saslauthd'):
+                if node.is_rhel_like():
+                    setup_script = dedent(f"""
+                        sudo yum install -y cyrus-sasl
+                        sudo systemctl enable saslauthd
+                        echo 'MECH=ldap' | sudo tee -a /etc/sysconfig/saslauthd
+                        sudo touch /etc/saslauthd.conf
+                    """)
+                else:
+                    setup_script = dedent(f"""
+                        sudo apt-get install -y sasl2-bin
+                        sudo systemctl enable saslauthd
+                        echo -e 'MECHANISMS=ldap\nSTART=yes\n' | sudo tee -a /etc/default/saslauthd
+                        sudo touch /etc/saslauthd.conf
+                        sudo adduser scylla sasl  # to avoid the permission issue of unit socket
+                    """)
+                node.remoter.run('bash -cxe "%s"' % setup_script)
+                conf = node.get_saslauthd_config()
+                for key in conf.keys():
+                    node.remoter.run(f'echo "{key}: {conf[key]}" | sudo tee -a /etc/saslauthd.conf')
+                with node.remote_scylla_yaml() as scylla_yml:
+                    scylla_yml['saslauthd_socket_path'] = '/run/saslauthd/mux'
+                node.remoter.sudo('systemctl restart saslauthd')
 
             if self.node_setup_requires_scylla_restart:
                 node.stop_scylla_server(verify_down=False)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4071,19 +4071,21 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
 
         if not Setup.REUSE_CLUSTER:
             node.disable_daily_triggered_services()
+
             # prepare and start saslauthd service
-            setup_script = dedent(f"""
-                sudo yum install -y cyrus-sasl
-                sudo systemctl enable saslauthd
-                echo 'MECH=ldap' | sudo tee -a /etc/sysconfig/saslauthd
-                sudo touch /etc/saslauthd.conf
-                echo 'saslauthd_socket_path: /run/saslauthd/mux' | sudo tee -a /etc/scylla/scylla.yaml
-            """)
-            node.remoter.run('bash -cxe "%s"' % setup_script)
-            conf = node.get_saslauthd_config()
-            for key in conf.keys():
-                node.remoter.run(f'echo "{key}: {conf[key]}" | sudo tee -a /etc/saslauthd.conf')
-            node.remoter.sudo('systemctl restart saslauthd')
+            if self.params.get('prepare_saslauthd'):
+                setup_script = dedent(f"""
+                    sudo yum install -y cyrus-sasl
+                    sudo systemctl enable saslauthd
+                    echo 'MECH=ldap' | sudo tee -a /etc/sysconfig/saslauthd
+                    sudo touch /etc/saslauthd.conf
+                    echo 'saslauthd_socket_path: /run/saslauthd/mux' | sudo tee -a /etc/scylla/scylla.yaml
+                """)
+                node.remoter.run('bash -cxe "%s"' % setup_script)
+                conf = node.get_saslauthd_config()
+                for key in conf.keys():
+                    node.remoter.run(f'echo "{key}: {conf[key]}" | sudo tee -a /etc/saslauthd.conf')
+                node.remoter.sudo('systemctl restart saslauthd')
 
             result = node.remoter.run('/sbin/ip -o link show |grep ether |awk -F": " \'{print $2}\'', verbose=True)
             devname = result.stdout.strip()

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -39,6 +39,7 @@ import zipfile
 from typing import Iterable, List, Callable, Optional, Dict, Union, Literal, Any
 from urllib.parse import urlparse
 from unittest.mock import Mock
+from textwrap import dedent
 
 from functools import wraps, cached_property
 from collections import defaultdict, namedtuple
@@ -2264,3 +2265,31 @@ def update_authenticator(nodes, authenticator='AllowAllAuthenticator', restart=T
             node.parent_cluster.params['are_ldap_users_on_scylla'] = node.use_saslauthd_authenticator
             node.restart_scylla_server()
             node.wait_db_up()
+
+
+def prepare_and_start_saslauthd_service(node):
+    """
+    Install and setup saslauthd service.
+    """
+    if node.is_rhel_like():
+        setup_script = dedent(f"""
+            sudo yum install -y cyrus-sasl
+            sudo systemctl enable saslauthd
+            echo 'MECH=ldap' | sudo tee -a /etc/sysconfig/saslauthd
+            sudo touch /etc/saslauthd.conf
+        """)
+    else:
+        setup_script = dedent(f"""
+            sudo apt-get install -y sasl2-bin
+            sudo systemctl enable saslauthd
+            echo -e 'MECHANISMS=ldap\nSTART=yes\n' | sudo tee -a /etc/default/saslauthd
+            sudo touch /etc/saslauthd.conf
+            sudo adduser scylla sasl  # to avoid the permission issue of unit socket
+        """)
+    node.remoter.run('bash -cxe "%s"' % setup_script)
+    conf = node.get_saslauthd_config()
+    for key in conf.keys():
+        node.remoter.run(f'echo "{key}: {conf[key]}" | sudo tee -a /etc/saslauthd.conf')
+    with node.remote_scylla_yaml() as scylla_yml:
+        scylla_yml['saslauthd_socket_path'] = '/run/saslauthd/mux'
+    node.remoter.sudo('systemctl restart saslauthd')


### PR DESCRIPTION
Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/3395
- only prepare saslauthd when it's enabled in config

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/3396
- add support to setup saslauthd of ubuntu distro

The PR fixes two issues in artifact-test, after merged https://github.com/scylladb/scylla-cluster-tests/pull/3120


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
