### PR TITLE
fix(scylla_bench_thread): auto install s-b if not installed

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4642,6 +4642,10 @@ class BaseLoaderSet():
                     self.log.warning('Terminate gemini on node %s:\n%s', loader, kill_result)
 
     @staticmethod
+    def is_scylla_bench_installed(node: BaseNode):
+        return node.remoter.run('ls /$HOME/go/bin/scylla-bench', ignore_status=True).ok
+
+    @staticmethod
     @retrying(n=5)
     def install_scylla_bench(node):
         if node.distro.is_rhel_like:

--- a/sdcm/scylla_bench_thread.py
+++ b/sdcm/scylla_bench_thread.py
@@ -152,6 +152,10 @@ class ScyllaBenchThread:
             loaders = self.loader_set.nodes if not self.use_single_loader else [self.loader_set.nodes[0]]
         LOGGER.debug("Round-Robin through loaders, Selected loader is {} ".format(loaders))
 
+        for loader in loaders:
+            if not self.loader_set.is_scylla_bench_installed(loader):
+                self.loader_set.install_scylla_bench(loader)
+
         self.max_workers = (os.cpu_count() or 1) * 5
         LOGGER.debug("Starting %d scylla-bench Worker threads", self.max_workers)
         self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.max_workers)


### PR DESCRIPTION
We are not installing s-b if it is not present in stress commands definitions
But there are cases when we still need it,
for example disrupt_truncate_large_partition still can fire

To cover such cases we need to install it by request

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
