### PR TITLE
branch-2021.1: fix boto3 import error

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -30,6 +30,7 @@ import signal
 import sys
 import traceback
 
+import boto3.session
 from invoke.exceptions import UnexpectedExit, Failure  # pylint: disable=import-error
 
 from cassandra.concurrent import execute_concurrent_with_args  # pylint: disable=no-name-in-module


### PR DESCRIPTION
Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/3400

NameError: name 'boto3' is not defined

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
