### PR TITLE
feature(operator): add new operator events

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -67,6 +67,8 @@ PrometheusAlertManagerEvent.start: WARNING
 PrometheusAlertManagerEvent.end: WARNING
 ScyllaOperatorLogEvent: ERROR
 ScyllaOperatorLogEvent.REAPPLY: WARNING
+ScyllaOperatorLogEvent.TLS_HANDSHAKE_ERROR: WARNING
+ScyllaOperatorLogEvent.OPERATOR_STARTED_INFO: NORMAL
 ScyllaOperatorRestartEvent: ERROR
 StartupTestEvent: NORMAL
 TestTimeoutEvent: CRITICAL

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -498,6 +498,8 @@ class KubernetesCluster(metaclass=abc.ABCMeta):
             readiness_timeout=5*60,
             namespace=SCYLLA_OPERATOR_NAMESPACE
         )
+        # Start the Scylla Operator logging thread
+        self.start_scylla_operator_journal_thread()
 
     @log_run_info
     def deploy_minio_s3_backend(self):

--- a/sdcm/cluster_k8s/operator_monitoring.py
+++ b/sdcm/cluster_k8s/operator_monitoring.py
@@ -26,7 +26,10 @@ from sdcm.sct_events.operator import ScyllaOperatorLogEvent, ScyllaOperatorResta
 class ScyllaOperatorLogMonitoring(threading.Thread):
     lookup_time = 0.1
     log = logging.getLogger('ScyllaOperatorLogMonitoring')
-    patterns = [re.compile('^\s*{\s*"L"\s*:\s*"ERROR"')]
+    patterns = [
+        re.compile('^\s*{\s*"L"\s*:\s*"ERROR"'),
+        re.compile('^\s*{\s*"L"\s*:\s*"INFO"'),
+    ]
 
     def __init__(self, kluster):
         self.termination_event = threading.Event()

--- a/sdcm/cluster_k8s/operator_monitoring.py
+++ b/sdcm/cluster_k8s/operator_monitoring.py
@@ -49,10 +49,12 @@ class ScyllaOperatorLogMonitoring(threading.Thread):
             event_to_log = None
             for pattern, event in SCYLLA_OPERATOR_EVENT_PATTERNS:
                 if pattern.search(log_record):
-                    event_to_log = event.clone()
+                    event_to_log = event.clone().add_info(
+                        node="N/A", line=log_record, line_number=0)
                     break
             if event_to_log is None:
-                event_to_log = ScyllaOperatorLogEvent()
+                # NOTE: here we have log line that doesn't match any pattern, so, move on
+                continue
             if event_to_log := event_to_log.load_from_json_string(log_record):
                 event_to_log.publish()
 

--- a/sdcm/sct_events/operator.py
+++ b/sdcm/sct_events/operator.py
@@ -26,6 +26,8 @@ LOGGER = logging.getLogger(__name__)
 
 class ScyllaOperatorLogEvent(LogEvent):
     REAPPLY: Type[LogEventProtocol]
+    TLS_HANDSHAKE_ERROR: Type[LogEventProtocol]
+    OPERATOR_STARTED_INFO: Type[LogEventProtocol]
     timestamp: str
     namespace: str
     cluster: str
@@ -95,11 +97,20 @@ class ScyllaOperatorRestartEvent(SctEvent):
 
 
 ScyllaOperatorLogEvent.add_subevent_type(
-    "REAPPLY", severity=Severity.WARNING, regex="please apply your changes to the latest version and try again")
+    "REAPPLY", severity=Severity.WARNING,
+    regex="please apply your changes to the latest version and try again")
+ScyllaOperatorLogEvent.add_subevent_type(
+    "TLS_HANDSHAKE_ERROR", severity=Severity.WARNING,
+    regex="TLS handshake error from .*: EOF")
+ScyllaOperatorLogEvent.add_subevent_type(
+    "OPERATOR_STARTED_INFO", severity=Severity.NORMAL,
+    regex="Starting the operator...")
 
 
 SCYLLA_OPERATOR_EVENTS = [
     ScyllaOperatorLogEvent.REAPPLY(),
+    ScyllaOperatorLogEvent.TLS_HANDSHAKE_ERROR(),
+    ScyllaOperatorLogEvent.OPERATOR_STARTED_INFO(),
 ]
 
 

--- a/sdcm/utils/remote_logger.py
+++ b/sdcm/utils/remote_logger.py
@@ -279,7 +279,7 @@ class ScyllaManagerLogger(CommandClusterLoggerBase):
     def _logger_cmd(self) -> str:
         cmd = self._cluster.kubectl_cmd(
             f"logs --previous=false -f --since={int(self.time_delta)}s --all-containers=true "
-            "-l app=scylla-manager",
+            "-l app.kubernetes.io/instance=scylla-manager",
             namespace=self._cluster._scylla_manager_namespace)
         return f"{cmd} >> {self._target_log_file} 2>&1"
 
@@ -290,8 +290,8 @@ class ScyllaOperatorLogger(CommandClusterLoggerBase):
     @property
     def _logger_cmd(self) -> str:
         cmd = self._cluster.kubectl_cmd(
-            f"logs  --previous=false -f --since={int(self.time_delta)}s scylla-operator-controller-manager-0 "
-            "--all-containers=true",
+            f"logs --previous=false -f --since={int(self.time_delta)}s --all-containers=true "
+            "-l app.kubernetes.io/instance=scylla-operator",
             namespace=self._cluster._scylla_operator_namespace)
         return f"{cmd} >> {self._target_log_file} 2>&1"
 


### PR DESCRIPTION
Add following new operator events:
- 'TLS_HANDSHAKE_ERROR' is used to test regressioin of
  https://github.com/scylladb/scylla-operator/issues/308
- 'OPERATOR_STARTED_INFO' is used to test regressioin of broken operator events, it is kind of indicator of operator events workability. It must appear just once.

Also, Do following changes to make operator events work:
    - Run operator log threads which mistakenly were not triggered.
    - Use proper reference to the scylla manager and operator pods. It was incorrectly refered and logs were not taken.
    - Process operator event patterns correctly using "add_info" method, without it events do not get published.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
