### PR TITLE
fix(performance_test): Wait compaction finalization before test

### DIFF
--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -445,8 +445,10 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
         # create new document in ES with doc_id = test_id + timestamp
         # allow to correctly save results for future compare
         self.create_test_stats(doc_id_with_timestamp=True)
-        # run a read workload
+        # wait compactions will be finished
+        self.wait_no_compactions_running()
         self.run_fstrim_on_all_db_nodes()
+        # run a read workload
         stress_queue = self.run_stress_thread(stress_cmd=base_cmd_r, stress_num=2, stats_aggregate_cmds=False)
         results = self.get_stress_results(queue=stress_queue)
 
@@ -478,6 +480,8 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
         # create new document in ES with doc_id = test_id + timestamp
         # allow to correctly save results for future compare
         self.create_test_stats(doc_id_with_timestamp=True)
+        # wait compactions will be finished
+        self.wait_no_compactions_running()
         self.run_fstrim_on_all_db_nodes()
         stress_queue = self.run_stress_thread(stress_cmd=base_cmd_m, stress_num=2, stats_aggregate_cmds=False)
         results = self.get_stress_results(queue=stress_queue)


### PR DESCRIPTION
Add to test_read and test_mixed (throughput tests) the no compaction
running waiter after preload data is done and berfore read/mixed
stress

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (CI)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
