### PR TITLE
fix(AMI loader): update both go and scylla-bench

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4486,7 +4486,7 @@ class BaseLoaderSet():
                           ">> /etc/security/limits.d/20-coredump.conf\"")
         if result.exit_status == 0:
             # Update existing scylla-bench to latest
-            node.remoter.run('go get -u github.com/scylladb/scylla-bench')
+            self.install_scylla_bench(node)
             self.log.debug('Skip loader setup for using a prepared AMI')
             return
 
@@ -4718,6 +4718,7 @@ class BaseLoaderSet():
                 apt-get install -y git
             """))
         node.remoter.sudo(shell_script_cmd("""\
+            rm -rf /usr/local/go
             curl -LO https://storage.googleapis.com/golang/go1.13.linux-amd64.tar.gz
             tar -C /usr/local -xvzf go1.13.linux-amd64.tar.gz
             echo 'export GOPATH=$HOME/go' >> $HOME/.bash_profile


### PR DESCRIPTION
ticket: https://trello.com/c/wfxdAsFz/3239-20211-longevity-5000-tables-test

In commit 2074826ef7bf78e015aaa9bd8e29fbe8625521a1, we updated go from
1.9.2 to 1.13 to avoid the scylla-bench install error.

But go in prepared AMI loader won't be updated, which caused
scylla-bench update fail.

This patch tried to clean the old go, and update the go for prepared AMI
loader.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
