### PR TITLE
fix(artifact debian10): changed scylla_mgmt_agent_repo

### DIFF
--- a/jenkins-pipelines/artifacts-debian10.jenkinsfile
+++ b/jenkins-pipelines/artifacts-debian10.jenkinsfile
@@ -7,7 +7,7 @@ artifactsPipeline(
     test_config: 'test-cases/artifacts/debian10.yaml',
     backend: 'gce',
     provision_type: 'spot',
-    scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/buster/master/latest/scylladb-manager-master/scylla-manager.list',
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/buster/branch-2.3/latest/scylladb-manager-2.3/scylla-manager.list',
 
     timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'

--- a/jenkins-pipelines/nonroot-offline-install/artifacts-debian10.jenkinsfile
+++ b/jenkins-pipelines/nonroot-offline-install/artifacts-debian10.jenkinsfile
@@ -8,7 +8,7 @@ artifactsPipeline(
     backend: 'gce',
     nonroot_offline_install: true,
     provision_type: 'spot',
-    scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/buster/master/latest/scylladb-manager-master/scylla-manager.list',
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/buster/branch-2.3/latest/scylladb-manager-2.3/scylla-manager.list',
 
     timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'

--- a/test-cases/artifacts/debian10.yaml
+++ b/test-cases/artifacts/debian10.yaml
@@ -17,4 +17,4 @@ scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/debian/scylla-
 test_duration: 60
 user_prefix: 'artifacts-debian10'
 system_auth_rf: 1
-scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/debian/scylladb-manager-2.3-buster.list'
+scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/buster/branch-2.3/latest/scylladb-manager-2.3/scylla-manager.list'


### PR DESCRIPTION
Since the released repo,
http://downloads.scylladb.com.s3.amazonaws.com/deb/debian/scylladb-manager-2.3-buster.list,
is currently malformed, we deceided to change the agent repo to the latest unstable release.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
