### PR TITLE
fix(kubernetes): define KUBECONFIG running cleanup resources

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -47,6 +47,7 @@ import concurrent.futures
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 from concurrent.futures.thread import _python_exit
 import hashlib
+from pathlib import Path
 
 import boto3
 from mypy_boto3_s3 import S3Client, S3ServiceResource
@@ -1816,6 +1817,11 @@ def clean_resources_according_post_behavior(params, config, logdir, dry_run=Fals
     success = get_testrun_status(params.get('TestId'), logdir, only_critical=True)
     actions_per_type = get_post_behavior_actions(config)
     LOGGER.debug(actions_per_type)
+
+    # Define 'KUBECONFIG' env var that is needed in some cases on K8S backends
+    testrun_dir = get_testrun_dir(test_id=params.get('TestId'), base_dir=logdir)
+    os.environ['KUBECONFIG'] = str(Path(testrun_dir) / ".kube/config")
+
     for cluster_nodes_type, action_type in actions_per_type.items():
         if action_type["action"] == "keep":
             LOGGER.info("Post behavior %s for %s. Keep resources running", action_type["action"], cluster_nodes_type)


### PR DESCRIPTION
Needed at least by 'gcloud' when deleting GKE clusters.

Without it we get following error during above operation:

    ERROR: (gcloud.container.clusters.delete)
        Could not create directory [/~/.kube]: Permission denied.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
