### PR TITLE
fix(k8s-eks): make K8S prometheus be reachable by test runner

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -724,6 +724,12 @@ class KubernetesCluster(metaclass=abc.ABCMeta):
                 scylla_operator_dir, "examples", "common", "monitoring", "values.yaml")
             with open(values_filepath, "r") as values_stream:
                 values_data = yaml.safe_load(values_stream)
+                # NOTE: we need to unset all the tags because latest chart version may be
+                # incompatible with old versions of apps.
+                # for example 'prometheus-operator' v0.48.0 compatible with
+                # 'kube-prometheus-stack' v16.1.2+
+                for values_key in values_data.keys():
+                    values_data[values_key].get("image", {}).pop("tag", "")
             if node_pool:
                 self.deploy_node_pool(node_pool)
                 monitoring_affinity_rules = get_helm_pool_affinity_values(
@@ -738,11 +744,21 @@ class KubernetesCluster(metaclass=abc.ABCMeta):
             #   alertmanager.alertmanagerSpec.affinity
             #   prometheusOperator.affinity
             #   prometheus.prometheusSpec.affinity
+            #   prometheus.prometheusSpec.service
             #   grafana.affinity
             helm_values.set('nodeExporter.enabled', False)
             helm_values.set('alertmanager.alertmanagerSpec', monitoring_affinity_rules)
             helm_values.set('prometheusOperator', monitoring_affinity_rules)
-            helm_values.set('prometheus.prometheusSpec', monitoring_affinity_rules)
+            prometheus_values = {
+                'prometheusSpec': monitoring_affinity_rules,
+                'service': {
+                    # NOTE: required for out-of-K8S-cluster access
+                    # nodeIp:30090 will redirect traffic to prometheusPod:9090
+                    'type': 'NodePort',
+                    'nodePort': 30090,
+                },
+            }
+            helm_values.set('prometheus', prometheus_values)
             helm_values.set('grafana', monitoring_affinity_rules)
             LOGGER.debug(f"Monitoring helm chart values are following: {helm_values.as_dict()}")
 
@@ -1011,6 +1027,10 @@ class KubernetesCluster(metaclass=abc.ABCMeta):
             return self.k8s_monitoring_prometheus_expose_service.service_ip
         else:
             return self.k8s_monitoring_prometheus_pod.status.pod_ip
+
+    @property
+    def k8s_monitoring_external_port(self) -> int:
+        return 9090
 
     def patch_kubectl_config(self):
         """
@@ -2053,12 +2073,18 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):
         self.log.debug('Check kubernetes monitoring health')
 
         kubernetes_prometheus_host = None
+        kubernetes_prometheus_port = None
         try:
             kubernetes_prometheus_host = self.k8s_cluster.k8s_monitoring_external_ip
-            kubernetes_prometheus = PrometheusDBStats(host=kubernetes_prometheus_host)
+            kubernetes_prometheus_port = self.k8s_cluster.k8s_monitoring_external_port
+            kubernetes_prometheus = PrometheusDBStats(
+                host=kubernetes_prometheus_host,
+                port=kubernetes_prometheus_port,
+            )
         except Exception as exc:
             ClusterHealthValidatorEvent.MonitoringStatus(
-                error=f'Failed to connect to kubernetes prometheus server at {kubernetes_prometheus_host},'
+                error=f'Failed to connect to kubernetes prometheus server at '
+                      f'{kubernetes_prometheus_host}:{kubernetes_prometheus_port},'
                       f' due to the: \n'
                       ''.join(traceback.format_exception(type(exc), exc, exc.__traceback__))).publish()
 

--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -324,6 +324,32 @@ class EksCluster(KubernetesCluster, EksClusterCleanupMixin):
         EksClusterCleanupMixin.destroy(self)
         self.stop_token_update_thread()
 
+    @property
+    def k8s_monitoring_external_ip(self) -> str:
+        if self.USE_MONITORING_EXPOSE_SERVICE:
+            return self.k8s_monitoring_prometheus_expose_service.service_ip
+        # Return any IP of the monitoring pod's hosting node
+        for ip_type in ("ExternalIP", "InternalIP"):
+            cmd = (
+                f"get node --no-headers "
+                f"-l {self.POOL_LABEL_NAME}={self.MONITORING_POOL_NAME} "
+                "-o jsonpath='{.items[*].status.addresses[?(@.type==\"" + ip_type + "\")].address}'"
+            )
+            if ip := self.kubectl(cmd, namespace="monitoring").stdout:
+                return ip
+        # Must not be reached but exists for safety of code logic
+        # the only comsumer which is '_check_kubernetes_monitoring_health'
+        # will reuse this value in it's error event reporting.
+        return "no_ip_detected"
+
+    @property
+    def k8s_monitoring_external_port(self) -> int:
+        if self.USE_MONITORING_EXPOSE_SERVICE:
+            # NOTE: direct connection to a prometheus pod via ELB service
+            return 9090
+        # NOTE: '30090' is node's port that redirects traffic to pod's port 9090
+        return 30090
+
     def get_ec2_instance_by_id(self, instance_id):
         return boto3.resource('ec2', region_name=self.region_name).Instance(id=instance_id)
 
@@ -335,6 +361,30 @@ class EksCluster(KubernetesCluster, EksClusterCleanupMixin):
                 }
             }
         })
+
+    def set_security_groups(self, instance):
+        for network_interface in instance.network_interfaces:
+            security_groups = [g["GroupId"] for g in network_interface.groups]
+            # NOTE: Make API call only if it is needed
+            if self.ec2_security_group_ids[0][0] not in security_groups:
+                security_groups.append(self.ec2_security_group_ids[0][0])
+                network_interface.modify_attribute(Groups=security_groups)
+
+    def set_security_groups_on_all_instances(self):
+        # NOTE: EKS doesn't apply nodeGroup's security groups to nodes
+        # So, we add it for each network interface of a node explicitly.
+        cmd = "get node --no-headers -o custom-columns=:.spec.providerID"
+        instance_ids = [name.split("/")[-1] for name in self.kubectl(cmd).stdout.split()]
+        for instance_id in instance_ids:
+            self.set_security_groups(self.get_ec2_instance_by_id(instance_id))
+
+    def deploy_scylla_cluster(self, *args, **kwargs) -> None:
+        super().deploy_scylla_cluster(*args, **kwargs)
+        self.set_security_groups_on_all_instances()
+
+    def deploy_monitoring_cluster(self, *args, **kwargs) -> None:
+        super().deploy_monitoring_cluster(*args, **kwargs)
+        self.set_security_groups_on_all_instances()
 
 
 class EksScyllaPodContainer(BaseScyllaPodContainer, IptablesPodIpRedirectMixin):
@@ -361,17 +411,6 @@ class EksScyllaPodContainer(BaseScyllaPodContainer, IptablesPodIpRedirectMixin):
     def ec2_instance_id(self):
         return self._node.spec.provider_id.split('/')[-1]
 
-    def set_security_groups(self):
-        # NOTE: EKS doesn't apply nodeGroup's security groups to nodes
-        # So, we add it for each network interface of a scylla node
-        # to be able to run CQL and other commands from test runner machines.
-        for network_interface in self.ec2_host.network_interfaces:
-            security_groups = self.parent_cluster.k8s_cluster.ec2_security_group_ids[0]
-            for security_group in network_interface.groups:
-                if security_group["GroupId"] not in security_groups:
-                    security_groups.append(security_group["GroupId"])
-            network_interface.modify_attribute(Groups=security_groups)
-
     def terminate_k8s_host(self):
         self.log.info('terminate_k8s_host: EC2 instance of kubernetes node will be terminated, '
                       'the following is affected :\n' + dedent('''
@@ -382,6 +421,7 @@ class EksScyllaPodContainer(BaseScyllaPodContainer, IptablesPodIpRedirectMixin):
             '''))
         self._instance_wait_safe(self.ec2_instance_destroy)
         self.wait_for_k8s_node_readiness()
+        self.parent_cluster.k8s_cluster.set_security_groups_on_all_instances()
 
     def ec2_instance_destroy(self):
         if self.ec2_host:
@@ -431,6 +471,7 @@ class EksScyllaPodContainer(BaseScyllaPodContainer, IptablesPodIpRedirectMixin):
 
         self.ec2_instance_destroy()
         self.wait_for_k8s_node_readiness()
+        self.parent_cluster.k8s_cluster.set_security_groups_on_all_instances()
         self.wait_for_pod_readiness()
 
 
@@ -464,7 +505,7 @@ class EksScyllaPodCluster(ScyllaPodCluster, IptablesClusterOpsMixin):
                                       rack=rack,
                                       enable_auto_bootstrap=enable_auto_bootstrap)
         for node in new_nodes:
-            node.set_security_groups()
+            self.k8s_cluster.set_security_groups(node.ec2_host)
         self.add_hydra_iptables_rules(nodes=new_nodes)
         self.update_nodes_iptables_redirect_rules(nodes=new_nodes, loaders=False)
         return new_nodes


### PR DESCRIPTION
We have 2 monitorings, one is outside of an EKS cluster and second is inside.
So, make prometheus in K8S be available to test runner node by doing following:
- Apply EKS main security group to EKS monitoring nodes
- Set up nodePort service for prometheus pod
- Reuse node IP for connection as it will use nodePort for traffic   redirection.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
