### PR TITLE
ci(getJobTimeouts): increase timeout for cleanup

### DIFF
--- a/vars/getJobTimeouts.groovy
+++ b/vars/getJobTimeouts.groovy
@@ -29,7 +29,7 @@ List<Integer> call(Map params, String region){
     Integer testStartupTimeout = 20
     Integer testTeardownTimeout = 40
     Integer collectLogsTimeout = 70
-    Integer resourceCleanupTimeout = 15
+    Integer resourceCleanupTimeout = 30
     Integer sendEmailTimeout = 5
     Integer testRunTimeout = testStartupTimeout + testDuration + testTeardownTimeout
     Integer runnerTimeout = testRunTimeout + collectLogsTimeout + resourceCleanupTimeout + sendEmailTimeout


### PR DESCRIPTION
Cleanup may take longer than 15 minutes.
So, increase it up to 30 minutes for now.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
