### PR TITLE
make full scan stop when test completed

### DIFF
--- a/sdcm/full_scan_thread.py
+++ b/sdcm/full_scan_thread.py
@@ -1,0 +1,109 @@
+import logging
+import random
+import threading
+import time
+
+from cassandra import ConsistencyLevel
+from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
+
+from sdcm.cluster import BaseNode, BaseScyllaCluster, BaseCluster
+from sdcm.sct_events import Severity
+from sdcm.sct_events.database import FullScanEvent
+
+
+# pylint: disable=too-many-instance-attributes
+class FullScanThread:
+    query_options = (
+        'select * from {}',
+        'select * from {} bypass cache'
+    )
+
+    # pylint: disable=too-many-arguments
+    def __init__(self, db_cluster: [BaseScyllaCluster, BaseCluster], ks_cf: str, duration: int, interval: int,
+                 termination_event: threading.Event, page_size: int = 100000):
+        self.ks_cf = ks_cf
+        self.db_cluster = db_cluster
+        self.page_size = page_size
+        self.duration = duration
+        self.interval = interval
+        self.termination_event = termination_event
+        self.log = logging.getLogger(self.__class__.__name__)
+        self._thread = threading.Thread(daemon=True, name=self.__class__.__name__, target=self.run)
+
+    def get_ks_cs(self, db_node: BaseNode):
+        ks_cf_list = self.db_cluster.get_non_system_ks_cf_list(db_node)
+        if self.ks_cf not in ks_cf_list:
+            return 'random'
+        elif 'random' in self.ks_cf.lower():
+            return random.choice(ks_cf_list)
+        return self.ks_cf
+
+    @staticmethod
+    def get_error_severity_from_exception(msg: str, db_node: BaseNode):
+        # 'unpack requires a string argument of length 4' error is received when cassandra.connection return
+        # "Error decoding response from Cassandra":
+        # failure like:
+        #   Operation failed for keyspace1.standard1 - received 0 responses and 1 failures from 1 CL=ONE
+        if db_node.running_nemesis or any(s in msg for s in ("timed out", "unpack requires", "timeout")):
+            return Severity.WARNING
+        return Severity.ERROR
+
+    @staticmethod
+    def randomly_add_timeout(cmd) -> str:
+        if random.choice([True] * 2 + [False]):
+            cql_timeout_seconds = str(random.choice([2, 4, 8, 30, 120, 300]))
+            cql_timeout_param = f" USING TIMEOUT {cql_timeout_seconds}s"
+            cmd += cql_timeout_param
+        return cmd
+
+    def randomly_form_cql_statement(self, ks_cf: str) -> str:
+        cmd = random.choice(self.query_options).format(ks_cf)
+        return self.randomly_add_timeout(cmd)
+
+    def create_session(self, db_node: BaseNode):
+        credentials = self.db_cluster.get_db_auth()
+        username, password = credentials if credentials else (None, None)
+        return self.db_cluster.cql_connection_patient(db_node, user=username, password=password)
+
+    def run_fullscan(self, db_node: BaseNode):  # pylint: disable=too-many-locals
+        ks_cf = self.get_ks_cs(db_node)
+        read_pages = random.choice([100, 1000, 0])
+        FullScanEvent.start(db_node_ip=db_node.ip_address, ks_cf=ks_cf).publish()
+        stop_event_severity = None
+        stop_event_message = 'finished successfully'
+        cmd = self.randomly_form_cql_statement(ks_cf)
+        try:
+            with self.create_session(db_node) as session:
+                self.log.info('Will run command "{}"'.format(cmd))
+                result = session.execute(SimpleStatement(
+                    cmd,
+                    fetch_size=self.page_size,
+                    consistency_level=ConsistencyLevel.ONE))
+                pages = 0
+                while result.has_more_pages and pages <= read_pages:
+                    if self.termination_event.is_set():
+                        stop_event_message = 'terminated'
+                        return
+                    result.fetch_next_page()
+                    if read_pages > 0:
+                        pages += 1
+        except Exception as exc:  # pylint: disable=broad-except
+            stop_event_message = str(exc)
+            stop_event_severity = self.get_error_severity_from_exception(stop_event_message, db_node)
+        finally:
+            FullScanEvent.finish(
+                db_node_ip=db_node.ip_address, ks_cf=self.ks_cf,
+                message=stop_event_message, **{'severity': stop_event_severity} if stop_event_severity else {}
+            ).publish()
+
+    def run(self):
+        end_time = time.time() + self.duration
+        while time.time() < end_time and not self.termination_event.is_set():
+            self.run_fullscan(db_node=random.choice(self.db_cluster.nodes))
+            time.sleep(self.interval)
+
+    def start(self):
+        self._thread.start()
+
+    def join(self, timeout=None):
+        return self._thread.join(timeout)

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -19,7 +19,6 @@ import os
 import re
 import stat
 import time
-import random
 import unittest
 import warnings
 from typing import NamedTuple, Optional, Union, List, Dict, Any, Type
@@ -36,7 +35,6 @@ from invoke.exceptions import UnexpectedExit, Failure
 
 from cassandra.concurrent import execute_concurrent_with_args  # pylint: disable=no-name-in-module
 from cassandra import ConsistencyLevel
-from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
 
 from sdcm import nemesis, cluster_docker, cluster_k8s, cluster_baremetal, db_stats, wait
 from sdcm.cluster import NoMonitorSet, SCYLLA_DIR, TestConfig, UserRemoteCredentials, BaseLoaderSet, BaseMonitorSet, \
