### PR TITLE
fix(email): correct snapshot links according to name

### DIFF
--- a/sdcm/report_templates/results_base.html
+++ b/sdcm/report_templates/results_base.html
@@ -314,10 +314,10 @@
         {% endif %}
         {% if grafana_screenshots %}
             {% if grafana_screenshots[0] %}
-                <li><a href={{ grafana_screenshots[0] }}>Download "Per server metrics nemesis" Grafana Screenshot</a></li>
+                <li><a href={{ grafana_screenshots[0] }}>Download "Overview metrics" Grafana Screenshot</a></li>
             {% endif %}
             {% if grafana_screenshots[1] %}
-                <li><a href={{ grafana_screenshots[1] }}>Download "Overview metrics" Grafana Screenshot</a></li>
+                <li><a href={{ grafana_screenshots[1] }}>Download "Per server metrics nemesis" Grafana Screenshot</a></li>
             {% endif %}
             {% if grafana_screenshots[2] %}
                 <li><a href={{ grafana_screenshots[2] }}>Download "Alternator metrics" Grafana Screenshot</a></li>
@@ -325,10 +325,10 @@
         {% endif %}
         {% if grafana_snapshots %}
             {% if grafana_snapshots[0] %}
-                <li><a href={{ grafana_snapshots[0] }}>Shared "Per server metrics nemesis" Grafana Snapshot</a></li>
+                <li><a href={{ grafana_snapshots[0] }}>Shared "Overview metrics" Grafana Snapshot</a></li>
             {% endif %}
             {% if grafana_snapshots[1] %}
-                <li><a href={{ grafana_snapshots[1] }}>Shared "Overview metrics" Grafana Snapshot</a></li>
+                <li><a href={{ grafana_snapshots[1] }}>Shared "Per server metrics nemesis" Grafana Snapshot</a></li>
             {% endif %}
             {% if grafana_snapshots[2] %}
                 <li><a href={{  grafana_snapshots[2] }}>Shared "Alternator metrics" Grafana Snapshot</a></li>


### PR DESCRIPTION
Links of snapshots/screenshors are not according to its names.
It should be by this order:

```
base_grafana_dashboards = [
monitoring_ui.OverviewDashboard(),
monitoring_ui.ServerMetricsNemesisDashboard(),
]
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
