### PR TITLE
fix(longevity-5000-tables): increase timeout

### DIFF
--- a/test-cases/longevity/longevity-5000-tables.yaml
+++ b/test-cases/longevity/longevity-5000-tables.yaml
@@ -1,4 +1,4 @@
-test_duration: 1500
+test_duration: 2160
 
 cs_duration: '55m'
 cs_user_profiles:


### PR DESCRIPTION
in https://github.com/scylladb/scylla-cluster-tests/pull/3643 the number
of cmds in batch was decreased by 2 but timeout less, this caused the job
to be aborted since not all c-s commands have time to finish.

![image](https://user-images.githubusercontent.com/5269241/125941922-90029163-3103-44d8-8f70-91c597c79cb5.png)



## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
