### PR TITLE
fix(k8s-monitoring): use just one values file for Helm chart

### DIFF
--- a/unit_tests/test_utils_k8s.py
+++ b/unit_tests/test_utils_k8s.py
@@ -1,0 +1,90 @@
+from sdcm.utils.k8s import HelmValues
+
+
+BASE_HELM_VALUES = {
+    "no_nesting_key": "no_nesting_value",
+    "nested_dict": {
+        "first_nested_dict_key": "first_nested_dict_value",
+        "second_nested_dict_key": "second_nested_dict_value",
+    },
+    "nested_list": [1, 2, 3],
+}
+
+
+def test_helm_values_init_with_dict_arg():
+    helm_values = HelmValues(BASE_HELM_VALUES)
+    assert helm_values.as_dict() == BASE_HELM_VALUES
+
+
+def test_helm_values_init_with_kwargs():
+    helm_values = HelmValues(**BASE_HELM_VALUES)
+    assert helm_values.as_dict() == BASE_HELM_VALUES
+
+
+def test_helm_values_get():
+    helm_values = HelmValues(BASE_HELM_VALUES)
+    assert helm_values.get("no_nesting_key") == "no_nesting_value"
+
+
+def test_helm_values_get_nonexistent():
+    helm_values = HelmValues(BASE_HELM_VALUES)
+    assert helm_values.get("fake_key") is None
+
+
+def test_helm_values_set_new():
+    helm_values = HelmValues(BASE_HELM_VALUES)
+    helm_values.set("new_key", "new_value")
+    assert helm_values.get("new_key") == "new_value"
+
+
+def test_helm_values_set_nested_new():
+    helm_values = HelmValues(BASE_HELM_VALUES)
+    helm_values.set("nested_dict.third_nested_dict_key", "third_nested_dict_value")
+    data = helm_values.as_dict()
+    assert "nested_dict" in data
+    assert "third_nested_dict_key" in data["nested_dict"]
+    assert data["nested_dict"]["third_nested_dict_key"] == "third_nested_dict_value"
+
+    assert "first_nested_dict_key" in data["nested_dict"]
+    assert data["nested_dict"]["first_nested_dict_key"] == "first_nested_dict_value"
+
+    assert "second_nested_dict_key" in data["nested_dict"]
+    assert data["nested_dict"]["second_nested_dict_key"] == "second_nested_dict_value"
+
+
+def test_helm_values_set_override():
+    helm_values = HelmValues(BASE_HELM_VALUES)
+    helm_values.set("no_nesting_key", "custom_value")
+    assert helm_values.get("no_nesting_key") == "custom_value"
+
+
+def test_helm_values_set_nested_override():
+    helm_values = HelmValues(BASE_HELM_VALUES)
+    helm_values.set("nested_dict.first_nested_dict_key", "new_value")
+    data = helm_values.as_dict()
+    assert "nested_dict" in data
+    assert "first_nested_dict_key" in data["nested_dict"]
+    assert data["nested_dict"]["first_nested_dict_key"] == "new_value"
+
+
+def test_helm_values_get_list():
+    helm_values = HelmValues(BASE_HELM_VALUES)
+    assert helm_values.get("nested_list") == [1, 2, 3]
+
+
+def test_helm_values_try_get_by_list_index():
+    helm_values = HelmValues(BASE_HELM_VALUES)
+    try:
+        helm_values.get("nested_list[0]")
+    except ValueError:
+        return
+    assert False, "expected 'ValueError' exception was not raised"
+
+
+def test_helm_values_try_set_by_list_index():
+    helm_values = HelmValues(BASE_HELM_VALUES)
+    try:
+        helm_values.set("nested_list[0]", 4)
+    except ValueError:
+        return
+    assert False, "expected 'ValueError' exception was not raised"


### PR DESCRIPTION
Current approach for installation of K8S monitoring uses two different 'values' files for Helm chart.
And it is problem just because Helm doesn't merge those and uses just one of it.
So, fix it by using one single set of values combined ourselves before applying it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
