### PR TITLE
fix(disrupt_memory_stress): stress-ng install

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2805,7 +2805,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.target_node.install_epel()
             self.target_node.remoter.sudo('yum install -y stress-ng')
         elif self.target_node.distro.is_ubuntu:
-            self.target_node.remoter.sudo('apt install -y stress-ng')
+            # Install stress on Ubuntu: https://snapcraft.io/install/stress-ng/ubuntu
+            self.target_node.remoter.sudo('snap install stress-ng')
         else:
             raise UnsupportedNemesis(f"{self.target_node.distro} OS not supported!")
         self.log.info('Try to allocate 120% available memory, the allocated memory will be swaped out')


### PR DESCRIPTION
stress-ng install failed with error:
"No apt package 'stress-ng', but there is a snap with that name.
Try snap install stress-ng"

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
