### PR TITLE
refactor(event types): add start/stop and 'info' event category

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -92,3 +92,4 @@ DbEventsFilter: NORMAL
 EventsFilter: NORMAL
 EventsSeverityChangerFilter: NORMAL
 NodetoolEvent: ERROR
+ScyllaBenchEvent: CRITICAL

--- a/sdcm/sct_events/loaders.py
+++ b/sdcm/sct_events/loaders.py
@@ -15,7 +15,7 @@ import re
 import json
 import time
 import logging
-from typing import Type, Optional, List, Tuple
+from typing import Type, Optional, List, Tuple, Any
 
 import dateutil.parser
 from invoke.runners import Result
@@ -24,7 +24,6 @@ from sdcm.sct_events import Severity
 from sdcm.sct_events.base import \
     SctEvent, SctEventProtocol, LogEvent, LogEventProtocol, T_log_event, \
     BaseStressEvent, StressEvent, StressEventProtocol
-
 
 LOGGER = logging.getLogger(__name__)
 
@@ -76,22 +75,14 @@ class CassandraStressEvent(StressEvent, abstract=True):
 CassandraStressEvent.add_stress_subevents(failure=Severity.CRITICAL, error=Severity.ERROR)
 
 
-class ScyllaBenchEvent(StressEvent, abstract=True):
-    failure: Type[StressEventProtocol]
-    error: Type[SctEventProtocol]
-    timeout: Type[StressEventProtocol]
-    start: Type[StressEventProtocol]
-    finish: Type[StressEventProtocol]
+class ScyllaBenchEvent(StressEvent):
 
     @property
     def msgfmt(self):
-        fmt = super(StressEvent, self).msgfmt + ": type={0.type} node={0.node} stress_cmd={0.stress_cmd}"
-        if self.errors:
+        fmt = super(StressEvent, self).msgfmt + " : type={0.type} node={0.node} stress_cmd={0.stress_cmd}"
+        if hasattr(self, "errors") and self.errors:
             return fmt + " error={0.errors_formatted}"
         return fmt
-
-
-ScyllaBenchEvent.add_stress_subevents(failure=Severity.CRITICAL, error=Severity.ERROR, timeout=Severity.ERROR)
 
 
 class BaseYcsbStressEvent(StressEvent, abstract=True):


### PR DESCRIPTION
This commit presents event categories:
- begin/end (continuous) event, like: Disruption, Stress load, Nodetool events.
  This events point when the event begins and when finishs
- informational event, mostly errors or any Info events that happens at one point of time,
  like LogEvents (DatabaseLogEvent, StresslogEvent).

Convert ScyllaBenchEvent and ScyllaBenchLogEvent according to new categories mechanism

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
