### PR TITLE
feature(k8s-monitoring): store K8S monitoring config in local yaml files

### DIFF
--- a/sdcm/k8s_configs/monitoring/scylla-manager-service-monitor.yaml
+++ b/sdcm/k8s_configs/monitoring/scylla-manager-service-monitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: scylla-manager-service-monitor
+  namespace: scylla-manager
+spec:
+  jobLabel: "app"
+  selector:
+    matchLabels:
+      app: scylla-manager
+  endpoints:
+    - port: metrics
+      metricRelabelings:
+        - sourceLabels: [ host ]
+          targetLabel: instance
+          regex: (.*)
+          replacement: ${1}

--- a/sdcm/k8s_configs/monitoring/scylla-service-monitor.yaml
+++ b/sdcm/k8s_configs/monitoring/scylla-service-monitor.yaml
@@ -1,0 +1,33 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: scylla-service-monitor
+  namespace: scylla
+spec:
+  jobLabel: "app"
+  targetLabels: ["scylla/cluster"]
+  podTargetLabels: ["scylla/datacenter","scylla/rack"]
+  selector:
+    matchLabels:
+      app: scylla
+  endpoints:
+    - port: agent-prometheus
+      metricRelabelings:
+        # rename job label to 'manager_agent' due to hardcoded name
+        # in Scylla Monitoring.
+        - sourceLabels: [ endpoint ]
+          targetLabel: job
+          regex: agent-prometheus
+          replacement: manager_agent
+    - port: prometheus
+      metricRelabelings:
+        - sourceLabels: [ scylla_cluster ]
+          targetLabel: cluster
+          regex: (.*)
+          replacement: ${1}
+          action: replace
+        - sourceLabels: [ scylla_datacenter ]
+          targetLabel: dc
+          regex: (.*)
+          replacement: ${1}
+          action: replace

