### PR TITLE
test(scylla-manager): set use_mgmt on test_default.yaml

### DIFF
--- a/configurations/alternator/streams-with-nemesis.yaml
+++ b/configurations/alternator/streams-with-nemesis.yaml
@@ -2,5 +2,3 @@ user_prefix: 'alternator-streams-nemesis'
 nemesis_class_name: 'DecommissionMonkey'
 nemesis_interval: 30
 nemesis_during_prepare: true
-
-use_mgmt: true

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -97,7 +97,7 @@ stress_cdc_log_reader_batching_enable: true
 use_legacy_cluster_init: false
 internode_encryption: 'all'
 
-use_mgmt: false
+use_mgmt: true
 manager_prometheus_port: 5090
 scylla_mgmt_pkg: ''
 

--- a/internal_test_data/complex_test_case_with_version.yaml
+++ b/internal_test_data/complex_test_case_with_version.yaml
@@ -24,8 +24,6 @@ append_scylla_args: '--blocked-reactor-notify-ms 500  --abort-on-lsa-bad-alloc 1
 instance_provision: 'on_demand'
 
 
-use_mgmt: true
-
 user_credentials_path: '~/.ssh/scylla-test'
 gce_network: 'qa-vpc'
 gce_image: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'

--- a/internal_test_data/multi_region_dc_test_case.yaml
+++ b/internal_test_data/multi_region_dc_test_case.yaml
@@ -10,8 +10,6 @@ ip_ssh_connections: 'public'
 
 ami_id_db_scylla_desc: VERSION
 
-use_mgmt: true
-
 instance_type_loader: 'c5.large'
 instance_type_monitor: 't2.small'
 

--- a/test-cases/PR-provision-test.yaml
+++ b/test-cases/PR-provision-test.yaml
@@ -22,8 +22,6 @@ instance_provision: 'spot'
 
 gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
 
-use_mgmt: true
-
 scylla_version: "4.0.0"
 workaround_kernel_bug_for_iotune: true
 

--- a/test-cases/features/system-sla-test.yaml
+++ b/test-cases/features/system-sla-test.yaml
@@ -18,5 +18,3 @@ authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra
 authenticator_password: cassandra
 authorizer: 'ScyllaAuthorizer'
-
-use_mgmt: true

--- a/test-cases/longevity/longevity-100GB-48h-cloud-CloudLimitedChaosMonkey-tls.yaml
+++ b/test-cases/longevity/longevity-100GB-48h-cloud-CloudLimitedChaosMonkey-tls.yaml
@@ -23,8 +23,6 @@ user_prefix: 'longevity-100gb-48h-cloud-limited-tls'
 
 space_node_threshold: 644245094
 
-use_mgmt: true
-
 server_encrypt: true
 authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra

--- a/test-cases/longevity/longevity-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-100gb-4h.yaml
@@ -20,6 +20,5 @@ seeds_num: 3
 user_prefix: 'longevity-100gb-4h'
 space_node_threshold: 64424
 
-use_mgmt: true
 pre_create_schema: True
 sstable_size: 100

--- a/test-cases/longevity/longevity-1TB-7days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-1TB-7days-authorization-and-tls-ssl.yaml
@@ -51,6 +51,5 @@ authenticator_user: 'cassandra'
 authenticator_password: 'cassandra'
 authorizer: 'CassandraAuthorizer'
 
-use_mgmt: true
 nemesis_during_prepare: false
 use_preinstalled_scylla: true

--- a/test-cases/longevity/longevity-200GB-48h-network-monkey.yaml
+++ b/test-cases/longevity/longevity-200GB-48h-network-monkey.yaml
@@ -21,8 +21,6 @@ user_prefix: 'longevity-200gb-48h-network'
 
 space_node_threshold: 644245094
 
-use_mgmt: true
-
 server_encrypt: true
 authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra

--- a/test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
+++ b/test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
@@ -20,8 +20,6 @@ user_prefix: 'longevity-200gb-48h-verify-limited-tls'
 
 space_node_threshold: 644245094
 
-use_mgmt: true
-
 server_encrypt: true
 client_encrypt: true
 authenticator: 'PasswordAuthenticator'

--- a/test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
+++ b/test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
@@ -36,5 +36,3 @@ authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra
 authenticator_password: cassandra
 authorizer: 'CassandraAuthorizer'
-
-use_mgmt: true

--- a/test-cases/longevity/longevity-50GB-12h-verifier-LimitedMonkey-tls.yaml
+++ b/test-cases/longevity/longevity-50GB-12h-verifier-LimitedMonkey-tls.yaml
@@ -19,8 +19,6 @@ user_prefix: 'longevity-50gb-12h'
 
 space_node_threshold: 644245094
 
-use_mgmt: true
-
 server_encrypt: true
 client_encrypt: true
 authenticator: 'PasswordAuthenticator'

--- a/test-cases/longevity/longevity-alternator-200GB-48h.yaml
+++ b/test-cases/longevity/longevity-alternator-200GB-48h.yaml
@@ -49,8 +49,6 @@ alternator_enforce_authorization: true
 alternator_access_key_id: 'alternator'
 alternator_secret_access_key: 'password'
 
