### PR TITLE
fix(upgrade test): ignore "Can't find column family" err

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -94,6 +94,10 @@ def ignore_upgrade_schema_errors():
             line="cql_server - exception while processing connection: seastar::nested_exception "
                  "(seastar::nested_exception)",
         ))
+        stack.enter_context(DbEventsFilter(
+            db_event=DatabaseLogEvent.DATABASE_ERROR,
+            line="Can't find a column family with UUID"
+        ))
         yield
 
 


### PR DESCRIPTION
Eliran suggested to ignore the error when the first node gets upgraded
to enterprise until all nodes have the service_levels table propagated
to them.

Related issue: https://github.com/scylladb/scylla-enterprise/issues/1698

[only for branch-2021.1]

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
