### PR TITLE
fix(hydra.sh): add sct arguments

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -21,6 +21,8 @@ export GIT_USER_EMAIL=$(git config --get user.email)
 
 # Hydra arguments parsing
 
+SCT_ARGUMENTS=()
+
 while [[ $# -gt 0 ]]; do
     case $1 in
         --execute-on-runner)
@@ -30,6 +32,16 @@ while [[ $# -gt 0 ]]; do
             ;;
         --dry-run-hydra)
             HYDRA_DRY_RUN="1"
+            shift
+            ;;
+        --install-package-from-directory)
+            SCT_ARGUMENTS+=("$1")
+            SCT_ARGUMENTS+=("$2")
+            shift
+            shift
+            ;;
+        --install-bash-completion)
+            SCT_ARGUMENTS+=("$1")
             shift
             ;;
         -*|--*)
@@ -285,7 +297,7 @@ COMMAND=${HYDRA_COMMAND[0]}
 if [[ "$COMMAND" == *'bash'* ]] || [[ "$COMMAND" == *'python'* ]]; then
     CMD=${HYDRA_COMMAND[@]}
 else
-    CMD="./sct.py ${HYDRA_COMMAND[@]}"
+    CMD="./sct.py ${SCT_ARGUMENTS[@]} ${HYDRA_COMMAND[@]}"
 fi
 
 run_in_docker "${CMD}" "${DOCKER_HOST}"


### PR DESCRIPTION
siren-test uses sct arguments in it's pipelines, currently
hydra fail to recognize them and throw an error, as result
siren pipelines are failing.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
