### PR TITLE
fix(EaR pipeline): correct the pipeline file name

### DIFF
--- a/jenkins-pipelines/EaR-longevity-kmip-50gb-4d.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-kmip-50gb-4d.jenkinsfile
@@ -7,7 +7,7 @@ longevityPipeline(
     backend: 'aws',
     aws_region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-50GB-4days-authorization-and-tls-ssl.yaml", "configurations/hytrust-kmip-ear.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "configurations/hytrust-kmip-ear.yaml"]''',
 
     timeout: [time: 6550, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/EaR-longevity-local-50gb-4d.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-local-50gb-4d.jenkinsfile
@@ -7,7 +7,7 @@ longevityPipeline(
     backend: 'aws',
     aws_region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-50GB-4days-authorization-and-tls-ssl.yaml", "configurations/local-ear.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "configurations/local-ear.yaml"]''',
 
     timeout: [time: 6550, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/EaR-longevity-replicated-50gb-4d.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-replicated-50gb-4d.jenkinsfile
@@ -7,7 +7,7 @@ longevityPipeline(
     backend: 'aws',
     aws_region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-50GB-4days-authorization-and-tls-ssl.yaml", "configurations/replicated-ear.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "configurations/replicated-ear.yaml"]''',
 
     timeout: [time: 6550, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/ics-longevity-50gb-4days.jenkinsfile
+++ b/jenkins-pipelines/ics-longevity-50gb-4days.jenkinsfile
@@ -7,7 +7,7 @@ longevityPipeline(
     backend: 'aws',
     aws_region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-50GB-4days-authorization-and-tls-ssl.yaml", "test-cases/enterprise-features/ics/longevity/ics-longevity-50GB-4days-authorization-and-tls-ssl.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "test-cases/enterprise-features/ics/longevity/ics-longevity-50GB-4days-authorization-and-tls-ssl.yaml"]''',
 
     timeout: [time: 6600, unit: 'MINUTES']
 )


### PR DESCRIPTION
The longevity-50GB-4days-authorization-and-tls-ssl.yaml had been rename
in commit 7a44d813196d64290a416c230c998b3b4462ae31. It causes the EaR
jobs failed for FileNotFoundError.

This patch corrected the pipeline file name.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
