### PR TITLE
improvement(distro.py): add debian-like property

### DIFF
--- a/sdcm/utils/distro.py
+++ b/sdcm/utils/distro.py
@@ -161,6 +161,10 @@ class Distro(enum.Enum):
         return self.value[0] == "debian"  # pylint: disable=unsubscriptable-object
 
     @property
+    def is_debian_like(self):
+        return self.value[0].lower() in ("debian", "ubuntu")  # pylint: disable=unsubscriptable-object
+
+    @property
     def uses_systemd(self):
         # Debian uses systemd as a default init system since 8.0, Ubuntu since 15.04, and RedHat-based since 7.0
         return self not in (self.UNKNOWN, self.UBUNTU14, )

--- a/unit_tests/test_utils_distro.py
+++ b/unit_tests/test_utils_distro.py
@@ -323,3 +323,10 @@ class TestDistro(unittest.TestCase):
 
     def test_parsing_error(self):
         self.assertRaises(DistroError, Distro.from_os_release, DISTROS_OS_RELEASE["Garbage"])
+
+    def test_debian_like(self):
+        self.assertTrue(Distro.DEBIAN10.is_debian10)
+        distro = Distro.from_os_release(DISTROS_OS_RELEASE["Debian 10"])
+        invalid_distro = Distro.from_os_release(DISTROS_OS_RELEASE["Amazon Linux 2"])
+        self.assertTrue(distro.is_debian_like)
+        self.assertFalse(invalid_distro.is_debian_like)


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
~~- [ ] I added the relevant `backport` labels~~
~~- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)~~
~~- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
~~- [ ] I have updated the Readme/doc folder accordingly (if needed)~~

Added is_debian_like() property to distro.py and extended unit tests for the is_debian_like() property.

Trello link: https://trello.com/c/EfZ9N6IG/3342-add-debianlike-property-to-distropy
