### PR TITLE
test(operator functional): new functional tests cover orphaned services issue

### DIFF
--- a/functional_tests/scylla_operator/libs/helpers.py
+++ b/functional_tests/scylla_operator/libs/helpers.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2021 ScyllaDB
+from sdcm.cluster_k8s import SCYLLA_NAMESPACE
+from sdcm.utils.k8s import KubernetesOps
+
+
+def get_orphaned_services(db_cluster):
+    pod_names = scylla_pod_names(db_cluster)
+    services_names = scylla_services_names(db_cluster)
+    return list(set(services_names) - set(pod_names))
+
+
+def scylla_pod_names(db_cluster):
+    pods = db_cluster.k8s_cluster.kubectl(f"get pods -n {SCYLLA_NAMESPACE} -l scylla/cluster=sct-cluster "
+                                          f"-o=custom-columns='NAME:.metadata.name'")
+
+    return [name for name in pods.stdout.split() if name != 'NAME']
+
+
+def scylla_services_names(db_cluster):
+    services = db_cluster.k8s_cluster.kubectl(f"get svc -n {SCYLLA_NAMESPACE} -l scylla/cluster=sct-cluster "
+                                              f"-o=custom-columns='NAME:.metadata.name'")
+    return [name for name in services.stdout.split() if name != 'NAME' and name != 'sct-cluster-client']


### PR DESCRIPTION
## PR pre-checks (self review)
Issue: https://github.com/scylladb/scylla-operator/issues/514
This commit presents tests that cover the issue when services were not cleaned after 
the member removing"

<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
