### PR TITLE
refactor(info events): convert all one-time events to informational

### DIFF
--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -16,8 +16,7 @@ import logging
 from typing import Type, List, Tuple, Generic, Optional
 
 from sdcm.sct_events import Severity, SctEventProtocol
-from sdcm.sct_events.base import SctEvent, LogEvent, LogEventProtocol, T_log_event
-
+from sdcm.sct_events.base import SctEvent, LogEvent, LogEventProtocol, T_log_event, InformationalEvent
 
 TOLERABLE_REACTOR_STALL: int = 1000  # ms
 
@@ -208,7 +207,7 @@ FullScanEvent.add_subevent_type("start")
 FullScanEvent.add_subevent_type("finish")
 
 
-class IndexSpecialColumnErrorEvent(SctEvent):
+class IndexSpecialColumnErrorEvent(InformationalEvent):
     def __init__(self, message: str, severity: Severity = Severity.ERROR):
         super().__init__(severity=severity)
 

--- a/sdcm/sct_events/health.py
+++ b/sdcm/sct_events/health.py
@@ -14,7 +14,7 @@
 from typing import Type, Protocol, Optional, runtime_checkable
 
 from sdcm.sct_events import Severity, SctEventProtocol
-from sdcm.sct_events.base import SctEvent
+from sdcm.sct_events.base import SctEvent, InformationalEvent
 
 
 @runtime_checkable
@@ -23,7 +23,7 @@ class ClusterHealthValidatorEventClusterHealthCheck(SctEventProtocol, Protocol):
     done: Type[SctEventProtocol]
 
 
-class ClusterHealthValidatorEvent(SctEvent, abstract=True):
+class ClusterHealthValidatorEvent(InformationalEvent, abstract=True):
     MonitoringStatus: Type[SctEventProtocol]
     NodeStatus: Type[SctEventProtocol]
     NodePeersNulls: Type[SctEventProtocol]
@@ -61,7 +61,7 @@ ClusterHealthValidatorEvent.add_subevent_type("Done", severity=Severity.NORMAL)
 ClusterHealthValidatorEvent.add_subevent_type("Info", severity=Severity.NORMAL)
 
 
-class DataValidatorEvent(SctEvent, abstract=True):
+class DataValidatorEvent(InformationalEvent, abstract=True):
     DataValidator: Type[SctEventProtocol]
     ImmutableRowsValidator: Type[SctEventProtocol]
     UpdatedRowsValidator: Type[SctEventProtocol]

--- a/sdcm/sct_events/system.py
+++ b/sdcm/sct_events/system.py
@@ -16,7 +16,7 @@ from typing import Any, Optional, Sequence
 from traceback import format_stack
 
 from sdcm.sct_events import Severity
-from sdcm.sct_events.base import SctEvent, SystemEvent
+from sdcm.sct_events.base import SctEvent, SystemEvent, InformationalEvent
 
 
 class StartupTestEvent(SystemEvent):
@@ -36,7 +36,7 @@ class TestTimeoutEvent(SctEvent):
         return f"{super().msgfmt}, Test started at {start_time}, reached it's timeout ({self.duration} minute)"
 
 
