### PR TITLE
fix(python3.8): make type annotations be python3.8 compatible

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -21,7 +21,7 @@ import datetime
 import tarfile
 import tempfile
 import traceback
-from typing import Optional
+from typing import List, Optional
 from pathlib import Path
 from functools import cached_property
 
@@ -699,7 +699,7 @@ class LogCollector:
                                        timeout=timeout)
         return local_dir
 
-    def collect_logs(self, local_search_path: Optional[str] = None) -> list[str]:
+    def collect_logs(self, local_search_path: Optional[str] = None) -> List[str]:
         def collect_logs_per_node(node):
             LOGGER.info('Collecting logs on host: %s', node.name)
             remote_node_dir = self.create_remote_storage_dir(node)
@@ -806,7 +806,7 @@ class ScyllaLogCollector(LogCollector):
     cluster_dir_prefix = "db-cluster"
     collect_timeout = 600
 
-    def collect_logs(self, local_search_path=None) -> list[str]:
+    def collect_logs(self, local_search_path=None) -> List[str]:
         self.collect_logs_for_inactive_nodes(local_search_path)
         return super().collect_logs(local_search_path)
 
@@ -835,7 +835,7 @@ class LoaderLogCollector(LogCollector):
                 search_locally=True),
     ]
 
-    def collect_logs(self, local_search_path=None) -> list[str]:
+    def collect_logs(self, local_search_path=None) -> List[str]:
         self.collect_logs_for_inactive_nodes(local_search_path)
         return super().collect_logs(local_search_path)
 
@@ -931,7 +931,7 @@ class SCTLogCollector(LogCollector):
     cluster_log_type = 'sct-runner'
     cluster_dir_prefix = 'sct-runner'
 
-    def collect_logs(self, local_search_path: Optional[str] = None) -> list[str]:
+    def collect_logs(self, local_search_path: Optional[str] = None) -> List[str]:
         for ent in self.log_entities:
             ent.collect(None, self.local_dir, None, local_search_path=local_search_path)
         if not os.listdir(self.local_dir):
@@ -976,7 +976,7 @@ class SCTLogCollector(LogCollector):
     def is_collect_to_a_single_archive(self) -> bool:
         return self.get_files_size() < 3*1024*1024*1024
 
-    def create_single_archive_and_upload(self) -> list[str]:
+    def create_single_archive_and_upload(self) -> List[str]:
         final_archive = self.archive_to_tarfile(self.local_dir)
 
         s3_link = upload_archive_to_s3(final_archive, f"{self.test_id}/{self.current_run}")
@@ -984,7 +984,7 @@ class SCTLogCollector(LogCollector):
         remove_files(final_archive)
         return [s3_link]
 
-    def create_achive_per_file_and_upload(self) -> list[str]:
+    def create_achive_per_file_and_upload(self) -> List[str]:
         s3_links = []
         for root, _, files in os.walk(self.local_dir):
             for current_file in files:
@@ -1019,7 +1019,7 @@ class JepsenLogCollector(LogCollector):
     cluster_log_type = "jepsen-data"
     cluster_dir_prefix = "jepsen-data"
 
-    def collect_logs(self, local_search_path: Optional[str] = None) -> list[str]:
+    def collect_logs(self, local_search_path: Optional[str] = None) -> List[str]:
         s3_link = []
         if self.nodes:
             jepsen_node = self.nodes[0]

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -917,7 +917,7 @@ def filter_gce_by_tags(tags_dict, instances):
     return filtered_instances
 
 
-def list_instances_gce(tags_dict=None, running=False, verbose=False) -> list[Node]:
+def list_instances_gce(tags_dict=None, running=False, verbose=False) -> List[Node]:
     """
     list all instances with specific tags GCE
 
@@ -1072,7 +1072,7 @@ def list_clusters_eks(tags_dict: Optional[dict] = None, verbose: bool = False) -
 
 
 def filter_k8s_clusters_by_tags(tags_dict: dict,
-                                clusters: list[Union["EksCluster", "GkeCluster"]]) -> list[Union["EksCluster", "GkeCluster"]]:
+                                clusters: List[Union["EksCluster", "GkeCluster"]]) -> List[Union["EksCluster", "GkeCluster"]]:
     if "NodeType" in tags_dict and tags_dict.get("NodeType") != "k8s":
         return []
 


### PR DESCRIPTION
In python 3.8 we must use 'typing.List[str]', not 'list[str]'.
Support for latter one was added only in python3.9:

https://docs.python.org/3/whatsnew/3.9.html#type-hinting-generics-in-standard-collections

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
