### PR TITLE
refactor(manager-upgrade): change base version to 2.4

### DIFF
--- a/jenkins-pipelines/manager/centos-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-upgrade.jenkinsfile
@@ -11,8 +11,8 @@ managerPipeline(
     target_scylla_mgmt_server_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
     target_scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
 
-    scylla_mgmt_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.3.repo',
-    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.3.repo',
+    scylla_mgmt_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.4.repo',
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.4.repo',
     scylla_version: '4.4',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',

--- a/jenkins-pipelines/manager/debian10-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian10-manager-upgrade.jenkinsfile
@@ -11,8 +11,8 @@ managerPipeline(
     target_scylla_mgmt_server_repo: 'http://downloads.scylladb.com/manager/deb/unstable/buster/master/latest/scylladb-manager-master/scylla-manager.list',
     target_scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
 
-    scylla_mgmt_repo: Null,  // no debian 10 build of branch 2.3, nothing to upgrade from
-    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.3.repo',
+    scylla_mgmt_repo: 'http://downloads.scylladb.com/deb/debian/scylladb-manager-2.4-buster.list',
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.4.repo',
     scylla_version: '4.4',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',

--- a/jenkins-pipelines/manager/debian9-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian9-manager-upgrade.jenkinsfile
@@ -11,8 +11,8 @@ managerPipeline(
     target_scylla_mgmt_server_repo: 'http://downloads.scylladb.com/manager/deb/unstable/stretch/master/latest/scylladb-manager-master/scylla-manager.list',
     target_scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
 
-    scylla_mgmt_repo: 'http://downloads.scylladb.com/deb/debian/scylladb-manager-2.3-stretch.list',
-    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.3.repo',
+    scylla_mgmt_repo: 'http://downloads.scylladb.com/deb/debian/scylladb-manager-2.4-stretch.list',
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.4.repo',
     scylla_version: '4.4',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',

--- a/jenkins-pipelines/manager/ubuntu16-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu16-manager-upgrade.jenkinsfile
@@ -11,8 +11,8 @@ managerPipeline(
     target_scylla_mgmt_server_repo: 'http://downloads.scylladb.com/manager/deb/unstable/xenial/master/latest/scylla-manager-master/scylla-manager.list',
     target_scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
 
-    scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-2.3-xenial.list',
-    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.3.repo',
+    scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-2.4-xenial.list',
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.4.repo',
     scylla_version: '4.4',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',

--- a/jenkins-pipelines/manager/ubuntu18-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu18-manager-upgrade.jenkinsfile
@@ -11,8 +11,8 @@ managerPipeline(
     target_scylla_mgmt_server_repo: 'http://downloads.scylladb.com/manager/deb/unstable/xenial/master/latest/scylla-manager-master/scylla-manager.list',
     target_scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
 
-    scylla_mgmt_repo: 'http://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.3-bionic.list',
-    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.3.repo',
+    scylla_mgmt_repo: 'http://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.4-bionic.list',
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.4.repo',
     scylla_version: '4.4',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',

--- a/jenkins-pipelines/manager/ubuntu20-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu20-manager-upgrade.jenkinsfile
@@ -11,8 +11,8 @@ managerPipeline(
     target_scylla_mgmt_server_repo: 'http://downloads.scylladb.com/manager/deb/unstable/focal/master/latest/scylla-manager-master/scylla-manager.list',
     target_scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo',
 
-    scylla_mgmt_repo: Null,  // no ubuntu 20 build of branch 2.3, nothing to upgrade from
-    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.3.repo',
+    scylla_mgmt_repo:'http://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.4-focal.list',
+    scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.4.repo',
     scylla_version: '4.4',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',


### PR DESCRIPTION
Since 2.4 has been released, I changed the base version of manager from 2.3
to 2.4 in all of the upgrade tests.
Also, since there was no 2.3 release for ubuntu 20 and debian 10,
their upgrade tests were disabled. Now that the base version is 2.4, which
has releases for both of those distributions, I enabled their upgrade tests

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
