### PR TITLE
Fix 3756

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -389,6 +389,11 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             # Let's wait for the target Node to have their services re-started
             self.log.info('Waiting scylla services to be restarted after we killed them...')
             self.target_node.wait_db_up(timeout=14400)
+            if self.cluster.params.get('use_mgmt'):
+                # Workaround for https://github.com/scylladb/scylla-manager/issues/2813
+                # When scylla take too long time to bring api port up
+                #  scylla-manager-agent fails to start and never go up
+                self.target_node.start_service(service_name='scylla-manager-agent', timeout=600, ignore_status=True)
             self.log.info('Waiting JMX services to be restarted after we killed them...')
             self.target_node.wait_jmx_up()
         self.cluster.wait_for_schema_agreement()


### PR DESCRIPTION
Fixes #3756 

```
Workaround for https://github.com/scylladb/scylla-manager/issues/2813
When scylla take too long time to bring api port up
scylla-manager-agent fails to start and never go up
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
