### PR TITLE
improvement(restart_with_resharding): don't publish compactionstat event

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2711,7 +2711,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         status : expected values: "start" or "finish"
         """
         patt = re.compile('RESHARD|RESHAP')
-        result = self.run_nodetool("compactionstats")
+        result = self.run_nodetool("compactionstats", publish_event=False)
         found = patt.search(result.stdout)
         # wait_for_status=='finish': If 'RESHARD' is not found in the compactionstats output, return True -
         # means resharding was finished


### PR DESCRIPTION
RestartNodeWithResharding nemesis used `nodetool compactionstats` and searched the results of calling that command to assert if resharding has taken place. This PR silences the publishing of the `NodeToolEvent` associated with the `nodetool compactionstats` call to the logs.

Trello task: https://trello.com/c/3RL23Yp9
"Before" jenkins pipeline run (208 "compactionstats" log lines): https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/maciej/job/mc-restart-with-resharding/6/
"After" jenkins pipeline run (0 "compactionstats" log lines): https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/maciej/job/mc-restart-with-resharding/7/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] ~~I added the relevant `backport` labels~~
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
