### PR TITLE
fix(mgmt/cli.py): Remove unneeded manager backup command stderr check

### DIFF
--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -436,17 +436,6 @@ class ManagerCluster(ScyllaManagerBase):
         if legacy_args:
             cmd += f" {legacy_args}"
         res = self.sctool.run(cmd=cmd, parse_table_res=False)
-        if not res.stdout:
-            raise ScyllaManagerError("Unknown failure for sctool '{}' command".format(cmd))
-
-        if res.stderr:
-            # We are ignoring "unable to resolve host" messages as they are being show on every command, because
-            # we had issues changing Ubuntu machines hostname.
-            if res.stderr.count('unable to resolve host'):
-                pass
-            else:
-                LOGGER.debug("Encountered an error on '{}' command response".format(cmd))
-                raise ScyllaManagerError(res.stderr)
 
         task_id = res.stdout.strip()
         LOGGER.debug("Created task id is: {}".format(task_id))


### PR DESCRIPTION
	fixes: https://github.com/scylladb/scylla-cluster-tests/issues/3818
	When running sdcm.nemesis.MgmtBackup with cloud manager it doesn't have
	the awkward meaningless stderr as in original manager.
	it is needless to check and raise for this if stdout returns the expected value -
	that's just manager design.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
