### PR TITLE
fix(longevity-1tb-7days-gce-jenkinsfile): Add a mgmt_agent_repo for c…

### DIFF
--- a/jenkins-pipelines/longevity-1tb-7days-gce.jenkinsfile
+++ b/jenkins-pipelines/longevity-1tb-7days-gce.jenkinsfile
@@ -7,4 +7,5 @@ longevityPipeline(
     backend: 'gce',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-1TB-7days-authorization-and-tls-ssl.yaml',
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.3.repo',
 )

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -39,6 +39,9 @@ def call(Map pipelineParams) {
             string(defaultValue: '', description: '', name: 'scylla_version')
             string(defaultValue: '', description: '', name: 'scylla_repo')
             string(defaultValue: '', description: '', name: 'scylla_mgmt_agent_version')
+            string(defaultValue: "${pipelineParams.get('scylla_mgmt_agent_repo', '')}",
+                   description: 'If empty - the default scylla manager agent repo will be taken',
+                   name: 'scylla_mgmt_agent_repo')
             string(defaultValue: "${pipelineParams.get('provision_type', 'spot')}",
                    description: 'spot|on_demand|spot_fleet',
                    name: 'provision_type')

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -39,6 +39,10 @@ def call(Map params, String region){
         export SCT_SCYLLA_MGMT_AGENT_VERSION=${params.scylla_mgmt_agent_version}
     fi
 
+    if [[ -n "${params.scylla_mgmt_agent_repo ? params.scylla_mgmt_agent_repo : ''}" ]] ; then
+        export SCT_SCYLLA_MGMT_AGENT_REPO=${params.scylla_mgmt_agent_repo}
+    fi
+
     if [[ -n "${params.scylla_ami_id ? params.scylla_ami_id : ''}" ]] ; then
         export SCT_AMI_ID_DB_SCYLLA="${params.scylla_ami_id}"
     elif [[ -n "${params.gce_image_db ? params.gce_image_db : ''}" ]] ; then


### PR DESCRIPTION
…entos

Since the gce image hasn't moved to ubuntu image yet, the job should use
a centos repo.
Base on @roydahan https://github.com/scylladb/scylla-cluster-tests/pull/3518 added
appropriate pipeline parameters to support mgmt_agent_repo configuration parameter
in jenkins job and jenkins pipeline files.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
