### PR TITLE
feature(load-and-stream): add nemesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -42,15 +42,15 @@ from sdcm.cluster import NodeStayInClusterAfterDecommission
 from sdcm.cluster_k8s.mini_k8s import MinikubeK8sMixin
 from sdcm.mgmt import TaskStatus
 from sdcm.utils.ldap import SASLAUTHD_AUTHENTICATOR
-from sdcm.utils.common import remote_get_file, get_db_tables, generate_random_string, \
-    update_certificates, reach_enospc_on_node, clean_enospc_on_node, parse_nodetool_listsnapshots, \
-    update_authenticator
+from sdcm.utils.common import (get_db_tables, generate_random_string,
+                               update_certificates, reach_enospc_on_node, clean_enospc_on_node,
+                               parse_nodetool_listsnapshots,
+                               update_authenticator)
 from sdcm.utils import cdc
 from sdcm.utils.decorators import retrying, latency_calculator_decorator
 from sdcm.utils.decorators import timeout as timeout_decor
 from sdcm.utils.docker_utils import ContainerManager
 from sdcm.log import SDCMAdapter
-from sdcm.keystore import KeyStore
 from sdcm.prometheus import nemesis_metrics_obj
 from sdcm import wait
 from sdcm.sct_events import Severity
@@ -60,8 +60,10 @@ from sdcm.sct_events.loaders import CassandraStressLogEvent
 from sdcm.sct_events.nemesis import DisruptionEvent
 from sdcm.sct_events.database import DatabaseLogEvent
 from sdcm.sct_events.decorators import raise_event_on_failure
-from sdcm.sct_events.group_common_events import ignore_alternator_client_errors, ignore_no_space_errors, ignore_scrub_invalid_errors
+from sdcm.sct_events.group_common_events import (ignore_alternator_client_errors, ignore_no_space_errors,
+                                                 ignore_scrub_invalid_errors)
 from sdcm.db_stats import PrometheusDBStats
+from sdcm.utils.sstable.load_utils import SstableLoadUtils
 from sdcm.utils.toppartition_util import NewApiTopPartitionCmd, OldApiTopPartitionCmd
 from sdcm.remote.libssh2_client.exceptions import UnexpectedExit as Libssh2UnexpectedExit
 from sdcm.cluster_k8s import PodCluster, ScyllaPodCluster
@@ -940,132 +942,66 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def disrupt_major_compaction(self):
         self.target_node.run_nodetool("compact")
 
+    def disrupt_load_and_stream(self):
+        # Checking the columns number of keyspace1.standard1
+        self.log.debug('Prepare keyspace1.standard1 if it does not exist')
+        self._prepare_test_table(ks='keyspace1', table='standard1')
+        column_num = SstableLoadUtils.calculate_columns_count_in_table(self.target_node)
+
+        # Run load-and-stream test on regular standard1 table of cassandra-stress.
+        if column_num < 5:
+            raise UnsupportedNemesis("Schema doesn't match the snapshot, not uploading")
+
+        test_data = SstableLoadUtils.get_load_test_data_inventory(column_num, big_sstable=False, load_and_stream=True)
+
+        result = self.target_node.run_nodetool(sub_cmd="cfstats", args="keyspace1.standard1")
+
+        if result is not None and result.exit_status == 0:
+            map_files_to_node = SstableLoadUtils.distribute_test_files_to_cluster_nodes(nodes=self.cluster.nodes,
+                                                                                        test_data=test_data)
+            for sstables_info, load_on_node in map_files_to_node:
+                SstableLoadUtils.upload_sstables(load_on_node, test_data=sstables_info)
+                system_log_follower = SstableLoadUtils.run_load_and_stream(load_on_node)
+                SstableLoadUtils.validate_load_and_stream_status(load_on_node, system_log_follower)
+
     # pylint: disable=too-many-statements
     def disrupt_nodetool_refresh(self, big_sstable: bool = False):
         # Checking the columns number of keyspace1.standard1
         self.log.debug('Prepare keyspace1.standard1 if it does not exist')
         self._prepare_test_table(ks='keyspace1', table='standard1')
-        query_cmd = "SELECT * FROM keyspace1.standard1 LIMIT 1"
-        result = self.target_node.run_cqlsh(query_cmd)
-        col_num = len(re.findall(r"(\| C\d+)", result.stdout))
+        column_num = SstableLoadUtils.calculate_columns_count_in_table(self.target_node)
 
