### PR TITLE
fix(scylla-upgrade): make fill_db_data module use proper queries

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -3018,6 +3018,9 @@ class FillDatabaseData(ClusterTester):
             # when it is True, not False as it is now.
             # As of now it behaves as "run_condition".
             if not item['skip'] and ('skip_condition' not in item or eval(str(item['skip_condition']))):
+                # NOTE: skip condition may change during upgrade, nail down it
+                # to be able to run proper queries on target scylla version
+                self.all_verification_items[i]['skip_condition'] = True
                 for create_table in item['create_tables']:
                     # wait a while before creating index, there is a delay of create table for waiting the schema agreement
                     if 'CREATE INDEX' in create_table.upper():
@@ -3028,6 +3031,8 @@ class FillDatabaseData(ClusterTester):
                         time.sleep(15)
                 for truncate in item['truncates']:
                     truncates.append(truncate)
+            else:
+                self.all_verification_items[i]['skip_condition'] = False
         # Sleep a while after creating test tables to avoid schema disagreement.
         # Refs: https://github.com/scylladb/scylla/issues/5235
         time.sleep(30)


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
