### PR TITLE
fix(results_analyze.get_events): Set correct variable type

### DIFF
--- a/sdcm/results_analyze/__init__.py
+++ b/sdcm/results_analyze/__init__.py
@@ -112,8 +112,7 @@ class BaseResultsAnalyzer:  # pylint: disable=too-many-instance-attributes
         last_events = dict()
         events_summary = dict()
         if not event_severity:
-            for event in Severity:
-                event_severity.append(event.name)
+            event_severity = [event.name for event in Severity]
 
         if self._events:
             for event in event_severity:


### PR DESCRIPTION
When getting events during prepare email report for performance
tests with compared results, next error happened:
Traceback (most recent call last):
File: sdcm/tester.py", line 2461, in check_regression
results_analyzer.check_regression(self._test_id, is_gce,
File "sdcm/results_analyze/__init__.py", line 576, in check_regression
last_events, events_summary = self.get_events()
File "sdcm/results_analyze/__init__.py", line 116, in get_events
     event_severity.append(event.name)
AttributeError: 'NoneType' object has no attribute 'append'

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
