### PR TITLE
fix(disable_daily_triggered_services): fix typo in repo path

### DIFF
--- a/test-cases/artifacts/debian10.yaml
+++ b/test-cases/artifacts/debian10.yaml
@@ -17,4 +17,4 @@ scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/debian/scylla-
 test_duration: 60
 user_prefix: 'artifacts-debian10'
 system_auth_rf: 1
-scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/buster/master/latest/scylladb-manager-master/scylla-manager.list',
+scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/buster/master/latest/scylladb-manager-master/scylla-manager.list'

--- a/test-cases/artifacts/debian9.yaml
+++ b/test-cases/artifacts/debian9.yaml
@@ -17,4 +17,4 @@ scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/debian/scylla-
 test_duration: 60
 user_prefix: 'artifacts-debian9'
 system_auth_rf: 1
-scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/stretch/master/latest/scylladb-manager-master/scylla-manager.list',
+scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/stretch/master/latest/scylladb-manager-master/scylla-manager.list'

--- a/test-cases/artifacts/ubuntu1604.yaml
+++ b/test-cases/artifacts/ubuntu1604.yaml
@@ -17,4 +17,4 @@ scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-
 test_duration: 60
 user_prefix: 'artifacts-ubuntu1604'
 system_auth_rf: 1
-scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/xenial/master/latest/scylla-manager-master/scylla-manager.list',
+scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/xenial/master/latest/scylla-manager-master/scylla-manager.list'

--- a/test-cases/artifacts/ubuntu1804.yaml
+++ b/test-cases/artifacts/ubuntu1804.yaml
@@ -17,4 +17,4 @@ scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-
 test_duration: 60
 user_prefix: 'artifacts-ubuntu1804'
 system_auth_rf: 1
-scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/bionic/master/latest/scylla-manager-master/scylla-manager.list',
+scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/bionic/master/latest/scylladb-manager-master/scylla-manager.list'

--- a/test-cases/artifacts/ubuntu2004.yaml
+++ b/test-cases/artifacts/ubuntu2004.yaml
@@ -17,4 +17,4 @@ scylla_repo: 'http://downloads.scylladb.com/deb/unstable/unified/master/latest/s
 test_duration: 60
 user_prefix: 'artifacts-ubuntu2004'
 system_auth_rf: 1
-scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/focal/master/latest/scylla-manager-master/scylla-manager.list',
+scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/focal/master/latest/scylla-manager-master/scylla-manager.list'


### PR DESCRIPTION
This patch removed the redundant comma in the end, and correct the
directory name in the repo path, the latest paths were verified
manually.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
