### PR TITLE
fix(artifactsPipeline): Added scylla_mgmt_agent_repo parameter

### DIFF
--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -29,6 +29,9 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('scylla_mgmt_repo', '')}",
                    description: 'a Scylla Manager repo to run against (for .rpm/.deb tests, should be blank otherwise)',
                    name: 'scylla_mgmt_repo')
+            string(defaultValue: "${pipelineParams.get('scylla_mgmt_agent_repo', '')}",
+                   description: 'manager agent repo',
+                   name: 'scylla_mgmt_agent_repo')
             string(defaultValue: '',
                    description: 'a Scylla AMI to run against (for AMI test, should be blank otherwise)',
                    name: 'scylla_ami_id')
@@ -107,6 +110,9 @@ def call(Map pipelineParams) {
                                                             export SCT_USE_MGMT=true
                                                             export SCT_SCYLLA_REPO_M="${params.scylla_repo}"
                                                             export SCT_SCYLLA_MGMT_REPO="${params.scylla_mgmt_repo}"
+                                                        fi
+                                                        if [[ ! -z "${params.scylla_mgmt_agent_repo}" ]] ; then
+                                                            export SCT_SCYLLA_MGMT_AGENT_REPO="${params.scylla_mgmt_agent_repo}"
                                                         fi
                                                     elif [[ ! -z "${params.unified_package}" ]]; then
                                                         export SCT_UNIFIED_PACKAGE="${params.unified_package}"


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
