### PR TITLE
revert(logcollector.py): Disable cloud manager log collection

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1119,7 +1119,9 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
                                                    instance=instance,
                                                    global_ip=instance['PublicIpAddress'],
                                                    tags={**self.tags, "NodeType": "monitor", }))
-        if self.params["use_cloud_manager"]:
+        # Temporarily disabling cloud-manager logs collection
+        # due to: https://github.com/scylladb/scylla-cluster-tests/issues/3816
+        if self.params["use_cloud_manager"] and False:  # pylint: disable=condition-evals-to-constant
             try:
                 from cluster_cloud import get_manager_instance_by_cluster_id  # pylint: disable=import-outside-toplevel
             except ImportError:


### PR DESCRIPTION
	due to: https://github.com/scylladb/scylla-cluster-tests/issues/3816

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
