### PR TITLE
[branch-2020.1] fix(upgrade test): ignore "Can't find column family error"

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -495,6 +495,7 @@ class UpgradeTest(FillDatabaseData):
                 DbEventsFilter(type='SCHEMA_FAILURE', line='Failed to load schema'), \
                 DbEventsFilter(type='DATABASE_ERROR', line='Failed to pull schema'), \
                 DbEventsFilter(type='RUNTIME_ERROR', line='Failed to load schema'), \
+                DbEventsFilter(type='DATABASE_ERROR', line='Can\'t find a column family with UUID'), \
                 DbEventsFilter(type='RUNTIME_ERROR', line='Could not retrieve CDC streams with timestamp'), \
                 DbEventsFilter(type='DATABASE_ERROR', line="cql_server - exception while processing connection: "
                                                            "seastar::nested_exception (seastar::nested_exception)"):
@@ -570,6 +571,7 @@ class UpgradeTest(FillDatabaseData):
                 DbEventsFilter(type='SCHEMA_FAILURE', line='Failed to load schema'), \
                 DbEventsFilter(type='DATABASE_ERROR', line='Failed to pull schema'), \
                 DbEventsFilter(type='RUNTIME_ERROR', line='Failed to load schema'), \
+                DbEventsFilter(type='DATABASE_ERROR', line='Can\'t find a column family with UUID'), \
                 DbEventsFilter(type='RUNTIME_ERROR', line='Could not retrieve CDC streams with timestamp'), \
                 DbEventsFilter(type='DATABASE_ERROR', line="cql_server - exception while processing connection: "
                                                            "seastar::nested_exception (seastar::nested_exception)"):


### PR DESCRIPTION
In the issue https://github.com/scylladb/scylla-enterprise/issues/1698
Eliran suggested to ignore the error when the first node gets upgraded
to enterprise until all nodes have the service_levels table propagated
to them.

For branch-2020.1 only.
Similar to fix in branch-2021.1:
https://github.com/scylladb/scylla-cluster-tests/pull/3520

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
