### PR TITLE
fix(k8s-eks): fix usage of aws runner for EKS

### DIFF
--- a/vars/runCleanupResource.groovy
+++ b/vars/runCleanupResource.groovy
@@ -3,7 +3,7 @@
 def call(Map params, String region){
     def aws_region = initAwsRegionParam(params.aws_region, region)
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)
-    def cloud_provider = params.backend.trim().toLowerCase()
+    def cloud_provider = getCloudProviderFromBackend(params.backend)
 
     sh """
     #!/bin/bash

--- a/vars/runCollectLogs.groovy
+++ b/vars/runCollectLogs.groovy
@@ -4,7 +4,7 @@
 def call(Map params, String region){
     def aws_region = initAwsRegionParam(params.aws_region, region)
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)
-    def cloud_provider = params.backend.trim().toLowerCase()
+    def cloud_provider = getCloudProviderFromBackend(params.backend)
     sh """
     #!/bin/bash
 

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -4,7 +4,7 @@ def call(Map params, String region){
     // handle params which can be a json list
     def aws_region = initAwsRegionParam(params.aws_region, region)
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)
-    def cloud_provider = params.backend.trim().toLowerCase()
+    def cloud_provider = getCloudProviderFromBackend(params.backend)
 
     sh """
     #!/bin/bash

--- a/vars/runSendEmail.groovy
+++ b/vars/runSendEmail.groovy
@@ -13,7 +13,7 @@ def call(Map params, RunWrapper currentBuild){
     }
 
     def email_recipients = groovy.json.JsonOutput.toJson(params.email_recipients)
-    def cloud_provider = params.backend.trim().toLowerCase()
+    def cloud_provider = getCloudProviderFromBackend(params.backend)
 
     sh """
     #!/bin/bash


### PR DESCRIPTION
When we use EKS backend we create AWS runner, but do not use it.
The reason is that file vars/runSctTest.groovy uses wrong value for checking the backend.
So, fix it using proper value and making EKS really use AWS runner.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
