### PR TITLE
feature(sct event): add POWER_OFF event

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -30,6 +30,7 @@ DatabaseLogEvent.REACTOR_STALLED: WARNING
 DatabaseLogEvent.BOOT: NORMAL
 DatabaseLogEvent.SUPPRESSED_MESSAGES: WARNING
 DatabaseLogEvent.stream_exception: ERROR
+DatabaseLogEvent.POWER_OFF: CRITICAL
 IndexSpecialColumnErrorEvent: ERROR
 GeminiEvent.error: CRITICAL
 GeminiEvent.warning: WARNING

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -692,6 +692,7 @@ class AWSNode(cluster.BaseNode):
                                   DbEventsFilter(db_event=DatabaseLogEvent.SCHEMA_FAILURE, node=self),
                                   DbEventsFilter(db_event=DatabaseLogEvent.NO_SPACE_ERROR, node=self),
                                   DbEventsFilter(db_event=DatabaseLogEvent.FILESYSTEM_ERROR, node=self),
+                                  DbEventsFilter(db_event=DatabaseLogEvent.POWER_OFF, node=self),
                                   DbEventsFilter(db_event=DatabaseLogEvent.RUNTIME_ERROR, node=self), ):
                     stack.enter_context(db_filter)
 

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -44,6 +44,7 @@ class DatabaseLogEvent(LogEvent, abstract=True):
     BOOT: Type[LogEventProtocol]
     SUPPRESSED_MESSAGES: Type[LogEventProtocol]
     stream_exception: Type[LogEventProtocol]
+    POWER_OFF: Type[LogEventProtocol]
 
 
 MILLI_RE = re.compile(r"(\d+) ms")
@@ -101,6 +102,7 @@ DatabaseLogEvent.add_subevent_type("SUPPRESSED_MESSAGES", severity=Severity.WARN
                                    regex="journal: Suppressed")
 DatabaseLogEvent.add_subevent_type("stream_exception", severity=Severity.ERROR,
                                    regex="stream_exception")
