### PR TITLE
fix(manager): internal wait functions to throw error on timeout

### DIFF
--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -273,7 +273,7 @@ class ManagerTask:
 
     def wait_for_status(self, list_status, check_task_progress=True, timeout=3600, step=120):
         text = "Waiting until task: {} reaches status of: {}".format(self.id, list_status)
-        is_status_reached = wait.wait_for(func=self.is_status_in_list, step=step,
+        is_status_reached = wait.wait_for(func=self.is_status_in_list, step=step, throw_exc=True,
                                           text=text, list_status=list_status, check_task_progress=check_task_progress,
                                           timeout=timeout)
         return is_status_reached
@@ -282,7 +282,7 @@ class ManagerTask:
         text = f"Waiting until task: {self.id} reaches at least {minimum_percentage}% progress"
         is_percentage_reached = wait.wait_for(func=self.has_progress_reached_percentage,
                                               minimum_percentage=minimum_percentage,
-                                              step=step, text=text, timeout=timeout)
+                                              step=step, text=text, timeout=timeout, throw_exc=True)
         return is_percentage_reached
 
     def has_progress_reached_percentage(self, minimum_percentage):
@@ -367,7 +367,7 @@ class BackupTask(ManagerTask):
     def wait_for_uploading_stage(self, timeout=1440, step=10):
         text = "Waiting until backup task: {} starts to upload snapshots".format(self.id)
         is_status_reached = wait.wait_for(func=self.is_task_in_uploading_stage, step=step,
-                                          text=text, timeout=timeout)
+                                          text=text, timeout=timeout, throw_exc=True)
         return is_status_reached
 
 


### PR DESCRIPTION
Since wait.wait_for does not throw exception when a timeout is reached by default,
I changed all of the wait_for function calls in sdcm.mgmt.cli to indeed throw
exception on timeout.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
