### PR TITLE
fix(fill_db_data): change sorted order due to fix issue 7443

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -854,9 +854,10 @@ class FillDatabaseData(ClusterTester):
             'queries': ["SELECT id FROM nameless_index_test_old_version WHERE birth_year = 42"],
             # Due the issue https://github.com/scylladb/scylla/issues/7443, the result of the query changed
             # from "[['Bob'], ['Tom']]" to "[['Tom'], ['Bob']]" from versions Scylla 4.4 and above
-            'results': [[['Bob'], ['Tom']]],
+            # Issue were fixed. Results from 4.5 is changed:
+            'results': [[['Tom'], ['Bob']]],
             'min_version': '3.0',
-            'max_version': '4.3',
+            'max_version': '4.5.rc2',
             'skip_condition': 'not self.version_new_sorting_order_with_secondary_indexes()',
             'skip': ''},
         # deletion_test: Test simple deletion and in particular check for CASSANDRA-4193 bug


### PR DESCRIPTION
Issue 7443 was fixed. Order for SGI was restored from 4.5.rc2
Job failed:
https://jenkins.scylladb.com/view/master/job/scylla-master/job/rolling-upgrade/job/rolling-upgrade-ubuntu20.04-test/9/console
```
11:11:00  < t:2021-06-04 04:10:59,465 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  >   File "/jenkins/slave/workspace/scylla-master/rolling-upgrade/rolling-upgrade-ubuntu20.04-test/scylla-cluster-tests/upgrade_test.py", line 472, in test_rolling_upgrade
11:11:00  < t:2021-06-04 04:10:59,465 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  >     self.fill_and_verify_db_data('BEFORE UPGRADE', pre_fill=True)
11:11:00  < t:2021-06-04 04:10:59,465 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  >   File "/jenkins/slave/workspace/scylla-master/rolling-upgrade/rolling-upgrade-ubuntu20.04-test/scylla-cluster-tests/upgrade_test.py", line 437, in fill_and_verify_db_data
11:11:00  < t:2021-06-04 04:10:59,465 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  >     self.verify_db_data()
11:11:00  < t:2021-06-04 04:10:59,465 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  >   File "/jenkins/slave/workspace/scylla-master/rolling-upgrade/rolling-upgrade-ubuntu20.04-test/scylla-cluster-tests/sdcm/fill_db_data.py", line 3283, in verify_db_data
11:11:00  < t:2021-06-04 04:10:59,465 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  >     self.run_db_queries(session, session.default_fetch_size)
11:11:00  < t:2021-06-04 04:10:59,465 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  >   File "/jenkins/slave/workspace/scylla-master/rolling-upgrade/rolling-upgrade-ubuntu20.04-test/scylla-cluster-tests/sdcm/fill_db_data.py", line 3205, in run_db_queries
11:11:00  < t:2021-06-04 04:10:59,465 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  >     raise ex
11:11:00  < t:2021-06-04 04:10:59,465 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  >   File "/jenkins/slave/workspace/scylla-master/rolling-upgrade/rolling-upgrade-ubuntu20.04-test/scylla-cluster-tests/sdcm/fill_db_data.py", line 3202, in run_db_queries
11:11:00  < t:2021-06-04 04:10:59,465 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  >     self.assertEqual([list(row) for row in res], item['results'][i])
11:11:00  < t:2021-06-04 04:10:59,465 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  > AssertionError: Lists differ: [['Tom'], ['Bob']] != [['Bob'], ['Tom']]
11:11:00  < t:2021-06-04 04:10:59,465 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  > 
11:11:00  < t:2021-06-04 04:10:59,465 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  > First differing element 0:
11:11:00  < t:2021-06-04 04:10:59,465 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  > ['Tom']
11:11:00  < t:2021-06-04 04:10:59,465 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  > ['Bob']
11:11:00  < t:2021-06-04 04:10:59,465 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  > 
11:11:00  < t:2021-06-04 04:10:59,465 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  > - [['Tom'], ['Bob']]
11:11:00  < t:2021-06-04 04:10:59,465 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  > + [['Bob'], ['Tom']]
```



## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
