### PR TITLE
fix(logcollector): remove collect_single_archive

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -67,7 +67,6 @@ email_recipients: ['qa@scylladb.com']
 email_subject_postfix: ''
 
 collect_logs: false
-collect_single_archive: false
 
 hinted_handoff: 'enabled'
 

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -276,4 +276,3 @@
 | **<a href="#user-content-max_events_severities" name="max_events_severities">max_events_severities</a>**  | Limit severity level for event types | N/A | SCT_MAX_EVENTS_SEVERITIES
 | **<a href="#user-content-scylla_rsyslog_setup" name="scylla_rsyslog_setup">scylla_rsyslog_setup</a>**  | Configure rsyslog on scylla nodes to send logs to monitoring nodes | False | SCT_SCYLLA_RSYSLOG_SETUP
 | **<a href="#user-content-events_limit_in_email" name="events_limit_in_email">events_limit_in_email</a>**  | Limit number events in email reports | False | SCT_EVENTS_LIMIT_IN_EMAIL
-| **<a href="#user-content-collect_single_archive" name="collect_single_archive">collect_single_archive</a>**  | Collect all logs to a single archive | False | SCT_COLLECT_SINGLE_ARCHIVE

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -954,12 +954,27 @@ class SCTLogCollector(LogCollector):
                 LOGGER.warning('Nothing found')
                 return []
 
-        if self.params.get("collect_single_archive"):
+        if self.is_collect_to_a_single_archive:
             s3_links = self.create_single_archive_and_upload()
         else:
+            LOGGER.info("SCT log files are too big, uploading them separately")
             s3_links = self.create_achive_per_file_and_upload()
 
         return s3_links
+
+    def get_files_size(self) -> int:
+        total_size = 0
+        for dirpath, dirnames, filenames in os.walk(self.local_dir):
+            for filename in filenames:
+                filepath = os.path.join(dirpath, filename)
+                # skip if it is symbolic link
+                if not os.path.islink(filepath):
+                    total_size += os.path.getsize(filepath)
+        return total_size
+
+    @property
+    def is_collect_to_a_single_archive(self) -> bool:
+        return self.get_files_size() < 3*1024*1024*1024
 
     def create_single_archive_and_upload(self) -> list[str]:
         final_archive = self.archive_to_tarfile(self.local_dir)

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1143,9 +1143,7 @@ class SCTConfiguration(dict):
              help="Configure rsyslog on Scylla nodes to send logs to monitoring nodes"),
 
         dict(name="events_limit_in_email", env="SCT_EVENTS_LIMIT_IN_EMAIL", type=int,
-             help="Limit number events in email reports"),
-        dict(name="collect_single_archive", env="SCT_COLLECT_SINGLE_ARCHIVE", type=boolean,
-             help="Collect all logs to a single archive"),
+             help="Limit number events in email reports")
     ]
 
     required_params = ['cluster_backend', 'test_duration', 'n_db_nodes', 'n_loaders', 'use_preinstalled_scylla',


### PR DESCRIPTION
https://trello.com/c/8aJ6BXmR/3673

PR: https://github.com/scylladb/scylla-cluster-tests/pull/3734
itroduced collect_single_archive to collect sct logs files by file
this makes sense only if sct files are too big.
Let's remove the option and just check weather sct log files are
 big enough to turn such behavior on.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
