### PR TITLE
fix(kill_gemini_thread): Switch signal for kill gemini process

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4736,7 +4736,7 @@ class BaseLoaderSet():
         for loader in self.nodes:
             sb_active = loader.remoter.run(cmd='pgrep -f gemini', verbose=False, ignore_status=True)
             if sb_active.exit_status == 0:
-                kill_result = loader.remoter.run('pkill -f -QUIT gemini', ignore_status=True)
+                kill_result = loader.remoter.run('pkill -f -SIGINT gemini', ignore_status=True)
                 if kill_result.exit_status != 0:
                     self.log.warning('Terminate gemini on node %s:\n%s', loader, kill_result)
 


### PR DESCRIPTION
Change signal for kill gemini process to SIGINT, to avoid
gemini garbage printed to log.
Prevously, used signal SIGQUIT, and gemini on termination
print a lot of debug and trace information to jenkins log

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] ~I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)~
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (CI)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
