### PR TITLE
fix(cassandra-stress event): change regex to recognise 'hint in flight' message and event publish mechanism 

### DIFF
--- a/sdcm/sct_events/loaders.py
+++ b/sdcm/sct_events/loaders.py
@@ -150,7 +150,7 @@ CassandraStressLogEvent.add_subevent_type("OperationOnKey", severity=Severity.CR
 # TODO: change TooManyHintsInFlight severity to CRITICAL, when we have more stable hinted handoff
 # TODO: backpressure mechanism.
 CassandraStressLogEvent.add_subevent_type("TooManyHintsInFlight", severity=Severity.ERROR,
-                                          regex="Too many hints in flight")
+                                          regex=r"Too many hints in flight|Too many in flight hints")
 
 CassandraStressLogEvent.add_subevent_type("IOException", severity=Severity.ERROR,
                                           regex=r"java\.io\.IOException")
@@ -159,10 +159,10 @@ CassandraStressLogEvent.add_subevent_type("ConsistencyError", severity=Severity.
 
 
 CS_ERROR_EVENTS = (
+    CassandraStressLogEvent.TooManyHintsInFlight(),
+    CassandraStressLogEvent.OperationOnKey(),
     CassandraStressLogEvent.IOException(),
     CassandraStressLogEvent.ConsistencyError(),
-    CassandraStressLogEvent.OperationOnKey(),
-    CassandraStressLogEvent.TooManyHintsInFlight(),
 )
 CS_ERROR_EVENTS_PATTERNS: List[Tuple[re.Pattern, LogEventProtocol]] = \
     [(re.compile(event.regex), event) for event in CS_ERROR_EVENTS]

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -58,6 +58,7 @@ class CassandraStressEventsPublisher(FileFollowerThread):
                 for pattern, event in CS_ERROR_EVENTS_PATTERNS:
                     if pattern.search(line):
                         event.add_info(node=self.node, line=line, line_number=line_number).publish()
+                        break  # Stop iterating patterns to avoid creating two events for one line of the log
 
 
 class CassandraStressThread:  # pylint: disable=too-many-instance-attributes

--- a/unit_tests/test_sct_events_loaders.py
+++ b/unit_tests/test_sct_events_loaders.py
@@ -21,7 +21,7 @@ from sdcm.sct_events.base import LogEvent
 from sdcm.sct_events.loaders import \
     GeminiEvent, CassandraStressEvent, ScyllaBenchEvent, YcsbStressEvent, NdbenchStressEvent, CDCReaderStressEvent, \
     KclStressEvent, CassandraStressLogEvent, ScyllaBenchLogEvent, GeminiLogEvent, \
-    CS_ERROR_EVENTS, SCYLLA_BENCH_ERROR_EVENTS
+    CS_ERROR_EVENTS, SCYLLA_BENCH_ERROR_EVENTS, CS_ERROR_EVENTS_PATTERNS
 
 
 class TestGeminiEvent(unittest.TestCase):
@@ -255,6 +255,49 @@ class TestCassandraStressLogEvent(unittest.TestCase):
     def test_cs_error_events_list(self):
         self.assertSetEqual(set(dir(CassandraStressLogEvent)) - set(dir(LogEvent)),
                             {ev.type for ev in CS_ERROR_EVENTS})
+
+    def test_cs_hint_in_flight_error(self):
+        def _get_event(line, expected_type, expected_severity):
+            for pattern, event in CS_ERROR_EVENTS_PATTERNS:
+                if pattern.search(line):
+                    event.add_info(node='self.node', line=line, line_number=1)
+                    assert event.type == expected_type, \
+                        f'Unexpected event.type {event.type}. Expected "{expected_type}"'
+                    assert event.severity == expected_severity, \
+                        f'Unexpected event.severity {event.severity}. Expected "{expected_severity}"'
+                    return
+
+            raise ValueError(f"Event is not recognized in the line {line}. Expected exception type is {expected_type},"
+                             f"expected severity is {expected_severity}")
+
+        _get_event(line='java.io.IOException: Operation x10 on key(s) [334f37384f4d32303430]: Error executing: '
+                        '(OverloadedException): Queried host (10.0.3.167/10.0.3.167:9042) was overloaded: Too many '
+                        'in flight hints: 10490670',
+                   expected_type='TooManyHintsInFlight',
+                   expected_severity=Severity.ERROR)
+
+        _get_event(line='java.io.IOException: Operation x10 on key(s) [334f37384f4d32303430]: Error executing: '
+                        '(OverloadedException): Queried host (10.0.3.167/10.0.3.167:9042) was overloaded: Too many '
+                        'hints in flight: 10490670',
+                   expected_type='TooManyHintsInFlight',
+                   expected_severity=Severity.ERROR)
+
+        _get_event(line='java.io.IOException: Operation x10 on key(s) [334f37384f4d32303430]: Error executing: '
+                        '(OverloadedException): Queried host (10.0.3.167/10.0.3.167:9042) ',
+                   expected_type='OperationOnKey',
+                   expected_severity=Severity.CRITICAL)
+
+        _get_event(line='java.io.IOException: Connection reset by peer',
+                   expected_type='IOException',
+                   expected_severity=Severity.ERROR)
+
+        _get_event(line='03:56:37.572 [cluster1-nio-worker-4] DEBUG com.datastax.driver.core.Connection - Connection['
+                        '/10.0.3.121:9042-11, inFlight=5, closed=false] Response received on stream 17856 but no '
+                        'handler set anymore (either the request has timed out or it was closed due to another error). '
+                        'Received message is ERROR UNAVAILABLE: Cannot achieve consistency level for cl QUORUM. '
+                        'Requires 2, alive 1',
+                   expected_type='ConsistencyError',
+                   expected_severity=Severity.ERROR)
 
 
 class TestScyllaBenchLogEvent(unittest.TestCase):


### PR DESCRIPTION
Two changes:
1. fix 'hints in flight' regex as we have different messages
2. Stop iterating patterns to avoid creating two events for one line of the log

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
