### PR TITLE
Revert "fix(scylla_args): workaround for doubled scylla options"

### DIFF
--- a/sdcm/utils/scylla_args.py
+++ b/sdcm/utils/scylla_args.py
@@ -38,7 +38,7 @@ class ScyllaArgError(Exception):
 
 class ScyllaArgParser(argparse.ArgumentParser):
     def __init__(self, prog: str) -> None:
-        super().__init__(prog=prog, argument_default=argparse.SUPPRESS, add_help=False, conflict_handler="resolve")
+        super().__init__(prog=prog, argument_default=argparse.SUPPRESS, add_help=False)
 
     def error(self, message: Text) -> NoReturn:
         LOGGER.error(message)


### PR DESCRIPTION
Reverts scylladb/scylla-cluster-tests#2686

Original issue https://github.com/scylladb/scylla-enterprise/issues/1473 was fixed.