### PR TITLE
refactor(sct_events): create bootstrap continuous event

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -84,3 +84,4 @@ NodetoolEvent: ERROR
 ScyllaBenchEvent: CRITICAL
 CassandraStressEvent: CRITICAL
 GeminiStressEvent: CRITICAL
+BootstrapEvent: NORMAL

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -16,7 +16,7 @@ import logging
 from typing import Type, List, Tuple, Generic, Optional
 
 from sdcm.sct_events import Severity, SctEventProtocol
-from sdcm.sct_events.base import SctEvent, LogEvent, LogEventProtocol, T_log_event, InformationalEvent, ContinuousEvent, \
+from sdcm.sct_events.base import SctEvent, LogEvent, LogEventProtocol, T_log_event, InformationalEvent, \
     DatabaseEvent
 
 TOLERABLE_REACTOR_STALL: int = 1000  # ms

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -16,7 +16,8 @@ import logging
 from typing import Type, List, Tuple, Generic, Optional
 
 from sdcm.sct_events import Severity, SctEventProtocol
-from sdcm.sct_events.base import SctEvent, LogEvent, LogEventProtocol, T_log_event, InformationalEvent
+from sdcm.sct_events.base import SctEvent, LogEvent, LogEventProtocol, T_log_event, InformationalEvent, ContinuousEvent, \
+    DatabaseEvent
 
 TOLERABLE_REACTOR_STALL: int = 1000  # ms
 
@@ -216,3 +217,7 @@ class IndexSpecialColumnErrorEvent(InformationalEvent):
     @property
     def msgfmt(self) -> str:
         return super().msgfmt + ": message={0.message}"
+
+
+class BootstrapEvent(DatabaseEvent):
+    ...

--- a/unit_tests/lib/events_utils.py
+++ b/unit_tests/lib/events_utils.py
@@ -37,7 +37,7 @@ class EventsUtilsMixin:
         cls.events_processes_registry = EventsProcessesRegistry(log_dir=cls.temp_dir)
         if registry_patcher:
             cls.events_processes_registry_patcher = \
-                unittest.mock.patch("sdcm.sct_events.base.SctEvent._events_processes_registry",
+                unittest.mock.patch("sdcm.sct_events.base.SctEvent.events_processes_registry",
                                     cls.events_processes_registry)
             cls.events_processes_registry_patcher.start()
         if events_device:

--- a/unit_tests/test_sct_events_base.py
+++ b/unit_tests/test_sct_events_base.py
@@ -28,7 +28,7 @@ Y = None  # define a global name for pickle.
 
 class TestSctEventDefaultRegistry(unittest.TestCase):
     def test_sct_event_is_in_registry(self):
-        self.assertIn("SctEvent", SctEvent._sct_event_types_registry)
+        self.assertIn("SctEvent", SctEvent.sct_event_types_registry)
 
 
 class SctEventTestCase(unittest.TestCase):
@@ -52,11 +52,11 @@ class SctEventTestCase(unittest.TestCase):
         os.unlink(cls.severities_conf)
 
     def setUp(self) -> None:
-        self._registry_bu = SctEvent._sct_event_types_registry
-        SctEvent._sct_event_types_registry = SctEventTypesRegistry(severities_conf=self.severities_conf)
+        self._registry_bu = SctEvent.sct_event_types_registry
+        SctEvent.sct_event_types_registry = SctEventTypesRegistry(severities_conf=self.severities_conf)
 
     def tearDown(self) -> None:
-        SctEvent._sct_event_types_registry = self._registry_bu
+        SctEvent.sct_event_types_registry = self._registry_bu
 
 
 class TestSctEvent(SctEventTestCase):

--- a/unit_tests/test_sct_events_bootstrap.py
+++ b/unit_tests/test_sct_events_bootstrap.py
@@ -1,0 +1,82 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2021 ScyllaDB
+
+
+import time
+import unittest
+import uuid
+from pathlib import Path
+
+from sdcm.sct_events.database import BootstrapEvent
+
+
+class TestBootstrapEvent(unittest.TestCase):
+    temp_log_file_path = Path(f"/tmp/{time.time()}.log")
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.temp_log_file_path.touch()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.temp_log_file_path.unlink()
+
+    def setUp(self) -> None:
+        self.event_id = uuid.uuid4()
+        self.node = "1.2.4.5.6"
+        self.bootstrap_event = BootstrapEvent(node=self.node,
+                                              log_file_name=str(self.temp_log_file_path),
+                                              publish_event=False)
+        self.bootstrap_event.event_id = self.event_id
+
+    def test_bootstrap_event_begin(self):
+        self.bootstrap_event.begin_event()
+        actual = str(self.bootstrap_event)
+        expected = f"(BootstrapEvent Severity.NORMAL) period_type=begin event_id={self.event_id} " \
+                   f"node={self.node}"
+
+        self.assertEqual(actual, expected)
+
+    def test_bootstrap_event_duration(self):
+        duration = 60
+        duration_fmt = "1m0s"
+        self.bootstrap_event.duration = duration
+        actual = str(self.bootstrap_event)
+        expected = f"(BootstrapEvent Severity.NORMAL) period_type=not-set " \
+                   f"event_id={self.event_id} duration={duration_fmt} node={self.node}"
+
+        self.assertEqual(actual, expected)
+
+    def test_bootstrap_as_ctx_manager(self):
+        duration = 10
+
+        with self.bootstrap_event:
+            self.assertEqual(self.bootstrap_event.period_type, "begin")
+            time.sleep(duration)
+
+        self.assertEqual(self.bootstrap_event.duration, duration)
+        self.assertEqual(self.bootstrap_event.period_type, "end")
+
+    def test_bootstrap_event_failure(self):
+        duration = 605
+        duration_fmt = "10m5s"
+        errors = ["Failed with status 1"]
+        self.bootstrap_event.add_error(errors)
+        self.bootstrap_event.duration = duration
+        self.bootstrap_event.end_event()
+
+        actual = str(self.bootstrap_event)
+        expected = f"(BootstrapEvent Severity.NORMAL) period_type=end event_id={self.event_id} " \
+                   f"duration={duration_fmt} node={self.node} errors=['{errors[0]}']"
+
+        self.assertEqual(actual, expected)

--- a/unit_tests/test_tester.py
+++ b/unit_tests/test_tester.py
@@ -48,7 +48,7 @@ class ClusterTesterForTests(ClusterTester):
         self.logdir = tempfile.mkdtemp()
         self.events_processes_registry = EventsProcessesRegistry(log_dir=self.logdir)
         self.events_processes_registry_patcher = \
-            unittest.mock.patch("sdcm.sct_events.base.SctEvent._events_processes_registry",
+            unittest.mock.patch("sdcm.sct_events.base.SctEvent.events_processes_registry",
                                 self.events_processes_registry)
         self.events_processes_registry_patcher.start()
         configure_logging(


### PR DESCRIPTION
Created some class infrastructure for continuous database events (such as bootstrapping, starting the Scylla service etc.) and a dedicated BootstrapEvent for the continuous event of bootstrapping a Scylla node. Added some unit tests for the new bootstrap event class.

Trello task: https://trello.com/c/IeNjhxSu


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] ~~I added the relevant `backport` labels~~
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
