### PR TITLE
fix(test_listen_address): one error reported twice

### DIFF
--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -145,7 +145,7 @@ def test_listen_address(db_cluster):
             listen_address = scylla_yaml.get('listen_address')
             if not listen_address:
                 all_errors.append(f"Not found listen_address flag in the {node.name} scylla.yaml")
-            if listen_address != '0.0.0.0':
+            elif listen_address != '0.0.0.0':
                 all_errors.append(f'Node {node.name} has wrong listen_address "{listen_address}" in scylla.yaml')
 
     assert not all_errors, "Following errors found:\n{'\n'.join(errors)}"


### PR DESCRIPTION
https://trello.com/c/cwiO3WH9/3662-fixtestlistenaddress-one-error-reported-twice

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
