### PR TITLE
feature(MS AD): test saslauthdAuth with MS AD

### DIFF
--- a/configurations/ms-ad-ldap-authenticator.yaml
+++ b/configurations/ms-ad-ldap-authenticator.yaml
@@ -1,0 +1,8 @@
+use_ms_ad_ldap: true
+authenticator: 'com.scylladb.auth.SaslauthdAuthenticator'
+prepare_saslauthd: true
+use_saslauthd_authenticator: true
+authenticator_user: 'cassandra'
+authenticator_password: 'cassandra'
+
+authorizer: 'CassandraAuthorizer'

--- a/configurations/ms-ad-ldap-authorization-and-authentication.yaml
+++ b/configurations/ms-ad-ldap-authorization-and-authentication.yaml
@@ -6,4 +6,4 @@ authenticator_user: 'cassandra'
 authenticator_password: 'cassandra'
 
 authorizer: 'CassandraAuthorizer'
-#use_ldap_authorization: true
+use_ldap_authorization: true

--- a/configurations/ms-ad-ldap-authorization-and-authentication.yaml
+++ b/configurations/ms-ad-ldap-authorization-and-authentication.yaml
@@ -1,0 +1,9 @@
+use_ms_ad_ldap: true
+authenticator: 'com.scylladb.auth.SaslauthdAuthenticator'
+prepare_saslauthd: true
+use_saslauthd_authenticator: true
+authenticator_user: 'cassandra'
+authenticator_password: 'cassandra'
+
+authorizer: 'CassandraAuthorizer'
+#use_ldap_authorization: true

--- a/configurations/ms-ad-ldap.yaml
+++ b/configurations/ms-ad-ldap.yaml
@@ -3,3 +3,4 @@ authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra
 authenticator_password: cassandra
 authorizer: 'CassandraAuthorizer'
+use_ldap_authorization: true

--- a/jenkins-pipelines/longevity-100gb-4h-ldap-authorization-authenticator-ms-ad.jenkinsfile
+++ b/jenkins-pipelines/longevity-100gb-4h-ldap-authorization-authenticator-ms-ad.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/ms-ad-ldap-authorization-and-authentication.yaml"]''',
+
+    timeout: [time: 360, unit: 'MINUTES']
+)

--- a/jenkins-pipelines/longevity-10gb-3h-saslauthd-authenticator-ms-ad.jenkinsfile
+++ b/jenkins-pipelines/longevity-10gb-3h-saslauthd-authenticator-ms-ad.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-10gb-3h.yaml", "configurations/ms-ad-ldap-authenticator.yaml"]''',
+
+    timeout: [time: 300, unit: 'MINUTES']
+)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2724,7 +2724,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
     def _gen_nodetool_cmd(self, sub_cmd, args, options):
         credentials = self.parent_cluster.get_db_auth()
         if credentials:
