### PR TITLE
fix(kubeconfig): use kubeconfig from single path

### DIFF
--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -216,6 +216,7 @@ class EksCluster(KubernetesCluster, EksClusterCleanupMixin):
     short_cluster_name: str
 
     def __init__(self,
+                 kubeconfig_filepath,
                  eks_cluster_version,
                  ec2_security_group_ids,
                  ec2_subnet_ids,
@@ -229,7 +230,12 @@ class EksCluster(KubernetesCluster, EksClusterCleanupMixin):
                  cluster_uuid=None,
                  region_name=None
                  ):
-        super().__init__(user_prefix=user_prefix, cluster_uuid=cluster_uuid, region_name=region_name, params=params)
+        super().__init__(
+            kubeconfig_filepath=kubeconfig_filepath,
+            user_prefix=user_prefix,
+            cluster_uuid=cluster_uuid,
+            region_name=region_name,
+            params=params)
         self.credentials = credentials
         self.eks_cluster_version = eks_cluster_version
         self.ec2_role_arn = ec2_role_arn

--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -145,6 +145,7 @@ class GkeCluster(KubernetesCluster):
     pools: Dict[str, GkeNodePool]
 
     def __init__(self,
+                 kubeconfig_filepath,
                  gke_cluster_version,
                  gke_k8s_release_channel,
                  gce_image_type,
@@ -159,6 +160,7 @@ class GkeCluster(KubernetesCluster):
                  n_nodes=1
                  ):
         super().__init__(
+            kubeconfig_filepath=kubeconfig_filepath,
             params=params,
             cluster_uuid=cluster_uuid,
             user_prefix=user_prefix

--- a/sdcm/localhost.py
+++ b/sdcm/localhost.py
@@ -26,11 +26,14 @@ LOGGER = logging.getLogger(__name__)
 
 
 class LocalHost(RSyslogContainerMixin, GcloudContainerMixin, HelmContainerMixin, LdapContainerMixin):
-    def __init__(self, user_prefix: Optional[str] = None, test_id: Optional[str] = None) -> None:
+    def __init__(self, user_prefix: Optional[str] = None, test_id: Optional[str] = None,
+                 kubeconfig_filepath: Optional[str] = None) -> None:
         self._containers = {}
         self.tags = {}
         self.name = (f"{user_prefix}-" if user_prefix else "") + "localhost" + (f"-{test_id}" if test_id else "")
         self.rsyslog_confpath = generate_rsyslog_conf_file()
+        self.kubeconfig_filepath = kubeconfig_filepath or os.path.expanduser(
+            os.environ.get('KUBECONFIG', '~/.kube/config'))
 
     @property
     def rsyslog_port(self) -> Optional[int]:

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -374,7 +374,11 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         return thread
 
     def _init_localhost(self):
-        return LocalHost(user_prefix=self.params.get("user_prefix"), test_id=TestConfig.test_id())
+        return LocalHost(
+            user_prefix=self.params.get("user_prefix"),
+            test_id=TestConfig.test_id(),
+            kubectl_config_path=self.kubectl_config_path,
+        )
 
     def _move_kubectl_config(self):
         secure_mode = stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR
@@ -1055,7 +1059,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         assert len(services) == 1, "Doesn't support multi DC setup for `k8s-gke' backend"
 
         services, gce_datacenter = list(services.values()), list(services.keys())
-        self.k8s_cluster = gke.GkeCluster(gke_cluster_version=self.params.get("gke_cluster_version"),
+        self.k8s_cluster = gke.GkeCluster(kubeconfig_filepath=self.kubectl_config_path,
+                                          gke_cluster_version=self.params.get("gke_cluster_version"),
                                           gke_k8s_release_channel=self.params.get("gke_k8s_release_channel"),
                                           gce_image_type=self.params.get("gce_root_disk_type_db"),
                                           gce_image_size=self.params.get("gce_root_disk_size_db"),
@@ -1178,7 +1183,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         init_db_info_from_params(db_info, params=self.params, regions=regions)
         init_monitoring_info_from_params(monitor_info, params=self.params, regions=regions)
 
-        self.k8s_cluster = eks.EksCluster(eks_cluster_version=self.params.get("eks_cluster_version"),
+        self.k8s_cluster = eks.EksCluster(kubeconfig_filepath=self.kubectl_config_path,
+                                          eks_cluster_version=self.params.get("eks_cluster_version"),
                                           ec2_security_group_ids=ec2_security_group_ids,
                                           ec2_subnet_ids=ec2_subnet_ids,
                                           credentials=self.credentials,

--- a/sdcm/utils/gce_utils.py
+++ b/sdcm/utils/gce_utils.py
@@ -109,8 +109,7 @@ class GcloudContainerMixin:
     _gcloud_container_instance = None
 
     def gcloud_container_run_args(self) -> dict:
-        kube_config_path = os.environ.get('KUBECONFIG', '~/.kube/config')
-        kube_config_dir_path = os.path.expanduser(kube_config_path)
+        kube_config_dir_path = os.path.expanduser(self.kubeconfig_filepath)
         volumes = {
             os.path.dirname(kube_config_dir_path): {"bind": os.path.dirname(kube_config_dir_path), "mode": "rw"},
         }
@@ -121,7 +120,7 @@ class GcloudContainerMixin:
                     volumes=volumes,
                     user=f"{os.getuid()}:{os.getgid()}",
                     tmpfs={'/.config': f'size=50M,uid={os.getuid()}'},
-                    environment={'KUBECONFIG': kube_config_path},
+                    environment={'KUBECONFIG': self.kubeconfig_filepath},
                     )
 
     def _get_gcloud_container(self) -> Container:

--- a/sdcm/utils/k8s.py
+++ b/sdcm/utils/k8s.py
@@ -385,7 +385,7 @@ class KubernetesOps:  # pylint: disable=too-many-public-methods
             k8s_configuration.host = kluster.k8s_server_url
         else:
             k8s.config.load_kube_config(
-                config_file=os.path.expanduser(os.environ.get('KUBECONFIG', '~/.kube/config')),
+                config_file=kluster.kubeconfig_filepath,
                 client_configuration=k8s_configuration)
         return k8s_configuration
 
@@ -609,8 +609,7 @@ class KubernetesOps:  # pylint: disable=too-many-public-methods
 
 class HelmContainerMixin:
     def helm_container_run_args(self) -> dict:
-        kube_config_path = os.environ.get('KUBECONFIG', '~/.kube/config')
-        kube_config_dir_path = os.path.expanduser(kube_config_path)
+        kube_config_dir_path = os.path.expanduser(self.kubeconfig_filepath)
         helm_config_path = os.path.expanduser(os.environ.get('HELM_CONFIG_HOME', '~/.helm'))
         volumes = {
             os.path.dirname(kube_config_dir_path): {"bind": os.path.dirname(kube_config_dir_path), "mode": "rw"},
@@ -624,7 +623,7 @@ class HelmContainerMixin:
                     name=f"{self.name}-helm",
                     network_mode="host",
                     volumes=volumes,
-                    environment={'KUBECONFIG': kube_config_path},
+                    environment={'KUBECONFIG': self.kubeconfig_filepath},
                     )
 
     @cached_property


### PR DESCRIPTION
We happen to catch race when KUBECONFIG env var is not set
and we pick up improper default path at '~/.kube/config'.
Proper path is located in the logdir for concrete test run.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
