### PR TITLE
feature(nodetool event): add event for nodetool command

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -86,3 +86,4 @@ DisruptionEvent: ERROR
 DbEventsFilter: NORMAL
 EventsFilter: NORMAL
 EventsSeverityChangerFilter: NORMAL
+NodetoolEvent: ERROR

--- a/performance_regression_lwt_test.py
+++ b/performance_regression_lwt_test.py
@@ -106,7 +106,8 @@ class PerformanceRegressionLWTTest(PerformanceRegressionTest):
     @retrying(n=3, sleep_time=15, allowed_exceptions=(UnexpectedExit, Failure))  # retrying since SSH can fail with 255
     def run_compaction_on_all_nodes(self):
         for node in self.db_cluster.nodes:
-            node.run_nodetool("compact")
+            node.run_nodetool("compact", warning_event_on_exception=(UnexpectedExit, Failure),
+                              error_message="Expected exception. ")
 
     def _run_workload(self, param_name, subtype, keyspace_num=1):
         cmd = self.params.get(param_name)

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -639,7 +639,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def disrupt_nodetool_drain(self):
         self._set_current_disruption('Drainer %s' % self.target_node)
         result = self.target_node.run_nodetool("drain", timeout=3600, coredump_on_timeout=True)
-        self.target_node.run_nodetool("status", ignore_status=True, verbose=True)
+        self.target_node.run_nodetool("status", ignore_status=True, verbose=True,
+                                      warning_event_on_exception=(Exception,))
 
         if result is not None:
             # workaround for issue #7332: don't interrupt test and don't raise exception
@@ -1831,14 +1832,14 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         @raise_event_on_failure
         def silenced_nodetool_repair_to_fail():
             try:
-                self.target_node.run_nodetool("repair", verbose=False)
+                self.target_node.run_nodetool("repair", verbose=False,
+                                              warning_event_on_exception=(UnexpectedExit, Libssh2UnexpectedExit),
+                                              error_message="Repair failed as expected. ")
             except (UnexpectedExit, Libssh2UnexpectedExit):
                 self.log.info('Repair failed as expected')
             except Exception:
                 self.log.error('Repair failed due to the unknown error')
                 raise
-            else:
-                raise RuntimeError('This repair should fail due to the being aborted')
 
         def repair_streaming_exists():
             active_repair_cmd = 'curl -s -X GET --header "Content-Type: application/json" --header ' \
@@ -2550,7 +2551,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 self._destroy_data_and_restart_scylla()
 
             try:
-                self.target_node.run_nodetool(nodetool_task)
+                self.target_node.run_nodetool(nodetool_task, warning_event_on_exception=(Exception,))
             except Exception:  # pylint: disable=broad-except
                 self.log.debug('%s is stopped' % nodetool_task)
 

--- a/sdcm/sct_events/nodetool.py
+++ b/sdcm/sct_events/nodetool.py
@@ -1,0 +1,63 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2021 ScyllaDB
+
+from sdcm.sct_events import Severity
+from sdcm.sct_events.base import SctEvent
+
+
+class NodetoolEvent(SctEvent):
+    def __init__(self,
+                 type,
+                 subtype,
+                 severity,
+                 options=None,
+                 node=None,
+                 start=None,
+                 end=None,
+                 duration=None,
+                 error=None,
+                 full_traceback=None):  # pylint: disable=redefined-builtin,too-many-arguments
+        super().__init__(severity=severity)
+
+        # handle the case if command is like "snapshot -kc keyspace1"
+        nodetool_cmd = type.split()[0]
+        if len(type.split()) > 1:
+            options_to_list = [options] if options else []
+            options = ' '.join(type.split()[1:] + options_to_list)
+
+        self.type = nodetool_cmd
+        self.subtype = subtype
+        self.options = options
+        self.node = str(node)
+        self.start = start
+        self.end = end
+        self.duration = duration
+
+        self.error = None
+        self.full_traceback = ""
+        if error:
+            self.error = error
+            self.full_traceback = str(full_traceback)
+
+    @property
+    def msgfmt(self) -> str:
+        fmt = super().msgfmt + ": type={0.type} subtype={0.subtype} node={0.node}"
+        if self.options:
+            fmt += " options={0.options}"
+        if self.duration:
+            fmt += " duration={0.duration}"
+        if self.error:
+            fmt += " error={0.error}"
+        if self.full_traceback:
+            fmt += "\n{0.full_traceback}"
+        return fmt


### PR DESCRIPTION
Add new event for `nodetool` command run.
Filter out this event for cluster health checker

Examples of events
```
2021-04-22 10:33:37.480: (NodetoolEvent Severity.NORMAL): type=repair subtype=start node=longevity-10gb-3h-add-node-db-node-fa7aa624-1
2021-04-22 10:33:40.018: (NodetoolEvent Severity.NORMAL): type=repair subtype=end node=longevity-10gb-3h-add-node-db-node-fa7aa624-1 duration=2.5371911910001472s
2021-04-22 10:43:51.717: (NodetoolEvent Severity.NORMAL): type=flush subtype=start node=longevity-10gb-3h-add-node-db-node-fa7aa624-1
2021-04-22 10:43:54.723: (NodetoolEvent Severity.NORMAL): type=flush subtype=end node=longevity-10gb-3h-add-node-db-node-fa7aa624-1 duration=3.00542277999989s
2021-04-22 10:43:57.575: (NodetoolEvent Severity.NORMAL): type=cfstats subtype=start node=longevity-10gb-3h-add-node-db-node-fa7aa624-1
2021-04-22 10:44:00.576: (NodetoolEvent Severity.NORMAL): type=cfstats subtype=end node=longevity-10gb-3h-add-node-db-node-fa7aa624-1 duration=2.999928956999838s
2021-04-22 10:47:56.440: (NodetoolEvent Severity.NORMAL): type=decommission subtype=start node=longevity-10gb-3h-add-node-db-node-fa7aa624-3
2021-04-22 10:49:13.618: (NodetoolEvent Severity.NORMAL): type=decommission subtype=end node=longevity-10gb-3h-add-node-db-node-fa7aa624-3 duration=77.1756486180002s
2021-04-22 11:01:28.841: (NodetoolEvent Severity.NORMAL): type=rebuild subtype=start node=longevity-10gb-3h-add-node-db-node-fa7aa624-7
2021-04-22 11:01:44.353: (NodetoolEvent Severity.NORMAL): type=rebuild subtype=end node=longevity-10gb-3h-add-node-db-node-fa7aa624-7 duration=15.511556761000065s
2021-04-22 11:18:00.415: (NodetoolEvent Severity.NORMAL): type=repair subtype=start node=longevity-10gb-3h-add-node-db-node-fa7aa624-7
2021-04-22 11:18:10.369: (NodetoolEvent Severity.WARNING): type=repair subtype=end node=longevity-10gb-3h-add-node-db-node-fa7aa624-7 duration=9s error=Repair failed as expected. Encountered a bad command exit code!
2021-04-22 11:18:20.614: (NodetoolEvent Severity.NORMAL): type=repair subtype=start node=longevity-10gb-3h-add-node-db-node-fa7aa624-7
2021-04-22 11:19:04.072: (NodetoolEvent Severity.NORMAL): type=repair subtype=end node=longevity-10gb-3h-add-node-db-node-fa7aa624-7 duration=43.457223243000044s
2021-04-22 11:36:17.936: (NodetoolEvent Severity.NORMAL): type=repair subtype=start node=longevity-10gb-3h-add-node-db-node-fa7aa624-4
```
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
