### PR TITLE
fix(scylla_bench_thread): make it tollerate empty value

### DIFF
--- a/sdcm/scylla_bench_thread.py
+++ b/sdcm/scylla_bench_thread.py
@@ -191,14 +191,19 @@ class ScyllaBenchThread:  # pylint: disable=too-many-instance-attributes
                     line.startswith('Rows per request:') or line.startswith('Page size:') or \
                     line.startswith('Concurrency:') or line.startswith('Connections:') or \
                     line.startswith('Maximum rate:') or line.startswith('Client compression:'):
-                split_idx = line.index(':')
-                key = line[:split_idx].strip()
-                value = line[split_idx + 1:].split()[0]
+                # Concurrency:             7
+                # Connections:             4
+                # Maximum rate:            32000 op/s
+                # Client compression:      true
+                split = line.split(':', maxsplit=1)
+                key = split[0].strip()
+                value = split[1].split()[0] if split[1] else ''
                 results[key] = value
             elif line.startswith('Clustering row size:'):
-                split_idx = line.index(':')
-                key = line[:split_idx].strip()
-                value = ' '.join(line[split_idx + 1:].split())
+                # Clustering row size:     Fixed(5120)
+                split = line.split(':', maxsplit=1)
+                key = split[0].strip()
+                value = ' '.join(split[1].split())
                 results[key] = value
 
             if line.startswith('Results'):


### PR DESCRIPTION
https://trello.com/c/9JKOduBs/3755-s-b-result-parsing-issue

ScyllaBenchThread._parse_bench_summary fails if value is absent:

```
event_id=d192f1d9-f6da-49b3-9b59-dfa3cf260258, source=LongevityTest.test_custom_time (longevity_test.LongevityTest)() message=Traceback (most recent call last):
23:56:55  < t:2021-08-06 20:56:55,633 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  >   File "/home/jenkins/slave/workspace/can_scylla-cluster-tests_PR-3860/scylla-cluster-tests/longevity_test.py", line 193, in test_custom_time
23:56:55  < t:2021-08-06 20:56:55,633 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  >     self.run_prepare_write_cmd()
23:56:55  < t:2021-08-06 20:56:55,633 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  >   File "/home/jenkins/slave/workspace/can_scylla-cluster-tests_PR-3860/scylla-cluster-tests/longevity_test.py", line 146, in run_prepare_write_cmd
23:56:55  < t:2021-08-06 20:56:55,633 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  >     self.verify_stress_thread(cs_thread_pool=stress)
23:56:55  < t:2021-08-06 20:56:55,633 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  >   File "/home/jenkins/slave/workspace/can_scylla-cluster-tests_PR-3860/scylla-cluster-tests/sdcm/tester.py", line 1544, in verify_stress_thread
23:56:55  < t:2021-08-06 20:56:55,633 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  >     results, errors = cs_thread_pool.verify_results()
23:56:55  < t:2021-08-06 20:56:55,633 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  >   File "/home/jenkins/slave/workspace/can_scylla-cluster-tests_PR-3860/scylla-cluster-tests/sdcm/scylla_bench_thread.py", line 98, in verify_results
23:56:55  < t:2021-08-06 20:56:55,633 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  >     node_cs_res = self._parse_bench_summary(lines)  # pylint: disable=protected-access
23:56:55  < t:2021-08-06 20:56:55,633 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  >   File "/home/jenkins/slave/workspace/can_scylla-cluster-tests_PR-3860/scylla-cluster-tests/sdcm/scylla_bench_thread.py", line 214, in _parse_bench_summary
23:56:55  < t:2021-08-06 20:56:55,633 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  >     value = line[split_idx + 1:].split()[0]
23:56:55  < t:2021-08-06 20:56:55,633 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  > IndexError: list index out of range
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
