### PR TITLE
fix(upgrade_test/yum): downgrade package with strict pattern

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -260,7 +260,7 @@ class UpgradeTest(FillDatabaseData):
             node.remoter.run('sudo systemctl daemon-reload')
 
         elif self.upgrade_rollback_mode == 'minor_release':
-            node.remoter.run(r'sudo yum downgrade scylla\*%s -y' % self.orig_ver.split('-')[0])
+            node.remoter.run(r'sudo yum downgrade scylla\*%s-\* -y' % self.orig_ver.split('-')[0])
         else:
             if new_introduced_pkgs:
                 node.remoter.run('sudo yum remove %s -y' % new_introduced_pkgs)


### PR DESCRIPTION
yum started to match the package name strictly from CentOS8.
This patch changed the downgrade command to use strict pattern.

Related: https://github.com/scylladb/scylla-enterprise/issues/1707

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
