### PR TITLE
test(functional tests): change specs while rollout restart

### DIFF
--- a/functional_tests/scylla_operator/libs/helpers.py
+++ b/functional_tests/scylla_operator/libs/helpers.py
@@ -12,7 +12,10 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2021 ScyllaDB
-from sdcm.cluster_k8s import SCYLLA_NAMESPACE
+# pylint: disable=import-error
+import yaml
+
+from sdcm.cluster_k8s import SCYLLA_NAMESPACE, SCYLLA_OPERATOR_NAMESPACE, ScyllaPodCluster
 
 
 def get_orphaned_services(db_cluster):
@@ -32,3 +35,33 @@ def scylla_services_names(db_cluster):
     services = db_cluster.k8s_cluster.kubectl(f"get svc -n {SCYLLA_NAMESPACE} -l scylla/cluster=sct-cluster "
                                               f"-o=custom-columns='NAME:.metadata.name'")
     return [name for name in services.stdout.split() if name not in ('NAME', 'sct-cluster-client')]
+
+
+def rollout_restart(db_cluster: ScyllaPodCluster, namespace: str, deployment: str = None):
+    db_cluster.k8s_cluster.kubectl(f"rollout restart deployment -n {namespace} {deployment if deployment else ''}")
+
+
+def scylla_operator_rollout_restart(db_cluster: ScyllaPodCluster):
+    rollout_restart(db_cluster, namespace=SCYLLA_OPERATOR_NAMESPACE)
+
+
+def get_deployment_rollout_status(db_cluster: ScyllaPodCluster, namespace: str, deployment: str, timeout: str):
+    return db_cluster.k8s_cluster.kubectl(f"rollout status deployment -n {namespace} {deployment} --timeout={timeout}")
+
+
+def wait_for_scylla_operator_rollout_complete(db_cluster: ScyllaPodCluster, timeout: str = '60s'):
+    status = []
+    for deployment in ['scylla-operator', 'webhook-server']:
+        deployment_rollout_status = get_deployment_rollout_status(db_cluster, namespace=SCYLLA_OPERATOR_NAMESPACE,
+                                                                  deployment=deployment, timeout=timeout)
+        if f"deployment \"{deployment}\" successfully rolled out" not in deployment_rollout_status.stdout:
+            status.append(f"{deployment}: {deployment_rollout_status.stdout}")
+    return status
+
+
+def scylla_operator_pods_and_statuses(db_cluster):
+    pods = db_cluster.k8s_cluster.kubectl(f"get pods -n {SCYLLA_OPERATOR_NAMESPACE} "
+                                          f"-l app.kubernetes.io/instance=scylla-operator "
+                                          f"-o=custom-columns='NAME:.metadata.name,STATUS:.status.phase' -o yaml")
+
+    return [[pod["metadata"]["name"], pod["status"]["phase"]] for pod in yaml.load(pods.stdout)["items"] if pod]


### PR DESCRIPTION
Issue: https://github.com/scylladb/scylla-operator/issues/410

Add the test validates that update ScyllaCluster CRD succeeds during rollout of the operator

Task:
https://trello.com/c/tLWEAEUg/3575-check-that-scylla-operator-has-2-replicas-with-leader-election

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
