### PR TITLE
fix(node_setup): Ignore status of cmd stop iptables service

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4205,8 +4205,8 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
     def node_setup(self, node: BaseNode, verbose: bool = False, timeout: int = 3600):  # pylint: disable=too-many-branches
         node.wait_ssh_up(verbose=verbose, timeout=timeout)
         if node.distro.is_centos8 or node.distro.is_rhel8 or node.distro.is_oel8:
-            node.remoter.sudo('systemctl stop iptables')
-            node.remoter.sudo('systemctl disable iptables')
+            node.remoter.sudo('systemctl stop iptables', ignore_status=True)
+            node.remoter.sudo('systemctl disable iptables', ignore_status=True)
         node.update_repo_cache()
 
         install_scylla = True


### PR DESCRIPTION
On latest rolling upgrades for centos8 job failed with error:
p:ERROR > sdcm.cluster.NodeSetupFailed:
    [Node rolling-upgrade-fix-roll-centos-db-node-4a324236-0-1 [35.243.248.221 | 10.142.0.54]
    (seed: True)] NodeSetupFailed: Encountered a bad command exit code!
p:ERROR >
p:ERROR > Command: 'sudo systemctl stop iptables'
p:ERROR >
p:ERROR > Exit code: 5
p:ERROR >
p:ERROR > Stdout:
p:ERROR >
p:ERROR >
p:ERROR >
p:ERROR > Stderr:
p:ERROR >
p:ERROR > Failed to stop iptables.service: Unit iptables.service not loaded.

Add ignore_status flag to aviod command failing if iptables is not started

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
