### PR TITLE
fix(poweroff-event): filtering when terminate is run

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -75,10 +75,10 @@ from sdcm.utils.get_username import get_username
 from sdcm.utils.remotewebbrowser import WebDriverContainerMixin
 from sdcm.utils.version_utils import SCYLLA_VERSION_RE, get_gemini_version, get_systemd_version
 from sdcm.sct_events.base import LogEvent
-from sdcm.sct_events.filters import EventsFilter
+from sdcm.sct_events.filters import EventsFilter, DbEventsFilter
 from sdcm.sct_events.health import ClusterHealthValidatorEvent
 from sdcm.sct_events.system import TestFrameworkEvent
-from sdcm.sct_events.database import SYSTEM_ERROR_EVENTS_PATTERNS, BACKTRACE_RE
+from sdcm.sct_events.database import SYSTEM_ERROR_EVENTS_PATTERNS, BACKTRACE_RE, DatabaseLogEvent
 from sdcm.sct_events.grafana import set_grafana_url
 from sdcm.sct_events.decorators import raise_event_on_failure
 from sdcm.utils.auto_ssh import AutoSshContainerMixin
@@ -4425,7 +4425,8 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             raise NodeStayInClusterAfterDecommission(error_msg)
 
         LOGGER.info('Decommission %s PASS', node)
-        self.terminate_node(node)  # pylint: disable=no-member
+        with DbEventsFilter(db_event=DatabaseLogEvent.POWER_OFF, node=node):
+            self.terminate_node(node)  # pylint: disable=no-member
         Setup.tester_obj().monitors.reconfigure_scylla_monitoring()
 
     def decommission(self, node):

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -765,7 +765,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         raise UnsupportedNemesis("Only GKE and EKS backends support this nemesis")
 
     def _terminate_cluster_node(self, node):
-        self.cluster.terminate_node(node)
+        with DbEventsFilter(db_event=DatabaseLogEvent.POWER_OFF, node=node):
+            self.cluster.terminate_node(node)
         self.monitoring_set.reconfigure_scylla_monitoring()
 
     def disrupt_nodetool_decommission(self, add_node=True, disruption_name=None):


### PR DESCRIPTION
In the [#3415](https://github.com/scylladb/scylla-cluster-tests/pull/3415)
critical Poweroff event was introduced. In some Nemesis like GrowShrink we
terminate the nodes that were previously created and that is not critical.
Need to add DBevents filter when we terminate nodes.
(this event is useful when the nodes was shut down not by the test)

https://trello.com/c/EeKXDIw3/3400-power-off-event-should-be-filtered-when-we-terminate-nodes-in-our-code

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
