### PR TITLE
Fix update cdc stressor

### DIFF
--- a/docker/cdcstressor/image
+++ b/docker/cdcstressor/image
@@ -1,1 +1,1 @@
-scylladb/hydra-loaders:cdc-stresser-20200430
+scylladb/hydra-loaders:cdc-stresser-20210630

--- a/sdcm/cdclog_reader_thread.py
+++ b/sdcm/cdclog_reader_thread.py
@@ -62,13 +62,6 @@ class CDCLogReaderThread(DockerBasedStressThread):
         docker = RemoteDocker(loader, CDCLOG_READER_IMAGE,
                               extra_docker_opts=f'--network=host --label shell_marker={self.shell_marker}')
 
-        # Update cdc-stressor with last changes.
-        docker.run(cmd="go get -u github.com/piodul/cdc-stressor",
-                   timeout=self.timeout,
-                   ignore_status=True,
-                   log_file=log_file_name,
-                   verbose=True)
-
         node_cmd = f'STRESS_TEST_MARKER={self.shell_marker}; {self.stress_cmd}'
 
         CDCReaderStressEvent.start(node=loader, stress_cmd=self.stress_cmd).publish()

--- a/sdcm/cdclog_reader_thread.py
+++ b/sdcm/cdclog_reader_thread.py
@@ -77,12 +77,13 @@ class CDCLogReaderThread(DockerBasedStressThread):
                                            stress_cmd=self.stress_cmd,
                                            errors=result.stderr.split("\n")).publish()
             return result
-        except Exception as exc:
+        except Exception as exc:  # pylint: disable=broad-except
             CDCReaderStressEvent.failure(node=loader,
                                          stress_cmd=self.stress_cmd,
                                          errors=[format_stress_cmd_error(exc), ]).publish()
         finally:
             CDCReaderStressEvent.finish(node=loader, stress_cmd=self.stress_cmd).publish()
+        return None
 
     @staticmethod
     def _parse_cdcreaderstressor_results(lines: List[str]) -> Dict:


### PR DESCRIPTION
https://trello.com/c/al4mEwqU/3597-cdc-stresser-changed-its-command-line-arguments-requirements
https://github.com/scylladb/scylla-cluster-tests/issues/3720

Test-id: 80fa4825-41a0-4634-ae74-53b65604e128


cdc-stressor fails with argument error

```
stress_cmd=cdc-stressor -username cassandra -password cassandra -duration 2h -stream-query-round-duration 30s -keyspace ks1 -table table1_scylla_cdc_log                             -nodes 10.142.0.122,10.142.0.10,10.142.0.125,10.142.0.127 -group-size 8                             -worker-id 0 -worker-count 1
errors:
flag provided but not defined: -username
Usage of cdc-stressor:
-backoff-max duration
maximum time to wait on backoff (default 1s)
-backoff-min duration
minimum time to wait on backoff (default 1s)
-backoff-multiplier float
multiplier that increases the wait time for consecutive backoffs (must be > 1) (default 2)
-bypass-cache
use BYPASS CACHE when querying the cdc log table (default true)
-client-compression
use compression for client-coordinator communication (default true)
-connection-count int
number of connections (default 4)
-consistency-level string
consistency level to use when reading (default "quorum")
-duration duration
test duration, value <= 0 makes the test run infinitely until stopped
-grace-period duration
queries only for log writes older than (now - grace-period), helps mitigate issues with client timestamps (default 100ms)
-keyspace string
keyspace name (default "scylla_bench")
-log-interval duration
how much time to wait between printing partial results (default 1s)
-nodes string
cluster nodes to connect to (default "127.0.0.1")
-page-size int
page size (default 1000)
-print-poll-size-histogram
enables printing poll size histogram at the end (default true)
-processing-batch-size uint
maximum count of rows to process in one batch; after each batch the goroutine will sleep some time proportional to the number of rows in batch
-processing-time-per-row duration
how much processing time one row adds to current batch
-table string
name of the cdc table to read from (default "test_scylla_cdc_log")
-timeout duration
request timeout (default 5s)
-verbose
enables printing error message each time a read operation on cdc log table fails
-worker-count int
number of workers reading from the same table (default 1)
-worker-id int
id of this worker, used when running multiple instances of this tool; each instance should have a different id, and it must be in range [0..N-1], where N is the number of workers
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
