### PR TITLE
fix(sct configuration): ami for wrong version may return

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1280,7 +1280,8 @@ class SCTConfiguration(dict):
 
                     amis = get_scylla_ami_versions(region)
                     for ami in amis:
-                        if scylla_version in ami['Name']:
+                        # ami['Name'] format example: ScyllaDB 4.4.0
+                        if f" {scylla_version}" in ami['Name']:
                             ami_list.append(ami['ImageId'])
                             break
                     else:


### PR DESCRIPTION
ami for wrong version may return.
Example:
if we ask version '4.0' it returns ami for 4.4.0.

It happens because of we search if the ami name includes the version number.
Version name '4.4.0' includes '4.0'

ami name format example: 'ScyllaDB 4.4.0'

rolling-upgrade-ami test in branch-2020.1 run on '4.4.0' when base_version is '4.0'

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
