### PR TITLE
fix(qaonlytimedistreport): add filter out qa user

### DIFF
--- a/sdcm/utils/cloud_monitor/report.py
+++ b/sdcm/utils/cloud_monitor/report.py
@@ -141,7 +141,7 @@ class QAonlyTimeDistributionReport(BaseReport):
 
     def to_html(self):
         for instance in self.cloud_instances.all:
-            if instance.owner not in self.qa_users or instance.state != "running":
+            if self._is_user_be_skipped(instance) or self._is_instance_be_skipped(instance):
                 continue
             if self._is_older_than_3days(instance.create_time):
                 self.report[3][instance.owner].append(instance)
@@ -170,3 +170,9 @@ class QAonlyTimeDistributionReport(BaseReport):
     @staticmethod
     def _is_older_than_7days(create_time):
         return create_time < pytz.utc.localize(datetime.utcnow() - timedelta(days=7))
+
+    def _is_user_be_skipped(self, instance):
+        return instance.owner == "qa" or instance.owner not in self.qa_users
+
+    def _is_instance_be_skipped(self, instance):
+        return instance.state != "running"

--- a/sdcm/utils/cloud_monitor/templates/per_qa_user.html
+++ b/sdcm/utils/cloud_monitor/templates/per_qa_user.html
@@ -1,4 +1,4 @@
-    <h2>Instances</h2>
+    <h2>Instances that are running</h2>
     {% for day, rep in report|dictsort(reverse=True) %}
         <h2> Older than {{ day }} days </h2>
         {% if rep %}


### PR DESCRIPTION
Remove from report instances with owner qa

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] ~All new and existing unit tests passed (CI)~
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
