### PR TITLE
fix(test_defaults scylla_mgmt_agent_repo): Changing default manager

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -7,8 +7,8 @@ ip_ssh_connections: 'private'
 mgmt_port: 10090
 scylla_repo: ''
 scylla_repo_m: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylla-2020.1.repo'
-scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-2.2.repo'
-
+scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-2.3.repo'
+scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/focal/branch-2.3/latest/scylla-manager-2.3/scylla-manager.list'
 scylla_repo_loader: ''
 
 experimental: true


### PR DESCRIPTION
Since we switched to Ubuntu AMI instead of CentOS AMI, the manager
agent we need to install on the db nodes is ubuntu package.

For enterprise 2021.1 we will use latest released  manager version
which is 2.3 both for agent and server.

