### PR TITLE
improvement(sct_events): modify 'begin' for JMX

### DIFF
--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -266,7 +266,7 @@ class RepairEvent(ScyllaDatabaseContinuousEvent):
 
 
 class JMXServiceEvent(ScyllaDatabaseContinuousEvent):
-    begin_pattern = r'Started Scylla JMX'
+    begin_pattern = r'Starting the JMX server'
     end_pattern = r'JMX is enabled to receive remote connections on port: \d+'
 
     def __init__(self, node: str, severity=Severity.NORMAL, **__):


### PR DESCRIPTION
During a local scylla operator run @juliayakovlev found that the "Started Scylla JMX" line is not being logged (but the JMX service seems to have been started). I'm expanding the regex for startign the JMX service to include the "Starting the JMX server" line as an alternative event trigger.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
