### PR TITLE
fix(sdcm/fill_db_data.py): use short scylla versions in comparisons

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -3043,7 +3043,11 @@ class FillDatabaseData(ClusterTester):
         node = self.db_cluster.nodes[0]
         if not node.scylla_version:
             node.get_scylla_version()
-        return node.scylla_version, node.is_enterprise
+        # NOTE: node.get_scylla_version() returns following structure of a scylla version:
+        #       4.4.1-0.20210406.00da6b5e9
+        #       And 'parse_version' behaves differently for full and short scylla versions
+        #       So, keep status quo and use short scylla version here.
+        return node.scylla_version.split("-")[0], node.is_enterprise
 
     def version_null_values_support(self):
         scylla_version, is_enterprise = self.get_scylla_version()


### PR DESCRIPTION
'get_scylla_version()' method of a "scylla node" started returning detailed scylla version [1].
And 'parse_version' function always calculates 'detailed' scylla version as lower than any short scylla version.
So, when we use '4.4.rc0' scylla version or newer one as a base in upgrade jobs we fail because improper queries are picked up.
So, fix it by making version comparison use short scylla versions always.

[1] https://github.com/scylladb/scylla-cluster-tests/commit/7bdb0e60

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
