### PR TITLE
refactor(manager): advanced the manager's scylla backend to 2021.1

### DIFF
--- a/configurations/manager/debian10.yaml
+++ b/configurations/manager/debian10.yaml
@@ -1,4 +1,4 @@
 ami_id_monitor: 'ami-07d02ee1eeb0c996c'  # Debian buster image - debian-10-amd64-20210208-542
 ami_monitor_user: 'admin'
 
-scylla_repo_m: null # no 2020 build for debian 10, no testing for it so far
+scylla_repo_m: "http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylla-2021.1.list"

--- a/configurations/manager/debian9.yaml
+++ b/configurations/manager/debian9.yaml
@@ -1,4 +1,4 @@
 ami_id_monitor: 'ami-0cfac3931b2a799d1'  # Debian stretch image
 ami_monitor_user: 'admin'
 
-scylla_repo_m: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/debian/scylla-2020.1-stretch.list'
+scylla_repo_m: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylla-2020.1.list'  # Notice: Uses 2020.1, while other (newer deb) use 2021, since we support both

--- a/configurations/manager/ubuntu16.yaml
+++ b/configurations/manager/ubuntu16.yaml
@@ -1,4 +1,4 @@
 ami_id_monitor: 'ami-092d0d014b7b31a08'  # Canonical, Ubuntu, 16.04 LTS, amd64 xenial image build on 2019-02-12
 ami_monitor_user: 'ubuntu'
 
-scylla_repo_m: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-2020.1-xenial.list'
+scylla_repo_m: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylla-2020.1.list'  # Notice: Uses 2020.1, while other (newer deb) use 2021, since we support both

--- a/configurations/manager/ubuntu18.yaml
+++ b/configurations/manager/ubuntu18.yaml
@@ -1,4 +1,4 @@
 ami_id_monitor: 'ami-08b314ce48a790a19'  # Canonical, Ubuntu, 18.04 LTS, amd64 bionic image build on 2019-07-22
 ami_monitor_user: 'ubuntu'
 
-scylla_repo_m: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-2020.1-bionic.list'
+scylla_repo_m: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylla-2020.1.list'  # Notice: Uses 2020.1, while other (newer deb) use 2021, since we support both

--- a/configurations/manager/ubuntu20.yaml
+++ b/configurations/manager/ubuntu20.yaml
@@ -1,4 +1,4 @@
 ami_id_monitor: 'ami-042e8287309f5df03'  # Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2021-02-23
 ami_monitor_user: 'ubuntu'
 
-scylla_repo_m: null  # no 2020 build for ubuntu 20, no testing for it so far
+scylla_repo_m: "http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylla-2021.1.list"

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -5,7 +5,7 @@ test_duration: 60
 ip_ssh_connections: 'private'
 
 scylla_repo: ''
-scylla_repo_m: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylla-2020.1.repo'
+scylla_repo_m: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylla-2020.1.repo'  # Notice: that default (centos) monitors use 2020.1, while other (newer deb) use 2021, since we support both
 scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo'
 scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/focal/master/latest/scylla-manager-master/scylla-manager.list'
 


### PR DESCRIPTION
Since 2021 has a build for both debian 10 and ubuntu 20,
I changed scylla_repo_m to use scylla enterprise 2021 across the board

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
