### PR TITLE
test(perf-test): new performance test with not 100% cached

### DIFF
--- a/jenkins-pipelines/perf-regression-throughput-125gb.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-throughput-125gb.jenkinsfile
@@ -1,0 +1,14 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    aws_region: "us-east-1",
+    test_name: "performance_regression_test.PerformanceRegressionTest",
+    test_config: "test-cases/performance/perf-regression-throughput-125gb.yaml",
+    sub_tests: ["test_write", "test_read", "test_mixed"],
+
+    timeout: [time: 600, unit: "MINUTES"]
+)

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -430,17 +430,10 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
         2. Run a read workload
         """
 
-        base_cmd_w = self.params.get('prepare_write_cmd')
         base_cmd_r = self.params.get('stress_cmd_r')
-        # create new document in ES with doc_id = test_id + timestamp
-        # allow to correctly save results for future compare
-        self.create_test_stats(sub_type='write-prepare', doc_id_with_timestamp=True)
         self.run_fstrim_on_all_db_nodes()
         # run a write workload
-        stress_queue = self.run_stress_thread(stress_cmd=base_cmd_w, stress_num=2, prefix='preload-',
-                                              stats_aggregate_cmds=False)
-        self.get_stress_results(queue=stress_queue, store_results=False)
-        self.update_test_details()
+        self.preload_data()
 
         # create new document in ES with doc_id = test_id + timestamp
         # allow to correctly save results for future compare
@@ -462,18 +455,10 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
         2. Run a mixed workload
         """
 
-        base_cmd_w = self.params.get('prepare_write_cmd')
         base_cmd_m = self.params.get('stress_cmd_m')
-        # create new document in ES with doc_id = test_id + timestamp
-        # allow to correctly save results for future compare
-        self.create_test_stats(sub_type='write-prepare', doc_id_with_timestamp=True)
         self.run_fstrim_on_all_db_nodes()
         # run a write workload as a preparation
-        stress_queue = self.run_stress_thread(stress_cmd=base_cmd_w, stress_num=2, prefix='preload-',
-                                              stats_aggregate_cmds=False)
-        self.get_stress_results(queue=stress_queue, store_results=False)
-        self.update_test_details()
-
+        self.preload_data()
         # run a mixed workload
         # create new document in ES with doc_id = test_id + timestamp
         # allow to correctly save results for future compare

--- a/test-cases/performance/perf-regression-throughput-125gb.yaml
+++ b/test-cases/performance/perf-regression-throughput-125gb.yaml
@@ -1,0 +1,36 @@
+test_duration: 580
+
+prepare_write_cmd: ["cassandra-stress write no-warmup cl=ALL n=31250000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..31250000",
+                    "cassandra-stress write no-warmup cl=ALL n=31250000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=31250001..62500000",
+                    "cassandra-stress write no-warmup cl=ALL n=31250000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=62500001..93750000",
+                    "cassandra-stress write no-warmup cl=ALL n=31250000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=93750001..125000000"]
+
+
+stress_cmd_w: "cassandra-stress write no-warmup cl=ALL n=125000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=150 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..125000000"
+stress_cmd_r: "cassandra-stress read no-warmup  cl=QUORUM duration=60m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=150 -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..125000000,62500000,125000000)' "
+stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=60m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=150 -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..125000000,62500000,125000000)' "
+
+n_db_nodes: 3
+n_loaders: 4
+n_monitor_nodes: 1
+
+instance_type_loader: 'c5.2xlarge'
+instance_type_monitor: 't3.large'
+instance_type_db: 'i3.2xlarge'
+
+user_prefix: 'perf-throughput-disk-and-cache'
+space_node_threshold: 644245094
+ami_id_db_scylla_desc: 'VERSION_DESC'
+
+round_robin: true
+append_scylla_args: '--blocked-reactor-notify-ms 5'
+backtrace_decoding: false
+
+use_mgmt: true
+
+store_perf_results: true
+send_email: true
+email_recipients: ['scylla-perf-results@scylladb.com']
+backtrace_decoding: false
+
+email_subject_postfix: 'disk and cache'


### PR DESCRIPTION
added new performance test that is not 100% cached data

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
