### PR TITLE
refactor(nemesis): Disable RestartThenRepairNodeMonkey

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -406,7 +406,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.target_node.start_scylla_server(verify_up=True, verify_down=False)
 
     # This nemesis should be run with "private" ip_ssh_connections till the issue #665 is not fixed
-    def disrupt_restart_then_repair_node(self):  # pylint: disable=invalid-name
+    def disabled_disrupt_restart_then_repair_node(self):  # pylint: disable=invalid-name
         self._set_current_disruption('RestartThenRepairNode %s' % self.target_node)
         # Task https://trello.com/c/llRuLIOJ/2110-add-dbeventfilter-for-nosuchcolumnfamily-error
         # If this error happens during the first boot with the missing disk this issue is expected and it's not an issue
@@ -3089,13 +3089,15 @@ class StopStartMonkey(Nemesis):
         self.disrupt_stop_start_scylla_server()
 
 
-class RestartThenRepairNodeMonkey(Nemesis):
-    disruptive = True
-    kubernetes = True
-
-    @log_time_elapsed_and_status
-    def disrupt(self):
-        self.disrupt_restart_then_repair_node()
+# Disabling this nemesis due to mulitple known issues like (https://github.com/scylladb/scylla/issues/5080).
+# When this issue will be solved, we can re-enable this nemesis.
+# class RestartThenRepairNodeMonkey(Nemesis):
+#     disruptive = True
+#     kubernetes = True
+#
+#     @log_time_elapsed_and_status
+#     def disrupt(self):
+#         self.disrupt_restart_then_repair_node()
 
 
 class MultipleHardRebootNodeMonkey(Nemesis):


### PR DESCRIPTION
Due to multiple known issues like https://github.com/scylladb/scylla/issues/5080
I decided to disable this nemesis for now, until we get a fix for these issues.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
