### PR TITLE
feature(upgrade test): add jepsen test during upgrade test

### DIFF
--- a/configurations/jepsen.yaml
+++ b/configurations/jepsen.yaml
@@ -1,0 +1,7 @@
+# jepsen can only run on Debian 10
+gce_image_db: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-10'
+gce_image_loader: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-10'
+scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/debian/scylla-4.4-buster.list'
+jepsen_scylla_repo: 'https://github.com/scylladb/jepsen.git'
+enable_jepsen_in_upgrade: true
+gce_image_username: 'sct'  # jepsen will kill wrong processes if username is scylla-test

--- a/jenkins-pipelines/rolling-upgrade-jepsen-debian10.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-jepsen-debian10.jenkinsfile
@@ -1,0 +1,17 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+rollingUpgradePipeline(
+    backend: 'gce',
+    base_versions: ['2020.1', '4.5', '2021.1'],
+    linux_distro: 'debian-buster',
+    gce_image_db: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-10',
+
+    test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
+    test_config: '''["test-cases/upgrades/rolling-upgrade.yaml", "configurations/jepsen.yaml"]''',
+    workaround_kernel_bug_for_iotune: false,
+
+    timeout: [time: 360, unit: 'MINUTES']
+)

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -362,6 +362,9 @@ class SCTConfiguration(dict):
         dict(name="email_subject_postfix", env="SCT_EMAIL_SUBJECT_POSTFIX", type=str,
              help="""Email subject postfix"""),
 
+        dict(name='enable_jepsen_in_upgrade', env='SCT_ENABLE_JEPSEN_IN_UPGRADE', type=boolean,
+             help="execute jepsen test during upgrade test"),
+
         dict(name="enable_test_profiling", env="SCT_ENABLE_TEST_PROFILING", type=bool,
              help="""Turn on sct profiling"""),
         dict(name="ssh_transport", env="SSH_TRANSPORT", type=str,


### PR DESCRIPTION
ticket: https://trello.com/c/g2XkPGXA/3068-jepsen-during-upgrade

    feature(upgrade test): add jepsen test during upgrade test
    
    The jepsen test is executed after upgrading/rollbacking each node.
    Let's start with 200 seconds, we don't want to extend the test duration
    of upgrade, it's already too big. Jepsen can only be executed with
    debian10 loader/db nodes.


Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
