### PR TITLE
fix(alert manager): decrease alert CassandraStressWriteTooSlow severity to "warning"

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4718,7 +4718,7 @@ class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-inst
                 for: 1s
                 labels:
                   severity: "1"
-                  sct_severity: "ERROR"
+                  sct_severity: "WARNING"
                 annotations:
                   description: "Cassandra Stress write latency more than 1000ms"
                   summary: "Cassandra Stress write latency is more than 1000ms during 1 sec period of time"


### PR DESCRIPTION
	The purpose of this 4.3.x fix is to workaround the load drop alert,
	that is triggered folowing abort-repair nemesis.
	this is caused by: https://github.com/scylladb/scylla/issues/7840

The 4.3.3 failed test is: scylla-4.3/longevity/longevity-cdc-100gb-4h-test#51: 2021-04-07 17:05:16
The error is:
```
2021-04-07 20:19:17.712: (PrometheusAlertManagerEvent Severity.ERROR): alert_name=CassandraStressWriteTooSlow type=start start=2021-04-07T20:19:09.591Z end=2021-04-07T20:22:09.591Z description=Cassandra Stress write latency more than 1000ms updated=2021-04-07T20:19:10.636Z state=active fingerprint=14499e4f82cd948a labels={'alertname': 'CassandraStressWriteTooSlow', 'cassandra_stress_write': '0', 'cpu_idx': '0', 'instance': '10.0.0.4', 'job': 'sct_metrics', 'loader_idx': '1', 'monitor': 'scylla-monitor', 'sct_severity': 'ERROR', 'severity': '1', 'type': 'lat_perc_99'}
```


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
