### PR TITLE
improvement(grow_shrink_cluster): few small improvements

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2671,7 +2671,13 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 self.set_target_node(is_seed=is_seed)
             self.log.info("Next node will be removed %s", self.target_node)
 
-            self.decommission_node(self.target_node)
+            try:
+                InfoEvent(message='StartEvent - ShrinkCluster started decommissioning a node').publish()
+                self.decommission_node(self.target_node)
+                InfoEvent(message='FinishEvent - ShrinkCluster has done decommissioning a node').publish()
+            except Exception as exc:
+                InfoEvent(message=f'FinishEvent - ShrinkCluster failed decommissioning a node with error {str(exc)}') \
+                    .publish()
 
     def disrupt_grow_shrink_cluster(self):
         self._disrupt_grow_shrink_cluster(rack=0)

--- a/test-cases/longevity/longevity-10gb-3h.yaml
+++ b/test-cases/longevity/longevity-10gb-3h.yaml
@@ -1,17 +1,17 @@
-test_duration: 40
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=30m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5"
+test_duration: 240
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5"
              ]
 
-n_db_nodes: 3
-n_loaders: 1
+n_db_nodes: 6
+n_loaders: 2
 n_monitor_nodes: 1
 
-instance_type_db: 'i3.2xlarge'
+instance_type_db: 'i3.4xlarge'
 gce_instance_type_db: 'n1-highmem-16'
 gce_instance_type_loader: 'e2-standard-4'
 scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-4.3.repo'
 
-nemesis_class_name: 'GrowShrinkClusterNemesis'
+nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '111'
 nemesis_interval: 2
 ssh_transport: 'libssh2'

--- a/test-cases/longevity/longevity-10gb-3h.yaml
+++ b/test-cases/longevity/longevity-10gb-3h.yaml
@@ -1,17 +1,17 @@
-test_duration: 240
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5"
+test_duration: 40
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=30m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5"
              ]
 
-n_db_nodes: 6
-n_loaders: 2
+n_db_nodes: 3
+n_loaders: 1
 n_monitor_nodes: 1
 
-instance_type_db: 'i3.4xlarge'
+instance_type_db: 'i3.2xlarge'
 gce_instance_type_db: 'n1-highmem-16'
 gce_instance_type_loader: 'e2-standard-4'
 scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-4.3.repo'
 
-nemesis_class_name: 'SisyphusMonkey'
+nemesis_class_name: 'GrowShrinkClusterNemesis'
 nemesis_seed: '111'
 nemesis_interval: 2
 ssh_transport: 'libssh2'


### PR DESCRIPTION
1. if nemesis failed, print failure message. Now we always get successful message
2. Add Disruption event when Grow cluster part is finished

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
