### PR TITLE
improvement(results_latency_during_ops.html): color lines

### DIFF
--- a/sdcm/report_templates/results_latency_during_ops.html
+++ b/sdcm/report_templates/results_latency_during_ops.html
@@ -45,7 +45,11 @@
                         {% endfor %}
 
                         {% for lat_type in lat_type_list|sort %}
-                            <tr>
+                            {% if 'color' in results and lat_type in results['color'] and results['color'][lat_type] == 'red' %}
+                                <tr style ="background-color: red">
+                            {% else %}
+                                   <tr>
+                            {% endif %}
                                 <td>{{ lat_type }}</td>
                                 {% for cycle in results['cycles'] %}
                                     <td>{{ cycle[lat_type] }}</td>

--- a/sdcm/utils/latency.py
+++ b/sdcm/utils/latency.py
@@ -110,5 +110,11 @@ def calculate_latency(latency_results):
                 if steady_val != 0:
                     result_dict[key]['Relative to Steady'][temp_key] = \
                         format((float(average) - steady_val), '.2f')
+                if 'color' not in result_dict[key]:
+                    result_dict[key]['color'] = {}
+                if float(average) >= 3 * steady_val:  # right now it is only a 10% difference, to test if it works
+                    result_dict[key]['color'][temp_key] = 'red'
+                else:
+                    result_dict[key]['color'][temp_key] = 'blue'
 
     return result_dict


### PR DESCRIPTION
improvement(results_latency_during_ops.html): color lines

when the average value for the line will be greater
or equal to 3 times the steady state, the line will
be marked as read, to bring more attention to the
biggest latency increases.


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
