### PR TITLE
fix(tester.py): move starting timeout thread to the end of setup

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -282,7 +282,7 @@ class ClusterTester(db_stats.TestStatsMixin,
         self.left_processes_log = os.path.join(self.logdir, 'left_processes.log')
         self.scylla_hints_dir = os.path.join(self.scylla_dir, "hints")
         self._logs = {}
-        self.timeout_thread = self._init_test_timeout_thread()
+        self.timeout_thread = None
         self.email_reporter = build_reporter(self.__class__.__name__,
                                              self.params.get('email_recipients'),
                                              self.logdir)
@@ -537,6 +537,7 @@ class ClusterTester(db_stats.TestStatsMixin,
         if self.monitors and self.monitors.nodes:
             self.prometheus_db = PrometheusDBStats(host=self.monitors.nodes[0].public_ip_address)
         self.start_time = time.time()
+        self.timeout_thread = self._init_test_timeout_thread()
 
         if self.db_cluster:
             self.db_cluster.validate_seeds_on_all_nodes()
@@ -2295,7 +2296,8 @@ class ClusterTester(db_stats.TestStatsMixin,
 
     @silence()
     def stop_timeout_thread(self):
-        self.timeout_thread.cancel()
+        if self.timeout_thread:
+            self.timeout_thread.cancel()
 
     @silence()
     def collect_sct_logs(self):


### PR DESCRIPTION
https://trello.com/c/mWkn1q2s/3439-start-timeout-thread-after-resources-were-created

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
