### PR TITLE
improvement(build-id on reports): adding Scylla build-id

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -73,7 +73,7 @@ from sdcm.utils.health_checker import check_nodes_status, check_node_status_in_g
 from sdcm.utils.decorators import retrying, log_run_info
 from sdcm.utils.get_username import get_username
 from sdcm.utils.remotewebbrowser import WebDriverContainerMixin
-from sdcm.utils.version_utils import SCYLLA_VERSION_RE, BUILD_ID_RE, get_gemini_version, get_systemd_version
+from sdcm.utils.version_utils import SCYLLA_VERSION_RE, get_gemini_version, get_systemd_version
 from sdcm.sct_events.base import LogEvent
 from sdcm.sct_events.filters import EventsFilter
 from sdcm.sct_events.health import ClusterHealthValidatorEvent
@@ -1660,9 +1660,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
     def get_scylla_build_id(self) -> Optional[str]:
         for scylla_executable in ("/usr/bin/scylla", "/opt/scylladb/libexec/scylla", ):
-            output = self.remoter.run(f"readelf -n {scylla_executable}", ignore_status=True).stdout
-            if match := BUILD_ID_RE.search(output):
-                return match.group("build_id")
+            build_id_result = self.remoter.run(f"{scylla_executable} --build-id", ignore_status=True)
+            if build_id_result.ok:
+                return build_id_result.stdout.strip()
         return None
 
     def get_scylla_debuginfo_file(self):
@@ -2266,8 +2266,10 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         if result.ok:
             self.scylla_version_detailed = result.stdout.strip()
             if build_id := self.get_scylla_build_id():
+                self.scylla_version = self.scylla_version_detailed
                 self.scylla_version_detailed += f" with build-id {build_id}"
                 self.log.info(f"Found ScyllaDB version with details: {self.scylla_version_detailed}")
+            self.log.debug(f"self.scylla_version_detailed={self.scylla_version_detailed}")
         else:
             if self.distro.is_rhel_like:
                 cmd = f"rpm --query --queryformat '%{{VERSION}}' {self.scylla_pkg()}"
@@ -2289,7 +2291,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         if not self.scylla_version_detailed:
             self.scylla_version_detailed = self.scylla_version
 
-        return self.scylla_version
+        return self.scylla_version_detailed
 
     @log_run_info("Detecting disks")
     def detect_disks(self, nvme=True):

--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -453,6 +453,10 @@ class TestStatsMixin(Stats):
         versions = {}
         try:
             node = self.db_cluster.nodes[0]
+            if node.scylla_version_detailed and 'build-id' in node.scylla_version_detailed:
+                build_id = node.scylla_version_detailed.split('with build-id ')[-1].strip()
+            else:
+                build_id = node.get_scylla_build_id()
             if node.is_rhel_like():
                 version_cmd = 'rpm -qa |grep scylla'
             else:
@@ -465,7 +469,8 @@ class TestStatsMixin(Stats):
                     if match:
                         versions[package.replace('-enterprise', '')] = {'version': match.group(2),
                                                                         'date': match.group(4),
-                                                                        'commit_id': match.group(5)}
+                                                                        'commit_id': match.group(5),
+                                                                        'build_id': build_id if build_id else ''}
         except Exception as ex:  # pylint: disable=broad-except
             LOGGER.error('Failed getting scylla versions: %s', ex)
 

--- a/sdcm/nemesis_publisher.py
+++ b/sdcm/nemesis_publisher.py
@@ -46,13 +46,22 @@ class NemesisElasticSearchPublisher:
     def publish(self, disrupt_name, status=True, data=None):
         test_data = self.stats
         assert test_data, "without self.stats data we can't publish nemesis ES"
+        if 'scylla-server' in test_data['versions']:
+            version = test_data['versions']['scylla-server']['version']
+            commit_id = test_data['versions']['scylla-server']['commit_id']
+        elif 'version' in test_data['versions'] and 'commit_id' in test_data['versions']:
+            version = test_data['versions']['version']
+            commit_id = test_data['versions']['commit_id']
+        else:
+            version = ''
+            commit_id = ''
 
         new_nemesis_data = dict(
             test_id=test_data['test_details']['test_id'],
             job_name=test_data['test_details']['job_name'],
             test_name=test_data['test_details']['test_name'],
-            scylla_version=test_data['versions']['scylla-server']['version'],
-            scylla_git_sha=test_data['versions']['scylla-server']['commit_id'],
+            scylla_version=version,
+            scylla_git_sha=commit_id,
         )
         if status:
             new_nemesis_data.update(

--- a/sdcm/report_templates/results_latency_during_ops.html
+++ b/sdcm/report_templates/results_latency_during_ops.html
@@ -11,7 +11,11 @@
         <span class="blue">{{ test_id }}</span>
         <br>
         <span>Scylla Server Version: </span>
-        <span class="blue">{{ test_version }} </span>
+        {% if build_id %}
+            <span class="blue">{{ test_version }} with build-id {{ build_id }}</span>
+        {% else %}
+            <span class="blue">{{ test_version }}</span>
+        {% endif %}
     </h3>
     <div>
         <span> Setup Details: </span>

--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -53,8 +53,6 @@ SYSTEMD_VERSION_RE = re.compile(r"^systemd (?P<version>\d+)")
 
 REPOMD_XML_PATH = "repodata/repomd.xml"
 
-BUILD_ID_RE = re.compile(r"Build ID: (?P<build_id>\w+)")
-
 SCYLLA_URL_RESPONSE_TIMEOUT = 30
 SUPPORTED_XML_EXTENSIONS = ("xml", "xml.gz")
 SUPPORTED_FILE_EXTENSIONS = ("list", "repo", "Packages", "gz") + SUPPORTED_XML_EXTENSIONS

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -215,8 +215,8 @@ class TestBaseNodeGetScyllaVersion(unittest.TestCase):
             ("/usr/bin/scylla --version", (127, "", "bash: scylla: command not found\n")),
             ("rpm --query --queryformat '%{VERSION}' scylla", (0, "3.3.rc1", "")),
         ))
