### PR TITLE
fix(k8s-gke): wait for minio app pod correctly

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -531,7 +531,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):
             namespace=MINIO_NAMESPACE)
 
         wait_for(lambda: self.minio_ip_address, text='Waiting for minio pod to popup', timeout=120, throw_exc=True)
-        self.kubectl("wait --timeout=10m --all --for=condition=Ready pod",
+        self.kubectl("wait --timeout=10m -l app=minio --for=condition=Ready pod",
                      timeout=605, namespace=MINIO_NAMESPACE)
 
     def get_scylla_cluster_helm_values(self, cpu_limit, memory_limit, pool_name: str = None) -> HelmValues:


### PR DESCRIPTION
Deploying minio service we get 2 pods created:
- Permanent one that serves as S3-like object storage
- Temporary one that creates predefined buckets

It happens that waiting for all the pods be in "Ready" state
timeout is reached just because second pod becomes "Completed"
and then gets deleted.

So, update waiter to wait for permanent pod only to avoid races.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
