### PR TITLE
fix(longevity-10gb-3h-gce): Increase test timeout to 300

### DIFF
--- a/jenkins-pipelines/longevity-10gb-3h-gce.jenkinsfile
+++ b/jenkins-pipelines/longevity-10gb-3h-gce.jenkinsfile
@@ -7,4 +7,6 @@ longevityPipeline(
     backend: 'gce',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-10gb-3h.yaml',
+
+    timeout: [time: 300, unit: 'MINUTES']
 )


### PR DESCRIPTION
Same as in the AWS test, where the timeout is 300.
At the moment the test fails for timeout as 240 minutes isn't enough.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
