### PR TITLE
fix(artifactsPipeline): fix cleanSCTRunners step

### DIFF
--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -199,19 +199,6 @@ def call(Map pipelineParams) {
                                                     echo "Email sent"
                                                 """
                                             }
-                                            stage('Clean SCT Runners') {
-                                                steps {
-                                                    catchError(stageResult: 'FAILURE') {
-                                                        script {
-                                                            wrap([$class: 'BuildUser']) {
-                                                                dir('scylla-cluster-tests') {
-                                                                    cleanSctRunners(params, currentBuild)
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
                                         }
                                     }
                                 }


### PR DESCRIPTION
Fixing the issue with `artifactsPipeline` falining on 'Clean SCT Runners' stage. artifactsPipeline uses shell scripts wrapped in `sctScript` rather than calls to the scripts themselves, so I'm moving the script inside the artifactesPipeline to align it with the other stages defined there.

Test run of the improved Jenkins pipeline: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/maciej/job/mc-artifacts/job/mc-artifacts-centos-7/24/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] ~~I added the relevant `backport` labels~~
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
