### PR TITLE
improvement(alert on stuck stress): Detect that one of the stress latency P99 is stuck

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -71,7 +71,7 @@ CassandraStressLogEvent.OperationOnKey: CRITICAL
 CassandraStressLogEvent.TooManyHintsInFlight: ERROR
 ScyllaBenchLogEvent.ConsistencyError: ERROR
 GeminiLogEvent.geminievent: CRITICAL
-PrometheusAlertManagerEvent.start: WARNING
+PrometheusAlertManagerEvent.start: CRITICAL
 PrometheusAlertManagerEvent.end: WARNING
 ScyllaOperatorLogEvent: ERROR
 ScyllaOperatorLogEvent.REAPPLY: WARNING

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -98,6 +98,7 @@ use_legacy_cluster_init: false
 internode_encryption: 'all'
 
 use_mgmt: true
+prometheus_stuck_stress_critical: false
 manager_prometheus_port: 5090
 scylla_mgmt_pkg: ''
 

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5152,6 +5152,22 @@ class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-inst
                   description: "YCSB verify errors more than 5 errors per min"
                   summary:  "YCSB verify errors more than 5 errors per min"
         """)
+
+        if self.params.get("prometheus_stuck_stress_critical"):
+            conf += dedent("""
+
+                # Alert for stuck stress latency P99
+                  - alert: LatencyP99Stuck
+                    expr: (collectd_cassandra_stress_write_gauge{type="lat_perc_99"} > 0 or collectd_cassandra_stress_read_gauge{type="lat_perc_99"} >0) and (delta(collectd_cassandra_stress_write_gauge{type="lat_perc_99"}[300s]) == 0 OR delta(collectd_cassandra_stress_read_gauge{type="lat_perc_99"}[300s]) == 0)
+                    for: 1s
+                    labels:
+                      severity: "4"
+                      sct_severity: "CRITICAL"
+                    annotations:
+                      description: "Stress latency P99 is stuck for more than 5 minutes"
+                      summary:  "Stress latency P99 is stuck for more than 5 minutes"
+            """)
+
         with tempfile.NamedTemporaryFile("w") as alert_cont_tmp_file:
             alert_cont_tmp_file.write(conf)
             alert_cont_tmp_file.flush()

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -269,6 +269,10 @@ class SCTConfiguration(dict):
         dict(name="manager_prometheus_port", env="SCT_MANAGER_PROMETHEUS_PORT", type=int,
              help="Port to be used by the manager to contact Prometheus"),
 
+        dict(name="prometheus_stuck_stress_critical", env="SCT_PROMETHEUS_STUCK_STRESS_CRITICAL", type=boolean,
+             help="Create or not Prometheus event when stress latency P99 is stuck (the same value for more than 5 "
+                  "minutes "),
+
         dict(name="target_scylla_mgmt_server_repo", env="SCT_TARGET_SCYLLA_MGMT_SERVER_REPO", type=str,
              help="Url to the repo of scylla manager version used to upgrade the manager server"),
 

--- a/sdcm/sct_events/monitors.py
+++ b/sdcm/sct_events/monitors.py
@@ -10,11 +10,13 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2020 ScyllaDB
-
+import logging
 from typing import Type
 
 from sdcm.sct_events import Severity
 from sdcm.sct_events.base import SctEvent, SctEventProtocol
+
+LOGGER = logging.getLogger()
 
 
 class PrometheusAlertManagerEvent(SctEvent, abstract=True):
@@ -49,9 +51,10 @@ class PrometheusAlertManagerEvent(SctEvent, abstract=True):
         self.alert_name = self.labels.get("alertname", "")
 
         try:
-            self.severity = Severity[self.labels["sct_severity"]]
-        except KeyError:
-            pass
+            if "sct_severity" in self.labels:
+                self.severity = Severity[self.labels["sct_severity"]]
+        except Exception as e:
+            LOGGER.error(f'PrometheusAlertManagerEvent failed to get severity ({self.labels["sct_severity"]}): {e}')
 
     @property
     def msgfmt(self) -> str:

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -327,7 +327,7 @@ class UpgradeTest(FillDatabaseData):
             # [3] https://github.com/scylladb/scylla-tools-java/pull/232
             main_dir, subdir = Path("/etc/scylla"), "cassandra"
             filename = "cassandra-rackdc.properties"
-            result = node.remoter.run(
+            result = node.remoter.sudo(
                 f"cp {main_dir / filename} {main_dir / subdir / filename}")
 
             node.run_nodetool(sub_cmd="upgradesstables", args="-a")


### PR DESCRIPTION
Detect that one of the stress latency P99 is stuck - the same value for more than 3 minutes
 (through AlertManager), raise an alert, the Alert will be caught and raise critical event.

[Task](https://trello.com/c/kGply3WI/2718-stress-failure-should-stop-the-test-immediately)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
