### PR TITLE
improvement(Alternator Streams Longevity): Added a short 3 hours lonegevity with nemesis

### DIFF
--- a/configurations/alternator/streams-with-nemesis.yaml
+++ b/configurations/alternator/streams-with-nemesis.yaml
@@ -1,4 +1,4 @@
 user_prefix: 'alternator-streams-nemesis'
 nemesis_class_name: 'DecommissionMonkey'
-nemesis_interval: 30
+nemesis_interval: 700
 nemesis_during_prepare: true

--- a/configurations/alternator/streams-with-nemesis.yaml
+++ b/configurations/alternator/streams-with-nemesis.yaml
@@ -1,4 +1,5 @@
 user_prefix: 'alternator-streams-nemesis'
-nemesis_class_name: 'DecommissionMonkey'
-nemesis_interval: 700
+nemesis_class_name: 'NoOpMonkey'
+# TODO: should be: 'DecommissionMonkey'
+nemesis_interval: 240
 nemesis_during_prepare: true

--- a/jenkins-pipelines/longevity-alternator-streams-3h-nemesis.jenkinsfile
+++ b/jenkins-pipelines/longevity-alternator-streams-3h-nemesis.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-alternator-streams-100gb-3h.yaml", "configurations/alternator/streams-with-nemesis.yaml"]''',
+)

--- a/sdcm/kcl_thread.py
+++ b/sdcm/kcl_thread.py
@@ -49,7 +49,12 @@ class KclStressThread(DockerBasedStressThread):  # pylint: disable=too-many-inst
         return stress_cmd
 
     def _run_stress(self, loader, loader_idx, cpu_idx):
