### PR TITLE
Fix k8s local reuse

### DIFF
--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -163,36 +163,36 @@ class KindK8sMixin:
     def start_k8s_software(self) -> None:
         LOGGER.debug("Start Kind cluster")
         script = dedent("""
-            sysctl fs.protected_regular=0
-            ip link set docker0 promisc on
-            kind delete cluster || true
-            cat >/tmp/kind.cluster.yaml <<- EndOfSpec
-            kind: Cluster
-            apiVersion: kind.x-k8s.io/v1alpha4
-            # patch the generated kubeadm config with some extra settings
-            networking:
-              podSubnet: 10.244.0.0/16
-              serviceSubnet: 10.96.0.0/16
-            kubeadmConfigPatches:
-            - |
-              apiVersion: kubelet.config.k8s.io/v1beta1
-              kind: KubeletConfiguration
-              evictionHard:
-                nodefs.available: 0%
-            nodes:
-              # the control plane node config
-              - role: control-plane
-                # the three workers
-              - role: worker
-              - role: worker
-              - role: worker
-              - role: worker
-            EndOfSpec
-            kind delete cluster || true
-            kind create cluster --config /tmp/kind.cluster.yaml
-            SERVICE_GATEWAY=`docker inspect kind-control-plane -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}'`
-            ip ro add 10.96.0.0/16 via $SERVICE_GATEWAY || ip ro change 10.96.0.0/16 via $SERVICE_GATEWAY
-            ip ro add 10.224.0.0/16 via $SERVICE_GATEWAY || ip ro change 10.224.0.0/16 via $SERVICE_GATEWAY 
+        sysctl fs.protected_regular=0
+        ip link set docker0 promisc on
+        kind delete cluster || true
+        cat >/tmp/kind.cluster.yaml <<- EndOfSpec
+        kind: Cluster
+        apiVersion: kind.x-k8s.io/v1alpha4
+        # patch the generated kubeadm config with some extra settings
+        networking:
+          podSubnet: 10.244.0.0/16
+          serviceSubnet: 10.96.0.0/16
+        kubeadmConfigPatches:
+        - |
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          kind: KubeletConfiguration
+          evictionHard:
+            nodefs.available: 0%
+        nodes:
+          # the control plane node config
+          - role: control-plane
+            # the three workers
+          - role: worker
+          - role: worker
+          - role: worker
+          - role: worker
+        EndOfSpec
+        kind delete cluster || true
+        kind create cluster --config /tmp/kind.cluster.yaml
+        SERVICE_GATEWAY=`docker inspect kind-control-plane -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}'`
+        ip ro add 10.96.0.0/16 via $SERVICE_GATEWAY || ip ro change 10.96.0.0/16 via $SERVICE_GATEWAY
+        ip ro add 10.224.0.0/16 via $SERVICE_GATEWAY || ip ro change 10.224.0.0/16 via $SERVICE_GATEWAY 
         """)
         self.host_node.remoter.run(f"sudo -E bash -cxe '{script}'")
 

--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -202,7 +202,7 @@ class KindK8sMixin:
     def on_deploy_completed(self):
         if self.scylla_image:
             self.docker_pull(self.scylla_image)
-            self.host_node.remoter.run(f"kind load docker-image {self.scylla_image}")
+            self.host_node.remoter.run(f"kind load docker-image {self.scylla_image}", ignore_status=True)
 
 
 class MinikubeK8sMixin:
@@ -261,7 +261,7 @@ class MinikubeK8sMixin:
     def on_deploy_completed(self):
         if self.scylla_image:
             self.docker_pull(self.scylla_image)
-            self.host_node.remoter.run(f'minikube image load {self.scylla_image}')
+            self.host_node.remoter.run(f'minikube image load {self.scylla_image}', ignore_status=True)
 
 
 class MinimalClusterBase(KubernetesCluster, metaclass=abc.ABCMeta):

--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -247,11 +247,6 @@ class MinikubeK8sMixin:
             minikube delete || true
             minikube start --driver=none --extra-config=apiserver.service-node-port-range=1-65535
             chmod 777 -R $MINIKUBE_HOME
-            # [ -z "$KUBECONFIG" ] || exit
-            # ABS_KUBECONFIG_DIR=$(dirname $(realpath -m $KUBECONFIG))
-            # ABS_MINIKUBE_DIR=$(realpath -m ~/.minikube)
-            # cp -r $ABS_MINIKUBE_DIR $ABS_KUBECONFIG_DIR
-            # sed -ri "s/${{ABS_MINIKUBE_DIR////\\\\/}}/${{ABS_KUBECONFIG_DIR////\\\\/}}\\/.minikube/g" $ABS_KUBECONFIG_DIR/config
         """)
         self.host_node.remoter.run(f"sudo -E bash -cxe '{script}'")
 


### PR DESCRIPTION
Small issue when cluster is reused image is in the cache `kind load docker-image` fails

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
