### PR TITLE
fix(gemini_cmd): Reduce gemini threads in test

### DIFF
--- a/test-cases/gemini/gemini-1tb-10h.yaml
+++ b/test-cases/gemini/gemini-1tb-10h.yaml
@@ -11,7 +11,7 @@ user_prefix: 'gemini-1tb-10h'
 nemesis_class_name: 'GeminiChaosMonkey'
 nemesis_interval: 5
 
-gemini_cmd: "gemini -d --duration 36000s --warmup 7200s -c 100 \
+gemini_cmd: "gemini -d --duration 36000s --warmup 7200s -c 50 \
 -m mixed -f --non-interactive --cql-features normal \
 --max-mutation-retries 5 --max-mutation-retries-backoff 500ms \
 --async-objects-stabilization-attempts 5 --async-objects-stabilization-backoff 500ms \

--- a/test-cases/gemini/gemini-3h-cdc-postimage-write.yaml
+++ b/test-cases/gemini/gemini-3h-cdc-postimage-write.yaml
@@ -7,7 +7,7 @@ instance_type_db: 'i3.4xlarge'
 user_prefix: "gemini-cdc-postimage-write"
 
 gemini_cmd: "gemini -d --duration 3h \
--c 50 -m write -f --non-interactive --cql-features normal \
+-c 30 -m write -f --non-interactive --cql-features normal \
 --max-mutation-retries 5 --max-mutation-retries-backoff 500ms \
 --async-objects-stabilization-attempts 5 --async-objects-stabilization-backoff 500ms \
 --replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '3'}\" "

--- a/test-cases/gemini/gemini-3h-cdc-preimage-write.yaml
+++ b/test-cases/gemini/gemini-3h-cdc-preimage-write.yaml
@@ -7,7 +7,7 @@ instance_type_db: 'i3.4xlarge'
 user_prefix: "gemini-cdc-preimage-write"
 
 gemini_cmd: "gemini -d --duration 3h \
--c 50 -m write -f --non-interactive --cql-features normal \
+-c 30 -m write -f --non-interactive --cql-features normal \
 --max-mutation-retries 5 --max-mutation-retries-backoff 500ms \
 --async-objects-stabilization-attempts 5 --async-objects-stabilization-backoff 500ms \
 --replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '3'}\" "

--- a/test-cases/gemini/gemini-3h-cdc-write.yaml
+++ b/test-cases/gemini/gemini-3h-cdc-write.yaml
@@ -7,7 +7,7 @@ instance_type_db: 'i3.4xlarge'
 user_prefix: "gemini-cdc-write"
 
 gemini_cmd: "gemini -d --duration 3h \
--c 50 -m write -f --non-interactive --cql-features normal \
+-c 30 -m write -f --non-interactive --cql-features normal \
 --max-mutation-retries 5 --max-mutation-retries-backoff 500ms \
 --async-objects-stabilization-attempts 5 --async-objects-stabilization-backoff 500ms \
 --replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '3'}\" "

--- a/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
@@ -13,7 +13,7 @@ nemesis_interval: 5
 # gemini
 # cmd: gemini -d -n [NUM_OF_TEST_ITERATIONS] -c [NUM_OF_THREADS] -m mixed -f
 # the below cmd runs about 3 hours
-gemini_cmd: "gemini -d --duration 3h --warmup 30m -c 100 -m mixed -f --non-interactive \
+gemini_cmd: "gemini -d --duration 3h --warmup 30m -c 50 -m mixed -f --non-interactive \
 --cql-features normal --table-options \"compaction={'class': 'IncrementalCompactionStrategy'}\" \
 --max-mutation-retries 5 --max-mutation-retries-backoff 500ms \
 --async-objects-stabilization-attempts 5 --async-objects-stabilization-backoff 500ms \

--- a/test-cases/gemini/gemini-3h-ics-with-nondisruptive-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-with-nondisruptive-nemesis.yaml
@@ -12,7 +12,7 @@ nemesis_interval: 5
 # gemini
 # cmd: gemini -d -n [NUM_OF_TEST_ITERATIONS] -c [NUM_OF_THREADS] -m mixed -f
 # the below cmd runs about 3 hours
-gemini_cmd: "gemini -d --duration 10800s --warmup 1800s -c 100 -m mixed -f --non-interactive \
+gemini_cmd: "gemini -d --duration 10800s --warmup 1800s -c 50 -m mixed -f --non-interactive \
 --cql-features normal --table-options \"compaction={'class': 'IncrementalCompactionStrategy'}\" \
 --max-mutation-retries 5 --max-mutation-retries-backoff 500ms \
 --async-objects-stabilization-attempts 5 --async-objects-stabilization-backoff 500ms "

