### PR TITLE
fix(k8s-eks): use latest scylla versions in upgrade CI jobs

### DIFF
--- a/jenkins-pipelines/operator/upgrade/upgrade-major-scylla-k8s-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-major-scylla-k8s-eks.jenkinsfile
@@ -5,8 +5,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 rollingOperatorUpgradePipeline(
     backend: 'k8s-eks',
     aws_region: 'eu-north-1',
-    base_versions: '["4.1.5"]',
-    new_version: '4.2.1',
+    base_versions: '["4.3.2"]',
+    new_version: '4.4.1',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_scylla_upgrade',
     test_config: 'test-cases/scylla-operator/kubernetes-scylla-upgrade.yaml',
 )

--- a/jenkins-pipelines/operator/upgrade/upgrade-scylla-k8s-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-scylla-k8s-eks.jenkinsfile
@@ -5,8 +5,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 rollingOperatorUpgradePipeline(
     backend: 'k8s-eks',
     aws_region: 'eu-north-1',
-    base_versions: '["4.2.0"]',
-    new_version: '4.2.1',
+    base_versions: '["4.4.0"]',
+    new_version: '4.4.1',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_scylla_upgrade',
     test_config: 'test-cases/scylla-operator/kubernetes-scylla-upgrade.yaml',
 )


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
