### PR TITLE
fix(k8s-loaders): remove upper limits for loader pods

### DIFF
--- a/sdcm/k8s_configs/loaders.yaml
+++ b/sdcm/k8s_configs/loaders.yaml
@@ -33,9 +33,7 @@ spec:
             - mountPath: /var/run/docker.sock
               name: docker-socket
           resources:
-            limits:
-              cpu: ${CPU_LIMIT}
-              memory: ${MEMORY_LIMIT}
+            # NOTE: set only 'requests' and not 'limits' to reuse as many resources as possible
             requests:
               cpu: ${CPU_LIMIT}
               memory: ${MEMORY_LIMIT}


### PR DESCRIPTION
For the moment we set fixed limit for resource utilization by loader pods.
For example, if we have 4 CPU cores then only 3 of them will be used by a loader pod.
Such restriction directly influences performance measurement.
So, remove upper limit and use only lower one for loader pods allowing K8S provide more when there are free resources.
And there must be free resources because laoder pods run on dedicated nodes where nothing else resource-consuming is going to run.

Running latency-read test I got following results for latency 99th percentile on my setup:
- 5.1ms with fix
- 5.7ms without fix

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
