### PR TITLE
Apt daily services fix

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2983,8 +2983,12 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             LOGGER.info("Disabling 'apt-daily' and 'apt-daily-upgrade' services...")
             self.remoter.sudo('systemctl disable apt-daily.timer')
             self.remoter.sudo('systemctl disable apt-daily-upgrade.timer')
+            self.remoter.sudo('systemctl disable apt-daily.service', ignore_status=True)
+            self.remoter.sudo('systemctl disable apt-daily-upgrade.service', ignore_status=True)
             self.remoter.sudo('systemctl stop apt-daily.timer', ignore_status=True)
             self.remoter.sudo('systemctl stop apt-daily-upgrade.timer', ignore_status=True)
+            self.remoter.sudo('systemctl stop apt-daily.service', ignore_status=True)
+            self.remoter.sudo('systemctl stop apt-daily-upgrade.service', ignore_status=True)
 
 
 class FlakyRetryPolicy(RetryPolicy):

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2979,7 +2979,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             self.log.extra['prefix'] = str(self)
 
     def disable_daily_triggered_services(self):
-        if self.distro.uses_systemd == 'systemd' and (self.is_ubuntu() or self.is_debian()):
+        if self.distro.uses_systemd and (self.is_ubuntu() or self.is_debian()):
             LOGGER.info("Disabling 'apt-daily' and 'apt-daily-upgrade' services...")
             self.remoter.sudo('systemctl disable apt-daily.timer')
             self.remoter.sudo('systemctl disable apt-daily-upgrade.timer')


### PR DESCRIPTION
This PR fixed a bug introduced by https://github.com/scylladb/scylla-cluster-tests/commit/afef6f9debfd4015513d4510ea10517ac022ab79 (Related PR (https://github.com/scylladb/scylla-cluster-tests/pull/3393))

- distro.uses_systemd is a bool type
- additional fix: try to disable/stop apt-daily services

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
