### PR TITLE
fix(ec2_instance_wait_public_ip): increase waiting timout up to 15 minutes

### DIFF
--- a/sdcm/utils/aws_utils.py
+++ b/sdcm/utils/aws_utils.py
@@ -294,7 +294,7 @@ class PublicIpNotReady(Exception):
     pass
 
 
-@retrying(n=7, sleep_time=10, allowed_exceptions=(PublicIpNotReady,),
+@retrying(n=90, sleep_time=10, allowed_exceptions=(PublicIpNotReady,),
           message="Waiting for instance to get public ip")
 def ec2_instance_wait_public_ip(instance):
     instance.reload()


### PR DESCRIPTION
Got situation when waiting 60 seconds to get public ip was not enough
Increaing timeout up to 15 minutes

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