-        if col_num == 1:
-            # Use special schema (one column) for refresh before https://github.com/scylladb/scylla/issues/6617 is fixed
-            if big_sstable:
-                sstable_url = 'https://s3.amazonaws.com/scylla-qa-team/refresh_nemesis_c0/keyspace1.standard1.100M.tar.gz'
-                sstable_file = '/tmp/keyspace1.standard1.100M.tar.gz'
-                sstable_md5 = 'e4f6addc2db8e9af3a906953288ef676'
-                keys_num = 1001000
-            else:
-                sstable_url = 'https://s3.amazonaws.com/scylla-qa-team/refresh_nemesis_c0/keyspace1.standard1.tar.gz'
-                sstable_file = "/tmp/keyspace1.standard1.tar.gz"
-                sstable_md5 = 'c4aee10691fa6343a786f52663e7f758'
-                keys_num = 1000
-        elif col_num >= 5:
-            # The snapshot has 5 columns, the snapshot (col=5) can be loaded to table (col > 5).
-            # they rest columns will be filled to 'null'.
-            if big_sstable:
-                # 100G, the big file will be saved to GCE image
-                # Fixme: It's very slow and unstable to download 100G files from S3 to GCE instances,
-                #        currently we actually uploaded a small file (3.6 K) to S3.
-                #        We had a solution to save the file in GCE image, it requires bigger boot disk.
-                #        In my old test, the instance init is easy to fail. We can try to use a
-                #        split shared disk to save the 100GB file.
-                # 100M (500000 rows)
-                sstable_url = 'https://s3.amazonaws.com/scylla-qa-team/refresh_nemesis/keyspace1.standard1.100M.tar.gz'
-                sstable_file = '/tmp/keyspace1.standard1.100M.tar.gz'
-                sstable_md5 = '9c5dd19cfc78052323995198b0817270'
-                keys_num = 501000
-            else:
-                sstable_url = 'https://s3.amazonaws.com/scylla-qa-team/refresh_nemesis/keyspace1.standard1.tar.gz'
-                sstable_file = "/tmp/keyspace1.standard1.tar.gz"
-                sstable_md5 = 'c033a3649a1aec3ba9b81c446c6eecfd'
-                keys_num = 1000
-        else:
-            # Note: when issue #6617 is fixed, we can try to load snapshot (cols=5) to a table (1 < cols < 5),
-            #       expect that refresh will fail (no serious db error).
+        # Note: when issue #6617 is fixed, we can try to load snapshot (cols=5) to a table (1 < cols < 5),
+        #       expect that refresh will fail (no serious db error).
+        if 1 < column_num < 5:
             raise UnsupportedNemesis("Schema doesn't match the snapshot, not uploading")
+
+        test_data = SstableLoadUtils.get_load_test_data_inventory(column_num, big_sstable=big_sstable,
+                                                                  load_and_stream=False)
 
         result = self.target_node.run_nodetool(sub_cmd="cfstats", args="keyspace1.standard1")
 
