### PR TITLE
fix(servernemesisdashboard): set new resolution

### DIFF
--- a/sdcm/monitorstack/ui.py
+++ b/sdcm/monitorstack/ui.py
@@ -168,7 +168,7 @@ class ServerMetricsNemesisDashboard(Dashboard):
 
     name = f'{test_name}scylla-per-server-metrics-nemesis'
     path = 'dashboard/db/{dashboard_name}-{version}'
-    resolution = '1920px*7000px'
+    resolution = '1920px*8000px'
     panels = [Panel("Total Requests"),
               Panel("Load per Instance"),
               Panel("Requests Served per Instance"),


### PR DESCRIPTION
Dashboard server metrics nemesis was updated with new panels
Need new resosultion for get full screenshot

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
