### PR TITLE
fix(k8s-eks): add aws_region option to basic k8s-eks job

### DIFF
--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-basic-3h-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-basic-3h-eks.jenkinsfile
@@ -4,6 +4,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 operatorPipeline(
     backend: 'k8s-eks',
+    aws_region: 'eu-north-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-basic-3h.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',


### PR DESCRIPTION
It is required option and must be set to run any EKS job correctly.
So add it to the only EKS job that doesn't have it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
