### PR TITLE
fix(k8s-minikube): install prerequisites correctly

### DIFF
--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -192,7 +192,7 @@ class KindK8sMixin:
         kind create cluster --config /tmp/kind.cluster.yaml
         SERVICE_GATEWAY=`docker inspect kind-control-plane -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}'`
         ip ro add 10.96.0.0/16 via $SERVICE_GATEWAY || ip ro change 10.96.0.0/16 via $SERVICE_GATEWAY
-        ip ro add 10.224.0.0/16 via $SERVICE_GATEWAY || ip ro change 10.224.0.0/16 via $SERVICE_GATEWAY 
+        ip ro add 10.224.0.0/16 via $SERVICE_GATEWAY || ip ro change 10.224.0.0/16 via $SERVICE_GATEWAY
         """)
         self.host_node.remoter.run(f"sudo -E bash -cxe '{script}'")
 
@@ -259,7 +259,7 @@ class MinikubeK8sMixin:
             self.host_node.remoter.run(f'minikube image load {self.scylla_image}', ignore_status=True)
 
 
-class MinimalClusterBase(KubernetesCluster, metaclass=abc.ABCMeta):
+class MinimalClusterBase(KubernetesCluster, metaclass=abc.ABCMeta):  # pylint: disable=too-many-public-methods
     # pylint: disable=too-many-arguments
     def __init__(self, mini_k8s_version, params: dict, user_prefix: str = '', region_name: str = None,
                  cluster_uuid: str = None, **_):
@@ -403,7 +403,7 @@ class MinimalClusterBase(KubernetesCluster, metaclass=abc.ABCMeta):
         docker_repo = self.params.get('docker_image')
         scylla_version = self.params.get('scylla_version')
         if not scylla_version or not docker_repo:
-            return
+            return ""
         return f"{docker_repo}:{scylla_version}"
 
     def deploy(self):
@@ -556,7 +556,7 @@ class GceMinikubeCluster(MinikubeK8sMixin, RemoteMinimalClusterBase, cluster_gce
         pass
 
 
-class LocalMinimalScyllaPodContainer(BaseScyllaPodContainer):
+class LocalMinimalScyllaPodContainer(BaseScyllaPodContainer):  # pylint: disable=abstract-method
     public_ip_via_service: bool = False
     parent_cluster: 'LocalMinimalScyllaPodCluster'
 
@@ -583,7 +583,7 @@ class LocalMinimalScyllaPodContainer(BaseScyllaPodContainer):
 
 
 # pylint: disable=too-many-ancestors
-class RemoteMinimalScyllaPodContainer(LocalMinimalScyllaPodContainer, IptablesPodPortsRedirectMixin):
+class RemoteMinimalScyllaPodContainer(LocalMinimalScyllaPodContainer, IptablesPodPortsRedirectMixin):  # pylint: disable=abstract-method
     parent_cluster: 'RemoteMinimalScyllaPodCluster'
     public_ip_via_service: bool = False
 


### PR DESCRIPTION
Do following fixes:
- Separate docker installation from other prerequisites installation such as installation fo required 'conntrack' package.
- Add creation of /etc/ssh/ssh_host_ecdsa_key if it is absent. It is needed at least for the minikube and installation of scylla for manager service.
- Remove usage of 'change_context=True' arg in 'node.remoter.sudo()' method, because it just doesn't have it.
  'LocalCmdRunner' class is different than the one used for remote sudo calls.
  Error that exists not fixing it:
    
      TypeError: sudo() got an unexpected keyword argument 'change_context'
    
  This error happens when some prerequisite is not installed.
  So, local K8S works for people who already have correct requirements setting.
- Add also possibility to run tests on 'debian', not only 'ubuntu'. Prerequisites code must work on both.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
