### PR TITLE
fix(cfstat event): not publish NodetoolEvent when waiting for space_node_threshold

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1102,8 +1102,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         wait.wait_for(keyspace_available, timeout=120, step=60,
                       text='Waiting until keyspace {} is available'.format(keyspace), throw_exc=False)
         try:
+            # Don't need NodetoolEvent when waiting for space_node_threshold before start the nemesis, not publish it
             result = self.run_nodetool(sub_cmd='cfstats', args=keyspace, timeout=60,
-                                       warning_event_on_exception=(Failure, UnexpectedExit))
+                                       warning_event_on_exception=(Failure, UnexpectedExit), publish_event=False)
         except (Failure, UnexpectedExit):
             self.log.error('nodetool error - see tcpdump thread uuid %s for '
                            'debugging info', tcpdump_id)


### PR DESCRIPTION
Don't need NodetoolEvent when waiting for space_node_threshold before start the nemesis, not publish it

[Task](https://trello.com/c/8L8hlG4t/3624-not-publish-nodetoolevent-when-waiting-for-spacenodethreshold)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
