### PR TITLE
fix(tester.py): fix it for cases when no loader and monitor cluster deployed

### DIFF
--- a/sdcm/utils/decorators.py
+++ b/sdcm/utils/decorators.py
@@ -165,6 +165,8 @@ def latency_calculator_decorator(func):
         all_nodes_list = list(set(start_node_list + end_node_list))
         end = time.time()
         test_name = args[0].tester.__repr__().split('testMethod=')[-1].split('>')[0]
+        if not args[0].monitoring_set or not args[0].monitoring_set.nodes:
+            return res
         monitor = args[0].monitoring_set.nodes[0]
         if 'read' in test_name:
             workload = 'read'


### PR DESCRIPTION
https://trello.com/c/zLsCi1KE/3407-create-an-infra-using-pytest-to-run-a-basic-set-of-operator-funcitonal-tests

Part of changes that targets scylla operator functional tests
This particular peace is addressing ability to run tests in the environment where there is no loaders and monitoring stack provisioned 

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
