### PR TITLE
longevity-100gb-4h-ReplaceNode.yaml: Make each replace takes longer

### DIFF
--- a/test-cases/features/repair-based-operations/longevity-100gb-4h-ReplaceNode.yaml
+++ b/test-cases/features/repair-based-operations/longevity-100gb-4h-ReplaceNode.yaml
@@ -1,21 +1,25 @@
 test_duration: 360
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=20971520 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
+# 20971520  -> 100GB
+# 62914560  -> 300GB
+# 104857600 -> 500GB
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=240m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=240m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=62914560 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=80 -pop seq=1..62914560 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
+
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=240m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop seq=1..62914560 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=240m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=40 -pop seq=1..62914560 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
              ]
 
-n_db_nodes: 6
+n_db_nodes: 4
 n_loaders: 2
 n_monitor_nodes: 1
 
 instance_type_db: 'i3.4xlarge'
 
 nemesis_class_name: 'NodeTerminateAndReplace'
-nemesis_interval: 5
+nemesis_interval: 1
 nemesis_filter_seeds: false
-seeds_num: 3
+seeds_num: 1
 
 user_prefix: 'longevity-100gb-4h'
 space_node_threshold: 64424


### PR DESCRIPTION
longevity-100gb-4h-ReplaceNode.yaml: Make each replace takes longer
    
- Reduce the nodes from 6 to 4
    
- Increase dataset from 100GB to 300GB

