### PR TITLE
fix(k8s-gke): disable basic auth for K8S

### DIFF
--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -191,10 +191,10 @@ class GkeCluster(KubernetesCluster):
         with self.gcloud as gcloud:
             # NOTE: only static K8S release channel supports disabling of autoupgrade
             gcloud.run(f"container --project {self.gce_project} clusters create {self.short_cluster_name}"
+                       f" --no-enable-basic-auth"
                        f" --zone {self.gce_zone}"
                        f" --cluster-version {self.gke_cluster_version}"
                        f"{' --release-channel ' + self.gke_k8s_release_channel if self.gke_k8s_release_channel else ''}"
-                       f" --username admin"
                        f" --network {self.gce_network}"
                        f" --num-nodes {self.n_nodes}"
                        f" --machine-type {self.gce_instance_type}"


### PR DESCRIPTION
We use K8S 1.19 and going to use only newer versions later.
Then, basic authentication is deprecated in GKE and has been removed in GKE 1.19 and later.

So, stop using basic auth specifying "--no-enable-basic-auth" option.
Also, remove uage of "--username" one which is mutually exclusive with the above mentioned one.

Link: https://cloud.google.com/kubernetes-engine/docs/how-to/api-server-authentication#legacy-auth

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
