### PR TITLE
fix(generic-rolling-upgrade): Disabling the usage of manager

### DIFF
--- a/test-cases/upgrades/generic-rolling-upgrade.yaml
+++ b/test-cases/upgrades/generic-rolling-upgrade.yaml
@@ -28,6 +28,8 @@ append_scylla_args: '--blocked-reactor-notify-ms 500 --abort-on-lsa-bad-alloc 1 
 use_legacy_cluster_init: false
 internode_compression: 'all'
 
+use_mgmt: false
+
 # those are needed to be give by the job, via environment variable
 # for the base version
 # SCT_SCYLLA_VERSION=3.0 or SCT_SCYLLA_REPO=


### PR DESCRIPTION
Due to several issues lately with manager agent installation,
I'm disabling the uage of manager in the rolling upgrades tests
for now.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
