### PR TITLE
Address test do not stop

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -170,14 +170,15 @@ class silence:  # pylint: disable=invalid-name
                 name = funct.__name__
             else:
                 name = self.name
+            result = None
             try:
                 self.log.debug("Silently running '%s'", name)
-                funct(*args, **kwargs)
+                result = funct(*args, **kwargs)
                 self.log.debug("Finished '%s'. No errors were silenced.", name)
             except Exception as exc:  # pylint: disable=broad-except
                 self.log.debug("Finished '%s'. %s exception was silenced.", name, str(type(exc)))
                 self._store_test_result(args[0], exc, exc.__traceback__, name)
-
+            return result
         return decor
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -25,11 +25,8 @@ from typing import NamedTuple, Optional, Union, List, Dict, Any, Type
 from uuid import uuid4
 from functools import wraps, cached_property
 import threading
-import multiprocessing
-import inspect
 import signal
 import sys
-import traceback
 
 from invoke.exceptions import UnexpectedExit, Failure
 
@@ -70,6 +67,8 @@ from sdcm.sct_events.file_logger import get_events_grouped_by_category, get_logg
 from sdcm.sct_events.events_analyzer import stop_events_analyzer
 from sdcm.stress_thread import CassandraStressThread
 from sdcm.gemini_thread import GeminiStressThread
+from sdcm.utils.threads_and_processes_alive import gather_live_processes_and_dump_to_file, \
+    gather_live_threads_and_dump_to_file
 from sdcm.ycsb_thread import YcsbStressThread
 from sdcm.ndbench_thread import NdBenchStressThread
 from sdcm.kcl_thread import KclStressThread, CompareTablesSizesThread
@@ -2185,72 +2184,11 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
     @silence()
     def show_alive_threads(self):
-        if not threading.active_count():
-            return False
-        source_modules = []
-        result = False
-        with open(self.left_processes_log, 'a') as log_file:
-            for thread in threading.enumerate():
-                if thread is threading.current_thread():
-                    continue
-                result = True
-                source = '<no code available>'
-                module = 'Unknown'
-                if thread.__class__ is threading.Thread:
-                    if thread.run.__func__ is not threading.Thread.run:
-                        module = thread.run.__module__
-                        source = inspect.getsource(thread.run)
-                    elif getattr(thread, '_target', None):
-                        module = thread._target.__module__  # pylint: disable=protected-access
-                        source = inspect.getsource(thread._target)  # pylint: disable=protected-access
-                else:
-                    module = thread.__module__
-                    source = inspect.getsource(thread.__class__)
-                if module not in source_modules:
-                    source_modules.append(module)
-                log_file.write(f"========= Thread {thread.name} from {module} =========\n")
-                log_file.write(f"========= SOURCE =========\n{source}\n")
-                log_file.write(f"========= STACK TRACE =========\n{self._get_stacktrace(thread)}\n")
-                log_file.write(f"========= END OF Thread {thread.name} from {module} =========\n")
-        if result:
-            self.log.error("There are some threads left alive from following modules: %s",
-                           ",".join(source_modules))
-        return result
-
-    def _get_stacktrace(self, thread):  # pylint: disable=no-self-use
-        frame = sys._current_frames().get(thread.ident, None)  # pylint: disable=protected-access
-        output = []
-        for filename, lineno, name, line in traceback.extract_stack(frame):
-            output.append('File: "%s", line %d, in %s' % (filename,
-                                                          lineno, name))
-            if line:
-                output.append("  %s" % (line.strip()))
-        return '\n'.join(output)
+        return gather_live_threads_and_dump_to_file(self.left_processes_log)
 
     @silence()
     def show_alive_processes(self):
-        if not multiprocessing.active_children():
-            return False
-        source_modules = []
-        with open(self.left_processes_log, 'a') as log_file:
-            for proc in multiprocessing.active_children():
-                source = '<no code available>'
-                module = 'Unknown'
-                if proc.__class__ is multiprocessing.Process:
-                    if proc.run.__func__ != multiprocessing.Process.run:
-                        module = proc.run.__module__
-                        source = inspect.getsource(proc.run)
-                else:
-                    module = proc.__module__
-                    source = inspect.getsource(proc.__class__)
-                if module not in source_modules:
-                    source_modules.append(module)
-                log_file.write(f"========= Process {proc.name} from {module} =========\n")
-                log_file.write(f"========= SOURCE =========\n{source}\n")
-                log_file.write(f"========= END OF Process {proc.name} from {module}  =========\n")
-        self.log.error("There are some processes left alive from the following modules %s",
-                       ",".join(source_modules))
-        return True
+        return gather_live_processes_and_dump_to_file(self.left_processes_log)
 
     @silence()
     def clean_resources(self):

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2279,9 +2279,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         self._check_alive_routines_and_report_them()
 
     def _check_alive_routines_and_report_them(self):
