### PR TITLE
fix(k8s-nemesis): fix logic of terminate_k8s_node nemesis

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1367,6 +1367,7 @@ class BasePodContainer(cluster.BaseNode):
         wait_for(self._wait_for_k8s_node_readiness,
                  text=f"Wait for k8s host {self.node_name} to be ready...",
                  timeout=self.pod_readiness_timeout * 60,
+                 step=5,
                  throw_exc=True)
 
     def _wait_for_k8s_node_readiness(self):


### PR DESCRIPTION
We have 2 skipped nemesises for termination of K8S nodes:
- terminate_k8s_node
- terminate_k8s_host

Both of these have implementation bugs such as attempt to get inexistent variable or using wrong one.
So, fix those bugs now. And later only uncomment it's usage when [1] is fixed.

[1] https://github.com/scylladb/scylla-operator/issues/643

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
