### PR TITLE
fix(prometheus): Don't return empty result if metric is missing

### DIFF
--- a/data_dir/scylla-dash-per-server-nemesis.master.json
+++ b/data_dir/scylla-dash-per-server-nemesis.master.json
@@ -329,7 +329,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(irate(scylla_transport_requests_served{cluster=~\"$cluster|$^\"}[60s])) + sum(irate(scylla_thrift_served{cluster=~\"$cluster|$^\"}[60s])) + (sum(irate(scylla_alternator_operation{cluster=~\"$cluster|$^\"}[60s])) or vector(0))",
+                                "expr": "(sum(irate(scylla_transport_requests_served{cluster=~\"$cluster|$^\"}[60s])) or vector(0)) + (sum(irate(scylla_thrift_served{cluster=~\"$cluster|$^\"}[60s])) or vector(0)) + (sum(irate(scylla_alternator_operation{cluster=~\"$cluster|$^\"}[60s])) or vector(0))",
                                 "intervalFactor": 1,
                                 "legendFormat": "Total Requests",
                                 "refId": "A",


### PR DESCRIPTION
if metric is missing then some prometheus query return empty
result and panel has no data.
Scylla issue: https://github.com/scylladb/scylla/issues/8497

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
