### PR TITLE
fix(mgmt agent repo): workaround to new base image

### DIFF
--- a/jenkins-pipelines/perf-regression-latency-250gb-with-nemesis.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-250gb-with-nemesis.jenkinsfile
@@ -8,6 +8,7 @@ perfRegressionParallelPipeline(
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: "test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml",
     sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"],
+    mgmt_agent_repo: "https://s3.amazonaws.com/downloads.scylladb.com/manager/deb/unstable/focal/branch-2.3/latest/scylla-manager-2.3/scylla-manager.list",
 
     timeout: [time: 1600, unit: "MINUTES"]
 )

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -96,6 +96,7 @@ def call(Map pipelineParams) {
                                                         export SCT_CLUSTER_BACKEND=${params.backend}
                                                         export SCT_REGION_NAME=${pipelineParams.aws_region}
                                                         export SCT_CONFIG_FILES=${pipelineParams.test_config}
+                                                        export SCT_SCYLLA_MGMT_AGENT_REPO=${pipelineParams.mgmt_agent_repo}
                                                         export SCT_EMAIL_RECIPIENTS="${email_recipients}"
                                                         if [[ ! -z "${params.scylla_ami_id}" ]] ; then
                                                             export SCT_AMI_ID_DB_SCYLLA=${params.scylla_ami_id}


### PR DESCRIPTION
this branch is used to releases and master, so
this workaround is to enable it to work for both
cases, adding a new paramenter to the pipeline
(defaults to master support), but enabling to use
the same job to releases as well.
This until @ShlomiBalalis adds his general fix
for the manager versions/distros support.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
