### PR TITLE
fix(nemesisterminatereplace): Skip nemesis if target node is single seed node

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -873,6 +873,11 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def disrupt_terminate_and_replace_node(self):  # pylint: disable=invalid-name
         # using "Replace a Dead Node" procedure from http://docs.scylladb.com/procedures/replace_dead_node/
         self._set_current_disruption('TerminateAndReplaceNode %s' % self.target_node)
+        # node_to_terminate and replace must not be the only seed in cluster
+        num_of_seed_nodes = len(self.cluster.seed_nodes)
+        if self.target_node.is_seed and num_of_seed_nodes < 2:
+            raise UnsupportedNemesis(
+                "Removing the only seed node is not yet supported. At least one node should be in cluster")
         old_node_ip = self.target_node.ip_address
         old_node_is_seed = self.target_node.is_seed
         InfoEvent(message='StartEvent - Terminate node and wait 5 minutes').publish()


### PR DESCRIPTION


if cluster configured with single seed node, then terminateandreplace nemesis
could fail if this node set as target and fail the test.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