+DatabaseLogEvent.add_subevent_type("POWER_OFF", severity=Severity.CRITICAL, regex="Powering Off")
 
 
 SYSTEM_ERROR_EVENTS = (
@@ -123,6 +125,7 @@ SYSTEM_ERROR_EVENTS = (
     DatabaseLogEvent.BOOT(),
     DatabaseLogEvent.SUPPRESSED_MESSAGES(),
     DatabaseLogEvent.stream_exception(),
+    DatabaseLogEvent.POWER_OFF(),
 )
 SYSTEM_ERROR_EVENTS_PATTERNS: List[Tuple[re.Pattern, LogEventProtocol]] = \
     [(re.compile(event.regex, re.IGNORECASE), event) for event in SYSTEM_ERROR_EVENTS]

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -14,18 +14,22 @@
 # pylint: disable=too-few-public-methods
 
 import json
+import time
 import shutil
 import logging
 import os.path
 import tempfile
 import unittest
 from weakref import proxy as weakproxy
+from contextlib import ExitStack
 
 from invoke import Result
 
 from sdcm.cluster import BaseNode, BaseCluster, BaseMonitorSet
 from sdcm.sct_events import Severity
 from sdcm.sct_events.group_common_events import ignore_upgrade_schema_errors
+from sdcm.sct_events.filters import DbEventsFilter
+from sdcm.sct_events.database import DatabaseLogEvent
 from sdcm.utils.distro import Distro
 
 from unit_tests.dummy_remote import DummyRemote
@@ -125,6 +129,25 @@ class TestBaseNode(unittest.TestCase, EventsUtilsMixin):
         with self.get_events_logger().events_logs_by_severity[Severity.ERROR].open() as events_file:
             events = [json.loads(line) for line in events_file]
             assert events == []
+
+    def test_search_power_off(self):
+        self.node.system_log = os.path.join(os.path.dirname(__file__), 'test_data', 'power_off.log')
+        self.node._read_system_log_and_publish_events(start_from_beginning=True)
+
+        time.sleep(0.1)
+        with self.get_events_logger().events_logs_by_severity[Severity.CRITICAL].open() as events_file:
+            events = [line for line in events_file if 'Powering Off' in line]
+            assert events != []
+
+    def test_ignore_power_off(self):
+        self.node.system_log = os.path.join(os.path.dirname(__file__), 'test_data', 'power_off.log')
+        with DbEventsFilter(db_event=DatabaseLogEvent.POWER_OFF, node=self.node):
+            self.node._read_system_log_and_publish_events(start_from_beginning=True)
+
+            time.sleep(0.1)
+            with self.get_events_logger().events_logs_by_severity[Severity.CRITICAL].open() as events_file:
+                events = [line for line in events_file if 'Powering Off' in line]
+                assert events == []
 
     def test_search_system_suppressed_messages(self):
         self.node.system_log = os.path.join(os.path.dirname(

--- a/unit_tests/test_data/power_off.log
+++ b/unit_tests/test_data/power_off.log
@@ -1,0 +1,35 @@
+2021-02-01T22:01:01+00:00  longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !INFO    | systemd-logind: Removed session 8570.
+2021-02-01T22:01:03+00:00  longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !WARNING | scylla: [shard 8] sstable - Unable to delete /var/lib/
+scylla/data/large_collection_test/table_with_large_collection-b75c53b0647311eb8d04000000000000/md-3596-big-TOC.txt because it doesn't exist.
+2021-02-01T22:01:03+00:00  longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !INFO    | scylla: [shard 8] compaction - [Cleanup large_collecti
+on_test.table_with_large_collection c0849500-64d8-11eb-afba-000000000007] Cleaned 1 sstables to [/var/lib/scylla/data/large_collection_test/table_w
+ith_large_collection-b75c53b0647311eb8d04000000000000/md-5480-big-Data.db:level=0, ]. 1GB to 1GB (~75% of original) in 96611ms = 11MB/s. ~1152 tota
+l partitions merged to 849.
+2021-02-01T22:01:03+00:00  longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !INFO    | scylla: [shard 8] compaction - [Cleanup large_collecti
+on_test.table_with_large_collection fa1c3c00-64d8-11eb-afba-000000000007] Cleaning [/var/lib/scylla/data/large_collection_test/table_with_large_col
+lection-b75c53b0647311eb8d04000000000000/md-3608-big-Data.db:level=0, ]
+2021-02-01T22:01:27+00:00  longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !INFO    | sshd[27535]: pam_unix(sshd:session): session closed fo
+r user centos
+2021-02-01T22:01:27+00:00  longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !INFO    | systemd-logind: Removed session 8575.
+2021-02-01T22:01:29+00:00  longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !INFO    | systemd-logind: Power key pressed.
+2021-02-01T22:01:29+00:00  longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !INFO    | systemd-logind: Powering Off...
+2021-02-01T22:01:29+00:00  longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !NOTICE  | systemd-logind: System is powering down.
+2021-02-01T22:01:29+00:00  longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !INFO    | systemd: Stopped target RPC Port Mapper.
+2021-02-01T22:01:29+00:00  longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !INFO    | systemd: Stopping Session 227 of user scyllaadm.
+2021-02-01T22:01:29+00:00  longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !INFO    | systemd: Stopping Session 11 of user scyllaadm.
+2021-02-01T22:01:29+00:00  longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !INFO    | systemd: Stopping RPC bind service...
+2021-02-01T22:01:29+00:00  longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !INFO    | systemd: Stopping Session 3 of user scyllaadm.
+2021-02-01T22:01:29+00:00  longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !INFO    | systemd: Stopped target Timers.
+2021-02-01T22:01:29+00:00  longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !INFO    | systemd: Stopped Daily Cleanup of Temporary Directories.
+2021-02-01T22:01:29+00:00  longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !INFO    | systemd: Stopped Run Scylla Housekeeping daily mode.
+2021-02-01T22:01:29+00:00  longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !INFO    | systemd: Stopped Run Scylla Housekeeping restart mode.
+2021-02-01T22:01:29+00:00  longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !INFO    | systemd: Stopped Dump dmesg to /var/log/dmesg.
+2021-02-01T22:01:29+00:00  longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !INFO    | systemd: Stopped target Cloud-init target.
+2021-02-01T22:01:29+00:00  longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !INFO    | systemd: Stopped Apply the settings specified in cloud-config.
+2021-02-01T22:01:29+00:00  longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !INFO    | systemd: Stopped target Cloud-config availability.
+2021-02-01T22:01:29+00:00  longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !INFO    | sshd[9478]: pam_unix(sshd:session): session closed for user centos
+2021-02-01T22:01:29+00:00  longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !INFO    | systemd: Stopped target rpc_pipefs.target.
+2021-02-01T22:01:29+00:00  longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !INFO    | systemd: Unmounting RPC Pipe File System...
+2021-02-01T22:01:29+00:00  longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !INFO    | systemd: Removed slice system-selinux\x2dpolicy\x2dmigrate\x2dlocal\x2dchanges.slice.
+2021-02-01T22:01:29+00:00  longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !INFO    | systemd: Stopping Session 4 of user scyllaadm.
+2021-02-01T22:01:29+00:00  longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !INFO    | systemd: Stopping Scylla JMX...

--- a/unit_tests/test_sct_events_database.py
+++ b/unit_tests/test_sct_events_database.py
@@ -40,6 +40,7 @@ class TestDatabaseLogEvent(unittest.TestCase):
         self.assertTrue(issubclass(DatabaseLogEvent.BOOT, DatabaseLogEvent)),
         self.assertTrue(issubclass(DatabaseLogEvent.SUPPRESSED_MESSAGES, DatabaseLogEvent)),
         self.assertTrue(issubclass(DatabaseLogEvent.stream_exception, DatabaseLogEvent)),
+        self.assertTrue(issubclass(DatabaseLogEvent.POWER_OFF, DatabaseLogEvent)),
 
     def test_reactor_stalled_severity(self):
         event1 = DatabaseLogEvent.REACTOR_STALLED()


### PR DESCRIPTION
In scylla/issues#8016, we touched a strange Power off of db nodes,
SpotTermination isn't watched, maybe it's just some unexpected power off
in aws.

This patch added a POWER_OFF event, it's helpful to address the problem.
We also ignored this event in general restart() of aws instance, restart()
of gce is implemented by soft reboot().

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