-        docker = RemoteDocker(loader, "scylladb/hydra-loaders:kcl-jdk8-20210526-ShardSyncStrategyType-PERIODIC",
+        # KCS Dockers list:
+        # scylladb/hydra-loaders:kcl-jdk8-20210310-extra-debug
+        # scylladb/hydra-loaders:kcl-jdk8-20210310-ShardSyncStrategyType-PERIODIC
+        # scylladb/hydra-loaders:kcl-jdk8-20210215
+        # scylladb/hydra-loaders:kcl-jdk8-20210526-ShardSyncStrategyType-PERIODIC
+        docker = RemoteDocker(loader, "yarongilor/alternator:kcl-jdk8-20210810",
                               extra_docker_opts=f'--label shell_marker={self.shell_marker}')
         stress_cmd = self.build_stress_cmd()
 

--- a/sdcm/kcl_thread.py
+++ b/sdcm/kcl_thread.py
@@ -44,9 +44,9 @@ class KclStressThread(DockerBasedStressThread):  # pylint: disable=too-many-inst
             target_address = self.node_list[0].parent_cluster.get_node().ip_address
         else:
             target_address = self.node_list[0].ip_address
-        stress_cmd = f"./gradlew run --args=\' {self.stress_cmd.replace('hydra-kcl', '')} " \
-                     f"-e http://{target_address}:{self.params.get('alternator_port')} \'"
-        return stress_cmd
+        stream_args = f'-e http://{target_address}:{self.params.get("alternator_port")} ' \
+            f'{self.stress_cmd.replace("hydra-kcl", "")}'
+        return stream_args
 
     def _run_stress(self, loader, loader_idx, cpu_idx):
         # KCS Dockers list:
@@ -54,9 +54,10 @@ class KclStressThread(DockerBasedStressThread):  # pylint: disable=too-many-inst
         # scylladb/hydra-loaders:kcl-jdk8-20210310-ShardSyncStrategyType-PERIODIC
         # scylladb/hydra-loaders:kcl-jdk8-20210215
         # scylladb/hydra-loaders:kcl-jdk8-20210526-ShardSyncStrategyType-PERIODIC
-        docker = RemoteDocker(loader, "yarongilor/alternator:kcl-jdk8-20210810",
+        # TODO: i have no permissions to upload the docker image to scylla QA repository. should be fixed by maintainers
+        docker = RemoteDocker(loader, "yarongilor/alternator:kcl-jdk8-20211026",
                               extra_docker_opts=f'--label shell_marker={self.shell_marker}')
-        stress_cmd = self.build_stress_cmd()
+        stream_args = self.build_stress_cmd()
 
         if not os.path.exists(loader.logdir):
             os.makedirs(loader.logdir, exist_ok=True)
@@ -64,16 +65,12 @@ class KclStressThread(DockerBasedStressThread):  # pylint: disable=too-many-inst
                                      (loader_idx, cpu_idx, uuid.uuid4()))
         LOGGER.debug('kcl-stress local log: %s', log_file_name)
 
-        LOGGER.debug("'running: %s", stress_cmd)
+        LOGGER.debug("'running: %s", stream_args)
 
-        if self.stress_num > 1:
-            node_cmd = 'taskset -c %s bash -c "%s"' % (cpu_idx, stress_cmd)
-        else:
-            node_cmd = stress_cmd
+        java_cmd = 'java -jar kraken-dynamo-syncer-0.0.1-SNAPSHOT-jar-with-dependencies.jar'
+        node_cmd = f'cd /kraken-dynamo/syncer/target && {java_cmd} {stream_args}'
 
-        node_cmd = 'cd /hydra-kcl && {}'.format(node_cmd)
-
-        KclStressEvent.start(node=loader, stress_cmd=stress_cmd).publish()
+        KclStressEvent.start(node=loader, stress_cmd=node_cmd).publish()
 
         try:
             result = docker.run(cmd=node_cmd,
@@ -93,7 +90,7 @@ class KclStressThread(DockerBasedStressThread):  # pylint: disable=too-many-inst
             ).publish()
             raise
         finally:
-            KclStressEvent.finish(node=loader, stress_cmd=stress_cmd, log_file_name=log_file_name).publish()
+            KclStressEvent.finish(node=loader, stress_cmd=node_cmd, log_file_name=log_file_name).publish()
 
 
 class CompareTablesSizesThread(DockerBasedStressThread):  # pylint: disable=too-many-instance-attributes

--- a/test-cases/longevity/longevity-alternator-streams-100gb-3h.yaml
+++ b/test-cases/longevity/longevity-alternator-streams-100gb-3h.yaml
@@ -1,21 +1,21 @@
-test_duration: 700
+test_duration: 240
 
 prepare_write_cmd:
   - >-
-    hydra-kcl -t usertable_streams --timeout 32400
+    hydra-kcl -t usertable_streams -k 1000000 --timeout 32400 --threads 15
 
   - >-
-    bin/ycsb load dynamodb -P workloads/workloadc -threads 10 -p recordcount=7812500
+    bin/ycsb load dynamodb -P workloads/workloadc -threads 7 -p recordcount=7812500
     -p fieldcount=1 -p fieldlength=128 -p dataintegrity=true
     -p insertstart=0 -p insertcount=3906250 -p table=usertable_streams
 
-  - >-
-    bin/ycsb load dynamodb -P workloads/workloadc -threads 10 -p recordcount=7812500
-    -p fieldcount=1 -p fieldlength=128 -p dataintegrity=true
-    -p insertstart=3906250 -p insertcount=3906250 -p table=usertable_streams
+#  - >-
+#    bin/ycsb load dynamodb -P workloads/workloadc -threads 10 -p recordcount=7812500
+#    -p fieldcount=1 -p fieldlength=128 -p dataintegrity=true
+#    -p insertstart=3906250 -p insertcount=3906250 -p table=usertable_streams
 
   - >-
-    table_compare interval=120 ; timeout=32400 ; src_table="alternator_usertable_streams".usertable_streams ; dst_table="alternator_usertable_streams-dest"."usertable_streams-dest"
+    table_compare interval=120 ; timeout=11000 ; src_table="alternator_usertable_streams".usertable_streams ; dst_table="alternator_usertable_streams-dest"."usertable_streams-dest"
 
 stress_cmd:
   - >-
@@ -25,16 +25,16 @@ stress_cmd:
     -p insertstart=0 -p insertcount=7812500
     -p dataintegrity=true -p table=usertable_streams
 
-  - >-
-    bin/ycsb run dynamodb -P workloads/workloadc -threads 80
-    -p readproportion=1.0 -p updateproportion=0.0 -p recordcount=7812500
-    -p fieldcount=1 -p fieldlength=128 -p operationcount=7812500
-    -p insertstart=0 -p insertcount=7812500
-    -p dataintegrity=true -p table=usertable_streams-dest
+#  - >-
+#    bin/ycsb run dynamodb -P workloads/workloadc -threads 80
+#    -p readproportion=1.0 -p updateproportion=0.0 -p recordcount=7812500
+#    -p fieldcount=1 -p fieldlength=128 -p operationcount=7812500
+#    -p insertstart=3906250 -p insertcount=7812500
+#    -p dataintegrity=true -p table=usertable_streams-dest
 
 round_robin: true
 
-n_loaders: 3
+n_loaders: 2  # 3
 n_db_nodes: 6
 n_monitor_nodes: 1
 

--- a/test-cases/longevity/longevity-alternator-streams-100gb-3h.yaml
+++ b/test-cases/longevity/longevity-alternator-streams-100gb-3h.yaml
@@ -1,0 +1,55 @@
+test_duration: 700
+
+prepare_write_cmd:
+  - >-
+    hydra-kcl -t usertable_streams --timeout 32400
+
+  - >-
+    bin/ycsb load dynamodb -P workloads/workloadc -threads 10 -p recordcount=7812500
+    -p fieldcount=1 -p fieldlength=128 -p dataintegrity=true
+    -p insertstart=0 -p insertcount=3906250 -p table=usertable_streams
+
+  - >-
+    bin/ycsb load dynamodb -P workloads/workloadc -threads 10 -p recordcount=7812500
+    -p fieldcount=1 -p fieldlength=128 -p dataintegrity=true
+    -p insertstart=3906250 -p insertcount=3906250 -p table=usertable_streams
+
+  - >-
+    table_compare interval=120 ; timeout=32400 ; src_table="alternator_usertable_streams".usertable_streams ; dst_table="alternator_usertable_streams-dest"."usertable_streams-dest"
+
+stress_cmd:
+  - >-
+    bin/ycsb run dynamodb -P workloads/workloadc -threads 80
+    -p readproportion=1.0 -p updateproportion=0.0 -p recordcount=7812500
+    -p fieldcount=1 -p fieldlength=128 -p operationcount=7812500
+    -p insertstart=0 -p insertcount=7812500
+    -p dataintegrity=true -p table=usertable_streams
+
+  - >-
+    bin/ycsb run dynamodb -P workloads/workloadc -threads 80
+    -p readproportion=1.0 -p updateproportion=0.0 -p recordcount=7812500
+    -p fieldcount=1 -p fieldlength=128 -p operationcount=7812500
+    -p insertstart=0 -p insertcount=7812500
+    -p dataintegrity=true -p table=usertable_streams-dest
+
+round_robin: true
+
+n_loaders: 3
+n_db_nodes: 6
+n_monitor_nodes: 1
+
+instance_type_db: 'i3.4xlarge'
+instance_type_loader: 'c5.4xlarge'
+
+nemesis_class_name: 'NoOpMonkey'
+nemesis_interval: 5
+
+user_prefix: 'alternator-streams-3h'
+space_node_threshold: 64424
+experimental: true
+
+alternator_port: 8080
+dynamodb_primarykey_type: HASH
+alternator_use_dns_routing: true
+
+use_mgmt: false # just to make setup quicker for now


### PR DESCRIPTION

	A short basic test of Alternator Streams with topology nemesis and data validation.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
