### PR TITLE
improvement(update_db_binary): add support to ubuntu packages

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -68,7 +68,7 @@ ScyllaOperatorLogEvent.TLS_HANDSHAKE_ERROR: WARNING
 ScyllaOperatorLogEvent.OPERATOR_STARTED_INFO: NORMAL
 StartupTestEvent: NORMAL
 TestTimeoutEvent: CRITICAL
-TestFrameworkEvent: ERROR
+TestFrameworkEvent: CRITICAL
 ElasticsearchEvent: ERROR
 SpotTerminationEvent: CRITICAL
 ScyllaRepoEvent: WARNING


### PR DESCRIPTION
so far we were able only to update RPM packages,
but as for now we have by default Ubuntu builds
we need to be able to update to .deb too.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
