### PR TITLE
fix(verify_snitch): use correct helper function for scylla.yaml

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -90,7 +90,7 @@ class ArtifactsTest(ClusterTester):
         the backend used.
         """
         describecluster_snitch = self.get_describecluster_info().snitch
-        with self.node.remote_manager_yaml(SCYLLA_YAML_PATH) as scylla_yaml:
+        with self.node.remote_scylla_yaml(SCYLLA_YAML_PATH) as scylla_yaml:
             scylla_yaml_snitch = scylla_yaml['endpoint_snitch']
         expected_snitches = BACKENDS[backend_name]
 


### PR DESCRIPTION
Currently nonroot offline artifact-test failed to access
/etc/scylla/scylla.yaml, which doesn't exist.

remote_scylla_yaml() will try to add the install prefix for nonroot
install scylla.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
