### PR TITLE
Fix circular reference in nodetool event to json

### DIFF
--- a/sdcm/sct_events/base.py
+++ b/sdcm/sct_events/base.py
@@ -23,6 +23,7 @@ import pickle
 import fnmatch
 import logging
 from enum import Enum
+from json import JSONEncoder
 from types import new_class
 from typing import \
     Any, Optional, Type, Dict, List, Tuple, Callable, Generic, TypeVar, Protocol, runtime_checkable, Union
@@ -313,13 +314,13 @@ class SctEvent:
         self._ready_to_publish = False
         LOGGER.debug("%s marked to not publish", self)
 
-    def to_json(self) -> str:
+    def to_json(self, encoder: Type[JSONEncoder] = JSONEncoder) -> str:
         return json.dumps({
             "base": self.base,
             "type": self.type,
             "subtype": self.subtype,
             **self.__getstate__(),
-        })
+        }, cls=encoder)
 
     def __getstate__(self):
         # Remove everything from the __dict__ that starts with "_".

--- a/sdcm/sct_events/nodetool.py
+++ b/sdcm/sct_events/nodetool.py
@@ -10,9 +10,33 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2021 ScyllaDB
+from dataclasses import dataclass, asdict
+from json import JSONEncoder
+from typing import Any, Type
 
 from sdcm.sct_events import Severity
 from sdcm.sct_events.base import ContinuousEvent
+
+
+@dataclass
+class NodetoolCommand:
+    cmd: str
+    options: str
+
+    def __post_init__(self):
+        cmd_split = self.cmd.split()
+        if len(cmd_split) > 1:
+            options_to_list = [self.options] if self.options else []
+            self.options = ' '.join(cmd_split[1:] + options_to_list)
+            self.cmd = cmd_split[0]
+
+
+class NodetoolEventEncoder(JSONEncoder):
+    def default(self, o: Any) -> Any:
+        if isinstance(o, NodetoolCommand):
+            return asdict(o)
+        else:
+            return super().default(o)
 
 
 # pylint: disable=too-many-instance-attributes
@@ -25,27 +49,22 @@ class NodetoolEvent(ContinuousEvent):
                  publish_event=True):
         super().__init__(severity=severity, publish_event=publish_event)
 
-        # handle the case if command is like "snapshot -kc keyspace1"
-        cmd_splitted = nodetool_command.split()
-        if len(cmd_splitted) > 1:
-            options_to_list = [options] if options else []
-            options = ' '.join(cmd_splitted[1:] + options_to_list)
-
-        if cmd_splitted:
-            self.nodetool_command = cmd_splitted[0]
-        self.options = options
+        self.nodetool_command = NodetoolCommand(cmd=nodetool_command, options=options)
         self.node = str(node)
         self.full_traceback = None
 
     @property
     def msgfmt(self) -> str:
-        fmt = super().msgfmt + ": nodetool_command={0.nodetool_command}"
+        fmt = super().msgfmt + ": nodetool_command={0.nodetool_command.cmd}"
         if self.node:
             fmt += " node={0.node}"
-        if self.options:
-            fmt += " options={0.options}"
+        if self.nodetool_command.options:
+            fmt += " options={0.nodetool_command.options}"
         if self.errors:
             fmt += " errors={0.errors}"
         if self.full_traceback:
             fmt += "\n{0.full_traceback}"
         return fmt
+
+    def to_json(self, encoder: Type[JSONEncoder] = NodetoolEventEncoder) -> str:
+        return super().to_json(encoder=encoder)

--- a/unit_tests/test_sct_events_nodetool.py
+++ b/unit_tests/test_sct_events_nodetool.py
@@ -76,3 +76,10 @@ class TestNodetoolEvent(unittest.TestCase):
             'drop_table_during_repair_ks_0 more '
             'options errors=[\'Failed with status 1\']\nTraceback:'
         )
+
+    def test_nodetool_serialization_to_json(self):
+        event = NodetoolEvent(nodetool_command="scrub --skip-corrupted drop_table_during_repair_ks_0", node='1.0.0.121',
+                              options="more options", publish_event=False)
+        event.event_id = "c2561d8b-97ca-44fb-b5b1-8bcc0d437318"
+        event.begin_event()
+        self.assertTrue(event.to_json())


### PR DESCRIPTION
After the recent refactor of the NodetoolEvent class, the `to_json()` method of `SctEvent` started throwing `ValueError: Circular reference detected`. This was caused by the refactor, as:

1. The refactor introduced a dataclass as one of the attributes of NodetoolEvent.
2. NodetoolEvent inherits from SctEvent, which calls `json.dumps()` with the default `JSONEncoder` as its encoder and uses a `**self.__getstate__()`, a method which returns all public attributes of the event class for jsonification. `self.__getstate__()` returns a simple dict of the attributes, so when we use composition, the attribute used will not be serializable by `JSONEncoder` out of the box.

The solution for this is to create a custom encoder class for dealing with the troublesome value type. This PR introduces a `NodetoolEventEncoder`, though if we see more dataclass composition in event classes, we might want to create a more general encoder in `base.py` for instance.
I also added a unit test for this case in `test_sct_events_nodetool.py`.

Trello task: https://trello.com/c/Ibglo9zI

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