-        def do_refresh(node):
-            key_store = KeyStore()
-            creds = key_store.get_scylladb_upload_credentials()
-            # Download the sstable files from S3
-            remote_get_file(node.remoter, sstable_url, sstable_file,
-                            hash_expected=sstable_md5, retries=2,
-                            user_agent=creds['user_agent'])
-            result = node.remoter.sudo("ls -t /var/lib/scylla/data/keyspace1/")
-            upload_dir = result.stdout.split()[0]
-            if node.is_docker():
-                node.remoter.run(f'tar xvfz {sstable_file} -C /var/lib/scylla/data/keyspace1/{upload_dir}/upload/')
-            else:
-                node.remoter.sudo(
-                    f'tar xvfz {sstable_file} -C /var/lib/scylla/data/keyspace1/{upload_dir}/upload/', user='scylla')
-
-            # Scylla Enterprise 2019.1 doesn't support to load schema.cql and manifest.json, let's remove them
-            node.remoter.sudo(f'rm -f /var/lib/scylla/data/keyspace1/{upload_dir}/upload/schema.cql')
-            node.remoter.sudo(f'rm -f /var/lib/scylla/data/keyspace1/{upload_dir}/upload/manifest.json')
-            self.log.debug(f'Loading {keys_num} keys to {node.name} by refresh')
-
-            # Resharding of the loaded sstable files is performed before they are moved from upload to the main folder.
-            # So we need to validate that resharded files are placed in the "upload" folder before moving.
-            # Find the compaction output that reported about the resharding
-
-            system_log_follower = node.follow_system_log(patterns=[r'Resharded.*\[/'])
-            node.run_nodetool(sub_cmd="refresh", args="-- keyspace1 standard1")
-            return system_log_follower
-
-        @timeout_decor(
-            timeout=60,
-            allowed_exceptions=(AssertionError,),
-            message="Waiting for resharding completion message to appear in logs")
-        def validate_resharding_after_refresh(system_log_follower):
-            """
-            # Validate that files after resharding were saved in the "upload" folder.
-            # Example of compaction output:
-
-            #   scylla[6653]:  [shard 0] compaction - [Reshard keyspace1.standard1 3cad4140-f8c3-11ea-acb1-000000000002]
-            #   Resharded 1 sstables to [
-            #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-9-big-Data.db:level=0,
-            #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-10-big-Data.db:level=0,
-            #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-11-big-Data.db:level=0,
-            #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-12-big-Data.db:level=0,
-            #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-13-big-Data.db:level=0,
-            #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-22-big-Data.db:level=0,
-            #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-15-big-Data.db:level=0,
-            #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-16-big-Data.db:level=0,
-            #   ]. 91MB to 92MB (~100% of original) in 5009ms = 18MB/s. ~370176 total partitions merged to 370150
-            """
-            resharding_logs = list(system_log_follower)
-            assert resharding_logs, "Resharding wasn't run"
-            self.log.debug(f"Found resharding: {resharding_logs}")
-
-            for line in resharding_logs:
-                # Find all files that were created after resharding
-                for one_file in re.findall(r"(/var/.*?),", line, re.IGNORECASE):
-                    # The file path have to include "upload" folder
-                    assert '/upload/' in one_file, "Loaded file was resharded not in 'upload' folder"
-
         if result is not None and result.exit_status == 0:
+            key = '0x32373131364f334f3830'
             # Check one special key before refresh, we will verify refresh by query in the end
             # Note: we can't DELETE the key before refresh, otherwise the old sstable won't be loaded
             #       TRUNCATE can be used the clean the table, but we can't do it for keyspace1.standard1
-            query_verify = "SELECT * FROM keyspace1.standard1 WHERE key=0x32373131364f334f3830"
+            query_verify = f"SELECT * FROM keyspace1.standard1 WHERE key={key}"
             result = self.target_node.run_cqlsh(query_verify)
             if '(0 rows)' in result.stdout:
-                self.log.debug('Key 0x32373131364f334f3830 does not exist before refresh')
+                self.log.debug('Key %s does not exist before refresh', key)
             else:
-                self.log.debug('Key 0x32373131364f334f3830 already exists before refresh')
+                self.log.debug('Key %s already exists before refresh', key)
 
             # Executing rolling refresh one by one
             for node in self.cluster.nodes:
-                system_log_follower = do_refresh(node)
-                validate_resharding_after_refresh(system_log_follower)
+                SstableLoadUtils.upload_sstables(node, test_data=test_data[0])
+                system_log_follower = SstableLoadUtils.run_refresh(node, test_data=test_data[0])
+                SstableLoadUtils.validate_resharding_after_refresh(node=node, system_log_follower=system_log_follower)
 
             # Verify that the special key is loaded by SELECT query
             result = self.target_node.run_cqlsh(query_verify)
-            assert '(1 rows)' in result.stdout, 'The key is not loaded by `nodetool refresh`'
+            assert '(1 rows)' in result.stdout, f'The key {key} is not loaded by `nodetool refresh`'
 
     def disrupt_nodetool_enospc(self, sleep_time=30, all_nodes=False):
         if isinstance(self.cluster, MinikubeK8sMixin):
@@ -3121,6 +3057,16 @@ class RefreshMonkey(Nemesis):
 
     def disrupt(self):
         self.disrupt_nodetool_refresh(big_sstable=False)
+
+
+class LoadAndStreamMonkey(Nemesis):
+    disruptive = False
+    run_with_gemini = False
+    kubernetes = True
+    limited = True
+
+    def disrupt(self):
+        self.disrupt_load_and_stream()
 
 
 class RefreshBigMonkey(Nemesis):

