### PR TITLE
improvement(commitlint): restrict header to be at max 72 symbols long

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,5 +1,7 @@
 module.exports = {
     rules: {
+        // Header
+        "header-max-length": [2, "always", 72],
         // Subject
         'subject-empty': [2, 'never'],
         'subject-full-stop': [2, 'never', '.'],


### PR DESCRIPTION
Reason:

    The number 72 comes from the fact that 80 characters is the widely
    accepted industry standard for readable character length of one
    line, git automatically adds a padding of 4 characters to the left
    of the commit message body, and to keep everything centered
    and looking nice, 4 characters should be padded to the right.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
