### PR TITLE
fix(scylla_rsyslog_setup): disable scylla_rsyslog_setup in branch-2021.1

### DIFF
--- a/test-cases/longevity/longevity-50GB-12h-verifier-LimitedMonkey-tls.yaml
+++ b/test-cases/longevity/longevity-50GB-12h-verifier-LimitedMonkey-tls.yaml
@@ -27,5 +27,3 @@ authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra
 authenticator_password: cassandra
 authorizer: 'CassandraAuthorizer'
-
-scylla_rsyslog_setup: true


### PR DESCRIPTION
scylla_rsyslog_setup is not supported in branch-2021.1.
Disable it

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
