### PR TITLE
fix(remotewebbrowser.py): hardcode selenuim backend

### DIFF
--- a/sdcm/utils/remotewebbrowser.py
+++ b/sdcm/utils/remotewebbrowser.py
@@ -26,7 +26,7 @@ from sdcm.utils.common import get_free_port, wait_for_port, normalize_ipv6_url
 from sdcm.utils.ssh_agent import SSHAgent
 
 
-WEB_DRIVER_IMAGE = "selenium/standalone-chrome:latest"
+WEB_DRIVER_IMAGE = "selenium/standalone-chrome:3.141.59-20210713"
 WEB_DRIVER_REMOTE_PORT = 4444
 WEB_DRIVER_CONTAINER_START_DELAY = 30  # seconds
 


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
