### PR TITLE
improvement(cloud nemesis): a list for cloud_limited_chaos_monkey

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3387,17 +3387,20 @@ class LimitedChaosMonkey(Nemesis):
         self.call_random_disrupt_method(disrupt_methods=self.disrupt_methods_list)
 
 
+CLOUD_LIMITED_CHAOS_MONKEY = ['disrupt_nodetool_cleanup',
+                              'disrupt_nodetool_drain', 'disrupt_nodetool_refresh',
+                              'disrupt_stop_start_scylla_server', 'disrupt_major_compaction',
+                              'disrupt_modify_table', 'disrupt_nodetool_enospc',
+                              'disrupt_stop_wait_start_scylla_server',
+                              'disrupt_soft_reboot_node',
+                              'disrupt_truncate']
+
+
 class ScyllaCloudLimitedChaosMonkey(Nemesis):
 
     def disrupt(self):
         # Limit the nemesis scope to only one relevant to scylla cloud, where we defined we don't have AWS api access:
-        self.call_random_disrupt_method(disrupt_methods=['disrupt_nodetool_cleanup',
-                                                         'disrupt_nodetool_drain', 'disrupt_nodetool_refresh',
-                                                         'disrupt_stop_start_scylla_server', 'disrupt_major_compaction',
-                                                         'disrupt_modify_table', 'disrupt_nodetool_enospc',
-                                                         'disrupt_stop_wait_start_scylla_server',
-                                                         'disrupt_soft_reboot_node',
-                                                         'disrupt_truncate'])
+        self.call_random_disrupt_method(disrupt_methods=CLOUD_LIMITED_CHAOS_MONKEY)
 
 
 class AllMonkey(Nemesis):


### PR DESCRIPTION
	Create a separate nemesis list for cloud_limited_chaos_monkey.
	used in siren-tests new CloudLimitedChaosAndOperationsMonkey.
The siren-tests part of this PR is: https://github.com/scylladb/siren-tests/pull/656
Trello: https://trello.com/c/6K3yRaoX
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
