### PR TITLE
test(manager): Backup purge removes orphans files

### DIFF
--- a/test-cases/manager/manager-regression-multiDC-set-distro.yaml
+++ b/test-cases/manager/manager-regression-multiDC-set-distro.yaml
@@ -1,4 +1,4 @@
-test_duration: 120
+test_duration: 240
 
 stress_cmd: "cassandra-stress write cl=QUORUM n=1200300 -schema 'replication(strategy=NetworkTopologyStrategy,us-eastscylla_node_east=2,us-west-2scylla_node_west=1)' -port jmx=6868 -mode cql3 native -rate threads=200 -pop seq=400200300..600200300"
 


### PR DESCRIPTION
New in manager 2.4
When a manager backup task is stopped midway through its upload stage,
or in other similar situations, the files that were already uploaded to
the destination bucket will unnecessarily remain there. Those kind of files
are nicknamed 'orphan files'.
In manager 2.4, a new check was added to the backup task precedure, so that
during the task's run, the manager will detect all of the cluster's existing
orphan files, and will remove them from the destination bucket.
The test, test_backup_purge_removes_orphan_files, checks this exact situation,
and verifies that the orphan files are indeed removed.
Due to the new tests, I extended manager regression test job timeout.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)

Successful run: f580b7b4-be02-485c-9872-dec73ffaf57e