### PR TITLE
fix(test_tester.py): fix ClusterTesterForTests to sleep before stopping event devices to reduce possibility to swallow events

### DIFF
--- a/unit_tests/test_tester.py
+++ b/unit_tests/test_tester.py
@@ -15,6 +15,7 @@ import os
 import shutil
 import logging
 import tempfile
+import time
 import unittest.mock
 from time import sleep
 
@@ -159,6 +160,10 @@ class ClusterTesterForTests(ClusterTester):
             return self._events
         self._events = get_events_grouped_by_category(_registry=self.events_processes_registry)
         return self._events
+
+    def stop_event_device(self):
+        time.sleep(0.5)
+        super().stop_event_device()
 
 
 class SubtestAndTeardownFailsTest(ClusterTesterForTests):


### PR DESCRIPTION
https://trello.com/c/he5IS00P/3444-subtestassertandteardownfailstest-unit-test-failure

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
