### PR TITLE
fix(repair-based-operations conf): Use 3 seed nodes

### DIFF
--- a/test-cases/features/repair-based-operations/longevity-100gb-4h-ReplaceNode.yaml
+++ b/test-cases/features/repair-based-operations/longevity-100gb-4h-ReplaceNode.yaml
@@ -20,7 +20,7 @@ nemesis_class_name: 'NodeTerminateAndReplace'
 nemesis_interval: 1
 nemesis_during_prepare: false
 nemesis_filter_seeds: false
-seeds_num: 1
+seeds_num: 3
 
 user_prefix: 'longevity-100gb-4h'
 space_node_threshold: 64424


### PR DESCRIPTION
SCT might fail the test if the only seed node is terminated. Revert to
use 3 seeds.