### PR TITLE
fix(performance): Disable use_mgmt for disk and cache

### DIFF
--- a/test-cases/performance/perf-regression-throughput-125gb.yaml
+++ b/test-cases/performance/perf-regression-throughput-125gb.yaml
@@ -34,3 +34,5 @@ email_recipients: ['scylla-perf-results@scylladb.com']
 backtrace_decoding: false
 
 email_subject_postfix: 'disk and cache'
+
+use_mgmt: false


### PR DESCRIPTION
To run for older version disk and cache performance
test use_mgmt should be disabled

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
