### PR TITLE
fix(kubernetes): Update ScyllaOperatorBasicOperationsMonkey

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3883,7 +3883,7 @@ class ScyllaOperatorBasicOperationsMonkey(Nemesis):
             'disrupt_grow_shrink_new_rack',
             'disrupt_stop_start_scylla_server',
             'disrupt_terminate_and_replace_node_kubernetes',
-            'disrupt_terminate_and_recover_node_kubernetes',
+            'disrupt_terminate_decommission_add_node_kubernetes',
             'disrupt_replace_node_kubernetes',
             'disrupt_mgmt_repair_cli',
             'disrupt_mgmt_backup_specific_keyspaces',


### PR DESCRIPTION
Update list of disruption methods in ScyllaOperatorBasicOperationsMonkey
nemesis by adding one missing element and removing another one unneeded.
Missing is 'disrupt_terminate_decommission_add_node_kubernetes'.
Unneded is 'disrupt_terminate_and_recover_node_kubernetes'.

The unneeded one is duplicate of other existing method called 'disrupt_terminate_and_replace_node_kubernetes'.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