-        result = self.show_alive_threads()
-        result = self.show_alive_processes() or result
-        if result:
+        threads_alive = self.show_alive_threads()
+        processes_alive = self.show_alive_processes()
+        if processes_alive or threads_alive:
             self.log.error('Please check %s log to see them', self.left_processes_log)
 
     def _get_test_result_event(self) -> TestResultEvent:

--- a/sdcm/utils/threads_and_processes_alive.py
+++ b/sdcm/utils/threads_and_processes_alive.py
@@ -44,7 +44,8 @@ def gather_live_threads_and_dump_to_file(dump_file_path: str) -> bool:
                 source = inspect.getsource(thread.__class__)
             if module not in source_modules:
                 source_modules.append(module)
-            log_file.write(f"========= Thread {thread.name} from {module} =========\n")
+            daemonic = getattr(thread, '_daemonic', getattr(thread, 'daemon', False))
+            log_file.write(f"========= Thread {thread.name} daemonic={daemonic} from {module} =========\n")
             log_file.write(f"========= SOURCE =========\n{source}\n")
             log_file.write(f"========= STACK TRACE =========\n{get_thread_stacktrace(thread)}\n")
             log_file.write(f"========= END OF Thread {thread.name} from {module} =========\n")
@@ -70,7 +71,8 @@ def gather_live_processes_and_dump_to_file(dump_file_path: str) -> bool:
                 source = inspect.getsource(proc.__class__)
             if module not in source_modules:
                 source_modules.append(module)
-            log_file.write(f"========= Process {proc.name} from {module} =========\n")
+            daemonic = getattr(proc, '_daemonic', getattr(proc, 'daemon', False))
+            log_file.write(f"========= Process {proc.name} daemonic={daemonic} from {module} =========\n")
             log_file.write(f"========= SOURCE =========\n{source}\n")
             log_file.write(f"========= END OF Process {proc.name} from {module}  =========\n")
     LOGGER.error("There are some processes left alive from the following modules %s", ",".join(source_modules))

--- a/sdcm/utils/threads_and_processes_alive.py
+++ b/sdcm/utils/threads_and_processes_alive.py
@@ -1,0 +1,77 @@
+import inspect
+import logging
+import multiprocessing
+import sys
+import threading
+import traceback
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get_thread_stacktrace(thread):  # pylint: disable=no-self-use
+    frame = sys._current_frames().get(thread.ident, None)  # pylint: disable=protected-access
+    output = []
+    for filename, lineno, name, line in traceback.extract_stack(frame):
+        output.append('File: "%s", line %d, in %s' % (filename,
+                                                      lineno, name))
+        if line:
+            output.append("  %s" % (line.strip()))
+    return '\n'.join(output)
+
+
+def gather_live_threads_and_dump_to_file(dump_file_path: str) -> bool:
+    if not threading.active_count():
+        return False
+    source_modules = []
+    result = False
+    with open(dump_file_path, 'a') as log_file:
+        for thread in threading.enumerate():
+            if thread is threading.current_thread():
+                continue
+            result = True
+            source = '<no code available>'
+            module = 'Unknown'
+            if thread.__class__ is threading.Thread:
+                if thread.run.__func__ is not threading.Thread.run:
+                    module = thread.run.__module__
+                    source = inspect.getsource(thread.run)
+                elif getattr(thread, '_target', None):
+                    module = thread._target.__module__  # pylint: disable=protected-access
+                    source = inspect.getsource(thread._target)  # pylint: disable=protected-access
+            else:
+                module = thread.__module__
+                source = inspect.getsource(thread.__class__)
+            if module not in source_modules:
+                source_modules.append(module)
+            log_file.write(f"========= Thread {thread.name} from {module} =========\n")
+            log_file.write(f"========= SOURCE =========\n{source}\n")
+            log_file.write(f"========= STACK TRACE =========\n{get_thread_stacktrace(thread)}\n")
+            log_file.write(f"========= END OF Thread {thread.name} from {module} =========\n")
+    if result:
+        LOGGER.error("There are some threads left alive from following modules: %s", ",".join(source_modules))
+    return result
+
+
+def gather_live_processes_and_dump_to_file(dump_file_path: str) -> bool:
+    if not multiprocessing.active_children():
+        return False
+    source_modules = []
+    with open(dump_file_path, 'a') as log_file:
+        for proc in multiprocessing.active_children():
+            source = '<no code available>'
+            module = 'Unknown'
+            if proc.__class__ is multiprocessing.Process:
+                if proc.run.__func__ != multiprocessing.Process.run:
+                    module = proc.run.__module__
+                    source = inspect.getsource(proc.run)
+            else:
+                module = proc.__module__
+                source = inspect.getsource(proc.__class__)
+            if module not in source_modules:
+                source_modules.append(module)
+            log_file.write(f"========= Process {proc.name} from {module} =========\n")
+            log_file.write(f"========= SOURCE =========\n{source}\n")
+            log_file.write(f"========= END OF Process {proc.name} from {module}  =========\n")
+    LOGGER.error("There are some processes left alive from the following modules %s", ",".join(source_modules))
+    return True


