### PR TITLE
fix(upgrade-on-K8S): perform proper check for scylla version

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -877,7 +877,11 @@ class UpgradeTest(FillDatabaseData):
     def wait_till_scylla_is_upgraded_on_all_nodes(self, target_version):
         def _is_cluster_upgraded():
             for node in self.db_cluster.nodes:
-                if target_version != node.get_scylla_version() or not node.db_up:
+                # NOTE: node.get_scylla_version() returns following structure of a scylla version:
+                #       4.4.1-0.20210406.00da6b5e9
+                full_version = node.get_scylla_version()
+                short_version = full_version.split("-")[0]
+                if target_version not in (full_version, short_version) or not node.db_up:
                     return False
             return True
         wait.wait_for(func=_is_cluster_upgraded, step=30, timeout=900, throw_exc=True,


### PR DESCRIPTION
'get_scylla_version()' method of a "scylla node" started returning
detailed scylla version [1] and upgrade test started failing on K8S
backends.
Fix it by making proper version check there.

[1] https://github.com/scylladb/scylla-cluster-tests/commit/7bdb0e60

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
