### PR TITLE
fix(get_monitoring_version): don't fail save_email_data if monitor node were killed

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -120,15 +120,20 @@ class BaseMonitoringEntity(BaseLogEntity):
         return BaseMonitorSet
 
     def get_monitoring_version(self, node):
-        basedir = self.get_monitoring_base_dir(node)
-        result = node.remoter.run(
-            f'ls {basedir} | grep scylla-monitoring-src', ignore_status=True, verbose=False)
-        name = result.stdout.strip()
-        if not name:
-            LOGGER.error("Dir with scylla monitoring stack was not found")
+        try:
+            basedir = self.get_monitoring_base_dir(node)
+            result = node.remoter.run(
+                f'ls {basedir} | grep scylla-monitoring-src', ignore_status=True, verbose=False)
+            name = result.stdout.strip()
+            if not name:
+                LOGGER.error("Dir with scylla monitoring stack was not found")
+                return None, None, None
+            result = node.remoter.run(
+                f"cat {basedir}/scylla-monitoring-src/monitor_version", ignore_status=True, verbose=False)
+        except Exception as details:
+            LOGGER.error(f"Failed to get monitoring version: {details}")
             return None, None, None
-        result = node.remoter.run(
-            f"cat {basedir}/scylla-monitoring-src/monitor_version", ignore_status=True, verbose=False)
+
         try:
             monitor_version, scylla_version = result.stdout.strip().split(':')
         except ValueError:


### PR DESCRIPTION
Trello: https://trello.com/c/zD8aXzzb

At the end of the job, during collecting email data,
on stage getting grafana screenshot and snapshot,
monitoring node was killed or connection lost.
These cause that Snapshot could n't get the monitoring version,
because could n't connect to monitor node and raise the exception
'exception=Unable to run "ls /home/scylla-test/sct-monitoring | grep scylla-monitoring-src":
 failed connecting to "10.142.15.192" during 60s'
and these exception failed to save_email_data and email report is not save to file.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
