### PR TITLE
fix(tester): make all threads daemonic by default

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -54,7 +54,7 @@ from sdcm.utils.aws_utils import init_monitoring_info_from_params, get_ec2_netwo
     get_common_params, init_db_info_from_params, ec2_ami_get_root_device_name
 from sdcm.utils.common import format_timestamp, wait_ami_available, tag_ami, update_certificates, \
     download_dir_from_cloud, get_post_behavior_actions, get_testrun_status, download_encrypt_keys, PageFetcher, \
-    rows_to_list
+    rows_to_list, make_threads_be_daemonic_by_default
 from sdcm.utils.get_username import get_username
 from sdcm.utils.decorators import log_run_info, retrying
 from sdcm.utils.ldap import LDAP_USERS, LDAP_PASSWORD, LDAP_ROLE, LDAP_BASE_OBJECT
@@ -481,7 +481,7 @@ class ClusterTester(db_stats.TestStatsMixin,
         self.monitors = None
         self.k8s_cluster = None
         self.connections = []
-
+        make_threads_be_daemonic_by_default()
         self.update_certificates()
 
         # download rpms for update_db_packages

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -2344,3 +2344,16 @@ def change_default_password(node, user='cassandra', password='cassandra'):
     """
     node.run_cqlsh(f"ALTER ROLE '{user}' with password='{password}{DEFAULT_PWD_SUFFIX}'")
     node.parent_cluster.added_password_suffix = True
+
+
+def make_threads_be_daemonic_by_default():
+    """
+    There is a problem with some code that uses Thread with no option to tweak it to be daemonic.
+    Good example of it would be concurent.futures.thread.ThreadPoolExecutor
+    Mostly this code do not pass daemon=True to __init__ and
+    therefore threading.Thread pick up value of this flag from current_thread
+    This code is to change this flag to True to make all threads daemonic by default
+    @return:
+    @rtype:
+    """
+    threading.current_thread()._daemonic = True


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
