### PR TITLE
feature(kubernetes): gather K8S logs after test ends

### DIFF
--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -28,9 +28,10 @@ from sdcm.cluster_k8s.iptables import IptablesPodIpRedirectMixin, IptablesCluste
 from sdcm.cluster_gce import MonitorSetGCE
 
 
-GKE_API_CALL_RATE_LIMIT = 0.5  # ops/s
+GKE_API_CALL_RATE_LIMIT = 5  # ops/s
 GKE_API_CALL_QUEUE_SIZE = 1000  # ops
-GKE_URLLIB_RETRY = 6  # How many times api request is retried before reporting failure
+GKE_URLLIB_RETRY = 5  # How many times api request is retried before reporting failure
+GKE_URLLIB_BACKOFF_FACTOR = 0.1
 
 LOADER_CLUSTER_CONFIG = sct_abs_path("sdcm/k8s_configs/gke-loaders.yaml")
 CPU_POLICY_DAEMONSET = sct_abs_path("sdcm/k8s_configs/cpu-policy-daemonset.yaml")
@@ -177,7 +178,8 @@ class GkeCluster(KubernetesCluster):
         self.api_call_rate_limiter = ApiCallRateLimiter(
             rate_limit=GKE_API_CALL_RATE_LIMIT,
             queue_size=GKE_API_CALL_QUEUE_SIZE,
-            urllib_retry=GKE_URLLIB_RETRY
+            urllib_retry=GKE_URLLIB_RETRY,
+            urllib_backoff_factor=GKE_URLLIB_BACKOFF_FACTOR,
         )
         self.api_call_rate_limiter.start()
 

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -15,6 +15,7 @@
 import datetime
 import logging
 import os
+from pathlib import Path
 import shutil
 import tempfile
 import time
@@ -219,6 +220,34 @@ class FileLog(CommandLog):
         if file_path := self.find_on_builder(builder, self.name, search_in_dir):
             if archive_logfile := LogCollector.archive_log_remotely(builder, file_path):
                 builder.remoter.receive_files(archive_logfile, local_dst, timeout=self.collect_timeout)
+
+
+class DirLog(FileLog):
+    """Get files that match provided filter keeping their dir placement the same.
+
+    It is useful when you want to copy whole dir with lots of files,
+    which could have dynamic names.
+
+    Usage example:
+         DirLog(name='some-dir-name-with-files/*', search_locally=True)
+    """
+
+    def collect(self, node, local_dst, remote_dst=None, local_search_path=None):
+        os.makedirs(local_dst, exist_ok=True)
+        if self.search_locally and local_search_path:
+            local_logfiles = self.find_local_files(local_search_path, self.name)
+            for logfile in local_logfiles:
+                relative_path = logfile.split(local_search_path)[-1]
+                if relative_path[0] == "/":
+                    relative_path = relative_path[1:]
+                current_dst = Path(local_dst) / relative_path
+                os.makedirs(str(current_dst).rsplit("/", 1)[0], exist_ok=True)
+                shutil.copy(src=logfile, dst=current_dst)
+        return local_dst
+
+    def collect_from_builder(self, builder, local_dst, search_in_dir) -> None:
+        # TODO: implement it to be able to gather whole dirs on remote nodes
+        raise NotImplementedError()
 
 
 class PrometheusSnapshots(BaseMonitoringEntity):
@@ -913,12 +942,14 @@ class SCTLogCollector(LogCollector):
 
 class KubernetesLogCollector(SCTLogCollector):
     """Gather K8S logs."""
-    # TODO: gather more logs when available
     log_entities = [
         FileLog(name='cert_manager.log', search_locally=True),
         FileLog(name='scylla_manager.log', search_locally=True),
         FileLog(name='scylla_operator.log', search_locally=True),
         FileLog(name='scylla_cluster_events.log', search_locally=True),
+        FileLog(name='kubectl.version', search_locally=True),
+        DirLog(name='cluster-scoped-resources/*', search_locally=True),
+        DirLog(name='namespaces/*', search_locally=True),
     ]
     cluster_log_type = "kubernetes"
     cluster_dir_prefix = "k8s-"

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2211,6 +2211,12 @@ class ClusterTester(db_stats.TestStatsMixin,
         self.stop_event_analyzer()
         self.stop_resources()
         self.get_test_failures()
+
+        # NOTE: running on K8S we need to gather logs otherwise a lot of
+        # debugging info is lost
+        if self.k8s_cluster:
+            self.k8s_cluster.gather_k8s_logs()
+
         if self.params.get('collect_logs'):
             self.collect_logs()
         self.clean_resources()


### PR DESCRIPTION
For the moment we have too few data kept after test run and we need alive cluster to debug when something goes wrong.
So, add logs gathering to be able to find failure root causes in most cases without a need to reproduce problems.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
