### PR TITLE
improvement(kubernetes): use latest versions for mgmt and mgmt-agent

### DIFF
--- a/defaults/k8s_eks_config.yaml
+++ b/defaults/k8s_eks_config.yaml
@@ -16,7 +16,7 @@ eks_vpc_cni_version: 'v1.7.5-eksbuild.1'
 eks_nodegroup_role_arn: 'arn:aws:iam::797456418907:role/helm-test-worker-nodes-NodeInstanceRole-6ACHDYEKNN3I'
 
 scylla_version: '4.4.1'
-scylla_mgmt_agent_version: '2.2.4'
+scylla_mgmt_agent_version: '2.3.0'
 k8s_cert_manager_version: '1.0.3'
 
 # Currently k8s monitoring does not work properly
@@ -44,4 +44,4 @@ n_db_nodes: 3
 
 append_scylla_args: ''
 docker_image: ''
-mgmt_docker_image: 'scylladb/scylla-manager:2.2.4'
+mgmt_docker_image: 'scylladb/scylla-manager:2.3.0'

--- a/defaults/k8s_gce_minikube_config.yaml
+++ b/defaults/k8s_gce_minikube_config.yaml
@@ -13,8 +13,8 @@ n_db_nodes: 3
 
 # '4.3.0' version doesn't work with GKE: https://github.com/scylladb/scylla/issues/8032
 scylla_version: '4.2.0'
-scylla_mgmt_agent_version: '2.2.1'
-mgmt_docker_image: 'scylladb/scylla-manager:2.2.1'
+scylla_mgmt_agent_version: '2.3.0'
+mgmt_docker_image: 'scylladb/scylla-manager:2.3.0'
 
 # NOTE: If 'k8s_scylla_operator_docker_image' not set then the one from helm chart will be used.
 # To test nightly builds define it like this: 'scylladb/scylla-operator:nightly'

--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -15,8 +15,8 @@ n_db_nodes: 3
 
 # '4.3.0' version doesn't work with GKE: https://github.com/scylladb/scylla/issues/8032
 scylla_version: '4.2.0'
-scylla_mgmt_agent_version: '2.2.4'
-mgmt_docker_image: 'scylladb/scylla-manager:2.2.4'
+scylla_mgmt_agent_version: '2.3.0'
+mgmt_docker_image: 'scylladb/scylla-manager:2.3.0'
 
 # NOTE: If 'k8s_scylla_operator_docker_image' not set then the one from helm chart will be used.
 # To test nightly builds define it like this: 'scylladb/scylla-operator:nightly'


### PR DESCRIPTION
Current latest is "2.3.0", so reuse it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
