### PR TITLE
feature(kubernetes): add operator upgrade test

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -158,9 +158,12 @@
 | **<a href="#user-content-gke_cluster_version" name="gke_cluster_version">gke_cluster_version</a>**  |  | N/A | SCT_GKE_CLUSTER_VERSION
 | **<a href="#user-content-gke_k8s_release_channel" name="gke_k8s_release_channel">gke_k8s_release_channel</a>**  |  | N/A | SCT_GKE_K8S_RELEASE_CHANNEL
 | **<a href="#user-content-k8s_deploy_monitoring" name="k8s_deploy_monitoring">k8s_deploy_monitoring</a>**  |  | N/A | SCT_K8S_DEPLOY_MONITORING
-| **<a href="#user-content-k8s_scylla_operator_docker_image" name="k8s_scylla_operator_docker_image">k8s_scylla_operator_docker_image</a>**  |  | N/A | SCT_K8S_SCYLLA_OPERATOR_DOCKER_IMAGE
 | **<a href="#user-content-k8s_scylla_operator_helm_repo" name="k8s_scylla_operator_helm_repo">k8s_scylla_operator_helm_repo</a>**  |  | N/A | SCT_K8S_SCYLLA_OPERATOR_HELM_REPO
 | **<a href="#user-content-k8s_scylla_operator_chart_version" name="k8s_scylla_operator_chart_version">k8s_scylla_operator_chart_version</a>**  |  | N/A | SCT_K8S_SCYLLA_OPERATOR_CHART_VERSION
+| **<a href="#user-content-k8s_scylla_operator_docker_image" name="k8s_scylla_operator_docker_image">k8s_scylla_operator_docker_image</a>**  |  | N/A | SCT_K8S_SCYLLA_OPERATOR_DOCKER_IMAGE
+| **<a href="#user-content-k8s_scylla_operator_upgrade_helm_repo" name="k8s_scylla_operator_upgrade_helm_repo">k8s_scylla_operator_upgrade_helm_repo</a>**  |  | N/A | SCT_K8S_SCYLLA_OPERATOR_UPGRADE_HELM_REPO
+| **<a href="#user-content-k8s_scylla_operator_upgrade_chart_version" name="k8s_scylla_operator_upgrade_chart_version">k8s_scylla_operator_upgrade_chart_version</a>**  |  | N/A | SCT_K8S_SCYLLA_OPERATOR_UPGRADE_CHART_VERSION
+| **<a href="#user-content-k8s_scylla_operator_upgrade_docker_image" name="k8s_scylla_operator_upgrade_docker_image">k8s_scylla_operator_upgrade_docker_image</a>**  |  | N/A | SCT_K8S_SCYLLA_OPERATOR_UPGRADE_DOCKER_IMAGE
 | **<a href="#user-content-k8s_scylla_datacenter" name="k8s_scylla_datacenter">k8s_scylla_datacenter</a>**  |  | N/A | SCT_K8S_SCYLLA_DATACENTER
 | **<a href="#user-content-k8s_scylla_rack" name="k8s_scylla_rack">k8s_scylla_rack</a>**  |  | N/A | SCT_K8S_SCYLLA_RACK
 | **<a href="#user-content-k8s_scylla_cluster_name" name="k8s_scylla_cluster_name">k8s_scylla_cluster_name</a>**  |  | N/A | SCT_K8S_SCYLLA_CLUSTER_NAME

--- a/jenkins-pipelines/operator/upgrade/upgrade-operator-k8s-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-operator-k8s-eks.jenkinsfile
@@ -1,0 +1,10 @@
+#!groovy
+
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+rollingOperatorUpgradePipeline(
+    backend: 'k8s-eks',
+    aws_region: 'eu-north-1',
+    test_name: 'upgrade_test.UpgradeTest.test_kubernetes_operator_upgrade',
+    test_config: 'test-cases/scylla-operator/kubernetes-operator-upgrade.yaml',
+)

