### PR TITLE
Number of small fixes to get operator functional tests running

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4063,7 +4063,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
 
     @retrying(n=60, sleep_time=3, allowed_exceptions=NETWORK_EXCEPTIONS + (ClusterNodesNotReady,),
               message="Waiting for nodes to join the cluster")
-    def wait_for_nodes_up_and_normal(self, nodes, verification_node=None):
+    def wait_for_nodes_up_and_normal(self, nodes=None, verification_node=None):
         self.check_nodes_up_and_normal(nodes=nodes, verification_node=verification_node)
 
     def get_scylla_version(self):

--- a/sdcm/cluster_k8s/minikube.py
+++ b/sdcm/cluster_k8s/minikube.py
@@ -310,8 +310,8 @@ class MinikubeScyllaPodCluster(ScyllaPodCluster, IptablesClusterOpsMixin):
 
     @retrying(n=20, sleep_time=60, allowed_exceptions=(cluster.ClusterNodesNotReady, UnexpectedExit),
               message="Waiting for nodes to join the cluster")
-    def wait_for_nodes_up_and_normal(self, nodes, verification_node=None):
-        super().wait_for_nodes_up_and_normal(nodes, verification_node)
+    def wait_for_nodes_up_and_normal(self, nodes=None, verification_node=None):
+        super().wait_for_nodes_up_and_normal(nodes=nodes, verification_node=verification_node)
 
 
 class MonitorSetMinikube(MonitorSetGCE):

--- a/sdcm/remote/kubernetes_cmd_runner.py
+++ b/sdcm/remote/kubernetes_cmd_runner.py
@@ -157,14 +157,14 @@ class KubernetesCmdRunner(RemoteCmdRunnerBase):
     # pylint: disable=too-many-arguments,unused-argument
     @retrying(n=3, sleep_time=5, allowed_exceptions=(RetryableNetworkException, ))
     def receive_files(self, src, dst, delete_dst=False, preserve_perm=True, preserve_symlinks=False, timeout=300):
-        KubernetesOps.copy_file(self, f"{self.namespace}/{self.pod}:{src}", dst,
+        KubernetesOps.copy_file(self.kluster, f"{self.namespace}/{self.pod}:{src}", dst,
                                 container=self.container, timeout=timeout)
         return True
 
     # pylint: disable=too-many-arguments,unused-argument
     @retrying(n=3, sleep_time=5, allowed_exceptions=(RetryableNetworkException, ))
     def send_files(self, src, dst, delete_dst=False, preserve_symlinks=False, verbose=False, timeout=300):
-        KubernetesOps.copy_file(self, src, f"{self.namespace}/{self.pod}:{dst}",
+        KubernetesOps.copy_file(self.kluster, src, f"{self.namespace}/{self.pod}:{dst}",
                                 container=self.container, timeout=timeout)
         return True
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1013,7 +1013,7 @@ class ClusterTester(db_stats.TestStatsMixin,
                 disk_size=self.params.get("gce_root_disk_size_monitor"),
                 disk_type=self.params.get("gce_root_disk_type_monitor"),
                 instance_type=self.params.get("gce_instance_type_monitor"),
-                num_nodes=self.params.get("n_monitor_nodes"),
+                num_nodes=1,
                 k8s_cluster=self.k8s_cluster)
             self.k8s_cluster.deploy_node_pool(monitor_pool, wait_till_ready=False)
 
@@ -1144,7 +1144,7 @@ class ClusterTester(db_stats.TestStatsMixin,
         if self.params.get('k8s_deploy_monitoring'):
             monitor_pool = eks.EksNodePool(
                 name=self.k8s_cluster.MONITORING_POOL_NAME,
-                num_nodes=self.params.get("n_monitor_nodes"),
+                num_nodes=1,
                 instance_type=self.params.get("instance_type_monitor"),
                 role_arn=self.params.get('eks_nodegroup_role_arn'),
                 disk_size=self.params.get('aws_root_disk_size_monitor'),

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2270,8 +2270,10 @@ class ClusterTester(db_stats.TestStatsMixin,
         if final_event.test_status == 'SUCCESS':
             self.log.info(str(final_event))
             return
-        self._remove_errors_from_unittest_results(self._outcome)
-        self._outcome.errors.append((self, (TestResultEvent, final_event, None)))
+        if self._outcome is not None:
+            # If there is not self._outcome, it means tests running in non-unittest environment
+            self._remove_errors_from_unittest_results(self._outcome)
+            self._outcome.errors.append((self, (TestResultEvent, final_event, None)))
 
     @silence()
     def destroy_localhost(self):


### PR DESCRIPTION
https://trello.com/c/zLsCi1KE/3407-create-an-infra-using-pytest-to-run-a-basic-set-of-operator-funcitonal-tests

Part of changes that targets scylla operator functional tests
This particular peace is addressing following problems:
1. Wrong number of nodes for k8s monitoring, needed to be hardcoded to 1
2. send_files and receive_files are not working on kubernetes remoter
3. Teardown and Setup on ClusterTester are not completing if no unittest envolved
4. wait_for_nodes_up_and_normal by default should wait all nodes in the cluster 

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/`~~ folder)
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