-use_mgmt: true
-
 server_encrypt: true
 client_encrypt: true
 authenticator: 'PasswordAuthenticator'

--- a/test-cases/longevity/longevity-alternator-3h-multidc.yaml
+++ b/test-cases/longevity/longevity-alternator-3h-multidc.yaml
@@ -46,7 +46,5 @@ alternator_port: 8080
 dynamodb_primarykey_type: HASH_AND_RANGE
 alternator_use_dns_routing: true
 
-use_mgmt: true
-
 ip_ssh_connections: 'public'
 intra_node_comm_public: true

--- a/test-cases/longevity/longevity-alternator-3h.yaml
+++ b/test-cases/longevity/longevity-alternator-3h.yaml
@@ -48,5 +48,3 @@ space_node_threshold: 64424
 alternator_port: 8080
 dynamodb_primarykey_type: HASH_AND_RANGE
 alternator_use_dns_routing: true
-
-use_mgmt: true

--- a/test-cases/longevity/longevity-counters-3h.yaml
+++ b/test-cases/longevity/longevity-counters-3h.yaml
@@ -15,5 +15,3 @@ space_node_threshold: 6442
 
 nemesis_class_name: 'ChaosMonkey'
 nemesis_interval: 5
-
-use_mgmt: true

--- a/test-cases/longevity/longevity-counters-multidc.yaml
+++ b/test-cases/longevity/longevity-counters-multidc.yaml
@@ -17,8 +17,6 @@ space_node_threshold: 6442
 nemesis_class_name: 'ChaosMonkey'
 nemesis_interval: 15
 
-use_mgmt: true
-
 server_encrypt: true
 internode_encryption: 'dc'
 

--- a/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
+++ b/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
@@ -19,8 +19,6 @@ user_prefix: 'longevity-encrypt-at-rest-200gb-6h-tls'
 
 space_node_threshold: 644245094
 
-use_mgmt: true
-
 server_encrypt: true
 authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra

--- a/test-cases/longevity/longevity-in-memory-36GB-1day.yaml
+++ b/test-cases/longevity/longevity-in-memory-36GB-1day.yaml
@@ -23,5 +23,3 @@ client_encrypt: false
 
 # 80GB in-memory storage - 36GB table is 45% of total in-memory store as recommended
 append_scylla_args: '--blocked-reactor-notify-ms 500  --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --in-memory-storage-size-mb 80000'
-
-use_mgmt: true

--- a/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
@@ -67,7 +67,4 @@ user_prefix: 'longevity-large-partitions-200k-pks-4d'
 
 space_node_threshold: 644245094
 
-# scylla-manager configuration
-# if running on aws and use_mgmt is true, the monitor image should not contain scylla
-use_mgmt: true
 stop_test_on_stress_failure: false

--- a/test-cases/longevity/longevity-large-partition-3h.yaml
+++ b/test-cases/longevity/longevity-large-partition-3h.yaml
@@ -40,7 +40,3 @@ nemesis_interval: 15
 user_prefix: 'longevity-large-partitions-3h'
 
 space_node_threshold: 644245094
-
-# scylla-manager configuration
-# if running on aws and use_mgmt is true, the monitor image should not contain scylla
-use_mgmt: true

--- a/test-cases/longevity/longevity-large-partition-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-4days.yaml
@@ -24,7 +24,3 @@ space_node_threshold: 644245094
 validate_partitions: true
 table_name: "scylla_bench.test"
 primary_key_column: "pk"
-
-# scylla-manager configuration
-# if running on aws and use_mgmt is true, the monitor image should not contain scylla
-use_mgmt: true

--- a/test-cases/longevity/longevity-large-partition-8h.yaml
+++ b/test-cases/longevity/longevity-large-partition-8h.yaml
@@ -46,7 +46,3 @@ nemesis_interval: 15
 user_prefix: 'longevity-large-partitions-8h'
 
 space_node_threshold: 644245094
-
-# scylla-manager configuration
-# if running on aws and use_mgmt is true, the monitor image should not contain scylla
-use_mgmt: true

--- a/test-cases/longevity/longevity-multi-keyspaces.yaml
+++ b/test-cases/longevity/longevity-multi-keyspaces.yaml
@@ -42,8 +42,5 @@ regions_data:
 # disables coredump on bad alloc temporary cause of https://github.com/scylladb/scylla/issues/4951
 append_scylla_args: '--blocked-reactor-notify-ms 500'
 
-# Manager
-use_mgmt: true
-
 # TODO: remove when https://github.com/scylladb/scylla-tools-java/issues/175 resolved
 stop_test_on_stress_failure: false

--- a/test-cases/longevity/longevity-mv-si-4days.yaml
+++ b/test-cases/longevity/longevity-mv-si-4days.yaml
@@ -22,7 +22,3 @@ nemesis_interval: 30
 user_prefix: 'longevity-mv-si-4d'
 
 space_node_threshold: 644245
