### PR TITLE
fix(offline install): disable scylla-manager for offline artifact-tests

### DIFF
--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -109,6 +109,7 @@ def call(Map pipelineParams) {
                                                     elif [[ ! -z "${params.unified_package}" ]]; then
                                                         export SCT_UNIFIED_PACKAGE="${params.unified_package}"
                                                         export SCT_NONROOT_OFFLINE_INSTALL=${params.nonroot_offline_install}
+                                                        export SCT_USE_MGMT=false
                                                     else
                                                         echo "need to choose one of SCT_GCE_IMAGE_DB | SCT_AMI_ID_DB_SCYLLA | SCT_SCYLLA_VERSION | SCT_SCYLLA_REPO | SCT_UNIFIED_PACKAGE"
                                                         exit 1


### PR DESCRIPTION
We already covered the scylla-manager tests in general artifact-tests,
and scylla-manager doesn't support offline installation right now.

Evgeniy disabled mgmt test for artifact test of Ubuntu 20.04 in commit
872e7962c. But use_mgmt is enabled by default by Fabio in commit d1ae0d063.

Currently we didn't pass scylla_mgmt_repo in trigger artifact-tests,
use_mgmt will be disabled after this change. When scylla_mgmt_repo is
assigned in executing the jenkins job, mgmt test will be enabled automatically.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
