### PR TITLE
fix(jepsen): comment out clean sct runners step

### DIFF
--- a/vars/jepsenPipeline.groovy
+++ b/vars/jepsenPipeline.groovy
@@ -187,19 +187,20 @@ def call(Map pipelineParams) {
                     }
                 }
             }
-            stage('Clean SCT Runners') {
-                steps {
-                    catchError(stageResult: 'FAILURE') {
-                        script {
-                            wrap([$class: 'BuildUser']) {
-                                dir('scylla-cluster-tests') {
-                                    cleanSctRunners(params, currentBuild)
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+//  This stage is not currently used, since we don't currently use SCT Runner in this pipeline
+//             stage('Clean SCT Runners') {
+//                 steps {
+//                     catchError(stageResult: 'FAILURE') {
+//                         script {
+//                             wrap([$class: 'BuildUser']) {
+//                                 dir('scylla-cluster-tests') {
+//                                     cleanSctRunners(params, currentBuild)
+//                                 }
+//                             }
+//                         }
+//                     }
+//                 }
+//             }
         }
         post {
             always {


### PR DESCRIPTION
Commenting out the `Clean SCT Runners` stage in the Jepsen pipeline, since we're not running a runner there at the moment.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] ~~I added the relevant `backport` labels~~
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
