### PR TITLE
fix(amazon2 artifact): changed manager repo defaults

### DIFF
--- a/jenkins-pipelines/artifacts-amazon2.jenkinsfile
+++ b/jenkins-pipelines/artifacts-amazon2.jenkinsfile
@@ -8,7 +8,7 @@ artifactsPipeline(
     backend: 'aws',
     region_name: 'eu-west-1',
     provision_type: 'spot_low_price',
-    scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-2.3.repo',
 
     timeout: [time: 60, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'


### PR DESCRIPTION
Removed unnecessary scylla_mgmt_repo from the pipeline file
and added proper scylla_mgmt_agent_repo default value to it.
This change was necessary due to the recent change to the default of scylla_mgmt_agent_repo
to contain a debian repo, instead of a centos one

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
