### PR TITLE
improvement(large_collections.yaml): Added a static column to c-s user-profile

### DIFF
--- a/data_dir/large_collections.yaml
+++ b/data_dir/large_collections.yaml
@@ -9,7 +9,7 @@ table: table_with_large_collection
 table_definition: |
 
   CREATE TABLE large_collection_test.table_with_large_collection (
-    pk_id text PRIMARY KEY,
+    pk_id text,
     init_time timestamp,
     user_name text,
     new_num int,
@@ -19,6 +19,9 @@ table_definition: |
     nums_set set<int>,
     names_set set<text>,
     books_set set<text>,
+    static_data1 blob static,
+    static_data2 blob static,
+    PRIMARY KEY(pk_id, user_name)
   ) WITH bloom_filter_fp_chance = 0.01
     AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
     AND comment = 'Request for unit level UIs'
@@ -72,13 +75,20 @@ columnspec:
     size: fixed(1024)
     population: uniform(1..1024)
 
+  - name: static_data1
+    size: uniform(2620..62400)
+
+  - name: static_data2
+    size: uniform(2620..62400)
+
+
 insert:
   batchtype: UNLOGGED
 
 queries:
   read1:
-    cql: select * from large_collection_test.table_with_large_collection where pk_id = ?
+    cql: select * from large_collection_test.table_with_large_collection where pk_id = ? and user_name = ?
     fields: samerow
   update1:
-    cql: update large_collection_test.table_with_large_collection set users_name=?,nums_list=?,nums_set=?,names_set=?,books_set=? where pk_id = ?
+    cql: update large_collection_test.table_with_large_collection set users_name=?,nums_list=?,nums_set=?,names_set=?,books_set=?, static_data1=?, static_data2=? where pk_id = ? and user_name = ?
     fields: samerow


### PR DESCRIPTION
	Adds testing of c-s user profile for a static column.
        It also adds coverage for https://github.com/scylladb/scylla/issues/6780

#6780 - Scylla records large data cells in the system.large_rows table. If such a large cell was part of a static rows, Scylla would crash.

The important goal is testing a static column, especially with large data size. the duplication of 2 columns just comes to get more data range covering, triggering the 2 different large-cell detectors ( 'cell' and 'row').

This enhancement adds 2 static columns to "table_with_large_collection". i think once this is tested and verified to run stable, we can consider turning one of the static column from blob to a set type if supported. (thus also testing another type of collection).

Trello task: https://trello.com/c/sDViRTCQ

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
