### PR TITLE
refactor(longevity-50gb-3d): Remove stress commands of compressed tables

### DIFF
--- a/test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml
@@ -1,18 +1,10 @@
 test_duration: 5000
-prepare_write_cmd: ["cassandra-stress write cl=QUORUM n=100000000 -schema 'replication(factor=3)                               compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native                    -rate threads=100 -pop seq=1..100000000",
-                    "cassandra-stress write cl=QUORUM n=100000000 -schema 'replication(factor=3) compression=LZ4Compressor     compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=lz4    -rate threads=20  -pop seq=1..100000000 -log interval=5",
-                    "cassandra-stress write cl=QUORUM n=100000000 -schema 'replication(factor=3) compression=ZstdCompressor    compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=none   -rate threads=20  -pop seq=1..100000000 -log interval=5",
-                    "cassandra-stress write cl=QUORUM n=100000000 -schema 'replication(factor=3) compression=SnappyCompressor  compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=snappy -rate threads=20  -pop seq=1..100000000 -log interval=5",
-                    "cassandra-stress write cl=QUORUM n=100000000 -schema 'replication(factor=3) compression=DeflateCompressor compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=none   -rate threads=20  -pop seq=1..100000000 -log interval=5"]
+prepare_write_cmd: ["cassandra-stress write cl=QUORUM n=100000000 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=1..100000000"]
 
-stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=4320m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native  -rate threads=50 -pop seq=1..100000000 -log interval=5",
+stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=4320m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native  -rate threads=100 -pop seq=1..100000000 -log interval=5",
              "cassandra-stress user profile=/tmp/cs_mv_profile.yaml ops'(insert=3,read1=1,read2=1,read3=1)' cl=QUORUM duration=4320m -port jmx=6868 -mode cql3 native -rate threads=20"]
 
-stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=4320m -port jmx=6868 -mode cql3 native  -rate threads=10 -pop seq=1..100000000 -log interval=5",
-                  "cassandra-stress read cl=QUORUM duration=4320m -schema 'replication(factor=3) compression=LZ4Compressor compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=lz4 -rate threads=10 -pop seq=1..100000000 -log interval=5",
-                  "cassandra-stress read cl=QUORUM duration=4320m -schema 'replication(factor=3) compression=ZstdCompressor compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=none -rate threads=10 -pop seq=1..100000000 -log interval=5",
-                  "cassandra-stress read cl=QUORUM duration=4320m -schema 'replication(factor=3) compression=SnappyCompressor compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=snappy -rate threads=10 -pop seq=1..100000000 -log interval=5",
-                  "cassandra-stress read cl=QUORUM duration=4320m -schema 'replication(factor=3) compression=DeflateCompressor compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=none -rate threads=10 -pop seq=1..100000000 -log interval=5"]
+stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=4320m -port jmx=6868 -mode cql3 native  -rate threads=50 -pop seq=1..100000000 -log interval=5"]
 
 run_fullscan: 'keyspace1.standard1, 60' # 'ks.cf|random, interval(min)''
 
@@ -32,8 +24,7 @@ user_prefix: 'longevity-tls-50gb-3d'
 space_node_threshold: 644245094
 
 server_encrypt: true
-# Setting client encryption to false for now, till we will find the way to make c-s work with that
-client_encrypt: false
+client_encrypt: true
 
 authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra


### PR DESCRIPTION
Since we introduced the critical event for stress failures, the
stress commands of compressed tables fails this longevity.
I decided to remove them from this longevity and added them to
a new longevity that will handle only compressed tables.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
