### PR TITLE
ci(artifactsPipeline): always export scylla_manager* params

### DIFF
--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -106,20 +106,22 @@ def call(Map pipelineParams) {
                                                         export SCT_SCYLLA_VERSION="${params.scylla_version}"
                                                     elif [[ ! -z "${params.scylla_repo}" ]]; then
                                                         export SCT_SCYLLA_REPO="${params.scylla_repo}"
-                                                        if [[ ! -z "${params.scylla_mgmt_repo}" ]]; then
-                                                            export SCT_USE_MGMT=true
-                                                            export SCT_SCYLLA_REPO_M="${params.scylla_repo}"
-                                                            export SCT_SCYLLA_MGMT_REPO="${params.scylla_mgmt_repo}"
-                                                        fi
-                                                        if [[ ! -z "${params.scylla_mgmt_agent_repo}" ]] ; then
-                                                            export SCT_SCYLLA_MGMT_AGENT_REPO="${params.scylla_mgmt_agent_repo}"
-                                                        fi
                                                     elif [[ ! -z "${params.unified_package}" ]]; then
                                                         export SCT_UNIFIED_PACKAGE="${params.unified_package}"
                                                         export SCT_NONROOT_OFFLINE_INSTALL=${params.nonroot_offline_install}
                                                     else
                                                         echo "need to choose one of SCT_GCE_IMAGE_DB | SCT_AMI_ID_DB_SCYLLA | SCT_SCYLLA_VERSION | SCT_SCYLLA_REPO | SCT_UNIFIED_PACKAGE"
                                                         exit 1
+                                                    fi
+
+                                                    if [[ ! -z "${params.scylla_mgmt_repo}" ]]; then
+                                                        export SCT_USE_MGMT=true
+                                                        export SCT_SCYLLA_REPO_M="${params.scylla_repo}"
+                                                        export SCT_SCYLLA_MGMT_REPO="${params.scylla_mgmt_repo}"
+                                                    fi
+
+                                                    if [[ ! -z "${params.scylla_mgmt_agent_repo}" ]] ; then
+                                                        export SCT_SCYLLA_MGMT_AGENT_REPO="${params.scylla_mgmt_agent_repo}"
                                                     fi
 
                                                     if [[ ! -z "${params.scylla_docker_image}" ]]; then


### PR DESCRIPTION
job https://jenkins.scylladb.com/job/scylla-master/job/
artifacts/job/artifacts-ami-test/387/consoleFull
was run with ami(centos). scylla_manager_agent_repo was set to use rpm packages,
but pipeline logic export provided parameter value only if scylla_repo was set.
Job failed because invalid deb link was written to yum repo conf file.

Move export parameter to use them independently

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
