### PR TITLE
fix(monitoring): removing unnecessary backslash

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5068,7 +5068,7 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
         labels = " ".join(f"--label {key}={value}" for key, value in node.tags.items())
         scylla_manager_servers_arg = ""
         if self.params.get("use_mgmt"):
-            scylla_manager_servers_arg = f'-N `realpath "{self.monitoring_conf_dir}/scylla_manager_servers.yml"` \\'
+            scylla_manager_servers_arg = f'-N `realpath "{self.monitoring_conf_dir}/scylla_manager_servers.yml"`'
         run_script = dedent(f"""
             cd -P {self.monitor_install_path}
             mkdir -p {self.monitoring_data_dir}


### PR DESCRIPTION
Related to https://github.com/scylladb/scylla-monitoring/issues/1445

Tested here: https://jenkins.scylladb.com/job/scylla-master/job/longevity/job/byo-longevity-test/149/consoleFull

Failure:
```
19:39:31  < t:2021-06-20 16:39:30,960 f:tester.py       l:132  c:sdcm.tester          p:ERROR >     raise UnexpectedExit(result)
19:39:31  < t:2021-06-20 16:39:30,960 f:tester.py       l:132  c:sdcm.tester          p:ERROR > invoke.exceptions.UnexpectedExit: Encountered a bad command exit code!
19:39:31  < t:2021-06-20 16:39:30,960 f:tester.py       l:132  c:sdcm.tester          p:ERROR > 
19:39:31  < t:2021-06-20 16:39:30,960 f:tester.py       l:132  c:sdcm.tester          p:ERROR > Command: 'bash -ce \'\ncd -P /home/centos/sct-monitoring/scylla-monitoring-src\nmkdir -p /home/centos/sct-monitoring/scylla-monitoring-data\n./start-all.sh             -D "--label RunByUser=amnonh --label TestName=longevity_test.LongevityTest.test_custom_time --label TestId=d69fe0a2-7d66-4970-991c-379ce8d2614b --label version=scylla-master --label JenkinsJobTag=jenkins-scylla-master-longevity-byo-longevity-test-148 --label NodeType=monitor --label keep_action=terminate --label Name=longevity-100gb-4h-master-monitor-node-d69fe0a2-1 --label NodeIndex=1"             -s `realpath "/home/centos/sct-monitoring/scylla-monitoring-src/config/scylla_servers.yml"`             -n `realpath "/home/centos/sct-monitoring/scylla-monitoring-src/config/node_exporter_servers.yml"`             -N `realpath "/home/centos/sct-monitoring/scylla-monitoring-src/config/scylla_manager_servers.yml"` \\             -d `realpath "/home/centos/sct-monitoring/scylla-monitoring-data"` -l -v master,master -b "-web.enable-admin-api"\n\''
19:39:31  < t:2021-06-20 16:39:30,960 f:tester.py       l:132  c:sdcm.tester          p:ERROR > 
19:39:31  < t:2021-06-20 16:39:30,960 f:tester.py       l:132  c:sdcm.tester          p:ERROR > Exit code: 1
19:39:31  < t:2021-06-20 16:39:30,960 f:tester.py       l:132  c:sdcm.tester          p:ERROR > 
19:39:31  < t:2021-06-20 16:39:30,960 f:tester.py       l:132  c:sdcm.tester          p:ERROR > Stdout:
19:39:31  < t:2021-06-20 16:39:30,960 f:tester.py       l:132  c:sdcm.tester          p:ERROR > 
19:39:31  < t:2021-06-20 16:39:30,960 f:tester.py       l:132  c:sdcm.tester          p:ERROR > Warning: without an external Prometheus directory, Prometheus data will be deleted on shutdown, use the -d command line flag for data persistence.
19:39:31  < t:2021-06-20 16:39:30,960 f:tester.py       l:132  c:sdcm.tester          p:ERROR > Wait for alert manager container to start
19:39:31  < t:2021-06-20 16:39:30,960 f:tester.py       l:132  c:sdcm.tester          p:ERROR > Wait for Loki container to start.
19:39:31  < t:2021-06-20 16:39:30,960 f:tester.py       l:132  c:sdcm.tester          p:ERROR > 58026551868cc08d2f039a6d8566045f789e33cf8fcb423007a71f2a33a94ad6
19:39:31  < t:2021-06-20 16:39:30,960 f:tester.py       l:132  c:sdcm.tester          p:ERROR > Wait for Prometheus container to start..
19:39:31  < t:2021-06-20 16:39:30,960 f:tester.py       l:132  c:sdcm.tester          p:ERROR > 
19:39:31  < t:2021-06-20 16:39:30,960 f:tester.py       l:132  c:sdcm.tester          p:ERROR > Stderr:
19:39:31  < t:2021-06-20 16:39:30,960 f:tester.py       l:132  c:sdcm.tester          p:ERROR > 
19:39:31  < t:2021-06-20 16:39:30,960 f:tester.py       l:132  c:sdcm.tester          p:ERROR > missing argument for -v
19:39:31  < t:2021-06-20 16:39:30,960 f:tester.py       l:132  c:sdcm.tester          p:ERROR > start-grafana.sh [-h] [-v comma separated versions ] [-g grafana port ] [-G path to external dir] [-n grafana container name ] [-p ip:port address of prometheus ] [-j additional dashboard to load to Grafana, multiple params are supported] [-c grafana enviroment variable, multiple params are supported] [-x http_proxy_host:port] [-m alert_manager address] [-a admin password] [ -M scylla-manager version ] [-D encapsulate docker param] [-Q Grafana anonymous role (Admin/Editor/Viewer)] [-S start with a system specific dashboard set] [-P ldap_config_file] -- loads the prometheus datasource and the Scylla dashboards into an existing grafana installation
19:39:31  < t:2021-06-20 16:39:30,960 f:tester.py       l:132  c:sdcm.tester          p:ERROR > 
19:39:31  < t:2021-06-20 16:39:30,960 f:tester.py       l:132  c:sdcm.tester          p:ERROR > 
19:39:31  < t:2021-06-20 16:39:30,967 f:tester.py       l:2360 c:LongevityTest        p:INFO  > TearDown is starting...

```


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
