### PR TITLE
fix(pre-commit-checks): exclude minio chart template yaml files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@ repos:
             (?x)^(
                 tests/.*|
                 data_dir/scylla.yaml|
+                sdcm/k8s_configs/minio/templates/.*|
                 sdcm/k8s_configs/provisioner/templates/.*
             )$
     -   id: check-added-large-files


### PR DESCRIPTION
'pre-commit' checks do not understand substitution parts
of yaml templates used in Helm charts.
So, exclude recently added 'minio' yaml templates the same way
as it is excluded for another existing local helm chart - 'provisioner'

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
