### PR TITLE
fix(scylla_bench_thread): prop up s-b version

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -160,3 +160,4 @@ scylla_rsyslog_setup: false
 backup_bucket_region: ''  # use the same region as a cluster
 
 events_limit_in_email: 10
+scylla_bench_version: v0.1.3

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4712,9 +4712,8 @@ class BaseLoaderSet():
     def is_scylla_bench_installed(node: BaseNode):
         return node.remoter.run('ls /$HOME/go/bin/scylla-bench', ignore_status=True).ok
 
-    @staticmethod
     @retrying(n=5)
-    def install_scylla_bench(node):
+    def install_scylla_bench(self, node):
         if node.distro.is_rhel_like:
             node.remoter.sudo("yum install -y git")
         else:
@@ -4722,14 +4721,14 @@ class BaseLoaderSet():
                 apt-get update
                 apt-get install -y git
             """))
-        node.remoter.sudo(shell_script_cmd("""\
+        node.remoter.sudo(shell_script_cmd(f"""\
             rm -rf /usr/local/go
             curl -LO https://storage.googleapis.com/golang/go1.16.3.linux-amd64.tar.gz
             tar -C /usr/local -xvzf go1.16.3.linux-amd64.tar.gz
             echo 'export GOPATH=$HOME/go' >> $HOME/.bash_profile
             echo 'export PATH=$PATH:/usr/local/go/bin' >> $HOME/.bash_profile
             source $HOME/.bash_profile
-            GO111MODULE=on go get -v github.com/scylladb/scylla-bench@v0.1.3
+            GO111MODULE=on go get -v github.com/scylladb/scylla-bench@{self.params.get('scylla_bench_version')}
         """))
 
 

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4729,7 +4729,7 @@ class BaseLoaderSet():
             echo 'export GOPATH=$HOME/go' >> $HOME/.bash_profile
             echo 'export PATH=$PATH:/usr/local/go/bin' >> $HOME/.bash_profile
             source $HOME/.bash_profile
-            GO111MODULE=on go get -v github.com/scylladb/scylla-bench@v0.1.2
+            GO111MODULE=on go get -v github.com/scylladb/scylla-bench@v0.1.3
         """))
 
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -161,7 +161,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self._add_drop_column_columns_info = {}
         self._add_drop_column_target_table = []
         self._add_drop_column_tables_to_ignore = {
-            'scylla_bench': '*',  # Ignore scylla-bench tables
             'alternator_usertable': '*',  # Ignore alternator tables
             'ks_truncate': 'counter1',  # Ignore counter table
             'keyspace1': 'counter1',  # Ignore counter table

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -365,6 +365,9 @@ class SCTConfiguration(dict):
         dict(name="server_encrypt", env="SCT_SERVER_ENCRYPT", type=boolean,
              help="when enable scylla will use encryption on the server side"),
 
+        dict(name="scylla_bench_version", env="SCT_SCYLLA_BENCH_VERSION", type=str,
+             help="A valid tag under the scylla bench repo: https://github.com/scylladb/scylla-bench"),
+
         dict(name="client_encrypt", env="SCT_CLIENT_ENCRYPT", type=boolean,
              help="when enable scylla will use encryption on the client side"),
 

--- a/sdcm/scylla_bench_thread.py
+++ b/sdcm/scylla_bench_thread.py
@@ -71,6 +71,7 @@ class ScyllaBenchThread:  # pylint: disable=too-many-instance-attributes
         self.stress_num = stress_num
         if credentials and 'username=' not in self.stress_cmd:
             self.stress_cmd += " -username {} -password {}".format(*credentials)
+        self.stress_cmd += ' -error-at-row-limit 1000'  # make it fail after having 1000 errors at row
         self.stop_test_on_failure = stop_test_on_failure
 
         self.executor = None


### PR DESCRIPTION
https://trello.com/c/eE4dRKSE/3724-prop-up-scylla-bench-version-on-sct

s-b got a new tag - https://github.com/scylladb/scylla-bench/releases/tag/v0.1.3
Let's prop version number up on sct, also we need to add additional options that were introduced by following commits:
https://github.com/scylladb/scylla-bench/commit/5662afcdd7ac81a5660679e87de3accf3ccf018e
https://github.com/scylladb/scylla-bench/commit/d1644082c188494a031eddb710ecf588b3913f44

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
