### PR TITLE
fix(BaseCluster): make property of test_config

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3017,7 +3017,6 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
     def __init__(self, cluster_uuid=None, cluster_prefix='cluster', node_prefix='node', n_nodes=3, params=None,
                  region_names=None, node_type=None, extra_network_interface=False):
         self.extra_network_interface = extra_network_interface
-        self.test_config = TestConfig()
         if params is None:
             params = {}
         if cluster_uuid is None:
@@ -3061,6 +3060,10 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
         self.coredumps = dict()
         self.latency_results = dict()
         super().__init__()
+
+    @cached_property
+    def test_config(self) -> TestConfig:  # pylint: disable=no-self-use
+        return TestConfig()
 
     @property
     def auto_bootstrap(self):


### PR DESCRIPTION
Initialization of clusters in sct is complex thing, BaseCluster init
usually is called when all other inits are done. If/when attribute that is
initiated in BaseCluster is used before BaseCluster.__init__ is called we get into
issue of unknown attrubute, test_config is good example of such problem.
It is always better to either go with property or with class attribute in such case

fixes regression after 0cd4862f0880e351bb1d163297ec9177855766ce :

```
06:08:57  < t:2021-07-30 03:08:56,429 f:tester.py       l:132  c:sdcm.tester          p:ERROR > Traceback (most recent call last):
06:08:57  < t:2021-07-30 03:08:56,429 f:tester.py       l:132  c:sdcm.tester          p:ERROR >   File "/home/ubuntu/scylla-cluster-tests/sdcm/tester.py", line 125, in wrapper
06:08:57  < t:2021-07-30 03:08:56,429 f:tester.py       l:132  c:sdcm.tester          p:ERROR >     return method(*args, **kwargs)
06:08:57  < t:2021-07-30 03:08:56,429 f:tester.py       l:132  c:sdcm.tester          p:ERROR >   File "/home/ubuntu/scylla-cluster-tests/sdcm/utils/decorators.py", line 111, in inner
06:08:57  < t:2021-07-30 03:08:56,429 f:tester.py       l:132  c:sdcm.tester          p:ERROR >     res = func(*args, **kwargs)
06:08:57  < t:2021-07-30 03:08:56,429 f:tester.py       l:132  c:sdcm.tester          p:ERROR >   File "/home/ubuntu/scylla-cluster-tests/sdcm/tester.py", line 520, in setUp
06:08:57  < t:2021-07-30 03:08:56,429 f:tester.py       l:132  c:sdcm.tester          p:ERROR >     self.init_resources()
06:08:57  < t:2021-07-30 03:08:56,429 f:tester.py       l:132  c:sdcm.tester          p:ERROR >   File "/home/ubuntu/scylla-cluster-tests/sdcm/tester.py", line 1311, in init_resources
06:08:57  < t:2021-07-30 03:08:56,429 f:tester.py       l:132  c:sdcm.tester          p:ERROR >     self.get_cluster_aws(loader_info=loader_info, db_info=db_info,
06:08:57  < t:2021-07-30 03:08:56,429 f:tester.py       l:132  c:sdcm.tester          p:ERROR >   File "/home/ubuntu/scylla-cluster-tests/sdcm/tester.py", line 842, in get_cluster_aws
06:08:57  < t:2021-07-30 03:08:56,429 f:tester.py       l:132  c:sdcm.tester          p:ERROR >     self.db_cluster = create_cluster(db_type)
06:08:57  < t:2021-07-30 03:08:56,429 f:tester.py       l:132  c:sdcm.tester          p:ERROR >   File "/home/ubuntu/scylla-cluster-tests/sdcm/tester.py", line 806, in create_cluster
06:08:57  < t:2021-07-30 03:08:56,429 f:tester.py       l:132  c:sdcm.tester          p:ERROR >     return ScyllaAWSCluster(
06:08:57  < t:2021-07-30 03:08:56,429 f:tester.py       l:132  c:sdcm.tester          p:ERROR >   File "/home/ubuntu/scylla-cluster-tests/sdcm/cluster_aws.py", line 834, in __init__
06:08:57  < t:2021-07-30 03:08:56,429 f:tester.py       l:132  c:sdcm.tester          p:ERROR >     cluster_uuid = self.test_config.test_id()
06:08:57  < t:2021-07-30 03:08:56,429 f:tester.py       l:132  c:sdcm.tester          p:ERROR > AttributeError: 'ScyllaAWSCluster' object has no attribute 'test_config'
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
