### PR TITLE
refactor(nodetool event): Convert NodetoolEvent to be continuous event

### DIFF
--- a/sdcm/sct_events/loaders.py
+++ b/sdcm/sct_events/loaders.py
@@ -22,8 +22,7 @@ from invoke.runners import Result
 
 from sdcm.sct_events import Severity
 from sdcm.sct_events.base import \
-    SctEvent, SctEventProtocol, LogEvent, LogEventProtocol, T_log_event, \
-    BaseStressEvent, StressEvent, StressEventProtocol
+    SctEvent, LogEvent, LogEventProtocol, T_log_event, BaseStressEvent, StressEvent, StressEventProtocol
 
 LOGGER = logging.getLogger(__name__)
 
@@ -33,8 +32,9 @@ class GeminiStressEvent(BaseStressEvent):
     def __init__(self, node: Any,
                  cmd: str,
                  log_file_name: Optional[str] = None,
-                 severity: Severity = Severity.NORMAL):
-        super().__init__(severity=severity)
+                 severity: Severity = Severity.NORMAL,
+                 publish_event: bool = True):
+        super().__init__(severity=severity, publish_event=publish_event)
 
         self.node = str(node)
         self.cmd = cmd
@@ -54,7 +54,9 @@ class GeminiStressEvent(BaseStressEvent):
         fmt = super().msgfmt + ":"
         if self.type:
             fmt += " type={0.type}"
-        fmt += " node={0.node} gemini_cmd={0.cmd}"
+        fmt += " node={0.node}"
+
+        fmt += " gemini_cmd={0.cmd}"
 
         if self.result:
             fmt += "\nresult={0.result}"

--- a/unit_tests/test_sct_events_nodetool.py
+++ b/unit_tests/test_sct_events_nodetool.py
@@ -10,71 +10,70 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2020 ScyllaDB
-
+import time
 import unittest
+from unittest import mock
 
-from sdcm.sct_events import Severity
-from sdcm.sct_events.base import LogEvent
-from sdcm.sct_events.database import \
-    DatabaseLogEvent, FullScanEvent, IndexSpecialColumnErrorEvent, TOLERABLE_REACTOR_STALL, SYSTEM_ERROR_EVENTS
 from sdcm.sct_events.nodetool import NodetoolEvent
 
 
 class TestNodetoolEvent(unittest.TestCase):
-
     def test_nodetool_cmd_no_options(self):
-        event = NodetoolEvent(type="scrub --skip-corrupted drop_table_during_repair_ks_0",
-                              subtype='start',
-                              severity=Severity.NORMAL,
-                              node='1.0.0.121',
-                              options="")
+        event = NodetoolEvent(nodetool_command="scrub", node='1.0.0.121',
+                              options="", publish_event=False)
         event.event_id = "3c8e2362-a987-4eff-953f-9cd1ad2017e5"
+        event.begin_event()
         self.assertEqual(
             str(event),
-            "(NodetoolEvent Severity.NORMAL) period_type=not-set event_id=3c8e2362-a987-4eff-953f-9cd1ad2017e5: "
-            "type=scrub subtype=start node=1.0.0.121 options=--skip-corrupted "
-            "drop_table_during_repair_ks_0"
+            "(NodetoolEvent Severity.NORMAL) period_type=begin event_id=3c8e2362-a987-4eff-953f-9cd1ad2017e5: "
+            "nodetool_command=scrub node=1.0.0.121"
         )
 
-        event = NodetoolEvent(type="scrub --skip-corrupted drop_table_during_repair_ks_0",
-                              subtype='end',
-                              severity=Severity.NORMAL,
-                              node='1.0.0.121',
-                              duration="20s",
-                              options="")
-        event.event_id = "3c8e2362-a987-4eff-953f-9cd1ad2017e5"
+        event.duration = 20.325
+        event.end_event()
         self.assertEqual(
             str(event),
-            '(NodetoolEvent Severity.NORMAL) period_type=not-set event_id=3c8e2362-a987-4eff-953f-9cd1ad2017e5: '
-            'type=scrub subtype=end node=1.0.0.121 '
-            'options=--skip-corrupted drop_table_during_repair_ks_0 duration=20s'
+            "(NodetoolEvent Severity.NORMAL) period_type=end event_id=3c8e2362-a987-4eff-953f-9cd1ad2017e5 "
+            "duration=20.325s: nodetool_command=scrub node=1.0.0.121"
         )
 
     def test_nodetool_cmd_with_options(self):
-        event = NodetoolEvent(type="scrub --skip-corrupted drop_table_during_repair_ks_0",
-                              subtype='start',
-                              severity=Severity.NORMAL,
-                              node='1.0.0.121',
-                              options="more options")
+        begin_event_timestamp = 1623596860.1202102
+        event = NodetoolEvent(nodetool_command="scrub --skip-corrupted drop_table_during_repair_ks_0", node='1.0.0.121',
+                              options="more options", publish_event=False)
         event.event_id = "ef4aeb1a-c004-40e4-af14-9d87a0526408"
