### PR TITLE
feature(sct.py): add run-pytest

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -677,6 +677,29 @@ def run_test(argv, backend, config, logdir):
                   failfast=False, buffer=False, catchbreak=True)
 
 
+@cli.command('run-pytest', help="Run tests using pytest")
+@click.argument('target')
+@click.option('-b', '--backend', type=click.Choice(SCTConfiguration.available_backends), help="Backend to use")
+@click.option('-c', '--config', multiple=True, type=click.Path(exists=True), help="Test config .yaml to use, can have multiple of those")
+@click.option('-l', '--logdir', help="Directory to use for logs")
+def run_pytest(target, backend, config, logdir):
+    if config:
+        os.environ['SCT_CONFIG_FILES'] = str(list(config))
+    if backend:
+        os.environ['SCT_CLUSTER_BACKEND'] = backend
+
+    if logdir:
+        os.environ['_SCT_LOGDIR'] = logdir
+
+    logfile = os.path.join(Setup.logdir(), 'output.log')
+    sys.stdout = OutputLogger(logfile, sys.stdout)
+    sys.stderr = OutputLogger(logfile, sys.stderr)
+    if not target:
+        print("argv is referring to the directory or file that contain tests, it can't be empty")
+        sys.exit(1)
+    pytest.main(args=[target])
+
+
 @cli.command("cloud-usage-report", help="Generate and send Cloud usage report")
 @click.option("-e", "--emails", required=True, type=str, help="Comma separated list of emails. Example a@b.com,c@d.com")
 def cloud_usage_report(emails):

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -6,6 +6,7 @@ def (testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCl
 def call(Map pipelineParams) {
 
     def builder = getJenkinsLabels(params.backend, params.aws_region)
+    def functional_test = pipelineParams.functional_test
 
     pipeline {
         agent {
@@ -173,7 +174,7 @@ def call(Map pipelineParams) {
                             wrap([$class: 'BuildUser']) {
                                 dir('scylla-cluster-tests') {
                                     timeout(time: testRunTimeout, unit: 'MINUTES') {
-                                        runSctTest(params, builder.region)
+                                        runSctTest(params, builder.region, functional_test)
                                     }
                                 }
                             }


### PR DESCRIPTION
https://trello.com/c/zLsCi1KE/3407-create-an-infra-using-pytest-to-run-a-basic-set-of-operator-funcitonal-tests

Part of changes that targets scylla operator functional tests
This particular peace is addressing ability to run tests pytest-based tests

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
