### PR TITLE
fix(test_defaults): make default mgmt_agent_repo rpm

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -7,7 +7,6 @@ ip_ssh_connections: 'private'
 scylla_repo: ''
 scylla_repo_m: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylla-2020.1.repo'
 scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo'
-scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/focal/master/latest/scylla-manager-master/scylla-manager.list'
 
 scylla_repo_loader: ''
 

--- a/test-cases/PR-provision-test-docker.yaml
+++ b/test-cases/PR-provision-test-docker.yaml
@@ -13,6 +13,8 @@ nemesis_filter_seeds: false
 
 user_prefix: 'PR-provision-docker'
 
-scylla_version: 4.0.0
+scylla_version: 4.4.1
+scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/branch-2.0/latest/scylla-manager.repo'
+
 system_auth_rf: 0
 monitor_swap_size: 0

--- a/test-cases/PR-provision-test-docker.yaml
+++ b/test-cases/PR-provision-test-docker.yaml
@@ -14,7 +14,7 @@ nemesis_filter_seeds: false
 user_prefix: 'PR-provision-docker'
 
 scylla_version: 4.4.1
-scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/branch-2.0/latest/scylla-manager.repo'
+scylla_mgmt_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.3.repo'
 
 system_auth_rf: 0
 monitor_swap_size: 0

--- a/test-cases/PR-provision-test.yaml
+++ b/test-cases/PR-provision-test.yaml
@@ -23,7 +23,7 @@ instance_provision: 'spot'
 gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
 
 scylla_version: 4.4.1
-scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/branch-2.0/latest/scylla-manager.repo'
+scylla_mgmt_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.3.repo'
 
 workaround_kernel_bug_for_iotune: true
 

--- a/test-cases/PR-provision-test.yaml
+++ b/test-cases/PR-provision-test.yaml
@@ -22,7 +22,9 @@ instance_provision: 'spot'
 
 gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
 
-scylla_version: "4.0.0"
+scylla_version: 4.4.1
+scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/branch-2.0/latest/scylla-manager.repo'
+
 workaround_kernel_bug_for_iotune: true
 
 post_behavior_db_nodes: "destroy"


### PR DESCRIPTION
Currently test_defaults.yaml points to scylla_mgmt_repo and scylla_mgmt_agent_repo to rpm and deb respectively:

```
scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo'
scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/focal/master/latest/scylla-manager-master/scylla-manager.list'
```
It makes test to fail if default values are used:
```
06:38:45  < t:2021-06-17 03:38:44,476 f:tester.py       l:132  c:sdcm.tester          p:ERROR > Command: 'sudo yum install -y scylla-manager-agent'
06:38:45  < t:2021-06-17 03:38:44,476 f:tester.py       l:132  c:sdcm.tester          p:ERROR > 
06:38:45  < t:2021-06-17 03:38:44,476 f:tester.py       l:132  c:sdcm.tester          p:ERROR > Exit code: 1
06:38:45  < t:2021-06-17 03:38:44,476 f:tester.py       l:132  c:sdcm.tester          p:ERROR > 
06:38:45  < t:2021-06-17 03:38:44,476 f:tester.py       l:132  c:sdcm.tester          p:ERROR > Stdout:
06:38:45  < t:2021-06-17 03:38:44,476 f:tester.py       l:132  c:sdcm.tester          p:ERROR > 
06:38:45  < t:2021-06-17 03:38:44,476 f:tester.py       l:132  c:sdcm.tester          p:ERROR > Loaded plugins: fastestmirror
06:38:45  < t:2021-06-17 03:38:44,476 f:tester.py       l:132  c:sdcm.tester          p:ERROR > 
06:38:45  < t:2021-06-17 03:38:44,476 f:tester.py       l:132  c:sdcm.tester          p:ERROR > Stderr:
06:38:45  < t:2021-06-17 03:38:44,476 f:tester.py       l:132  c:sdcm.tester          p:ERROR > 
06:38:45  < t:2021-06-17 03:38:44,476 f:tester.py       l:132  c:sdcm.tester          p:ERROR > 
06:38:45  < t:2021-06-17 03:38:44,476 f:tester.py       l:132  c:sdcm.tester          p:ERROR > 
06:38:45  < t:2021-06-17 03:38:44,476 f:tester.py       l:132  c:sdcm.tester          p:ERROR > File contains no section headers.
06:38:45  < t:2021-06-17 03:38:44,476 f:tester.py       l:132  c:sdcm.tester          p:ERROR > file: file:///etc/yum.repos.d/scylla-manager.repo, line: 1
06:38:45  < t:2021-06-17 03:38:44,476 f:tester.py       l:132  c:sdcm.tester          p:ERROR > 'deb [arch=amd64] http://downloads.scylladb.com/manager/deb/unstable/focal/master/42/scylla-manager-master focal multiverse\n'
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
