### PR TITLE
fix(pipelines): make them tollerate if no params.post_behavior_k8s_cluster

### DIFF
--- a/vars/byoOperatorPipeline.groovy
+++ b/vars/byoOperatorPipeline.groovy
@@ -46,6 +46,9 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('post_behavior_monitor_nodes', 'keep-on-failure')}",
                    description: 'keep|keep-on-failure|destroy',
                    name: 'post_behavior_monitor_nodes')
+            string(defaultValue: "${pipelineParams.get('post_behavior_k8s_cluster', 'keep-on-failure')}",
+                   description: 'keep|keep-on-failure|destroy',
+                   name: 'post_behavior_k8s_cluster')
             string(defaultValue: "qa@scylladb.com",
                    description: 'email recipients of email report',
                    name: 'email_recipients')
@@ -100,9 +103,18 @@ def call(Map pipelineParams) {
                             export SCT_SCYLLA_VERSION=${params.scylla_version}
                             export SCT_SCYLLA_MGMT_AGENT_VERSION=${params.scylla_mgmt_agent_version}
 
-                            export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
-                            export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
-                            export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"
+                            if [[ -n "${params.post_behavior_db_nodes ? params.post_behavior_db_nodes : ''}" ]] ; then
+                                export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
+                            fi
+                            if [[ -n "${params.post_behavior_loader_nodes ? params.post_behavior_loader_nodes : ''}" ]] ; then
+                                export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
+                            fi
+                            if [[ -n "${params.post_behavior_monitor_nodes ? params.post_behavior_monitor_nodes : ''}" ]] ; then
+                                export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"
+                            fi
+                            if [[ -n "${params.post_behavior_k8s_cluster ? params.post_behavior_k8s_cluster : ''}" ]] ; then
+                                export SCT_POST_BEHAVIOR_K8S_CLUSTER="${params.post_behavior_k8s_cluster}"
+                            fi
 
                             echo "start test ......."
                             ./docker/env/hydra.sh run-test ${params.test_name} --logdir "`pwd`"
@@ -132,9 +144,18 @@ def call(Map pipelineParams) {
                         def test_config = groovy.json.JsonOutput.toJson(params.test_config)
 
                         sctScript """
-                            export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
-                            export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
-                            export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"
+                            if [[ -n "${params.post_behavior_db_nodes ? params.post_behavior_db_nodes : ''}" ]] ; then
+                                export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
+                            fi
+                            if [[ -n "${params.post_behavior_loader_nodes ? params.post_behavior_loader_nodes : ''}" ]] ; then
+                                export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
+                            fi
+                            if [[ -n "${params.post_behavior_monitor_nodes ? params.post_behavior_monitor_nodes : ''}" ]] ; then
+                                export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"
+                            fi
+                            if [[ -n "${params.post_behavior_k8s_cluster ? params.post_behavior_k8s_cluster : ''}" ]] ; then
+                                export SCT_POST_BEHAVIOR_K8S_CLUSTER="${params.post_behavior_k8s_cluster}"
+                            fi
                             export SCT_CLUSTER_BACKEND="${params.backend}"
 
                             echo "start clean resources ..."

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -42,6 +42,9 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('post_behavior_monitor_nodes', 'destroy')}",
                    description: 'keep|keep-on-failure|destroy',
                    name: 'post_behavior_monitor_nodes')
+            string(defaultValue: "${pipelineParams.get('post_behavior_k8s_cluster', 'destroy')}",
+                   description: 'keep|keep-on-failure|destroy',
+                   name: 'post_behavior_k8s_cluster')
             booleanParam(defaultValue: "${pipelineParams.get('workaround_kernel_bug_for_iotune', false)}",
                  description: 'Workaround a known kernel bug which causes iotune to fail in scylla_io_setup, only effect GCE backend',
                  name: 'workaround_kernel_bug_for_iotune')
@@ -108,9 +111,18 @@ def call(Map pipelineParams) {
                                                         export SCT_SCYLLA_VERSION=${base_version}
                                                         export SCT_NEW_SCYLLA_REPO=${params.new_scylla_repo}
 
-                                                        export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
-                                                        export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
-                                                        export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"
+                                                        if [[ -n "${params.post_behavior_db_nodes ? params.post_behavior_db_nodes : ''}" ]] ; then
+                                                            export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
+                                                        fi
+                                                        if [[ -n "${params.post_behavior_loader_nodes ? params.post_behavior_loader_nodes : ''}" ]] ; then
+                                                            export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
+                                                        fi
+                                                        if [[ -n "${params.post_behavior_monitor_nodes ? params.post_behavior_monitor_nodes : ''}" ]] ; then
+                                                            export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"
+                                                        fi
+                                                        if [[ -n "${params.post_behavior_k8s_cluster ? params.post_behavior_k8s_cluster : ''}" ]] ; then
+                                                            export SCT_POST_BEHAVIOR_K8S_CLUSTER="${params.post_behavior_k8s_cluster}"
+                                                        fi
                                                         export SCT_INSTANCE_PROVISION="${params.provision_type}"
                                                         export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$GIT_BRANCH | sed -E 's+(origin/|origin/branch-)++')
                                                         export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$SCT_AMI_ID_DB_SCYLLA_DESC | tr ._ - | cut -c1-8 )
@@ -164,9 +176,19 @@ def call(Map pipelineParams) {
                                                         set -xe
                                                         env
 
-                                                        export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
-                                                        export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
-                                                        export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"
+                                                        if [[ -n "${params.post_behavior_db_nodes ? params.post_behavior_db_nodes : ''}" ]] ; then
+                                                            export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
+                                                        fi
+                                                        if [[ -n "${params.post_behavior_loader_nodes ? params.post_behavior_loader_nodes : ''}" ]] ; then
+                                                            export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
+                                                        fi
+                                                        if [[ -n "${params.post_behavior_monitor_nodes ? params.post_behavior_monitor_nodes : ''}" ]] ; then
+                                                            export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"
+                                                        fi
+                                                        if [[ -n "${params.post_behavior_k8s_cluster ? params.post_behavior_k8s_cluster : ''}" ]] ; then
+                                                            export SCT_POST_BEHAVIOR_K8S_CLUSTER="${params.post_behavior_k8s_cluster}"
+                                                        fi
+
                                                         export SCT_CLUSTER_BACKEND="${params.backend}"
 
                                                         echo "start clean resources ..."

--- a/vars/runCleanupResource.groovy
+++ b/vars/runCleanupResource.groovy
@@ -18,10 +18,18 @@ def call(Map params, String region){
         export SCT_REGION_NAME=${aws_region}
     fi
 
-    export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
-    export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
-    export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"
-    export SCT_POST_BEHAVIOR_K8S_CLUSTER="${params.post_behavior_k8s_cluster}"
+    if [[ -n "${params.post_behavior_db_nodes ? params.post_behavior_db_nodes : ''}" ]] ; then
+        export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
+    fi
+    if [[ -n "${params.post_behavior_loader_nodes ? params.post_behavior_loader_nodes : ''}" ]] ; then
+        export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
+    fi
+    if [[ -n "${params.post_behavior_monitor_nodes ? params.post_behavior_monitor_nodes : ''}" ]] ; then
+        export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"
+    fi
+    if [[ -n "${params.post_behavior_k8s_cluster ? params.post_behavior_k8s_cluster : ''}" ]] ; then
+        export SCT_POST_BEHAVIOR_K8S_CLUSTER="${params.post_behavior_k8s_cluster}"
+    fi
 
     echo "Starting to clean resources ..."
     if [[ "$cloud_provider" == "aws" || "$cloud_provider" == "gce" ]]; then

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -83,10 +83,18 @@ def call(Map params, String region, functional_test = false){
         export SCT_GEMINI_SEED="${params.gemini_seed}"
     fi
 
-    export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
-    export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
-    export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"
-    export SCT_POST_BEHAVIOR_K8S_CLUSTER="${params.post_behavior_k8s_cluster}"
+    if [[ -n "${params.post_behavior_db_nodes ? params.post_behavior_db_nodes : ''}" ]] ; then
+        export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
+    fi
+    if [[ -n "${params.post_behavior_loader_nodes ? params.post_behavior_loader_nodes : ''}" ]] ; then
+        export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
+    fi
+    if [[ -n "${params.post_behavior_monitor_nodes ? params.post_behavior_monitor_nodes : ''}" ]] ; then
+        export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"
+    fi
+    if [[ -n "${params.post_behavior_k8s_cluster ? params.post_behavior_k8s_cluster : ''}" ]] ; then
+        export SCT_POST_BEHAVIOR_K8S_CLUSTER="${params.post_behavior_k8s_cluster}"
+    fi
 
     if [[ -n "${params.provision_type ? params.provision_type : ''}" ]] ; then
         export SCT_INSTANCE_PROVISION="${params.provision_type}"


### PR DESCRIPTION
https://trello.com/c/vqvXXbHw/3747-fix-issue-with-k8s-post-behavior-on-k8s-pipelines

https://jenkins.scylladb.com/view/scylla-operator/job/scylla-operator/job/operator-1.4/job/upgrade/job/upgrade-major-scylla-k8s-eks/6/console

```
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR > Traceback (most recent call last):
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >   File "/home/ubuntu/scylla-cluster-tests/./sct.py", line 1072, in <module>
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >     cli()
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >   File "/usr/local/lib/python3.9/site-packages/click/core.py", line 764, in __call__
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >     return self.main(*args, **kwargs)
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >   File "/usr/local/lib/python3.9/site-packages/click/core.py", line 717, in main
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >     rv = self.invoke(ctx)
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >   File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1137, in invoke
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >     return _process_result(sub_ctx.command.invoke(sub_ctx))
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >   File "/usr/local/lib/python3.9/site-packages/click/core.py", line 956, in invoke
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >     return ctx.invoke(self.callback, **ctx.params)
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >   File "/usr/local/lib/python3.9/site-packages/click/core.py", line 555, in invoke
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >     return callback(*args, **kwargs)
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >   File "/home/ubuntu/scylla-cluster-tests/./sct.py", line 751, in run_test
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >     unittest.main(module=None, argv=['python -m unittest', argv],
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >   File "/usr/local/lib/python3.9/unittest/main.py", line 100, in __init__
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >     self.parseArgs(argv)
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >   File "/usr/local/lib/python3.9/unittest/main.py", line 147, in parseArgs
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >     self.createTests()
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >   File "/usr/local/lib/python3.9/unittest/main.py", line 158, in createTests
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >     self.test = self.testLoader.loadTestsFromNames(self.testNames,
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >   File "/usr/local/lib/python3.9/unittest/loader.py", line 220, in loadTestsFromNames
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >     suites = [self.loadTestsFromName(name, module) for name in names]
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >   File "/usr/local/lib/python3.9/unittest/loader.py", line 220, in <listcomp>
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >     suites = [self.loadTestsFromName(name, module) for name in names]
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >   File "/usr/local/lib/python3.9/unittest/loader.py", line 198, in loadTestsFromName
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >     inst = parent(name)
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >   File "/home/ubuntu/scylla-cluster-tests/sdcm/tester.py", line 241, in __init__
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >     self._init_params()
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >   File "/home/ubuntu/scylla-cluster-tests/sdcm/tester.py", line 403, in _init_params
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >     self.params = init_and_verify_sct_config()
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >   File "/home/ubuntu/scylla-cluster-tests/sdcm/sct_config.py", line 1740, in init_and_verify_sct_config
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >     sct_config.verify_configuration()
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >   File "/home/ubuntu/scylla-cluster-tests/sdcm/sct_config.py", line 1559, in verify_configuration
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >     self._validate_sct_variable_values()
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >   File "/home/ubuntu/scylla-cluster-tests/sdcm/sct_config.py", line 1597, in _validate_sct_variable_values
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >     self._validate_value(opt)
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >   File "/home/ubuntu/scylla-cluster-tests/sdcm/sct_config.py", line 1500, in _validate_value
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR >     assert cur_val in choices, "failed to validate '{}': {} not in {}".format(opt['name'], cur_val, choices)
09:35:01  < t:2021-08-06 06:35:01,024 f:log.py          l:20   c:sdcm.utils.log       p:ERROR > AssertionError: failed to validate 'post_behavior_k8s_cluster': null not in ('keep', 'keep-on-failure', 'destroy')
09:35:01  Cleaning SSH
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
