### PR TITLE
test(perf-latency-dick-and-cache): New perf latency test

### DIFF
--- a/jenkins-pipelines/perf-regression-latency-125gb.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-125gb.jenkinsfile
@@ -1,0 +1,14 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    aws_region: "us-east-1",
+    test_name: "performance_regression_test.PerformanceRegressionTest",
+    test_config: "test-cases/performance/perf-regression-latency-125gb.yaml",
+    sub_tests: ["test_latency"],
+
+    timeout: [time: 680, unit: "MINUTES"]
+)

--- a/test-cases/performance/perf-regression-latency-125gb.yaml
+++ b/test-cases/performance/perf-regression-latency-125gb.yaml
@@ -1,0 +1,32 @@
+test_duration: 600
+prepare_write_cmd: ["cassandra-stress write no-warmup cl=ALL n=31250000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..31250000",
+                    "cassandra-stress write no-warmup cl=ALL n=31250000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=31250001..62500000",
+                    "cassandra-stress write no-warmup cl=ALL n=31250000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=62500001..93750000",
+                    "cassandra-stress write no-warmup cl=ALL n=31250000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=93750001..125000000"]
+
+stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=60m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=100 throttle=15000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..125000000,62500000,12500000)' "
+stress_cmd_r: "cassandra-stress read no-warmup  cl=QUORUM duration=60m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=100 throttle=10000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..125000000,62500000,12500000)' "
+stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=60m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=100 throttle=10000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..125000000,62500000,12500000)' "
+
+n_db_nodes: 3
+n_loaders: 4
+n_monitor_nodes: 1
+
+instance_type_loader: 'c5.2xlarge'
+instance_type_monitor: 't3.large'
+instance_type_db: 'i3.2xlarge'
+
+user_prefix: 'perf-latency-disk-and-cache'
+space_node_threshold: 644245094
+ami_id_db_scylla_desc: 'VERSION_DESC'
+
+round_robin: true
+append_scylla_args: '--blocked-reactor-notify-ms 5'
+backtrace_decoding: false
+
+use_mgmt: true
+
+store_perf_results: true
+send_email: true
+email_recipients: ['scylla-perf-results@scylladb.com']
+backtrace_decoding: false


### PR DESCRIPTION
Added new perf latency test for checking performance
when data are not full in cache

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
