### PR TITLE
fix(get_grafana_snapshot): collect all created snapshots

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -579,7 +579,6 @@ class GrafanaSnapshot(GrafanaEntity):
                     snapshots.append(dashboard.get_snapshot(self.remote_browser.browser))
                 except Exception as details:  # pylint: disable=broad-except
                     LOGGER.error("Error get snapshot %s: %s", dashboard.name, details)
-
             LOGGER.info(snapshots)
             return snapshots
 


### PR DESCRIPTION
When grafana snapshots were been taken, if getting any of snapshot
failed, no snapshots were saved.
Collect all snapshots which were created and save them

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~
