### PR TITLE
fix(ubuntu2004): switch to new unified source

### DIFF
--- a/test-cases/artifacts/ubuntu2004.yaml
+++ b/test-cases/artifacts/ubuntu2004.yaml
@@ -13,7 +13,7 @@ n_loaders: 0
 n_monitor_nodes: 0
 nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'ubuntu-focal'
-scylla_repo: 'http://downloads.scylladb.com/deb/unstable/unified/master/latest/scylladb-master/scylla.list'
+scylla_repo: 'http://downloads.scylladb.com/unstable/scylla/master/deb/unified/latest/scylladb-master/scylla.list'
 test_duration: 60
 user_prefix: 'artifacts-ubuntu2004'
 system_auth_rf: 1


### PR DESCRIPTION
In collect-logs and clean-resources of artifacts-ubuntu2004-test,
ScyllaRepoEvent warnning are always raised, it's harmless.

(ScyllaRepoEvent Severity.WARNING):
  url=http://downloads.scylladb.com/deb/unstable/unified/master/latest/scylladb-master/scylla.list
  error=http://downloads.scylladb.com/deb/unstable/unified/master/latest/scylladb-master/scylla.list
  doesn't point to the latest repo (http://downloads.scylladb.com/deb/unstable/unified/master/2020-12-17T18:51:16Z/scylladb-master/scylla.list)
Actual latest build is 2020-12-17T18:51:16Z, not 2020-12-08T19:40:17Z

Actually we already moved to new directory:
- old: http://downloads.scylladb.com/deb/unstable/unified/master/latest/
- new: http://downloads.scylladb.com/unstable/scylla/master/deb/unified/latest/

This patch changed the default scylla_repo to new directory.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
