### PR TITLE
Fix na email report data

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -405,15 +405,13 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         return 'true' in result.stdout.lower()
 
     @property
-    def cpu_cores(self):
+    def cpu_cores(self) -> Optional[int]:
         try:
             result = self.remoter.run("nproc", ignore_status=True)
-            cores = result.stdout.lower()
+            return int(result.stdout)
         except Exception as details:  # pylint: disable=broad-except
-            self.log.error("Command 'nproc' error: %s", details)
-            cores = None
-        cores = int(cores) if cores else None
-        return cores
+            self.log.error("Failed to get number of cores due to the %s", details)
+        return None
 
     @property
     def scylla_shards(self):

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -406,8 +406,12 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
     @property
     def cpu_cores(self):
-        result = self.remoter.run("nproc", ignore_status=True)
-        cores = result.stdout.lower()
+        try:
+            result = self.remoter.run("nproc", ignore_status=True)
+            cores = result.stdout.lower()
+        except Exception as details:  # pylint: disable=broad-except
+            self.log.error("Command 'nproc' error: %s", details)
+            cores = None
         cores = int(cores) if cores else None
         return cores
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1986,6 +1986,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 self.log.debug('Create new table with cql: {}'.format(create_cql))
                 session.execute(create_cql)
                 return True
+            return False
 
     @retrying(n=4, sleep_time=5, message='Fetch all rows', raise_on_exceeded=False)
     def fetch_all_rows(self, session, default_fetch_size, statement, verbose=True):
@@ -2580,6 +2581,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             return int(re.search(r"n=(\d+) ", cs_cmd).group(1))
         except Exception:  # pylint: disable=broad-except
             self.fail("Unable to get data set size from cassandra-stress command: %s" % cs_cmd)
+            return None
 
     @retrying(n=60, sleep_time=60, allowed_exceptions=(AssertionError,))
     def wait_data_dir_reaching(self, size, node):
@@ -2661,6 +2663,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 email_subject=email_subject)
         except Exception as ex:  # pylint: disable=broad-except
             self.log.exception('Failed to check regression: %s', ex)
+            return False
 
     def check_specified_stats_regression(self, stats):
         perf_analyzer = SpecifiedStatsPerformanceAnalyzer(es_index=self._test_index, es_doc_type=self._es_doc_type,
@@ -3062,6 +3065,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         for result in parallel_obj_results:
             if not result.exc:
                 return result.result
+        return None
 
     @staticmethod
     def _check_ssh_node_connectivity(node: BaseNode) -> Optional[BaseNode]:

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -3018,8 +3018,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 "region_name": region_name,
                 "scylla_instance_type": scylla_instance_type,
                 "scylla_version": scylla_version,
-                "live_nodes_shards": nodes_shards['live_nodes'],
-                "dead_nodes_shards": nodes_shards['dead_nodes'],
+                "live_nodes_shards": nodes_shards.get('live_nodes'),
+                "dead_nodes_shards": nodes_shards.get('dead_nodes'),
                 "kernel_version": kernel_version,
                 "start_time": start_time,
                 "subject": f"{test_status}: {os.environ.get('JOB_NAME') or config_file_name}{build_id}: {start_time}",
@@ -3052,6 +3052,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         return output
 
     def _get_live_node(self) -> Optional[BaseNode]:  # pylint: disable=inconsistent-return-statements
+        if not self.db_cluster or not self.db_cluster.nodes:
+            self.log.error("Cluster object was not initialized")
+            return None
         parallel_obj = ParallelObject(objects=self.db_cluster.nodes)
         parallel_obj_results = parallel_obj.run(self._check_ssh_node_connectivity,
                                                 ignore_exceptions=True)


### PR DESCRIPTION
Trello: https://trello.com/c/HnI978Y9

_self._get_common_email_data() could fail during getting the scylla shard or when Tester.db_cluster is not set if test failed during setup.
Added appropriate checks to avoid failing _self._get_common_email_data()

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
