### PR TITLE
fix(logcollector): Added dmesg output to collecting logs

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -810,7 +810,9 @@ class ScyllaLogCollector(LogCollector):
                     CommandLog(name='coredumps.info',
                                command='sudo coredumpctl info'),
                     CommandLog(name='io-properties.yaml',
-                               command='cat /etc/scylla.d/io_properties.yaml')
+                               command='cat /etc/scylla.d/io_properties.yaml'),
+                    CommandLog(name='dmesg.log',
+                               command='dmesg -P')
                     ]
     cluster_log_type = "db-cluster"
     cluster_dir_prefix = "db-cluster"


### PR DESCRIPTION
Added output of dmesg command to collection logs for
scylla node

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (CI)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
