### PR TITLE
fix(scylla_repo_m): Fixed scylla db 2020 manager backend url

### DIFF
--- a/configurations/manager/debian9.yaml
+++ b/configurations/manager/debian9.yaml
@@ -1,4 +1,4 @@
 ami_id_monitor: 'ami-0cfac3931b2a799d1'  # Debian stretch image
 ami_monitor_user: 'admin'
 
-scylla_repo_m: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylla-2020.1.list'  # Notice: Uses 2020.1, while other (newer deb) use 2021, since we support both
+scylla_repo_m: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/debian/scylla-2020.1-stretch.list'  # Notice: Uses 2020.1, while other (newer deb) use 2021, since we support both

--- a/configurations/manager/ubuntu16.yaml
+++ b/configurations/manager/ubuntu16.yaml
@@ -1,4 +1,4 @@
 ami_id_monitor: 'ami-092d0d014b7b31a08'  # Canonical, Ubuntu, 16.04 LTS, amd64 xenial image build on 2019-02-12
 ami_monitor_user: 'ubuntu'
 
-scylla_repo_m: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylla-2020.1.list'  # Notice: Uses 2020.1, while other (newer deb) use 2021, since we support both
+scylla_repo_m: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-2020.1-xenial.list'  # Notice: Uses 2020.1, while other (newer deb) use 2021, since we support both

--- a/configurations/manager/ubuntu18.yaml
+++ b/configurations/manager/ubuntu18.yaml
@@ -1,4 +1,4 @@
 ami_id_monitor: 'ami-08b314ce48a790a19'  # Canonical, Ubuntu, 18.04 LTS, amd64 bionic image build on 2019-07-22
 ami_monitor_user: 'ubuntu'
 
-scylla_repo_m: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylla-2020.1.list'  # Notice: Uses 2020.1, while other (newer deb) use 2021, since we support both
+scylla_repo_m: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-2020.1-bionic.list'  # Notice: Uses 2020.1, while other (newer deb) use 2021, since we support both


### PR DESCRIPTION
Current scylla_repo_m in ubuntu 16, 18 and debian 9 urls are erroneous,
restored them to previous, correct, urls

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)

Fixes an error I made in #3674 