### PR TITLE
fix(gkenodepool): Add cluster tags to each node-pool

### DIFF
--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -77,12 +77,14 @@ class GkeNodePool(CloudK8sNodePool):
 
     @property
     def _deploy_cmd(self) -> str:
+        tags = ",".join(f"{key}={value}" for key, value in self.tags.items())
         cmd = [f"container --project {self.gce_project} node-pools create {self.name}",
                f"--zone {self.gce_zone}",
                f"--cluster {self.k8s_cluster.short_cluster_name}",
                f"--num-nodes {self.num_nodes}",
                f"--machine-type {self.instance_type}",
-               "--image-type UBUNTU"
+               "--image-type UBUNTU",
+               f"--metadata {tags}"
                ]
         if not self.k8s_cluster.gke_k8s_release_channel:
             # NOTE: only static K8S release channel supports disabling of autoupgrade

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1084,7 +1084,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 name=self.k8s_cluster.LOADER_POOL_NAME,
                 instance_type=self.params.get("gce_instance_type_loader"),
                 num_nodes=self.params.get("n_loaders"),
-                k8s_cluster=self.k8s_cluster)
+                k8s_cluster=self.k8s_cluster,
+                tags=self.k8s_cluster.tags)
             self.k8s_cluster.deploy_node_pool(loader_pool, wait_till_ready=False)
 
         monitor_pool = None
@@ -1096,7 +1097,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 disk_type=self.params.get("gce_root_disk_type_monitor"),
                 instance_type=self.params.get("gce_instance_type_monitor"),
                 num_nodes=1,
-                k8s_cluster=self.k8s_cluster)
+                k8s_cluster=self.k8s_cluster,
+                tags=self.k8s_cluster.tags
+            )
             self.k8s_cluster.deploy_node_pool(monitor_pool, wait_till_ready=False)
 
         scylla_pool = gke.GkeNodePool(
@@ -1106,7 +1109,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             disk_type=self.params.get("gce_root_disk_type_db"),
             instance_type=self.params.get("gce_instance_type_db"),
             num_nodes=int(self.params.get("n_db_nodes")) + 1,
-            k8s_cluster=self.k8s_cluster)
+            k8s_cluster=self.k8s_cluster,
+            tags=self.k8s_cluster.tags)
+
         self.k8s_cluster.deploy_node_pool(scylla_pool, wait_till_ready=False)
 
         self.k8s_cluster.wait_all_node_pools_to_be_ready()


### PR DESCRIPTION
Tags were added only for default node-pool upon
gke cluster creation. Add same tags to each
nodepool

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
