### PR TITLE
fix(multi_hard_reboot): add to global filters and cdc generation check

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -104,6 +104,14 @@ class DefaultValue:  # pylint: disable=too-few-public-methods
     ...
 
 
+class CdcStreamsWasNotUpdated(Exception):
+    """ raised if messages:
+          - Generation {}: streams description table already updated
+          - CDC description table successfully updated with generation
+        were not found in logs
+    """
+
+
 class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-methods
 
     disruptive = False
@@ -463,9 +471,17 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.cluster.wait_for_nodes_up_and_normal(nodes=[self.target_node])
 
     def disrupt_multiple_hard_reboot_node(self):  # pylint: disable=invalid-name
+        # If this messages appeared, cdc successfully update generation
+        cdc_success_msg = ["streams description table already updated",
+                           "CDC description table successfully updated with generation"]
         num_of_reboots = random.randint(2, 10)
+        InfoEvent(message=f'MultipleHardRebootNode {self.target_node}')
         for i in range(num_of_reboots):
-            self.log.info("Rebooting {} out of {} times".format(i + 1, num_of_reboots))
+            self.log.debug("Rebooting {} out of {} times".format(i + 1, num_of_reboots))
+            cdc_expected_error = self.target_node.follow_system_log(
+                patterns=["cdc - Could not update CDC description table with generation"])
+            cdc_success_msg = self.target_node.follow_system_log(
+                patterns=cdc_success_msg)
             self.target_node.reboot(hard=True)
             if random.choice([True, False]):
                 self.log.info('Waiting scylla services to start after node reboot')
@@ -474,6 +490,17 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 self.log.info('Waiting JMX services to start after node reboot')
                 self.target_node.wait_jmx_up()
             self.cluster.wait_for_nodes_up_and_normal(nodes=[self.target_node])
+            found_cdc_error = list(cdc_expected_error)
+            found_success_info = list(cdc_success_msg)
+            if found_cdc_error and not found_success_info:
+                # if cdc error message "cdc - Could not update CDC description..."
+                # was found in log during reboot, but after that success messages:
+                # "streams description updated" or "CDC desc table updated" were not
+                # found in logs, raise Exception to fail the nemesis.
+                raise CdcStreamsWasNotUpdated(
+                    f"After '{found_cdc_error[0]}', messages '{' or '.join(cdc_success_msg)}' were not found")
+
+            cdc_success_msg = cdc_expected_error = None
             sleep_time = random.randint(0, 100)
             self.log.info(
                 'Sleep {} seconds after hard reboot and service-up for node {}'.format(sleep_time, self.target_node))

--- a/sdcm/sct_events/setup.py
+++ b/sdcm/sct_events/setup.py
@@ -60,6 +60,9 @@ def start_events_device(log_dir: Optional[Union[str, Path]] = None,
                                 event_class=DatabaseLogEvent.DATABASE_ERROR,
                                 regex=r'.*workload prioritization - update_service_levels_from_distributed_data: an '
                                       r'error occurred while retrieving configuration').publish()
+    EventsSeverityChangerFilter(new_severity=Severity.WARNING,
+                                event_class=DatabaseLogEvent.DATABASE_ERROR,
+                                regex='cdc - Could not update CDC description table with generation').publish()
     DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line='Rate-limit: supressed').publish()
     DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line='Rate-limit: suppressed').publish()
 


### PR DESCRIPTION
in order to fix issue ##3705 and avoid annoying error messages which confuse
next were done:
1. Added to global filter list with reduction severity error message
for cdc: "cdc - Could not update CDC description table with generation"
2. disrupt method multiple_hard_reboot_node was updated to check
if generation was succesfully update after node reboot


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