-class TestFrameworkEvent(SctEvent):  # pylint: disable=too-many-instance-attributes
+class TestFrameworkEvent(InformationalEvent):  # pylint: disable=too-many-instance-attributes
     __test__ = False  # Mark this class to be not collected by pytest.
 
     def __init__(self,
@@ -83,7 +83,7 @@ class TestFrameworkEvent(SctEvent):  # pylint: disable=too-many-instance-attribu
         return fmt
 
 
-class ElasticsearchEvent(SctEvent):
+class ElasticsearchEvent(InformationalEvent):
     def __init__(self, doc_id: str, error: str):
         super().__init__(severity=Severity.ERROR)
 
@@ -95,7 +95,7 @@ class ElasticsearchEvent(SctEvent):
         return super().msgfmt + ": doc_id={0.doc_id} error={0.error}"
 
 
-class SpotTerminationEvent(SctEvent):
+class SpotTerminationEvent(InformationalEvent):
     def __init__(self, node: Any, message: str):
         super().__init__(severity=Severity.CRITICAL)
 
@@ -107,7 +107,7 @@ class SpotTerminationEvent(SctEvent):
         return super().msgfmt + ": node={0.node} message={0.message}"
 
 
-class ScyllaRepoEvent(SctEvent):
+class ScyllaRepoEvent(InformationalEvent):
     def __init__(self, url: str, error: str):
         super().__init__(severity=Severity.WARNING)
 
@@ -130,7 +130,7 @@ class InfoEvent(SctEvent):
         return super().msgfmt + ": message={0.message}"
 
 
-class ThreadFailedEvent(SctEvent):
+class ThreadFailedEvent(InformationalEvent):
     def __init__(self, message: str, traceback: Any):
         super().__init__(severity=Severity.ERROR)
 
@@ -142,7 +142,7 @@ class ThreadFailedEvent(SctEvent):
         return super().msgfmt + ": message={0.message}\n{0.traceback}"
 
 
-class CoreDumpEvent(SctEvent):
+class CoreDumpEvent(InformationalEvent):
     def __init__(self,
                  node: Any,
                  corefile_url: str,
@@ -176,7 +176,7 @@ class CoreDumpEvent(SctEvent):
         return fmt
 
 
-class TestResultEvent(SctEvent, Exception):
+class TestResultEvent(InformationalEvent, Exception):
     """An event that is published and raised at the end of the test.
 
     It holds and displays all errors of the tests and framework happened.

--- a/unit_tests/test_sct_events_database.py
+++ b/unit_tests/test_sct_events_database.py
@@ -94,5 +94,5 @@ class TestIndexSpecialColumnErrorEvent(unittest.TestCase):
         event = IndexSpecialColumnErrorEvent(message="m1")
         event.event_id = "ac449879-485a-4b06-8596-3fbe58881093"
         self.assertEqual(str(event),
-                         "(IndexSpecialColumnErrorEvent Severity.ERROR) period_type=not-set "
+                         "(IndexSpecialColumnErrorEvent Severity.ERROR) period_type=one-time "
                          "event_id=ac449879-485a-4b06-8596-3fbe58881093: message=m1")

--- a/unit_tests/test_sct_events_health.py
+++ b/unit_tests/test_sct_events_health.py
@@ -38,7 +38,7 @@ class TestValidators(unittest.TestCase):
         critical_event.event_id = "712128d0-4837-4213-8a60-d6e2ec106c52"
         self.assertEqual(
             str(critical_event),
-            "(ClusterHealthValidatorEvent Severity.CRITICAL) period_type=not-set "
+            "(ClusterHealthValidatorEvent Severity.CRITICAL) period_type=one-time "
             "event_id=712128d0-4837-4213-8a60-d6e2ec106c52: type=NodeStatus node=n1 error=e1"
         )
         self.assertEqual(critical_event, pickle.loads(pickle.dumps(critical_event)))
@@ -47,7 +47,7 @@ class TestValidators(unittest.TestCase):
         error_event.event_id = "712128d0-4837-4213-8a60-d6e2ec106c52"
         self.assertEqual(
             str(error_event),
-            "(ClusterHealthValidatorEvent Severity.ERROR) period_type=not-set "
+            "(ClusterHealthValidatorEvent Severity.ERROR) period_type=one-time "
             "event_id=712128d0-4837-4213-8a60-d6e2ec106c52: type=NodePeersNulls node=n2 error=e2"
         )
         self.assertEqual(error_event, pickle.loads(pickle.dumps(error_event)))
@@ -57,7 +57,7 @@ class TestValidators(unittest.TestCase):
         warning_event.event_id = "712128d0-4837-4213-8a60-d6e2ec106c52"
         self.assertEqual(
             str(warning_event),
-            "(ClusterHealthValidatorEvent Severity.WARNING) period_type=not-set "
+            "(ClusterHealthValidatorEvent Severity.WARNING) period_type=one-time "
             "event_id=712128d0-4837-4213-8a60-d6e2ec106c52: type=NodeSchemaVersion node=n3 message=m3"
         )
         self.assertEqual(warning_event, pickle.loads(pickle.dumps(warning_event)))
@@ -66,7 +66,7 @@ class TestValidators(unittest.TestCase):
         info_event.event_id = "712128d0-4837-4213-8a60-d6e2ec106c52"
         self.assertEqual(
             str(info_event),
-            "(ClusterHealthValidatorEvent Severity.WARNING) period_type=not-set "
+            "(ClusterHealthValidatorEvent Severity.WARNING) period_type=one-time "
             "event_id=712128d0-4837-4213-8a60-d6e2ec106c52: type=NodesNemesis node=n4 message=m4"
         )
         self.assertEqual(info_event, pickle.loads(pickle.dumps(info_event)))
@@ -75,7 +75,7 @@ class TestValidators(unittest.TestCase):
         info_event.event_id = "712128d0-4837-4213-8a60-d6e2ec106c52"
         self.assertEqual(
             str(info_event),
-            "(ClusterHealthValidatorEvent Severity.NORMAL) period_type=not-set "
+            "(ClusterHealthValidatorEvent Severity.NORMAL) period_type=one-time "
             "event_id=712128d0-4837-4213-8a60-d6e2ec106c52: type=Info node=n4 message=m4"
         )
         self.assertEqual(info_event, pickle.loads(pickle.dumps(info_event)))
@@ -84,7 +84,7 @@ class TestValidators(unittest.TestCase):
         info_event.event_id = "712128d0-4837-4213-8a60-d6e2ec106c52"
         self.assertEqual(
             str(info_event),
-            "(ClusterHealthValidatorEvent Severity.NORMAL) period_type=not-set "
+            "(ClusterHealthValidatorEvent Severity.NORMAL) period_type=one-time "
             "event_id=712128d0-4837-4213-8a60-d6e2ec106c52: type=Done node=n4 message=m4"
         )
         self.assertEqual(info_event, pickle.loads(pickle.dumps(info_event)))
@@ -104,7 +104,7 @@ class TestValidators(unittest.TestCase):
         critical_event.event_id = "3916da00-643c-4886-bdd0-963d3ebac536"
         self.assertEqual(
             str(critical_event),
-            "(DataValidatorEvent Severity.ERROR) period_type=not-set "
+            "(DataValidatorEvent Severity.ERROR) period_type=one-time "
             "event_id=3916da00-643c-4886-bdd0-963d3ebac536: type=DataValidator error=e1"
         )
         self.assertEqual(critical_event, pickle.loads(pickle.dumps(critical_event)))
@@ -113,7 +113,7 @@ class TestValidators(unittest.TestCase):
         error_event.event_id = "3916da00-643c-4886-bdd0-963d3ebac536"
         self.assertEqual(
             str(error_event),
-            "(DataValidatorEvent Severity.ERROR) period_type=not-set "
+            "(DataValidatorEvent Severity.ERROR) period_type=one-time "
             "event_id=3916da00-643c-4886-bdd0-963d3ebac536: type=ImmutableRowsValidator error=e2"
         )
         self.assertEqual(error_event, pickle.loads(pickle.dumps(error_event)))
@@ -122,7 +122,7 @@ class TestValidators(unittest.TestCase):
         warning_event.event_id = "3916da00-643c-4886-bdd0-963d3ebac536"
         self.assertEqual(
             str(warning_event),
-            "(DataValidatorEvent Severity.WARNING) period_type=not-set "
+            "(DataValidatorEvent Severity.WARNING) period_type=one-time "
             "event_id=3916da00-643c-4886-bdd0-963d3ebac536: type=UpdatedRowsValidator message=m3"
         )
         self.assertEqual(warning_event, pickle.loads(pickle.dumps(warning_event)))
@@ -131,7 +131,7 @@ class TestValidators(unittest.TestCase):
         info_event.event_id = "3916da00-643c-4886-bdd0-963d3ebac536"
         self.assertEqual(
             str(info_event),
-            "(DataValidatorEvent Severity.NORMAL) period_type=not-set "
+            "(DataValidatorEvent Severity.NORMAL) period_type=one-time "
             "event_id=3916da00-643c-4886-bdd0-963d3ebac536: type=DeletedRowsValidator message=m4"
         )
         self.assertEqual(info_event, pickle.loads(pickle.dumps(info_event)))

--- a/unit_tests/test_sct_events_system.py
+++ b/unit_tests/test_sct_events_system.py
@@ -39,7 +39,7 @@ class TestSystemEvents(unittest.TestCase):
         event.event_id = "aff29bce-d75c-4f86-9890-c6d9c1c25d3e"
         self.assertEqual(
             str(event),
-            "(TestFrameworkEvent Severity.ERROR) period_type=not-set "
+            "(TestFrameworkEvent Severity.ERROR) period_type=one-time "
             "event_id=aff29bce-d75c-4f86-9890-c6d9c1c25d3e, source=s1.m1(args=('a1', 'a2'), "
             "kwargs={'k1': 'v1', 'k2': 'v2'})"
             " message=msg1\nexception=e1",
@@ -50,7 +50,7 @@ class TestSystemEvents(unittest.TestCase):
         event = ElasticsearchEvent(doc_id="d1", error="e1")
         event.event_id = "aff29bce-d75c-4f86-9890-c6d9c1c25d3e"
         self.assertEqual(str(event),
-                         "(ElasticsearchEvent Severity.ERROR) period_type=not-set "
+                         "(ElasticsearchEvent Severity.ERROR) period_type=one-time "
                          "event_id=aff29bce-d75c-4f86-9890-c6d9c1c25d3e: doc_id=d1 error=e1")
         self.assertEqual(event, pickle.loads(pickle.dumps(event)))
 
@@ -58,7 +58,7 @@ class TestSystemEvents(unittest.TestCase):
         event = SpotTerminationEvent(node="node1", message="m1")
         event.event_id = "aff29bce-d75c-4f86-9890-c6d9c1c25d3e"
         self.assertEqual(str(event),
-                         "(SpotTerminationEvent Severity.CRITICAL) period_type=not-set "
+                         "(SpotTerminationEvent Severity.CRITICAL) period_type=one-time "
                          "event_id=aff29bce-d75c-4f86-9890-c6d9c1c25d3e: node=node1 message=m1")
         self.assertEqual(event, pickle.loads(pickle.dumps(event)))
 
@@ -66,7 +66,7 @@ class TestSystemEvents(unittest.TestCase):
         event = ScyllaRepoEvent(url="u1", error="e1")
         event.event_id = "aff29bce-d75c-4f86-9890-c6d9c1c25d3e"
         self.assertEqual(str(event),
-                         "(ScyllaRepoEvent Severity.WARNING) period_type=not-set "
+                         "(ScyllaRepoEvent Severity.WARNING) period_type=one-time "
                          "event_id=aff29bce-d75c-4f86-9890-c6d9c1c25d3e: url=u1 error=e1")
         self.assertEqual(event, pickle.loads(pickle.dumps(event)))
 
@@ -82,7 +82,7 @@ class TestSystemEvents(unittest.TestCase):
         event = ThreadFailedEvent(message="m1", traceback="t1")
         event.event_id = "aff29bce-d75c-4f86-9890-c6d9c1c25d3e"
         self.assertEqual(str(event),
-                         "(ThreadFailedEvent Severity.ERROR) period_type=not-set "
+                         "(ThreadFailedEvent Severity.ERROR) period_type=one-time "
                          "event_id=aff29bce-d75c-4f86-9890-c6d9c1c25d3e: message=m1\nt1")
         self.assertEqual(event, pickle.loads(pickle.dumps(event)))
 
@@ -91,7 +91,7 @@ class TestSystemEvents(unittest.TestCase):
         event.event_id = "aff29bce-d75c-4f86-9890-c6d9c1c25d3e"
         self.assertEqual(
             str(event),
-            "(CoreDumpEvent Severity.ERROR) period_type=not-set "
+            "(CoreDumpEvent Severity.ERROR) period_type=one-time "
             "event_id=aff29bce-d75c-4f86-9890-c6d9c1c25d3e node=node1\ncorefile_url=url1\nbacktrace=b1\n"
             "download_instructions=d1\n",
         )


### PR DESCRIPTION
Extention of commit:
https://github.com/scylladb/scylla-cluster-tests/pull/3638

[Task](https://trello.com/c/JeaRyS0N/3541-convert-all-remained-informational-events)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
