### PR TITLE
improvement(fullscan): Add CQL TIMEOUT parameter to full-scan query

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1527,6 +1527,10 @@ class ClusterTester(db_stats.TestStatsMixin,
         cmd_select_all = 'select * from {}'
         cmd_bypass_cache = 'select * from {} bypass cache'
         cmd = random.choice([cmd_select_all, cmd_bypass_cache]).format(ks_cf)
+        if random.choice([True] * 2 + [False]):
+            cql_timeout_seconds = str(random.choice([2, 4, 8, 30, 120, 300]))
+            cql_timeout_param = f" USING TIMEOUT {cql_timeout_seconds}s"
+            cmd += cql_timeout_param
         try:
             credentials = self.db_cluster.get_db_auth()
             username, password = credentials if credentials else (None, None)


### PR DESCRIPTION
	In order to test real duration measurements, a random value for TIMEOUT
	is added to the full-scan query, ranges from 2 minutes to 5 hours.

Testing description:

SCT has a ‘full-scan’ nemesis-like operation that reads an entire table.
An optional ‘timeout’ parameter can be added to this query, that gets a randomized value between several minutes - to several hours.
During the time processing this query TIMEOUT threshold, the DB nodes are having other disruptive nemesis as well.

The idea is to challenge this new cql timeout mechanism and to generally verify there are no unexpected results. that means its queries either succeed or fail for the timeout threshold expected error message. it doesn't validate that the timeout did measure the correct time duration (that is covered in Dtest).
 
The full scans can last either few minutes or much longer (depend on selected table) so the idea is taking these specific time points to challenge both successful and unsuccessful query to all relevant tables and duration in a balanced probability.

see also full test plan here: https://docs.google.com/document/d/1TF_GmKWwjw3OsS_ZwGIScNUYrWjnWedRpVxzAcL2lqg/edit?usp=sharing

Trello task: https://trello.com/c/lMwG7YIV

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
