### PR TITLE
fix(manager): Added ending message to test_enospc_during_backup

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -724,6 +724,7 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
             finally:
                 if has_enospc_been_reached:
                     clean_enospc_on_node(target_node=target_node, sleep_time=30)
+        self.log.info('finishing test_enospc_during_backup')
 
     def _delete_keyspace_directory(self, db_node, keyspace_name):
         # Stop scylla service before deleting sstables to avoid partial deletion of files that are under compaction


### PR DESCRIPTION
In each test function of the manager, we have log messages to indicate the start
and the end of the test function. Added missing end log message to test_enospc_during_backup

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
