### PR TITLE
fix(gemini-1tb-10h): Change test duration to 10h

### DIFF
--- a/test-cases/gemini/gemini-1tb-10h.yaml
+++ b/test-cases/gemini/gemini-1tb-10h.yaml
@@ -11,7 +11,7 @@ user_prefix: 'gemini-1tb-10h'
 nemesis_class_name: 'GeminiChaosMonkey'
 nemesis_interval: 5
 
-gemini_cmd: "gemini -d --duration 36000s --warmup 7200s -c 50 \
+gemini_cmd: "gemini -d --duration 8h --warmup 2h -c 50 \
 -m mixed -f --non-interactive --cql-features normal \
 --max-mutation-retries 5 --max-mutation-retries-backoff 500ms \
 --async-objects-stabilization-attempts 5 --async-objects-stabilization-backoff 500ms \


### PR DESCRIPTION
fix issue #3739 by changing the duration + warmup = 10h

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
