### PR TITLE
fix(sctEvent): fix __del__ to do not raise when hit race condition with dealloc of LOGGER

### DIFF
--- a/sdcm/sct_events/base.py
+++ b/sdcm/sct_events/base.py
@@ -203,8 +203,11 @@ class SctEvent:
 
     def __del__(self):
         if self._ready_to_publish:
-            LOGGER.warning(
-                "[SCT internal warning] %s has not been published or dumped, maybe you missed .publish()", self)
+            warning = f"[SCT internal warning] {self} has not been published or dumped, maybe you missed .publish()"
+            try:
+                LOGGER.warning(warning)
+            except:
+                print(warning)
 
 
 def add_severity_limit_rules(rules: List[str]) -> None:


### PR DESCRIPTION
https://trello.com/c/tmppHeqY/3449-fix-del-of-sctevent

Stop it from throwing:

```
Call stack:
  File "/extra/scylladb/scylla-cluster-tests/dkropachev2/sdcm/sct_events/base.py", line 218, in __del__
    LOGGER.warning(
Message: '[SCT internal warning] %s has not been published or dumped, maybe you missed .publish()'
Arguments: (<sdcm.sct_events.loaders.CassandraStressLogEvent.TooManyHintsInFlight object at 0x7fcf31f3fb50>,)
Exception ignored in: <function SctEvent.__del__ at 0x7fcf3854d040>
Traceback (most recent call last):
  File "/extra/scylladb/scylla-cluster-tests/dkropachev2/sdcm/sct_events/base.py", line 218, in __del__
  File "/usr/lib/python3.8/logging/__init__.py", line 1446, in warning
  File "/usr/lib/python3.8/logging/__init__.py", line 1577, in _log
  File "/usr/lib/python3.8/logging/__init__.py", line 1587, in handle
  File "/usr/lib/python3.8/logging/__init__.py", line 1649, in callHandlers
  File "/usr/lib/python3.8/logging/__init__.py", line 950, in handle
  File "/usr/lib/python3.8/logging/__init__.py", line 1182, in emit
  File "/usr/lib/python3.8/logging/__init__.py", line 1172, in _open
NameError: name 'open' is not defined
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
