### PR TITLE
k8s-local-kind: kill old cluster if REUSE_CLUSTER is not set

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1457,6 +1457,9 @@ class BasePodContainer(cluster.BaseNode):  # pylint: disable=too-many-public-met
 
 
 class BaseScyllaPodContainer(BasePodContainer):  # pylint: disable=abstract-method
+    def restart(self):
+        pass
+
     parent_cluster: ScyllaPodCluster
 
     @contextlib.contextmanager
@@ -1722,7 +1725,7 @@ class PodCluster(cluster.BaseCluster):
     def get_node_ips_param(self, public_ip=True):
         raise NotImplementedError("Derived class must implement 'get_node_ips_param' method!")
 
-    def wait_for_init(self):
+    def wait_for_init(self, *_, node_list=None, verbose=False, timeout=None, **__):
         raise NotImplementedError("Derived class must implement 'wait_for_init' method!")
 
     def get_nodes_reboot_timeout(self, count) -> Union[float, int]:
@@ -1786,7 +1789,7 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
     get_scylla_args = cluster_docker.ScyllaDockerCluster.get_scylla_args
 
     @cluster.wait_for_init_wrap
-    def wait_for_init(self, node_list=None, verbose=False, timeout=None, *_, **__):  # pylint: disable=signature-differs,keyword-arg-before-vararg
+    def wait_for_init(self, *_, node_list=None, verbose=False, timeout=None, **__):
         node_list = node_list if node_list else self.nodes
         self.wait_for_nodes_up_and_normal(nodes=node_list)
         if self.scylla_yaml_update_required:


### PR DESCRIPTION
https://trello.com/c/iCmqi4N2/3622-investigate-functional-tests-issues

Make kind cluster to be deleted if no SCT_REUSE_CLUSTER is set

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
