### PR TITLE
feature(grafana_snapshot): Add ability to login to grafana

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -25,7 +25,7 @@ scylla_linux_distro_loader: 'centos'
 ssh_transport: 'fabric'
 system_auth_rf: 3
 
-monitor_branch: 'branch-3.7'
+monitor_branch: 'branch-3.8'
 
 space_node_threshold: 0
 

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -538,6 +538,9 @@ class GrafanaSnapshot(GrafanaEntity):
             return snapshots
         try:
             self.remote_browser = RemoteBrowser(node)
+            monitoring_ui.Login(self.remote_browser.browser,
+                                ip=normalize_ipv6_url(node.grafana_address),
+                                port=self.grafana_port).use_default_creds()
             for dashboard in self.grafana_dashboards:
                 dashboard_exists = MonitoringStack.dashboard_exists(grafana_ip=normalize_ipv6_url(node.grafana_address),
                                                                     uid="-".join([dashboard.name, version]))


### PR DESCRIPTION
Next versions of scylla-monitoring is going new grafana versions,
which require authentication for getting grafana livesnapshots.

Added new class to monitoring.ui, which allow to logged in to
grafana and get access to grafana livesnapshots functionality.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
