### PR TITLE
fix(convert s-b metrics): fix metric conversion to float

### DIFF
--- a/sdcm/scylla_bench_thread.py
+++ b/sdcm/scylla_bench_thread.py
@@ -225,7 +225,7 @@ class ScyllaBenchThread:
             if line.startswith('Results'):
                 enable_parse = True
                 continue
-            if line.startswith('Latency:') or ':' not in line:
+            if line.startswith('Latency:') or ':' not in line or 'EOF' in line:
                 continue
             if not enable_parse:
                 continue

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -2140,12 +2140,42 @@ def parse_nodetool_listsnapshots(listsnapshots_output: str) -> defaultdict:
 
 
 def convert_metric_to_ms(metric: str) -> float:
-    # Convert metric value to ms and float
+    """
+    Convert metric value to ms and float.
+    Expected values:
+        "8.592961906s"
+        "18.120703ms"
+        "5.963775µs"
+        "9h0m0.024080491s"
+        "1m0.024080491s"
+        "546431"
+        "950µs"
+        "30ms"
+    """
+    def _convert_to_ms(units, value):
+        if not value:
+            return 0
+
+        if units == 'hour':
+            return float(value) * 3600 * 1000
+        elif units == 'min':
+            return float(value) * 60 * 1000
+        elif units == 's':
+            return float(value) * 1000
+        elif units == 'µs':
+            return float(value) / 1000
+        else:
+            return float(value)
+
+    pattern = r"^((?P<hour>\d+)h)?((?P<min>\d+)m)?(?P<sec>\d+\.?(\d+)?)(?P<units>s|ms|µs)?"
     try:
-        if metric.endswith('µs'):
-            metric_converted = float(metric[:-2]) / 1000
-        elif metric.endswith('ms'):
-            metric_converted = float(metric[:-2])
+        found = re.match(pattern, metric)
+        if found:
+            parsed_values = found.groupdict()
+            metric_converted = 0
+            metric_converted += _convert_to_ms('hour', parsed_values['hour'])
+            metric_converted += _convert_to_ms('min', parsed_values['min'])
+            metric_converted += _convert_to_ms(parsed_values['units'], parsed_values['sec'])
         else:
             metric_converted = float(metric)
     except ValueError as ve:

--- a/unit_tests/test_utils_common.py
+++ b/unit_tests/test_utils_common.py
@@ -19,7 +19,7 @@ import unittest
 import unittest.mock
 from pathlib import Path
 
-from sdcm.utils.common import tag_ami
+from sdcm.utils.common import tag_ami, convert_metric_to_ms
 from sdcm.utils.common import download_dir_from_cloud
 
 logging.basicConfig(level=logging.DEBUG)
@@ -29,6 +29,14 @@ class TestUtils(unittest.TestCase):
     def test_tag_ami_01(self):  # pylint: disable=no-self-use
         tag_ami(ami_id='ami-0876bfff890e17a06',
                 tags_dict={'JOB_longevity-multi-keyspaces-60h': 'PASSED'}, region_name='eu-west-1')
+
+    def test_scylla_bench_metrics_conversion(self):
+        metrics = {"4ms": 4.0, "950µs": 0.95, "30ms": 30.0, "8.592961906s": 8592.961905999999,
+                   "18.120703ms": 18.120703, "5.963775µs": 0.005963775, "9h0m0.024080491s": 32400024.080491,
+                   "1m0.024080491s": 60024.080491, "546431": 546431.0}
+        for metric, converted in metrics.items():
+            actual = convert_metric_to_ms(metric)
+            assert actual == converted, f"Expected {converted}, got {actual}"
 
 
 class TestDownloadDir(unittest.TestCase):


### PR DESCRIPTION
Task https://trello.com/c/iY1FHM8k/3231-conversion-to-float-fails-during-scylla-bench-run
1. Fix metric convertion to float. Support different formats like:
8.592961906s
        18.120703ms
        5.963775µs
        9h0m0.024080491s
        1m0.024080491s
        546431
2. Ignore line with 'EOF' substring

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
