### PR TITLE
improvement(events): delete ScyllaOperatorRestartEvent event

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -72,7 +72,6 @@ ScyllaOperatorLogEvent: ERROR
 ScyllaOperatorLogEvent.REAPPLY: WARNING
 ScyllaOperatorLogEvent.TLS_HANDSHAKE_ERROR: WARNING
 ScyllaOperatorLogEvent.OPERATOR_STARTED_INFO: NORMAL
-ScyllaOperatorRestartEvent: ERROR
 StartupTestEvent: NORMAL
 TestTimeoutEvent: CRITICAL
 TestFrameworkEvent: ERROR

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -61,7 +61,7 @@ from sdcm.utils.remote_logger import get_system_logging_thread, CertManagerLogge
     KubectlClusterEventsLogger, ScyllaManagerLogger
 from sdcm.utils.version_utils import get_git_tag_from_helm_chart_version
 from sdcm.wait import wait_for
-from sdcm.cluster_k8s.operator_monitoring import ScyllaOperatorLogMonitoring, ScyllaOperatorStatusMonitoring
+from sdcm.cluster_k8s.operator_monitoring import ScyllaOperatorLogMonitoring
 
 
 ANY_KUBERNETES_RESOURCE = Union[Resource, ResourceField, ResourceInstance, ResourceList, Subresource]
@@ -239,7 +239,6 @@ class KubernetesCluster(metaclass=abc.ABCMeta):
     _scylla_cluster_events_thread: Optional[KubectlClusterEventsLogger] = None
 
     _scylla_operator_log_monitor_thread: Optional[ScyllaOperatorLogMonitoring] = None
-    _scylla_operator_status_monitor_thread: Optional[ScyllaOperatorStatusMonitoring] = None
     _token_update_thread: Optional[TokenUpdateThread] = None
     pools: Dict[str, CloudK8sNodePool]
 
@@ -450,8 +449,6 @@ class KubernetesCluster(metaclass=abc.ABCMeta):
         self._scylla_operator_journal_thread.start()
         self._scylla_operator_log_monitor_thread = ScyllaOperatorLogMonitoring(self)
         self._scylla_operator_log_monitor_thread.start()
-        self._scylla_operator_status_monitor_thread = ScyllaOperatorStatusMonitoring(self)
-        self._scylla_operator_status_monitor_thread.start()
 
     def start_scylla_cluster_events_thread(self) -> None:
         self._scylla_cluster_events_thread = KubectlClusterEventsLogger(self, self.scylla_cluster_event_log)
@@ -774,8 +771,6 @@ class KubernetesCluster(metaclass=abc.ABCMeta):
             self._cert_manager_journal_thread.stop(timeout)
         if self._scylla_operator_log_monitor_thread:
             self._scylla_operator_log_monitor_thread.stop()
-        if self._scylla_operator_status_monitor_thread:
-            self._scylla_operator_status_monitor_thread.stop()
         if self._scylla_operator_journal_thread:
             self._scylla_operator_journal_thread.stop(timeout)
         if self._scylla_cluster_events_thread:

--- a/sdcm/sct_events/operator.py
+++ b/sdcm/sct_events/operator.py
@@ -85,17 +85,6 @@ class ScyllaOperatorLogEvent(LogEvent):
         return self
 
 
-class ScyllaOperatorRestartEvent(SctEvent):
-    def __init__(self, restart_count):
-        super().__init__(severity=Severity.ERROR)
-
-        self.restart_count = restart_count
-
-    @property
-    def msgfmt(self):
-        return super().msgfmt + ": Scylla Operator has been restarted, restart_count={0.restart_count}"
-
-
 ScyllaOperatorLogEvent.add_subevent_type(
     "REAPPLY", severity=Severity.WARNING,
     regex="please apply your changes to the latest version and try again")
@@ -118,4 +107,4 @@ SCYLLA_OPERATOR_EVENT_PATTERNS: List[Tuple[re.Pattern, LogEventProtocol]] = \
     [(re.compile(event.regex, re.IGNORECASE), event) for event in SCYLLA_OPERATOR_EVENTS]
 
 
-__all__ = ("ScyllaOperatorLogEvent", "ScyllaOperatorRestartEvent", "SCYLLA_OPERATOR_EVENT_PATTERNS")
+__all__ = ("ScyllaOperatorLogEvent", "SCYLLA_OPERATOR_EVENT_PATTERNS")

--- a/unit_tests/test_sct_events_operator.py
+++ b/unit_tests/test_sct_events_operator.py
@@ -16,7 +16,7 @@ import re
 import unittest
 
 from sdcm.sct_events.base import LogEvent
-from sdcm.sct_events.operator import ScyllaOperatorLogEvent, ScyllaOperatorRestartEvent
+from sdcm.sct_events.operator import ScyllaOperatorLogEvent
 
 
 class TestOperatorEvents(unittest.TestCase):
@@ -67,12 +67,3 @@ class TestOperatorEvents(unittest.TestCase):
             f"line_number=0 node=N/A\n{log_record} None None: None, None",
             str(event),
         )
-
-    def test_scylla_operator_restart_event(self):
-        event = ScyllaOperatorRestartEvent(restart_count=10)
-        self.assertEqual(
-            str(event),
-            "(ScyllaOperatorRestartEvent Severity.ERROR): "
-            "Scylla Operator has been restarted, restart_count=10",
-        )
-        self.assertEqual(event, pickle.loads(pickle.dumps(event)))


### PR DESCRIPTION
scylla-operator v1.2 started having 2 pod instances where one is leader and second is replica trying to acquire lock.
And that replica may be restarted from time to time.
So, such change makes 'ScyllaOperatorRestartEvent' event become useless and, even more, harmful, because it is going to be triggered all the time and mark our tests as failed without real reason for it.
So, just delete it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