--- a/sdcm/utils/sstable/load_inventory.py
+++ b/sdcm/utils/sstable/load_inventory.py
@@ -1,0 +1,92 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2021 ScyllaDB
+"""
+Keep AWS S3 info about test sstables for refresh nemesis
+"""
+
+from typing import NamedTuple
+
+
+class TestDataInventory(NamedTuple):
+    sstable_url: str
+    sstable_file: str
+    sstable_md5: str
+    keys_num: int
+
+
+URL_TEMPLATE = "https://s3.amazonaws.com/scylla-qa-team/%s/%s"
+TEMP_FILE_TEMPLATE = "/tmp/%s"
+ONE_COLUMN_FOLDER = "refresh_nemesis_c0"
+MULTI_COLUMN_FOLDER = "refresh_nemesis"
+LOAD_AND_STREAM_FOLDER = f"{MULTI_COLUMN_FOLDER}/load_and_stream"
+STANDARD1_100M_FILE_NAME = "keyspace1.standard1.100M.tar.gz"
+STANDARD1_FILE_NAME = "keyspace1.standard1.tar.gz"
+
+BIG_SSTABLE_COLUMN_1_DATA = [TestDataInventory(
+    sstable_url=URL_TEMPLATE % (ONE_COLUMN_FOLDER, STANDARD1_100M_FILE_NAME),
+    sstable_file=TEMP_FILE_TEMPLATE % STANDARD1_100M_FILE_NAME,
+    sstable_md5='e4f6addc2db8e9af3a906953288ef676',
+    keys_num=1001000)]
+
+COLUMN_1_DATA = [TestDataInventory(
+    sstable_url=URL_TEMPLATE % (ONE_COLUMN_FOLDER, STANDARD1_FILE_NAME),
+    sstable_file=TEMP_FILE_TEMPLATE % STANDARD1_FILE_NAME,
+    sstable_md5='c4aee10691fa6343a786f52663e7f758',
+    keys_num=1000)]
+
+# 100G, the big file will be saved to GCE image
+# Fixme: It's very slow and unstable to download 100G files from S3 to GCE instances,
+#        currently we actually uploaded a small file (3.6 K) to S3.
+#        We had a solution to save the file in GCE image, it requires bigger boot disk.
+#        In my old test, the instance init is easy to fail. We can try to use a
+#        split shared disk to save the 100GB file.
+# 100M (500000 rows)
+BIG_SSTABLE_MULTI_COLUMNS_DATA = [TestDataInventory(
+    sstable_url=URL_TEMPLATE % (MULTI_COLUMN_FOLDER, STANDARD1_100M_FILE_NAME),
+    sstable_file=TEMP_FILE_TEMPLATE % STANDARD1_100M_FILE_NAME,
+    sstable_md5='9c5dd19cfc78052323995198b0817270',
+    keys_num=501000)]
+
+MULTI_COLUMNS_DATA = [TestDataInventory(
+    sstable_url=URL_TEMPLATE % (MULTI_COLUMN_FOLDER, STANDARD1_FILE_NAME),
+    sstable_file=TEMP_FILE_TEMPLATE % STANDARD1_FILE_NAME,
+    sstable_md5='c033a3649a1aec3ba9b81c446c6eecfd',
+    keys_num=1000)]
+
+MULTI_NODE_DATA = [
+    TestDataInventory(
+        sstable_url=URL_TEMPLATE % (LOAD_AND_STREAM_FOLDER, f'node1.{STANDARD1_FILE_NAME}'),
+        sstable_file=TEMP_FILE_TEMPLATE % f'node1.{STANDARD1_FILE_NAME}',
+        sstable_md5='994bdcef67cd9748c0214a67f0f1864d',
+        keys_num=500000),
+    TestDataInventory(
+        sstable_url=URL_TEMPLATE % (LOAD_AND_STREAM_FOLDER, f'node2.part1.{STANDARD1_FILE_NAME}'),
+        sstable_file=TEMP_FILE_TEMPLATE % f'node2.part1.{STANDARD1_FILE_NAME}',
+        sstable_md5='651ceab061723d078525fb996d2e17a4',
+        keys_num=500000),
+    TestDataInventory(
+        sstable_url=URL_TEMPLATE % (LOAD_AND_STREAM_FOLDER, f'node2.part2.{STANDARD1_FILE_NAME}'),
+        sstable_file=TEMP_FILE_TEMPLATE % f'node2.part2.{STANDARD1_FILE_NAME}',
+        sstable_md5='a30df21bfa4e66b99d5de30c11456d2b',
+        keys_num=500000),
+    TestDataInventory(
+        sstable_url=URL_TEMPLATE % (LOAD_AND_STREAM_FOLDER, f'node3.{STANDARD1_FILE_NAME}'),
+        sstable_file=TEMP_FILE_TEMPLATE % f'node3.{STANDARD1_FILE_NAME}',
+        sstable_md5='ace4eb18bd77811fdf627f1044909f18',
+        keys_num=500000),
+    TestDataInventory(
+        sstable_url=URL_TEMPLATE % (LOAD_AND_STREAM_FOLDER, f'node4.{STANDARD1_FILE_NAME}'),
+        sstable_file=TEMP_FILE_TEMPLATE % f'node4.{STANDARD1_FILE_NAME}',
+        sstable_md5='e7ff37333c1e331acac58103e6e0406d',
+        keys_num=500000)
+]

