### PR TITLE
improvement(db-events): add scylla server stop event

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -28,6 +28,7 @@ DatabaseLogEvent.SEGMENTATION: ERROR
 DatabaseLogEvent.INTEGRITY_CHECK: ERROR
 DatabaseLogEvent.REACTOR_STALLED: WARNING
 DatabaseLogEvent.BOOT: NORMAL
+DatabaseLogEvent.STOP: NORMAL
 DatabaseLogEvent.SUPPRESSED_MESSAGES: WARNING
 DatabaseLogEvent.stream_exception: ERROR
 IndexSpecialColumnErrorEvent: ERROR

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -44,6 +44,7 @@ class DatabaseLogEvent(LogEvent, abstract=True):
     SEGMENTATION: Type[LogEventProtocol]
     INTEGRITY_CHECK: Type[LogEventProtocol]
     BOOT: Type[LogEventProtocol]
+    STOP: Type[LogEventProtocol]
     SUPPRESSED_MESSAGES: Type[LogEventProtocol]
     stream_exception: Type[LogEventProtocol]
 
@@ -101,6 +102,8 @@ DatabaseLogEvent.add_subevent_type("INTEGRITY_CHECK", severity=Severity.ERROR,
                                    regex="integrity check failed")
 DatabaseLogEvent.add_subevent_type("BOOT", severity=Severity.NORMAL,
                                    regex="Starting Scylla Server")
+DatabaseLogEvent.add_subevent_type("STOP", severity=Severity.NORMAL,
+                                   regex="Stopping Scylla Server")
 DatabaseLogEvent.add_subevent_type("SUPPRESSED_MESSAGES", severity=Severity.WARNING,
                                    regex="journal: Suppressed")
 DatabaseLogEvent.add_subevent_type("stream_exception", severity=Severity.ERROR,
@@ -127,6 +130,7 @@ SYSTEM_ERROR_EVENTS = (
     DatabaseLogEvent.SEGMENTATION(),
     DatabaseLogEvent.INTEGRITY_CHECK(),
     DatabaseLogEvent.BOOT(),
+    DatabaseLogEvent.STOP(),
     DatabaseLogEvent.SUPPRESSED_MESSAGES(),
     DatabaseLogEvent.stream_exception(),
 )

--- a/unit_tests/test_sct_events_database.py
+++ b/unit_tests/test_sct_events_database.py
@@ -38,6 +38,7 @@ class TestDatabaseLogEvent(unittest.TestCase):
         self.assertTrue(issubclass(DatabaseLogEvent.INTEGRITY_CHECK, DatabaseLogEvent)),
         self.assertTrue(issubclass(DatabaseLogEvent.REACTOR_STALLED, DatabaseLogEvent)),
         self.assertTrue(issubclass(DatabaseLogEvent.BOOT, DatabaseLogEvent)),
+        self.assertTrue(issubclass(DatabaseLogEvent.STOP, DatabaseLogEvent)),
         self.assertTrue(issubclass(DatabaseLogEvent.SUPPRESSED_MESSAGES, DatabaseLogEvent)),
         self.assertTrue(issubclass(DatabaseLogEvent.stream_exception, DatabaseLogEvent)),
 


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
