### PR TITLE
improvement(k8s-eks): reduce number of reserved IP addresses by nodes

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1116,11 +1116,13 @@ class ClusterTester(db_stats.TestStatsMixin,
                                           )
 
         self.k8s_cluster.deploy()
+        self.k8s_cluster.tune_network()
+
         self.k8s_cluster.deploy_node_pool(
             eks.EksNodePool(
                 name=self.k8s_cluster.AUXILIARY_POOL_NAME,
-                num_nodes=1,
-                instance_type="t3.xlarge",
+                num_nodes=2,
+                instance_type="t3.large",
                 # It should have at least 3 vCPU to be able to hold all the pods
                 disk_size=40,
                 role_arn=self.k8s_cluster.nodegroup_role_arn,


### PR DESCRIPTION
EKS networking is designed to have cached/reserved IP addresses on each
EC2 instance which is part of an EKS cluster.
Each network interface of an EC2 instance has limit for number of IPs.

For example, we use 'i3.4xlarge' instance type for our 4 scylla nodes.
Each of these nodes will have 2 network interfaces where each one
contains 30 IP addresses (1 for itself and 29 reserved).
So, our 4 scylla nodes take out 240 IP addresses from a subnet that is
used for deployment. In our case it is /22 subnet which is <1024 IPs.
And we also have other nodes such as loader, monitor and default ones.
In summary one our EKS cluster reserves about 321 IP address from a
subnet. So, using /22 subnet we can run just 3 EKS clusters at once
assuming there are no other significant usages of IP addresses in this
subnet.

It is possible to change and we can do it by tuning configuration
of 'aws-node' daemonset which configures networking among other stuff.

In EKS clsuter with scylla manager deployed we have about 48 pods.
Each pod takes 1 IP from subnet, plus IPs from network interfaces.
The highest number of pods we have are in default node pool.
There are 16 pods. So, we need 16 IPs for pods plus 2 for nodes.

Knowing that we can configure networking for ALL nodes only start
using 2 smaller (t3.large) nodes in 'default' node pool instead of
1 bigger (t3.xlarge). It will allow us to spread those 16 pods onto
2 nodes reducing requirement for IPs for each of the nodes and reduce
highest IP number requirement per node.
So, configure default reservation of IPs as '8' having '2'
warm/ready-to-use/cached IPs and disable creation of
warm/ready-to-use/cached additional network interfaces by default.
Doing it our one EKS cluster will take approximately 81-82 IPs now.

So, as a result, with this small change, we will be able to run
12 (twelve) EKS clusters at once using /22 subnet (<1024 IPs) if
there are no other consumers.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
