### PR TITLE
fix(unit_tests): fix flaky event registry test

### DIFF
--- a/sdcm/sct_events/nodetool.py
+++ b/sdcm/sct_events/nodetool.py
@@ -10,12 +10,25 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2021 ScyllaDB
+from dataclasses import dataclass
 
 from sdcm.sct_events import Severity
 from sdcm.sct_events.base import ContinuousEvent
 
 
-# pylint: disable=too-many-instance-attributes
+@dataclass
+class NodetoolCommand:
+    cmd: str
+    options: str
+
+    def __post_init__(self):
+        cmd_split = self.cmd.split()
+        if len(cmd_split) > 1:
+            options_to_list = [self.options] if self.options else []
+            self.options = ' '.join(cmd_split[1:] + options_to_list)
+            self.cmd = cmd_split[0]
+
+
 class NodetoolEvent(ContinuousEvent):
     def __init__(self,  # pylint: disable=too-many-arguments
                  nodetool_command,
@@ -24,26 +37,17 @@ class NodetoolEvent(ContinuousEvent):
                  options=None,
                  publish_event=True):
         super().__init__(severity=severity, publish_event=publish_event)
-
-        # handle the case if command is like "snapshot -kc keyspace1"
-        cmd_splitted = nodetool_command.split()
-        if len(cmd_splitted) > 1:
-            options_to_list = [options] if options else []
-            options = ' '.join(cmd_splitted[1:] + options_to_list)
-
-        if cmd_splitted:
-            self.nodetool_command = cmd_splitted[0]
-        self.options = options
+        self.nodetool_command = NodetoolCommand(cmd=nodetool_command, options=options)
         self.node = str(node)
         self.full_traceback = None
 
     @property
     def msgfmt(self) -> str:
-        fmt = super().msgfmt + ": nodetool_command={0.nodetool_command}"
+        fmt = super().msgfmt + ": nodetool_command={0.nodetool_command.cmd}"
         if self.node:
             fmt += " node={0.node}"
-        if self.options:
-            fmt += " options={0.options}"
+        if self.nodetool_command.options:
+            fmt += " options={0.nodetool_command.options}"
         if self.errors:
             fmt += " errors={0.errors}"
         if self.full_traceback:

--- a/unit_tests/test_sct_events_continuous_events_registry.py
+++ b/unit_tests/test_sct_events_continuous_events_registry.py
@@ -38,11 +38,11 @@ class TestContinuousEventsRegistry:
         yield registry
 
     def test_add_event(self,
-                       registry: ContinuousEventsRegistry,
-                       nodetool_stress_event: NodetoolEvent):
-        registry.add_event(nodetool_stress_event)
+                       registry: ContinuousEventsRegistry):
+        # continuous events are added to the registry on event instantiation
+        event = NodetoolEvent(nodetool_command="mock cmd")
 
-        assert nodetool_stress_event in registry.continuous_events
+        assert event in registry.continuous_events
 
     def test_add_multiple_events(self,
                                  registry: ContinuousEventsRegistry):


### PR DESCRIPTION
In `test_add_event` we were getting a new instance of a NodetoolEvent (via a fixture) and then explicitly adding it to the registry. This however doubled the event in the registry: the event got registered on instantiation (in the fixture) and then the second time in the test. Since `test_get_event_by_id` randomly chooses an event from the registry and attempts to find it with the `get_event_by_id()` method, it sometimes chose the doubled event and triggered an error (since the method throws if there are multiple events with the same id).

I also moved the uniqueness check into the `add_event()` method in `ContinuousEventsRegistry`. It makes more sense to run the check on event registration than in the getters.

Trello task: https://trello.com/c/UzZDXnwj/3766-check-why-testgeteventbyid-is-flaky

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
