### PR TITLE
fix(email-report): Fix getting instance type for all the backends

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2796,13 +2796,19 @@ class ClusterTester(db_stats.TestStatsMixin,
         build_id = f'#{os.environ.get("BUILD_NUMBER")}' if os.environ.get('BUILD_NUMBER', '') else ''
         scylla_version = self.db_cluster.nodes[0].scylla_version_detailed if self.db_cluster else "N/A"
         kernel_version = self.db_cluster.nodes[0].kernel_version if self.db_cluster else "N/A"
-        if backend == "aws":
-            scylla_instance_type = self.params.get('instance_type_db') or "N/A"
-        elif backend == "gce":
-            scylla_instance_type = self.params.get('gce_instance_type_db') or "N/A"
-        else:
-            self.log.error(f"Can't discover instance type for {backend}!")
+
+        if backend in ("aws", "aws-siren", "k8s-eks"):
+            scylla_instance_type = self.params.get("instance_type_db") or "Unknown"
+        elif backend in ("gce", "gce-siren", "k8s-gke"):
+            scylla_instance_type = self.params.get("gce_instance_type_db") or "Unknown"
+        elif backend == "k8s-gce-minikube":
+            scylla_instance_type = self.params.get("gce_instance_type_minikube") or "Unknown"
+        elif backend in ("baremetal", "docker"):
             scylla_instance_type = "N/A"
+        else:
+            self.log.error(f"Don't know how to get instance type for the '{backend}' backend.")
+            scylla_instance_type = "N/A"
+
         job_name = os.environ.get('JOB_NAME').split("/")[-1] if os.environ.get('JOB_NAME') else config_file_name
         nodes_shards = self.all_nodes_scylla_shards()
 


### PR DESCRIPTION
Right now we have 'instance type' in an email report only using "aws" and "gce" backends.
Fix it making all the backends be correctly identified during the data gathering in the email report logic.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
