### PR TITLE
fix(cdc.options): Fix assertion of cdc properties

### DIFF
--- a/sdcm/utils/cdc/options.py
+++ b/sdcm/utils/cdc/options.py
@@ -61,7 +61,7 @@ def parse_cdc_blob_settings(blob: bytes) -> Dict[str, Union[bool, str]]:
         res = re.search(regexp, blob.decode())
         if res:
             for key, value in res.groupdict().items():
-                if value == 'false':
+                if value == 'false' or value == "off":
                     value = False
                 elif value == 'true':
                     value = True


### PR DESCRIPTION
if cdc property was disabled with off, in table options
it stored with value false.
Current:  {'delta': 'full', 'enabled': True, 'preimage': False, 'postimage': True, 'ttl': '86400'} 
expected: {'delta': 'full', 'enabled': True, 'preimage': 'off', 'postimage': True, 'ttl': '86400'}

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [x] All new and existing unit tests passed (CI)
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
