### PR TITLE
fix(email-report): fix calculation of scylla-version for email reports

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4120,6 +4120,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                 node.wait_jmx_up(verbose=verbose, timeout=200)
                 return
 
+            self.get_scylla_version()
             if Setup.BACKTRACE_DECODING:
                 node.install_scylla_debuginfo()
 


### PR DESCRIPTION
Right now, if we disable 'backtrace_decoding' then scylla-version doesn't get calculated and, as a result, email report doesn't have that value.
So, fix it by running 'get_scylla_version' method without regards to the 'backtrace_decoding' configuration.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
