### PR TITLE
fix(get_scylla_versions): add to regex corner case

### DIFF
--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -461,7 +461,7 @@ class TestStatsMixin(Stats):
             for line in versions_output:
                 for package in ['scylla-jmx', 'scylla-server', 'scylla-tools', 'scylla-enterprise-jmx',
                                 'scylla-enterprise-server', 'scylla-enterprise-tools']:
-                    match = re.search(r'(%s-([\w.]+)-(0.)?([0-9]{8,8}).(\w+).)' % package, line)
+                    match = re.search(r'(%s-([\w.~]+)-(0.)?([0-9]{8,8}).(\w+).)' % package, line)
                     if match:
                         versions[package.replace('-enterprise', '')] = {'version': match.group(2),
                                                                         'date': match.group(4),


### PR DESCRIPTION
we see in 4.5 jobs that it is not finding the results
because in the version i looked at, it had version as:
`scylla-server-4.5~rc1-0.20210429.b8a502fab0-1` and the
"~" wasn't being recognized in this case.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
