### PR TITLE
improvement(DBaas GCP): Get credentials for opening ssh access

### DIFF
--- a/sdcm/keystore.py
+++ b/sdcm/keystore.py
@@ -50,6 +50,9 @@ class KeyStore:
     def get_gcp_credentials(self):
         return self.get_json("gcp.json")
 
+    def get_dbaaslab_gcp_credentials(self):
+        return self.get_json("gcp-scylladbaaslab.json")
+
     def get_gcp_service_accounts(self):
         return self.get_json("gcp_service_accounts.json")
 


### PR DESCRIPTION
	Credentials are required in order to query a cloud gcp cluster
	for the purpose of opening ssh access to its nodes.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
