### PR TITLE
fix(replace nemesis): add sleep before repair

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -883,6 +883,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         new_node = self.replace_node(old_node_ip, rack=self.target_node.rack)
         try:
             if new_node.get_scylla_config_param("enable_repair_based_node_ops") == 'false':
+                time.sleep(300)  # sleep 5 minutes to give some time to the bootstrap will settle before running repair
                 InfoEvent(message='StartEvent - Run repair on new node').publish()
                 self.repair_nodetool_repair(new_node)
                 InfoEvent(message='FinishEvent - Finished running repair on new node').publish()


### PR DESCRIPTION
in a perf job we saw that while hints were replayed
the repair started running, causing peaks of latency
as both of them are competing for resources, and it
made pressure in the new node. Was suggested to add
a small sleep after the replace command, and before
running `nodetool repair` as both will run with less
pressure.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
