### PR TITLE
fix(manager): reinstated mgmt_segments_per_repair

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -5,6 +5,7 @@ ip_ssh_connections: 'private'
 mgmt_port: 10090
 scylla_repo_m: 'http://downloads.scylladb.com/rpm/centos/scylla-2020.1.repo'
 scylla_mgmt_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.3.repo'
+mgmt_segments_per_repair: 10
 
 experimental: true
 round_robin: false


### PR DESCRIPTION
The parameter was falsly removed from test default, reinstating it

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
