### PR TITLE
improvement(filters.py): Add extra parameters to printout for filters

### DIFF
--- a/sdcm/sct_events/filters.py
+++ b/sdcm/sct_events/filters.py
@@ -50,6 +50,17 @@ class DbEventsFilter(BaseFilter):
 
         return result
 
+    @property
+    def msgfmt(self) -> str:
+        output = ['{0.base}']
+        if self.filter_type:
+            output.append('type={0.filter_type}')
+        if self.filter_line:
+            output.append('line={0.filter_line}')
+        if self.filter_node:
+            output.append('type={0.filter_node}')
+        return '(' + (' '.join(output)) + ')'
+
 
 class EventsFilter(BaseFilter):
     def __init__(self,
@@ -92,6 +103,15 @@ class EventsFilter(BaseFilter):
             result &= self._regex.match(str(event)) is not None
 
         return result
+
+    @property
+    def msgfmt(self) -> str:
+        output = ['{0.base}']
+        if self.event_class:
+            output.append('event_class={0.event_class}')
+        if self.regex:
+            output.append('regex={0.regex}')
+        return '(' + (' '.join(output)) + ')'
 
 
 class EventsSeverityChangerFilter(EventsFilter):


### PR DESCRIPTION
Needed to investigate - https://trello.com/c/Qr4KlZ1l/3401-repair-error-events-were-not-filtered-during-terminateandremovenodemonkey

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
