### PR TITLE
fix(TerminateAndRemoveNode): remove node from dead list

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2324,7 +2324,19 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             # the entire nemesis.
 
             exit_status = remove_node()
-            assert exit_status == 0, "nodetool removenode command exited with status {}".format(exit_status)
+
+            # if remove node command failed by any reason,
+            # we will remove the terminated node from
+            # dead_nodes_list, so the health validator terminate the job
+            if exit_status != 0:
+                self.log.error(f"nodetool removenode command exited with status {exit_status}")
+                self.log.debug(
+                    f"Remove failed node {node_to_remove} from dead node list {self.cluster.dead_nodes_list}")
+                node = next((n for n in self.cluster.dead_nodes_list if n.ip_address == node_to_remove.ip_address), None)
+                if node:
+                    self.cluster.dead_nodes_list.remove(node)
+                else:
+                    self.log.debug(f"Node {node.name} with ip {node.ip_address} was not found in dead_nodes_list")
 
             # verify node is removed by nodetool status
             removed_node_status = self.cluster.get_node_status_dictionary(


### PR DESCRIPTION
Nemesis TerminateAndRemoveNode fails on nodetool remove node
and could leave cluster with nodes in status DN Issue #3173.
if command `nodetool removenode` failed, remove node from
dead list allowing HealthValidator to terminate test with
critical event

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [x] All new and existing unit tests passed (CI)
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
