### PR TITLE
fix(disrupt_memory_stress): use is_rhel_like, is_ubuntu as properties

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2797,10 +2797,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         no coredump, serious db error occur during the heavy load of memory.
         """
         self._set_current_disruption(f'MemoryStress on {self.target_node}')
-        if self.target_node.distro.is_rhel_like():
+        if self.target_node.distro.is_rhel_like:
             self.target_node.install_epel()
             self.target_node.remoter.sudo('yum install -y stress-ng')
-        elif self.target_node.distro.is_ubuntu():
+        elif self.target_node.distro.is_ubuntu:
             self.target_node.remoter.sudo('apt install -y stress-ng')
         else:
             raise UnsupportedNemesis(f"{self.target_node.distro} OS not supported!")


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
