### PR TITLE
fix(node_setup): try to disable iptables and firewalld services

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4205,8 +4205,10 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
     def node_setup(self, node: BaseNode, verbose: bool = False, timeout: int = 3600):  # pylint: disable=too-many-branches
         node.wait_ssh_up(verbose=verbose, timeout=timeout)
         if node.distro.is_centos8 or node.distro.is_rhel8 or node.distro.is_oel8:
-            node.remoter.sudo('systemctl stop iptables')
-            node.remoter.sudo('systemctl disable iptables')
+            node.remoter.sudo('systemctl stop iptables', ignore_status=True)
+            node.remoter.sudo('systemctl disable iptables', ignore_status=True)
+            node.remoter.sudo('systemctl stop firewalld', ignore_status=True)
+            node.remoter.sudo('systemctl disable firewalld', ignore_status=True)
         node.update_repo_cache()
 
         install_scylla = True


### PR DESCRIPTION
The firewalld was introduced as a replacement for the previous iptables
service from RHEL7. The iptables service is still enabled in our OEL8 AMI,
it doesn't allow to ping scylla-manager server by the public ip.

So we need try to stop both iptables service or firewalld service. the
exception should be ignored if the service doesn't exist.

refs:
- https://oracle-base.com/articles/linux/linux-firewall-firewalld
- https://linuxize.com/post/how-to-configure-and-manage-firewall-on-centos-8/

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
