### PR TITLE
refactor(scale test): Switching to m5d instance and one seed

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4227,7 +4227,17 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             if install_scylla:
                 self._scylla_install(node)
             else:
+                self.log.info("Waiting for preinstalled Scylla")
                 self._wait_for_preinstalled_scylla(node)
+                self.log.info("Done waiting for preinstalled Scylla")
+
+                if self.params.get('workaround_kernel_bug_for_iotune'):
+                    self.log.info("This AMI need to be tweaked for io.conf and properties")
+                    for conf in ['io.conf', 'io_properties.yaml']:
+                        node.remoter.send_files(src=os.path.join('./configurations/', conf),
+                                                # pylint: disable=not-callable
+                                                dst='/tmp/')
+                        node.remoter.run('sudo mv /tmp/{0} /etc/scylla.d/{0}'.format(conf))
             if node.is_nonroot_install:
                 node.stop_scylla_server(verify_down=False)
                 node.remoter.run(f'{INSTALL_DIR}/sbin/scylla_setup --nic {devname} --no-raid-setup --no-io-setup',

--- a/test-cases/features/scale-cluster.yaml
+++ b/test-cases/features/scale-cluster.yaml
@@ -23,4 +23,3 @@ nemesis_class_name: 'ChaosMonkey'
 cluster_health_check: false
 
 workaround_kernel_bug_for_iotune: true
-

--- a/test-cases/features/scale-cluster.yaml
+++ b/test-cases/features/scale-cluster.yaml
@@ -3,15 +3,14 @@ cassandra_stress_population_size: 10000000
 space_node_threshold: 100
 
 add_node_cnt: 1
-seeds_num: 3
-seeds_selector: 'first'
+seeds_num: 1
 
 n_db_nodes: 3
 n_loaders: 1
 n_monitor_nodes: 1
 cluster_target_size: 5
 
-instance_type_db: 'i3.large'
+instance_type_db: 'm5d.large'
 
 user_prefix: 'cluster-scale-test'
 ssh_transport: 'libssh2'
@@ -22,3 +21,6 @@ nemesis_interval: 5
 nemesis_class_name: 'ChaosMonkey'
 
 cluster_health_check: false
+
+workaround_kernel_bug_for_iotune: true
+


### PR DESCRIPTION
Changing the scale test to use m5d instance type instead of i3,
increases dramatically the chances of getting 200 spot instances
for the entire test period.

However, m5d instances aren't officially optimized for scylla,
hence the node_setup will fail for them.
In order to start them it requires to either run scylla_io_setup
(iotune) or to workaround it by adding "fake" io.conf files
the workaround).

Another required refactor is changing the test to use only one
seed. Otherwise, the test can hang waiting for the seeds to start
and it seems like we no longer need it since scylla removed the
seed concept.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
