### PR TITLE
fix(break_streaming_task_and_rebuild): ignored warning messages

### DIFF
--- a/sdcm/sct_events/setup.py
+++ b/sdcm/sct_events/setup.py
@@ -62,6 +62,8 @@ def start_events_device(log_dir: Optional[Union[str, Path]] = None,
                                       r'error occurred while retrieving configuration').publish()
     DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line='Rate-limit: supressed').publish()
     DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line='Rate-limit: suppressed').publish()
+    DbEventsFilter(db_event=DatabaseLogEvent.DATABASE_ERROR,
+                   line="update_from_distributed_data: failed to update configuration").publish()
 
     atexit.register(stop_events_device, _registry=_registry)
 


### PR DESCRIPTION
During the streaming stage of the DecommissionStreamingErr nemesis,
warning messages could rise from the target node's service_level_controller
(which sct would consider as error messages).
As such, I added a filter fo those kind of messages during the streaming stage of the nemesis

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
