### PR TITLE
refactor(monitor-3.7): Change monitor branch to monitor 3.7

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -25,7 +25,7 @@ scylla_linux_distro_loader: 'centos'
 ssh_transport: 'fabric'
 system_auth_rf: 3
 
-monitor_branch: 'branch-3.6'
+monitor_branch: 'branch-3.7'
 
 space_node_threshold: 0
 


### PR DESCRIPTION
We would like to start testing and releasing monitor 3.7.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