--- a/jenkins-pipelines/operator/upgrade/upgrade-operator-k8s-gke.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-operator-k8s-gke.jenkinsfile
@@ -1,0 +1,9 @@
+#!groovy
+
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+rollingOperatorUpgradePipeline(
+    backend: 'k8s-gke',
+    test_name: 'upgrade_test.UpgradeTest.test_kubernetes_operator_upgrade',
+    test_config: 'test-cases/scylla-operator/kubernetes-operator-upgrade.yaml',
+)

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -676,17 +676,29 @@ class SCTConfiguration(dict):
         dict(name="k8s_deploy_monitoring", env="SCT_K8S_DEPLOY_MONITORING", type=str,
              help=""),
 
-        dict(name="k8s_scylla_operator_docker_image", env="SCT_K8S_SCYLLA_OPERATOR_DOCKER_IMAGE", type=str,
-             help=""),
+        dict(name="k8s_scylla_operator_docker_image",
+             env="SCT_K8S_SCYLLA_OPERATOR_DOCKER_IMAGE", type=str,
+             help="Docker image to be used for installation of scylla operator."),
+        dict(name="k8s_scylla_operator_upgrade_docker_image",
+             env="SCT_K8S_SCYLLA_OPERATOR_UPGRADE_DOCKER_IMAGE", type=str,
+             help="Docker image to be used for upgrade of scylla operator."),
 
         dict(name="k8s_scylla_operator_helm_repo", env="SCT_K8S_SCYLLA_OPERATOR_HELM_REPO",
              type=str,
              help="Link to the Helm repository where to get 'scylla-operator' charts from."),
+        dict(name="k8s_scylla_operator_upgrade_helm_repo", env="SCT_K8S_SCYLLA_OPERATOR_UPGRADE_HELM_REPO",
+             type=str,
+             help="Link to the Helm repository where to get 'scylla-operator' charts for upgrade."),
 