### PR DESCRIPTION
https://trello.com/c/94P1SEZ4/3770-investigate-why-test-is-not-killed-after-teardown
https://jenkins.scylladb.com/view/scylla-4.5/job/scylla-4.5/job/Reproducers/job/longevity-50gb-3d-reproducer/6/

teardown errros:

```
< t:2021-08-09 16:18:17,180 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  > exception=Critical Error has failed the test
< t:2021-08-09 16:18:17,275 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  > exception=Critical Error has failed the test
< t:2021-08-09 16:18:17,375 f:cluster.py      l:4654 c:sdcm.cluster         p:WARNING > Cluster longevity-tls-50gb-3d-repro-wi-loader-set-eafe2044 (AMI: ['ami-08516c9b78d5d6d1e'] Type: c5.2xlarge): failed to kil
l stress-command on [Node longevity-tls-50gb-3d-repro-wi-loader-node-eafe2044-3 [34.201.9.104 | 10.0.1.68] (seed: False)]: [Critical Error has failed the test]
< t:2021-08-09 16:48:31,239 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  >     raise AssertionError("Critical Error has failed the test")
< t:2021-08-09 16:48:31,239 f:file_logger.py  l:80   c:sdcm.sct_events.file_logger p:INFO  > AssertionError: Critical Error has failed the test
```

db-cluster  | https://cloudius-jenkins-test.s3.amazonaws.com/eafe2044-cd99-49a0-a29e-4f89a8745203/20210810_111750/db-cluster-eafe2044.tar.gz
monitor-set | https://cloudius-jenkins-test.s3.amazonaws.com/eafe2044-cd99-49a0-a29e-4f89a8745203/20210810_111750/monitor-set-eafe2044.tar.gz
loader-set  | https://cloudius-jenkins-test.s3.amazonaws.com/eafe2044-cd99-49a0-a29e-4f89a8745203/20210810_111750/loader-set-eafe2044.tar.gz
sct-runner  | https://cloudius-jenkins-test.s3.amazonaws.com/eafe2044-cd99-49a0-a29e-4f89a8745203/20210810_111750/email_data.json.tar.gz
sct-runner  | https://cloudius-jenkins-test.s3.amazonaws.com/eafe2044-cd99-49a0-a29e-4f89a8745203/20210810_111750/raw_events.log.tar.gz
sct-runner  | https://cloudius-jenkins-test.s3.amazonaws.com/eafe2044-cd99-49a0-a29e-4f89a8745203/20210810_111750/left_processes.log.tar.gz
sct-runner  | https://cloudius-jenkins-test.s3.amazonaws.com/eafe2044-cd99-49a0-a29e-4f89a8745203/20210810_111750/output.log.tar.gz
sct-runner  | https://cloudius-jenkins-test.s3.amazonaws.com/eafe2044-cd99-49a0-a29e-4f89a8745203/20210810_111750/error.log.tar.gz
sct-runner  | https://cloudius-jenkins-test.s3.amazonaws.com/eafe2044-cd99-49a0-a29e-4f89a8745203/20210810_111750/summary.log.tar.gz
sct-runner  | https://cloudius-jenkins-test.s3.amazonaws.com/eafe2044-cd99-49a0-a29e-4f89a8745203/20210810_111750/events.log.tar.gz
sct-runner  | https://cloudius-jenkins-test.s3.amazonaws.com/eafe2044-cd99-49a0-a29e-4f89a8745203/20210810_111750/sct.log.tar.gz
sct-runner  | https://cloudius-jenkins-test.s3.amazonaws.com/eafe2044-cd99-49a0-a29e-4f89a8745203/20210810_111750/warning.log.tar.gz
sct-runner  | https://cloudius-jenkins-test.s3.amazonaws.com/eafe2044-cd99-49a0-a29e-4f89a8745203/20210810_111750/critical.log.tar.gz
sct-runner  | https://cloudius-jenkins-test.s3.amazonaws.com/eafe2044-cd99-49a0-a29e-4f89a8745203/20210810_111750/normal.log.tar.gz
sct-runner  | https://cloudius-jenkins-test.s3.amazonaws.com/eafe2044-cd99-49a0-a29e-4f89a8745203/20210810_111750/debug.log.tar.gz


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
