### PR TITLE
Fix double args

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -9,6 +9,7 @@ DataValidatorEvent.DataValidator: ERROR
 DataValidatorEvent.ImmutableRowsValidator: ERROR
 DataValidatorEvent.UpdatedRowsValidator: WARNING
 DataValidatorEvent.DeletedRowsValidator: ERROR
+ScyllaHelpErrorEvent.duplicate: ERROR
 FullScanEvent.start: NORMAL
 FullScanEvent.finish: ERROR
 DatabaseLogEvent.NO_SPACE_ERROR: ERROR

--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -10,6 +10,7 @@ DataValidatorEvent.ImmutableRowsValidator: ERROR
 DataValidatorEvent.UpdatedRowsValidator: WARNING
 DataValidatorEvent.DeletedRowsValidator: ERROR
 ScyllaHelpErrorEvent.duplicate: ERROR
+ScyllaHelpErrorEvent.filtered: ERROR
 FullScanEvent.start: NORMAL
 FullScanEvent.finish: ERROR
 DatabaseLogEvent.NO_SPACE_ERROR: ERROR

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1763,7 +1763,12 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                     message=f"Scylla help contains duplicate for the following arguments: {','.join(dups)}"
                 ).publish()
             )
-            append_scylla_args = scylla_arg_parser.filter_args(append_scylla_args)
+            append_scylla_args = scylla_arg_parser.filter_args(
+                append_scylla_args,
+                unknown_args_cb=lambda args: ScyllaHelpErrorEvent.filtered(
+                    message="Following arguments are filtered out: " + ','.join(args)
+                ).publish()
+            )
         if self.parent_cluster.params.get('db_nodes_shards_selection') == 'random':
             append_scylla_args += f" --smp {self.scylla_random_shards()}"
 

--- a/sdcm/sct_events/__init__.py
+++ b/sdcm/sct_events/__init__.py
@@ -34,6 +34,7 @@ class SctEventProtocol(Protocol):
     timestamp: Optional[float]
     severity: Severity
 
+    # pylint: disable=super-init-not-called
     def __init__(self, *args, **kwargs):
         ...
 

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -155,6 +155,28 @@ SYSTEM_ERROR_EVENTS_PATTERNS: List[Tuple[re.Pattern, LogEventProtocol]] = \
 BACKTRACE_RE = re.compile(r'(?P<other_bt>/lib.*?\+0x[0-f]*\n)|(?P<scylla_bt>0x[0-f]*\n)', re.IGNORECASE)
 
 
+class ScyllaHelpErrorEvent(SctEvent, abstract=True):
+    duplicate: Type[SctEventProtocol]
+    message: str
+
+    def __init__(self, message: Optional[str] = None, severity=Severity.ERROR):
+        super().__init__(severity=severity)
+
+        # Don't include `message' to the state if it's None.
+        if message is not None:
+            self.message = message
+
+    @property
+    def msgfmt(self):
+        fmt = super().msgfmt + ": type={0.type}"
+        if hasattr(self, "message"):
+            fmt += " message={0.message}"
+        return fmt
+
+
+ScyllaHelpErrorEvent.add_subevent_type("duplicate")
+
+
 class FullScanEvent(SctEvent, abstract=True):
     start: Type[SctEventProtocol]
     finish: Type[SctEventProtocol]

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -55,6 +55,7 @@ class DatabaseLogEvent(LogEvent, abstract=True):
 MILLI_RE = re.compile(r"(\d+) ms")
 
 
