### PR TITLE
fix(cassandra stress): Stress failure should stop the test immediately

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -64,6 +64,8 @@ KclStressEvent.start: NORMAL
 KclStressEvent.finish: NORMAL
 CassandraStressLogEvent.IOException: ERROR
 CassandraStressLogEvent.ConsistencyError: ERROR
+CassandraStressLogEvent.OperationOnKey: CRITICAL
+CassandraStressLogEvent.TooManyHintsInFlight: CRITICAL
 ScyllaBenchLogEvent.ConsistencyError: ERROR
 GeminiLogEvent.geminievent: CRITICAL
 PrometheusAlertManagerEvent.start: WARNING

--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -65,7 +65,9 @@ KclStressEvent.finish: NORMAL
 CassandraStressLogEvent.IOException: ERROR
 CassandraStressLogEvent.ConsistencyError: ERROR
 CassandraStressLogEvent.OperationOnKey: CRITICAL
-CassandraStressLogEvent.TooManyHintsInFlight: CRITICAL
+# TODO: change TooManyHintsInFlight severity to CRITICAL, when we have more stable hinted handoff backpressure
+# TODO: mechanism.
+CassandraStressLogEvent.TooManyHintsInFlight: ERROR
 ScyllaBenchLogEvent.ConsistencyError: ERROR
 GeminiLogEvent.geminievent: CRITICAL
 PrometheusAlertManagerEvent.start: WARNING

--- a/sdcm/sct_events/loaders.py
+++ b/sdcm/sct_events/loaders.py
@@ -147,7 +147,9 @@ class CassandraStressLogEvent(LogEvent, abstract=True):
 # Task: https://trello.com/c/kGply3WI/2718-stress-failure-should-stop-the-test-immediately
 CassandraStressLogEvent.add_subevent_type("OperationOnKey", severity=Severity.CRITICAL,
                                           regex=r"Operation x10 on key\(s\) \[")
-CassandraStressLogEvent.add_subevent_type("TooManyHintsInFlight", severity=Severity.CRITICAL,
+# TODO: change TooManyHintsInFlight severity to CRITICAL, when we have more stable hinted handoff
+# TODO: backpressure mechanism.
+CassandraStressLogEvent.add_subevent_type("TooManyHintsInFlight", severity=Severity.ERROR,
                                           regex="Too many hints in flight")
 
 CassandraStressLogEvent.add_subevent_type("IOException", severity=Severity.ERROR,

--- a/sdcm/sct_events/loaders.py
+++ b/sdcm/sct_events/loaders.py
@@ -140,7 +140,15 @@ KclStressEvent.add_stress_subevents(failure=Severity.ERROR)
 class CassandraStressLogEvent(LogEvent, abstract=True):
     IOException: Type[LogEventProtocol]
     ConsistencyError: Type[LogEventProtocol]
+    OperationOnKey: Type[LogEventProtocol]
+    TooManyHintsInFlight: Type[LogEventProtocol]
 
+
+# Task: https://trello.com/c/kGply3WI/2718-stress-failure-should-stop-the-test-immediately
+CassandraStressLogEvent.add_subevent_type("OperationOnKey", severity=Severity.CRITICAL,
+                                          regex=r"Operation x10 on key\(s\) \[")
+CassandraStressLogEvent.add_subevent_type("TooManyHintsInFlight", severity=Severity.CRITICAL,
+                                          regex="Too many hints in flight")
 
 CassandraStressLogEvent.add_subevent_type("IOException", severity=Severity.ERROR,
                                           regex=r"java\.io\.IOException")
@@ -151,6 +159,8 @@ CassandraStressLogEvent.add_subevent_type("ConsistencyError", severity=Severity.
 CS_ERROR_EVENTS = (
     CassandraStressLogEvent.IOException(),
     CassandraStressLogEvent.ConsistencyError(),
+    CassandraStressLogEvent.OperationOnKey(),
+    CassandraStressLogEvent.TooManyHintsInFlight(),
 )
 CS_ERROR_EVENTS_PATTERNS: List[Tuple[re.Pattern, LogEventProtocol]] = \
     [(re.compile(event.regex), event) for event in CS_ERROR_EVENTS]

--- a/unit_tests/test_sct_events_loaders.py
+++ b/unit_tests/test_sct_events_loaders.py
@@ -249,6 +249,8 @@ class TestCassandraStressLogEvent(unittest.TestCase):
     def test_known_cs_errors(self):
         self.assertTrue(issubclass(CassandraStressLogEvent.IOException, CassandraStressLogEvent))
         self.assertTrue(issubclass(CassandraStressLogEvent.ConsistencyError, CassandraStressLogEvent))
+        self.assertTrue(issubclass(CassandraStressLogEvent.OperationOnKey, CassandraStressLogEvent))
+        self.assertTrue(issubclass(CassandraStressLogEvent.TooManyHintsInFlight, CassandraStressLogEvent))
 
     def test_cs_error_events_list(self):
         self.assertSetEqual(set(dir(CassandraStressLogEvent)) - set(dir(LogEvent)),


### PR DESCRIPTION
Errors like:

- Operation x10 on key(s) [343638324b34504e3231 should stop the test immediately.
- Too many hints in flight

should raise critical event

Task: https://trello.com/c/kGply3WI/2718-stress-failure-should-stop-the-test-immediately

![Screenshot from 2021-04-25 14-19-42](https://user-images.githubusercontent.com/34435448/115991488-4b990700-a5d1-11eb-85b5-188148a8fe8f.png)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
