### PR TITLE
fix(check_regression): Limit number of events for perf email

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -158,3 +158,5 @@ k8s_deploy_monitoring: false
 scylla_rsyslog_setup: false
 
 backup_bucket_region: ''  # use the same region as a cluster
+
+events_limit_in_email: 10

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -272,3 +272,4 @@
 | **<a href="#user-content-jepsen_test_run_policy" name="jepsen_test_run_policy">jepsen_test_run_policy</a>**  | Jepsen test run policy (i.e., what we want to consider as passed for a single test)<br><br>'most' - most test runs are passed<br>'any'  - one pass is enough<br>'all'  - all test runs should pass | all | SCT_JEPSEN_TEST_RUN_POLICY
 | **<a href="#user-content-max_events_severities" name="max_events_severities">max_events_severities</a>**  | Limit severity level for event types | N/A | SCT_MAX_EVENTS_SEVERITIES
 | **<a href="#user-content-scylla_rsyslog_setup" name="scylla_rsyslog_setup">scylla_rsyslog_setup</a>**  | Configure rsyslog on scylla nodes to send logs to monitoring nodes | False | SCT_SCYLLA_RSYSLOG_SETUP
+| **<a href="#user-content-events_limit_in_email" name="events_limit_in_email">events_limit_in_email</a>**  | Limit number events in email reports | False | SCT_EVENTS_LIMIT_IN_EMAIL

--- a/sdcm/results_analyze/__init__.py
+++ b/sdcm/results_analyze/__init__.py
@@ -571,7 +571,8 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
         ycsb = doc['_source']['test_details'].get('ycsb')
         dashboard_path = "app/kibana#/dashboard/03414b70-0e89-11e9-a976-2fe0f5890cd0?_g=()"
 
-        last_events, events_summary = self.get_events()
+        last_events, events_summary = self.get_events(event_severity=[
+            Severity.CRITICAL.name, Severity.ERROR.name, Severity.DEBUG.name])
 
         results = dict(test_name=full_test_name,
                        test_start_time=str(test_start_time),

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1128,7 +1128,10 @@ class SCTConfiguration(dict):
              help="Limit severity level for event types"),
 
         dict(name="scylla_rsyslog_setup", env="SCT_SCYLLA_RSYSLOG_SETUP", type=boolean,
-             help="Configure rsyslog on Scylla nodes to send logs to monitoring nodes")
+             help="Configure rsyslog on Scylla nodes to send logs to monitoring nodes"),
+
+        dict(name="events_limit_in_email", env="SCT_EVENTS_LIMIT_IN_EMAIL", type=int,
+             help="Limit number events in email reports"),
     ]
 
     required_params = ['cluster_backend', 'test_duration', 'n_db_nodes', 'n_loaders', 'use_preinstalled_scylla',

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2611,7 +2611,8 @@ class ClusterTester(db_stats.TestStatsMixin,
                                                       send_email=self.params.get('send_email'),
                                                       email_recipients=self.params.get('email_recipients'),
                                                       events=get_events_grouped_by_category(
-                                                          _registry=self.events_processes_registry))
+                                                          _registry=self.events_processes_registry, limit=self.params.get('events_limit_in_email'))
+                                                      )
         is_gce = bool(self.params.get('cluster_backend') == 'gce')
         try:
             results_analyzer.check_regression(self._test_id, is_gce,
@@ -2625,7 +2626,8 @@ class ClusterTester(db_stats.TestStatsMixin,
                                                       send_email=self.params.get('send_email'),
                                                       email_recipients=self.params.get('email_recipients'),
                                                       events=get_events_grouped_by_category(
-                                                          _registry=self.events_processes_registry))
+                                                          _registry=self.events_processes_registry, limit=self.params.get('events_limit_in_email'))
+                                                      )
         is_gce = bool(self.params.get('cluster_backend') == 'gce')
         try:
             results_analyzer.check_regression_with_subtest_baseline(self._test_id,
@@ -2640,7 +2642,8 @@ class ClusterTester(db_stats.TestStatsMixin,
                                                       send_email=self.params.get('send_email'),
                                                       email_recipients=self.params.get('email_recipients'),
                                                       events=get_events_grouped_by_category(
-                                                          _registry=self.events_processes_registry))
+                                                          _registry=self.events_processes_registry, limit=self.params.get('events_limit_in_email'))
+                                                      )
         if email_subject is None:
             email_subject = 'Performance Regression Compare Results - {test.test_name} - {test.software.scylla_server_any.version.as_string}'
             email_postfix = self.params.get('email_subject_postfix')


### PR DESCRIPTION
Limit number of events for perf emails. In case of large number
of events, screenshots could be out of visible part of email.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
