### PR TITLE
fix(gemini event): Convert GeminiEvent to be continuous event

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -35,10 +35,6 @@ DatabaseLogEvent.SUPPRESSED_MESSAGES: WARNING
 DatabaseLogEvent.stream_exception: ERROR
 DatabaseLogEvent.POWER_OFF: CRITICAL
 IndexSpecialColumnErrorEvent: ERROR
-GeminiEvent.error: CRITICAL
-GeminiEvent.warning: WARNING
-GeminiEvent.start: NORMAL
-GeminiEvent.finish: NORMAL
 YcsbStressEvent.failure: CRITICAL
 YcsbStressEvent.error: ERROR
 YcsbStressEvent.start: NORMAL
@@ -61,7 +57,7 @@ CassandraStressLogEvent.OperationOnKey: CRITICAL
 # TODO: mechanism.
 CassandraStressLogEvent.TooManyHintsInFlight: ERROR
 ScyllaBenchLogEvent.ConsistencyError: ERROR
-GeminiLogEvent.geminievent: CRITICAL
+GeminiStressLogEvent.GeminiEvent: CRITICAL
 PrometheusAlertManagerEvent.start: WARNING
 PrometheusAlertManagerEvent.end: WARNING
 ScyllaOperatorLogEvent: ERROR
@@ -85,3 +81,4 @@ EventsSeverityChangerFilter: NORMAL
 NodetoolEvent: ERROR
 ScyllaBenchEvent: CRITICAL
 CassandraStressEvent: CRITICAL
+GeminiStressEvent: CRITICAL


### PR DESCRIPTION
Convert GeminiEvent to be continuous event and report when it begins and ends.

Extention of commit:
https://github.com/scylladb/scylla-cluster-tests/pull/3638

Events:
```
2021-06-20 15:39:21.213: (GeminiStressEvent Severity.NORMAL) period_type=begin event_id=a22ce53d-4f63-404d-bdcb-4aa0e2337e4f: node=Node gemini-basic-3h-event-re-loader-node-9bbd40a9-1 [54.217.52.215 | 10.0.2.53] (seed: False) gemini_cmd=/$HOME/gemini -d --duration 6000s --warmup 1800s -c 100 -m mixed -f --non-interactive --cql-features normal --max-mutation-retries 5 --max-mutation-retries-backoff 500ms --async-objects-stabilization-attempts 5 --async-objects-stabilization-backoff 500ms --replication-strategy "{'class': 'SimpleStrategy', 'replication_factor': '3'}" --oracle-replication-strategy "{'class': 'SimpleStrategy', 'replication_factor': '1'}" --test-cluster=10.0.3.147,10.0.2.24,10.0.1.160 --outfile /home/centos/gemini_result_058a8432-da24-4e96-9c97-b4b448858793.log --seed 53 --oracle-cluster=10.0.0.62
2021-06-20 15:39:27.569: (GeminiStressLogEvent Severity.NORMAL) period_type=one-time event_id=a22ce53d-4f63-404d-bdcb-4aa0e2337e4f: type=GeminiEvent line_number=166 node=Node gemini-basic-3h-event-re-loader-node-9bbd40a9-1 [54.217.52.215 | 10.0.2.53] (seed: False)
line=starting partition key generation loop (N="generator")
2021-06-20 17:39:20.639: (GeminiStressLogEvent Severity.NORMAL) period_type=one-time event_id=a22ce53d-4f63-404d-bdcb-4aa0e2337e4f: type=GeminiEvent line_number=167 node=Node gemini-basic-3h-event-re-loader-node-9bbd40a9-1 [54.217.52.215 | 10.0.2.53] (seed: False)
line=Told to stop, exiting.
2021-06-20 17:39:20.639: (GeminiStressLogEvent Severity.NORMAL) period_type=one-time event_id=a22ce53d-4f63-404d-bdcb-4aa0e2337e4f: type=GeminiEvent line_number=168 node=Node gemini-basic-3h-event-re-loader-node-9bbd40a9-1 [54.217.52.215 | 10.0.2.53] (seed: False)
line=Test run stopped. Exiting. (N="pump")
2021-06-20 17:39:28.398: (GeminiStressLogEvent Severity.NORMAL) period_type=one-time event_id=a22ce53d-4f63-404d-bdcb-4aa0e2337e4f: type=GeminiEvent line_number=169 node=Node gemini-basic-3h-event-re-loader-node-9bbd40a9-1 [54.217.52.215 | 10.0.2.53] (seed: False)
line=result channel closed
2021-06-20 17:39:33.463: (GeminiStressEvent Severity.NORMAL) period_type=end event_id=a22ce53d-4f63-404d-bdcb-4aa0e2337e4f: node=Node gemini-basic-3h-event-re-loader-node-9bbd40a9-1 [54.217.52.215 | 10.0.2.53] (seed: False) gemini_cmd=/$HOME/gemini -d --duration 6000s --warmup 1800s -c 100 -m mixed -f --non-interactive --cql-features normal --max-mutation-retries 5 --max-mutation-retries-backoff 500ms --async-objects-stabilization-attempts 5 --async-objects-stabilization-backoff 500ms --replication-strategy "{'class': 'SimpleStrategy', 'replication_factor': '3'}" --oracle-replication-strategy "{'class': 'SimpleStrategy', 'replication_factor': '1'}" --test-cluster=10.0.3.147,10.0.2.24,10.0.1.160 --outfile /home/centos/gemini_result_058a8432-da24-4e96-9c97-b4b448858793.log --seed 53 --oracle-cluster=10.0.0.62
```

[Test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/yulia/job/yulia-gemini-3h-test/8/console)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
