### PR TITLE
fix(k8s-eks-upgrade): make scylla upgrade on EKS be workable

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2755,8 +2755,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             return result
         except Exception as details:  # pylint: disable=broad-except
             event_severity_on_failure = Severity.ERROR
-            if warning_event_on_exception and type(details) in warning_event_on_exception or \
-                    Exception in warning_event_on_exception:
+            if warning_event_on_exception and isinstance(details, warning_event_on_exception):
                 event_severity_on_failure = Severity.WARNING
 
             self.log.critical(f"Command '{cmd}' error: {details}")

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -790,6 +790,7 @@ class UpgradeTest(FillDatabaseData):
         self.log.info('Step6 - Wait till cluster got upgraded')
         self.wait_till_scylla_is_upgraded_on_all_nodes(target_upgrade_version)
         self.log.info('Step7 - Upgrade sstables')
+        self.expected_sstable_format_version = self.get_highest_supported_sstable_version()
         upgradesstables = self.db_cluster.run_func_parallel(func=self.upgradesstables_if_command_available)
         # only check sstable format version if all nodes had 'nodetool upgradesstables' available
         if all(upgradesstables):


### PR DESCRIPTION
Operator upgrade job fails with following error:

```
    WARN  13:58:44,341 Unable to read cassandra-rackdc.properties
    error: DC or rack not found in snitch properties,
    check your configuration in: cassandra-rackdc.properties
```

Using scylla 4.4.1 docker image on K8S backends.

So, workaround it by copying 'cassandra-rackdc.properties' file to "/etc/scylla/cassandra" dir.

Also, handle "run_nodetool" method's exceptions correctly and calculate latest available sstable format automatically isntead of using hardcoded version.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