-        self.assertEqual(self.node.get_scylla_version(), "3.3.rc1")
-        self.assertEqual(self.node.scylla_version, "3.3.rc1")
+        self.assertEqual("3.3.rc1", self.node.get_scylla_version())
+        self.assertEqual("3.3.rc1", self.node.scylla_version)
 
     def test_no_scylla_binary_other(self):
         self.node.distro = Distro.DEBIAN9
@@ -224,42 +224,42 @@ class TestBaseNodeGetScyllaVersion(unittest.TestCase):
             ("/usr/bin/scylla --version", (127, "", "bash: scylla: command not found\n")),
             ("dpkg-query --show --showformat '${Version}' scylla", (0, "3.3~rc1-0.20200209.0d0c1d43188-1", "")),
         ))
-        self.assertEqual(self.node.get_scylla_version(), "3.3.rc1")
-        self.assertEqual(self.node.scylla_version, "3.3.rc1")
+        self.assertEqual("3.3.rc1", self.node.get_scylla_version())
+        self.assertEqual("3.3.rc1", self.node.scylla_version)
 
     def test_scylla(self):
         self.node.remoter = VersionDummyRemote(self, (
             ("/usr/bin/scylla --version", (0, "3.3.rc1-0.20200209.0d0c1d43188\n", "")),
-            ("readelf -n /usr/bin/scylla", (0, "Build ID: xxx", "")),
+            ("/usr/bin/scylla --build-id", (0, "xxx", "")),
         ))
-        self.assertEqual(self.node.get_scylla_version(), "3.3.rc1")
-        self.assertEqual(self.node.scylla_version, "3.3.rc1")
-        self.assertEqual(self.node.scylla_version_detailed, "3.3.rc1-0.20200209.0d0c1d43188 with build-id xxx")
+        self.assertEqual("3.3.rc1-0.20200209.0d0c1d43188 with build-id xxx", self.node.get_scylla_version())
+        self.assertEqual("3.3.rc1", self.node.scylla_version)
+        self.assertEqual("3.3.rc1-0.20200209.0d0c1d43188 with build-id xxx", self.node.scylla_version_detailed)
 
     def test_scylla_master(self):
         self.node.remoter = VersionDummyRemote(self, (
             ("/usr/bin/scylla --version", (0, "666.development-0.20200205.2816404f575\n", "")),
-            ("readelf -n /usr/bin/scylla", (0, "Build ID: xxx", "")),
+            ("/usr/bin/scylla --build-id", (0, "xxx", "")),
         ))
-        self.assertEqual(self.node.get_scylla_version(), "666.development")
-        self.assertEqual(self.node.scylla_version, "666.development")
+        self.assertEqual("666.development-0.20200205.2816404f575 with build-id xxx", self.node.get_scylla_version())
+        self.assertEqual("666.development", self.node.scylla_version)
 
     def test_scylla_master_new_format(self):
         self.node.remoter = VersionDummyRemote(self, (
             ("/usr/bin/scylla --version", (0, "4.4.dev-0.20200205.2816404f575\n", "")),
-            ("readelf -n /usr/bin/scylla", (0, "Build ID: xxx", "")),
+            ("/usr/bin/scylla --build-id", (0, "xxx", "")),
         ))
-        self.assertEqual(self.node.get_scylla_version(), "4.4.dev")
-        self.assertEqual(self.node.scylla_version, "4.4.dev")
+        self.assertEqual("4.4.dev-0.20200205.2816404f575 with build-id xxx", self.node.get_scylla_version())
+        self.assertEqual("4.4.dev", self.node.scylla_version)
 
     def test_scylla_enterprise(self):
         self.node.is_enterprise = True
         self.node.remoter = VersionDummyRemote(self, (
             ("/usr/bin/scylla --version", (0, "2019.1.4-0.20191217.b59e92dbd\n", "")),
-            ("readelf -n /usr/bin/scylla", (0, "Build ID: xxx", "")),
+            ("/usr/bin/scylla --build-id", (0, "xxx", "")),
         ))
-        self.assertEqual(self.node.get_scylla_version(), "2019.1.4")
-        self.assertEqual(self.node.scylla_version, "2019.1.4")
+        self.assertEqual("2019.1.4-0.20191217.b59e92dbd with build-id xxx", self.node.get_scylla_version())
+        self.assertEqual("2019.1.4", self.node.scylla_version)
 
     def test_scylla_enterprise_no_scylla_binary(self):
         self.node.is_enterprise = True
@@ -267,8 +267,8 @@ class TestBaseNodeGetScyllaVersion(unittest.TestCase):
             ("/usr/bin/scylla --version", (127, "", "bash: scylla: command not found\n")),
             ("rpm --query --queryformat '%{VERSION}' scylla-enterprise", (0, "2019.1.4", "")),
         ))
-        self.assertEqual(self.node.get_scylla_version(), "2019.1.4")
-        self.assertEqual(self.node.scylla_version, "2019.1.4")
+        self.assertEqual("2019.1.4", self.node.get_scylla_version())
+        self.assertEqual("2019.1.4", self.node.scylla_version)
 
 
 class TestBaseMonitorSet(unittest.TestCase):


### PR DESCRIPTION
there were many cases where the emails with report had
Scylla version, but without build-id. During perf jobs
while we bisect many issues and regressions, we had to
download either sct.log or db logs to find the build-id,
because if there were more than one build in the same day
the only way to identify the relocatable packages is using
the build-id.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
