### PR TITLE
fix(mgmt-backup): use proper bucket on EKS backend

### DIFF
--- a/defaults/k8s_eks_config.yaml
+++ b/defaults/k8s_eks_config.yaml
@@ -46,6 +46,4 @@ append_scylla_args: ''
 docker_image: ''
 mgmt_docker_image: 'scylladb/scylla-manager:2.3.0'
 
-# TODO: create 'manager-on-k8s-backup-tests-eu-north-1' in the 'eu-north-1' region
-#       when limits stop being exceeded.
-backup_bucket_location: 'manager-backup-tests-eu-west-1'
+backup_bucket_location: 'manager-backup-tests-eu-north-1'


### PR DESCRIPTION
We run EKS tests in eu-north-1 region and need to use it's S3 bucket.
So, specify S3 bucket from eu-north-1 region in our EKS configuration

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
