### PR TITLE
improvement(sct_events): add scylla server and boostrap events

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -84,3 +84,5 @@ NodetoolEvent: ERROR
 ScyllaBenchEvent: CRITICAL
 CassandraStressEvent: CRITICAL
 GeminiStressEvent: CRITICAL
+ScyllaServerStatusEvent: NORMAL
+BootstrapEvent: NORMAL

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1338,9 +1338,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 if index not in self._system_log_errors_index or start_from_beginning:
                     ''' for each line, if it matches a continuous event pattern, 
                     call the appropriate function with the class tied to that pattern'''
-                    db_event_pattern_func_map = get_pattern_to_event_to_func_mapping(
-                        event_registry=self.continuous_events_registry,
-                        node=self.ip_address)
+                    db_event_pattern_func_map = get_pattern_to_event_to_func_mapping(node=self.ip_address)
                     for item in db_event_pattern_func_map:
                         event_match = item.pattern.search(line)
                         if event_match:

--- a/sdcm/sct_events/base.py
+++ b/sdcm/sct_events/base.py
@@ -133,7 +133,7 @@ class ContinuousEventsRegistry(metaclass=Singleton):
                              period_type: EventPeriod) -> List[ContinuousEvent]:
         event_filter = self.get_registry_filter()
         found_events = event_filter \
-            .filter_by_period(period_type=period_type) \
+            .filter_by_period(period_type=period_type.value) \
             .get_filtered()
 
         if not found_events:
@@ -353,11 +353,9 @@ class ContinuousEvent(SctEvent, abstract=True):
     _duration: Optional[int] = None
 
     def __init__(self,
-                 node: str = "",
                  severity: Severity = Severity.UNKNOWN,
                  publish_event: bool = True):
         super().__init__(severity=severity)
-        self.node = node
         self.log_file_name = None
         self.errors = []
         self.publish_event = publish_event

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -98,7 +98,7 @@ class TestBaseNode(unittest.TestCase, EventsUtilsMixin):
 
     def test_search_system_log(self):
         critical_errors = list(self.node.follow_system_log(start_from_beginning=True))
-        self.assertEqual(36, len(critical_errors))
+        self.assertEqual(34, len(critical_errors))
 
     def test_search_system_log_specific_log(self):
         errors = list(self.node.follow_system_log(

--- a/unit_tests/test_sct_events_continuous_events_registry.py
+++ b/unit_tests/test_sct_events_continuous_events_registry.py
@@ -33,9 +33,7 @@ class TestContinuousEventsRegistry:
     def populated_registry(self,
                            registry: ContinuousEventsRegistry) -> Generator[ContinuousEventsRegistry, None, None]:
         for _ in range(100):
-            new_nodetool_event = NodetoolEvent(nodetool_command="mock cmd", publish_event=False)
-            new_gemini_event = GeminiStressEvent(node="2323432", cmd="gemini hello", publish_event=False)
-            registry.add_event(random.choice([new_gemini_event, new_nodetool_event]))
+            NodetoolEvent(nodetool_command="mock cmd", publish_event=False)
 
         yield registry
 
@@ -48,13 +46,12 @@ class TestContinuousEventsRegistry:
 
     def test_add_multiple_events(self,
                                  registry: ContinuousEventsRegistry):
+        pre_insertion_item_count = len(registry.continuous_events)
         number_of_insertions = 10
-        for _ in range(number_of_insertions - 1):
-            new_nodetool_event = NodetoolEvent(nodetool_command="mock cmd", publish_event=False)
-            new_gemini_event = GeminiStressEvent(node="2323432", cmd="gemini hello", publish_event=False)
-            registry.add_event(random.choice([new_nodetool_event, new_gemini_event]))
+        for _ in range(number_of_insertions):
+            GeminiStressEvent(node="2323432", cmd="gemini hello", publish_event=False)
 
-        assert len(registry.continuous_events) == number_of_insertions
+        assert pre_insertion_item_count + number_of_insertions == len(registry.continuous_events)
 
     def test_adding_a_non_continuous_event_raises_error(self,
                                                         registry: ContinuousEventsRegistry,
@@ -83,8 +80,8 @@ class TestContinuousEventsRegistry:
     def test_get_events_by_period_type(self,
                                        populated_registry: ContinuousEventsRegistry,
                                        nodetool_stress_event: NodetoolEvent):
-        populated_registry.add_event(nodetool_stress_event)
+        count_of_begun_events_pre = len(populated_registry.get_events_by_period(period_type=EventPeriod.Begin))
         nodetool_stress_event.begin_event()
         found_events = populated_registry.get_events_by_period(period_type=EventPeriod.Begin)
 
-        assert len(found_events) == 1
+        assert len(found_events) == count_of_begun_events_pre + 1

--- a/unit_tests/test_sct_events_database.py
+++ b/unit_tests/test_sct_events_database.py
@@ -39,8 +39,6 @@ class TestDatabaseLogEvent(unittest.TestCase):
         self.assertTrue(issubclass(DatabaseLogEvent.SEGMENTATION, DatabaseLogEvent)),
         self.assertTrue(issubclass(DatabaseLogEvent.INTEGRITY_CHECK, DatabaseLogEvent)),
         self.assertTrue(issubclass(DatabaseLogEvent.REACTOR_STALLED, DatabaseLogEvent)),
-        self.assertTrue(issubclass(DatabaseLogEvent.BOOT, DatabaseLogEvent)),
-        self.assertTrue(issubclass(DatabaseLogEvent.STOP, DatabaseLogEvent)),
         self.assertTrue(issubclass(DatabaseLogEvent.SUPPRESSED_MESSAGES, DatabaseLogEvent)),
         self.assertTrue(issubclass(DatabaseLogEvent.stream_exception, DatabaseLogEvent)),
         self.assertTrue(issubclass(DatabaseLogEvent.POWER_OFF, DatabaseLogEvent)),


### PR DESCRIPTION
Added 2 new types of ContinuousEvents for the start / stop of bootstrapping and start / stop of the Scylla Server. I also modified the base ContinuousEvent class to register a new event in the ContinuousEventRegistry at init time and added the creation of the ContinuousEventRegistry to the BaseNode class.

Trello tasks: https://trello.com/c/IeNjhxSu, https://trello.com/c/NYDtUaH9
Jenkins job with debug logs showing the ContinousEventsRegistry being populated and new events being logged: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/maciej/job/mc-artifacts/job/mc-artifacts-ubuntu-20.04/54/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] ~~I added the relevant `backport` labels~~
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI) (pylint failures only)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
