### PR TITLE
fix(upgrade_mgmt): skip interactive in upgrading scylla-manager

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2350,7 +2350,10 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             # 1) scylla-manager
             # 2) scylla-manager-client
             # 3) scylla-manager-server
-            self.remoter.run('sudo apt-get dist-upgrade scylla-manager-server scylla-manager-client -y ')
+            self.remoter.sudo('DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade '
+                              '-o Dpkg::Options::="--force-confold" '
+                              '-o Dpkg::Options::="--force-confdef" '
+                              'scylla-manager-server scylla-manager-client -y ')
         time.sleep(3)
         if start_manager_after_upgrade:
             if self.is_docker():


### PR DESCRIPTION
We should reserve those options for upgrade only.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
