### PR TITLE
fix(install_scylla_bench): Add verbose option and retrying

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4834,6 +4834,7 @@ class BaseLoaderSet():
                     self.log.warning('Terminate gemini on node %s:\n%s', loader, kill_result)
 
     @staticmethod
+    @retrying(n=5)
     def install_scylla_bench(node):
         if node.distro.is_rhel_like:
             node.remoter.sudo("yum install -y git")
@@ -4849,7 +4850,7 @@ class BaseLoaderSet():
             echo 'export GOPATH=$HOME/go' >> $HOME/.bash_profile
             echo 'export PATH=$PATH:/usr/local/go/bin' >> $HOME/.bash_profile
             source $HOME/.bash_profile
-            go get -u github.com/scylladb/scylla-bench
+            go get -v -u github.com/scylladb/scylla-bench
         """))
 
 


### PR DESCRIPTION
Sometimes the go get command fails for timeouts or unclear error.
This will add the verbosity required to understand it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
