### PR TITLE
fix(k8s-logs): fix k8s log collector

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -147,7 +147,7 @@ class CommandLog(BaseLogEntity):  # pylint: disable=too-few-public-methods
     """
 
     def collect(self, node, local_dst, remote_dst=None, local_search_path=None) -> Optional[str]:
-        if not node.remoter or remote_dst is None:
+        if not node or not node.remoter or remote_dst is None:
             return None
         remote_logfile = LogCollector.collect_log_remotely(node=node,
                                                            cmd=self.cmd,
@@ -762,44 +762,6 @@ class ScyllaLogCollector(LogCollector):
         return super(ScyllaLogCollector, self).collect_logs(local_search_path)
 
 
-class KubernetesLogCollector(LogCollector):
-    """Minikube cluster log collecting
-
-    Collect on each node the logs for Scylla DB cluster
-
-    Extends:
-        LogCollector
-
-    Variables:
-        log_entities {list} -- LogEntities to collect
-        cluster_log_type {str} -- cluster type name
-    """
-    log_entities = [FileLog(name='system.log',
-                            command="sudo journalctl --no-tail --no-pager",
-                            search_locally=True),
-                    FileLog(name='scylla_operator.log', search_locally=True),
-                    FileLog(name='cert_manager.log', search_locally=True),
-                    FileLog(name='scylla_cluster_events.log', search_locally=True),
-                    CommandLog(name='cpu_info',
-                               command='cat /proc/cpuinfo'),
-                    CommandLog(name='mem_info',
-                               command='cat /proc/meminfo'),
-                    CommandLog(name='interrupts',
-                               command='cat /proc/interrupts'),
-                    CommandLog(name='vmstat',
-                               command='cat /proc/vmstat'),
-                    CommandLog(name='coredumps.info',
-                               command='sudo coredumpctl info')
-                    ]
-    cluster_log_type = "kubernetes"
-    cluster_dir_prefix = "k8s-"
-    collect_timeout = 600
-
-    def collect_logs(self, local_search_path=None):
-        self.collect_logs_for_inactive_nodes(local_search_path)
-        return super().collect_logs(local_search_path)
-
-
 class LoaderLogCollector(LogCollector):
     cluster_log_type = "loader-set"
     cluster_dir_prefix = "loader-set"
@@ -945,6 +907,20 @@ class SCTLogCollector(LogCollector):
         remove_files(self.local_dir)
         remove_files(final_archive)
         return s3_link
+
+
+class KubernetesLogCollector(SCTLogCollector):
+    """Gather K8S logs."""
+    # TODO: gather more logs when available
+    log_entities = [
+        FileLog(name='cert_manager.log', search_locally=True),
+        FileLog(name='scylla_manager.log', search_locally=True),
+        FileLog(name='scylla_operator.log', search_locally=True),
+        FileLog(name='scylla_cluster_events.log', search_locally=True),
+    ]
+    cluster_log_type = "kubernetes"
+    cluster_dir_prefix = "k8s-"
+    collect_timeout = 600
 
 
 class JepsenLogCollector(LogCollector):


### PR DESCRIPTION
All the logs we have for K8S are stored on a runner machine,
but current logic of k8s log collector assumes that we depend on a list of nodes.
So, reuse logic from "SCT log collector" that has the same approach for storing logs
and fix set of files to be searched in a log dir.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
