### PR TITLE
refactor(TestConfig): convert usages to instance

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -46,6 +46,7 @@ class BackupFunctionsMixIn:
 
     backup_azure_blob_service = None
     backup_azure_blob_sas = None
+    test_config = TestConfig()
 
     @cached_property
     def locations(self) -> list[str]:
@@ -82,8 +83,8 @@ class BackupFunctionsMixIn:
                 tar xz -C /usr/bin --strip-components 1 --wildcards '*/azcopy'
         """))
         self.backup_azure_blob_service = \
-            f"https://{TestConfig.backup_azure_blob_credentials['account']}.blob.core.windows.net/"
-        self.backup_azure_blob_sas = TestConfig.backup_azure_blob_credentials["download_sas"]
+            f"https://{self.test_config.backup_azure_blob_credentials['account']}.blob.core.windows.net/"
+        self.backup_azure_blob_sas = self.test_config.backup_azure_blob_credentials["download_sas"]
 
     @staticmethod
     def download_from_s3(node, source, destination):

--- a/sct.py
+++ b/sct.py
@@ -83,7 +83,7 @@ def install_package_from_dir(ctx, _, directories):
 
 def add_file_logger(level: int = logging.DEBUG) -> None:
     cmd_path = "-".join(click.get_current_context().command_path.split()[1:])
-    logdir = TestConfig.make_new_logdir(update_latest_symlink=False, postfix=f"-{cmd_path}")
+    logdir = TestConfig().make_new_logdir(update_latest_symlink=False, postfix=f"-{cmd_path}")
     handler = logging.FileHandler(os.path.join(logdir, "hydra.log"))
     handler.setLevel(level)
     LOGGER.addHandler(handler)
@@ -159,7 +159,7 @@ def clean_resources(ctx, post_behavior, user, test_id, logdir, dry_run, backend)
         params = (user_param, )
     else:
         if not logdir and (post_behavior or not test_id):
-            logdir = TestConfig.base_logdir()
+            logdir = TestConfig().base_logdir()
 
         if not test_id and (latest_test_id := search_test_id_in_latest(logdir)):
             click.echo(f"Latest TestId in {logdir} is {latest_test_id}")
@@ -748,7 +748,7 @@ def run_test(argv, backend, config, logdir):
     if logdir:
         os.environ['_SCT_LOGDIR'] = logdir
 
-    logfile = os.path.join(TestConfig.logdir(), 'output.log')
+    logfile = os.path.join(TestConfig().logdir(), 'output.log')
     sys.stdout = OutputLogger(logfile, sys.stdout)
     sys.stderr = OutputLogger(logfile, sys.stderr)
 
@@ -770,7 +770,7 @@ def run_pytest(target, backend, config, logdir):
     if logdir:
         os.environ['_SCT_LOGDIR'] = logdir
 
-    logfile = os.path.join(TestConfig.logdir(), 'output.log')
+    logfile = os.path.join(TestConfig().logdir(), 'output.log')
     sys.stdout = OutputLogger(logfile, sys.stdout)
     sys.stderr = OutputLogger(logfile, sys.stderr)
     if not target:

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -196,6 +196,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         self.name = name
         self.rack = rack
         self.parent_cluster = parent_cluster  # reference to the Cluster object that the node belongs to
+        self.test_config = TestConfig()
         self.ssh_login_info = ssh_login_info
         self.logdir = os.path.join(base_logdir, self.name) if base_logdir else None
         self.dc_idx = dc_idx
@@ -264,7 +265,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         # Start task threads after ssh is up, otherwise the dense ssh attempts from task
         # threads will make SCT builder to be blocked by sshguard of gce instance.
         self.wait_ssh_up(verbose=True)
-        if not TestConfig.REUSE_CLUSTER:
+        if not self.test_config.REUSE_CLUSTER:
             self.set_hostname()
 
         self.start_task_threads()
@@ -277,22 +278,22 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         self.log.debug(self.remoter.ssh_debug_cmd())
 
     def _init_port_mapping(self):
-        if TestConfig.IP_SSH_CONNECTIONS == 'public' or TestConfig.MULTI_REGION:
-            if TestConfig.RSYSLOG_ADDRESS:
+        if self.test_config.IP_SSH_CONNECTIONS == 'public' or self.test_config.MULTI_REGION:
+            if self.test_config.RSYSLOG_ADDRESS:
                 try:
                     ContainerManager.destroy_container(self, "auto_ssh:rsyslog", ignore_keepalive=True)
                 except NotFound:
                     pass
                 ContainerManager.run_container(self, "auto_ssh:rsyslog",
-                                               local_port=TestConfig.RSYSLOG_ADDRESS[1],
-                                               remote_port=TestConfig.RSYSLOG_SSH_TUNNEL_LOCAL_PORT)
-            if TestConfig.LDAP_ADDRESS and self.parent_cluster.node_type == "scylla-db":
+                                               local_port=self.test_config.RSYSLOG_ADDRESS[1],
+                                               remote_port=self.test_config.RSYSLOG_SSH_TUNNEL_LOCAL_PORT)
+            if self.test_config.LDAP_ADDRESS and self.parent_cluster.node_type == "scylla-db":
                 try:
                     ContainerManager.destroy_container(self, "auto_ssh:ldap", ignore_keepalive=True)
                 except NotFound:
                     pass
                 ContainerManager.run_container(self, "auto_ssh:ldap",
-                                               local_port=TestConfig.LDAP_ADDRESS[1],
+                                               local_port=self.test_config.LDAP_ADDRESS[1],
                                                remote_port=LDAP_SSH_TUNNEL_LOCAL_PORT)
 
     @property
@@ -330,7 +331,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
     def set_keep_alive(self):
         node_type = None if self.parent_cluster is None else self.parent_cluster.node_type
-        if TestConfig.should_keep_alive(node_type) and self._set_keep_alive():
+        if self.test_config.should_keep_alive(node_type) and self._set_keep_alive():
             self.log.info("Keep this node alive")
 
     @property
@@ -346,8 +347,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
     def system_log(self):
         orig_log_path = os.path.join(self.logdir, 'system.log')
 
-        if TestConfig.RSYSLOG_ADDRESS:
-            rsys_log_path = os.path.join(TestConfig.logdir(), 'hosts', self.short_hostname, 'messages.log')
+        if self.test_config.RSYSLOG_ADDRESS:
+            rsys_log_path = os.path.join(self.test_config.logdir(), 'hosts', self.short_hostname, 'messages.log')
             if os.path.exists(rsys_log_path) and (not os.path.islink(orig_log_path)):
                 os.symlink(os.path.relpath(rsys_log_path, self.logdir), orig_log_path)
             return rsys_log_path
@@ -699,9 +700,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
     @property
     def ip_address(self):
-        if TestConfig.IP_SSH_CONNECTIONS == "ipv6":
+        if self.test_config.IP_SSH_CONNECTIONS == "ipv6":
             return self.ipv6_ip_address
-        elif TestConfig.INTRA_NODE_COMM_PUBLIC:
+        elif self.test_config.INTRA_NODE_COMM_PUBLIC:
             return self.public_ip_address
         else:
             return self.private_ip_address
@@ -712,9 +713,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         the communication address for usage between the test and the nodes
         :return:
         """
