### PR TITLE
refactor(snitch_test)-move-snitch-test-to-artifacts-tests

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -948,7 +948,7 @@ class ScyllaAWSCluster(cluster.BaseScyllaCluster, AWSCluster):
         node.run_startup_script()  # Reconfigure rsyslog.
 
     def get_endpoint_snitch(self, default_multi_region="Ec2MultiRegionSnitch"):
-        return super().get_endpoint_snitch(default_multi_region)
+        return super().get_endpoint_snitch(default_multi_region,)
 
     def destroy(self):
         self.stop_nemesis()


### PR DESCRIPTION
Moved the snitch test to artficarts tests with the addition of running the node health check in artifacts testing and a small refactor for get_endpoint_snitch() method.

Change list:
- moved and refactored one test from snitch_test.py to artifacts_test.py The original test was written for GCE images specifically, so it required some generalization to make it work with AMI and GCE images. The test is now one of the artifacts_test verification methods
- added a new verification method in artifacts_test.py for running node health checks with the artifacts tests
- added a Backends NamedTuple in artifacts_test.py to avoid using magic strings in test methods
- added get_describecluster_info() method in tester.py with an associated NamedTuple for capturing nodetool describecluster output
- slighlty reworked get_endpoint_snitch() method in cluster.py and cluster_aws.py to avoid it None returns from it in artifacts_test.py


Trello task link: https://trello.com/c/Vm2D2x3r/2074-move-cloud-snitch-tests-to-the-artifact-tests
Artifacts jobs runs: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/maciej/job/mc-artifacts/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~



