### PR TITLE
test(listen address): Let scylla listen on 0.0.0.0

### DIFF
--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -31,7 +31,7 @@ def test_cassandra_rackdc(cassandra_rackdc_properties):
     with cassandra_rackdc_properties() as props:
         original = props['prefer_local']
 
-    log.info(f"cassandra-rackdc.properties.prefer_local = {original}")
+    log.info("cassandra-rackdc.properties.prefer_local = %s", original)
 
     if original == 'false':
         changed = 'true'
@@ -72,7 +72,7 @@ def test_grow_shrink_cluster(tester, db_cluster):
 def test_drain_and_replace_node_kubernetes(tester, db_cluster):
     target_node = random.choice(db_cluster.non_seed_nodes)
     old_uid = target_node.k8s_pod_uid
-    log.info(f'TerminateNode %s (uid=%s)', target_node, old_uid)
+    log.info('TerminateNode %s (uid=%s)', target_node, old_uid)
     target_node.drain_k8s_node()
     target_node.mark_to_be_replaced()
     target_node.wait_till_k8s_pod_get_uid(ignore_uid=old_uid)
@@ -84,11 +84,11 @@ def test_drain_and_replace_node_kubernetes(tester, db_cluster):
 def test_drain_wait_and_replace_node_kubernetes(tester, db_cluster):
     target_node = random.choice(db_cluster.non_seed_nodes)
     old_uid = target_node.k8s_pod_uid
-    log.info(f'TerminateNode %s (uid=%s)', target_node, old_uid)
+    log.info('TerminateNode %s (uid=%s)', target_node, old_uid)
     target_node.drain_k8s_node()
     target_node.wait_till_k8s_pod_get_uid(ignore_uid=old_uid)
     old_uid = target_node.k8s_pod_uid
-    log.info(f'Mark %s (uid=%s) to be replaced', target_node, old_uid)
+    log.info('Mark %s (uid=%s) to be replaced', target_node, old_uid)
     target_node.mark_to_be_replaced()
     target_node.wait_till_k8s_pod_get_uid(ignore_uid=old_uid)
     target_node.wait_for_pod_readiness()

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1504,6 +1504,9 @@ class BaseScyllaPodContainer(BasePodContainer):  # pylint: disable=abstract-meth
 
     parent_cluster: ScyllaPodCluster
 
+    def actual_scylla_yaml(self):
+        return super().remote_scylla_yaml()
+
     @contextlib.contextmanager
     def remote_scylla_yaml(self) -> ContextManager:
         """Update scylla.yaml, k8s way


### PR DESCRIPTION
--listen-address flag description says 'Never specify 0.0.0.0; it is always wrong.'
which isn't true as using 0.0.0.0 is valid when using explicit --broadcast-address

Issues:
https://github.com/scylladb/scylla-operator/issues/484
https://github.com/scylladb/scylla/issues/8381

[Task](https://trello.com/c/MYF0CO7a/3578-check-that-scylla-listens-on-0000)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
