### PR TITLE
fix(nodetool): prevent reporting event as error if it should be warning

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2627,15 +2627,16 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 nodetool_event.duration = result.duration
                 return result
             except Exception as details:  # pylint: disable=broad-except
-                if warning_event_on_exception and isinstance(details, warning_event_on_exception):
-                    nodetool_event.severity = Severity.WARNING
-
                 if coredump_on_timeout and isinstance(details, CommandTimedOut):
                     self.generate_coredump_file()
 
                 nodetool_event.add_error([f"{error_message}{str(details)}"])
                 nodetool_event.full_traceback = traceback.format_exc()
-                raise
+
+                if warning_event_on_exception and isinstance(details, warning_event_on_exception):
+                    nodetool_event.severity = Severity.WARNING
+                else:
+                    raise
 
     def check_node_health(self, retries: int = CHECK_NODE_HEALTH_RETRIES) -> None:
         # Task 1443: ClusterHealthCheck is bottle neck in scale test and create a lot of noise in 5000 tables test.


### PR DESCRIPTION
If exception happens during nodetool run and this exception is expected (exception type is in
warning_event_on_exception parameter value), this event should be WARNING and the exception
should not be raised to prevent catching it in the '__exit__' and changing severity to ERROR.
Actually in this case the exception has no value for the test.

Example when expected failure was reported as ERROR and failed the test
(disrupt_repair_streaming_err nemesis nemesis):
https://jenkins.scylladb.com/job/scylla-master/job/gemini-/job/gemini-3h-with-nemesis-test/240

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