--- a/sdcm/k8s_configs/monitoring/values.yaml
+++ b/sdcm/k8s_configs/monitoring/values.yaml
@@ -1,0 +1,165 @@
+defaultRules:
+  enabled: false
+
+# Install node exported as a DaemonSet.
+nodeExporter:
+  enabled: false
+
+grafana:
+  defaultDashboardsEnabled: false
+  adminPassword: admin
+
+  sidecar:
+    dashboards:
+      enabled: true
+      # ConfigMaps with label below will be added to Grafana as dashboards.
+      label: grafana_dashboard
+    datasources:
+      # Disable default datasource, instead create our own below
+      defaultDatasourceEnabled: false
+
+  additionalDataSources:
+  # Scylla Monitoring use hardcoded name for datasource.
+  # Default one is called "Prometheus" where SM requires "prometheus".
+  - name: prometheus
+    type: prometheus
+    url: http://prometheus-operated:9090
+
+  plugins:
+    - grafana-piechart-panel
+    - camptocamp-prometheus-alertmanager-datasource
+    # Disabled because it's not available in grafana repo
+    # - scylla-plugin
+
+  # This might need to be increased for bigger deployments.
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  # Configure NodePort service to make grafana be available outside of a K8S cluster
+  service:
+    type: NodePort
+    nodePort: 30000
+    port: 30000
+
+  # Configure anonymous access
+  grafana.ini:
+    users:
+      viewers_can_edit: true
+    auth:
+      disable_login_form: true
+      disable_signout_menu: true
+    auth.anonymous:
+      enabled: true
+      org_role: Editor
+
+  affinity: {}
+
+alertmanager:
+  alertmanagerSpec:
+    affinity: {}
+
+prometheusOperator:
+  kubeletService:
+    enabled: false
+
+  # This might need to be increased for bigger deployments.
+  resources:
+    limits:
+      cpu: 200m
+      memory: 200Mi
+    requests:
+      cpu: 100m
+      memory: 100Mi
+
+  affinity: {}
+
+prometheus:
+  # This might need to be increased for bigger deployments.
+  resources:
+    limits:
+      cpu: 4
+      memory: 8Gi
+    requests:
+      cpu: 1
+      memory: 2Gi
+
+  # Configure NodePort service to make prometheus be available outside of a K8S cluster
+  service:
+    type: NodePort
+    nodePort: 30090
+
+  prometheusSpec:
+    # Set scrapeInterval and scrapeTimeout the same as in SCT (standalone) monitoring
+    scrapeInterval: 20s
+    scrapeTimeout: 15s
+
+    affinity: {}
+
+    # Instruct prometheus operator to search for any ServiceMonitor
+    serviceMonitorSelector: { }
+    # This prevents from adding any Helm label to serviceMonitorSelector if
+    # above is empty.
+    serviceMonitorSelectorNilUsesHelmValues: false
+
+    # Relabelings needed for Scylla dashboards
+    additionalScrapeConfigs:
+      - job_name: scylla
+        relabel_configs:
+        - source_labels: [ __address__ ]
+          regex: '([^:]+)'
+          target_label: __address__
+          replacement: '${1}:9180'
+        - source_labels: [ __address__ ]
+          regex: '(.*):.+'
+          target_label: instance
+          replacement: '${1}'
+        metric_relabel_configs:
+          - source_labels: [ version ]
+            regex: '(.+)'
+            target_label: CPU
+            replacement: 'cpu'
+          - source_labels: [ version ]
+            regex: '(.+)'
+            target_label: CQL
+            replacement: 'cql'
+          - source_labels: [ version ]
+            regex: '(.+)'
+            target_label: OS
+            replacement: 'os'
+          - source_labels: [ version ]
+            regex: '(.+)'
+            target_label: IO
+            replacement: 'io'
+          - source_labels: [ version ]
+            regex: '(.+)'
+            target_label: Errors
+            replacement: 'errors'
+          - regex: 'help|exported_instance|type'
+            action: labeldrop
+          - source_labels: [ version ]
+            regex: '([0-9]+\.[0-9]+)(\.?[0-9]*).*'
+            replacement: '$1$2'
+            target_label: svr
+
+# Disable monitoring for k8s internals
+kubeApiServer:
+  enabled: false
+kubelet:
+  enabled: false
+kubeControllerManager:
+  enabled: false
+coreDns:
+  enabled: false
+kubeEtcd:
+  enabled: false
+kubeScheduler:
+  enabled: false
+kubeProxy:
+  enabled: false
+kubeStateMetrics:
+  enabled: false

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -949,7 +949,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
         if self.params.get('k8s_deploy_monitoring'):
             self.k8s_cluster.deploy_monitoring_cluster(
-                scylla_operator_tag=self.params.get('k8s_scylla_operator_docker_image').split(':')[-1],
                 is_manager_deployed=self.params.get('use_mgmt')
             )
         if self.params.get("n_loaders"):
@@ -997,7 +996,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
         if self.params.get('k8s_deploy_monitoring'):
             self.k8s_cluster.deploy_monitoring_cluster(
-                self.params.get('k8s_scylla_operator_docker_image').split(':')[-1],
                 is_manager_deployed=self.params.get('use_mgmt')
             )
 
@@ -1123,7 +1121,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
         if self.params.get('k8s_deploy_monitoring'):
             self.k8s_cluster.deploy_monitoring_cluster(
-                scylla_operator_tag=self.params.get('k8s_scylla_operator_docker_image').split(':')[-1],
                 is_manager_deployed=self.params.get('use_mgmt'),
                 node_pool=monitor_pool
             )
@@ -1262,7 +1259,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
         if self.params.get('k8s_deploy_monitoring'):
             self.k8s_cluster.deploy_monitoring_cluster(
-                scylla_operator_tag=self.params.get('k8s_scylla_operator_docker_image').split(':')[-1],
                 is_manager_deployed=self.params.get('use_mgmt'),
                 node_pool=monitor_pool
             )


### PR DESCRIPTION
For the moment we parse operator helm chart version for getting git tag and picking up monitoring helm chart values file.
Such approach doesn't work when operator helm chart doesn't contain any info related to tags such as developer custom charts.
    
So, knowing above, start storing values.yaml file for monitoring helm chart locally with all the data we were adding separately.
It will allow us to achieve following:
- We do not depend anymore on the helm chart versions parsability.
- Python code for deployment of K8S monitoring becomes simplier because all the configuration is stored in local yaml files.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
