### PR TITLE
feature(sdcm/cluster): implement remote_cassandra_rackdc_properties

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -72,6 +72,7 @@ DOCKER_CGROUP_RE = re.compile("/docker/([0-9a-f]+)")
 SCYLLA_AMI_OWNER_ID = "797456418907"
 MAX_SPOT_DURATION_TIME = 360
 SCYLLA_YAML_PATH = "/etc/scylla/scylla.yaml"
+SCYLLA_PROPERTIES_PATH = "/etc/scylla/cassandra-rackdc.properties"
 
 
 def deprecation(message):

--- a/sdcm/utils/properties.py
+++ b/sdcm/utils/properties.py
@@ -1,0 +1,60 @@
+import io
+from typing import Union, TextIO
+
+
+class PropertiesDict(dict):
+    """
+    Class that represents properties file of the following format:
+        <key>=<value>
+        #Some comment
+        <key>=<value>
+    """
+    all_items = dict.items
+    all_keys = dict.keys
+    all_values = dict.values
+
+    def items(self):
+        for key, value in super().items():
+            if key.lstrip()[0] != '#':
+                yield key, value
+
+    def keys(self):
+        for key in super().keys():
+            if key.lstrip()[0] != '#':
+                yield key
+
+    def values(self):
+        for _, value in self.items():
+            yield value
+
+
+def serialize(data: Union[dict, PropertiesDict]) -> str:
+    output = []
+    items = data.all_items() if isinstance(data, PropertiesDict) else data.items()
+    for key, value in items:
+        if value is None:
+            output.append(key)
+            continue
+        if ' ' in value:
+            output.append(f'{key} = "{value}"')
+        else:
+            output.append(f'{key} = {value}')
+    return '\n'.join(output)
+
+
+def deserialize(data: Union[str, TextIO]) -> PropertiesDict:
+    if not isinstance(data, str):
+        data = data.read()
+    output = PropertiesDict()
+    for line in data.splitlines():
+        if line.lstrip()[0] == '#':
+            output[line] = None
+            continue
+        line = line.split('=', 1)
+        if len(line) == 2:
+            value = line[1]
+            comment_pos = value.find('#')
+            if comment_pos >= 0:
+                value = value[0:value]
+            output[line[0].strip()] = value.strip().strip('"').strip("'")
+    return output


### PR DESCRIPTION
https://trello.com/c/zLsCi1KE/3407-create-an-infra-using-pytest-to-run-a-basic-set-of-operator-funcitonal-tests

Part of changes that targets scylla operator functional tests
This particular peace is bringing cassandra rack property that is needed in particular test 

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
