### PR TITLE
improvement(kcl-stress): collect logs at the end of the test

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -782,6 +782,8 @@ class LoaderLogCollector(LogCollector):
                 search_locally=True),
         FileLog(name='scylla-bench-l*.log',
                 search_locally=True),
+        FileLog(name='kcl-l*.log',
+                search_locally=True),
     ]
 
     def collect_logs(self, local_search_path=None):


### PR DESCRIPTION
	The KCL stress logging configuration is enhanced.
	now it is usefull to collect it for Alternator Streams test analysis.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
