### PR TITLE
fix(artifacts_test.py): fix string formatting in log calls

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -89,7 +89,7 @@ class ArtifactsTest(ClusterTester):
         the backend used.
         """
         if not self.params["use_preinstalled_scylla"]:
-            self.log.info(f"Skipping verifying the snitch due to the 'use_preinstalled_scylla' being set to False")
+            self.log.info("Skipping verifying the snitch due to the 'use_preinstalled_scylla' being set to False")
             return
 
         describecluster_snitch = self.get_describecluster_info().snitch


### PR DESCRIPTION
Small fix for log string.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] ~~I added the relevant `backport` labels~~
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