-        if TestConfig.IP_SSH_CONNECTIONS == "ipv6":
+        if self.test_config.IP_SSH_CONNECTIONS == "ipv6":
             return self.ipv6_ip_address
-        elif TestConfig.IP_SSH_CONNECTIONS == 'public' or TestConfig.INTRA_NODE_COMM_PUBLIC:
+        elif self.test_config.IP_SSH_CONNECTIONS == 'public' or self.test_config.INTRA_NODE_COMM_PUBLIC:
             return self.public_ip_address
         else:
             return self.private_ip_address
@@ -840,7 +841,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             self.name,
             self.public_ip_address,
             self.private_ip_address,
-            " | %s" % self.ipv6_ip_address if TestConfig.IP_SSH_CONNECTIONS == "ipv6" else "",
+            " | %s" % self.ipv6_ip_address if self.test_config.IP_SSH_CONNECTIONS == "ipv6" else "",
             self.is_seed)
 
     def restart(self):
@@ -929,7 +930,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         elif self.node_type == 'monitor':
             # TODO: start alert manager thread here when start_task_threads will be run after node setup
             # self.start_alert_manager_thread()
-            if TestConfig.BACKTRACE_DECODING:
+            if self.test_config.BACKTRACE_DECODING:
                 self.start_decode_on_monitor_node_thread()
 
     def get_backtraces(self):
@@ -1303,7 +1304,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                         json_log = json.loads(line)
                     except Exception:  # pylint: disable=broad-except
                         pass
-                if not start_from_beginning and TestConfig.RSYSLOG_ADDRESS:
+                if not start_from_beginning and self.test_config.RSYSLOG_ADDRESS:
                     line = line.strip()
                     if not exclude_from_logging:
                         LOGGER.debug(line)
@@ -1376,7 +1377,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             try:
                 if (last_error and
                         backtrace['event'].line_number <= filter_backtraces.last_error.line_number + 20
-                        and not filter_backtraces.last_error.type == 'BACKTRACE' and backtrace['event'].type == 'BACKTRACE'):
+                        and not filter_backtraces.last_error.type == 'BACKTRACE'
+                        and backtrace['event'].type == 'BACKTRACE'):
                     last_error.raw_backtrace = "\n".join(backtrace['backtrace'])
                     backtrace['event'].dont_publish()
                     return False
@@ -1390,10 +1392,10 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             backtraces = list(filter(filter_backtraces, backtraces))
 
         for backtrace in backtraces:
