### PR TITLE
fix(offline install): disable scylla-manager for all offline artifac-tests

### DIFF
--- a/jenkins-pipelines/nonroot-offline-install/artifacts-centos8.jenkinsfile
+++ b/jenkins-pipelines/nonroot-offline-install/artifacts-centos8.jenkinsfile
@@ -8,7 +8,7 @@ artifactsPipeline(
     backend: 'gce',
     nonroot_offline_install: true,
     provision_type: 'spot',
-    scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+    scylla_mgmt_repo: '',
 
     timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'

--- a/jenkins-pipelines/nonroot-offline-install/artifacts-debian10.jenkinsfile
+++ b/jenkins-pipelines/nonroot-offline-install/artifacts-debian10.jenkinsfile
@@ -8,7 +8,7 @@ artifactsPipeline(
     backend: 'gce',
     nonroot_offline_install: true,
     provision_type: 'spot',
-    scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/buster/master/latest/scylladb-manager-master/scylla-manager.list',
+    scylla_mgmt_repo: '',
 
     timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'

--- a/jenkins-pipelines/nonroot-offline-install/artifacts-debian9.jenkinsfile
+++ b/jenkins-pipelines/nonroot-offline-install/artifacts-debian9.jenkinsfile
@@ -8,7 +8,7 @@ artifactsPipeline(
     backend: 'gce',
     nonroot_offline_install: true,
     provision_type: 'spot',
-    scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/stretch/master/latest/scylladb-manager-master/scylla-manager.list',
+    scylla_mgmt_repo: '',
 
     timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'

--- a/jenkins-pipelines/nonroot-offline-install/artifacts-oel76.jenkinsfile
+++ b/jenkins-pipelines/nonroot-offline-install/artifacts-oel76.jenkinsfile
@@ -9,7 +9,7 @@ artifactsPipeline(
     nonroot_offline_install: true,
     region_name: 'eu-west-1',
     provision_type: 'spot_low_price',
-    scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
+    scylla_mgmt_repo: '',
 
     timeout: [time: 60, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'

--- a/jenkins-pipelines/nonroot-offline-install/artifacts-ubuntu1604.jenkinsfile
+++ b/jenkins-pipelines/nonroot-offline-install/artifacts-ubuntu1604.jenkinsfile
@@ -8,7 +8,7 @@ artifactsPipeline(
     backend: 'gce',
     nonroot_offline_install: true,
     provision_type: 'spot',
-    scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/xenial/master/latest/scylla-manager-master/scylla-manager.list',
+    scylla_mgmt_repo: '',
 
     timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'

--- a/jenkins-pipelines/nonroot-offline-install/artifacts-ubuntu1804.jenkinsfile
+++ b/jenkins-pipelines/nonroot-offline-install/artifacts-ubuntu1804.jenkinsfile
@@ -8,7 +8,7 @@ artifactsPipeline(
     backend: 'gce',
     nonroot_offline_install: true,
     provision_type: 'spot',
-    scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/bionic/master/latest/scylladb-manager-master/scylla-manager.list',
+    scylla_mgmt_repo: '',
 
     timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'

--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -115,7 +115,7 @@ def call(Map pipelineParams) {
                                                         exit 1
                                                     fi
 
-                                                    if [[ ! -z "${params.scylla_mgmt_repo}" ]]; then
+                                                    if [[ ! -z "${params.scylla_mgmt_repo}" && -z "${params.unified_package}" ]]; then
                                                         export SCT_USE_MGMT=true
                                                         export SCT_SCYLLA_REPO_M="${params.scylla_repo}"
                                                         export SCT_SCYLLA_MGMT_REPO="${params.scylla_mgmt_repo}"


### PR DESCRIPTION
We shared test config (test-cases/artifacts/*.yaml) for general
artifact-tests and root-offline artifact-tests. So `scylla_mgmt_repo`
can't be set to empty in the shared configs.

This patch changed the upgrade groovy to always disable use_mgmt for all
(root & nonroot) offiline artifact-tests.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
