### PR TITLE
improvement(kubernetes): schedule pods on proper nodes

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -341,6 +341,18 @@ class KubernetesCluster(metaclass=abc.ABCMeta):
         self._scylla_manager_journal_thread = ScyllaManagerLogger(self, self.scylla_manager_log)
         self._scylla_manager_journal_thread.start()
 
+    def set_nodeselector_for_kubedns(self, pool_name):
+        # EKS and GKE deploy kube-dns pods, so make it be deployed on default nodes, not any other
+        data = {"spec": {"template": {"spec": {"nodeSelector": {
+            self.POOL_LABEL_NAME: pool_name,
+        }}}}}
+        deployment_name = self.kubectl(
+            "get deployments -l k8s-app=kube-dns --no-headers -o custom-columns=:.metadata.name",
+            namespace="kube-system").stdout.strip()
+        self.kubectl(
+            f"patch deployments {deployment_name} -p '{json.dumps(data)}'",
+            namespace="kube-system")
+
     @log_run_info
     def deploy_cert_manager(self, pool_name: str = None) -> None:
         if not self.params.get('reuse_cluster'):

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -352,7 +352,10 @@ class KubernetesCluster(metaclass=abc.ABCMeta):
             LOGGER.debug(self.helm("repo add jetstack https://charts.jetstack.io"))
 
             if pool_name:
-                helm_values = HelmValues(get_helm_pool_affinity_values(self.POOL_LABEL_NAME, pool_name))
+                values_dict = get_helm_pool_affinity_values(self.POOL_LABEL_NAME, pool_name)
+                values_dict["cainjector"] = {"affinity": values_dict["affinity"]}
+                values_dict["webhook"] = {"affinity": values_dict["affinity"]}
+                helm_values = HelmValues(values_dict)
             else:
                 helm_values = HelmValues()
 

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -411,12 +411,29 @@ class KubernetesCluster(metaclass=abc.ABCMeta):
         # controllerImage.tag        -> self.params.get(
         #                                   'k8s_scylla_operator_docker_image').split(':')[-1]
         if not self.params.get('reuse_cluster'):
-            if pool_name is None:
-                pool_name = self.AUXILIARY_POOL_NAME
             LOGGER.info("Deploy scylla-manager")
 
-            helm_affinity = get_helm_pool_affinity_values(self.POOL_LABEL_NAME, pool_name) if pool_name else {}
+            helm_affinity = get_helm_pool_affinity_values(
+                self.POOL_LABEL_NAME, pool_name) if pool_name else {}
             values = HelmValues(**helm_affinity)
+            values.set("controllerAffinity", helm_affinity.get("affinity", {}))
+            values.set("scylla", {
+                "developerMode": True,
+                "datacenter": "manager-dc",
+                "racks": [{
+                    "name": "manager-rack",
+                    "members": 1,
+                    # TODO: uncomment 'placement' field when it is allowed to be provided
+                    #       as part of the scylla-manager helm chart.
+                    #       https://github.com/scylladb/scylla-operator/issues/631
+                    # "placement": {"nodeAffinity": helm_affinity["affinity"]},
+                    "storage": {"capacity": "10Gi"},
+                    "resources": {
+                        "limits": {"cpu": 1, "memory": "200Mi"},
+                        "requests": {"cpu": 1, "memory": "200Mi"},
+                    },
+                }],
+            })
 
             mgmt_docker_image_tag = self.params.get('mgmt_docker_image').split(':')[-1]
             if mgmt_docker_image_tag:
@@ -432,15 +449,15 @@ class KubernetesCluster(metaclass=abc.ABCMeta):
             if scylla_operator_image_tag:
                 values.set('controllerImage.tag', scylla_operator_image_tag)
 
-            # Install and wait for initialization of the Scylla Manager chart
-            LOGGER.info("Deploy scylla-manager")
             self.kubectl(f'create namespace {SCYLLA_MANAGER_NAMESPACE}')
 
-            # TODO: usage of 'cordon' feature below is a workaround for the scylla-operator issue #496
-            # where it is not possible to provide node/pod affinity for the scylla server
-            # which gets installed for the scylla-manager deployed by scylla-operator.
+            # TODO: usage of 'cordon' feature below is a workaround for the scylla-operator issue
+            #       https://github.com/scylladb/scylla-operator/issues/631
+            #       where it is not possible to provide node/pod affinity for the scylla server
+            #       which gets installed for the scylla-manager deployed by scylla-operator.
             to_cordon = ", ".join(['loader-pool', 'monitoring-pool', 'scylla-pool'])
             with CordonNodes(self.kubectl, f"{self.POOL_LABEL_NAME} in ({to_cordon})"):
+                # Install and wait for initialization of the Scylla Manager chart
                 LOGGER.debug(self.helm_install(
                     target_chart_name="scylla-manager",
                     source_chart_name="scylla-operator/scylla-manager",
@@ -449,8 +466,6 @@ class KubernetesCluster(metaclass=abc.ABCMeta):
                     values=values,
                     namespace=SCYLLA_MANAGER_NAMESPACE,
                 ))
