### PR TITLE
fix(k8s-gke): specify major K8S version for GKE cluster creation

### DIFF
--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -3,7 +3,7 @@ gce_datacenter: 'us-east1-b'
 gce_network: 'qa-vpc'
 gce_image_username: 'scylla-test'
 
-gke_cluster_version: '1.19.9-gke.1400'
+gke_cluster_version: '1.19'
 gke_k8s_release_channel: ''
 
 gce_instance_type_db: 'n1-standard-8'


### PR DESCRIPTION
Right now we use specific K8S version on GKE which are build specific.
Example, currently used one: '1.19.9-gke.1400'
This one became obsolete and not available anymore for usage.
So, instead of providing one another specific version, use 'major'
one to forget such problem as regular sudden GKE cluster creation
failures caused by non-supported versions.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