+        event.begin_event()
+        event.begin_timestamp = event.timestamp = begin_event_timestamp
         self.assertEqual(
             str(event),
-            '(NodetoolEvent Severity.NORMAL) period_type=not-set event_id=ef4aeb1a-c004-40e4-af14-9d87a0526408: '
-            'type=scrub subtype=start node=1.0.0.121 options=--skip-corrupted '
-            'drop_table_during_repair_ks_0 more options'
+            '(NodetoolEvent Severity.NORMAL) period_type=begin event_id=ef4aeb1a-c004-40e4-af14-9d87a0526408: '
+            'nodetool_command=scrub node=1.0.0.121 options=--skip-corrupted drop_table_during_repair_ks_0 more options'
         )
 
+        # validate duration calculation
+        with mock.patch('time.time', return_value=begin_event_timestamp + 1):
+            event.end_event()
+            self.assertEqual(
+                str(event),
+                '(NodetoolEvent Severity.NORMAL) period_type=end event_id=ef4aeb1a-c004-40e4-af14-9d87a0526408 '
+                'duration=1s: nodetool_command=scrub node=1.0.0.121 options=--skip-corrupted '
+                'drop_table_during_repair_ks_0 more options'
+            )
+
     def test_nodetool_failure(self):
-        event = NodetoolEvent(type="scrub --skip-corrupted drop_table_during_repair_ks_0",
-                              subtype='end',
-                              severity=Severity.ERROR,
-                              node='1.0.0.121',
-                              error="Failed with status 1",
-                              full_traceback="Traceback:")
+        event = NodetoolEvent(nodetool_command="scrub --skip-corrupted drop_table_during_repair_ks_0", node='1.0.0.121',
+                              options="more options", publish_event=False)
         event.event_id = "c2561d8b-97ca-44fb-b5b1-8bcc0d437318"
+        event.begin_event()
+
+        event.add_error(["Failed with status 1"])
+        event.full_traceback = "Traceback:"
+        event.duration = 90358
+        event.end_event()
         self.assertEqual(
             str(event),
-            '(NodetoolEvent Severity.ERROR) period_type=not-set event_id=c2561d8b-97ca-44fb-b5b1-8bcc0d437318: '
-            'type=scrub subtype=end node=1.0.0.121 options=--skip-corrupted '
-            'drop_table_during_repair_ks_0 error=Failed with status 1\nTraceback:'
+            '(NodetoolEvent Severity.NORMAL) period_type=end event_id=c2561d8b-97ca-44fb-b5b1-8bcc0d437318 '
+            'duration=1d1h5m58s: nodetool_command=scrub node=1.0.0.121 options=--skip-corrupted '
+            'drop_table_during_repair_ks_0 more '
+            'options errors=[\'Failed with status 1\']\nTraceback:'
         )


### PR DESCRIPTION
Convert NodetoolEvent to be continuous event and report when it begins and ends.

Extention of commit:
https://github.com/scylladb/scylla-cluster-tests/pull/3638

Event example:
```
2021-06-23 14:43:10.490: (NodetoolEvent Severity.NORMAL) period_type=begin event_id=b25368e9-5091-4fc9-aaa6-44da583025e7: nodetool_command=flush node=longevity-10gb-3h-nodetool-db-node-34a51554-1
2021-06-23 14:43:20.001: (NodetoolEvent Severity.NORMAL) period_type=end event_id=b25368e9-5091-4fc9-aaa6-44da583025e7 duration=9s: nodetool_command=flush node=longevity-10gb-3h-nodetool-db-node-34a51554-1
```

raw events:
```
{"base": "NodetoolEvent", "type": null, "subtype": null, "timestamp": 1624459390.4906101, "severity": "NORMAL", "event_id": "b25368e9-5091-4fc9-aaa6-44da583025e7", "log_file_name": null, "errors": [], "publish_event": true, "begin_timestamp": 1624459390.4906101, "end_timestamp": null, "nodetool_command": "flush", "options": "", "node": "longevity-10gb-3h-nodetool-db-node-34a51554-1", "full_traceback": null, "period_type": "begin"}
{"base": "NodetoolEvent", "type": null, "subtype": null, "timestamp": 1624459400.001463, "severity": "NORMAL", "event_id": "b25368e9-5091-4fc9-aaa6-44da583025e7", "log_file_name": null, "errors": [], "publish_event": true, "begin_timestamp": 1624459390.4906101, "end_timestamp": 1624459400.001463, "nodetool_command": "flush", "options": "", "node": "longevity-10gb-3h-nodetool-db-node-34a51554-1", "full_traceback": null, "period_type": "end"}
```

[Test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/yulia/job/staging-10gb-3h/205)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