--- a/sdcm/utils/sstable/load_utils.py
+++ b/sdcm/utils/sstable/load_utils.py
@@ -1,0 +1,187 @@
+import random
+import re
+from collections import namedtuple
+from typing import Any, List, Iterable
+
+from sdcm.keystore import KeyStore
+from sdcm.utils.common import remote_get_file, LOGGER
+from sdcm.utils.decorators import timeout as timeout_decor
+from sdcm.utils.sstable.load_inventory import (TestDataInventory, BIG_SSTABLE_COLUMN_1_DATA, COLUMN_1_DATA,
+                                               MULTI_NODE_DATA, BIG_SSTABLE_MULTI_COLUMNS_DATA, MULTI_COLUMNS_DATA)
+
+
+class SstableLoadUtils:
+    LOAD_AND_STREAM_RUN_EXPR = r'storage_service - load_and_stream:'
+    LOAD_AND_STREAM_DONE_EXPR = r'storage_service - Done loading new SSTables for keyspace={}, table={}, ' \
+                                r'load_and_stream=true.*status=(.*)'
+
+    @staticmethod
+    def calculate_columns_count_in_table(target_node, keyspace_name: str = 'keyspace1',
+                                         table_name: str = 'standard1') -> int:
+        query_cmd = f"SELECT * FROM {keyspace_name}.{table_name} LIMIT 1"
+        result = target_node.run_cqlsh(query_cmd)
+        return len(re.findall(r"(\| C\d+)", result.stdout))
+
+    @staticmethod
+    def get_random_item(items: list, pop: bool = False) -> Any:
+        if pop:
+            return items.pop(random.randint(0, len(items) - 1))
+
+        return items[random.randint(0, len(items) - 1)]
+
+    @classmethod
+    def distribute_test_files_to_cluster_nodes(cls, nodes, test_data: List[TestDataInventory]) -> List:
+        """
+        Distribute test sstables over cluster nodes for `load-and-stream` test:
+        the feature allow loading arbitrary sstables that do not belong to a node into the cluster.
+        So we want to distribute sstables randomly.
+        Also add case when the 50% sstables of node2 (from test data cluster) will be loaded on the one node
+        and other 50% - on another
+        """
+        map_files_to_node = []
+        nodes_bucket = nodes.copy()
+        for data in test_data:
+            if not nodes_bucket:
+                nodes_bucket = nodes.copy()
+            map_files_to_node.append([data, nodes_bucket.pop()])
+
+        return map_files_to_node
+
+    @staticmethod
+    def upload_sstables(node, test_data: TestDataInventory, keyspace_name: str = 'keyspace1'):
+        key_store = KeyStore()
+        creds = key_store.get_scylladb_upload_credentials()
+        # Download the sstable files from S3
+        remote_get_file(node.remoter, test_data.sstable_url, test_data.sstable_file,
+                        hash_expected=test_data.sstable_md5, retries=2,
+                        user_agent=creds['user_agent'])
+        result = node.remoter.sudo(f"ls -t /var/lib/scylla/data/{keyspace_name}/")
+        upload_dir = result.stdout.split()[0]
+        if node.is_docker():
+            node.remoter.run(f'tar xvfz {test_data.sstable_file} -C /'
+                             f'var/lib/scylla/data/{keyspace_name}/{upload_dir}/upload/')
+        else:
+            node.remoter.sudo(
+                f'tar xvfz {test_data.sstable_file} -C /var/lib/scylla/data/{keyspace_name}/{upload_dir}/upload/',
+                user='scylla')
+
+        # Scylla Enterprise 2019.1 doesn't support to load schema.cql and manifest.json, let's remove them
+        node.remoter.sudo(f'rm -f /var/lib/scylla/data/{keyspace_name}/{upload_dir}/upload/schema.cql')
+        node.remoter.sudo(f'rm -f /var/lib/scylla/data/{keyspace_name}/{upload_dir}/upload/manifest.json')
+
+    @classmethod
+    def run_load_and_stream(cls, node, keyspace_name: str = 'keyspace1', table_name: str = 'standard1'):
+        system_log_follower = node.follow_system_log(
+            patterns=[cls.LOAD_AND_STREAM_DONE_EXPR.format(keyspace_name, table_name),
+                      cls.LOAD_AND_STREAM_RUN_EXPR])
+        LOGGER.info("Running load and stream on the node %s for %s.%s'", node.name, keyspace_name, table_name)
+
+        # `load_and_stream` parameter is not supported by nodetool yet. This is workaround
+        # https://github.com/scylladb/scylla-tools-java/issues/253
+        load_api_cmd = 'curl -X POST --header "Content-Type: application/json" --header ' \
+                       f'"Accept: application/json" "http://127.0.0.1:10000/storage_service/sstables/{keyspace_name}?' \
+                       f'cf={table_name}&load_and_stream=true"'
+        node.remoter.run(load_api_cmd)
+        return system_log_follower
+
+    @staticmethod
+    def run_refresh(node, test_data: namedtuple) -> Iterable[str]:
+        LOGGER.debug('Loading %s keys to %s by refresh', test_data.keys_num, node.name)
+        # Resharding of the loaded sstable files is performed before they are moved from upload to the main folder.
+        # So we need to validate that resharded files are placed in the "upload" folder before moving.
+        # Find the compaction output that reported about the resharding
+
+        system_log_follower = node.follow_system_log(patterns=[r'Resharded.*\[/'])
+        node.run_nodetool(sub_cmd="refresh", args="-- keyspace1 standard1")
+        return system_log_follower
+
+    @staticmethod
+    @timeout_decor(
+        timeout=60,
+        allowed_exceptions=(AssertionError,),
+        message="Waiting for resharding completion message to appear in logs")
+    def validate_resharding_after_refresh(node, system_log_follower):
+        """
+        # Validate that files after resharding were saved in the "upload" folder.
+        # Example of compaction output:
+
+        #   scylla[6653]:  [shard 0] compaction - [Reshard keyspace1.standard1 3cad4140-f8c3-11ea-acb1-000000000002]
+        #   Resharded 1 sstables to [
+        #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-9-big-Data.db:level=0,
+        #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-10-big-Data.db:level=0,
+        #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-11-big-Data.db:level=0,
+        #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-12-big-Data.db:level=0,
+        #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-13-big-Data.db:level=0,
+        #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-22-big-Data.db:level=0,
+        #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-15-big-Data.db:level=0,
+        #   /var/lib/scylla/data/keyspace1/standard1-9fbed8d0f8c211ea9bb1000000000000/upload/md-16-big-Data.db:level=0,
+        #   ]. 91MB to 92MB (~100% of original) in 5009ms = 18MB/s. ~370176 total partitions merged to 370150
+        """
+        resharding_logs = list(system_log_follower)
+        assert resharding_logs, f"Resharding wasn't run on the node {node.name}"
+        LOGGER.debug("Found resharding on the node %s: %s", node.name, resharding_logs)
+
+        for line in resharding_logs:
+            # Find all files that were created after resharding
+            for one_file in re.findall(r"(/var/.*?),", line, re.IGNORECASE):
+                # The file path have to include "upload" folder
+                assert '/upload/' in one_file, \
+                    f"Loaded file was resharded not in 'upload' folder on the node {node.name}"
+
+    @classmethod
+    @timeout_decor(
+        timeout=60,
+        allowed_exceptions=(AssertionError,),
+        message="Waiting for load_and_stream completion message to appear in logs")
+    def validate_load_and_stream_status(cls, node, system_log_follower,
+                                        keyspace_name='keyspace1', table_name='standard1'):
+        """
+        Validate that load_and_stream was started and has been completed successfully.
+        Search for a messages like:
+            storage_service - load_and_stream: ops_uuid=c06c76bb-d178-4e9c-87ff-90df7b80bd5e, ks=keyspace1, table=standard1,
+            target_node=10.0.3.31, num_partitions_sent=45721, num_bytes_sent=24140688
+
+           storage_service - Done loading new SSTables for keyspace=keyspace1, table=standard1, load_and_stream=true,
+           primary_replica_only=false, status=succeeded
+        """
+        load_and_stream_messages = list(system_log_follower)
+        assert load_and_stream_messages, f"Load and stream wasn't run on the node {node.name}"
+        LOGGER.debug("Found load_and_stream messages: %s", load_and_stream_messages)
+
+        load_and_stream_started = False
+        load_and_stream_status = ""
+        for line in load_and_stream_messages:
+            if not load_and_stream_started and re.findall(cls.LOAD_AND_STREAM_RUN_EXPR, line):
+                load_and_stream_started = True
+
+            load_and_stream_done = re.search(cls.LOAD_AND_STREAM_DONE_EXPR.format(keyspace_name, table_name), line)
+            if load_and_stream_done:
+                load_and_stream_status = load_and_stream_done.groups()[0]
+                break
+
+        assert load_and_stream_started, f'Load and stream has not been run on the node {node.name}'
+        assert load_and_stream_status == 'succeeded', \
+            f'Load and stream status  on the node {node.name} is "{load_and_stream_status}". Expected "succeeded"'
+
+    @classmethod
+    def get_load_test_data_inventory(cls, column_number: int, big_sstable: bool,
+                                     load_and_stream: bool) -> List[TestDataInventory]:
+        if column_number == 1:
+            # Use special schema (one column) for refresh before https://github.com/scylladb/scylla/issues/6617 is fixed
+            if big_sstable:
+                return BIG_SSTABLE_COLUMN_1_DATA
+
+            return COLUMN_1_DATA
+
+        if column_number >= 5:
+            # The snapshot has 5 columns, the snapshot (col=5) can be loaded to table (col > 5).
+            # they rest columns will be filled to 'null'.
+            if load_and_stream:
+                return MULTI_NODE_DATA
+
+            if big_sstable:
+                return BIG_SSTABLE_MULTI_COLUMNS_DATA
+
+            return MULTI_COLUMNS_DATA
+
+        return []

