### PR TITLE
fix(option parse): fix a typo in choise list of --dist-version

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -405,7 +405,7 @@ def list_ami_branch(region, version):
 @cli.command('list-repos', help='List repos url of Scylla formal versions')
 @click.option('-d', '--dist-type', type=click.Choice(['centos', 'ubuntu', 'debian']),
               default='centos', help='Distribution type')
-@click.option('-v', '--dist-version', type=click.Choice(['xenial', 'trusty', 'bionic', 'focal'  # Ubuntu
+@click.option('-v', '--dist-version', type=click.Choice(['xenial', 'trusty', 'bionic', 'focal',  # Ubuntu
                                                          'jessie', 'stretch', 'buster']),       # Debian
               default=None, help='deb style versions')
 def list_repos(dist_type, dist_version):


### PR DESCRIPTION
Lack of a comma after 'focal', then 'focal' and 'jessie' are connected
unexpectedly.

Error: Invalid value for "-v" / "--dist-version": invalid choice: focal.
       (choose from xenial, trusty, bionic, focaljessie, stretch, buster)

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
