### PR TITLE
fix(kubernetes): add node affinity rules for dns resolver pod

### DIFF
--- a/sdcm/k8s_configs/dns-resolver-pod.yaml
+++ b/sdcm/k8s_configs/dns-resolver-pod.yaml
@@ -4,6 +4,46 @@ metadata:
   name: ${POD_NAME}
   namespace: default
 spec:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+
+      # EKS
+      - weight: 100
+        preference:
+          matchExpressions:
+          - key: eks.amazonaws.com/nodegroup
+            operator: In
+            values:
+            - auxiliary-pool
+            - default-pool
+      - weight: 50
+        preference:
+          matchExpressions:
+          - key: eks.amazonaws.com/nodegroup
+            operator: In
+            values:
+            - loader-pool
+            - monitoring-pool
+
+      # GKE
+      - weight: 100
+        preference:
+          matchExpressions:
+          - key: cloud.google.com/gke-nodepool
+            operator: In
+            values:
+            - auxiliary-pool
+            - default-pool
+      - weight: 50
+        preference:
+          matchExpressions:
+          - key: cloud.google.com/gke-nodepool
+            operator: In
+            values:
+            - loader-pool
+            - monitoring-pool
+
   containers:
   - name: ${POD_NAME}
     image: gcr.io/kubernetes-e2e-test-images/dnsutils:1.3


### PR DESCRIPTION
Nothing else except system and scylla pods must be scheduled on the scylla K8S nodes.
So, add node affinity rules for dns pod resolver the way that it will try to be scheduled on the default/auxiliary pool first and if cannot then on a loader or monitoring ones.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
