### PR TITLE
fix(k8s-gke): use existing k8s version

### DIFF
--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -3,8 +3,8 @@ gce_datacenter: 'us-east1-b'
 gce_network: 'qa-vpc'
 gce_image_username: 'scylla-test'
 
-gke_cluster_version: '1.19.9-gke.100'
-gke_k8s_release_channel: 'rapid'
+gke_cluster_version: '1.19.9-gke.1400'
+gke_k8s_release_channel: ''
 
 gce_instance_type_db: 'n1-standard-8'
 gce_root_disk_type_db: 'pd-ssd'


### PR DESCRIPTION
Do 2 changes:
- switch to the 'static' k8s release channel, as it is preferred  due to possibility to disable autoupgrade.
- bump k8s version to the supported '1.19.9-gke.1400'. '1.19.9-gke.100' is not available anymore.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
