### PR TITLE
improvement(sct): remove runner on test success

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -52,6 +52,7 @@ from sdcm.cluster import TestConfig
 from sdcm.utils.log import setup_stdout_logger
 from sdcm.utils.prepare_region import AwsRegion
 from sdcm.utils.get_username import get_username
+from sdcm.send_email import get_running_instances_for_email_report, read_email_data_from_file, build_reporter
 from utils.build_system.create_test_release_jobs import JenkinsPipelines
 
 LOGGER = setup_stdout_logger()
@@ -836,19 +837,20 @@ def collect_logs(test_id=None, logdir=None, backend=None, config_file=None):
     click.echo(table.get_string(title="Collected logs by test-id: {}".format(collector.test_id)))
 
 
+# pylint: disable=too-many-arguments,too-many-branches
 @cli.command('send-email', help='Send email with results for testrun')
 @click.option('--test-id', help='Test-id of run')
 @click.option('--test-status', help='Override test status FAILED|ABORTED')
 @click.option('--start-time', help='Override test start time')
 @click.option('--started-by', help='Default user that started the test')
+@click.option('--runner-ip', type=str, required=False, help="Sct runner ip for the running test")
 @click.option('--email-recipients', help="Send email to next recipients")
 @click.option('--logdir', help='Directory where to find testrun folder')
-def send_email(test_id=None, test_status=None, start_time=None, started_by=None, email_recipients=None, logdir=None):  # pylint: disable=too-many-arguments,too-many-branches
+def send_email(test_id=None, test_status=None, start_time=None, started_by=None, runner_ip=None,
+               email_recipients=None, logdir=None):
     if started_by is None:
         started_by = get_username()
     add_file_logger()
-
-    from sdcm.send_email import get_running_instances_for_email_report, read_email_data_from_file, build_reporter  # pylint: disable=import-outside-toplevel
 
     if not email_recipients:
         LOGGER.warning("No email recipients. Email will not be sent")
