### PR TITLE
fix(deploy_scylla_operator): fix pod readiness timeout

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -600,7 +600,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
             KubernetesOps.wait_for_pods_readiness(
                 kluster=self,
                 total_pods=lambda pods: pods > 0,
-                readiness_timeout=5*60,
+                readiness_timeout=5,
                 namespace=SCYLLA_OPERATOR_NAMESPACE
             )
         # Start the Scylla Operator logging thread

--- a/sdcm/utils/k8s.py
+++ b/sdcm/utils/k8s.py
@@ -561,7 +561,7 @@ class KubernetesOps:  # pylint: disable=too-many-public-methods
             result = kluster.kubectl(
                 f"wait --timeout={readiness_timeout // 5}m --all --for=condition=Ready pod",
                 namespace=namespace,
-                timeout=readiness_timeout // 5 * 60 + 10)
+                timeout=readiness_timeout * 60 // 5 + 10)
             count = result.stdout.count('condition met')
             if isinstance(total_pods, (int, float)):
                 if total_pods != count:


### PR DESCRIPTION
https://trello.com/c/FwcrygA9/3726-scylla-operator-fix-pods-readiness-timeout-on-deployscyllaoperator

Currently we are waiting for 5 hours

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
