### PR TITLE
fix(gemini-tests): Change gemini oracle cluster scylla version to 4.3.3

### DIFF
--- a/test-cases/gemini/gemini-1tb-10h.yaml
+++ b/test-cases/gemini/gemini-1tb-10h.yaml
@@ -22,5 +22,5 @@ gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json'
 
 db_type: mixed_scylla
 instance_type_db_oracle: 'i3.16xlarge'
-oracle_scylla_version: '3.3.2'
+oracle_scylla_version: '4.3.3'
 append_scylla_args_oracle: '--enable-cache false'

--- a/test-cases/gemini/gemini-3h-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nemesis.yaml
@@ -26,5 +26,5 @@ gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json'
 
 db_type: mixed_scylla
 instance_type_db_oracle: 'i3.8xlarge'
-oracle_scylla_version: '3.3.2'
+oracle_scylla_version: '4.3.3'
 append_scylla_args_oracle: '--enable-cache false'

--- a/test-cases/gemini/gemini-basic-3h.yaml
+++ b/test-cases/gemini/gemini-basic-3h.yaml
@@ -22,5 +22,5 @@ gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json'
 
 db_type: mixed_scylla
 instance_type_db_oracle: 'i3.8xlarge'
-oracle_scylla_version: '3.3.2'
+oracle_scylla_version: '4.3.3'
 append_scylla_args_oracle: '--enable-cache false'


### PR DESCRIPTION
Most of jobs for master, branch-4.5 for gemini which are run with gemini
oracle cluster are failed, because used old scylla version 3.3.2 for
oracle cluster. The reason, is that ami of 3.3.2 doesn't have
user scyllaadm for ssh.
Another reason, is that scylla 3.3.2 is a quite old.

Version is changed to 4.3.3

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] ~I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)~
- [ ] ~I didn't leave commented-out/debugging code~
- [ ] ~I added the relevant `backport` labels~
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (CI)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
