### PR TITLE
fix(k8s-eks): enable terminate and replace nemesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -60,6 +60,7 @@ from sdcm.db_stats import PrometheusDBStats
 from sdcm.remote.libssh2_client.exceptions import UnexpectedExit as Libssh2UnexpectedExit
 from sdcm.cluster_k8s import PodCluster
 from sdcm.cluster_k8s.minikube import MinikubeScyllaPodCluster
+from sdcm.cluster_k8s.eks import EksScyllaPodCluster
 from sdcm.cluster_k8s.gke import GkeScyllaPodCluster
 from sdcm.nemesis_publisher import NemesisElasticSearchPublisher
 from test_lib.compaction import CompactionStrategy, get_compaction_strategy, get_compaction_random_additional_params
@@ -731,7 +732,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         return new_node
 
     def _get_kubernetes_node_break_methods(self):
-        if isinstance(self.cluster, GkeScyllaPodCluster):
+        if isinstance(self.cluster, (GkeScyllaPodCluster, EksScyllaPodCluster)):
             return [
                 'drain_k8s_node',
                 # NOTE: enable below methods when it's support fully implemented
@@ -741,7 +742,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 # 'terminate_k8s_host',
                 # 'terminate_k8s_node',
             ]
-        raise UnsupportedNemesis("Only GkeScyllaPodCluster is supported")
+        raise UnsupportedNemesis("Only GKE and EKS backends support this nemesis")
 
     def _terminate_cluster_node(self, node):
         self.cluster.terminate_node(node)


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
