### PR TITLE
feature(SctRunner): add kubectl bin

### DIFF
--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -27,7 +27,7 @@ class ImageType(Enum):
 
 class SctRunner:
     """Provisions and configures the SCT runner"""
-    VERSION = 1.2  # Version of the Image
+    VERSION = 1.4  # Version of the Image
     IMAGE_NAME = f"sct-runner-{VERSION}"
     NODE_TYPE = "sct-runner"
     RUNNER_NAME = "SCT-Runner"
@@ -92,6 +92,9 @@ class SctRunner:
             apt update
             apt install -y docker-ce docker-ce-cli containerd.io
             usermod -aG docker {self.LOGIN_USER}
+            # add kubectl
+            curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+            sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
             # configure Jenkins user
             apt install -y openjdk-14-jre-headless
             adduser --disabled-password --gecos "" jenkins
@@ -104,7 +107,6 @@ class SctRunner:
             # Jenkins pipelines run /bin/sh for some reason
             unlink /bin/sh
             ln -s /bin/bash /bin/sh
-
         """)
         remoter = self.get_remoter(host=public_ip)
         result = remoter.run(f"sudo bash -cxe '{prereqs_script}'", ignore_status=True)


### PR DESCRIPTION
Adding the `kubectl` binary to our base SctRunner classes `prereqs_script` so that we have an additional tool for kubernetes deployments debugging.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- ~~[ ] I added the relevant `backport` labels~~
- ~~[ ] New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