@@ -872,7 +874,7 @@ def send_email(test_id=None, test_status=None, start_time=None, started_by=None,
 
     if test_results:
         reporter = test_results.get("reporter", "")
-        test_results['nodes'] = get_running_instances_for_email_report(test_id)
+        test_results['nodes'] = get_running_instances_for_email_report(test_id, runner_ip)
     else:
         LOGGER.warning("Failed to read test results for %s", test_id)
         reporter = "TestAborted"
@@ -894,7 +896,7 @@ def send_email(test_id=None, test_status=None, start_time=None, started_by=None,
         if test_id:
             test_results.update({
                 "test_id": test_id,
-                "nodes": get_running_instances_for_email_report(test_id)
+                "nodes": get_running_instances_for_email_report(test_id, runner_ip)
             })
     test_results['logs_links'] = list_logs_by_test_id(test_results.get('test_id', test_id))
     email_recipients = email_recipients.split(',')
@@ -1100,9 +1102,11 @@ def create_runner_instance(cloud_provider, region, availability_zone, test_id, d
 
 
 @cli.command("clean-runner-instances", help="Clean all unused SCT runner instances")
-def clean_runner_instances():
+@click.option("-ts", "--test-status", required=False, type=str, default="FAILED")
+@click.option("-ip", "--runner-ip", required=False, type=str, default="")
+def clean_runner_instances(test_status: str = None, runner_ip: str = None):
     add_file_logger()
-    clean_sct_runners()
+    clean_sct_runners(test_status=test_status, test_runner_ip=runner_ip)
 
 
 if __name__ == '__main__':

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -58,9 +58,10 @@ from mypy_boto3_ec2 import EC2Client, EC2ServiceResource
 import docker  # pylint: disable=wrong-import-order; false warning because of docker import (local file vs. package)
 import libcloud.storage.providers
 import libcloud.storage.types
-import yaml
+from libcloud.compute.base import Node
 from libcloud.compute.providers import get_driver
 from libcloud.compute.types import Provider
+import yaml
 from packaging.version import Version
 
 from sdcm.utils.aws_utils import EksClusterCleanupMixin
@@ -715,7 +716,7 @@ def clean_instances_aws(tags_dict, dry_run=False):
 
 
 # pylint: disable=too-many-locals,too-many-branches,too-many-statements
-def clean_sct_runners():
+def clean_sct_runners(test_status: Optional[str] = None, test_runner_ip: str = None):
     LOGGER.info("Looking for SCT runner instances...")
     sct_runners = []
     all_instances = list_instances_aws(verbose=True)
@@ -762,6 +763,11 @@ def clean_sct_runners():
             region = sct_runner['Placement']['AvailabilityZone'][:-1]
             instance_id = sct_runner['InstanceId']
             launch_time = sct_runner['LaunchTime']
+            LOGGER.info("[%s] %s, launched at %s UTC, keep: %s",
+                        region,
+                        sct_runner["InstanceId"],
+                        tags.get('launch_time'),
+                        tags["keep"])
         else:
             tags = gce_meta_to_dict(sct_runner.extra['metadata'])
             keep = tags.get("keep", "")
@@ -770,9 +776,13 @@ def clean_sct_runners():
             if tags.get("launch_time") is None:
                 LOGGER.warning("Skipping gce instance (%s) without launch_time!", sct_runner.name)
                 continue
+            LOGGER.info("[%s] %s, launched at %s UTC, keep: %s",
+                        region,
+                        sct_runner.id,
+                        tags.get('launch_time'),
+                        tags["keep"])
             launch_time = datetime.datetime.strptime(tags.get("launch_time"), "%B %d, %Y, %H:%M:%S")
             launch_time = launch_time.replace(tzinfo=pytz.utc)
-            LOGGER.info("[%s] %s, launched at %s UTC", region, sct_runner.name, tags.get('launch_time'))
 
         seconds_running = (utc_now - launch_time).total_seconds()
         keep_hours = 0
@@ -787,8 +797,16 @@ def clean_sct_runners():
         if not keep or seconds_running > keep_hours * 3600:
             LOGGER.info("[%s] Runner instance '%s'<keep=%s> that launched at '%s' UTC "
                         "is unused/expired, cleaning ...", region, instance_id, keep, launch_time)
-            terminate_runner_instance(backend, region, sct_runner)
+            terminate_runner_instance(backend=backend, region=region, sct_runner=sct_runner)
             runners_cleaned.append(sct_runner)
+
+        if test_status == "SUCCESS" and test_runner_ip:
+            LOGGER.info("Removing the sct runner on success...")
+            if backend == "aws" and test_runner_ip == sct_runner["PublicIpAddress"] or \
+                    backend == "gce" and test_runner_ip in sct_runner.public_ips:
+                terminate_runner_instance(backend=backend, region=region, sct_runner=sct_runner)
+                runners_cleaned.append(sct_runner)
+
     if runners_cleaned:
         LOGGER.info("Cleaned '%s' runners.", len(runners_cleaned))
     else:
@@ -899,7 +917,7 @@ def filter_gce_by_tags(tags_dict, instances):
     return filtered_instances
 
 
-def list_instances_gce(tags_dict=None, running=False, verbose=False):
+def list_instances_gce(tags_dict=None, running=False, verbose=False) -> list[Node]:
     """
     list all instances with specific tags GCE
 

--- a/sdcm/utils/gce_utils.py
+++ b/sdcm/utils/gce_utils.py
@@ -49,7 +49,7 @@ def get_gce_services(regions: list) -> dict:
     return {region_az: _get_gce_service(credentials, region_az) for region_az in map(append_zone, regions)}
 
 
-def get_gce_service(region: str):
+def get_gce_service(region: str) -> GceDriver:
     credentials = KeyStore().get_gcp_credentials()
     return _get_gce_service(credentials, append_zone(region))
 

--- a/test-cases/longevity/longevity-ndbench-12-nodes-multidc-4h.yaml
+++ b/test-cases/longevity/longevity-ndbench-12-nodes-multidc-4h.yaml
@@ -10,6 +10,7 @@ stress_cmd: >-
   readEnabled=true; numReaders=100; numWriters=100 ; cass.writeConsistencyLevel=LOCAL_QUORUM ; generateChecksum=true;
   cli.timeoutMillis=14400000; writeRateLimit=1350 ; readRateLimit=12000
 
+region_name: 'us-east-1 eu-west-1'
 n_db_nodes: '6 6'
 n_loaders: '2 2'
 n_monitor_nodes: 1

--- a/test-cases/longevity/longevity-ndbench-192-nodes-4h.yaml
+++ b/test-cases/longevity/longevity-ndbench-192-nodes-4h.yaml
@@ -10,6 +10,7 @@ stress_cmd: >-
   readEnabled=true; numReaders=60; numWriters=60 ; cass.writeConsistencyLevel=LOCAL_QUORUM ; generateChecksum=true;
   cli.timeoutMillis=14400000; writeRateLimit=18000 ; readRateLimit=1350
 
+region_name: 'us-east-1 eu-west-1'
 n_db_nodes: '96 96'
 n_loaders: '32 32'
 n_monitor_nodes: 1

--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -199,6 +199,19 @@ def call(Map pipelineParams) {
                                                     echo "Email sent"
                                                 """
                                             }
+                                            stage('Clean SCT Runners') {
+                                                steps {
+                                                    catchError(stageResult: 'FAILURE') {
+                                                        script {
+                                                            wrap([$class: 'BuildUser']) {
+                                                                dir('scylla-cluster-tests') {
+                                                                    cleanSctRunners(params, currentBuild)
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
                                         }
                                     }
                                 }

--- a/vars/byoLongevityPipeline.groovy
+++ b/vars/byoLongevityPipeline.groovy
@@ -192,6 +192,19 @@ def call() {
                     }
                 }
             }
+            stage('Clean SCT Runners') {
+                steps {
+                    catchError(stageResult: 'FAILURE') {
+                        script {
+                            wrap([$class: 'BuildUser']) {
+                                dir('scylla-cluster-tests') {
+                                    cleanSctRunners(params, currentBuild)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/vars/byoOperatorPipeline.groovy
+++ b/vars/byoOperatorPipeline.groovy
@@ -157,6 +157,19 @@ def call(Map pipelineParams) {
                     }
                 }
             }
+            stage('Clean SCT Runners') {
+                steps {
+                    catchError(stageResult: 'FAILURE') {
+                        script {
+                            wrap([$class: 'BuildUser']) {
+                                dir('scylla-cluster-tests') {
+                                    cleanSctRunners(params, currentBuild)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/vars/cdcReplicationPipeline.groovy
+++ b/vars/cdcReplicationPipeline.groovy
@@ -228,6 +228,19 @@ def call(Map pipelineParams) {
                     }
                 }
             }
+            stage('Clean SCT Runners') {
+                steps {
+                    catchError(stageResult: 'FAILURE') {
+                        script {
+                            wrap([$class: 'BuildUser']) {
+                                dir('scylla-cluster-tests') {
+                                    cleanSctRunners(params, currentBuild)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
         post {
             always {

--- a/vars/cleanSctRunners.groovy
+++ b/vars/cleanSctRunners.groovy
@@ -1,0 +1,28 @@
+#!groovy
+
+import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
+
+def call(Map params, RunWrapper currentBuild){
+    def cloud_provider = getCloudProviderFromBackend(params.backend)
+    def test_status = currentBuild.currentResult
+
+    sh """
+    #!/bin/bash
+
+    set -xe
+    env
+
+    echo "Test status on runCleanupResource is: " + "$test_status"
+
+    echo "Starting to clean runner instances"
+    if [[ "$cloud_provider" == "aws" || "$cloud_provider" == "gce" ]]; then
+        export SCT_RUNNER_IP=\$(cat sct_runner_ip||echo "")
+        ./docker/env/hydra.sh clean-runner-instances --test-status "$test_status" --runner-ip \${SCT_RUNNER_IP}
+
+    else
+        echo "Not running on AWS or GCP. Skipping cleaning runner instances."
+    fi
+
+    echo "Finished cleaning runner instances."
+    """
+}

--- a/vars/jepsenPipeline.groovy
+++ b/vars/jepsenPipeline.groovy
@@ -187,6 +187,19 @@ def call(Map pipelineParams) {
                     }
                 }
             }
+            stage('Clean SCT Runners') {
+                steps {
+                    catchError(stageResult: 'FAILURE') {
+                        script {
+                            wrap([$class: 'BuildUser']) {
+                                dir('scylla-cluster-tests') {
+                                    cleanSctRunners(params, currentBuild)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
         post {
             always {

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -229,6 +229,19 @@ def call(Map pipelineParams) {
                     }
                 }
             }
+            stage('Clean SCT Runners') {
+                steps {
+                    catchError(stageResult: 'FAILURE') {
+                        script {
+                            wrap([$class: 'BuildUser']) {
+                                dir('scylla-cluster-tests') {
+                                    cleanSctRunners(params, currentBuild)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
         post {
             always {

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -353,6 +353,19 @@ def call(Map pipelineParams) {
                     }
                 }
             }
+            stage('Clean SCT Runners') {
+                steps {
+                    catchError(stageResult: 'FAILURE') {
+                        script {
+                            wrap([$class: 'BuildUser']) {
+                                dir('scylla-cluster-tests') {
+                                    cleanSctRunners(params, currentBuild)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
         post {
             always {

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -215,6 +215,19 @@ def call(Map pipelineParams) {
                                                 }
                                             }
                                         }
+                                        stage('Clean SCT Runners') {
+                                            steps {
+                                                catchError(stageResult: 'FAILURE') {
+                                                    script {
+                                                        wrap([$class: 'BuildUser']) {
+                                                            dir('scylla-cluster-tests') {
+                                                                cleanSctRunners(params, currentBuild)
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }

--- a/vars/rollingOperatorUpgradePipeline.groovy
+++ b/vars/rollingOperatorUpgradePipeline.groovy
@@ -180,6 +180,19 @@ def call(Map pipelineParams) {
                                         }
                                     }
                                 }
+                                stage('Clean SCT Runners') {
+                                    steps {
+                                        catchError(stageResult: 'FAILURE') {
+                                            script {
+                                                wrap([$class: 'BuildUser']) {
+                                                    dir('scylla-cluster-tests') {
+                                                        cleanSctRunners(params, currentBuild)
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                         parallel tasks

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -196,11 +196,23 @@ def call(Map pipelineParams) {
                                                 }
                                             }
                                         }
+                                        stage('Clean SCT Runners') {
+                                            steps {
+                                                catchError(stageResult: 'FAILURE') {
+                                                    script {
+                                                        wrap([$class: 'BuildUser']) {
+                                                            dir('scylla-cluster-tests') {
+                                                                cleanSctRunners(params, currentBuild)
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }
                         }
-
                         parallel tasks
                     }
                 }

--- a/vars/runCleanupResource.groovy
+++ b/vars/runCleanupResource.groovy
@@ -34,7 +34,6 @@ def call(Map params, String region){
     else
         ./docker/env/hydra.sh clean-resources --post-behavior --logdir "`pwd`"
     fi
-    ./docker/env/hydra.sh clean-runner-instances
     echo "Finished cleaning resources."
     """
 }

--- a/vars/runSendEmail.groovy
+++ b/vars/runSendEmail.groovy
@@ -23,7 +23,8 @@ def call(Map params, RunWrapper currentBuild){
     if [[ "$cloud_provider" == "aws" || "$cloud_provider" == "gce" ]]; then
         SCT_RUNNER_IP=\$(cat sct_runner_ip||echo "")
         if [[ -n "\${SCT_RUNNER_IP}" ]] ; then
-            ./docker/env/hydra.sh --execute-on-runner \${SCT_RUNNER_IP} send-email ${test_status} ${start_time} --email-recipients "${email_recipients}"
+            ./docker/env/hydra.sh --execute-on-runner \${SCT_RUNNER_IP} send-email ${test_status} ${start_time} \
+            --runner-ip \${SCT_RUNNER_IP} --email-recipients "${email_recipients}"
         else
             echo "SCT runner IP file is empty. Probably SCT Runner was not created."
             ./docker/env/hydra.sh send-email ${test_status} ${start_time} --logdir "`pwd`" --email-recipients "${email_recipients}"


### PR DESCRIPTION
Adding a separate pipeline step to remove the sct runnner instance the test was using if the test has successfully completed it's run.

Trello task: https://trello.com/c/OubAbKOP
GCE run: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/maciej/job/mc-longevity/job/mc-byo-longevity-test/167/
AWS run: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/maciej/job/mc-longevity/job/mc-byo-longevity-test/172/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
