### PR TITLE
fix(test_read test_mixed): Wait for compactions to settle

### DIFF
--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -440,6 +440,8 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
         self.create_test_stats(doc_id_with_timestamp=True)
         # run a read workload
         self.run_fstrim_on_all_db_nodes()
+        # In order to get cleaner results of the measured stage, it must wait for the compactions to settle
+        self.wait_no_compactions_running()
         stress_queue = self.run_stress_thread(stress_cmd=base_cmd_r, stress_num=2, stats_aggregate_cmds=False)
         results = self.get_stress_results(queue=stress_queue)
 
@@ -464,6 +466,8 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
         # allow to correctly save results for future compare
         self.create_test_stats(doc_id_with_timestamp=True)
         self.run_fstrim_on_all_db_nodes()
+        # In order to get cleaner results of the measured stage, it must wait for the compactions to settle
+        self.wait_no_compactions_running()
         stress_queue = self.run_stress_thread(stress_cmd=base_cmd_m, stress_num=2, stats_aggregate_cmds=False)
         results = self.get_stress_results(queue=stress_queue)
 

--- a/test-cases/performance/perf-regression.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys.yaml
@@ -1,9 +1,9 @@
 test_duration: 300
 
-stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=60m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=1..30000000"
+stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=60m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=80 -pop seq=1..30000000"
 prepare_write_cmd: "cassandra-stress write no-warmup cl=QUORUM n=30000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=1..30000000"
-stress_cmd_r: "cassandra-stress read no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop 'dist=gauss(1..30000000,15000000,1500000)' "
-stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop 'dist=gauss(1..30000000,15000000,1500000)' "
+stress_cmd_r: "cassandra-stress read no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=80 -pop 'dist=gauss(1..30000000,15000000,1500000)' "
+stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=80 -pop 'dist=gauss(1..30000000,15000000,1500000)' "
 
 n_db_nodes: 3
 n_loaders: 4

--- a/test-cases/performance/perf-regression.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys.yaml
@@ -1,6 +1,6 @@
 test_duration: 300
 
-stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=60m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=70 -pop seq=1..30000000"
+stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=60m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=80 -pop seq=1..30000000"
 prepare_write_cmd: "cassandra-stress write no-warmup cl=QUORUM n=30000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=1..30000000"
 stress_cmd_r: "cassandra-stress read no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=70 -pop 'dist=gauss(1..30000000,15000000,1500000)' "
 stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=70 -pop 'dist=gauss(1..30000000,15000000,1500000)' "
@@ -22,3 +22,10 @@ store_perf_results: true
 use_mgmt: false
 send_email: true
 email_recipients: ['roy@scylladb.com']
+
+regions_data:
+  us-east-1: # US East (N. Virginia)
+    ami_id_loader: 'ami-0a14770b684e1a0cd' # Loader dedicated AMI v16-temp by Roy to test non-shard-aware driver
+    ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
+    backup_bucket_location: 'manager-backup-tests-us-east-1'
+

--- a/test-cases/performance/perf-regression.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys.yaml
@@ -1,9 +1,9 @@
 test_duration: 300
 
-stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=60m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=80 -pop seq=1..30000000"
+stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=60m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=70 -pop seq=1..30000000"
 prepare_write_cmd: "cassandra-stress write no-warmup cl=QUORUM n=30000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=1..30000000"
-stress_cmd_r: "cassandra-stress read no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=80 -pop 'dist=gauss(1..30000000,15000000,1500000)' "
-stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=80 -pop 'dist=gauss(1..30000000,15000000,1500000)' "
+stress_cmd_r: "cassandra-stress read no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=70 -pop 'dist=gauss(1..30000000,15000000,1500000)' "
+stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=70 -pop 'dist=gauss(1..30000000,15000000,1500000)' "
 
 n_db_nodes: 3
 n_loaders: 4
@@ -21,4 +21,4 @@ backtrace_decoding: false
 store_perf_results: true
 use_mgmt: false
 send_email: true
-email_recipients: ['scylla-perf-results@scylladb.com']
+email_recipients: ['roy@scylladb.com']


### PR DESCRIPTION
In the past these tests used to be pretty steady, but since there
were changes in compaction behaviour, the compactions that started
in the prepare stage were affecting more and more on the load we try
to measure.

The correct solution is to wait for these compactions to finish and
only then  start the read/mixed stage.

This change makes all past results of these tests uncomparable to the
results we will get from this point onwards.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
