### PR TITLE
fix(kubrnetes nemesis): set current disruption for kubernetes nemesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -805,12 +805,13 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self._disrupt_terminate_and_recover_node_kubernetes(self.target_node, node_terminate_method_name)
 
     def disrupt_terminate_and_replace_node_kubernetes(self):  # pylint: disable=invalid-name
-        if not self._is_it_on_kubernetes():
-            raise UnsupportedNemesis('OperatorNodeTerminateAndReplace is supported only on kubernetes')
         for node_terminate_method_name in self._get_kubernetes_node_break_methods():
             self.set_target_node()
             self._set_current_disruption(
                 f'OperatorNodeTerminateAndReplace ({node_terminate_method_name}) {self.target_node}')
+            if not self._is_it_on_kubernetes():
+                raise UnsupportedNemesis('OperatorNodeTerminateAndReplace is supported only on kubernetes')
+
             self._disrupt_terminate_and_replace_node_kubernetes(self.target_node, node_terminate_method_name)
 
     def disrupt_terminate_decommission_add_node_kubernetes(self):  # pylint: disable=invalid-name


### PR DESCRIPTION
If 'UnsupportedNemesis' error is raised before current disruption was set,
the skipped nemesis is reported without its name.
Move 'UnsupportedNemesis' error after current disruption setting.

Example:
https://jenkins.scylladb.com/job/scylla-master/job/longevity/job/longevity-large-partition-asymmetric-cluster-3h/6/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
