### PR TITLE
improvement(kubernetes): restart scylla pods using proper API

### DIFF
--- a/functional_tests/scylla_operator/conftest.py
+++ b/functional_tests/scylla_operator/conftest.py
@@ -134,6 +134,9 @@ def _bring_cluster_back_to_original_state(
                 rack['members'] = 0
             original_rack_specs.extend(new_racks)
 
+        # NOTE: ignore 'forceRedeploymentReason' field always to avoid redundant restarts
+        original_scylla_cluster_spec.pop("forceRedeploymentReason", None)
+        current_cluster_spec.pop("forceRedeploymentReason", None)
         if original_scylla_cluster_spec != current_cluster_spec:
             # If cluster spec we currently have is not equal to what we want replace it and
             #  remember to restart the cluster afterwards

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2243,20 +2243,8 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
     def restart_scylla(self, nodes=None, random_order=False):
         # TODO: add support for the "nodes" param to have compatible logic with
         # other backends.
-
-        # NOTE: starting with operator-1.4 if we run rollout restart of a scylla statefulset object
-        # we cause update of it's annotations.
-        # And any update to a scylla statefulset unknown to the scylla operator
-        # will cause additional rollout on the member number change which we apply
-        # in our nemesis.
-        # So, while we do not have API to rollout restart by ScyllaCluster CRD
-        # do it in a hacky way by making harmless spec update to sysctls.
         scyllacluster_name = self.params.get("k8s_scylla_cluster_name")
-        new_sysctls = self.k8s_cluster.kubectl(
-            f"get scyllacluster {scyllacluster_name} "
-            "--no-headers -o custom-columns=:.spec.sysctls[*]",
-            namespace=self.namespace).stdout.strip().split(',') + ['']
-        patch_data = {"spec": {"sysctls": new_sysctls}}
+        patch_data = {"spec": {"forceRedeploymentReason": f"Triggered at {time.time()}"}}
         self.k8s_cluster.kubectl(
             f"patch scyllacluster {scyllacluster_name} --type merge -p '{json.dumps(patch_data)}'",
             namespace=self.namespace)


### PR DESCRIPTION
In operator v1.4.0 was added possibility to recreate all Scylla
pods by changing string value in 'spec.forceRedeploymentReason' field.
So, reuse this field instead of Scylla statefulsets roll out,
because the latter one causes additional redundant rollout by update
of annotations.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
