### PR TITLE
fix(disrupt_nodetool_refresh): make it wait for resharding log messages

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -63,6 +63,7 @@ from sdcm.db_stats import PrometheusDBStats
 from sdcm.remote.libssh2_client.exceptions import UnexpectedExit as Libssh2UnexpectedExit
 from sdcm.cluster_k8s import PodCluster, ScyllaPodCluster
 from sdcm.nemesis_publisher import NemesisElasticSearchPublisher
+from sdcm.wait import wait_for
 from test_lib.compaction import CompactionStrategy, get_compaction_strategy, get_compaction_random_additional_params
 from test_lib.cql_types import CQLTypeBuilder
 
@@ -1002,12 +1003,15 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             # So we need to validate that resharded files are placed in the "upload" folder before moving.
             # Find the compaction output that reported about the resharding
 
-            search_reshard = node.follow_system_log(patterns=['Resharded.*\[/'])
+            system_log_follower = node.follow_system_log(patterns=['Resharded.*\[/'])
             node.run_nodetool(sub_cmd="refresh", args="-- keyspace1 standard1")
-            resharding_done = list(search_reshard)
-            return resharding_done
+            return system_log_follower
 
-        def validate_resharding_after_refresh(resharding_done):
+        @timeout(
+            timeout=60,
+            allowed_exceptions=(AssertionError,),
+            message="Waiting for resharding completion message to appear in logs")
+        def validate_resharding_after_refresh(system_log_follower):
             """
             # Validate that files after resharding were saved in the "upload" folder.
             # Example of compaction output:
@@ -1024,10 +1028,11 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-16-big-Data.db:level=0,
             #   ]. 91MB to 92MB (~100% of original) in 5009ms = 18MB/s. ~370176 total partitions merged to 370150
             """
-            assert resharding_done, "Resharding wasn't run"
-            self.log.debug(f"Found resharding: {resharding_done}")
+            resharding_logs = list(system_log_follower)
+            assert resharding_logs, "Resharding wasn't run"
+            self.log.debug(f"Found resharding: {resharding_logs}")
 
-            for line in resharding_done:
+            for line in resharding_logs:
                 # Find all files that were created after resharding
                 for one_file in re.findall(r"(/var/.*?),", line, re.IGNORECASE):
                     # The file path have to include "upload" folder
@@ -1046,8 +1051,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
             # Executing rolling refresh one by one
             for node in self.cluster.nodes:
-                resharding_done = do_refresh(node)
-                validate_resharding_after_refresh(resharding_done)
+                system_log_follower = do_refresh(node)
+                validate_resharding_after_refresh(system_log_follower)
 
             # Verify that the special key is loaded by SELECT query
             result = self.target_node.run_cqlsh(query_verify)


### PR DESCRIPTION
fixes #3714

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