-
-            time.sleep(10)
 
         self.kubectl("wait --timeout=10m --all --for=condition=Ready pod",
                      namespace=SCYLLA_MANAGER_NAMESPACE)

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1010,7 +1010,7 @@ class ClusterTester(db_stats.TestStatsMixin,
         # NOTE: between GKE cluster creation and addition of new node pools we need
         # several minutes gap to avoid "repair" status of a cluster when API server goes down.
         # So, deploy apps specific to default-pool in between above mentioned deployment steps.
-        self.k8s_cluster.deploy_cert_manager()
+        self.k8s_cluster.deploy_cert_manager(pool_name=self.k8s_cluster.AUXILIARY_POOL_NAME)
         self.k8s_cluster.deploy_scylla_operator()
         if self.params.get('use_mgmt'):
             self.k8s_cluster.deploy_scylla_manager()
@@ -1177,7 +1177,7 @@ class ClusterTester(db_stats.TestStatsMixin,
             self.k8s_cluster.deploy_node_pool(monitor_pool, wait_till_ready=False)
         self.k8s_cluster.wait_all_node_pools_to_be_ready()
 
-        self.k8s_cluster.deploy_cert_manager()
+        self.k8s_cluster.deploy_cert_manager(pool_name=self.k8s_cluster.AUXILIARY_POOL_NAME)
         self.k8s_cluster.deploy_scylla_operator()
         if self.params.get('use_mgmt'):
             self.k8s_cluster.deploy_scylla_manager()

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1013,7 +1013,7 @@ class ClusterTester(db_stats.TestStatsMixin,
         self.k8s_cluster.deploy_cert_manager(pool_name=self.k8s_cluster.AUXILIARY_POOL_NAME)
         self.k8s_cluster.deploy_scylla_operator()
         if self.params.get('use_mgmt'):
-            self.k8s_cluster.deploy_scylla_manager()
+            self.k8s_cluster.deploy_scylla_manager(pool_name=self.k8s_cluster.AUXILIARY_POOL_NAME)
 
         loader_pool = None
         if self.params.get("n_loaders"):
@@ -1180,7 +1180,7 @@ class ClusterTester(db_stats.TestStatsMixin,
         self.k8s_cluster.deploy_cert_manager(pool_name=self.k8s_cluster.AUXILIARY_POOL_NAME)
         self.k8s_cluster.deploy_scylla_operator()
         if self.params.get('use_mgmt'):
-            self.k8s_cluster.deploy_scylla_manager()
+            self.k8s_cluster.deploy_scylla_manager(pool_name=self.k8s_cluster.AUXILIARY_POOL_NAME)
 
         self.db_cluster = eks.EksScyllaPodCluster(
             k8s_cluster=self.k8s_cluster,

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1010,6 +1010,8 @@ class ClusterTester(db_stats.TestStatsMixin,
         # NOTE: between GKE cluster creation and addition of new node pools we need
         # several minutes gap to avoid "repair" status of a cluster when API server goes down.
         # So, deploy apps specific to default-pool in between above mentioned deployment steps.
+        self.k8s_cluster.set_nodeselector_for_kubedns(
+            pool_name=self.k8s_cluster.AUXILIARY_POOL_NAME)
         self.k8s_cluster.deploy_cert_manager(pool_name=self.k8s_cluster.AUXILIARY_POOL_NAME)
         self.k8s_cluster.deploy_scylla_operator()
         if self.params.get('use_mgmt'):
@@ -1131,6 +1133,8 @@ class ClusterTester(db_stats.TestStatsMixin,
 
         self.k8s_cluster.deploy()
         self.k8s_cluster.tune_network()
+        self.k8s_cluster.set_nodeselector_for_kubedns(
+            pool_name=self.k8s_cluster.AUXILIARY_POOL_NAME)
 
         self.k8s_cluster.deploy_node_pool(
             eks.EksNodePool(

--- a/sdcm/utils/k8s.py
+++ b/sdcm/utils/k8s.py
@@ -361,9 +361,14 @@ class CordonNodes:
         self.cordon_cmd = f"cordon -l '{selector}'"
 
     def __enter__(self):
-        return self.kubectl(self.cordon_cmd)
+        result = self.kubectl(self.cordon_cmd)
+        # NOTE: sleep for some time to make kube scheduler fit the cordon nodes time range
+        time.sleep(5)
+        return result
 
     def __exit__(self, *exc):
+        # NOTE: sleep for some time to make kube scheduler fit the cordon nodes time range
+        time.sleep(5)
         self.kubectl(f"un{self.cordon_cmd}")
 
 


### PR DESCRIPTION
We deploy lots of pods in our K8S clusters which, if not defined,
may be scheduled unexpectedly onto scylla nodes taking it's resources.
And those pods may be victims of nemesis disruptions we do with scylla K8S nodes.
So, schedule properly following apps:
- cert-manager
- scylla-manager
- kube-dns (coredns)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