-            options += '-u {} -pw {} '.format(*credentials)
+            options += "-u {} -pw '{}' ".format(*credentials)
         return f"{self.add_install_prefix('/usr/bin/nodetool')} {options} {sub_cmd} {args}"
 
     def run_nodetool(self, sub_cmd, args="", options="", timeout=None,
@@ -2909,7 +2909,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
     def _gen_cqlsh_cmd(self, command, keyspace, timeout, host, port, connect_timeout):
         """cqlsh [options] [host [port]]"""
         credentials = self.parent_cluster.get_db_auth()
-        auth_params = '-u {} -p {}'.format(*credentials) if credentials else ''
+        auth_params = "-u {} -p '{}'".format(*credentials) if credentials else ''
         use_keyspace = "--keyspace {}".format(keyspace) if keyspace else ""
         ssl_params = '--ssl' if self.parent_cluster.params.get("client_encrypt") else ''
         options = "--no-color {auth_params} {use_keyspace} --request-timeout={timeout} " \

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1923,10 +1923,10 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             if internode_compression:
                 scylla_yml['internode_compression'] = internode_compression
 
-            if ldap:
-                scylla_yml.update(self.get_ldap_config())
-            elif ms_ad_ldap:
+            if ldap and ms_ad_ldap:
                 scylla_yml.update(self.get_ldap_ms_ad_config())
+            elif ldap:
+                scylla_yml.update(self.get_ldap_config())
 
             if append_scylla_yaml:
                 scylla_yml.update(yaml.safe_load(append_scylla_yaml))

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -37,6 +37,7 @@ from cassandra import ConsistencyLevel
 from sdcm.cluster import SCYLLA_YAML_PATH, NodeSetupTimeout, NodeSetupFailed, ClusterNodesNotReady
 from sdcm.cluster import NodeStayInClusterAfterDecommission
 from sdcm.mgmt import TaskStatus
+from sdcm.utils.ldap import SASLAUTHD_AUTHENTICATOR
 from sdcm.utils.common import remote_get_file, get_db_tables, generate_random_string, \
     update_certificates, reach_enospc_on_node, clean_enospc_on_node, parse_nodetool_listsnapshots, \
     update_authenticator
@@ -495,10 +496,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         with self.target_node.remote_scylla_yaml() as scylla_yml:
             orig_auth = scylla_yml.get('authenticator')
-            if orig_auth == 'com.scylladb.auth.SaslauthdAuthenticator':
+            if orig_auth == SASLAUTHD_AUTHENTICATOR:
                 opposite_auth = 'PasswordAuthenticator'
             elif orig_auth == 'PasswordAuthenticator':
-                opposite_auth = 'com.scylladb.auth.SaslauthdAuthenticator'
+                opposite_auth = SASLAUTHD_AUTHENTICATOR
             else:
                 raise UnsupportedNemesis(
                     'This nemesis only supports to switch between SaslauthdAuthenticator and PasswordAuthenticator')

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -261,7 +261,7 @@ class SCTConfiguration(dict):
              help="When defined true, will install and start saslauthd service"),
 
         dict(name="use_ms_ad_ldap", env="SCT_USE_MS_AD_LDAP", type=boolean,
-             help="This option will use LDAP authorization from QA MS Active Directory"),
+             help="This option will use ldap server of QA MS Active Directory, not default openldap"),
 
         dict(name="use_mgmt", env="SCT_USE_MGMT", type=boolean,
              help="When define true, will install scylla management"),

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -291,12 +291,15 @@ class ClusterTester(db_stats.TestStatsMixin,
             Setup.configure_rsyslog(self.localhost, enable_ngrok=False)
 
         self.alternator: alternator.api.Alternator = alternator.api.Alternator(sct_params=self.params)
-        if self.params.get("use_ldap_authorization") or self.params.get("prepare_saslauthd") or self.params.get(
-                "use_saslauthd_authenticator"):
+        if (self.params.get("use_ldap_authorization") or self.params.get("prepare_saslauthd") or self.params.get(
+                "use_saslauthd_authenticator")) and not self.params.get("use_ms_ad_ldap"):
             self.configure_ldap(node=self.localhost, use_ssl=False)
+        if self.params.get("use_ms_ad_ldap"):
+            ldap_ms_ad_credentials = KeyStore().get_ldap_ms_ad_credentials()
+            Setup.LDAP_ADDRESS = ldap_ms_ad_credentials["server_address"]
 
         ldap_username = f'cn=admin,{LDAP_BASE_OBJECT}'
-        if self.params.get("use_ldap_authorization"):
+        if self.params.get("use_ldap_authorization") and not self.params.get("use_ms_ad_ldap"):
             self.params['are_ldap_users_on_scylla'] = False
             ldap_role = LDAP_ROLE
             ldap_users = LDAP_USERS.copy()
@@ -308,7 +311,7 @@ class ClusterTester(db_stats.TestStatsMixin,
                           {'uniqueMember': unique_members_list, 'userPassword': user_password}]
             self.localhost.add_ldap_entry(ip=ldap_address[0], ldap_port=ldap_address[1],
                                           user=ldap_username, password=LDAP_PASSWORD, ldap_entry=ldap_entry)
-        if self.params.get("prepare_saslauthd") or self.params.get("use_saslauthd_authenticator"):
+        if (self.params.get("prepare_saslauthd") or self.params.get("use_saslauthd_authenticator")) and not self.params.get("use_ms_ad_ldap"):
             ldap_users = LDAP_USERS.copy()
             ldap_address = list(Setup.LDAP_ADDRESS).copy()
             ldap_entry = [f'ou=Person,{LDAP_BASE_OBJECT}',

--- a/sdcm/utils/ldap.py
+++ b/sdcm/utils/ldap.py
@@ -25,10 +25,13 @@ LDAP_SSH_TUNNEL_LOCAL_PORT = 5001
 LDAP_SSH_TUNNEL_SSL_PORT = 5002
 ORGANISATION = 'ScyllaDB'
 LDAP_DOMAIN = 'scylla-qa.com'
-LDAP_PASSWORD = 'scylla'
+# Ths suffix is added to default cassandra password to make it stronger, otherwise MS-AD doesn't allow it
+DEFAULT_PWD_SUFFIX = '-0'
+LDAP_PASSWORD = 'scylla-0'
 LDAP_ROLE = 'scylla_ldap'
 LDAP_USERS = ['scylla-qa', 'dummy-user']
 LDAP_BASE_OBJECT = (lambda l: ','.join([f'dc={part}' for part in l.split('.')]))(LDAP_DOMAIN)
+SASLAUTHD_AUTHENTICATOR = 'com.scylladb.auth.SaslauthdAuthenticator'
 
 
 class LdapServerNotReady(Exception):


### PR DESCRIPTION
ticket: https://trello.com/c/7zOM6mFa/3205-ldap-sasl-authentication-with-ms-ad

    When saslauthdAuthenticator is used, the ldap server connected with
    saslauthd service can be Microsoft Active Directory(MS AD), docker ldap
    server is another option.
    
    The MS AD server we used is in AWS us-east-1, the LDAP users
    (cassandra/scylla-qa/qa-user/dummy) had been added in the server.
    
    - CN=cassandra,OU=People,DC=scylla-qa,DC=com
    - CN=scylla-qa,OU=People,DC=scylla-qa,DC=com
    - CN=qa-user,OU=People,DC=scylla-qa,DC=com
    - CN=dummy,OU=People,DC=scylla-qa,DC=com

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
