### PR TITLE
fix(logcollector.py): Fixing collect logs for Sirenada run

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1125,8 +1125,9 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
             except ImportError:
                 LOGGER.error("Couldn't collect Siren manager logs, cluster_cloud module isn't installed")
             else:
-                instance = get_manager_instance_by_cluster_id(cluster_id=self.params["cloud_cluster_id"],
-                                                              region_name=self.params["region_name"][0])
+                instance = get_manager_instance_by_cluster_id(
+                    cluster_id=self.params["cloud_cluster_id"], region_name=self.params["region_name"][0],
+                    manager_id=self.params["cloud_manager_id"])
                 name = [tag["Value"]
                         for tag in instance["Tags"] if tag["Key"] == "Name"]
                 self.siren_manager_set.append(CollectingNode(name=name[0],


### PR DESCRIPTION
* Trello: https://trello.com/c/5w9nGofd/3688-sct-collect-longevity-run-failed-because-manager-resource-does-not-found

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
