### PR TITLE
refactor(nemesis event): convert nemesis event to be continuous

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -16,6 +16,7 @@
 """
 Classes that introduce disruption in clusters.
 """
+import copy
 import inspect
 import logging
 import random
@@ -113,8 +114,16 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     HOUR_IN_SEC = 60 * MINUTE_IN_SEC
     disruptions_list = []
     has_steady_run = False
+    DISRUPT_NAME_PREF = "disrupt_"
 
-    def __init__(self, tester_obj, termination_event):
+    def __new__(cls, tester_obj, termination_event, *args):
+        for name, member in inspect.getmembers(cls, lambda x: inspect.isfunction(x) or inspect.ismethod(x)):
+            if name.startswith(cls.DISRUPT_NAME_PREF):
+                # add "disrupt_method_wrapper" decorator to all methods are started with "disrupt_"
+                setattr(cls, name, disrupt_method_wrapper(member))
+        return object.__new__(cls)
+
+    def __init__(self, tester_obj, termination_event, *args):  # args -  compatible with CategoricalMonkey
         self.tester = tester_obj  # ClusterTester object
         self.cluster = tester_obj.db_cluster
         self.loaders = tester_obj.loaders
@@ -197,10 +206,11 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if not data:
             data = {}
         data['node'] = self.target_node
-        DisruptionEvent(type=disrupt, status=status, **data).publish()
+        severity = Severity.NORMAL if status else Severity.ERROR
+        DisruptionEvent(nemesis_name=disrupt, severity=severity, **data).publish()
 
     def set_current_running_nemesis(self, node):
-        node.running_nemesis = self.__class__.__name__
+        node.running_nemesis = self.current_disruption
 
     def unset_current_running_nemesis(self, node):
         if node is not None:
@@ -268,8 +278,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.log.info('Interval: %s s', self.interval)
         while not self.termination_event.is_set():
             cur_interval = self.interval
-            self.set_target_node()
-            self._set_current_disruption(report=False)
             try:
                 self.disrupt()
             except UnsupportedNemesis:
@@ -394,7 +402,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.cluster.wait_for_schema_agreement()
 
     def disrupt_stop_wait_start_scylla_server(self, sleep_time=300):  # pylint: disable=invalid-name
-        self._set_current_disruption('StopWaitStartService %s' % self.target_node)
         self.target_node.stop_scylla_server(verify_up=False, verify_down=True)
         self.log.info("Sleep for %s seconds", sleep_time)
         time.sleep(sleep_time)
@@ -405,13 +412,11 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.target_node.start_scylla_server(verify_up=True, verify_down=False)
 
     def disrupt_stop_start_scylla_server(self):  # pylint: disable=invalid-name
-        self._set_current_disruption('StopStartService %s' % self.target_node)
         self.target_node.stop_scylla_server(verify_up=False, verify_down=True)
         self.target_node.start_scylla_server(verify_up=True, verify_down=False)
 
     # This nemesis should be run with "private" ip_ssh_connections till the issue #665 is not fixed
     def disabled_disrupt_restart_then_repair_node(self):  # pylint: disable=invalid-name
