### PR TITLE
improvement(disable_daily_triggered_services): remove unattended-upgrades and its config

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3066,6 +3066,13 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             self.remoter.sudo('systemctl stop apt-daily-upgrade.timer', ignore_status=True)
             self.remoter.sudo('systemctl stop apt-daily.service', ignore_status=True)
             self.remoter.sudo('systemctl stop apt-daily-upgrade.service', ignore_status=True)
+            self.wait_apt_not_running()
+            self.remoter.sudo('rm -f /etc/apt/apt.conf.d/*unattended-upgrades', ignore_status=True)
+            self.remoter.sudo('rm -f /etc/apt/apt.conf.d/*auto-upgrades', ignore_status=True)
+            self.remoter.sudo('rm -f /etc/apt/apt.conf.d/*periodic', ignore_status=True)
+            self.remoter.sudo('rm -f /etc/apt/apt.conf.d/*update-notifier', ignore_status=True)
+            self.remoter.sudo('apt-get remove -y unattended-upgrades', ignore_status=True)
+            self.remoter.sudo('apt-get remove -y update-manager', ignore_status=True)
 
 
 class FlakyRetryPolicy(RetryPolicy):


### PR DESCRIPTION
    Fabio already fix the apt lock problem around install scylla manager.
    But The problem may also occur in installing other packages, especial in the
    early phase of node setup. We can run wait_apt_not_running() before
    installtion to avoid the apt lock, but it's not convenient to change all
    related codes.
    
    This patch tried to disable unattended-upgrade by removing the package
    and config.

Ref: https://linoxide.com/enable-disable-unattended-upgrades-ubuntu-16-04/

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
