### PR TITLE
fix(logcollector): log warning using DirLog class on remote nodes

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -247,7 +247,9 @@ class DirLog(FileLog):
 
     def collect_from_builder(self, builder, local_dst, search_in_dir) -> None:
         # TODO: implement it to be able to gather whole dirs on remote nodes
-        raise NotImplementedError()
+        LOGGER.warning(
+            "'DirLog' class doesn't support 'collect_from_builder' method. "
+            f"It is to be implemented. Ignoring gathering following logs: '{self.name}'")
 
 
 class PrometheusSnapshots(BaseMonitoringEntity):
@@ -1011,10 +1013,11 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
             MonitorLogCollector: self.monitor_set,
             SirenManagerLogCollector: self.siren_manager_set,
             LoaderLogCollector: self.loader_set,
-            KubernetesLogCollector: self.kubernetes_set,
             SCTLogCollector: self.sct_set,
             JepsenLogCollector: self.loader_set,
         }
+        if self.backend.startswith("k8s"):
+            self.cluster_log_collectors[KubernetesLogCollector] = self.kubernetes_set
 
     @property
     def test_id(self):


### PR DESCRIPTION
instead of raising 'NotImplementedError' exception.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
