### PR TITLE
fix(mgmt agent repo): make the URL entry connect to the job

### DIFF
--- a/jenkins-pipelines/perf-regression-latency-250gb-with-nemesis.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-250gb-with-nemesis.jenkinsfile
@@ -8,7 +8,6 @@ perfRegressionParallelPipeline(
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: "test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml",
     sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"],
-    mgmt_agent_repo: "https://s3.amazonaws.com/downloads.scylladb.com/manager/deb/unstable/focal/branch-2.3/latest/scylla-manager-2.3/scylla-manager.list",
 
     timeout: [time: 1600, unit: "MINUTES"]
 )

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -27,6 +27,9 @@ def call(Map pipelineParams) {
             string(defaultValue: '', description: '', name: 'scylla_ami_id')
             string(defaultValue: '', description: '', name: 'scylla_version')
             string(defaultValue: '', description: '', name: 'scylla_repo')
+            string(defaultValue: ${pipelineParams.get('mgmt_agent_repo', 'https://s3.amazonaws.com/downloads.scylladb.com/manager/deb/unstable/focal/branch-2.3/latest/scylla-manager-2.3/scylla-manager.list')},
+                   description: 'default manager agent repo URL (on master it is on Ubuntu)',
+                   name: 'mgmt_agent_repo')
             string(defaultValue: "${pipelineParams.get('provision_type', 'spot')}",
                    description: 'spot_low_price|on_demand|spot_fleet|spot_low_price|spot_duration|spot',
                    name: 'provision_type')


### PR DESCRIPTION
it missed the part that connects the pipeline to the job
in Jenkins.
this new change will do it.

previous PR (#3425) missed the most important part, that is to connect the option in the Jenkins job.
this current change will do it (previous PR now allows to run jobs with Scylla master, but without the ability to change it).

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
