### PR TITLE
fix(sctlogcollector): Add email_data.json file to sctlog arch

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -400,7 +400,9 @@ class MonitoringStack(BaseMonitoringEntity):
         checked_dashboard_url = "http://{grafana_ip}:{grafana_port}/api/dashboards/db/{uid}"
         try:
             LOGGER.info(
-                "Check dashboard: %s", checked_dashboard_url.format(grafana_ip=grafana_ip, grafana_port=MonitoringStack.grafana_port, uid=uid))
+                "Check dashboard: %s", checked_dashboard_url.format(grafana_ip=grafana_ip,
+                                                                    grafana_port=MonitoringStack.grafana_port,
+                                                                    uid=uid))
             res = requests.get(checked_dashboard_url.format(grafana_ip=grafana_ip,
                                                             grafana_port=MonitoringStack.grafana_port,
                                                             uid=uid))
@@ -780,7 +782,8 @@ class ScyllaLogCollector(LogCollector):
         cluster_log_type {str} -- cluster type name
     """
     log_entities = [FileLog(name='system.log',
-                            command="sudo journalctl --no-tail --no-pager -u scylla-ami-setup.service -u scylla-image-setup.service -u scylla-io-setup.service -u scylla-server.service -u scylla-jmx.service", search_locally=True),
+                            command="sudo journalctl --no-tail --no-pager -u scylla-ami-setup.service -u scylla-image-setup.service "
+                                    "-u scylla-io-setup.service -u scylla-server.service -u scylla-jmx.service", search_locally=True),
                     CommandLog(name='cpu_info',
                                command='cat /proc/cpuinfo'),
                     CommandLog(name='mem_info',

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -400,7 +400,7 @@ class MonitoringStack(BaseMonitoringEntity):
         checked_dashboard_url = "http://{grafana_ip}:{grafana_port}/api/dashboards/db/{uid}"
         try:
             LOGGER.info(
-                "Check dashbaord: %s", checked_dashboard_url.format(grafana_ip=grafana_ip, grafana_port=MonitoringStack.grafana_port, uid=uid))
+                "Check dashboard: %s", checked_dashboard_url.format(grafana_ip=grafana_ip, grafana_port=MonitoringStack.grafana_port, uid=uid))
             res = requests.get(checked_dashboard_url.format(grafana_ip=grafana_ip,
                                                             grafana_port=MonitoringStack.grafana_port,
                                                             uid=uid))
@@ -780,8 +780,7 @@ class ScyllaLogCollector(LogCollector):
         cluster_log_type {str} -- cluster type name
     """
     log_entities = [FileLog(name='system.log',
-                            command="sudo journalctl --no-tail --no-pager -u scylla-ami-setup.service -u scylla-image-setup.service -u scylla-io-setup.service -u scylla-server.service -u scylla-jmx.service",
-                            search_locally=True),
+                            command="sudo journalctl --no-tail --no-pager -u scylla-ami-setup.service -u scylla-image-setup.service -u scylla-io-setup.service -u scylla-server.service -u scylla-jmx.service", search_locally=True),
                     CommandLog(name='cpu_info',
                                command='cat /proc/cpuinfo'),
                     CommandLog(name='mem_info',
@@ -898,6 +897,8 @@ class SCTLogCollector(LogCollector):
         FileLog(name='profile.stats',
                 search_locally=True),
         FileLog(name='sct.log',
+                search_locally=True),
+        FileLog(name='email_data.json',
                 search_locally=True),
         FileLog(name='left_processes.log',
                 search_locally=True),

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2613,7 +2613,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                                       send_email=self.params.get('send_email'),
                                                       email_recipients=self.params.get('email_recipients'),
                                                       events=get_events_grouped_by_category(
-                                                          _registry=self.events_processes_registry, limit=self.params.get('events_limit_in_email'))
+                                                          _registry=self.events_processes_registry,
+                                                          limit=self.params.get('events_limit_in_email'))
                                                       )
         is_gce = bool(self.params.get('cluster_backend') == 'gce')
         try:
@@ -2628,7 +2629,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                                       send_email=self.params.get('send_email'),
                                                       email_recipients=self.params.get('email_recipients'),
                                                       events=get_events_grouped_by_category(
-                                                          _registry=self.events_processes_registry, limit=self.params.get('events_limit_in_email'))
+                                                          _registry=self.events_processes_registry,
+                                                          limit=self.params.get('events_limit_in_email'))
                                                       )
         is_gce = bool(self.params.get('cluster_backend') == 'gce')
         try:
@@ -2645,7 +2647,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                                       send_email=self.params.get('send_email'),
                                                       email_recipients=self.params.get('email_recipients'),
                                                       events=get_events_grouped_by_category(
-                                                          _registry=self.events_processes_registry, limit=self.params.get('events_limit_in_email'))
+                                                          _registry=self.events_processes_registry,
+                                                          limit=self.params.get('events_limit_in_email'))
                                                       )
         if email_subject is None:
             email_subject = ('Performance Regression Compare Results - {test.test_name} - '
@@ -2916,6 +2919,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         if email_data:
             email_data["reporter"] = self.email_reporter.__class__.__name__
             self.log.debug('Save email data to file %s', json_file_path)
+            self.log.debug('Email data: %s', email_data)
             save_email_data_to_file(email_data, json_file_path)
 
     @silence()


### PR DESCRIPTION
during job scylla-master/longevity-200gb-48h/126/
email_data.json file was not saved correctly due to
error:
t:2021-07-11 04:34:51,531 f:send_email.py l:643 c:sdcm.send_email
 p:WARNING > Error during collecting data for email Circular reference detected
And when this file was read durin email_send stage it failed with error:
 t:2021-07-11 04:34:51,742 f:send_email.py l:625 c:sdcm.send_email p:WARNING >
 Error during read email data file /home/ubuntu/sct-results/20210709-030744-525604/email_data.json:
Expecting value: line 1 column 97262 (char 97261)

the main error happened during dumping email_data object to json file:
json.dump(email_data, json_file)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