-            if TestConfig.BACKTRACE_DECODING and backtrace["event"].raw_backtrace:
+            if self.test_config.BACKTRACE_DECODING and backtrace["event"].raw_backtrace:
                 scylla_debug_info = self.get_scylla_debuginfo_file()
                 self.log.debug("Debug info file %s", scylla_debug_info)
-                TestConfig.DECODING_QUEUE.put({
+                self.test_config.DECODING_QUEUE.put({
                     "node": self,
                     "debug_file": scylla_debug_info,
                     "event": backtrace["event"],
@@ -1413,16 +1415,16 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             event = None
             obj = None
             try:
-                obj = TestConfig.DECODING_QUEUE.get(timeout=5)
+                obj = self.test_config.DECODING_QUEUE.get(timeout=5)
                 if obj is None:
-                    TestConfig.DECODING_QUEUE.task_done()
+                    self.test_config.DECODING_QUEUE.task_done()
                     break
                 event = obj["event"]
                 if not scylla_debug_file:
                     scylla_debug_file = self.copy_scylla_debug_info(obj["node"], obj["debug_file"])
                 output = self.decode_raw_backtrace(scylla_debug_file, " ".join(event.raw_backtrace.split('\n')))
                 event.backtrace = output.stdout
-                TestConfig.DECODING_QUEUE.task_done()
+                self.test_config.DECODING_QUEUE.task_done()
             except queue.Empty:
                 pass
             except Exception as details:  # pylint: disable=broad-except
@@ -1431,7 +1433,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 if event:
                     event.publish()
 
-            if self.termination_event.isSet() and TestConfig.DECODING_QUEUE.empty():
+            if self.termination_event.isSet() and self.test_config.DECODING_QUEUE.empty():
                 break
 
     def copy_scylla_debug_info(self, node, debug_file):
@@ -1549,14 +1551,13 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
     def remote_manager_agent_yaml(self):
         return self._remote_yaml(path=SCYLLA_MANAGER_AGENT_YAML_PATH)
 
-    @staticmethod
-    def get_openldap_config():
-        if TestConfig.LDAP_ADDRESS is None:
+    def get_openldap_config(self):
+        if self.test_config.LDAP_ADDRESS is None:
             return {}
-        ldap_server_ip = '127.0.0.1' if TestConfig.IP_SSH_CONNECTIONS == 'public' \
-            or TestConfig.MULTI_REGION else TestConfig.LDAP_ADDRESS[0]
-        ldap_port = LDAP_SSH_TUNNEL_LOCAL_PORT if TestConfig.IP_SSH_CONNECTIONS == 'public' or TestConfig.MULTI_REGION else \
-            TestConfig.LDAP_ADDRESS[1]
+        ldap_server_ip = '127.0.0.1' if self.test_config.IP_SSH_CONNECTIONS == 'public' \
+            or self.test_config.MULTI_REGION else self.test_config.LDAP_ADDRESS[0]
+        ldap_port = LDAP_SSH_TUNNEL_LOCAL_PORT if self.test_config.IP_SSH_CONNECTIONS == 'public' \
+            or self.test_config.MULTI_REGION else self.test_config.LDAP_ADDRESS[1]
         return {'role_manager': 'com.scylladb.auth.LDAPRoleManager',
                 'ldap_url_template': f'ldap://{ldap_server_ip}:{ldap_port}/'
                                      f'{LDAP_BASE_OBJECT}?cn?sub?(uniqueMember='
@@ -1565,9 +1566,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 'ldap_bind_dn': f'cn=admin,{LDAP_BASE_OBJECT}',
                 'ldap_bind_passwd': LDAP_PASSWORD}
 
-    @staticmethod
-    def get_ldap_ms_ad_config():
-        if TestConfig.LDAP_ADDRESS is None:
+    def get_ldap_ms_ad_config(self):
+        if self.test_config.LDAP_ADDRESS is None:
             return {}
         ldap_ms_ad_credentials = KeyStore().get_ldap_ms_ad_credentials()
         return {'ldap_attr_role': 'cn',
@@ -1578,14 +1578,13 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                     f'(member=CN={{USER}},DC=scylla-qa,DC=com)',
                 'role_manager': 'com.scylladb.auth.LDAPRoleManager'}
 
-    @staticmethod
-    def get_saslauthd_config():
-        if TestConfig.LDAP_ADDRESS is None:
+    def get_saslauthd_config(self):
+        if self.test_config.LDAP_ADDRESS is None:
             return {}
-        ldap_server_ip = '127.0.0.1' if TestConfig.IP_SSH_CONNECTIONS == 'public' or TestConfig.MULTI_REGION else TestConfig.LDAP_ADDRESS[
-            0]
-        ldap_port = LDAP_SSH_TUNNEL_LOCAL_PORT if TestConfig.IP_SSH_CONNECTIONS == 'public' or TestConfig.MULTI_REGION else \
-            TestConfig.LDAP_ADDRESS[1]
+        ldap_server_ip = '127.0.0.1' if self.test_config.IP_SSH_CONNECTIONS == 'public' \
+            or self.test_config.MULTI_REGION else self.test_config.LDAP_ADDRESS[0]
+        ldap_port = LDAP_SSH_TUNNEL_LOCAL_PORT if self.test_config.IP_SSH_CONNECTIONS == 'public' \
+            or self.test_config.MULTI_REGION else self.test_config.LDAP_ADDRESS[1]
         return {'ldap_servers': f'ldap://{ldap_server_ip}:{ldap_port}/',
                 'ldap_search_base': f'ou=Person,{LDAP_BASE_OBJECT}',
                 'ldap_bind_dn': f'cn=admin,{LDAP_BASE_OBJECT}',
@@ -1879,7 +1878,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             tls_key_file = SCYLLA_MANAGER_TLS_KEY_FILE
 
         with self.remote_manager_agent_yaml() as manager_agent_yaml:
-            manager_agent_yaml["auth_token"] = TestConfig.test_id()
+            manager_agent_yaml["auth_token"] = self.test_config.test_id()
             manager_agent_yaml["tls_cert_file"] = tls_cert_file
             manager_agent_yaml["tls_key_file"] = tls_key_file
             manager_agent_yaml["prometheus"] = f":{self.parent_cluster.params.get('manager_prometheus_port')}"
@@ -1901,8 +1900,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         elif backup_backend == "gcs":
             pass
         elif backup_backend == "azure":
-            backup_backend_config["account"] = TestConfig.backup_azure_blob_credentials["account"]
-            backup_backend_config["key"] = TestConfig.backup_azure_blob_credentials["key"]
+            backup_backend_config["account"] = self.test_config.backup_azure_blob_credentials["account"]
+            backup_backend_config["key"] = self.test_config.backup_azure_blob_credentials["key"]
         else:
             raise ValueError(f"{backup_backend=} is not supported")
 
@@ -2823,7 +2822,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         startup_script_remote_path = '/tmp/sct-startup.sh'
 
         with tempfile.NamedTemporaryFile(mode='w+', delete=False, encoding='utf-8') as tmp_file:
-            tmp_file.write(TestConfig.get_startup_script())
+            tmp_file.write(self.test_config.get_startup_script())
             tmp_file.flush()
             self.remoter.send_files(src=tmp_file.name, dst=startup_script_remote_path)  # pylint: disable=not-callable
 
@@ -3018,10 +3017,11 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
     def __init__(self, cluster_uuid=None, cluster_prefix='cluster', node_prefix='node', n_nodes=3, params=None,
                  region_names=None, node_type=None, extra_network_interface=False):
         self.extra_network_interface = extra_network_interface
+        self.test_config = TestConfig()
         if params is None:
             params = {}
         if cluster_uuid is None:
-            self.uuid = TestConfig.test_id()
+            self.uuid = self.test_config.test_id()
         else:
             self.uuid = cluster_uuid
         self.node_type = node_type
@@ -3045,7 +3045,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
         # default 'cassandra' password is weak password, MS AD doesn't allow to use it.
         self.added_password_suffix = False
 
-        if TestConfig.REUSE_CLUSTER:
+        if self.test_config.REUSE_CLUSTER:
             # get_node_ips_param should be defined in child
             self._node_public_ips = self.params.get(self.get_node_ips_param(public_ip=True)) or []
             self._node_private_ips = self.params.get(self.get_node_ips_param(public_ip=False)) or []
@@ -3073,7 +3073,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
     def tags(self) -> Dict[str, str]:
         key = self.node_type if "db" not in self.node_type else "db"
         action = self.params.get(f"post_behavior_{key}_nodes")
-        return {**TestConfig.common_tags(),
+        return {**self.test_config.common_tags(),
                 "NodeType": str(self.node_type),
                 "keep_action": "terminate" if action == "destroy" else "", }
 
@@ -3174,7 +3174,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
                 name=node.name,
                 public_ip=node.public_ip_address,
                 private_ip=node.private_ip_address,
-                ipv6_ip=node.ipv6_ip_address if TestConfig.IP_SSH_CONNECTIONS == "ipv6" else '',
+                ipv6_ip=node.ipv6_ip_address if self.test_config.IP_SSH_CONNECTIONS == "ipv6" else '',
                 ip_address=node.ip_address,
                 shards=node.scylla_shards,
                 termination_time=datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f"),
@@ -3525,12 +3525,12 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         self.nemesis = []
         self.nemesis_threads = []
         self.nemesis_count = 0
+        self.test_config = TestConfig()
         self._node_cycle = None
         super().__init__(*args, **kwargs)
 
-    @staticmethod
-    def get_node_ips_param(public_ip=True):
-        if TestConfig.MIXED_CLUSTER:
+    def get_node_ips_param(self, public_ip=True):
+        if self.test_config.MIXED_CLUSTER:
             return 'oracle_db_nodes_public_ip' if public_ip else 'oracle_db_nodes_private_ip'
         return 'db_nodes_public_ip' if public_ip else 'db_nodes_private_ip'
 
@@ -3557,7 +3557,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             node.wait_ssh_up()
             seed_nodes_ips = [node.ip_address]
 
-        elif seeds_selector == 'reflector' or TestConfig.REUSE_CLUSTER or cluster_backend == 'aws-siren':
+        elif seeds_selector == 'reflector' or self.test_config.REUSE_CLUSTER or cluster_backend == 'aws-siren':
             node = self.nodes[0]
             node.wait_ssh_up()
             # When cluster just started, seed IP in the scylla.yaml may be like '127.0.0.1'
@@ -4105,7 +4105,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         if self.params.get("use_preinstalled_scylla") and node.is_scylla_installed(raise_if_not_installed=True):
             install_scylla = False
 
-        if not TestConfig.REUSE_CLUSTER:
+        if not self.test_config.REUSE_CLUSTER:
             node.disable_daily_triggered_services()
             nic_devname = node.get_nic_devices()[0]
             if install_scylla:
@@ -4122,10 +4122,10 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                 return
 
             self.get_scylla_version()
-            if TestConfig.BACKTRACE_DECODING:
+            if self.test_config.BACKTRACE_DECODING:
                 node.install_scylla_debuginfo()
 
-            if TestConfig.MULTI_REGION:
+            if self.test_config.MULTI_REGION:
                 node.datacenter_setup(self.datacenter)  # pylint: disable=no-member
             self.node_config_setup(node, ','.join(self.seed_nodes_ips), self.get_endpoint_snitch())
 
@@ -4196,7 +4196,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
 
     def get_endpoint_snitch(self, default_multi_region="GossipingPropertyFileSnitch"):
         endpoint_snitch = self.params.get('endpoint_snitch')
-        if TestConfig.MULTI_REGION:
+        if self.test_config.MULTI_REGION:
             if not endpoint_snitch:
                 endpoint_snitch = default_multi_region
         return endpoint_snitch
@@ -4341,7 +4341,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         LOGGER.info('Decommission %s PASS', node)
         with DbEventsFilter(db_event=DatabaseLogEvent.POWER_OFF, node=node):
             self.terminate_node(node)  # pylint: disable=no-member
-        TestConfig.tester_obj().monitors.reconfigure_scylla_monitoring()
+        self.test_config.tester_obj().monitors.reconfigure_scylla_monitoring()
 
     def decommission(self, node):
         node.run_nodetool("decommission")
@@ -4349,11 +4349,11 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
 
     @property
     def scylla_manager_node(self) -> BaseNode:
-        return TestConfig.tester_obj().monitors.nodes[0]
+        return self.test_config.tester_obj().monitors.nodes[0]
 
     @property
     def scylla_manager_auth_token(self) -> str:
-        return TestConfig.tester_obj().monitors.mgmt_auth_token
+        return self.test_config.tester_obj().monitors.mgmt_auth_token
 
     @property
     def scylla_manager_cluster_name(self):
@@ -4444,7 +4444,7 @@ class BaseLoaderSet():
         # update repo cache and system after system is up
         node.update_repo_cache()
 
-        if TestConfig.REUSE_CLUSTER:
+        if TestConfig().REUSE_CLUSTER:
             self.kill_stress_thread()
             return
 
@@ -4724,6 +4724,7 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
         self.phantomjs_installed = False
         self.grafana_start_time = 0
         self._sct_dashboard_json_file = None
+        self.test_config = TestConfig()
 
     @staticmethod
     @retrying(n=5)
@@ -4800,7 +4801,7 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
         self.log.info('TestConfig in BaseMonitorSet')
         node.wait_ssh_up()
         # add swap file
-        if not TestConfig.REUSE_CLUSTER:
+        if not self.test_config.REUSE_CLUSTER:
             monitor_swap_size = self.params.get("monitor_swap_size")
             if not monitor_swap_size:
                 self.log.info("Swap file for the monitor is not configured")
@@ -4808,9 +4809,9 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
                 node.create_swap_file(monitor_swap_size)
         # update repo cache and system after system is up
         node.update_repo_cache()
-        self.mgmt_auth_token = TestConfig.test_id()  # pylint: disable=attribute-defined-outside-init
+        self.mgmt_auth_token = self.test_config.test_id()  # pylint: disable=attribute-defined-outside-init
 
-        if TestConfig.REUSE_CLUSTER:
+        if self.test_config.REUSE_CLUSTER:
             self.configure_scylla_monitoring(node)
             self.restart_scylla_monitoring(sct_metrics=True)
             set_grafana_url(f"http://{normalize_ipv6_url(node.external_address)}:{self.grafana_port}")
@@ -5208,7 +5209,7 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
                                                      extra_entities=grafana_extra_dashboards)
             screenshot_files = screenshot_collector.collect(node, self.logdir)
             for screenshot in screenshot_files:
-                s3_path = "{test_id}/{date}".format(test_id=TestConfig.test_id(), date=date_time)
+                s3_path = "{test_id}/{date}".format(test_id=self.test_config.test_id(), date=date_time)
                 screenshot_links.append(S3Storage().upload_file(screenshot, s3_path))
 
             snapshots_collector = GrafanaSnapshot(name="grafana-snapshot",
@@ -5225,7 +5226,7 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
         try:
             annotations = self.get_grafana_annotations(self.nodes[0])
             if annotations:
-                annotations_url = S3Storage().generate_url('annotations.json', TestConfig.test_id())
+                annotations_url = S3Storage().generate_url('annotations.json', self.test_config.test_id())
                 self.log.info("Uploading 'annotations.json' to {s3_url}".format(
                     s3_url=annotations_url))
                 response = requests.put(annotations_url, data=annotations, headers={
@@ -5243,7 +5244,7 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
         try:
             if snapshot_archive := PrometheusSnapshots(name='prometheus_snapshot').collect(self.nodes[0], self.logdir):
                 self.log.debug("Snapshot local path: %s", snapshot_archive)
-                return upload_archive_to_s3(snapshot_archive, TestConfig.test_id())
+                return upload_archive_to_s3(snapshot_archive, self.test_config.test_id())
         except Exception as details:  # pylint: disable=broad-except
             self.log.error("Error downloading prometheus data dir: %s", details)
         return ""

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -150,7 +150,7 @@ class DockerCluster(cluster.BaseCluster):  # pylint: disable=abstract-method
                  n_nodes: Union[list, int] = 3,
                  params: dict = None) -> None:
         self.source_image = f"{docker_image}:{docker_image_tag}"
-        self.node_container_image_tag = f"scylla-sct:{node_type}-{str(cluster.TestConfig.test_id())[:8]}"
+        self.node_container_image_tag = f"scylla-sct:{node_type}-{str(self.test_config.test_id())[:8]}"
         self.node_container_key_file = node_key_file
 
         super().__init__(cluster_prefix=cluster_prefix,
@@ -204,7 +204,7 @@ class DockerCluster(cluster.BaseCluster):  # pylint: disable=abstract-method
         return self.nodes
 
     def add_nodes(self, count, ec2_user_data="", dc_idx=0, rack=0, enable_auto_bootstrap=False):
-        return self._get_nodes() if cluster.TestConfig.REUSE_CLUSTER else self._create_nodes(count, enable_auto_bootstrap)
+        return self._get_nodes() if self.test_config.REUSE_CLUSTER else self._create_nodes(count, enable_auto_bootstrap)
 
 
 class ScyllaDockerCluster(cluster.BaseScyllaCluster, DockerCluster):  # pylint: disable=abstract-method
@@ -236,7 +236,7 @@ class ScyllaDockerCluster(cluster.BaseScyllaCluster, DockerCluster):  # pylint: 
 
         self.check_aio_max_nr(node)
 
-        if cluster.TestConfig.BACKTRACE_DECODING:
+        if self.test_config.BACKTRACE_DECODING:
             node.install_scylla_debuginfo()
 
         self.node_config_setup(node, seed_address, endpoint_snitch)

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -316,7 +316,7 @@ class GCECluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
         # Name must start with a lowercase letter followed by up to 63
         # lowercase letters, numbers, or hyphens, and cannot end with a hyphen
         assert len(name) <= 63, "Max length of instance name is 63"
-        startup_script = cluster.TestConfig.get_startup_script()
+        startup_script = self.test_config.get_startup_script()
 
         if self.params.get("scylla_linux_distro") in ("ubuntu-bionic", "ubuntu-xenial", "ubuntu-focal",):
             # we need to disable sshguard to prevent blocking connections from the builder
@@ -387,7 +387,7 @@ class GCECluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
         return found[0] if found else None
 
     def _get_instances(self, dc_idx):
-        test_id = cluster.TestConfig.test_id()
+        test_id = self.test_config.test_id()
         if not test_id:
             raise ValueError("test_id should be configured for using reuse_cluster")
         instances_by_nodetype = list_instances_gce(tags_dict={'TestId': test_id, 'NodeType': self.node_type})
@@ -431,10 +431,10 @@ class GCECluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
             return []
         self.log.info("Adding nodes to cluster")
         nodes = []
-        if cluster.TestConfig.REUSE_CLUSTER:
+        if self.test_config.REUSE_CLUSTER:
             instances = self._get_instances(dc_idx)
             if not instances:
-                raise RuntimeError("No nodes found for testId %s " % (cluster.TestConfig.test_id(),))
+                raise RuntimeError("No nodes found for testId %s " % (self.test_config.test_id(),))
         else:
             instances = self._create_instances(count, dc_idx)
 

--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -27,7 +27,6 @@ from sdcm.cluster_k8s import KubernetesCluster, ScyllaPodCluster, BaseScyllaPodC
 
 from sdcm.cluster_k8s.iptables import IptablesPodIpRedirectMixin, IptablesClusterOpsMixin
 from sdcm.cluster_gce import MonitorSetGCE
-from sdcm.test_config import TestConfig
 
 GKE_API_CALL_RATE_LIMIT = 5  # ops/s
 GKE_API_CALL_QUEUE_SIZE = 1000  # ops
@@ -234,7 +233,7 @@ class GkeCluster(KubernetesCluster):
 
     @cached_property
     def gcloud(self) -> GcloudContextManager:  # pylint: disable=no-self-use
-        return cluster.TestConfig.tester_obj().localhost.gcloud
+        return self.test_config.tester_obj().localhost.gcloud
 
     def deploy_node_pool(self, pool: GkeNodePool, wait_till_ready=True) -> None:
         self._add_pool(pool)
@@ -305,13 +304,13 @@ class GkeScyllaPodContainer(BaseScyllaPodContainer, IptablesPodIpRedirectMixin):
 
     @cached_property
     def hydra_dest_ip(self) -> str:
-        if TestConfig.IP_SSH_CONNECTIONS == "public" or TestConfig.INTRA_NODE_COMM_PUBLIC:
+        if self.test_config.IP_SSH_CONNECTIONS == "public" or self.test_config.INTRA_NODE_COMM_PUBLIC:
             return self.gce_node_ips[0][0]
         return self.gce_node_ips[1][0]
 
     @cached_property
     def nodes_dest_ip(self) -> str:
-        if cluster.TestConfig.INTRA_NODE_COMM_PUBLIC:
+        if self.test_config.INTRA_NODE_COMM_PUBLIC:
             return self.gce_node_ips[0][0]
         return self.gce_node_ips[1][0]
 

--- a/sdcm/cluster_k8s/iptables.py
+++ b/sdcm/cluster_k8s/iptables.py
@@ -16,9 +16,8 @@ import logging
 from itertools import chain
 from typing import Literal, List, Optional
 
-from sdcm import cluster
 from sdcm.remote import LOCALRUNNER, shell_script_cmd
-
+from sdcm.test_config import TestConfig
 
 IPTABLES_BIN = "iptables"
 IPTABLES_LEGACY_BIN = "iptables-legacy"
@@ -85,7 +84,7 @@ class IptablesClusterOpsMixin:
                                              loaders: bool = True,
                                              monitors: bool = True) -> None:
         nodes_to_update = []
-        if tester := cluster.TestConfig.tester_obj():
+        if tester := TestConfig().tester_obj():
             if loaders and tester.loaders:
                 nodes_to_update.extend(tester.loaders.nodes)
             if monitors and tester.monitors:

--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -437,10 +437,10 @@ class MinimalClusterBase(KubernetesCluster, metaclass=abc.ABCMeta):  # pylint: d
         if not self.is_k8s_software_installed:
             self.setup_k8s_software()
         if not self.is_k8s_software_running:
-            if cluster.TestConfig.REUSE_CLUSTER:
+            if self.test_config.REUSE_CLUSTER:
                 raise RuntimeError("SCT_REUSE_CLUSTER is set, but target host is not ready")
             self.start_k8s_software()
-        elif not cluster.TestConfig.REUSE_CLUSTER:
+        elif not self.test_config.REUSE_CLUSTER:
             self.stop_k8s_software()
             self.start_k8s_software()
         self.create_kubectl_config()

--- a/sdcm/sct_events/events_analyzer.py
+++ b/sdcm/sct_events/events_analyzer.py
@@ -53,7 +53,7 @@ class EventsAnalyzer(BaseEventsProcess[Tuple[str, Any], None], threading.Thread)
 
     def kill_test(self, backtrace_with_reason) -> None:
         self.terminate()
-        if tester := TestConfig.tester_obj():
+        if tester := TestConfig().tester_obj():
             tester.kill_test(backtrace_with_reason)
         else:
             LOGGER.error("No test was registered using `TestConfig.set_tester_obj()', do not kill")

--- a/sdcm/test_config.py
+++ b/sdcm/test_config.py
@@ -208,7 +208,7 @@ class TestConfig(metaclass=Singleton):  # pylint: disable=too-many-public-method
                ''')
         if cls.RSYSLOG_ADDRESS:
 
-            if cls.IP_SSH_CONNECTIONS == 'public' or TestConfig.MULTI_REGION:
+            if cls.IP_SSH_CONNECTIONS == 'public' or cls.MULTI_REGION:
                 post_boot_script += dedent('''
                        sudo echo 'action(type="omfwd" Target="{0}" Port="{1}" Protocol="tcp")'>> /etc/rsyslog.conf
                        sudo systemctl restart rsyslog

--- a/unit_tests/test_decode_backtrace.py
+++ b/unit_tests/test_decode_backtrace.py
@@ -43,6 +43,7 @@ class TestDecodeBactraces(unittest.TestCase, EventsUtilsMixin):
         cls.monitor_node = DecodeDummyNode(name='test_monitor_node', parent_cluster=None,
                                            base_logdir=cls.temp_dir, ssh_login_info=dict(key_file='~/.ssh/scylla-test'))
         cls.monitor_node.remoter = DummyRemote()
+        cls.test_config = TestConfig()
 
     @classmethod
     def tearDownClass(cls):
@@ -52,8 +53,8 @@ class TestDecodeBactraces(unittest.TestCase, EventsUtilsMixin):
         self.node.system_log = os.path.join(os.path.dirname(__file__), 'test_data', 'system.log')
 
     def test_01_reactor_stall_is_not_decoded_if_disabled(self):
-        TestConfig.DECODING_QUEUE = queue.Queue()
-        TestConfig.BACKTRACE_DECODING = False
+        self.test_config.DECODING_QUEUE = queue.Queue()
+        self.test_config.BACKTRACE_DECODING = False
 
         self.monitor_node.start_decode_on_monitor_node_thread()
         self.node._read_system_log_and_publish_events()  # pylint: disable=protected-access
@@ -71,9 +72,9 @@ class TestDecodeBactraces(unittest.TestCase, EventsUtilsMixin):
                 self.assertIsNone(event['backtrace'])
 
     def test_02_reactor_stalls_is_decoded_if_enabled(self):
-        TestConfig.BACKTRACE_DECODING = True
+        self.test_config.BACKTRACE_DECODING = True
 
-        TestConfig.DECODING_QUEUE = queue.Queue()
+        self.test_config.DECODING_QUEUE = queue.Queue()
 
         self.monitor_node.start_decode_on_monitor_node_thread()
         self.node._read_system_log_and_publish_events()  # pylint: disable=protected-access
@@ -94,8 +95,8 @@ class TestDecodeBactraces(unittest.TestCase, EventsUtilsMixin):
 
     def test_03_decode_interlace_reactor_stall(self):  # pylint: disable=invalid-name
 
-        TestConfig.DECODING_QUEUE = queue.Queue()
-        TestConfig.BACKTRACE_DECODING = True
+        self.test_config.DECODING_QUEUE = queue.Queue()
+        self.test_config.BACKTRACE_DECODING = True
 
         self.monitor_node.start_decode_on_monitor_node_thread()
         self.node.system_log = os.path.join(os.path.dirname(__file__), 'test_data', 'system_interlace_stall.log')
@@ -118,8 +119,8 @@ class TestDecodeBactraces(unittest.TestCase, EventsUtilsMixin):
 
     def test_04_decode_backtraces_core(self):
 
-        TestConfig.DECODING_QUEUE = queue.Queue()
-        TestConfig.BACKTRACE_DECODING = True
+        self.test_config.DECODING_QUEUE = queue.Queue()
+        self.test_config.BACKTRACE_DECODING = True
 
         self.monitor_node.start_decode_on_monitor_node_thread()
         self.node.system_log = os.path.join(os.path.dirname(__file__), 'test_data', 'system_core.log')

--- a/unit_tests/test_seed_selector.py
+++ b/unit_tests/test_seed_selector.py
@@ -7,6 +7,7 @@ import os.path
 from tenacity import RetryError
 
 import sdcm.cluster
+from sdcm.test_config import TestConfig
 from unit_tests.dummy_remote import DummyRemote
 
 
@@ -90,7 +91,7 @@ class TestSeedSelector(unittest.TestCase):
         self.setup_cluster(nodes_number=3)
         self.cluster.set_test_params(seeds_selector='first', seeds_num=2, db_type='scylla')
         sdcm.cluster.SCYLLA_YAML_PATH = os.path.join(os.path.dirname(__file__), 'test_data', 'scylla.yaml')
-        sdcm.cluster.TestConfig.reuse_cluster(True)
+        TestConfig().reuse_cluster(True)
         self.cluster.set_seeds()
         self.assertTrue(self.cluster.seed_nodes == [self.cluster.nodes[1]])
         self.assertTrue(self.cluster.non_seed_nodes == [self.cluster.nodes[0], self.cluster.nodes[2]])


### PR DESCRIPTION
Converting TestConfig class usages to instance usages where possible. This also involved some light refactoring, i.e. adding a `self.test_config` attribute in some classes to avoid unnecessary instantiation calls to the test `TestConfig` class and for readability.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] ~~I added the relevant `backport` labels~~
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