-        self._set_current_disruption('RestartThenRepairNode %s' % self.target_node)
         # Task https://trello.com/c/llRuLIOJ/2110-add-dbeventfilter-for-nosuchcolumnfamily-error
         # If this error happens during the first boot with the missing disk this issue is expected and it's not an issue
         with DbEventsFilter(db_event=DatabaseLogEvent.DATABASE_ERROR,
@@ -427,8 +432,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.repair_nodetool_repair()
 
     def disrupt_resetlocalschema(self):  # pylint: disable=invalid-name
-        self._set_current_disruption('ResetLocalSchema %s' % self.target_node)
-
         result = self.target_node.run_nodetool(sub_cmd='help', args='resetlocalschema')
         if 'Unknown command resetlocalschema' in result.stdout:
             raise UnsupportedNemesis("nodetool doesn't support resetlocalschema")
@@ -443,7 +446,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         time.sleep(60)
 
     def disrupt_hard_reboot_node(self):
-        self._set_current_disruption('HardRebootNode %s' % self.target_node)
         self.target_node.reboot(hard=True)
         self.log.info('Waiting scylla services to start after node reboot')
         self.target_node.wait_db_up()
@@ -454,8 +456,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def disrupt_multiple_hard_reboot_node(self):  # pylint: disable=invalid-name
         num_of_reboots = random.randint(2, 10)
         for i in range(num_of_reboots):
-            self._set_current_disruption('MultipleHardRebootNode %s' % self.target_node)
-            self.log.debug("Rebooting {} out of {} times".format(i + 1, num_of_reboots))
+            self.log.info("Rebooting {} out of {} times".format(i + 1, num_of_reboots))
             self.target_node.reboot(hard=True)
             if random.choice([True, False]):
                 self.log.info('Waiting scylla services to start after node reboot')
@@ -470,7 +471,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             time.sleep(sleep_time)
 
     def disrupt_soft_reboot_node(self):
-        self._set_current_disruption('SoftRebootNode %s' % self.target_node)
         self.target_node.reboot(hard=False)
         self.log.info('Waiting scylla services to start after node reboot')
         self.target_node.wait_db_up()
@@ -479,7 +479,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.cluster.wait_for_nodes_up_and_normal(nodes=[self.target_node])
 
     def disrupt_rolling_restart_cluster(self, random_order=False):
-        self._set_current_disruption('RollingRestartCluster %s' % self.target_node)
         self.cluster.restart_scylla(random_order=random_order)
 
     def disrupt_switch_between_PasswordAuthenticator_and_SaslauthdAuthenticator_and_back(self):
@@ -491,7 +490,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         It's only support to switch between PasswordAuthenticator and SaslauthdAuthenticator,
         the authenticator will be reset back in the end of nemesis.
         """
-        self._set_current_disruption('SwitchBetweenPasswordAuthAndSaslauthdAuth %s' % self.target_node)
         if not self.cluster.params.get('prepare_saslauthd'):
             raise UnsupportedNemesis("SaslauthdAuthenticator can't work without saslauthd environment")
         if not self.cluster.nodes[0].is_enterprise:
@@ -526,7 +524,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             values_to_toggle = list(filter(lambda value: value != current_compression, values))
             return random.choice(values_to_toggle)
 
-        self._set_current_disruption('RollingConfigAndRandomSetCompressionOnAllNodes')
         key = 'internode_compression'
         with self.target_node.remote_scylla_yaml() as scylla_yaml:
             current = scylla_yaml.get(key, 'dummy_value_no_internode_compression_key_and_value')
@@ -539,7 +536,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             node.restart_scylla_server()
 
     def disrupt_restart_with_resharding(self):
-        self._set_current_disruption('RestartNodeWithResharding %s' % self.target_node)
         murmur3_partitioner_ignore_msb_bits = 15  # pylint: disable=invalid-name
         self.log.info(f'Restart node with resharding. New murmur3_partitioner_ignore_msb_bits value: '
                       f'{murmur3_partitioner_ignore_msb_bits}')
@@ -633,35 +629,24 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         return self.__class__.__name__.replace('Monkey', '')
 
     def _set_current_disruption(self, label=None, report=True, node=None):
-        current_node = node if node else self.target_node
+        self.target_node = node if node else self.target_node
 
         if not label:
-            label = "%s on target node %s" % (self.__class__.__name__, current_node)
+            label = "%s on target node %s" % (self.__class__.__name__, self.target_node)
         self.log.debug('Set current_disruption -> %s', label)
         self.current_disruption = label
-        self.log.info(label)
-        if report:
-            DisruptionEvent(
-                type=self.get_disrupt_name(),
-                subtype="start",
-                status=True,
-                node=current_node
-            ).publish()
 
     def disrupt_destroy_data_then_repair(self):  # pylint: disable=invalid-name
-        self._set_current_disruption('CorruptThenRepair %s' % self.target_node)
         self._destroy_data_and_restart_scylla()
         # try to save the node
         self.repair_nodetool_repair()
 
     def disrupt_destroy_data_then_rebuild(self):  # pylint: disable=invalid-name
-        self._set_current_disruption('CorruptThenRebuild %s' % self.target_node)
         self._destroy_data_and_restart_scylla()
         # try to save the node
         self.repair_nodetool_rebuild()
 
     def disrupt_nodetool_drain(self):
-        self._set_current_disruption('Drainer %s' % self.target_node)
         result = self.target_node.run_nodetool("drain", timeout=3600, coredump_on_timeout=True)
         self.target_node.run_nodetool("status", ignore_status=True, verbose=True,
                                       warning_event_on_exception=(Exception,))
@@ -674,7 +659,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.target_node.start_scylla_server(verify_up=True, verify_down=False)
 
     def disrupt_ldap_connection_toggle(self):
-        self._set_current_disruption('LDAP_Disconnect_and_Reconnect_connection')
         if not self.cluster.params.get('use_ldap_authorization'):
             raise UnsupportedNemesis('Cluster is not configured to run with LDAP authorization, hence skipping')
 
@@ -687,7 +671,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.log.info('finished with nemesis')
 
     def disrupt_disable_enable_ldap_authorization(self):
-        self._set_current_disruption('LDAP_Toggle_authorization_configuration')
         if not self.cluster.params.get('use_ldap_authorization'):
             raise UnsupportedNemesis('Cluster is not configured to run with LDAP authorization, hence skipping')
         ldap_config = {'role_manager': '',
@@ -769,7 +752,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def disrupt_nodetool_decommission(self, add_node=True, disruption_name=None):
         if self._is_it_on_kubernetes() and disruption_name is None:
             self.set_target_node(allow_only_last_node_in_rack=True)
-        self._set_current_disruption(f"{disruption_name or 'Decommission'} {self.target_node}")
         target_is_seed = self.target_node.is_seed
         self.cluster.decommission(self.target_node)
         new_node = None
@@ -818,8 +800,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def disrupt_terminate_and_replace_node_kubernetes(self):  # pylint: disable=invalid-name
         for node_terminate_method_name in self._get_kubernetes_node_break_methods():
             self.set_target_node()
-            self._set_current_disruption(
-                f'OperatorNodeTerminateAndReplace ({node_terminate_method_name}) {self.target_node}')
+            InfoEvent(f'OperatorNodeTerminateAndReplace ({node_terminate_method_name}) {self.target_node}').publish()
             if not self._is_it_on_kubernetes():
                 raise UnsupportedNemesis('OperatorNodeTerminateAndReplace is supported only on kubernetes')
 
@@ -831,12 +812,11 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         for node_terminate_method_name in self._get_kubernetes_node_break_methods():
             self.set_target_node(rack=random.choice(list(self.cluster.racks)),
                                  allow_only_last_node_in_rack=True)
-            self._set_current_disruption(
-                f'OperatorNodeTerminateDecommissionAdd ({node_terminate_method_name}) {self.target_node}')
+            InfoEvent(
+                f'OperatorNodeTerminateDecommissionAdd ({node_terminate_method_name}) {self.target_node}').publish()
             self._disrupt_terminate_decommission_add_node_kubernetes(self.target_node, node_terminate_method_name)
 
     def disrupt_replace_node_kubernetes(self):
-        self._set_current_disruption('OperatorNodeReplace %s' % self.target_node)
         if not self._is_it_on_kubernetes():
             raise UnsupportedNemesis('OperatorNodeReplace is supported only on kubernetes')
         old_uid = self.target_node.k8s_pod_uid
@@ -877,7 +857,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def disrupt_terminate_and_replace_node(self):  # pylint: disable=invalid-name
         # using "Replace a Dead Node" procedure from http://docs.scylladb.com/procedures/replace_dead_node/
-        self._set_current_disruption('TerminateAndReplaceNode %s' % self.target_node)
         old_node_ip = self.target_node.ip_address
         InfoEvent(message='StartEvent - Terminate node and wait 5 minutes').publish()
         self._terminate_and_wait(target_node=self.target_node)
@@ -903,12 +882,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.unset_current_running_nemesis(new_node)
 
     def disrupt_kill_scylla(self):
-        self._set_current_disruption('ScyllaKillMonkey %s' % self.target_node)
         self._kill_scylla_daemon()
 
     def disrupt_no_corrupt_repair(self):
-        self._set_current_disruption('NoCorruptRepair %s' % self.target_node)
-
         # prepare test tables and fill test data
         for i in range(10):
             self.log.debug('Prepare test tables if they do not exist')
@@ -926,12 +902,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         thread1.join(timeout=120)
 
     def disrupt_major_compaction(self):
-        self._set_current_disruption('MajorCompaction %s' % self.target_node)
         self.target_node.run_nodetool("compact")
 
     def disrupt_nodetool_refresh(self, big_sstable: bool = False):
-        self._set_current_disruption('Refresh keyspace1.standard1 on {}'.format(self.target_node.name))
-
         # Checking the columns number of keyspace1.standard1
         self.log.debug('Prepare keyspace1.standard1 if it does not exist')
         self._prepare_test_table(ks='keyspace1', table='standard1')
@@ -1061,9 +1034,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         if all_nodes:
             nodes = self.cluster.nodes
+            InfoEvent('Enospc test on {}'.format([n.name for n in nodes])).publish()
         else:
             nodes = [self.target_node]
-        self._set_current_disruption('Enospc test on {}'.format([n.name for n in nodes]))
 
         for node in nodes:
             with ignore_no_space_errors(node=node):
@@ -1178,7 +1151,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         # This fix important when just user profile is run in the test and "keyspace1" doesn't exist.
         test_keyspaces = self.cluster.get_test_keyspaces()
         for node in self.cluster.nodes:
-            self._set_current_disruption('NodetoolCleanupMonkey %s' % node, node=node)
+            InfoEvent('NodetoolCleanupMonkey %s' % node).publish()
             for keyspace in test_keyspaces:
                 node.run_nodetool(sub_cmd="cleanup", args=keyspace)
 
@@ -1196,8 +1169,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             cs_thread.verify_results()
 
     def disrupt_truncate(self):
-        self._set_current_disruption('TruncateMonkey {}'.format(self.target_node))
-
         keyspace_truncate = 'ks_truncate'
         table = 'standard1'
 
@@ -1214,8 +1185,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         it's used to cover one improvement of compaction.
         The increase frequency of checking abortion is very useful for truncate.
         """
-        self._set_current_disruption('TruncateMonkeyLargePartition {}'.format(self.target_node))
-
         ks_name = 'ks_truncate_large_partition'
         table = 'test_table'
         stress_cmd = "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=10 " + \
@@ -1233,7 +1202,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def _modify_table_property(self, name, val, filter_out_table_with_counter=False, modify_all_tables=False):
         disruption_name = "".join([p.strip().capitalize() for p in name.split("_")])
-        self._set_current_disruption('ModifyTableProperties%s %s' % (disruption_name, self.target_node))
+        InfoEvent('ModifyTableProperties%s %s' % (disruption_name, self.target_node)).publish()
 
         ks_cfs = self.cluster.get_non_system_ks_cf_list(
             db_node=self.target_node, filter_out_table_with_counter=filter_out_table_with_counter,
@@ -1528,7 +1497,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         Delete few partitions in the table with large partitions
         """
         self.verify_initial_inputs_for_delete_nemesis()
-        self._set_current_disruption('DeleteByPartitionsMonkey {}'.format(self.target_node))
 
         ks_cf = 'scylla_bench.test'
         partitions_for_delete = self.choose_partitions_for_delete(10, ks_cf)
@@ -1548,7 +1516,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         Delete few partitions in the table with large partitions
         """
         self.verify_initial_inputs_for_delete_nemesis()
-        self._set_current_disruption('DeleteByRowsRangeMonkey {}'.format(self.target_node))
 
         ks_cf = 'scylla_bench.test'
         partitions_for_exclude = self.delete_half_partition(ks_cf)
@@ -1566,7 +1533,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self._add_drop_column_target_table)
         if self._add_drop_column_target_table is None:
             raise UnsupportedNemesis("AddDropColumnMonkey: can't find table to run on")
-        self._set_current_disruption(f'AddDropColumnMonkey table {".".join(self._add_drop_column_target_table)}')
+        InfoEvent(f'AddDropColumnMonkey table {".".join(self._add_drop_column_target_table)}').publish()
         self._add_drop_column_run_in_cycle()
 
     def modify_table_comment(self):
@@ -1762,7 +1729,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self._modify_table_property(name="speculative_retry", val=random.choice(options))
 
     def disrupt_toggle_table_ics(self):
-        self._set_current_disruption('ToggleTableICS')
         self.toggle_table_ics()
 
     def disrupt_modify_table(self):
@@ -1772,11 +1738,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         disrupt_func()
 
     def disrupt_mgmt_backup_specific_keyspaces(self):
-        self._set_current_disruption('ManagementBackupWithSpecificKeyspaces')
         self._mgmt_backup(backup_specific_tables=True)
 
     def disrupt_mgmt_backup(self):
-        self._set_current_disruption('ManagementBackup')
         self._mgmt_backup(backup_specific_tables=False)
 
     def _mgmt_backup(self, backup_specific_tables):
@@ -1810,7 +1774,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     @latency_calculator_decorator
     def disrupt_mgmt_repair_cli(self):
-        self._set_current_disruption('ManagementRepair')
         if not self.cluster.params.get('use_mgmt') and not self.cluster.params.get('use_cloud_manager'):
             raise UnsupportedNemesis('Scylla-manager configuration is not defined!')
         mgr_cluster = self.cluster.get_cluster_manager()
@@ -1824,7 +1787,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         """
         Start repair target_node in background, then try to abort the repair streaming.
         """
-        self._set_current_disruption('AbortRepairMonkey')
         self.log.debug("Start repair target_node in background")
 
         @raise_event_on_failure
@@ -1888,7 +1850,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             Validates that hinted handoff mechanism works: there were no drops and errors
             during short stop of one of the nodes in cluster
         """
-        self._set_current_disruption("ValidateHintedHandoffShortDowntime")
         if self.cluster.params.get('hinted_handoff') == 'disabled':
             raise UnsupportedNemesis('For this nemesis to work, `hinted_handoff` needs to be set to `enabled`')
 
@@ -2020,7 +1981,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
             return f'snapshot {selected_keyspace} -cf {tables}'
 
-        self._set_current_disruption('SnapshotOperations')
         functions_map = [(_few_tables,), (_full_snapshot,), (_ks_snapshot, True), (_ks_snapshot, False)]
         snapshot_option = random.choice(functions_map)
 
@@ -2138,7 +2098,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 'duration': str(random.randint(1000, 10000))
             }
 
-        self._set_current_disruption("ShowTopPartitions")
         result = self.target_node.run_nodetool(sub_cmd='help', args='toppartitions')
         if 'Unknown command toppartitions' in result.stdout:
             raise UnsupportedNemesis("nodetool doesn't support toppartitions")
@@ -2193,7 +2152,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def disrupt_network_random_interruptions(self):  # pylint: disable=invalid-name
         # pylint: disable=too-many-locals
-        self._set_current_disruption('NetworkRandomInterruption')
         if not self.cluster.extra_network_interface:
             raise UnsupportedNemesis("for this nemesis to work, you need to set `extra_network_interface: True`")
 
@@ -2227,7 +2185,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         option_name, selected_option = random.choice(list_of_tc_options)
         wait_time = random.choice(list_of_timeout_options)
 
-        self._set_current_disruption(option_name)
+        InfoEvent(option_name).publish()
         self.log.debug("NetworkRandomInterruption: [%s] for %dsec", selected_option, wait_time)
         self.target_node.traffic_control(None)
         try:
@@ -2238,7 +2196,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self._wait_all_nodes_un()
 
     def disrupt_network_block(self):
-        self._set_current_disruption('BlockNetwork')
         if not self.cluster.extra_network_interface:
             raise UnsupportedNemesis("for this nemesis to work, you need to set `extra_network_interface: True`")
 
@@ -2274,7 +2231,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if self.cluster.params.get("cluster_backend") == 'aws-siren':
             raise UnsupportedNemesis("Skipping this nemesis due this job run from Siren cloud with 2019 version!")
 
-        self._set_current_disruption('TerminateAndRemoveNodeMonkey')
         node_to_remove = self.target_node
         up_normal_nodes = self.cluster.get_nodes_up_and_normal(verification_node=node_to_remove)
         # node_to_remove must be different than node
@@ -2371,9 +2327,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         textual_matching_rule, matching_rule = self._iptables_randomly_get_random_matching_rule()
         textual_pkt_action, pkt_action = self._iptables_randomly_get_disrupting_target()
         wait_time = random.choice([10, 60, 120, 300, 500])
-        self._set_current_disruption(f'{name} {textual_matching_rule} that belongs to '
-                                     'inter node communication connections (port=7000 and 7001) will be'
-                                     f' {textual_pkt_action} for {wait_time}s')
+        InfoEvent(f'{name} {textual_matching_rule} that belongs to '
+                  'inter node communication connections (port=7000 and 7001) will be'
+                  f' {textual_pkt_action} for {wait_time}s').publish()
 
         # because of https://github.com/scylladb/scylla/issues/5802, we ignore YCSB client errors here
         with ignore_alternator_client_errors():
@@ -2399,8 +2355,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         textual_matching_rule, matching_rule = self._iptables_randomly_get_random_matching_rule()
         textual_pkt_action, pkt_action = self._iptables_randomly_get_disrupting_target()
         wait_time = random.choice([10, 60, 120, 300, 500])
-        self._set_current_disruption(f'{name} {textual_matching_rule} that belongs to '
-                                     f'node-exporter(port=9100) connections will be {textual_pkt_action} for {wait_time}s')
+        InfoEvent(f'{name} {textual_matching_rule} that belongs to '
+                  f'node-exporter(port=9100) connections will be {textual_pkt_action} for {wait_time}s').publish()
         return self._run_commands_wait_and_cleanup(
             self.target_node,
             name=name,
@@ -2417,8 +2373,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         textual_matching_rule, matching_rule = self._iptables_randomly_get_random_matching_rule()
         textual_pkt_action, pkt_action = self._iptables_randomly_get_disrupting_target()
         wait_time = random.choice([10, 60, 120, 300, 500])
-        self._set_current_disruption(f'{name} {textual_matching_rule} that belongs to '
-                                     f'Thrift(port=9160) connections will be {textual_pkt_action} for {wait_time}s')
+        InfoEvent(f'{name} {textual_matching_rule} that belongs to '
+                  f'Thrift(port=9160) connections will be {textual_pkt_action} for {wait_time}s').publish()
         return self._run_commands_wait_and_cleanup(
             self.target_node,
             name=name,
@@ -2518,7 +2474,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                                f"{cmd} on node {node} due to the following error: {str(exc)}")
 
     def disrupt_network_start_stop_interface(self):  # pylint: disable=invalid-name
-        self._set_current_disruption('StopStartNetworkInterfaces')
         if not self.cluster.extra_network_interface:
             raise UnsupportedNemesis("for this nemesis to work, you need to set `extra_network_interface: True`")
 
@@ -2629,21 +2584,18 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         Stop decommission in middle to trigger some streaming fails, then rebuild the data on the node.
         If the node is decommission unexpectedly, need to re-add a new node to cluster.
         """
-        self._set_current_disruption('DecommissionStreamingErr')
         self.break_streaming_task_and_rebuild(task='decommission')
 
     def disrupt_rebuild_streaming_err(self):
         """
         Stop rebuild in middle to trigger some streaming fails, then rebuild the data on the node.
         """
-        self._set_current_disruption('RebuildStreamingErr')
         self.break_streaming_task_and_rebuild(task='rebuild')
 
     def disrupt_repair_streaming_err(self):
         """
         Stop repair in middle to trigger some streaming fails, then rebuild the data on the node.
         """
-        self._set_current_disruption('RepairStreamingErr')
         self.break_streaming_task_and_rebuild(task='repair')
 
     def _corrupt_data_file(self):
@@ -2657,8 +2609,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         data_file_pattern = self._choose_file_for_destroy(ks_cfs)
         res = self.target_node.remoter.run('sudo find {}-Data.db'.format(data_file_pattern))
         for sstable_file in res.stdout.split():
-            result = self.target_node.remoter.run(
-                'sudo dd if=/dev/urandom of={} count=1024'.format(sstable_file))
+            self.target_node.remoter.run('sudo dd if=/dev/urandom of={} count=1024'.format(sstable_file))
             self.log.debug('File {} was corrupted by dd'.format(sstable_file))
 
     def disrupt_corrupt_then_scrub(self):
@@ -2666,7 +2617,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         Try to rebuild the sstables of all test keyspaces by scrub, the corrupted partitions
         will be skipped.
         """
-        self._set_current_disruption('CorruptThenScrub')
         self.log.debug("Rebuild sstables by scrub with `--skip-corrupted`, corrupted partitions will be skipped.")
         with ignore_scrub_invalid_errors():
             for ks in self.cluster.get_test_keyspaces():
@@ -2689,20 +2639,23 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.log.info("Next node will be removed %s", self.target_node)
 
             try:
-                InfoEvent(message='StartEvent - ShrinkCluster started decommissioning a node').publish()
+                InfoEvent(f'StartEvent - ShrinkCluster started decommissioning a node {self.target_node}').publish()
                 self.decommission_node(self.target_node)
-                InfoEvent(message='FinishEvent - ShrinkCluster has done decommissioning a node').publish()
+                InfoEvent(f'FinishEvent - ShrinkCluster has done decommissioning a node {self.target_node}').publish()
             except Exception as exc:
-                InfoEvent(message=f'FinishEvent - ShrinkCluster failed decommissioning a node with error {str(exc)}') \
-                    .publish()
+                InfoEvent(f'FinishEvent - ShrinkCluster failed decommissioning a node {self.target_node} with error '
+                          f'{str(exc)}').publish()
 
     def disrupt_grow_shrink_cluster(self):
-        self._disrupt_grow_shrink_cluster(rack=0)
+        self._grow_cluster(rack=0)
+        self._shrink_cluster(rack=0)
 
     def disrupt_grow_shrink_new_rack(self):
-        self._disrupt_grow_shrink_cluster(rack=max(self.cluster.racks) + 1)
+        rack = max(self.cluster.racks) + 1
+        self._grow_cluster(rack)
+        self._shrink_cluster(rack)
 
-    def _disrupt_grow_shrink_cluster(self, rack=0):
+    def _grow_cluster(self, rack=0):
         if rack > 0:
             if not self._is_it_on_kubernetes():
                 raise UnsupportedNemesis("SCT rack functionality is implemented only on kubernetes")
@@ -2710,30 +2663,21 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                           "Please see https://github.com/scylladb/scylla-operator/issues/287")
 
         add_nodes_number = self.tester.params.get('nemesis_add_node_cnt')
-        self.unset_current_running_nemesis(self.target_node)
-        self._set_current_disruption("GrowCluster")
-        start_time = time.time()
-        try:
-            self.log.info("Start grow cluster on %s nodes", add_nodes_number)
-            for _ in range(add_nodes_number):
-                InfoEvent(message=f'GrowCluster - Add New node to {rack} rack').publish()
-                added_node = self.add_new_node(rack=rack)
-                self.unset_current_running_nemesis(added_node)
-                InfoEvent(message=f'GrowCluster - Done adding New node {added_node.name}').publish()
-            self.log.info("Finish cluster grow")
-            time.sleep(self.interval)
-            status = True
-            log_info = {}
-        except Exception as details:
-            log_info = {'error': details, 'full_traceback': traceback.format_exc()}
-            status = False
-        finally:
-            end_time = time.time()
-            time_elapsed = int(time.time() - start_time)
-            DisruptionEvent(type=self.get_disrupt_name(), subtype="end", status=status, node=self.target_node,
-                            end=end_time, duration=time_elapsed, **log_info).publish()
+        self.log.info("Start grow cluster on %s nodes", add_nodes_number)
+        for _ in range(add_nodes_number):
+            InfoEvent(message=f'GrowCluster - Add New node to {rack} rack').publish()
+            added_node = self.add_new_node(rack=rack)
+            self.unset_current_running_nemesis(added_node)
+            InfoEvent(message=f'GrowCluster - Done adding New node {added_node.name}').publish()
+        self.log.info("Finish cluster grow")
+        time.sleep(self.interval)
 
-        self._set_current_disruption("ShrinkCluster")
+    def _shrink_cluster(self, rack=0):
+        add_nodes_number = self.tester.params.get('nemesis_add_node_cnt')
+        if int(add_nodes_number + self.tester.params.get('n_db_nodes')) != len(self.cluster.nodes):
+            raise UnsupportedNemesis(f"The nemesis {self.current_disruption} can't be started as previous Grow nemesis "
+                                     f"was not completed successfully")
+
         self.log.info("Start shrink cluster on %s nodes", add_nodes_number)
         # Currently on kubernetes first two nodes of each rack are getting seed status
         # Because of such behavior only way to get them decommission is to enable decommissioning
@@ -2747,7 +2691,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         Scylla has the ability to hot reload SSL certificates.
         This test will create and reload new certificates for the inter node communication.
         """
-        self._set_current_disruption('ServerSslHotReloadingNemesis')
         if not self.cluster.params.get('server_encrypt'):
             raise UnsupportedNemesis('Server Encryption is not enabled, hence skipping')
 
@@ -2813,7 +2756,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         we don't monitor swap usage in /proc/$scylla_pid/status, just make sure
         no coredump, serious db error occur during the heavy load of memory.
         """
-        self._set_current_disruption(f'MemoryStress on {self.target_node}')
         if self.target_node.distro.is_rhel_like:
             self.target_node.install_epel()
             self.target_node.remoter.sudo('yum install -y stress-ng')
@@ -2838,8 +2780,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         Toggle the selected parameter state (True/False) or select a random value for TTL
 
         """
-        self._set_current_disruption("ToggleCDCProperties")
-
         ks_tables_with_cdc = self.cluster.get_all_tables_with_cdc(self.target_node)
         self.log.debug(f"Found next tables with enabled cdc feature: {ks_tables_with_cdc}")
 
@@ -2869,8 +2809,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         InfoEvent(f"{ks}.{table} have new cdc settings {cdc_settings}").publish()
 
     def disrupt_run_cdcstressor_tool(self):
-        self._set_current_disruption(label="RunCDCStressorTool")
-
         ks_tables_with_cdc = self.cluster.get_all_tables_with_cdc(self.target_node)
         if not ks_tables_with_cdc:
             self.log.warning("CDC is not enabled on any table. Skipping")
@@ -2933,7 +2871,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 f"CDC extension settings are differs. Current: {actual_cdc_settings} expected: {cdc_settings}"
 
 
-def log_time_elapsed_and_status(method):  # pylint: disable=too-many-statements
+def disrupt_method_wrapper(method):  # pylint: disable=too-many-statements
     """
     Log time elapsed for method to run
 
@@ -2952,8 +2890,12 @@ def log_time_elapsed_and_status(method):  # pylint: disable=too-many-statements
         except Exception as err:  # pylint: disable=broad-except
             args[0].log.debug(f'Data validator error: {err}')
 
+    @wraps(method)
     def wrapper(*args, **kwargs):  # pylint: disable=too-many-statements
         # pylint: disable=too-many-locals
+        args[0].set_target_node()
+        method_name = method.__name__
+        args[0].current_disruption = "".join(p.capitalize() for p in method_name.replace("disrupt_", "").split("_"))
         args[0].cluster.check_cluster_health()
         num_nodes_before = len(args[0].cluster.nodes)
         start_time = time.time()
@@ -2963,6 +2905,8 @@ def log_time_elapsed_and_status(method):  # pylint: disable=too-many-statements
             args[0].metrics_srv.event_start(class_name)
         result = None
         status = True
+        args[0]._set_current_disruption(f"{args[0].current_disruption} {args[0].target_node}")
+        args[0].set_current_running_nemesis(node=args[0].target_node)
         log_info = {
             'operation': args[0].current_disruption,
             'start': int(start_time),
@@ -2974,52 +2918,57 @@ def log_time_elapsed_and_status(method):  # pylint: disable=too-many-statements
         # TODO: Temporary print. Will be removed later
         data_validation_prints(args=args)
 
-        try:
-            result = method(*args, **kwargs)
-        except UnsupportedNemesis as exp:
-            log_info.update({'subtype': 'skipped', 'skip_reason': str(exp)})
-            logging.info("skipping %s", args[0].get_disrupt_name())
-            logging.info("cause of: %s", str(exp))
-            raise
+        with DisruptionEvent(nemesis_name=args[0].get_disrupt_name(),
+                             node=args[0].target_node, publish_event=True) as nemesis_event:
+            try:
+                result = method(*args, **kwargs)
+            except UnsupportedNemesis as exp:
+                skip_reason = str(exp)
+                log_info.update({'subtype': 'skipped', 'skip_reason': skip_reason})
+                nemesis_event.skip(skip_reason=skip_reason)
 
-        except Exception as details:  # pylint: disable=broad-except
-            details = str(details)
-            args[0].error_list.append(details)
-            args[0].log.error('Unhandled exception in method %s', method, exc_info=True)
-            log_info.update({'error': details, 'full_traceback': traceback.format_exc()})
-            status = False
-        finally:
-            end_time = time.time()
-            time_elapsed = int(end_time - start_time)
-            log_info.update({
-                'end': int(end_time),
-                'duration': time_elapsed,
-            })
-            args[0].duration_list.append(time_elapsed)
-            args[0].operation_log.append(log_info)
-            args[0].log.debug('%s duration -> %s s', args[0].current_disruption, time_elapsed)
+            except Exception as details:  # pylint: disable=broad-except
+                nemesis_event.add_error([str(details)])
+                nemesis_event.full_traceback = traceback.format_exc()
+                nemesis_event.severity = Severity.ERROR
+                args[0].error_list.append(details)
+                args[0].log.error('Unhandled exception in method %s', method, exc_info=True)
+                log_info.update({'error': details, 'full_traceback': traceback.format_exc()})
+                status = False
 
-            if class_name.find('Chaos') < 0:
-                args[0].metrics_srv.event_stop(class_name)
-            disrupt = args[0].get_disrupt_name()
-            del log_info['operation']
+            finally:
+                end_time = time.time()
+                time_elapsed = int(end_time - start_time)
+                log_info.update({
+                    'end': int(end_time),
+                    'duration': time_elapsed,
+                })
+                args[0].duration_list.append(time_elapsed)
+                args[0].operation_log.append(copy.deepcopy(log_info))
+                args[0].log.debug('%s duration -> %s s', args[0].current_disruption, time_elapsed)
 
-            try:  # So that the nemesis thread won't stop due to elasticsearch failure
-                args[0].update_stats(disrupt, status, log_info)
-            except ElasticSearchConnectionTimeout as err:
-                args[0].log.warning(f"Connection timed out when attempting to update elasticsearch statistics:\n"
-                                    f"{err}")
-            except Exception as err:
-                args[0].log.warning(f"Unexpected error when attempting to update elasticsearch statistics:\n"
-                                    f"{err}")
-            DisruptionEvent(type=disrupt, status=status, **log_info).publish()
-            args[0].cluster.check_cluster_health()
-            num_nodes_after = len(args[0].cluster.nodes)
-            if num_nodes_before != num_nodes_after:
-                args[0].log.error('num nodes before %s and nodes after %s does not match' %
-                                  (num_nodes_before, num_nodes_after))
-            # TODO: Temporary print. Will be removed later
-            data_validation_prints(args=args)
+                if class_name.find('Chaos') < 0:
+                    args[0].metrics_srv.event_stop(class_name)
+                disrupt = args[0].get_disrupt_name()
+                del log_info['operation']
+
+                try:  # So that the nemesis thread won't stop due to elasticsearch failure
+                    args[0].update_stats(disrupt, status, log_info)
+                except ElasticSearchConnectionTimeout as err:
+                    args[0].log.warning(f"Connection timed out when attempting to update elasticsearch statistics:\n"
+                                        f"{err}")
+                except Exception as err:
+                    args[0].log.warning(f"Unexpected error when attempting to update elasticsearch statistics:\n"
+                                        f"{err}")
+                args[0].log.info(f"log_info: {log_info}")
+                nemesis_event.duration = time_elapsed
+                args[0].cluster.check_cluster_health()
+                num_nodes_after = len(args[0].cluster.nodes)
+                if num_nodes_before != num_nodes_after:
+                    args[0].log.error('num nodes before %s and nodes after %s does not match' %
+                                      (num_nodes_before, num_nodes_after))
+                # TODO: Temporary print. Will be removed later
+                data_validation_prints(args=args)
         return result
 
     return wrapper
@@ -3028,7 +2977,6 @@ def log_time_elapsed_and_status(method):  # pylint: disable=too-many-statements
 class SslHotReloadingNemesis(Nemesis):
     disruptive = False
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_hot_reloading_internode_certificate()
 
@@ -3037,7 +2985,6 @@ class PauseLdapNemesis(Nemesis):
     disruptive = False
     limited = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_ldap_connection_toggle()
 
@@ -3046,7 +2993,6 @@ class ToggleLdapConfiguration(Nemesis):
     disruptive = True
     limited = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_disable_enable_ldap_authorization()
 
@@ -3054,7 +3000,6 @@ class ToggleLdapConfiguration(Nemesis):
 class NoOpMonkey(Nemesis):
     kubernetes = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         time.sleep(300)
 
@@ -3063,7 +3008,6 @@ class GrowShrinkClusterNemesis(Nemesis):
     disruptive = True
     kubernetes = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_grow_shrink_cluster()
 
@@ -3072,7 +3016,6 @@ class AddRemoveRackNemesis(Nemesis):
     disruptive = True
     kubernetes = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_grow_shrink_new_rack()
 
@@ -3082,7 +3025,6 @@ class StopWaitStartMonkey(Nemesis):
     kubernetes = True
     limited = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_stop_wait_start_scylla_server(600)
 
@@ -3092,7 +3034,6 @@ class StopStartMonkey(Nemesis):
     kubernetes = True
     limited = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_stop_start_scylla_server()
 
@@ -3103,7 +3044,6 @@ class StopStartMonkey(Nemesis):
 #     disruptive = True
 #     kubernetes = True
 #
-#     @log_time_elapsed_and_status
 #     def disrupt(self):
 #         self.disrupt_restart_then_repair_node()
 
@@ -3112,7 +3052,6 @@ class MultipleHardRebootNodeMonkey(Nemesis):
     disruptive = True
     kubernetes = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_multiple_hard_reboot_node()
 
@@ -3122,7 +3061,6 @@ class HardRebootNodeMonkey(Nemesis):
     kubernetes = True
     limited = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_hard_reboot_node()
 
@@ -3132,7 +3070,6 @@ class SoftRebootNodeMonkey(Nemesis):
     kubernetes = True
     limited = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_soft_reboot_node()
 
@@ -3142,7 +3079,6 @@ class DrainerMonkey(Nemesis):
     kubernetes = True
     limited = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_nodetool_drain()
 
@@ -3151,7 +3087,6 @@ class CorruptThenRepairMonkey(Nemesis):
     disruptive = True
     kubernetes = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_destroy_data_then_repair()
 
@@ -3160,7 +3095,6 @@ class CorruptThenRebuildMonkey(Nemesis):
     disruptive = True
     kubernetes = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_destroy_data_then_rebuild()
 
@@ -3169,7 +3103,6 @@ class DecommissionMonkey(Nemesis):
     disruptive = True
     limited = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_nodetool_decommission()
 
@@ -3177,7 +3110,6 @@ class DecommissionMonkey(Nemesis):
 class DecommissionSeedNode(Nemesis):
     disruptive = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_nodetool_seed_decommission()
 
@@ -3187,7 +3119,6 @@ class NoCorruptRepairMonkey(Nemesis):
     kubernetes = True
     limited = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_no_corrupt_repair()
 
@@ -3197,7 +3128,6 @@ class MajorCompactionMonkey(Nemesis):
     kubernetes = True
     limited = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_major_compaction()
 
@@ -3208,7 +3138,6 @@ class RefreshMonkey(Nemesis):
     kubernetes = True
     limited = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_nodetool_refresh(big_sstable=False)
 
@@ -3218,7 +3147,6 @@ class RefreshBigMonkey(Nemesis):
     run_with_gemini = False
     kubernetes = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_nodetool_refresh(big_sstable=True)
 
@@ -3228,7 +3156,6 @@ class EnospcMonkey(Nemesis):
     kubernetes = True
     limited = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_nodetool_enospc()
 
@@ -3237,7 +3164,6 @@ class EnospcAllNodesMonkey(Nemesis):
     disruptive = True
     kubernetes = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_nodetool_enospc(all_nodes=True)
 
@@ -3247,7 +3173,6 @@ class NodeToolCleanupMonkey(Nemesis):
     kubernetes = True
     limited = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_nodetool_cleanup()
 
@@ -3257,7 +3182,6 @@ class TruncateMonkey(Nemesis):
     kubernetes = True
     limited = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_truncate()
 
@@ -3266,7 +3190,6 @@ class TruncateLargeParititionMonkey(Nemesis):
     disruptive = False
     kubernetes = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_truncate_large_partition()
 
@@ -3275,7 +3198,6 @@ class DeleteByPartitionsMonkey(Nemesis):
     disruptive = False
     kubernetes = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_delete_10_full_partitions()
 
@@ -3284,14 +3206,12 @@ class DeleteByRowsRangeMonkey(Nemesis):
     disruptive = False
     kubernetes = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_delete_by_rows_range()
 
 
 class ChaosMonkey(Nemesis):
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.call_random_disrupt_method()
 
@@ -3369,7 +3289,6 @@ class CategoricalMonkey(Nemesis):
         super(CategoricalMonkey, self).__init__(tester_obj, termination_event)
         self.disruption_distribution = CategoricalMonkey.get_disruption_distribution(dist, default_weight)
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self._random_disrupt()
 
@@ -3388,7 +3307,6 @@ class LimitedChaosMonkey(Nemesis):
         super().__init__(*args, **kwargs)
         self.disrupt_methods_list = self.get_list_of_methods_compatible_with_backend(limited=True)
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         # Limit the nemesis scope:
         #  - NodeToolCleanupMonkey
@@ -3418,7 +3336,6 @@ class LimitedChaosMonkey(Nemesis):
 
 class ScyllaCloudLimitedChaosMonkey(Nemesis):
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         # Limit the nemesis scope to only one relevant to scylla cloud, where we defined we don't have AWS api access:
         self.call_random_disrupt_method(disrupt_methods=['disrupt_nodetool_cleanup',
@@ -3432,14 +3349,12 @@ class ScyllaCloudLimitedChaosMonkey(Nemesis):
 
 class AllMonkey(Nemesis):
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.call_random_disrupt_method(predefined_sequence=True)
 
 
 class MdcChaosMonkey(Nemesis):
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.call_random_disrupt_method(
             disrupt_methods=['disrupt_destroy_data_then_repair', 'disrupt_no_corrupt_repair',
@@ -3493,7 +3408,6 @@ class UpgradeNemesis(Nemesis):
     #     if orig_ver == new_ver:
     #         self.log.error('scylla-server version isn\'t changed')
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.log.info('Upgrade Nemesis begin')
         # get the number of nodes
@@ -3514,7 +3428,6 @@ class UpgradeNemesis(Nemesis):
 
 class UpgradeNemesisOneNode(UpgradeNemesis):
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.log.info('UpgradeNemesisOneNode begin')
         self.upgrade_node(self.cluster.node_to_upgrade)  # pylint: disable=no-member
@@ -3524,7 +3437,6 @@ class UpgradeNemesisOneNode(UpgradeNemesis):
 
 class RollbackNemesis(Nemesis):
 
-    # rollback a single node
     def rollback_node(self, node):
         self.log.info('Rollbacking a Node')
         orig_ver = node.remoter.run('rpm -qa scylla-server')
@@ -3546,7 +3458,6 @@ class RollbackNemesis(Nemesis):
         if orig_ver == new_ver:
             raise ValueError('scylla-server version isn\'t changed')
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.log.info('Rollback Nemesis begin')
         # get the number of nodes
@@ -3570,7 +3481,6 @@ class ModifyTableMonkey(Nemesis):
     kubernetes = True
     limited = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_modify_table()
 
@@ -3582,7 +3492,6 @@ class AddDropColumnMonkey(Nemesis):
     kubernetes = True
     limited = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_add_drop_column()
 
@@ -3590,7 +3499,6 @@ class AddDropColumnMonkey(Nemesis):
 class ToggleTableIcsMonkey(Nemesis):
     kubernetes = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_toggle_table_ics()
 
@@ -3599,7 +3507,6 @@ class MgmtBackup(Nemesis):
     disruptive = False
     limited = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_mgmt_backup()
 
@@ -3608,7 +3515,6 @@ class MgmtBackupSpecificKeyspaces(Nemesis):
     disruptive = False
     limited = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_mgmt_backup_specific_keyspaces()
 
@@ -3618,7 +3524,6 @@ class MgmtRepair(Nemesis):
     kubernetes = True
     limited = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.log.info('disrupt_mgmt_repair_cli Nemesis begin')
         self.disrupt_mgmt_repair_cli()
@@ -3631,7 +3536,6 @@ class AbortRepairMonkey(Nemesis):
     kubernetes = True
     limited = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_abort_repair()
 
@@ -3642,7 +3546,6 @@ class NodeTerminateAndReplace(Nemesis):
     # While on kubernetes we put it all on scylla-operator
     kubernetes = False
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_terminate_and_replace_node()
 
@@ -3651,7 +3554,6 @@ class OperatorNodeTerminateAndReplace(Nemesis):
     disruptive = True
     kubernetes = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_terminate_and_replace_node_kubernetes()
 
@@ -3660,7 +3562,6 @@ class OperatorNodeTerminateDecommissionAdd(Nemesis):
     disruptive = True
     kubernetes = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_terminate_decommission_add_node_kubernetes()
 
@@ -3669,7 +3570,6 @@ class OperatorNodeReplace(Nemesis):
     disruptive = True
     kubernetes = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_replace_node_kubernetes()
 
@@ -3678,7 +3578,6 @@ class ScyllaKillMonkey(Nemesis):
     disruptive = True
     kubernetes = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_kill_scylla()
 
@@ -3687,7 +3586,6 @@ class ValidateHintedHandoffShortDowntime(Nemesis):
     disruptive = True
     kubernetes = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disable_disrupt_validate_hh_short_downtime()
 
@@ -3697,7 +3595,6 @@ class SnapshotOperations(Nemesis):
     kubernetes = True
     limited = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_snapshot_operations()
 
@@ -3706,7 +3603,6 @@ class NodeRestartWithResharding(Nemesis):
     disruptive = True
     kubernetes = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_restart_with_resharding()
 
@@ -3715,7 +3611,6 @@ class ClusterRollingRestart(Nemesis):
     disruptive = True
     kubernetes = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_rolling_restart_cluster(random_order=False)
 
@@ -3724,7 +3619,6 @@ class RollingRestartConfigChangeInternodeCompression(Nemesis):
     disruptive = True
     full_cluster_restart = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_rolling_config_change_internode_compression()
 
@@ -3733,7 +3627,6 @@ class ClusterRollingRestartRandomOrder(Nemesis):
     disruptive = True
     kubernetes = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_rolling_restart_cluster(random_order=True)
 
@@ -3741,7 +3634,6 @@ class ClusterRollingRestartRandomOrder(Nemesis):
 class SwitchBetweenPasswordAuthAndSaslauthdAuth(Nemesis):
     disruptive = True  # the nemesis has rolling restart
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_switch_between_PasswordAuthenticator_and_SaslauthdAuthenticator_and_back()
 
@@ -3751,7 +3643,6 @@ class TopPartitions(Nemesis):
     kubernetes = True
     limited = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_show_toppartitions()
 
@@ -3761,7 +3652,6 @@ class RandomInterruptionNetworkMonkey(Nemesis):
     networking = True
     run_with_gemini = False
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_network_random_interruptions()
 
@@ -3771,7 +3661,6 @@ class BlockNetworkMonkey(Nemesis):
     networking = True
     run_with_gemini = False
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_network_block()
 
@@ -3781,7 +3670,6 @@ class RejectInterNodeNetworkMonkey(Nemesis):
     networking = True
     run_with_gemini = False
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self._disrupt_network_reject_inter_node_communication()
 
@@ -3791,7 +3679,6 @@ class RejectNodeExporterNetworkMonkey(Nemesis):
     networking = True
     run_with_gemini = False
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_network_reject_node_exporter()
 
@@ -3801,7 +3688,6 @@ class RejectThriftNetworkMonkey(Nemesis):
     networking = True
     run_with_gemini = False
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_network_reject_thrift()
 
@@ -3811,7 +3697,6 @@ class StopStartInterfacesNetworkMonkey(Nemesis):
     networking = True
     run_with_gemini = False
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_network_start_stop_interface()
 
@@ -3837,7 +3722,6 @@ class DisruptiveMonkey(Nemesis):
         super(DisruptiveMonkey, self).__init__(*args, **kwargs)
         self.disrupt_methods_list = self.get_list_of_methods_compatible_with_backend(disruptive=True)
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.call_random_disrupt_method(disrupt_methods=self.disrupt_methods_list)
 
@@ -3855,7 +3739,6 @@ class NonDisruptiveMonkey(Nemesis):
         super(NonDisruptiveMonkey, self).__init__(*args, **kwargs)
         self.disrupt_methods_list = self.get_list_of_methods_compatible_with_backend(disruptive=False)
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.call_random_disrupt_method(disrupt_methods=self.disrupt_methods_list)
 
@@ -3869,7 +3752,6 @@ class NetworkMonkey(Nemesis):
         super(NetworkMonkey, self).__init__(*args, **kwargs)
         self.disrupt_methods_list = self.get_list_of_methods_compatible_with_backend(networking=True)
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.call_random_disrupt_method(disrupt_methods=self.disrupt_methods_list)
 
@@ -3882,7 +3764,6 @@ class GeminiChaosMonkey(Nemesis):
         super(GeminiChaosMonkey, self).__init__(*args, **kwargs)
         self.disrupt_methods_list = self.get_list_of_methods_compatible_with_backend(run_with_gemini=True)
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.call_random_disrupt_method(disrupt_methods=self.disrupt_methods_list)
 
@@ -3894,7 +3775,6 @@ class GeminiNonDisruptiveChaosMonkey(Nemesis):
         non_disruptive = set(self.get_list_of_methods_compatible_with_backend(disruptive=False))
         self.disrupt_methods_list = run_with_gemini.intersection(non_disruptive)
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.call_random_disrupt_method(disrupt_methods=self.disrupt_methods_list)
 
@@ -3915,7 +3795,6 @@ class KubernetesScyllaOperatorMonkey(Nemesis):
         self.disrupt_methods_list = list(
             set(self.get_list_of_methods_compatible_with_backend()) - set(ignore_methods))
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.call_random_disrupt_method(disrupt_methods=self.disrupt_methods_list)
 
@@ -3941,7 +3820,6 @@ class ScyllaOperatorBasicOperationsMonkey(Nemesis):
             'disrupt_mgmt_backup',
         ]
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.call_random_disrupt_method(disrupt_methods=self.disrupt_methods_list, predefined_sequence=True)
 
@@ -3951,7 +3829,6 @@ class NemesisSequence(Nemesis):
     networking = False
     run_with_gemini = False
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_run_unique_sequence()
 
@@ -3963,7 +3840,6 @@ class TerminateAndRemoveNodeMonkey(Nemesis):
     # While on kubernetes we put it all on scylla-operator
     kubernetes = False
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_remove_node_then_add_node()
 
@@ -3975,7 +3851,6 @@ class SisyphusMonkey(Nemesis):
         self.get_all_disrupt_methods()
         self.shuffle_list_of_disruptions()
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.call_next_nemesis()
 
@@ -3998,7 +3873,6 @@ class DecommissionStreamingErrMonkey(Nemesis):
 
     disruptive = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_decommission_streaming_err()
 
@@ -4007,7 +3881,6 @@ class RebuildStreamingErrMonkey(Nemesis):
 
     disruptive = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_rebuild_streaming_err()
 
@@ -4016,7 +3889,6 @@ class RepairStreamingErrMonkey(Nemesis):
 
     disruptive = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_repair_streaming_err()
 
@@ -4035,7 +3907,6 @@ COMPLEX_NEMESIS = [NoOpMonkey, ChaosMonkey,
 class CorruptThenScrubMonkey(Nemesis):
     disruptive = False
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_corrupt_then_scrub()
 
@@ -4043,7 +3914,6 @@ class CorruptThenScrubMonkey(Nemesis):
 class MemoryStressMonkey(Nemesis):
     disruptive = True
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_memory_stress()
 
@@ -4051,6 +3921,5 @@ class MemoryStressMonkey(Nemesis):
 class ResetLocalSchemaMonkey(Nemesis):
     disruptive = False
 
-    @log_time_elapsed_and_status
     def disrupt(self):
         self.disrupt_resetlocalschema()

--- a/sdcm/sct_events/nemesis.py
+++ b/sdcm/sct_events/nemesis.py
@@ -10,43 +10,32 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2020 ScyllaDB
-
 from sdcm.sct_events import Severity
-from sdcm.sct_events.base import SctEvent
+from sdcm.sct_events.base import ContinuousEvent
 
 
-class DisruptionEvent(SctEvent):
+class DisruptionEvent(ContinuousEvent):
     def __init__(self,
-                 type,
-                 subtype,
-                 status,
-                 node=None,
-                 start=None,
-                 end=None,
-                 duration=None,
-                 error=None,
-                 full_traceback=None,
-                 **kwargs):  # pylint: disable=redefined-builtin,too-many-arguments
-        super().__init__(severity=Severity.NORMAL if status else Severity.ERROR)
+                 nemesis_name,
+                 node,
+                 severity=Severity.NORMAL,
+                 publish_event=True):  # pylint: disable=redefined-builtin,too-many-arguments
+        super().__init__(severity=severity, publish_event=publish_event)
 
-        self.type = type
-        self.subtype = subtype
+        self.nemesis_name = nemesis_name
         self.node = str(node)
-        self.start = start
-        self.end = end
-        self.duration = duration
-
-        self.error = None
+        self.duration = None
         self.full_traceback = ""
-        if error:
-            self.error = error
-            self.full_traceback = str(full_traceback)
-
-        self.__dict__.update(kwargs)
 
     @property
     def msgfmt(self) -> str:
-        fmt = super().msgfmt + ": type={0.type} subtype={0.subtype} target_node={0.node} duration={0.duration}"
-        if self.severity == Severity.ERROR:
-            fmt += " error={0.error}\n{0.full_traceback}"
+        fmt = super().msgfmt + ": nemesis_name={0.nemesis_name} target_node={0.node}"
+        if self.is_skipped:
+            fmt += " skipped"
+        if self.skip_reason:
+            fmt += " skip_reason={0.skip_reason}"
+        if self.errors:
+            fmt += " errors={0.errors_formatted}"
+        if self.full_traceback:
+            fmt += "\n{0.full_traceback}"
         return fmt


### PR DESCRIPTION
Extention of commit:
https://github.com/scylladb/scylla-cluster-tests/pull/3638

Messages examples:
```
2021-07-05 07:01:43.993: (DisruptionEvent Severity.NORMAL) period_type=begin event_id=a383c335-e448-4c67-bd6e-929ba6ba88aa: nemesis_name=DeleteByRowsRange target_node=Node longevity-10gb-3h-event-re-db-node-46d0b056-2 [13.49.222.216 | 10.0.3.54] (seed: False)
2021-07-05 07:02:29.515: (DisruptionEvent Severity.NORMAL) period_type=end event_id=a383c335-e448-4c67-bd6e-929ba6ba88aa duration=45s: nemesis_name=DeleteByRowsRange target_node=Node longevity-10gb-3h-event-re-db-node-46d0b056-2 [13.49.222.216 | 10.0.3.54] (seed: False) skipped skip_reason=This nemesis can run on scylla_bench test only

2021-07-05 07:05:10.089: (DisruptionEvent Severity.NORMAL) period_type=begin event_id=dbc16ce8-eafb-4920-a825-cd438fb941c3: nemesis_name=DecommissionStreamingErr target_node=Node longevity-10gb-3h-event-re-db-node-46d0b056-2 [13.49.222.216 | 10.0.3.54] (seed: False)
2021-07-05 07:19:01.861: (DisruptionEvent Severity.NORMAL) period_type=end event_id=dbc16ce8-eafb-4920-a825-cd438fb941c3 duration=13m51s: nemesis_name=DecommissionStreamingErr target_node=Node longevity-10gb-3h-event-re-db-node-46d0b056-2 [13.49.222.216 | 10.0.3.54] (seed: False)

2021-07-05 09:57:54.998: (DisruptionEvent Severity.NORMAL) period_type=begin event_id=571f8246-50ef-4623-b2fb-06baecc2d84e: nemesis_name=TerminateDecommissionAddNodeKubernetes target_node=Node longevity-10gb-3h-event-re-db-node-46d0b056-5 [13.51.173.82 | 10.0.2.3] (seed: False)
2021-07-05 09:58:25.458: (DisruptionEvent Severity.NORMAL) period_type=end event_id=571f8246-50ef-4623-b2fb-06baecc2d84e duration=30s: nemesis_name=TerminateDecommissionAddNodeKubernetes target_node=Node longevity-10gb-3h-event-re-db-node-46d0b056-5 [13.51.173.82 | 10.0.2.3] (seed: False) skipped skip_reason=OperatorNodeTerminateDecommissionAdd is supported only on kubernetes

2021-07-05 13:54:01.578: (DisruptionEvent Severity.NORMAL) period_type=begin event_id=762b7b99-ec11-4b22-983d-ffee83a8940c: nemesis_name=NetworkRandomInterruptions target_node=Node longevity-10gb-3h-event-re-db-node-46d0b056-2 [13.51.173.82 | 10.0.2.3] (seed: False)
2021-07-05 13:55:04.157: (DisruptionEvent Severity.ERROR) period_type=end event_id=762b7b99-ec11-4b22-983d-ffee83a8940c duration=1m2s: nemesis_name=NetworkRandomInterruptions target_node=Node longevity-10gb-3h-event-re-db-node-46d0b056-2 [13.51.173.82 | 10.0.2.3] (seed: False) errors=['Encountered a bad command exit code!\n\nCommand: \'sudo bash -cxe "/sbin/tc qdisc add dev eth1 root handle 16f1: htb default 1\\n/sbin/tc class add dev eth1 parent 16f1: classid 16f1:1 htb rate 32000000.0kbit\\n/sbin/tc class add dev eth1 parent 16f1: classid 16f1:167 htb rate 32000000.0Kbit ceil 32000000.0Kbit\\n/sbin/tc qdisc add dev eth1 parent 16f1:167 handle 2e33: netem loss 12.000000%\\n/sbin/tc filter add dev eth1 protocol ip parent 16f1: prio 5 u32 match ip dst 0.0.0.0/0 match ip src 0.0.0.0/0 flowid 16f1:167\\n"\'\n\nExit code: 1\n\nStdout:\n\n\n\nStderr:\n\n+ /sbin/tc qdisc add dev eth1 root handle 16f1: htb default 1\nCannot find device "eth1"\n\n']

2021-07-05 13:57:35.869: (DisruptionEvent Severity.NORMAL) period_type=begin event_id=be13ef0f-ba3a-497b-9332-79f6c32233d2: nemesis_name=NetworkRejectNodeExporter target_node=Node longevity-10gb-3h-event-re-db-node-46d0b056-2 [13.51.173.82 | 10.0.2.3] (seed: False)
2021-07-05 13:58:16.984: (DisruptionEvent Severity.NORMAL) period_type=end event_id=be13ef0f-ba3a-497b-9332-79f6c32233d2 duration=41s: nemesis_name=NetworkRejectNodeExporter target_node=Node longevity-10gb-3h-event-re-db-node-46d0b056-2 [13.51.173.82 | 10.0.2.3] (seed: False)

2021-07-05 13:47:00.454: (DisruptionEvent Severity.NORMAL) period_type=begin event_id=d41d9623-d77b-4a23-939e-57d83e33e78c: nemesis_name=NetworkStartStopInterface target_node=Node longevity-10gb-3h-event-re-db-node-46d0b056-3 [13.53.122.10 | 10.0.3.173] (seed: False)
2021-07-05 13:47:33.794: (DisruptionEvent Severity.ERROR) period_type=end event_id=d41d9623-d77b-4a23-939e-57d83e33e78c duration=33s: nemesis_name=NetworkStartStopInterface target_node=Node longevity-10gb-3h-event-re-db-node-46d0b056-3 [13.53.122.10 | 10.0.3.173] (seed: False) errors=["Encountered a bad command exit code!\n\nCommand: 'sudo /sbin/ifup eth1'\n\nExit code: 1\n\nStdout:\n\n\n\nStderr:\n\nsudo: /sbin/ifup: command not found\n\n"]

2021-07-05 13:15:39.740: (DisruptionEvent Severity.NORMAL) period_type=begin event_id=3d520f5a-5d99-4ca4-8d33-9122bb004bf3: nemesis_name=NodetoolCleanup target_node=Node longevity-10gb-3h-event-re-db-node-46d0b056-2 [13.51.173.82 | 10.0.2.3] (seed: False)
2021-07-05 13:15:40.916: (InfoEvent Severity.NORMAL) period_type=not-set event_id=266f46e2-f8c3-4f28-bf57-4424fa184ea6: message=NodetoolCleanupMonkey Node longevity-10gb-3h-event-re-db-node-46d0b056-1 [13.51.47.214 | 10.0.3.202] (seed: True)
2021-07-05 13:17:00.210: (InfoEvent Severity.NORMAL) period_type=not-set event_id=2609755d-c7ec-4825-8426-e285222dd76f: message=NodetoolCleanupMonkey Node longevity-10gb-3h-event-re-db-node-46d0b056-2 [13.51.173.82 | 10.0.2.3] (seed: False)
2021-07-05 13:18:07.978: (InfoEvent Severity.NORMAL) period_type=not-set event_id=e1f91980-cb7c-4cff-afda-828e53c403e3: message=NodetoolCleanupMonkey Node longevity-10gb-3h-event-re-db-node-46d0b056-3 [13.53.122.10 | 10.0.3.173] (seed: False)
2021-07-05 13:19:49.741: (DisruptionEvent Severity.NORMAL) period_type=end event_id=3d520f5a-5d99-4ca4-8d33-9122bb004bf3 duration=4m10s: nemesis_name=NodetoolCleanup target_node=Node longevity-10gb-3h-event-re-db-node-46d0b056-2 [13.51.173.82 | 10.0.2.3] (seed: False)
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
