### PR TITLE
fix(get_cluster_aws): disable use_mgmt for oracle cluster

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -516,7 +516,10 @@ class ClusterTester(db_stats.TestStatsMixin,
 
         # cs_db_cluster is created in case MIXED_CLUSTER. For example, gemini test
         if self.cs_db_cluster:
+            init_value = self.params["use_mgmt"]
+            self.params["use_mgmt"] = False
             self.init_nodes(db_cluster=self.cs_db_cluster)
+            self.params["use_mgmt"] = init_value
 
         if self.create_stats:
             self.create_test_stats()


### PR DESCRIPTION
if db_type set as mixed, sct will configure 2 clusters: test and oracle
this mode is mostly used with gemini tests. Oracle cluster uses
older version of scylla and older ami(Centos). to avoid installing
scylla-manager-agent on oracle cluster, disalbe it during initialization
of oracle cluster.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
