### PR TITLE
improvement(logcollector): make tar.gz archives instead of zip ones

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -17,8 +17,8 @@ import time
 import shutil
 import fnmatch
 import logging
-import zipfile
 import datetime
+import tarfile
 import tempfile
 import traceback
 from typing import Optional
@@ -717,7 +717,7 @@ class LogCollector:
             LOGGER.warning('Directory %s is empty', self.local_dir)
             return None
 
-        final_archive = self.archive_dir_with_zip64(self.local_dir)
+        final_archive = self.archive_dir_to_tarfile(self.local_dir)
         if not final_archive:
             return None
         s3_link = upload_archive_to_s3(final_archive, f"{self.test_id}/{self.current_run}")
@@ -746,23 +746,16 @@ class LogCollector:
         pass
 
     @staticmethod
-    def archive_dir_with_zip64(logdir):
-        archive_base_name = os.path.basename(logdir)
-        archive_storage_dir = os.path.dirname(logdir)
-        archive_full_name = os.path.join(archive_storage_dir, archive_base_name + ".zip")
-        cur_dir = os.getcwd()
+    def archive_dir_to_tarfile(logdir):
+        logdir_name = os.path.basename(logdir)
+        archive_name = f"{logdir_name}.tar.gz"
         try:
-            with zipfile.ZipFile(archive_full_name, "w", allowZip64=True) as arch:
-                os.chdir(logdir)
-                for root, _, files in os.walk(logdir):
-                    for log_file in files:
-                        full_path = os.path.join(root, log_file)
-                        arch.write(full_path, full_path.replace(logdir, ""))
-                os.chdir(cur_dir)
-        except Exception as details:  # pylint: disable=broad-except
-            LOGGER.error("Error during creating archive. Error details: \n%s", details)
-            archive_full_name = None
-        return archive_full_name
+            with tarfile.open(archive_name, "w:gz") as tar:
+                tar.add(logdir, arcname=logdir_name)
+        except Exception as details:
+            LOGGER.error("Error during archive creation. Details: \n%s", details)
+            return None
+        return archive_name
 
 
 class ScyllaLogCollector(LogCollector):
@@ -948,7 +941,7 @@ class SCTLogCollector(LogCollector):
                 LOGGER.warning('Nothing found')
                 return None
 
-        final_archive = self.archive_dir_with_zip64(self.local_dir)
+        final_archive = self.archive_dir_to_tarfile(self.local_dir)
 
         s3_link = upload_archive_to_s3(final_archive, f"{self.test_id}/{self.current_run}")
         remove_files(self.local_dir)


### PR DESCRIPTION
Zip does per-file compression and tar does it per-dir.
And we compress directories with lots of files then upload it to S3.

Compression example of the same K8S logs set:
- 36Mb using zip
- 2.9Mb using tar.gz

So, make our 'logcollector' compress files using 'tar' and not 'zip'
to be able to reduce the used S3 storage and reduce download time
significantly.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