--- a/test-cases/gemini/gemini-3h-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nemesis.yaml
@@ -15,7 +15,7 @@ nemesis_interval: 5
 #--async-objects-stabilization-backoff duration   Duration between attempts to validate result sets from MV and SI for example 10ms or 1s (default 10ms)
 # the below cmd runs about 3 hours
 gemini_cmd: "gemini -d --duration 3h --warmup 30m \
--c 100 -m mixed -f --non-interactive --cql-features normal \
+-c 50 -m mixed -f --non-interactive --cql-features normal \
 --max-mutation-retries 5 --max-mutation-retries-backoff 500ms \
 --async-objects-stabilization-attempts 5 --async-objects-stabilization-backoff 500ms \
 --replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '3'}\" \

--- a/test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml
@@ -13,7 +13,7 @@ nemesis_interval: 5
 # gemini
 # cmd: gemini -d -n [NUM_OF_TEST_ITERATIONS] -c [NUM_OF_THREADS] -p [NUM_OF_PARTITION_KEYS_PER_THREAD] -m mixed -f
 # the below cmd runs about 3 hours
-gemini_cmd: "gemini -d --duration 10800s --warmup 1800s -c 100 \
+gemini_cmd: "gemini -d --duration 10800s --warmup 1800s -c 50 \
 -m mixed -f --non-interactive --cql-features normal \
 --max-mutation-retries 5 --max-mutation-retries-backoff 500ms \
 --async-objects-stabilization-attempts 5 --async-objects-stabilization-backoff 500ms \

--- a/test-cases/gemini/gemini-8h-large-num-columns.yaml
+++ b/test-cases/gemini/gemini-8h-large-num-columns.yaml
@@ -15,7 +15,7 @@ nemesis_interval: 5
 # cmd: gemini -d -n [NUM_OF_TEST_ITERATIONS] -c [NUM_OF_THREADS] -p [NUM_OF_PARTITION_KEYS_PER_THREAD] -m mixed -f
 # the below cmd runs about 3 hours
 gemini_cmd: "gemini -d --duration 7h --warmup 1h \
--c 20 -m mixed -f --non-interactive \
+-c 10 -m mixed -f --non-interactive \
 --cql-features normal --async-objects-stabilization-backoff 500ms \
 --replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '3'}\" \
 --max-mutation-retries 5 --max-mutation-retries-backoff 500ms \

--- a/test-cases/gemini/gemini-basic-3h-ics.yaml
+++ b/test-cases/gemini/gemini-basic-3h-ics.yaml
@@ -10,7 +10,7 @@ user_prefix: 'ics-gemini-basic-3h'
 # gemini
 # cmd: gemini -d -n [NUM_OF_TEST_ITERATIONS] -c [NUM_OF_THREADS] -m mixed -f
 # the below cmd runs about 3 hours
-gemini_cmd: "gemini -d --duration 10800s --warmup 1800s -c 100 -m mixed -f --non-interactive \
+gemini_cmd: "gemini -d --duration 10800s --warmup 1800s -c 50 -m mixed -f --non-interactive \
 --cql-features normal --table-options \"compaction={'class': 'IncrementalCompactionStrategy'}\" \
 --max-mutation-retries 5 --max-mutation-retries-backoff 500ms \
 --async-objects-stabilization-attempts 5 --async-objects-stabilization-backoff 500ms "

--- a/test-cases/gemini/gemini-basic-3h.yaml
+++ b/test-cases/gemini/gemini-basic-3h.yaml
@@ -10,7 +10,7 @@ user_prefix: 'gemini-basic-3h'
 # gemini
 # cmd: gemini -d -n [NUM_OF_TEST_ITERATIONS] -c [NUM_OF_THREADS] -m mixed -f
 # the below cmd runs about 3 hours
-gemini_cmd: "gemini -d --duration 10800s --warmup 1800s -c 100 \
+gemini_cmd: "gemini -d --duration 10800s --warmup 1800s -c 50 \
 -m mixed -f --non-interactive --cql-features normal \
 --max-mutation-retries 5 --max-mutation-retries-backoff 500ms \
 --async-objects-stabilization-attempts 5 --async-objects-stabilization-backoff 500ms \


### PR DESCRIPTION
To avoid cluster overloading number of concurrent threads
was decreased from 100 to 50

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
