### PR TITLE
feature(k8s-gke): add possibility to specify k8s release channel

### DIFF
--- a/defaults/k8s_eks_config.yaml
+++ b/defaults/k8s_eks_config.yaml
@@ -9,7 +9,7 @@ availability_zone: 'a,b'
 instance_provision: 'on_demand'
 instance_type_db: 'i3.4xlarge'
 
-eks_cluster_version: '1.18'
+eks_cluster_version: '1.19'
 eks_role_arn: 'arn:aws:iam::797456418907:role/eksServicePolicy'
 eks_service_ipv4_cidr: '172.20.0.0/16'
 eks_vpc_cni_version: 'v1.7.5-eksbuild.1'

--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -3,7 +3,8 @@ gce_datacenter: 'us-east1-b'
 gce_network: 'qa-vpc'
 gce_image_username: 'scylla-test'
 
-gke_cluster_version: '1.18.16-gke.2100'
+gke_cluster_version: '1.19.9-gke.100'
+gke_k8s_release_channel: 'rapid'
 
 gce_instance_type_db: 'n1-standard-8'
 gce_root_disk_type_db: 'pd-ssd'

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -154,6 +154,7 @@
 | **<a href="#user-content-gce_root_disk_type_minikube" name="gce_root_disk_type_minikube">gce_root_disk_type_minikube</a>**  |  | N/A | SCT_GCE_ROOT_DISK_TYPE_MINIKUBE
 | **<a href="#user-content-gce_root_disk_size_minikube" name="gce_root_disk_size_minikube">gce_root_disk_size_minikube</a>**  |  | N/A | SCT_GCE_ROOT_DISK_SIZE_MINIKUBE
 | **<a href="#user-content-gke_cluster_version" name="gke_cluster_version">gke_cluster_version</a>**  |  | N/A | SCT_GKE_CLUSTER_VERSION
+| **<a href="#user-content-gke_k8s_release_channel" name="gke_k8s_release_channel">gke_k8s_release_channel</a>**  |  | N/A | SCT_GKE_K8S_RELEASE_CHANNEL
 | **<a href="#user-content-k8s_deploy_monitoring" name="k8s_deploy_monitoring">k8s_deploy_monitoring</a>**  |  | N/A | SCT_K8S_DEPLOY_MONITORING
 | **<a href="#user-content-k8s_scylla_operator_docker_image" name="k8s_scylla_operator_docker_image">k8s_scylla_operator_docker_image</a>**  |  | N/A | SCT_K8S_SCYLLA_OPERATOR_DOCKER_IMAGE
 | **<a href="#user-content-k8s_scylla_operator_helm_repo" name="k8s_scylla_operator_helm_repo">k8s_scylla_operator_helm_repo</a>**  |  | N/A | SCT_K8S_SCYLLA_OPERATOR_HELM_REPO

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -661,6 +661,9 @@ class SCTConfiguration(dict):
         # k8s-gke options
         dict(name="gke_cluster_version", env="SCT_GKE_CLUSTER_VERSION", type=str,
              help=""),
+        dict(name="gke_k8s_release_channel", env="SCT_GKE_K8S_RELEASE_CHANNEL", type=str,
+             help="K8S release channel name to be used. Expected values are: "
+                  "'rapid', 'regular', 'stable' and '' (static / No channel)."),
 
         # k8s options
         dict(name="k8s_deploy_monitoring", env="SCT_K8S_DEPLOY_MONITORING", type=str,

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -966,6 +966,7 @@ class ClusterTester(db_stats.TestStatsMixin,
 
         services, gce_datacenter = list(services.values()), list(services.keys())
         self.k8s_cluster = gke.GkeCluster(gke_cluster_version=self.params.get("gke_cluster_version"),
+                                          gke_k8s_release_channel=self.params.get("gke_k8s_release_channel"),
                                           gce_image_type=self.params.get("gce_root_disk_type_db"),
                                           gce_image_size=self.params.get("gce_root_disk_size_db"),
                                           gce_network=self.params.get("gce_network"),


### PR DESCRIPTION
GKE has release channels for K8S versions.
Add additional option that allows to specify release channel that must be used.
Also, set 'rapid' as default and specify k8s 1.19 version which is needed in our testing.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
