### PR TITLE
improvement(kubernetes): use custom cache dir for kubectl

### DIFF
--- a/sdcm/utils/k8s.py
+++ b/sdcm/utils/k8s.py
@@ -25,6 +25,7 @@ import contextlib
 from tempfile import NamedTemporaryFile
 from typing import Optional, Union, Callable, List
 from functools import cached_property
+from pathlib import Path
 
 import kubernetes as k8s
 import yaml
@@ -427,6 +428,8 @@ class KubernetesOps:
     @staticmethod
     def kubectl_cmd(kluster, *command, namespace=None, ignore_k8s_server_url=False):
         cmd = [KUBECTL_BIN, ]
+        if sct_test_logdir := os.environ.get('_SCT_TEST_LOGDIR'):
+            cmd.append(f"--cache-dir={Path(sct_test_logdir) / '.kube/http-cache'}")
         if not ignore_k8s_server_url and kluster.k8s_server_url is not None:
             cmd.append(f"--server={kluster.k8s_server_url}")
         if namespace:


### PR DESCRIPTION
When custom cache dir is not set for kubectl it uses '~/.kube/http-cache' dir as default one.
And we faced issue with this approach when default '.kube' dir had unexpected permissions and couldn't be accessed.
Impossibility to write cache caused significant slow down of interaction with K8S API server.

So, use the same dir for cache as we use for storing kubeconfig.
This dir is autocreated by test runner and won't have described problem.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
