### PR TITLE
improvement(ScyllaServerStatusEvent): catch service failures to start

### DIFF
--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -243,7 +243,7 @@ class ScyllaDatabaseContinuousEvent(ContinuousEvent, abstract=True):
 
 class ScyllaServerStatusEvent(ScyllaDatabaseContinuousEvent):
     begin_pattern = r'Starting Scylla Server'
-    end_pattern = r'Stopping Scylla Server'
+    end_pattern = r'Stopping Scylla Server|Failed to start Scylla Server'
 
     def __init__(self, node: str, severity=Severity.NORMAL, **__):
         super().__init__(node=node, severity=severity)


### PR DESCRIPTION
Adding an "Failed to start Scylla Server" pattern to the stop patterns:
```
2021-07-26T03:16:36+00:00  longevity-lwt-3h-master-db-node-5fd7f1e0-1 !INFO    | systemd[1]: Starting Scylla Server...
2021-07-26T03:16:36+00:00  longevity-lwt-3h-master-db-node-5fd7f1e0-1 !INFO    | systemd-udevd[240]: Network interface NamePolicy= disabled on kernel command line, ignoring.
2021-07-26T03:16:36+00:00  longevity-lwt-3h-master-db-node-5fd7f1e0-1 !NOTICE  | systemd[1]: scylla-server.service: Control process exited, code=exited, status=1/FAILURE
2021-07-26T03:16:36+00:00  longevity-lwt-3h-master-db-node-5fd7f1e0-1 !WARNING | systemd[1]: scylla-server.service: Failed with result 'exit-code'.
2021-07-26T03:16:36+00:00  longevity-lwt-3h-master-db-node-5fd7f1e0-1 !ERR     | systemd[1]: Failed to start Scylla Server.
2021-07-26T03:16:36+00:00  longevity-lwt-3h-master-db-node-5fd7f1e0-1 !WARNING | systemd[1]: Dependency failed for Scylla JMX.
2021-07-26T03:16:36+00:00  longevity-lwt-3h-master-db-node-5fd7f1e0-1 !NOTICE  | systemd[1]: scylla-jmx.service: Job scylla-jmx.service/start failed with result 'dependency'.
2021-07-26T03:16:36+00:00  longevity-lwt-3h-master-db-node-5fd7f1e0-1 !WARNING | systemd[1]: Dependency failed for Run Scylla Housekeeping daily mode.

```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
