### PR TITLE
improvement(sct_events): jmx event

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -90,3 +90,4 @@ GeminiStressEvent: CRITICAL
 ScyllaServerStatusEvent: NORMAL
 BootstrapEvent: NORMAL
 RepairEvent: NORMAL
+JMXServiceEvent: NORMAL

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -265,10 +265,19 @@ class RepairEvent(ScyllaDatabaseContinuousEvent):
         super().__init__(node=node, shard=shard, severity=severity)
 
 
+class JMXServiceEvent(ScyllaDatabaseContinuousEvent):
+    begin_pattern = r'Started Scylla JMX'
+    end_pattern = r'JMX is enabled to receive remote connections on port: \d+'
+
+    def __init__(self, node: str, severity=Severity.NORMAL, **__):
+        super().__init__(node=node, severity=severity)
+
+
 SCYLLA_DATABASE_CONTINUOUS_EVENTS = [
     ScyllaServerStatusEvent,
     BootstrapEvent,
-    RepairEvent
+    RepairEvent,
+    JMXServiceEvent
 ]
 
 


### PR DESCRIPTION
We want the JMX service start and end to be logged as a continuous event. This PR introduces a JMXServiceEvent that does just that, using the previously added ScyllaDatabaseContinuousEvent class.

Example log lines:
```
[2021-07-23T15:10:24.463Z] < t:2021-07-23 15:10:23,836 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  > 2021-07-23 15:10:23.829: (JMXServiceEvent Severity.NORMAL) period_type=begin event_id=06c887a5-543c-427a-a9c8-307d1a39fb67 node=artifacts-ubuntu2004-jenkins-db-node-db08c5ed-0-1
[2021-07-23T15:10:24.463Z] < t:2021-07-23 15:10:23,865 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  > 2021-07-23 15:10:23.862: (JMXServiceEvent Severity.NORMAL) period_type=end event_id=06c887a5-543c-427a-a9c8-307d1a39fb67 duration=0s node=artifacts-ubuntu2004-jenkins-db-node-db08c5ed-0-1
```

Trello task: https://trello.com/c/fNlICfjH
Example jenkins run with events logged: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/maciej/job/mc-artifacts/job/mc-artifacts-ubuntu-20.04/59/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
