### PR TITLE
k8s-local-kind: give from userspace to kind networks and speedup cluster init

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -936,8 +936,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         self.k8s_cluster.deploy_scylla_operator(pool_name='')
         if self.params.get('use_mgmt'):
             self.k8s_cluster.deploy_scylla_manager(pool_name='')
-        # This should remove some of the unpredictability of pods startup time.
-        self.k8s_cluster.docker_pull(f"{self.params.get('docker_image')}:{self.params.get('scylla_version')}")
 
         self.db_cluster = mini_k8s.LocalMinimalScyllaPodCluster(
             k8s_cluster=self.k8s_cluster,


### PR DESCRIPTION
https://trello.com/c/iCmqi4N2/3622-investigate-functional-tests-issues

Do following things:
1. Speedup kind cluster initialization by pushing scylla image into the workers
2. FIxes problem with unavialability of kind networks from userspace

Fixes:
https://github.com/scylladb/scylla-cluster-tests/issues/3750

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
