### PR TITLE
fix(scylla-bench): log time inconsistency

### DIFF
--- a/sdcm/sct_events/base.py
+++ b/sdcm/sct_events/base.py
@@ -311,7 +311,20 @@ class LogEvent(Generic[T_log_event], SctEvent, abstract=True):
         """
 
         try:
-            self.timestamp = dateutil.parser.parse(line.split(None, 1)[0]).timestamp()
+            splitted_line = line.split()
+            if "T" in splitted_line[0]:
+                # Cover messages log time format. Example:
+                # 2021-04-06T13:03:28  ...
+                event_time = splitted_line[0]
+            else:
+                # Cover ScyllaBench event time format. Example:
+                # 2021/04/06 13:03:28 Operation timed out for scylla_bench.test - received only 1 responses from ...
+                #
+                # And regular log time. Example:
+                # 2021-04-06 13:03:28  ...
+                event_time = " ".join(splitted_line[:2])
+
+            self.timestamp = dateutil.parser.parse(event_time).timestamp()
         except ValueError:
             self.timestamp = time.time()
         self.node = str(node)


### PR DESCRIPTION
Scylla-bench use different time format. Example:
  2021/04/06 13:03:28 Operation timed out for scylla_bench.test - received only ..

For this error the event time in the log is '2021-04-06 00:00:00' because the date
only is taken.
This fix cover different time formats:
- 2021/04/06 13:03:28
- 2021-04-06 13:03:28
- 2021-04-06T13:03:28

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
