### PR TITLE
fix(system_auth and ldap): possible race condition

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -496,10 +496,14 @@ class ClusterTester(db_stats.TestStatsMixin,
                 self.legacy_init_nodes(db_cluster=self.db_cluster)
             else:
                 self.init_nodes(db_cluster=self.db_cluster)
-            if (self.params.get('use_ldap_authorization') and not self.params.get('are_ldap_users_on_scylla')) or self.params.get('prepare_saslauthd'):
+
+            # running `set_system_auth_rf()` before changing authorization/authentication protocols
+            self.set_system_auth_rf()
+
+            if (self.params.get('use_ldap_authorization') and not self.params.get('are_ldap_users_on_scylla')) or \
+                    self.params.get('prepare_saslauthd'):
                 self.db_cluster.nodes[0].create_ldap_users_on_scylla()
                 self.params['are_ldap_users_on_scylla'] = True
-            self.set_system_auth_rf()
 
             db_node_address = self.db_cluster.nodes[0].ip_address
             self.loaders.wait_for_init(db_node_address=db_node_address)


### PR DESCRIPTION
because the change in system_auth was the very first
thing running after configuring LDAP and changing SCT
to use LDAP users, it possible was not yet sync'ed on
all nodes, making nodetool commands to fail.
I think this change will resolve this small issue.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
