### PR TITLE
fix(list_of_stress_tools): make it work when command is a list

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1476,9 +1476,18 @@ class SCTConfiguration(dict):
     def list_of_stress_tools(self) -> Set[str]:
         stress_tools = set()
         for param_name in self.stress_cmd_params:
-            if stress_cmd := self.get(param_name):
+            stress_cmds = self.get(param_name)
+            if not (isinstance(stress_cmds, (list, str)) and stress_cmds):
+                continue
+            if isinstance(stress_cmds, str):
+                stress_cmds = [stress_cmds]
+
+            for stress_cmd in stress_cmds:
+                if not stress_cmd:
+                    continue
                 if stress_tool := stress_cmd.split(maxsplit=2)[0]:
                     stress_tools.add(stress_tool)
+
         return stress_tools
 
     def check_required_files(self):


### PR DESCRIPTION

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
