### PR TITLE
fix(longevity-1TB): Fix the number of local_ssd_disk needed for 1TB

### DIFF
--- a/test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml
@@ -22,7 +22,7 @@ n_monitor_nodes: 1
 
 instance_type_db: 'i3.4xlarge'
 gce_instance_type_db: 'n1-highmem-16'
-gce_n_local_ssd_disk_db: 6
+gce_n_local_ssd_disk_db: 16
 
 instance_type_loader: 'c5.4xlarge'
 gce_instance_type_loader: 'c2-standard-16'


### PR DESCRIPTION
Each local_ssd disk size is 375 GB, using only 6 disks is not enough
for this dataset and during a rebuild a node is running out of space.
I set it to 10 to match the size of i3.4xlarge (3.8 TB).

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
