### PR TITLE
fix(artifacts_test): skip snitch test when not using a preinstalled version

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -88,6 +88,10 @@ class ArtifactsTest(ClusterTester):
         Verify that the snitch used in the cluster is appropriate for
         the backend used.
         """
+        if not self.params["use_preinstalled_scylla"]:
+            self.log.info(f"Skipping verifying the snitch due to the 'use_preinstalled_scylla' being set to False")
+            return
+
         describecluster_snitch = self.get_describecluster_info().snitch
         with self.node.remote_scylla_yaml() as scylla_yaml:
             scylla_yaml_snitch = scylla_yaml['endpoint_snitch']


### PR DESCRIPTION
Our artifacts tests were checking for the correct snitch according to the backend used. When we are not using a preinstalled Scylla version, the snitch is not set to the backend-specific version, so the tests fail. This PR adds a simple `if`-check for the `use_preinstalled_scylla` param: if we're not using a preinstalled Scylla, we skip the snitch check altogether.

Jenkins jobs:
- with skip (without preinstalled scylla): https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/maciej/job/mc-artifacts/job/mc-artifacts-centos-7/14/
- without skip (without preinstalled scylla): https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/maciej/job/mc-artifacts/job/mc-artifacts-centos-7/13/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] ~~I added the relevant `backport` labels~~
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
