### PR TITLE
fix(k8s-eks): use K8S v1.20 instead of v1.19 in EKS

### DIFF
--- a/defaults/k8s_eks_config.yaml
+++ b/defaults/k8s_eks_config.yaml
@@ -9,7 +9,7 @@ availability_zone: 'a,b'
 instance_provision: 'on_demand'
 instance_type_db: 'i3.4xlarge'
 
-eks_cluster_version: '1.19'
+eks_cluster_version: '1.20'
 eks_role_arn: 'arn:aws:iam::797456418907:role/eksServicePolicy'
 eks_service_ipv4_cidr: '172.20.0.0/16'
 eks_vpc_cni_version: 'v1.8.0-eksbuild.1'

--- a/defaults/k8s_eks_config.yaml
+++ b/defaults/k8s_eks_config.yaml
@@ -12,7 +12,7 @@ instance_type_db: 'i3.4xlarge'
 eks_cluster_version: '1.19'
 eks_role_arn: 'arn:aws:iam::797456418907:role/eksServicePolicy'
 eks_service_ipv4_cidr: '172.20.0.0/16'
-eks_vpc_cni_version: 'v1.7.5-eksbuild.1'
+eks_vpc_cni_version: 'v1.8.0-eksbuild.1'
 eks_nodegroup_role_arn: 'arn:aws:iam::797456418907:role/helm-test-worker-nodes-NodeInstanceRole-6ACHDYEKNN3I'
 
 scylla_version: '4.4.1'


### PR DESCRIPTION
The reason for it is that EKS uses too old minor version for 1.19
Scylla Operator v1.4-alpha requires at least v1.19.10, but EKS has only 1.19.8
So, switch to usage of v1.20.x because all of these have required bugfix [1].

[1] https://github.com/kubernetes/kubernetes/pull/98732

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
