### PR TITLE
fix(functional-tests-logs): fix naming of local K8S clusters logs

### DIFF
--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -457,6 +457,7 @@ class LocalMinimalClusterBase(MinimalClusterBase):
         self.node_prefix = cluster.prepend_user_prefix(user_prefix, "node")
         super().__init__(
             mini_k8s_version=software_version,
+            user_prefix=user_prefix,
             params=params)
 
     # pylint: disable=invalid-overridden-method

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -929,6 +929,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         )
         self.k8s_cluster = cluster_type(
             software_version=self.params.get("mini_k8s_version"),
+            user_prefix=self.params.get("user_prefix"),
             params=self.params,
         )
         self.k8s_cluster.deploy()


### PR DESCRIPTION
For the moment logs are saved in dirs named like "-e4ad3ad7".
Where prefix is missing.
Fix it by providing missing "user_prefix" to the appropriate classes.
After doing it, the "user_prefix" config option will be used correctly for K8S cluster names running it using "kind" and "minikube" backends on local machines.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] ~~All new and existing unit tests passed (CI)~~
- [ ] I have updated the Readme/doc folder accordingly (if needed)
