### PR TITLE
fix(functional_tests): make it work for all cwd

### DIFF
--- a/functional_tests/scylla_operator/libs/auxiliary.py
+++ b/functional_tests/scylla_operator/libs/auxiliary.py
@@ -12,10 +12,13 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2021 ScyllaDB
-
+import os
 
 from sdcm.cluster_k8s import ScyllaPodCluster
 from sdcm.tester import ClusterTester
+
+
+SCT_ROOT = os.path.realpath(os.path.join(__file__, '..', '..', '..', '..'))
 
 
 class ScyllaOperatorFunctionalClusterTester(ClusterTester):
@@ -43,3 +46,7 @@ class ScyllaOperatorFunctionalClusterTester(ClusterTester):
             if test_data[0] != 'SUCCESS':
                 return 'FAILED'
         return 'SUCCESS'
+
+
+def sct_abs_path(relative_filename=""):
+    return os.path.join(SCT_ROOT, relative_filename)


### PR DESCRIPTION
Currently if cwd is different from sct path it fails

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
