### PR TITLE
fix(upgrade test): extend the time to ignore cdc error

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -208,8 +208,7 @@ class UpgradeTest(FillDatabaseData):
         check_reload_systemd_config(node)
         # Current default 300s aren't enough for upgrade test of Debian 9.
         # Related issue: https://github.com/scylladb/scylla-cluster-tests/issues/1726
-        with ignore_upgrade_cdc_errors(self.orig_ver):
-            node.start_scylla_server(verify_up_timeout=500)
+        node.start_scylla_server(verify_up_timeout=500)
         result = node.remoter.run('scylla --version')
         new_ver = result.stdout
         assert self.orig_ver != self.new_ver, "scylla-server version isn't changed"
@@ -507,12 +506,15 @@ class UpgradeTest(FillDatabaseData):
             # upgrade first node
             self.db_cluster.node_to_upgrade = self.db_cluster.nodes[indexes[0]]
             self.log.info('Upgrade Node %s begin', self.db_cluster.node_to_upgrade.name)
-            self.upgrade_node(self.db_cluster.node_to_upgrade)
-            self.log.info('Upgrade Node %s ended', self.db_cluster.node_to_upgrade.name)
-            self.db_cluster.node_to_upgrade.check_node_health()
+            result = self.db_cluster.node_to_upgrade.remoter.run('scylla --version')
+            self.orig_ver = result.stdout
+            with ignore_upgrade_cdc_errors(self.orig_ver):
+                self.upgrade_node(self.db_cluster.node_to_upgrade)
+                self.log.info('Upgrade Node %s ended', self.db_cluster.node_to_upgrade.name)
+                self.db_cluster.node_to_upgrade.check_node_health()
 
-            # wait for the prepare write workload to finish
-            self.verify_stress_thread(prepare_write_cs_thread_pool)
+                # wait for the prepare write workload to finish
+                self.verify_stress_thread(prepare_write_cs_thread_pool)
 
             # read workload (cl=QUORUM)
             self.log.info('Starting c-s read workload (cl=QUORUM n=10000000)')
@@ -537,13 +539,15 @@ class UpgradeTest(FillDatabaseData):
             # upgrade second node
             self.db_cluster.node_to_upgrade = self.db_cluster.nodes[indexes[1]]
             self.log.info('Upgrade Node %s begin', self.db_cluster.node_to_upgrade.name)
-            self.upgrade_node(self.db_cluster.node_to_upgrade)
-            self.log.info('Upgrade Node %s ended', self.db_cluster.node_to_upgrade.name)
-            self.db_cluster.node_to_upgrade.check_node_health()
+            with ignore_upgrade_cdc_errors(self.orig_ver):
+                self.upgrade_node(self.db_cluster.node_to_upgrade)
+                self.log.info('Upgrade Node %s ended', self.db_cluster.node_to_upgrade.name)
+                self.db_cluster.node_to_upgrade.check_node_health()
 
-            # wait for the 10m read workload to finish
-            self.verify_stress_thread(read_10m_cs_thread_pool)
-            self.fill_and_verify_db_data('after upgraded two nodes')
+                # wait for the 10m read workload to finish
+                self.verify_stress_thread(read_10m_cs_thread_pool)
+                self.fill_and_verify_db_data('after upgraded two nodes')
+
             self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
                                                           step=step+' - after upgraded two nodes')
 
@@ -569,7 +573,7 @@ class UpgradeTest(FillDatabaseData):
         self.search_for_idx_token_error_after_upgrade(node=self.db_cluster.node_to_upgrade,
                                                       step=step)
 
-        with ignore_upgrade_schema_errors():
+        with ignore_upgrade_schema_errors(), ignore_upgrade_cdc_errors(self.orig_ver):
 
             step = 'Step5 - Upgrade rest of the Nodes '
             self.log.info(step)


### PR DESCRIPTION
    fix(upgrade test): extend the time to ignore cdc error
    
    In one upgraded test, the cdc error (Could not find CDC generation with
    timestamp) raised before 9042 is ready, but the SCT event was delayed 3+ mins,
    it's after db is up, so it won't be ignored.
    
    This patch tried to extend the time to ignore cdc error, I know it's not
    a grace solution.


In https://jenkins.scylladb.com/job/enterprise-2021.1/job/rolling-upgrade/job/rolling-upgrade-centos7-test/26/execution/node/68/log/?console
Test id: 36056316-249d-4b00-b886-651225418a85

[cdc-err-occurred-after-db-is-up.txt](https://github.com/scylladb/scylla-cluster-tests/files/6595121/cdc-err-occurred-after-db-is-up.txt)

NOTE: cdc error was raised at `12:55:00`, the node is up (9042 port is ready) at `2021-06-03T12:55:13`, but the event was raised at `12:58:28,554`. The fail was caused by the SCT EVENT delay.


Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
