### PR TITLE
fix(artifact ami test): does not remove scylla data dir during scylla_image_setup

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2025,7 +2025,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         See https://docs.scylladb.com/operating-scylla/procedures/cluster-management/clear_data/
         """
         clean_commands_list = [
-            "sudo rm -rf /var/lib/scylla/data",
+            "sudo rm -rf /var/lib/scylla/data/*",
             "sudo find /var/lib/scylla/commitlog -type f -delete",
             "sudo find /var/lib/scylla/hints -type f -delete",
             "sudo find /var/lib/scylla/view_hints -type f -delete"


### PR DESCRIPTION
Artifact ami test failed during scylla_image_setup with error:
`ValueError: invalid literal for int() with base 16: '/var/lib/scylla/data doesnot
exist - skipping\n000000ff'`

In the master branch only files under data folder are removed.
Change 'clean_scylla_data' function accordingly

[Failed job](https://jenkins.scylladb.com/job/enterprise-2020.1/job/artifacts/job/artifacts-ami-test/411/console)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
