### PR TITLE
fix(longevity): make save_email_data() robust to email data gathering…

### DIFF
--- a/longevity_test.py
+++ b/longevity_test.py
@@ -555,9 +555,20 @@ class LongevityTest(ClusterTester):
 
     def get_email_data(self):
         self.log.info("Prepare data for email")
+        email_data = {}
+        grafana_dataset = {}
 
-        email_data = self._get_common_email_data()
-        grafana_dataset = self.monitors.get_grafana_screenshot_and_snapshot(self.start_time) if self.monitors else {}
+        try:
+            email_data = self._get_common_email_data()
+        except Exception as e:
+            self.log.error(f"Error in gathering common email data: Error:\n{e}")
+
+        try:
+            grafana_dataset = self.monitors.get_grafana_screenshot_and_snapshot(
+                self.start_time) if self.monitors else {}
+        except Exception as e:
+            self.log.error(f"Error in gathering Grafana screenshots and snapshots. Error:\n{e}")
+
         email_data.update({"grafana_screenshots": grafana_dataset.get("screenshots", []),
                            "grafana_snapshots": grafana_dataset.get("snapshots", []),
                            "nemesis_details": self.get_nemesises_stats(),

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4841,7 +4841,7 @@ class BaseLoaderSet():
         """))
 
 
-class BaseMonitorSet():  # pylint: disable=too-many-public-methods,too-many-instance-attributes
+class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instance-attributes
     # This is a Mixin for monitoring cluster and should not be inherited
     DB_NODES_IP_ADDRESS = 'ip_address'
     json_file_params_for_replace = {"$test_name": get_test_name()}


### PR DESCRIPTION
… issues

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
~~- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)~~
~~- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
~~- [ ] I have updated the Readme/doc folder accordingly (if needed)~~

The save_email_data() method is failing when trying to get email data from an unavailable node. To avoid the method failing I wrapped the method calls used in save_email_data() in try/catch blocks and also added a node liveness check in _get_common_email_data().

Trello link: https://trello.com/c/qASNDmsr