### PR TITLE
fix(mgmt-backup-on-k8s-eks): use minio as S3 backend

### DIFF
--- a/defaults/k8s_eks_config.yaml
+++ b/defaults/k8s_eks_config.yaml
@@ -46,4 +46,4 @@ append_scylla_args: ''
 docker_image: ''
 mgmt_docker_image: 'scylladb/scylla-manager:2.3.0'
 
-backup_bucket_location: 'manager-backup-tests-eu-north-1'
+backup_bucket_location: 'minio-bucket'


### PR DESCRIPTION
To be able to use real S3 service in our tests we need either to use creds or add full public access to a bucket.
Later one is not acceptable.
First one requires update of secret for scylla manager agent with creds. If we use constant creds we have security vulnerability
because we will need to specify creds in K8S secrets which may be mistakenly shared as part of K8S logs for debugging.
Last option is to use temporary creds. But, it's generation requires special permissions on test runner account which are absent as of now.
So, since none of possible ways is suitable reuse 'MinIO' service the same way we do it for GKE and 'minikube' backends.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
