### PR TITLE
fix(kubernetes): make SCT support seedless scylla using operator

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1970,9 +1970,15 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
 
         if TestConfig.MULTI_REGION:
             node.datacenter_setup(self.datacenter)  # pylint: disable=no-member
+        try:
+            # NOTE: case of seedful scylla (operator v1.3.0-)
+            seed_nodes = ','.join(self.seed_nodes_ips)
+        except AssertionError:
+            # NOTE: case of seedless scylla (operator v1.4.0+)
+            seed_nodes = None
         self.node_config_setup(
             node,
-            seed_address=','.join(self.seed_nodes_ips),
+            seed_address=seed_nodes,
             endpoint_snitch=self.get_endpoint_snitch(),
         )
 

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1767,7 +1767,7 @@ class PodCluster(cluster.BaseCluster):
     def get_node_ips_param(self, public_ip=True):
         raise NotImplementedError("Derived class must implement 'get_node_ips_param' method!")
 
-    def wait_for_init(self, *_, node_list=None, verbose=False, timeout=None, **__):
+    def wait_for_init(self, *_, node_list=None, verbose=False, timeout=None, **__):  # pylint: disable=arguments-differ
         raise NotImplementedError("Derived class must implement 'wait_for_init' method!")
 
     def get_nodes_reboot_timeout(self, count) -> Union[float, int]:
@@ -1831,7 +1831,7 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
     get_scylla_args = cluster_docker.ScyllaDockerCluster.get_scylla_args
 
     @cluster.wait_for_init_wrap
-    def wait_for_init(self, *_, node_list=None, verbose=False, timeout=None, **__):
+    def wait_for_init(self, *_, node_list=None, verbose=False, timeout=None, **__):  # pylint: disable=arguments-differ
         node_list = node_list if node_list else self.nodes
         self.wait_for_nodes_up_and_normal(nodes=node_list)
         if self.scylla_yaml_update_required:


### PR DESCRIPTION
Operator v1.4.x switched to usage of seedless approach for scylla and now we should not fail test run if no seed nodes are found.
So, make it be smart enough and do not fail when seed nodes are not defined, but still allow it to be set.
It will allow us to run old and new operator versions using the same code.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
