### PR TITLE
Fix k8s mgmt

### DIFF
--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -113,6 +113,7 @@ def test_drain_terminate_decommission_add_node_kubernetes(db_cluster):
 def test_mgmt_repair(db_cluster):
     mgr_cluster = db_cluster.get_cluster_manager()
     mgr_task = mgr_cluster.create_repair_task()
+    assert mgr_task, "Failed to create repair task"
     task_final_status = mgr_task.wait_and_get_final_status(timeout=86400)  # timeout is 24 hours
     assert task_final_status == TaskStatus.DONE, 'Task: {} final status is: {}.'.format(
         mgr_task.id, str(mgr_task.status))
@@ -124,6 +125,7 @@ def test_mgmt_backup(db_cluster):
     backup_bucket_location = db_cluster.params.get('backup_bucket_location')
     bucket_name = f"s3:{backup_bucket_location.split()[0]}"
     mgr_task = mgr_cluster.create_backup_task(location_list=[bucket_name, ])
+    assert mgr_task, "Failed to create backup task"
     status = mgr_task.wait_and_get_final_status(timeout=54000, step=5, only_final=True)
     assert TaskStatus.DONE == status
 

--- a/sdcm/mgmt/operator.py
+++ b/sdcm/mgmt/operator.py
@@ -242,8 +242,10 @@ class OperatorManagerCluster(ManagerCluster):
             start_date=start_date,
             upload_parallel_list=upload_parallel_list,
         )
-        so_task_status = self.wait_for_operator_backup_task_status(so_task)
-        return self.get_mgr_backup_task_by_id(so_task_status.mgmt_task_id)
+        return wait_for(
+            lambda: self.get_mgr_backup_task_by_id(self.wait_for_operator_backup_task_status(so_task).mgmt_task_id),
+            timeout=15,
+        )
 
     def _create_scylla_operator_repair_task(self, dc_list=None, keyspace=None, interval=None, num_retries=None,
                                             fail_fast=None, intensity=None, parallel=None,
@@ -276,8 +278,10 @@ class OperatorManagerCluster(ManagerCluster):
         so_task = self._create_scylla_operator_repair_task(dc_list=dc_list, keyspace=keyspace, interval=interval,
                                                            num_retries=num_retries, fail_fast=fail_fast,
                                                            intensity=intensity, parallel=parallel, name=name)
-        so_task_status = self.wait_for_operator_repair_task_status(so_task)
-        return self.get_mgr_repair_task_by_id(so_task_status.mgmt_task_id)
+        return wait_for(
+            lambda: self.get_mgr_repair_task_by_id(self.wait_for_operator_repair_task_status(so_task).mgmt_task_id),
+            timeout=15,
+        )
 
     def wait_for_operator_repair_task_status(
             self, so_repair_task: ScyllaOperatorRepairTask, timeout=120, step=1) -> ScyllaOperatorRepairTaskStatus:


### PR DESCRIPTION
https://trello.com/c/L5aBRsYs/3718-fix-sct-operator-part-to-find-active-manager-node

s-o create temporarily task_id and when pass it down to scylla-manager changing this id to task id that scylla-manager assign to it.
This fix will make sct wait till concreate task is created on scylla-manager side to make sure that task_id is not temporary one.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
