### PR TITLE
improvement(functional-tests): print test run details

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -777,7 +777,7 @@ def run_pytest(target, backend, config, logdir):
     if not target:
         print("argv is referring to the directory or file that contain tests, it can't be empty")
         sys.exit(1)
-    sys.exit(pytest.main(['-v', '-p', 'no:warnings', target]))
+    sys.exit(pytest.main(['-s', '-v', '-p', 'no:warnings', target]))
 
 
 @cli.command("cloud-usage-report", help="Generate and send Cloud usage report")


### PR DESCRIPTION
For the moment, running functional tests, we see only list of tests
and it's status. But there is no info about prerequisites installation.

So, enable details output by using "-s" flag for pytest.
Also, make bunch of "debug" log messages be "info" ones.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
