### PR TITLE
feature(manager): sanities trigger upgrade and downstream jobs

### DIFF
--- a/jenkins-pipelines/manager/centos-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-sanity.jenkinsfile
@@ -18,5 +18,7 @@ managerPipeline(
     timeout: [time: 120, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
-    post_behavior_monitor_nodes: 'destroy'
+    post_behavior_monitor_nodes: 'destroy',
+
+    downstream_jobs_to_run: 'centos-upgrade-test, centos-sanity-ipv6-test, sct-feature-test-backup, sct-feature-test-backup-azure, sct-feature-test-backup-gce'
 )

--- a/jenkins-pipelines/manager/debian10-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/debian10-manager-sanity.jenkinsfile
@@ -17,5 +17,7 @@ managerPipeline(
     timeout: [time: 120, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
-    post_behavior_monitor_nodes: 'destroy'
+    post_behavior_monitor_nodes: 'destroy',
+
+    downstream_jobs_to_run: 'debian10-upgrade-test'
 )

--- a/jenkins-pipelines/manager/debian9-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/debian9-manager-sanity.jenkinsfile
@@ -17,5 +17,7 @@ managerPipeline(
     timeout: [time: 120, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
-    post_behavior_monitor_nodes: 'destroy'
+    post_behavior_monitor_nodes: 'destroy',
+
+    downstream_jobs_to_run: 'debian9-upgrade-test'
 )

--- a/jenkins-pipelines/manager/ubuntu16-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu16-manager-sanity.jenkinsfile
@@ -17,5 +17,7 @@ managerPipeline(
     timeout: [time: 120, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
-    post_behavior_monitor_nodes: 'destroy'
+    post_behavior_monitor_nodes: 'destroy',
+
+    downstream_jobs_to_run: 'ubuntu16-upgrade-test'
 )

--- a/jenkins-pipelines/manager/ubuntu18-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu18-manager-sanity.jenkinsfile
@@ -16,5 +16,7 @@ managerPipeline(
     timeout: [time: 120, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
-    post_behavior_monitor_nodes: 'destroy'
+    post_behavior_monitor_nodes: 'destroy',
+
+    downstream_jobs_to_run: 'ubuntu18-upgrade-test'
 )

--- a/jenkins-pipelines/manager/ubuntu20-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu20-manager-sanity.jenkinsfile
@@ -16,5 +16,7 @@ managerPipeline(
     timeout: [time: 120, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
-    post_behavior_monitor_nodes: 'destroy'
+    post_behavior_monitor_nodes: 'destroy',
+
+    downstream_jobs_to_run: 'ubuntu20-upgrade-test'
 )


### PR DESCRIPTION
To prevent triggering the manager upgrade and feature jobs unnecessarily,
I modified the manager pipeline as such that the upstream job will
be triggered by the matching sanity, and only when it passes successfully.

The rest of the jobs, like backup feature and upv6 sanity, will be triggered
by the centos sanity

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
