### PR TITLE
fix(k8s-eks): gather monitoring set data correctly

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1136,18 +1136,14 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
                                                   tags={**self.tags, "NodeType": "loader", }))
 
     def get_running_cluster_sets(self, backend):
-        if backend == 'aws':
+        if backend in ("aws", "aws-siren", "k8s-eks"):
             self.get_aws_instances_by_testid()
-        elif backend == 'aws-siren':
-            self.get_aws_instances_by_testid()
-        elif backend == 'gce':
+        elif backend in ("gce", "gce-siren", "k8s-gke", "k8s-gce-minikube"):
             self.get_gce_instances_by_testid()
         elif backend == 'docker':
             self.get_docker_instances_by_testid()
-        elif backend == 'k8s-gce-minikube':
-            self.get_gce_instances_by_testid()
-        elif backend == 'k8s-gke':
-            self.get_gce_instances_by_testid()
+        else:
+            LOGGER.debug(f"get_running_cluster_sets: unknown backend type: {backend}")
 
     def run(self):
         """Run collect logs process as standalone operation


### PR DESCRIPTION
"k8s-eks" backend is new one and it is missing in the monitoring logs gathering logic.
So, fix it by making backend checks be "k8s-eks"-aware.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
