### PR TITLE
fix(rbno): Set nemesis_during_prepare to false

### DIFF
--- a/test-cases/features/repair-based-operations/longevity-100gb-4h-Decommission.yaml
+++ b/test-cases/features/repair-based-operations/longevity-100gb-4h-Decommission.yaml
@@ -14,6 +14,7 @@ instance_type_db: 'i3.4xlarge'
 
 nemesis_class_name: 'DecommissionMonkey'
 nemesis_interval: 5
+nemesis_during_prepare: false
 nemesis_filter_seeds: false
 seeds_num: 3
 

--- a/test-cases/features/repair-based-operations/longevity-100gb-4h-ReplaceNode.yaml
+++ b/test-cases/features/repair-based-operations/longevity-100gb-4h-ReplaceNode.yaml
@@ -18,6 +18,7 @@ instance_type_db: 'i3.4xlarge'
 
 nemesis_class_name: 'NodeTerminateAndReplace'
 nemesis_interval: 1
+nemesis_during_prepare: false
 nemesis_filter_seeds: false
 seeds_num: 1
 

--- a/test-cases/features/repair-based-operations/longevity-1TB-12h-GrowShrink.yaml
+++ b/test-cases/features/repair-based-operations/longevity-1TB-12h-GrowShrink.yaml
@@ -24,6 +24,7 @@ scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/
 nemesis_class_name: 'GrowShrinkClusterNemesis'
 nemesis_add_node_cnt: 5
 nemesis_interval: 30
+nemesis_during_prepare: false
 nemesis_filter_seeds: false
 seeds_num: 2
 

--- a/test-cases/features/repair-based-operations/longevity-50GB-12h-RemoveNode.yaml
+++ b/test-cases/features/repair-based-operations/longevity-50GB-12h-RemoveNode.yaml
@@ -18,6 +18,7 @@ instance_type_loader: 'c5.2xlarge'
 
 nemesis_class_name: 'TerminateAndRemoveNodeMonkey'
 nemesis_interval: 5
+nemesis_during_prepare: false
 
 user_prefix: 'longevity-tls-50gb-3d'
 

--- a/test-cases/features/repair-based-operations/longevity-50GB-12h-ReplaceNode.yaml
+++ b/test-cases/features/repair-based-operations/longevity-50GB-12h-ReplaceNode.yaml
@@ -18,6 +18,7 @@ instance_type_loader: 'c5.2xlarge'
 
 nemesis_class_name: 'NodeTerminateAndReplace'
 nemesis_interval: 5
+nemesis_during_prepare: false
 
 user_prefix: 'longevity-tls-50gb-3d'
 

--- a/test-cases/features/repair-based-operations/longevity-cdc-100gb-4h-Decommission.yaml
+++ b/test-cases/features/repair-based-operations/longevity-cdc-100gb-4h-Decommission.yaml
@@ -14,6 +14,7 @@ instance_type_db: 'i3.4xlarge'
 
 nemesis_class_name: 'DecommissionMonkey'
 nemesis_interval: 5
+nemesis_during_prepare: false
 
 user_prefix: 'longevity-cdc-100gb-4h'
 space_node_threshold: 64424

--- a/test-cases/features/repair-based-operations/longevity-cdc-100gb-4h-RemoveNode.yaml
+++ b/test-cases/features/repair-based-operations/longevity-cdc-100gb-4h-RemoveNode.yaml
@@ -14,6 +14,7 @@ instance_type_db: 'i3.4xlarge'
 
 nemesis_class_name: 'TerminateAndRemoveNodeMonkey'
 nemesis_interval: 5
+nemesis_during_prepare: false
 
 user_prefix: 'longevity-cdc-100gb-4h'
 space_node_threshold: 64424

--- a/test-cases/features/repair-based-operations/longevity-cdc-100gb-4h-ReplaceNode.yaml
+++ b/test-cases/features/repair-based-operations/longevity-cdc-100gb-4h-ReplaceNode.yaml
@@ -14,6 +14,7 @@ instance_type_db: 'i3.4xlarge'
 
 nemesis_class_name: 'NodeTerminateAndReplace'
 nemesis_interval: 5
+nemesis_during_prepare: false
 
 user_prefix: 'longevity-cdc-100gb-4h'
 space_node_threshold: 64424


### PR DESCRIPTION
Otherwise node operations will be started before prepare_write_cmd
finishes. As a result, the dataset will be very small during operations.

