### PR TITLE
fix(k8s-local*): fix kubectl proxy issue with reuse cluster

### DIFF
--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -101,8 +101,10 @@ class MinimalK8SOps:
         LOCALRUNNER.sudo(f"fuser -v4k {KUBECTL_PROXY_PORT}/tcp", ignore_status=True)
 
         LOGGER.debug("Start kubectl proxy in detached mode")
+        proxy_port = get_free_port(address='127.0.0.1')
         LOCALRUNNER.run(
-            "setsid kubectl proxy --disable-filter --accept-hosts '.*' > proxy.log 2>&1 < /dev/null & sleep 1")
+            f"setsid kubectl proxy --disable-filter --address '127.0.0.1' --port {proxy_port} "
+            "--accept-hosts '.*' > proxy.log 2>&1 < /dev/null & sleep 1")
 
         def get_proxy_ip_port():
             return LOCALRUNNER.run("grep -P '^Starting' proxy.log | grep -oP '127.0.0.1:[0-9]+'").stdout
@@ -116,6 +118,7 @@ class MinimalK8SOps:
         node.remoter.sudo(f"fuser -v4k {KUBECTL_PROXY_PORT}/tcp", ignore_status=True)
 
         LOGGER.debug("Start kubectl proxy in detached mode")
+        node.remoter.run("kill -9 $(ps aux | grep 'kubectl proxy' | awk '{print $2}')", ignore_status=True)
         node.remoter.run(
             "setsid kubectl proxy --disable-filter --accept-hosts '.*' > proxy.log 2>&1 < /dev/null & sleep 1")
 

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1323,9 +1323,9 @@ class version():  # pylint: disable=invalid-name,too-few-public-methods
         return inner
 
 
-def get_free_port():
+def get_free_port(address: str = ''):
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.bind(('', 0))
+    sock.bind((address, 0))
     addr = sock.getsockname()
     port = addr[1]
     sock.close()


### PR DESCRIPTION
https://trello.com/c/CxYG4RQ3/3647-fixfunctional-fix-kubectl-proxy-starting-logic-to-cover-reuse-cluster-case

kubectl can be running from priviouse run when reuse_cluster=1
For remote run it is okay to kill it,
since one node can be used only for one run
While it is not okay for local runs, since it is possible
that kubectl proxy is ran by user for it's purpose.
So for local run let's find free port and feed it to kubectl proxy

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
