### PR TITLE
refactor(wait_for): Changed throw_exc default to True

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1360,7 +1360,7 @@ class BasePodContainer(cluster.BaseNode):
         if timeout is None:
             timeout = self.pod_replace_timeout
         wait_for(lambda: self.k8s_pod_uid and self.k8s_pod_uid != ignore_uid, timeout=timeout,
-                 text=f"Wait till host {self} get uid")
+                 text=f"Wait till host {self} get uid", throw_exc=False)
         return self.k8s_pod_uid
 
     def wait_for_k8s_node_readiness(self):

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1697,7 +1697,7 @@ class ClusterTester(db_stats.TestStatsMixin,
                                          step=5):  # pylint: disable=invalid-name
         text = 'waiting for the keyspace "{}" to be created in the cluster'.format(keyspace_name)
         does_keyspace_exist = wait.wait_for(func=self.is_keyspace_in_cluster, step=step, text=text, timeout=timeout,
-                                            session=session, keyspace_name=keyspace_name)
+                                            session=session, keyspace_name=keyspace_name, throw_exc=False)
         return does_keyspace_exist
 
     def create_keyspace(self, keyspace_name, replication_factor, replication_strategy=None):

--- a/sdcm/utils/aws_utils.py
+++ b/sdcm/utils/aws_utils.py
@@ -170,7 +170,8 @@ class EksClusterCleanupMixin:
             return wait_for(lambda: not self._get_attached_nodegroup_names(status='DELETING'),
                             text='Waiting till target nodegroups are deleted',
                             step=10,
-                            timeout=300)
+                            timeout=300,
+                            throw_exc=False)
 
         wait_for(_destroy_attached_nodegroups, timeout=400, throw_exc=False)
 

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -2110,6 +2110,7 @@ def reach_enospc_on_node(target_node):
                   timeout=300,
                   step=5,
                   text='Wait for new ENOSPC error occurs in database',
+                  throw_exc=False
                   )
 
 

--- a/sdcm/utils/k8s.py
+++ b/sdcm/utils/k8s.py
@@ -303,7 +303,8 @@ class ApiCallRateLimiter(threading.Thread):
             self.check_if_api_not_operational,
             timeout=max_waiting_time,
             kluster=kluster,
-            num_requests=num_requests
+            num_requests=num_requests,
+            throw_exc=False
         )
 
     def wait_till_api_become_stable(self, kluster, num_requests=20, max_waiting_time=1200):

--- a/sdcm/wait.py
+++ b/sdcm/wait.py
@@ -24,7 +24,7 @@ from tenacity import RetryError
 LOGGER = logging.getLogger('sdcm.wait')
 
 
-def wait_for(func, step=1, text=None, timeout=None, throw_exc=False, **kwargs):
+def wait_for(func, step=1, text=None, timeout=None, throw_exc=True, **kwargs):
     """
     Wrapper function to wait with timeout option.
 

--- a/unit_tests/test_wait.py
+++ b/unit_tests/test_wait.py
@@ -15,7 +15,7 @@ class TestSdcmWait(unittest.TestCase):
             calls.append((arg1, arg2))
             raise Exception("error")
 
-        wait_for(callback, timeout=1, step=0.5, arg1=1, arg2=3)
+        wait_for(callback, timeout=1, step=0.5, arg1=1, arg2=3, throw_exc=False)
         self.assertEqual(len(calls), 3)
 
     def test_02_throw_exc(self):
@@ -36,7 +36,7 @@ class TestSdcmWait(unittest.TestCase):
             calls.append((arg1, arg2))
             return False
 
-        wait_for(callback, timeout=1, step=0.5, arg1=1, arg2=3)
+        wait_for(callback, timeout=1, step=0.5, arg1=1, arg2=3, throw_exc=False)
         self.assertEqual(len(calls), 3)
 
     def test_03_false_return_rerise(self):
@@ -57,5 +57,5 @@ class TestSdcmWait(unittest.TestCase):
             calls.append((arg1, arg2))
             return 'what ever'
 
-        self.assertEqual(wait_for(callback, timeout=2, step=0.5, arg1=1, arg2=3), 'what ever')
+        self.assertEqual(wait_for(callback, timeout=2, step=0.5, arg1=1, arg2=3, throw_exc=False), 'what ever')
         self.assertEqual(len(calls), 1)


### PR DESCRIPTION
We've decided to change the default of throw_exc to True,
since when the function is used with throw_exc=False, and it reaches timeout,
there is next to no indication, other than a print message, that the wait_for has failed.
Also, this change aligns the default with the parallel function in dtest.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
