### PR TITLE
fix(manager): removed segments_per_repair config option entirely

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -5,7 +5,6 @@ ip_ssh_connections: 'private'
 mgmt_port: 10090
 scylla_repo_m: 'http://downloads.scylladb.com/rpm/centos/scylla-2020.1.repo'
 scylla_mgmt_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.3.repo'
-mgmt_segments_per_repair: 10
 
 experimental: true
 round_robin: false

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -41,7 +41,6 @@
 | **<a name="use_cloud_manager">use_cloud_manager</a>**  | When define true, will install scylla cloud manager | N/A | SCT_USE_CLOUD_MANAGER
 | **<a name="use_mgmt">use_mgmt</a>**  | When define true, will install scylla management | N/A | SCT_USE_MGMT
 | **<a name="mgmt_port">mgmt_port</a>**  | The port of scylla management | 10090 | SCT_MGMT_PORT
-| **<a name="mgmt_segments_per_repair">mgmt_segments_per_repair</a>**  | the number of segments per repair used for the manager's repair | 10 | MGMT_SEGMENTS_PER_REPAIR
 | **<a name="manager_prometheus_port">manager_prometheus_port</a>**  | Port to be used by the manager to contact Prometheus | N/A | SCT_MANAGER_PROMETHEUS_PORT
 | **<a name="target_scylla_mgmt_repo">target_scylla_mgmt_repo</a>**  | Url to the repo of scylla manager version used to upgrade the manager and agents | N/A | SCT_TARGET_SCYLLA_MGMT_REPO
 | **<a name="update_db_packages">update_db_packages</a>**  | A local directory of rpms to install a custom version on top of<br>the scylla installed (or from repo or from ami) | N/A | SCT_UPDATE_DB_PACKAGES

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -255,9 +255,6 @@ class SCTConfiguration(dict):
         dict(name="mgmt_port", env="SCT_MGMT_PORT", type=int,
              help="The port of scylla management"),
 
-        dict(name="mgmt_segments_per_repair", env="MGMT_SEGMENTS_PER_REPAIR", type=int,
-             help="the number of segments per repair used for the manager's repair"),
-
         dict(name="manager_prometheus_port", env="SCT_MANAGER_PROMETHEUS_PORT", type=int,
              help="Port to be used by the manager to contact Prometheus"),
 


### PR DESCRIPTION
Since the 'segments_per_repair' config option was removed in manager 2.3,
we removed it entirely from SCT.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
