### PR TITLE
refactor(cassandra-stress event): define c-s event as continuous event

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -39,10 +39,6 @@ GeminiEvent.error: CRITICAL
 GeminiEvent.warning: WARNING
 GeminiEvent.start: NORMAL
 GeminiEvent.finish: NORMAL
-CassandraStressEvent.failure: CRITICAL
-CassandraStressEvent.error: ERROR
-CassandraStressEvent.start: NORMAL
-CassandraStressEvent.finish: NORMAL
 YcsbStressEvent.failure: CRITICAL
 YcsbStressEvent.error: ERROR
 YcsbStressEvent.start: NORMAL
@@ -88,3 +84,4 @@ EventsFilter: NORMAL
 EventsSeverityChangerFilter: NORMAL
 NodetoolEvent: ERROR
 ScyllaBenchEvent: CRITICAL
+CassandraStressEvent: CRITICAL

--- a/sdcm/sct_events/base.py
+++ b/sdcm/sct_events/base.py
@@ -272,7 +272,18 @@ class ContinuousEvent(SctEvent, abstract=True):
             self.publish()
 
     def add_error(self, errors: Optional[List[str]]) -> None:
-        self.errors = errors
+        if not isinstance(self.errors, list):
+            self.errors = []
+
+        self.errors.extend(errors)
+
+    # TODO: rename function to "error" after the refactor will be done
+    def event_error(self, publish: bool = True):
+        self.timestamp = time.time()
+        self.period_type = EventPeriod.Informational.value
+        if publish:
+            self._ready_to_publish = True
+            self.publish()
 
 
 def add_severity_limit_rules(rules: List[str]) -> None:

--- a/sdcm/sct_events/loaders.py
+++ b/sdcm/sct_events/loaders.py
@@ -58,21 +58,8 @@ class GeminiEvent(BaseStressEvent, abstract=True):
 GeminiEvent.add_stress_subevents(error=Severity.CRITICAL, warning=Severity.WARNING)
 
 
-class CassandraStressEvent(StressEvent, abstract=True):
-    failure: Type[StressEventProtocol]
-    error: Type[StressEventProtocol]
-    start: Type[StressEventProtocol]
-    finish: Type[StressEventProtocol]
-
-    @property
-    def msgfmt(self):
-        fmt = super(StressEvent, self).msgfmt + ": type={0.type} node={0.node}\n"
-        if self.errors:
-            return fmt + "{0.errors_formatted}"
-        return fmt + "stress_cmd={0.stress_cmd}"
-
-
-CassandraStressEvent.add_stress_subevents(failure=Severity.CRITICAL, error=Severity.ERROR)
+class CassandraStressEvent(StressEvent):
+    ...
 
 
 class ScyllaBenchEvent(StressEvent):


### PR DESCRIPTION
Convert CassandraStressEvent to be continuous event and report when it begins and ends.

Extention of commit:
https://github.com/scylladb/scylla-cluster-tests/pull/3638

[Task](https://trello.com/c/bOEw6JcD/3467-convert-cassandrastressevent-to-be-continuous-event)

[Test with event](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/yulia/job/staging-10gb-3h/lastBuild/console)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
