### PR TITLE
fix(k8s-eks): use proper instance type for loader nodes

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1142,7 +1142,7 @@ class ClusterTester(db_stats.TestStatsMixin,
             loader_pool = eks.EksNodePool(
                 name=self.k8s_cluster.LOADER_POOL_NAME,
                 num_nodes=self.params.get("n_loaders"),
-                instance_type=self.params.get("instance_type_monitor"),
+                instance_type=self.params.get("instance_type_loader"),
                 role_arn=self.params.get('eks_nodegroup_role_arn'),
                 disk_size=self.params.get('aws_root_disk_size_monitor'),
                 k8s_cluster=self.k8s_cluster)


### PR DESCRIPTION
For the moment 'monitor' instance type is used for deployment of loader nodes. It is incorrect.
So, reuse appropriate config option for creation of loader nodes on EKS.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
