### PR TITLE
fix(node_setup): disable iptables service

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4183,6 +4183,9 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
 
     def node_setup(self, node: BaseNode, verbose: bool = False, timeout: int = 3600):  # pylint: disable=too-many-branches
         node.wait_ssh_up(verbose=verbose, timeout=timeout)
+        if node.distro.is_centos8 or node.distro.is_rhel8 or node.distro.is_oel8:
+            node.remoter.sudo('systemctl stop iptables')
+            node.remoter.sudo('systemctl disable iptables')
         node.update_repo_cache()
 
         install_scylla = True


### PR DESCRIPTION
Iptables service is enabled in OEL8 of aws market, it only allows to
access a few tcp ports (eg: 22) from external host. This patch disabled
iptable service for rhel8 like distros.

Iptable service doesn't exist in rhel7 like distros. The problem doesn't
exist with CentOS8 of GCP, iptable should already been disabled in it.

Fixes #3502

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