--- a/unit_tests/test_data/load_and_stream.log
+++ b/unit_tests/test_data/load_and_stream.log
@@ -1,0 +1,29 @@
+2021-08-12T06:07:19+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 7] compaction - [Compact keyspace1.standard1 8d418f80-fb33-11eb-9b17-403073af4e08] Compacting [/var/lib/scylla/
+data/keyspace1/standard1-501e29b0fb3311ebb71a4875c5785232/md-55-big-Data.db:level=0:origin=streaming,/var/lib/scylla/data/keyspace1/standard1-501e29b0fb3311ebb71a4875c5785232/md-47-big-Data.db:level=0:origin=com
+paction]
+2021-08-12T06:07:19+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 7] storage_service - load_and_stream: ops_uuid=180d1761-f0f0-4527-a5aa-4b547b321adc, ks=keyspace1, table=standa
+rd1, target_node=10.0.2.144, num_partitions_sent=47973, num_bytes_sent=25329744
+2021-08-12T06:07:19+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 7] storage_service - load_and_stream: ops_uuid=180d1761-f0f0-4527-a5aa-4b547b321adc, ks=keyspace1, table=standa
+rd1, target_node=10.0.1.134, num_partitions_sent=47973, num_bytes_sent=25329744
+2021-08-12T06:07:19+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 7] storage_service - load_and_stream: ops_uuid=180d1761-f0f0-4527-a5aa-4b547b321adc, ks=keyspace1, table=standa
+rd1, target_node=10.0.0.79, num_partitions_sent=47973, num_bytes_sent=25329744
+2021-08-12T06:07:19+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 7] storage_service - load_and_stream: finished ops_uuid=180d1761-f0f0-4527-a5aa-4b547b321adc, ks=keyspace1, tab
+le=standard1, partitions_processed=47973 partitions, bytes_processed=25329744 bytes, partitions_per_second=7844.177 partitions/s, bytes_per_second=3.949857 MiB/s, duration=6.115747 s, status=succeeded
+2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 3] stream_session - [Stream #178968e4-4e41-4fe1-b11f-4c05eafc9868] Write to sstable for ks=keyspace1, cf=standa
+rd1, estimated_partitions=47872, received_partitions=47859
+2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 3] compaction - [Compact keyspace1.standard1 8d76a940-fb33-11eb-900d-403173af4e08] Compacting [/var/lib/scylla/
+data/keyspace1/standard1-501e29b0fb3311ebb71a4875c5785232/md-51-big-Data.db:level=0:origin=streaming,/var/lib/scylla/data/keyspace1/standard1-501e29b0fb3311ebb71a4875c5785232/md-43-big-Data.db:level=0:origin=com
+paction]
+2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 3] storage_service - load_and_stream: ops_uuid=178968e4-4e41-4fe1-b11f-4c05eafc9868, ks=keyspace1, table=standa
+rd1, target_node=10.0.2.144, num_partitions_sent=47859, num_bytes_sent=25269552
+2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 3] storage_service - load_and_stream: ops_uuid=178968e4-4e41-4fe1-b11f-4c05eafc9868, ks=keyspace1, table=standa
+rd1, target_node=10.0.1.134, num_partitions_sent=47859, num_bytes_sent=25269552
+2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 3] storage_service - load_and_stream: ops_uuid=178968e4-4e41-4fe1-b11f-4c05eafc9868, ks=keyspace1, table=standa
+rd1, target_node=10.0.0.79, num_partitions_sent=47859, num_bytes_sent=25269552
+2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 3] storage_service - load_and_stream: finished ops_uuid=178968e4-4e41-4fe1-b11f-4c05eafc9868, ks=keyspace1, tab
+le=standard1, partitions_processed=47859 partitions, bytes_processed=25269552 bytes, partitions_per_second=7398.4717 partitions/s, bytes_per_second=3.7254267 MiB/s, duration=6.4687686 s, status=succeeded
+2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 4] storage_service - Done loading new SSTables for keyspace=keyspace1, table=standard1, load_and_stream=true, primary_replica_only=false, status=succeeded
+2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 5] compaction - [Compact keyspace1.standard1 8c410f70-fb33-11eb-a548-402e73af4e08] Compacted 2 sstables to [/var/lib/scylla/data/keyspace1/standard1-501e29b0fb3311ebb71a4875c5785232/md-61-big-Data.db:level=0]. 28MB to 15MB (~55% of original) in 2079ms = 7MB/s. ~110464 total partitions merged to 62353.
+2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | scylla:  [shard 6] compaction - [Compact keyspace1.standard1 8c42bd20-fb33-11eb-b3fa-402b73af4e08] Compacted 2 sstables to [/var/lib/scylla/data/keyspace1/standard1-501e29b0fb3311ebb71a4875c5785232/md-62-big-Data.db:level=0]. 28MB to 15MB (~55% of original) in 2142ms = 7MB/s. ~110848 total partitions merged to 62499.
+2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !NOTICE  | sudo: scyllaadm : TTY=unknown ; PWD=/home/scyllaadm ; USER=root ; COMMAND=/usr/bin/coredumpctl --no-pager --no-legend
+2021-08-12T06:07:20+00:00  longevity-10gb-3h-load-and-db-node-65bd71ec-1 !INFO    | sudo: pam_unix(sudo:session): session opened for user root by (uid=0)


### PR DESCRIPTION
Issue:
https://github.com/scylladb/scylla/commit/df3ef800c20c60d7929ffa600649793aa6c73064

Task:
https://trello.com/c/nwktmFqq/3478-dtest-7831-the-load-and-stream-feature-has-been-merged-this-allows-nodetool-refresh-to-split-loaded-sstables-into-owned-and-non

This feature extends the nodetool refresh to allow loading arbitrary sstables
that do not belong to a node into the cluster. It loads the sstables from disk
and calculates the owning nodes of the data and streams to the owners
automatically.

New nemesis runs refresh with 'load_and_stream' parameter and validate by the log that 
load_and_stream has been started and finished successfully.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
