### PR TITLE
fix(Debian repo support): Fix regular expression to account for multiple architectures

### DIFF
--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -157,7 +157,7 @@ def get_branch_version_from_centos_repository(urls):
 
 
 def get_repository_details(url):
-    urls = list({line for line in get_url_content(url=url)})
+    urls = get_url_content(url=url)
 
     for file_type, regex_list in FILE_REGEX_DICT.items():
         for _url in urls:
@@ -236,7 +236,7 @@ def _list_repo_file_etag(s3_client: S3Client, prefix: str) -> Optional[dict]:
     return repo_file["Contents"][0]["ETag"]
 
 
-def resolve_latest_repo_symlink(url: str) -> str:
+def resolve_latest_repo_symlink(url: str) -> str:  # pylint: disable=too-many-branches
     """Resolve `url' to the actual repo link if it contains `latest' substring, otherwise, return `url' as is.
 
     If `url' doesn't point to the latest repo file then raise ScyllaRepoEvent (warning severity).
@@ -336,7 +336,7 @@ def get_git_tag_from_helm_chart_version(chart_version: str) -> str:
     | v1.0.0-rc0-51-ga52c206-latest     | v1.0.0-rc0     |
     +-----------------------------------+----------------+
     """
-    pattern = "^(v[a-z0-9.-]+)-[\d]{1,3}-g[0-9a-z]{7}|(v[a-z0-9.-]+){1}$"
+    pattern = r"^(v[a-z0-9.-]+)-[\d]{1,3}-g[0-9a-z]{7}|(v[a-z0-9.-]+){1}$"
     search_result = re.search(pattern, chart_version)
     if search_result:
         git_tag = search_result.group(1) or search_result.group(2)

--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -74,7 +74,7 @@ class ScyllaFileType(Enum):
 
 FILE_REGEX_DICT = {
     ScyllaFileType.DEBIAN: [
-        (re.compile(r"deb\s+\[arch=(?P<arch>.*?)\]\s(?P<url>http.*?)\s(?P<version_code_name>.*?)\s(?P<component>.*?)$"),
+        (re.compile(r"deb\s+\[arch=(?P<arch>[^,]*)+?(,(?P<additional_archs>[^,]*?))*\]\s(?P<url>http.*?)\s(?P<version_code_name>.*?)\s(?P<component>.*?)$"),
          "{url}/dists/{version_code_name}/{component}/binary-{arch}/Packages"),
     ],
     ScyllaFileType.YUM:


### PR DESCRIPTION
The regualr expression that is used to extract a version from a debian
repo didn't account for multiple architectures in the list file. This change
makes it account for additional architectures and saves the additional
architectures in another group that can be iterated through if needed.
The side effect of this is that the first mentioned arciteture will be
used for assembling the url for extracting the binary version.

Ref scylladb/scylla-pkg#2156
This fails for example:
https://jenkins.scylladb.com/job/scylla-master/job/artifacts/job/artifacts-debian9-test/402/

I tested it using the console:
before the change:
```
python
Python 3.9.5 (default, May 14 2021, 00:00:00) 
[GCC 10.3.1 20210422 (Red Hat 10.3.1-1)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sdcm.utils.version_utils
>>> sdcm.utils.version_utils.get_branch_version_for_multiple_repositories(["http://downloads.scylladb.com/unstable/scylla/master/deb/unified/2021-06-23T10:53:35Z/scylladb-master/scylla.list"])
'get_url_content': Number of retries exceeded!
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/eliransin/SourceCode/scylla-cluster-tests/sdcm/utils/version_utils.py", line 184, in get_branch_version_for_multiple_repositories
    threads = ParallelObject(objects=urls, timeout=SCYLLA_URL_RESPONSE_TIMEOUT).run(func=get_branch_version)
  File "/home/eliransin/SourceCode/scylla-cluster-tests/sdcm/utils/common.py", line 433, in run
    raise ParallelObjectException(results=results)
sdcm.utils.common.ParallelObjectException: http://downloads.scylladb.com/unstable/scylla/master/deb/unified/2021-06-23T10:53:35Z/scylladb-master/scylla.list: http://downloads.scylladb.com/unstable/scylla/master/deb/unified/2021-06-23T10:53:35Z/scylladb-master/dists/stable/main/binary-amd64,arm64/Packages: The following repository URL 'http://downloads.scylladb.com/unstable/scylla/master/deb/unified/2021-06-23T10:53:35Z/scylladb-master/dists/stable/main/binary-amd64,arm64/Packages' is incorrect
```

after the change:
```
 python
Python 3.9.5 (default, May 14 2021, 00:00:00) 
[GCC 10.3.1 20210422 (Red Hat 10.3.1-1)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sdcm.utils.version_utils
>>> sdcm.utils.version_utils.get_branch_version_for_multiple_repositories(["http://downloads.scylladb.com/unstable/scylla/master/deb/unified/2021-06-23T10:53:35Z/scylladb-master/scylla.list"])
['4.6.dev']
>>> 
```

Also I ran a reproducer which clearly passed this stage and failed on something else (to be tested if it happens on the original
job after this change).

https://jenkins.scylladb.com/job/scylla-master/job/reproducers/job/artifacts-debian9-test/2