-        dict(name="k8s_scylla_operator_chart_version", env="SCT_K8S_SCYLLA_OPERATOR_CHART_VERSION",
+        dict(name="k8s_scylla_operator_chart_version",
+             env="SCT_K8S_SCYLLA_OPERATOR_CHART_VERSION",
              type=str,
              help=("Version of 'scylla-operator' Helm chart to use. "
                    "If not set then latest one will be used.")),
+        dict(name="k8s_scylla_operator_upgrade_chart_version",
+             env="SCT_K8S_SCYLLA_OPERATOR_UPGRADE_CHART_VERSION",
+             type=str,
+             help="Version of 'scylla-operator' Helm chart to use for upgrade."),
 
         dict(name="k8s_scylla_datacenter", env="SCT_K8S_SCYLLA_DATACENTER", type=str,
              help=""),

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -42,7 +42,7 @@ def str_or_list(value: Union[str, List[str]]) -> List[str]:
     if isinstance(value, str):
         try:
             return ast.literal_eval(value)
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             pass
         return [str(value), ]
 
@@ -1442,7 +1442,8 @@ class SCTConfiguration(dict):
                 try:
                     environment_vars[opt['name']] = opt['type'](os.environ[opt['env']])
                 except Exception as ex:
-                    raise ValueError("failed to parse {} from environment variable:\n\t\t{}".format(opt['env'], ex))
+                    raise ValueError(
+                        "failed to parse {} from environment variable".format(opt['env'])) from ex
         return environment_vars
 
     def _update_environment_variables(self, replace=False):
@@ -1455,7 +1456,7 @@ class SCTConfiguration(dict):
         get the value of test configuration parameter by the name
         """
 
-        ret_val = super(SCTConfiguration, self).get(key)
+        ret_val = super().get(key)
 
         if key in self.multi_region_params and isinstance(ret_val, list):
             ret_val = ' '.join(ret_val)
@@ -1466,7 +1467,7 @@ class SCTConfiguration(dict):
         try:
             opt['type'](self.get(opt['name']))
         except Exception as ex:
-            raise ValueError("failed to validate {}:\n\t\t{}".format(opt['name'], ex))
+            raise ValueError("failed to validate {}".format(opt['name'])) from ex
         choices = opt.get('choices')
         if choices:
             cur_val = self.get(opt['name'])
@@ -1548,7 +1549,7 @@ class SCTConfiguration(dict):
     def _check_unexpected_sct_variables(self):
         # check if there are SCT_* environment variable which aren't documented
         config_keys = {opt['env'] for opt in self.config_options}
-        env_keys = {o for o in os.environ.keys() if o.startswith('SCT_')}
+        env_keys = {o for o in os.environ if o.startswith('SCT_')}
         unknown_env_keys = env_keys.difference(config_keys)
         if unknown_env_keys:
             output = ["{}={}".format(key, os.environ.get(key)) for key in unknown_env_keys]

--- a/test-cases/scylla-operator/kubernetes-operator-upgrade.yaml
+++ b/test-cases/scylla-operator/kubernetes-operator-upgrade.yaml
@@ -1,0 +1,20 @@
+test_duration: 300
+
+# workloads
+stress_cmd_r: cassandra-stress read no-warmup cl=QUORUM n=2010020 -schema 'keyspace=keyspace_entire_test replication(factor=3) compression=LZ4Compressor' -port jmx=6868 -mode cql3 native compression=lz4 -rate threads=100 -pop seq=1..2010020 -log interval=5
+stress_cmd_w: cassandra-stress write no-warmup cl=QUORUM n=2010020 -schema 'keyspace=keyspace_entire_test replication(factor=3) compression=LZ4Compressor' -port jmx=6868 -mode cql3 native compression=lz4 -rate threads=100 -pop seq=1..2010020 -log interval=5
+
+n_db_nodes: 3
+n_loaders: 1
+n_monitor_nodes: 1
+
+k8s_scylla_operator_helm_repo: 'https://storage.googleapis.com/scylla-operator-charts/stable'
+k8s_scylla_operator_chart_version: 'latest'  # will pick up the latest stable version, i.e. 'v1.3.0'
+k8s_scylla_operator_docker_image: ''  # default value from the Helm chart will be used
+
+k8s_scylla_operator_upgrade_helm_repo: 'https://storage.googleapis.com/scylla-operator-charts/latest'
+k8s_scylla_operator_upgrade_chart_version: 'latest'  # never the same as above. Latest dev-version
+k8s_scylla_operator_upgrade_docker_image: ''  # default value from the Helm chart will be used
+
+use_mgmt: false
+user_prefix: 'kubernetes-operator-upgrade'

--- a/test-cases/scylla-operator/kubernetes-scylla-upgrade.yaml
+++ b/test-cases/scylla-operator/kubernetes-scylla-upgrade.yaml
@@ -8,6 +8,8 @@ n_db_nodes: 3
 n_loaders: 1
 n_monitor_nodes: 1
 
+use_mgmt: false
+
 user_prefix: 'kubernetes-scylla-upgrade'
 
 # Following configurations does not currently work on kubernetes, due to the lack of ssl certificate support.

--- a/vars/rollingOperatorUpgradePipeline.groovy
+++ b/vars/rollingOperatorUpgradePipeline.groovy
@@ -27,12 +27,24 @@ def call(Map pipelineParams) {
                    name: 'new_version')
             string(defaultValue: "${pipelineParams.get('scylla_mgmt_agent_version', '')}",
                    name: 'scylla_mgmt_agent_version')
-            string(defaultValue: "${pipelineParams.get('k8s_scylla_operator_docker_image', '')}",
-                   name: 'k8s_scylla_operator_docker_image')
             string(defaultValue: "${pipelineParams.get('k8s_scylla_operator_helm_repo', '')}",
+                   description: 'Example: https://storage.googleapis.com/scylla-operator-charts/latest',
                    name: 'k8s_scylla_operator_helm_repo')
             string(defaultValue: "${pipelineParams.get('k8s_scylla_operator_chart_version', '')}",
+                   description: 'Example: v1.4.0-alpha.0-45-g5adf54a',
                    name: 'k8s_scylla_operator_chart_version')
+            string(defaultValue: "${pipelineParams.get('k8s_scylla_operator_docker_image', '')}",
+                   description: 'Example: scylladb/scylla-operator:latest or scylladb/scylla-operator:1.3.0',
+                   name: 'k8s_scylla_operator_docker_image')
+            string(defaultValue: "${pipelineParams.get('k8s_scylla_operator_upgrade_helm_repo', '')}",
+                   description: 'Example: https://storage.googleapis.com/scylla-operator-charts/latest',
+                   name: 'k8s_scylla_operator_upgrade_helm_repo')
+            string(defaultValue: "${pipelineParams.get('k8s_scylla_operator_upgrade_chart_version', '')}",
+                   description: 'Example: v1.4.0-alpha.0-34-gf13771d',
+                   name: 'k8s_scylla_operator_upgrade_chart_version')
+            string(defaultValue: "${pipelineParams.get('k8s_scylla_operator_upgrade_docker_image', '')}",
+                   description: 'Example: scylladb/scylla-operator:latest or scylladb/scylla-operator:1.3.0',
+                   name: 'k8s_scylla_operator_upgrade_docker_image')
             string(defaultValue: "${pipelineParams.get('provision_type', 'spot_low_price')}",
                    description: 'spot_low_price|on_demand|spot_fleet|spot_low_price|spot_duration',
                    name: 'provision_type')

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -36,11 +36,20 @@ def call(Map params, String region, functional_test = false){
     if [[ -n "${params.k8s_scylla_operator_docker_image ? params.k8s_scylla_operator_docker_image : ''}" ]] ; then
         export SCT_K8S_SCYLLA_OPERATOR_DOCKER_IMAGE=${params.k8s_scylla_operator_docker_image}
     fi
+    if [[ -n "${params.k8s_scylla_operator_upgrade_docker_image ? params.k8s_scylla_operator_upgrade_docker_image : ''}" ]] ; then
+        export SCT_K8S_SCYLLA_OPERATOR_UPGRADE_DOCKER_IMAGE=${params.k8s_scylla_operator_upgrade_docker_image}
+    fi
     if [[ -n "${params.k8s_scylla_operator_helm_repo ? params.k8s_scylla_operator_helm_repo : ''}" ]] ; then
         export SCT_K8S_SCYLLA_OPERATOR_HELM_REPO=${params.k8s_scylla_operator_helm_repo}
     fi
+    if [[ -n "${params.k8s_scylla_operator_upgrade_helm_repo ? params.k8s_scylla_operator_upgrade_helm_repo : ''}" ]] ; then
+        export SCT_K8S_SCYLLA_OPERATOR_UPGRADE_HELM_REPO=${params.k8s_scylla_operator_upgrade_helm_repo}
+    fi
     if [[ -n "${params.k8s_scylla_operator_chart_version ? params.k8s_scylla_operator_chart_version : ''}" ]] ; then
         export SCT_K8S_SCYLLA_OPERATOR_CHART_VERSION=${params.k8s_scylla_operator_chart_version}
+    fi
+    if [[ -n "${params.k8s_scylla_operator_upgrade_chart_version ? params.k8s_scylla_operator_upgrade_chart_version : ''}" ]] ; then
+        export SCT_K8S_SCYLLA_OPERATOR_UPGRADE_CHART_VERSION=${params.k8s_scylla_operator_upgrade_chart_version}
     fi
 
     if [[ -n "${params.scylla_mgmt_agent_version ? params.scylla_mgmt_agent_version : ''}" ]] ; then


### PR DESCRIPTION
Add test case which allows us to run scylla operator upgrade.
    
Following new config options are added:
- **k8s_scylla_operator_upgrade_helm_repo**
  It can be empty. In such case will be used value
  from the main 'k8s_scylla_operator_helm_repo' option.
- **k8s_scylla_operator_upgrade_chart_version**
  It can be '' (empty), 'latest' or specific like "v1.3.0"
- **k8s_scylla_operator_upgrade_docker_image**
  It can be empty or be like 'scylladb/scylla-operator:latest'

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