-
-# scylla-manager configuration
-# if running on aws and use_mgmt is true, the monitor image should not contain scylla
-use_mgmt: true

--- a/test-cases/longevity/longevity-ndbench-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-ndbench-100gb-4h.yaml
@@ -24,5 +24,3 @@ nemesis_interval: 5
 
 user_prefix: 'longevity-ndbench-100gb-4h'
 space_node_threshold: 64424
-
-use_mgmt: true

--- a/test-cases/manager/manager-backup-1TB-gce.yaml
+++ b/test-cases/manager/manager-backup-1TB-gce.yaml
@@ -37,5 +37,4 @@ scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/un
 
 space_node_threshold: 644245094
 
-use_mgmt: true
 nemesis_during_prepare: false

--- a/test-cases/manager/manager-regression-gce.yaml
+++ b/test-cases/manager/manager-regression-gce.yaml
@@ -14,7 +14,5 @@ user_prefix: manager-regression
 space_node_threshold: 6442
 # ip_ssh_connections: 'public'
 
-use_mgmt: true
-
 gce_datacenter: 'us-east1'
 backup_bucket_location: 'manager-backup-tests-us-east1'

--- a/test-cases/manager/manager-regression-ipv6.yaml
+++ b/test-cases/manager/manager-regression-ipv6.yaml
@@ -18,6 +18,4 @@ user_prefix: manager-regression
 space_node_threshold: 6442
 ip_ssh_connections: 'ipv6'
 
-use_mgmt: true
-
 aws_instance_profile_name: 'qa-scylla-manager-backup-instance-profile'

--- a/test-cases/manager/manager-regression-multiDC-set-distro.yaml
+++ b/test-cases/manager/manager-regression-multiDC-set-distro.yaml
@@ -18,6 +18,4 @@ user_prefix: manager-regression
 space_node_threshold: 6442
 ip_ssh_connections: 'public'
 
-use_mgmt: true
-
 aws_instance_profile_name: 'qa-scylla-manager-backup-instance-profile'

--- a/test-cases/manager/manager-repair-control.yaml
+++ b/test-cases/manager/manager-repair-control.yaml
@@ -20,5 +20,3 @@ n_monitor_nodes: 1
 
 user_prefix: manager-repair-control
 space_node_threshold: 6442
-
-use_mgmt: true

--- a/test-cases/manager/manager-repair-intensity-multiple-repaired-nodes.yaml
+++ b/test-cases/manager/manager-repair-intensity-multiple-repaired-nodes.yaml
@@ -20,5 +20,3 @@ n_monitor_nodes: 1
 
 user_prefix: manager-repair
 space_node_threshold: 6442
-
-use_mgmt: true

--- a/test-cases/manager/manager-repair-intensity-single-repaired-nodes.yaml
+++ b/test-cases/manager/manager-repair-intensity-single-repaired-nodes.yaml
@@ -20,5 +20,3 @@ n_monitor_nodes: 1
 
 user_prefix: manager-repair
 space_node_threshold: 6442
-
-use_mgmt: true

--- a/test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml
+++ b/test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml
@@ -29,8 +29,6 @@ round_robin: true
 append_scylla_args: '--blocked-reactor-notify-ms 5'
 backtrace_decoding: false
 
-use_mgmt: true
-
 store_perf_results: true
 send_email: true
 email_recipients: ["scylla-perf-results@scylladb.com"]

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-backup.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-backup.yaml
@@ -7,7 +7,6 @@ n_monitor_nodes: 1
 
 nemesis_class_name: 'MgmtBackup'
 nemesis_interval: 5
-use_mgmt: true
 
 user_prefix: 'longevity-scylla-operator-3h'
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-repair.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-repair.yaml
@@ -7,7 +7,6 @@ n_monitor_nodes: 1
 
 nemesis_class_name: 'MgmtRepair'
 nemesis_interval: 5
-use_mgmt: true
 
 user_prefix: 'longevity-scylla-operator-3h'
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h.yaml
@@ -7,7 +7,6 @@ n_monitor_nodes: 1
 
 nemesis_class_name: 'KubernetesScyllaOperatorMonkey'
 nemesis_interval: 5
-use_mgmt: true
 
 user_prefix: 'longevity-scylla-operator-3h'
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-basic-3h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-basic-3h.yaml
@@ -7,7 +7,6 @@ n_monitor_nodes: 1
 
 nemesis_class_name: 'ScyllaOperatorBasicOperationsMonkey'
 nemesis_interval: 5
-use_mgmt: true
 
 user_prefix: 'longevity-scylla-operator-basic-3h'
 

--- a/test-cases/upgrades/manager-upgrade.yaml
+++ b/test-cases/upgrades/manager-upgrade.yaml
@@ -18,7 +18,6 @@ user_prefix: manager-upgrade
 space_node_threshold: 6442
 ip_ssh_connections: 'private'
 
-use_mgmt: true
 manager_prometheus_port: 10091
 scylla_mgmt_agent_repo: "http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.1.repo"
 


### PR DESCRIPTION
many tests already used scylla-manager, but now
the majority will use it too, unless set false
for the test yaml itself.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
