### PR TITLE
feature(nemesis.py) New rolling internode communication configuration…

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -513,6 +513,25 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         else:
             raise UnsupportedNemesis("SaslauthdAuthenticator can't work without saslauthd environment")
 
+    def disrupt_rolling_config_change_internode_compression(self):
+        def get_internode_compression_new_value_randomly(current_compression):
+            self.log.debug(f"Current compression is {current_compression}")
+            values = ['dc', 'all', 'none']
+            values_to_toggle = list(filter(lambda value: value != current_compression, values))
+            return random.choice(values_to_toggle)
+
+        self._set_current_disruption('RollingConfigAndRandomSetCompressionOnAllNodes')
+        key = 'internode_compression'
+        with self.target_node.remote_scylla_yaml() as scylla_yaml:
+            current = scylla_yaml.get(key, 'dummy_value_no_internode_compression_key_and_value')
+        new_value = get_internode_compression_new_value_randomly(current)
+        for node in self.cluster.nodes:
+            self.log.debug(f"Changing {node} inter node compression to {new_value}")
+            with node.remote_scylla_yaml() as scylla_yaml:
+                scylla_yaml[key] = new_value
+            self.log.info(f"Restarting node {node}")
+            node.restart_scylla_server()
+
     def disrupt_restart_with_resharding(self):
         self._set_current_disruption('RestartNodeWithResharding %s' % self.target_node)
         murmur3_partitioner_ignore_msb_bits = 15  # pylint: disable=invalid-name
@@ -3685,6 +3704,15 @@ class ClusterRollingRestart(Nemesis):
     @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_rolling_restart_cluster(random=False)
+
+
+class RollingRestartConfigChangeInternodeCompression(Nemesis):
+    disruptive = True
+    full_cluster_restart = True
+
+    @log_time_elapsed_and_status
+    def disrupt(self):
+        self.disrupt_rolling_config_change_internode_compression()
 
 
 class ClusterRollingRestartRandomOrder(Nemesis):


### PR DESCRIPTION
feature(nemesis.py) New rolling internode communication configuration change.
https://trello.com/c/toDOP4Mp/2749-new-nemesis-rolling-configuration-change-rolling-restart-with-a-config-change

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] ~~I added the relevant `backport` labels~~
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
-
