### PR TITLE
fix(apt install lock): since moved to Ubuntu base image

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1966,8 +1966,13 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 self.parent_cluster.params.get("scylla_mgmt_repo"))
             package_name = 'scylla-manager-agent'
         package_mgr = "yum" if self.distro.is_rhel_like else "apt-get"
+
+        @retrying(n=10, sleep_time=5, allowed_exceptions=UnexpectedExit)
+        def install_package():
+            self.remoter.sudo(f'{package_mgr} install -y {package_name}')
+
+        install_package()
         install_and_config_agent_command = dedent(r"""
-            {} install -y {}
             sed -i 's/# auth_token:.*$/auth_token: {}/' /etc/scylla-manager-agent/scylla-manager-agent.yaml
             scyllamgr_ssl_cert_gen
             sed -i 's/#tls_cert_file/tls_cert_file/' /etc/scylla-manager-agent/scylla-manager-agent.yaml
@@ -1975,7 +1980,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             sed -i 's/#prometheus: .*/prometheus: :{}/' /etc/scylla-manager-agent/scylla-manager-agent.yaml
             systemctl restart scylla-manager-agent
             systemctl enable scylla-manager-agent
-        """.format(package_mgr, package_name, auth_token, manager_prometheus_port))
+        """.format(auth_token, manager_prometheus_port))
         self.remoter.run('sudo bash -cxe "%s"' % install_and_config_agent_command)
         version = self.remoter.run('scylla-manager-agent --version').stdout
         self.log.info(f'node {self.name} has scylla-manager-agent version {version}')


### PR DESCRIPTION
we are getting multiple jobs failing with apt install
lock issue:
Could not get lock /var/lib/dpkg/lock-frontend.
It is held by process 10738
Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend),
is another process using it?

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
