### PR TITLE
improvement(results_latency_during_ops.html): add legend to table result

### DIFF
--- a/sdcm/report_templates/results_latency_during_ops.html
+++ b/sdcm/report_templates/results_latency_during_ops.html
@@ -64,6 +64,7 @@
                             </tr>
                         {% endfor %}
                     </table>
+                    <span STYLE="font-size:12px" class="red">* All latency values are in ms.</span>
                 {% endif %}
             {% endfor %}
         </div>

--- a/sdcm/report_templates/results_latency_during_ops.html
+++ b/sdcm/report_templates/results_latency_during_ops.html
@@ -27,6 +27,16 @@
         {% endfor %}
         </ul>
     </div>
+    <div>
+        {% for severity, events in debug_events.items() %}
+            {% if debug_events_summary.get(severity, 0) > 0 %}
+                <h3>
+                    <span>Amount of reactor stalls:</span>
+                    <span class="blue">{{ debug_events_summary.get(severity) }}</span>
+                </h3>
+            {% endif %}
+        {% endfor %}
+    </div>
         <div>
             {% for operation, results in stats.items() %}
                 {% if operation != 'Steady State' %}

--- a/sdcm/results_analyze/__init__.py
+++ b/sdcm/results_analyze/__init__.py
@@ -182,7 +182,7 @@ class LatencyDuringOperationsPerformanceAnalyzer(BaseResultsAnalyzer):
             events=events)
 
     def get_debug_events(self):
-        return self.get_events(event_severity=[Severity.DEBUG])
+        return self.get_events(event_severity=[Severity.DEBUG.name])
 
     def check_regression(self, test_id, data, is_gce=False):  # pylint: disable=too-many-locals, too-many-branches, too-many-statements
         doc = self.get_test_by_id(test_id)
@@ -198,9 +198,8 @@ class LatencyDuringOperationsPerformanceAnalyzer(BaseResultsAnalyzer):
             build_id = ''
 
         last_events, events_summary = self.get_events(event_severity=[
-            Severity.CRITICAL, Severity.ERROR, Severity.WARNING])
+            Severity.CRITICAL.name, Severity.ERROR.name, Severity.WARNING.name])
         reactor_stall_events, reactor_stall_events_summary = self.get_debug_events()
-
         subject = f'Performance Regression Compare Results (latency during operations) -' \
                   f' {test_name} - {test_version} - {str(test_start_time)}'
         results = dict(

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2447,7 +2447,7 @@ class ClusterTester(db_stats.TestStatsMixin,
                                                                           _registry=self.events_processes_registry))
         if self.db_cluster.latency_results and self.create_stats:
             self.db_cluster.latency_results = calculate_latency(self.db_cluster.latency_results)
-            self.log.debug(f'collected latency are: {self.db_cluster.latency_results}')
+            self.log.debug(f'collected latency values are: {self.db_cluster.latency_results}')
             self.update({"latency_during_ops": self.db_cluster.latency_results})
 
             self.update_test_details()


### PR DESCRIPTION
the tables have results of latency, and to be sure
every reader is in the same page, this commit will
be adding a legend to the tables, that the latency
results are displayed in ms (miliseconds).

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
