### PR TITLE
feature(cloud-monitor): Report with resources older 3,5,7 days for qa

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -32,7 +32,7 @@ from prettytable import PrettyTable
 from sdcm.results_analyze import PerformanceResultsAnalyzer
 from sdcm.sct_config import SCTConfiguration
 from sdcm.sct_runner import SctRunner
-from sdcm.utils.cloud_monitor import cloud_report
+from sdcm.utils.cloud_monitor import cloud_report, cloud_qa_report
 from sdcm.utils.common import (list_instances_aws, list_instances_gce, list_resources_docker, clean_cloud_resources,
                                all_aws_regions, get_scylla_ami_versions, get_s3_scylla_repos_mapping,
                                list_logs_by_test_id, get_branched_ami, gce_meta_to_dict,
@@ -685,6 +685,18 @@ def cloud_usage_report(emails):
     email_list = emails.split(",")
     click.secho(message="Will send Cloud Usage report to %s" % email_list, fg="green")
     cloud_report(mail_to=email_list)
+    click.secho(message="Done." % email_list, fg="yellow")
+
+
+@cli.command("cloud-usage-qa-report", help="Generate and send Cloud usage report")
+@click.option("-e", "--emails", required=True, type=str, help="Comma separated list of emails. Example a@b.com,c@d.com")
+@click.option("-u", "--user", required=False, type=str, help="User or instance owner")
+def cloud_usage_qa_report(emails, user=None):
+    add_file_logger()
+
+    email_list = emails.split(",")
+    click.secho(message="Will send Cloud Usage report to %s" % email_list, fg="green")
+    cloud_qa_report(mail_to=email_list, user=user)
     click.secho(message="Done." % email_list, fg="yellow")
 
 

--- a/sdcm/utils/cloud_monitor/__init__.py
+++ b/sdcm/utils/cloud_monitor/__init__.py
@@ -1,1 +1,1 @@
-from sdcm.utils.cloud_monitor.cloud_monitor import cloud_report
+from sdcm.utils.cloud_monitor.cloud_monitor import cloud_report, cloud_qa_report

--- a/sdcm/utils/cloud_monitor/cloud_monitor.py
+++ b/sdcm/utils/cloud_monitor/cloud_monitor.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from logging import getLogger
 from sdcm.send_email import Email
 from sdcm.utils.cloud_monitor.resources.instances import CloudInstances
-from sdcm.utils.cloud_monitor.report import GeneralReport, DetailedReport
+from sdcm.utils.cloud_monitor.report import GeneralReport, DetailedReport, QAonlyTimeDistributionReport
 from sdcm.utils.cloud_monitor.resources.static_ips import StaticIPs
 
 LOGGER = getLogger(__name__)
@@ -20,12 +20,32 @@ def notify_by_email(general_report: GeneralReport, detailed_report: DetailedRepo
                       )
 
 
+def notify_qa_by_email(general_report: GeneralReport, detailed_report: DetailedReport = None, recipients: list = None):
+    email_client = Email()
+    if not recipients:
+        recipients = ["qa@scylladb.com"]
+    attaching_files = [detailed_report.to_file()] if detailed_report else []
+    LOGGER.info("Sending email to '%s'", recipients)
+    email_client.send(subject="Cloud resources: QA only usage report - {}".format(datetime.now()),
+                      content=general_report.to_html(),
+                      recipients=recipients,
+                      html=True,
+                      files=attaching_files
+                      )
+
+
 def cloud_report(mail_to):
     cloud_instances = CloudInstances()
     static_ips = StaticIPs(cloud_instances)
     notify_by_email(general_report=GeneralReport(cloud_instances=cloud_instances, static_ips=static_ips),
                     detailed_report=DetailedReport(cloud_instances=cloud_instances, static_ips=static_ips),
                     recipients=mail_to)
+
+
+def cloud_qa_report(mail_to, user=None):
+    cloud_instances = CloudInstances()
+    notify_qa_by_email(general_report=QAonlyTimeDistributionReport(cloud_instances=cloud_instances, static_ips=None, user=user),
+                       recipients=mail_to)
 
 
 if __name__ == "__main__":

--- a/sdcm/utils/cloud_monitor/templates/per_qa_user.html
+++ b/sdcm/utils/cloud_monitor/templates/per_qa_user.html
@@ -1,0 +1,31 @@
+    <h2>Instances</h2>
+    {% for day, rep in report|dictsort(reverse=True) %}
+        <h2> Older than {{ day }} days </h2>
+        {% if rep %}
+            {% for user, instances in rep|dictsort %}
+                {% if instances %}
+                    <h3>{{ user }}</h3>
+                    <table id="results_table">
+                        <tr>
+                            <th>Cloud</th>
+                            <th>Region-AZ</th>
+                            <th>Name</th>
+                            <th>State</th>
+                            <th>Launch time</th>
+                        </tr>
+                        {% for instance in instances|sort(attribute="create_time") %}
+                        <tr>
+                            <td>{{ instance.cloud }}</td>
+                            <td>{{ instance.region_az }}</td>
+                            <td>{{ instance.name }}</td>
+                            <td>{{ instance.state }}</td>
+                            <td>{{ instance.create_time }}</td>
+                        </tr>
+                        {% endfor %}
+                    </table>
+                {% endif %}
+            {% endfor %}
+        {% else %}
+            <h4> No instances found </h4>
+        {% endif %}
+    {% endfor %}


### PR DESCRIPTION
New command added to sct. It allow to generate report with cloud resources
usage only for qa + timer and build report with instances
older than 3 days, 5 days, 7 days.

to run command for all qa team:
hydra cloud-usage-qa-report -e qa@scylladb.com

to run command for specific user
hydra cloaud-usage-report -e <email> -u <user>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
