### PR TITLE
fix(manager): changed default post behavior in all jobs to destroy

### DIFF
--- a/jenkins-pipelines/manager/centos-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-upgrade.jenkinsfile
@@ -18,5 +18,8 @@ managerPipeline(
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: 'test-cases/upgrades/manager-upgrade.yaml',
 
-    timeout: [time: 360, unit: 'MINUTES']
+    timeout: [time: 360, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy'
 )

--- a/jenkins-pipelines/manager/debian10-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian10-manager-upgrade.jenkinsfile
@@ -18,5 +18,8 @@ managerPipeline(
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/debian10.yaml"]''',
 
-    timeout: [time: 360, unit: 'MINUTES']
+    timeout: [time: 360, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy'
 )

--- a/jenkins-pipelines/manager/debian9-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian9-manager-upgrade.jenkinsfile
@@ -18,5 +18,8 @@ managerPipeline(
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/debian9.yaml"]''',
 
-    timeout: [time: 360, unit: 'MINUTES']
+    timeout: [time: 360, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy'
 )

--- a/jenkins-pipelines/manager/ubuntu16-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu16-manager-upgrade.jenkinsfile
@@ -18,5 +18,8 @@ managerPipeline(
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/ubuntu16.yaml"]''',
 
-    timeout: [time: 360, unit: 'MINUTES']
+    timeout: [time: 360, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy'
 )

--- a/jenkins-pipelines/manager/ubuntu18-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu18-manager-upgrade.jenkinsfile
@@ -18,5 +18,8 @@ managerPipeline(
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/ubuntu18.yaml"]''',
 
-    timeout: [time: 360, unit: 'MINUTES']
+    timeout: [time: 360, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy'
 )

--- a/jenkins-pipelines/manager/ubuntu20-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu20-manager-upgrade.jenkinsfile
@@ -18,5 +18,8 @@ managerPipeline(
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/ubuntu20.yaml"]''',
 
-    timeout: [time: 360, unit: 'MINUTES']
+    timeout: [time: 360, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy'
 )


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