@@ -50,6 +48,7 @@ from sdcm.cluster_aws import LoaderSetAWS
 from sdcm.cluster_aws import MonitorSetAWS
 from sdcm.cluster_k8s import mini_k8s, gke, eks, LOADER_CLUSTER_CONFIG
 from sdcm.cluster_k8s.eks import MonitorSetEKS
+from sdcm.full_scan_thread import FullScanThread
 from sdcm.scylla_bench_thread import ScyllaBenchThread
 from sdcm.utils.aws_utils import init_monitoring_info_from_params, get_ec2_network_configuration, get_ec2_services, \
     get_common_params, init_db_info_from_params, ec2_ami_get_root_device_name
@@ -67,7 +66,6 @@ from sdcm.sct_config import init_and_verify_sct_config
 from sdcm.sct_events import Severity
 from sdcm.sct_events.setup import start_events_device, stop_events_device
 from sdcm.sct_events.system import InfoEvent, TestFrameworkEvent, TestResultEvent, TestTimeoutEvent
-from sdcm.sct_events.database import FullScanEvent
 from sdcm.sct_events.file_logger import get_events_grouped_by_category, get_logger_event_summary
 from sdcm.sct_events.events_analyzer import stop_events_analyzer
 from sdcm.stress_thread import CassandraStressThread
@@ -1599,62 +1597,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                          'errors': stats['errors']})
         return stats
 
-    def run_fullscan(self, ks_cf, db_node, page_size=100000):  # pylint: disable=too-many-locals
-        """Run cql select count(*) request
-
-        if ks_cf is not random, use value from config
-        if ks_cf is random, choose random from not system
-
-        Arguments:
-            loader_node {BaseNode} -- loader cluster node
-            db_node {BaseNode} -- db cluster node
-
-        Returns:
-            object -- object with result of remoter.run command
-        """
-        ks_cf_list = self.db_cluster.get_non_system_ks_cf_list(db_node)
-        if ks_cf not in ks_cf_list:
-            ks_cf = 'random'
-
-        if 'random' in ks_cf.lower():
-            ks_cf = random.choice(ks_cf_list)
-
-        read_pages = random.choice([100, 1000, 0])
-
-        FullScanEvent.start(db_node_ip=db_node.ip_address, ks_cf=ks_cf).publish()
-
-        cmd_select_all = 'select * from {}'
-        cmd_bypass_cache = 'select * from {} bypass cache'
-        cmd = random.choice([cmd_select_all, cmd_bypass_cache]).format(ks_cf)
-        if random.choice([True] * 2 + [False]):
-            cql_timeout_seconds = str(random.choice([2, 4, 8, 30, 120, 300]))
-            cql_timeout_param = f" USING TIMEOUT {cql_timeout_seconds}s"
-            cmd += cql_timeout_param
-        try:
-            credentials = self.db_cluster.get_db_auth()
-            username, password = credentials if credentials else (None, None)
-            with self.db_cluster.cql_connection_patient(db_node, user=username, password=password) as session:
-                self.log.info('Will run command "{}"'.format(cmd))
-                result = session.execute(SimpleStatement(cmd, fetch_size=page_size,
-                                                         consistency_level=ConsistencyLevel.ONE))
-                pages = 0
-                while result.has_more_pages and pages <= read_pages:
-                    result.fetch_next_page()
-                    if read_pages > 0:
-                        pages += 1
-            FullScanEvent.finish(db_node_ip=db_node.ip_address, ks_cf=ks_cf, message="finished successfully").publish()
-        except Exception as exc:  # pylint: disable=broad-except
-            # 'unpack requires a string argument of length 4' error is received when cassandra.connection return
-            # "Error decoding response from Cassandra":
-            # failure like:
-            #   Operation failed for keyspace1.standard1 - received 0 responses and 1 failures from 1 CL=ONE
-            msg = str(exc)
-            if db_node.running_nemesis or any(s in msg for s in ("timed out", "unpack requires", "timeout")):
-                severity = Severity.WARNING
-            else:
-                severity = Severity.ERROR
-            FullScanEvent.finish(db_node_ip=db_node.ip_address, ks_cf=ks_cf, message=msg, severity=severity).publish()
-
     def run_fullscan_thread(self, ks_cf='random', interval=1, duration=None):
         """Run thread of cql command select *
 
@@ -1667,20 +1609,13 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             timeout {number} -- interval between request in min (default: {1})
             duration {int} -- duration of running thread in min (default: {None})
         """
-        duration = self.get_duration(duration)
-        interval = interval * 60
-
-        @log_run_info('Fullscan thread')
-        def run_in_thread():
-            start = current = time.time()
-            while current - start < duration:
-                db_node = random.choice(self.db_cluster.nodes)
-                self.run_fullscan(ks_cf, db_node)
-                time.sleep(interval)
-                current = time.time()
-
-        thread = threading.Thread(target=run_in_thread, name='FullScanThread', daemon=True)
-        thread.start()
+        FullScanThread(
+            db_cluster=self.db_cluster,
+            ks_cf=ks_cf,
+            duration=self.get_duration(duration),
+            interval=interval * 60,
+            termination_event=self.db_cluster.nemesis_termination_event,
+        ).start()
 
     @staticmethod
     def is_keyspace_in_cluster(session, keyspace_name):


### PR DESCRIPTION
FIxes https://github.com/scylladb/scylla-cluster-tests/issues/3851

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
