### PR TITLE
fix(SaslauthdAuth): read config by remote_scylla_yaml helper

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1732,14 +1732,15 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         for user in LDAP_USERS:
             # Cannot create passwords with SaslauthdAuthenticator
             self.run_cqlsh(f'CREATE ROLE \'{user}\' WITH login=true')
-        result = self.remoter.run("grep -o '^authenticator: .*' /etc/scylla/scylla.yaml")
-        if 'com.scylladb.auth.SaslauthdAuthenticator' in result.stdout:
-            opposite_auth = 'PasswordAuthenticator'
-            update_authenticator([self], opposite_auth)
+        orig_auth = None
+        with self.remote_scylla_yaml() as scylla_yml:
+            if scylla_yml.get('authenticator') == 'com.scylladb.auth.SaslauthdAuthenticator':
+                orig_auth = 'com.scylladb.auth.SaslauthdAuthenticator'
+                opposite_auth = 'PasswordAuthenticator'
+                update_authenticator([self], opposite_auth)
         # First LDAP_USERS will be used to alter system tables, so change it to superuser.
         self.run_cqlsh(f'ALTER ROLE \'{LDAP_USERS[0]}\' with SUPERUSER=true and password=\'{LDAP_PASSWORD}\'')
-        if 'com.scylladb.auth.SaslauthdAuthenticator' in result.stdout:
-            orig_auth = 'com.scylladb.auth.SaslauthdAuthenticator'
+        if orig_auth:
             update_authenticator([self], orig_auth)
 
     # pylint: disable=invalid-name,too-many-arguments,too-many-locals,too-many-branches,too-many-statements


### PR DESCRIPTION
No functional change, just a cleanup.
Suggested by Fabio.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
