### PR TITLE
refactor(TestConfig): convert to Singleton

### DIFF
--- a/sdcm/sct_events/base.py
+++ b/sdcm/sct_events/base.py
@@ -38,19 +38,11 @@ from dateutil.relativedelta import relativedelta
 from sdcm import sct_abs_path
 from sdcm.sct_events import Severity, SctEventProtocol
 from sdcm.sct_events.events_processes import EventsProcessesRegistry
+from sdcm.utils.metaclasses import Singleton
 
 DEFAULT_SEVERITIES = sct_abs_path("defaults/severities.yaml")
 
 LOGGER = logging.getLogger(__name__)
-
-
-class Singleton(type):
-    _instances = {}
-
-    def __call__(cls, *args, **kwargs):
-        if cls not in cls._instances:
-            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
-        return cls._instances[cls]
 
 
 class ContinuousRegistryFilter:

--- a/sdcm/test_config.py
+++ b/sdcm/test_config.py
@@ -12,12 +12,13 @@ from sdcm.utils.decorators import retrying
 from sdcm.utils.docker_utils import ContainerManager
 from sdcm.utils.get_username import get_username
 from sdcm.utils.ldap import LdapServerNotReady
+from sdcm.utils.metaclasses import Singleton
 
 
 LOGGER = logging.getLogger(__name__)
 
 
-class TestConfig:  # pylint: disable=too-many-public-methods
+class TestConfig(metaclass=Singleton):  # pylint: disable=too-many-public-methods
     TEST_DURATION = 60
     RSYSLOG_SSH_TUNNEL_LOCAL_PORT = 5000
     IP_SSH_CONNECTIONS = 'private'

--- a/sdcm/utils/metaclasses.py
+++ b/sdcm/utils/metaclasses.py
@@ -1,0 +1,21 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2021 ScyllaDB
+
+
+class Singleton(type):
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super().__call__(*args, **kwargs)
+        return cls._instances[cls]


### PR DESCRIPTION
Moving the Singleton metaclass definition to `sdcm/utils/common.py` and making TestConfig be a singleton class (since we don't want to have at most one instance of the test config at a given time).

Trello task: https://trello.com/c/BvTku0Iq
Example Jenkins run: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/maciej/job/mc-longevity/job/mc-byo-longevity-test-2/2/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
