### PR TITLE
feature (ami upgrade): split ami upgrade to two jobs

### DIFF
--- a/jenkins-pipelines/rolling-upgrade-ubuntu-ami.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-ubuntu-ami.jenkinsfile
@@ -5,8 +5,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'aws',
-    base_versions: ['2020.1', '4.3'],
-    linux_distro: 'centos',
+    base_versions: ['2021.1'],
+    linux_distro: 'ubuntu-focal',
 
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
     test_config: 'test-cases/upgrades/rolling-upgrade.yaml',

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -253,7 +253,7 @@ class UpgradeTest(FillDatabaseData):
             else:
                 node.remoter.run(r'sudo apt-get remove scylla\* -y')
                 node.remoter.run(
-                    r'sudo apt-get install %s -y '
+                    r'sudo apt-get install %s\* -y '
                     r'-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" ' % node.scylla_pkg())
                 node.remoter.run(
                     r'for conf in $(cat /var/lib/dpkg/info/scylla-*server.conffiles /var/lib/dpkg/info/scylla-*conf.conffiles /var/lib/dpkg/info/scylla-*jmx.conffiles | grep -v init ); do sudo cp -v $conf.backup $conf; done')

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -84,6 +84,10 @@ def call(Map pipelineParams) {
 
                                                         export SCT_CLUSTER_BACKEND=${params.backend}
 
+                                                        if [[ -n "${params.aws_region ? params.aws_region : ''}" ]] ; then
+                                                            export SCT_REGION_NAME=${aws_region}
+                                                        fi
+
                                                         export SCT_CONFIG_FILES=${test_config}
                                                         export SCT_SCYLLA_VERSION=${base_version}
                                                         export SCT_NEW_SCYLLA_REPO=${params.new_scylla_repo}


### PR DESCRIPTION
Currently 2021.1 in base_version switched to Ubuntu AMI, we should pass
different kind of new_scylla_repo to the subtests.

This patch split the tests to two jobs. I will create a new jenkins job,
and asked rel-eng to trigger it with Ubuntu AMI.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
