### PR TITLE
test(test_functional): add test for scylla-operator pods

### DIFF
--- a/functional_tests/scylla_operator/libs/helpers.py
+++ b/functional_tests/scylla_operator/libs/helpers.py
@@ -12,7 +12,7 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2021 ScyllaDB
-from sdcm.cluster_k8s import SCYLLA_NAMESPACE
+from sdcm.cluster_k8s import SCYLLA_NAMESPACE, SCYLLA_OPERATOR_NAMESPACE  # pylint: disable=import-error
 
 
 def get_orphaned_services(db_cluster):
@@ -32,3 +32,11 @@ def scylla_services_names(db_cluster):
     services = db_cluster.k8s_cluster.kubectl(f"get svc -n {SCYLLA_NAMESPACE} -l scylla/cluster=sct-cluster "
                                               f"-o=custom-columns='NAME:.metadata.name'")
     return [name for name in services.stdout.split() if name not in ('NAME', 'sct-cluster-client')]
+
+
+def scylla_operator_pods_and_statuses(db_cluster):
+    pods = db_cluster.k8s_cluster.kubectl(f"get pods -n {SCYLLA_OPERATOR_NAMESPACE} "
+                                          f"-o=custom-columns='NAME:.metadata.name,STATUS:.status.phase'")
+
+    return [name.split() for name in pods.stdout.split('\n') if
+            'NAME' not in name and SCYLLA_OPERATOR_NAMESPACE in name]


### PR DESCRIPTION
Issue: https://github.com/scylladb/scylla-operator/issues/410

Need two scylla-operator pods to be StatefulSet.
Added new test that check that there are 2 operator pods, both are healthy and running.
Also check their logs that one took lock and another wait for it.

Task:
https://trello.com/c/tLWEAEUg/3575-check-that-scylla-operator-has-2-replicas-with-leader-election

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