+# pylint: disable=too-few-public-methods
 class ReactorStalledMixin(Generic[T_log_event]):
     tolerable_reactor_stall: int = TOLERABLE_REACTOR_STALL
 

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -157,6 +157,7 @@ BACKTRACE_RE = re.compile(r'(?P<other_bt>/lib.*?\+0x[0-f]*\n)|(?P<scylla_bt>0x[0
 
 class ScyllaHelpErrorEvent(SctEvent, abstract=True):
     duplicate: Type[SctEventProtocol]
+    filtered: Type[SctEventProtocol]
     message: str
 
     def __init__(self, message: Optional[str] = None, severity=Severity.ERROR):
@@ -175,6 +176,7 @@ class ScyllaHelpErrorEvent(SctEvent, abstract=True):
 
 
 ScyllaHelpErrorEvent.add_subevent_type("duplicate")
+ScyllaHelpErrorEvent.add_subevent_type("filtered")
 
 
 class FullScanEvent(SctEvent, abstract=True):

--- a/sdcm/utils/scylla_args.py
+++ b/sdcm/utils/scylla_args.py
@@ -45,10 +45,10 @@ class ScyllaArgParser(argparse.ArgumentParser):
         raise ScyllaArgError(message)
 
     @classmethod
-    def from_scylla_help(cls, help: Text, duplicate_cb: Callable = None) -> "ScyllaArgParser":
+    def from_scylla_help(cls, help_text: Text, duplicate_cb: Callable = None) -> "ScyllaArgParser":
         parser = cls(prog="scylla")
         duplicates = set()
-        for *args, val in SCYLLA_ARG.findall(help):
+        for *args, val in SCYLLA_ARG.findall(help_text):
             try:
                 parser.add_argument(*filter(bool, args), action="store" if val else "store_false")
             except argparse.ArgumentError:

--- a/sdcm/utils/scylla_args.py
+++ b/sdcm/utils/scylla_args.py
@@ -59,10 +59,10 @@ class ScyllaArgParser(argparse.ArgumentParser):
 
         return parser
 
-    def filter_args(self, args: str) -> str:
+    def filter_args(self, args: str, unknown_args_cb: Callable = None) -> str:
         parsed_args, unknown_args = self.parse_known_args(args.split())
-        if unknown_args:
-            LOGGER.warning("Following arguments are filtered out: %s", unknown_args)
+        if unknown_args and unknown_args_cb:
+            unknown_args_cb(unknown_args)
         filtered_args = []
         for arg, val in vars(parsed_args).items():
             filtered_args.append(f"--{arg.replace('_', '-')}")

--- a/unit_tests/test_utils_scylla_args.py
+++ b/unit_tests/test_utils_scylla_args.py
@@ -36,6 +36,13 @@ class TestScyllaArgParser(unittest.TestCase):
     def setUp(self):
         self.parser = ScyllaArgParser.from_scylla_help(SCYLLA_HELP_EXAMPLE)
 
+    def test_double_args(self):
+        ScyllaArgParser.from_scylla_help(
+            SCYLLA_HELP_EXAMPLE + '\n' + SCYLLA_HELP_EXAMPLE,
+            duplicate_cb=lambda dups: self.assertEqual(
+                ['--help', '--options-file', '--version', '--workdir'], sorted(dups))
+        )
+
     def test_filter_args(self):
         self.assertEqual(self.parser.filter_args("--arg1 arg --version -W arg --arg2 -h --options-file arg"),
                          "--version --workdir arg --help --options-file arg")

--- a/unit_tests/test_utils_scylla_args.py
+++ b/unit_tests/test_utils_scylla_args.py
@@ -44,8 +44,13 @@ class TestScyllaArgParser(unittest.TestCase):
         )
 
     def test_filter_args(self):
-        self.assertEqual(self.parser.filter_args("--arg1 arg --version -W arg --arg2 -h --options-file arg"),
-                         "--version --workdir arg --help --options-file arg")
+        self.assertEqual(
+            self.parser.filter_args(
+                "--arg1 arg --version -W arg --arg2 -h --options-file arg",
+                unknown_args_cb=lambda args: self.assertEqual(['--arg1', 'arg', '--arg2'], args)
+            ),
+            "--version --workdir arg --help --options-file arg",
+        )
 
     def test_filter_args_unchanged(self):
         args = "--version --workdir arg --help --options-file arg"


### PR DESCRIPTION
https://trello.com/c/EPQYaUeU/3537-investigate-enterprise-version-running-on-sct-master-failure

When scylla help mentions any variable twice, scylla node fails to start.
This fix will publish error event instead.

TIme to time enterprise scylla have doubled help message and it blocks us from running tests on it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
