### PR TITLE
fix(pylint): address false import-error pylint errors

### DIFF
--- a/functional_tests/__init__.py
+++ b/functional_tests/__init__.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2021 ScyllaDB

--- a/functional_tests/scylla_operator/libs/__init__.py
+++ b/functional_tests/scylla_operator/libs/__init__.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2021 ScyllaDB

--- a/functional_tests/scylla_operator/libs/helpers.py
+++ b/functional_tests/scylla_operator/libs/helpers.py
@@ -12,7 +12,6 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2021 ScyllaDB
-# pylint: disable=import-error
 import yaml
 
 from sdcm.cluster_k8s import SCYLLA_NAMESPACE, SCYLLA_OPERATOR_NAMESPACE, ScyllaPodCluster

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -37,8 +37,8 @@ from dataclasses import dataclass
 import yaml
 import requests
 from paramiko import SSHException
-from tenacity import RetryError  # pylint: disable=import-error
-from invoke.exceptions import UnexpectedExit, Failure, CommandTimedOut  # pylint: disable=import-error
+from tenacity import RetryError
+from invoke.exceptions import UnexpectedExit, Failure, CommandTimedOut
 from cassandra import ConsistencyLevel
 from cassandra.auth import PlainTextAuthProvider
 from cassandra.cluster import Cluster as ClusterDriver  # pylint: disable=no-name-in-module

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -33,7 +33,7 @@ from collections import defaultdict, Counter, namedtuple
 from concurrent.futures import ThreadPoolExecutor
 from elasticsearch.exceptions import ConnectionTimeout as ElasticSearchConnectionTimeout
 
-from invoke import UnexpectedExit  # pylint: disable=import-error
+from invoke import UnexpectedExit
 from cassandra import ConsistencyLevel
 
 from sdcm.paths import SCYLLA_YAML_PATH

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -23,7 +23,7 @@ import getpass
 import pathlib
 from typing import List, Union, Set
 
-from distutils.util import strtobool  # pylint: disable=import-error,no-name-in-module
+from distutils.util import strtobool
 
 import anyconfig
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -32,7 +32,7 @@ import signal
 import sys
 import traceback
 
-from invoke.exceptions import UnexpectedExit, Failure  # pylint: disable=import-error
+from invoke.exceptions import UnexpectedExit, Failure
 
 from cassandra.concurrent import execute_concurrent_with_args  # pylint: disable=no-name-in-module
 from cassandra import ConsistencyLevel

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2021 ScyllaDB

--- a/utils/build_system/__init__.py
+++ b/utils/build_system/__init__.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2021 ScyllaDB

--- a/utils/build_system/create_test_release_jobs.py
+++ b/utils/build_system/create_test_release_jobs.py
@@ -1,10 +1,10 @@
 import logging
-
 from pathlib import Path
 
-import jenkins  # pylint: disable=import-error
+import jenkins
 
-from sdcm.wait import wait_for  # pylint: disable=import-error
+from sdcm.wait import wait_for
+
 
 DIR_TEMPLATE = open(Path(__file__).parent / 'folder-template.xml').read()
 JOB_TEMPLATE = open(Path(__file__).parent / 'template.xml').read()


### PR DESCRIPTION
By adding missing '__init__.py' files.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
