### PR TITLE
improvement(keep_alive): set to 11 hours

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -235,7 +235,7 @@ class Setup:
 
     @classmethod
     def should_keep_alive(cls, node_type: Optional[str]) -> bool:
-        if TEST_DURATION >= 24 * 60:
+        if TEST_DURATION >= 11 * 60:
             return True
         if node_type is None:
             return False


### PR DESCRIPTION
Cloud instance stopper stops GCE instances if
they are 11 hours old and untagged, and for AWS
the value is set to 12 hours. So selecting the min
between those to make sure our instances are not
stopped prematurely.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
