### PR TITLE
fix(terminateandreplace): choose new seed before termination old one

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2275,10 +2275,13 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         # node_to_remove must be different than node
         verification_node = random.choice([n for n in self.cluster.nodes if n is not node_to_remove])
 
-        # node_to_remove must not be the only seed in cluster
+        # node_to_remove is single/last seed in cluster, before
+        # it will be terminated, choose new seed node
         num_of_seed_nodes = len(self.cluster.seed_nodes)
         if node_to_remove.is_seed and num_of_seed_nodes < 2:
-            raise UnsupportedNemesis("Removing the only seed node is not yet supported")
+            new_seed_node = random.choice([n for n in self.cluster.nodes if n is not node_to_remove])
+            new_seed_node.set_seed_flag(True)
+            self.cluster.update_seed_provider()
 
         # get node's host_id
         removed_node_status = self.cluster.get_node_status_dictionary(
@@ -2339,8 +2342,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
             # add new node
             new_node = self._add_and_init_new_cluster_node(rack=self.target_node.rack)
-            # in case the removed node was a seed
-            if node_to_remove.is_seed:
+            # in case the removed node was not last seed.
+            if node_to_remove.is_seed and num_of_seed_nodes > 1:
                 new_node.set_seed_flag(True)
                 self.cluster.update_seed_provider()
             # after add_node, the left nodes have data that isn't part of their tokens anymore.


### PR DESCRIPTION
The issue that if we have one seed node, we first terminate it and
then try to add new node, but it will failed, because no seeds left in cluster.
As a solution,

1.check if node is single seed
2.if yes, then choose random node and set it as seed
3.terminate target seed node and replace with new one.
4.leave cluster as is with seed node choosen on step 2

related to
https://github.com/scylladb/scylla-cluster-tests/pull/3651

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
