### PR TITLE
feature(cs_driver): Check is shared awarnes or not driver is used

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -62,6 +62,7 @@ CassandraStressLogEvent.OperationOnKey: CRITICAL
 # TODO: change TooManyHintsInFlight severity to CRITICAL, when we have more stable hinted handoff backpressure
 # TODO: mechanism.
 CassandraStressLogEvent.TooManyHintsInFlight: ERROR
+CassandraStressLogEvent.ShardAwareDriver: NORMAL
 ScyllaBenchLogEvent.ConsistencyError: ERROR
 GeminiStressLogEvent.GeminiEvent: CRITICAL
 PrometheusAlertManagerEvent.start: WARNING

--- a/sdcm/report_templates/results_base.html
+++ b/sdcm/report_templates/results_base.html
@@ -205,6 +205,9 @@
             {% if gemini_version %}
             <li>Gemini version: {{ gemini_version }}</li>
             {% endif %}
+            {% if shard_awareness_driver %}
+                <li> Cassandra-stress uses shared-aware driver</li>
+            {% endif %}
         </ul>
     </div>
 

--- a/sdcm/sct_events/loaders.py
+++ b/sdcm/sct_events/loaders.py
@@ -143,6 +143,7 @@ class CassandraStressLogEvent(LogEvent, abstract=True):
     ConsistencyError: Type[LogEventProtocol]
     OperationOnKey: Type[LogEventProtocol]
     TooManyHintsInFlight: Type[LogEventProtocol]
+    ShardAwareDriver: Type[LogEventProtocol]
 
 
 # Task: https://trello.com/c/kGply3WI/2718-stress-failure-should-stop-the-test-immediately
@@ -157,7 +158,8 @@ CassandraStressLogEvent.add_subevent_type("IOException", severity=Severity.ERROR
                                           regex=r"java\.io\.IOException")
 CassandraStressLogEvent.add_subevent_type("ConsistencyError", severity=Severity.ERROR,
                                           regex="Cannot achieve consistency level")
-
+CassandraStressLogEvent.add_subevent_type("ShardAwareDriver", severity=Severity.NORMAL,
+                                          regex="Using optimized driver")
 
 CS_ERROR_EVENTS = (
     CassandraStressLogEvent.TooManyHintsInFlight(),
@@ -165,8 +167,13 @@ CS_ERROR_EVENTS = (
     CassandraStressLogEvent.IOException(),
     CassandraStressLogEvent.ConsistencyError(),
 )
+CS_NORMAL_EVENTS = (CassandraStressLogEvent.ShardAwareDriver(), )
+
 CS_ERROR_EVENTS_PATTERNS: List[Tuple[re.Pattern, LogEventProtocol]] = \
     [(re.compile(event.regex), event) for event in CS_ERROR_EVENTS]
+
+CS_NORMAL_EVENTS_PATTERNS: List[Tuple[re.Pattern, LogEventProtocol]] = \
+    [(re.compile(event.regex), event) for event in CS_NORMAL_EVENTS]
 
 
 class ScyllaBenchLogEvent(LogEvent, abstract=True):

--- a/sdcm/send_email.py
+++ b/sdcm/send_email.py
@@ -147,6 +147,7 @@ class BaseEmailReporter:
         "test_name",
         "test_status",
         "username",
+        "shard_awareness_driver",
     )
     _fields = ()
     email_template_file = 'results_base.html'

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -19,13 +19,14 @@ import random
 import logging
 import concurrent.futures
 from typing import Any
+from itertools import chain
 
 from sdcm.loader import CassandraStressExporter
 from sdcm.cluster import BaseLoaderSet
 from sdcm.prometheus import nemesis_metrics_obj
 from sdcm.sct_events import Severity
 from sdcm.utils.common import FileFollowerThread, generate_random_string, get_profile_content
-from sdcm.sct_events.loaders import CassandraStressEvent, CS_ERROR_EVENTS_PATTERNS
+from sdcm.sct_events.loaders import CassandraStressEvent, CS_ERROR_EVENTS_PATTERNS, CS_NORMAL_EVENTS_PATTERNS
 
 
 LOGGER = logging.getLogger(__name__)
@@ -57,7 +58,7 @@ class CassandraStressEventsPublisher(FileFollowerThread):
                 if self.stopped():
                     break
 
-                for pattern, event in CS_ERROR_EVENTS_PATTERNS:
+                for pattern, event in chain(CS_NORMAL_EVENTS_PATTERNS, CS_ERROR_EVENTS_PATTERNS):
                     if self.event_id:
                         # Connect the event to the stress load
                         event.event_id = self.event_id

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2978,7 +2978,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 "test_id": self.test_id,
                 "test_name": self.id(),
                 "test_status": test_status,
-                "username": get_username(), }
+                "username": get_username(),
+                "shard_awareness_driver": self.is_shard_awareness_driver}
 
     @silence()
     def tag_ami_with_result(self):
@@ -3019,3 +3020,11 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         node.wait_ssh_up(verbose=False, timeout=50)
 
         return node
+
+    @property
+    def is_shard_awareness_driver(self) -> bool:
+        all_events = get_events_grouped_by_category()
+        for event_str in all_events["NORMAL"]:
+            if "type=ShardAwareDriver" in event_str:
+                return True
+        return False

--- a/unit_tests/test_sct_events_loaders.py
+++ b/unit_tests/test_sct_events_loaders.py
@@ -14,6 +14,8 @@
 import pickle
 import unittest
 
+from itertools import chain
+
 from invoke.runners import Result
 
 from sdcm.sct_events import Severity
@@ -21,7 +23,7 @@ from sdcm.sct_events.base import LogEvent
 from sdcm.sct_events.loaders import \
     GeminiStressEvent, CassandraStressEvent, ScyllaBenchEvent, YcsbStressEvent, NdBenchStressEvent, CDCReaderStressEvent, \
     KclStressEvent, CassandraStressLogEvent, ScyllaBenchLogEvent, GeminiStressLogEvent, \
-    CS_ERROR_EVENTS, SCYLLA_BENCH_ERROR_EVENTS, CS_ERROR_EVENTS_PATTERNS
+    CS_ERROR_EVENTS, CS_NORMAL_EVENTS, SCYLLA_BENCH_ERROR_EVENTS, CS_ERROR_EVENTS_PATTERNS, CS_NORMAL_EVENTS_PATTERNS
 
 
 class TestGeminiEvent(unittest.TestCase):
@@ -367,58 +369,67 @@ class TestKclStressEvent(unittest.TestCase):
 
 
 class TestCassandraStressLogEvent(unittest.TestCase):
+    @staticmethod
+    def get_event(line, expected_type, expected_severity):
+        for pattern, event in chain(CS_NORMAL_EVENTS_PATTERNS, CS_ERROR_EVENTS_PATTERNS):
+            if pattern.search(line):
+                event.add_info(node='self.node', line=line, line_number=1).dont_publish()
+                assert event.type == expected_type, \
+                    f'Unexpected event.type {event.type}. Expected "{expected_type}"'
+                assert event.severity == expected_severity, \
+                    f'Unexpected event.severity {event.severity}. Expected "{expected_severity}"'
+                return
+
+        raise ValueError(f"Event is not recognized in the line {line}. Expected exception type is {expected_type},"
+                         f"expected severity is {expected_severity}")
+
     def test_known_cs_errors(self):
         self.assertTrue(issubclass(CassandraStressLogEvent.IOException, CassandraStressLogEvent))
         self.assertTrue(issubclass(CassandraStressLogEvent.ConsistencyError, CassandraStressLogEvent))
         self.assertTrue(issubclass(CassandraStressLogEvent.OperationOnKey, CassandraStressLogEvent))
         self.assertTrue(issubclass(CassandraStressLogEvent.TooManyHintsInFlight, CassandraStressLogEvent))
 
-    def test_cs_error_events_list(self):
+    def test_known_cs_normal(self):
+        self.assertTrue(issubclass(CassandraStressLogEvent.ShardAwareDriver, CassandraStressLogEvent))
+
+    def test_cs_all_events_list(self):
         self.assertSetEqual(set(dir(CassandraStressLogEvent)) - set(dir(LogEvent)),
-                            {ev.type for ev in CS_ERROR_EVENTS})
+                            {ev.type for ev in chain(CS_NORMAL_EVENTS, CS_ERROR_EVENTS)})
 
     def test_cs_hint_in_flight_error(self):  # pylint: disable=no-self-use
-        def _get_event(line, expected_type, expected_severity):
-            for pattern, event in CS_ERROR_EVENTS_PATTERNS:
-                if pattern.search(line):
-                    event.add_info(node='self.node', line=line, line_number=1).dont_publish()
-                    assert event.type == expected_type, \
-                        f'Unexpected event.type {event.type}. Expected "{expected_type}"'
-                    assert event.severity == expected_severity, \
-                        f'Unexpected event.severity {event.severity}. Expected "{expected_severity}"'
-                    return
+        self.get_event(line='java.io.IOException: Operation x10 on key(s) [334f37384f4d32303430]: Error executing: '
+                       '(OverloadedException): Queried host (10.0.3.167/10.0.3.167:9042) was overloaded: Too many '
+                       'in flight hints: 10490670',
+                       expected_type='TooManyHintsInFlight',
+                       expected_severity=Severity.ERROR)
 
-            raise ValueError(f"Event is not recognized in the line {line}. Expected exception type is {expected_type},"
-                             f"expected severity is {expected_severity}")
+        self.get_event(line='java.io.IOException: Operation x10 on key(s) [334f37384f4d32303430]: Error executing: '
+                       '(OverloadedException): Queried host (10.0.3.167/10.0.3.167:9042) was overloaded: Too many '
+                       'hints in flight: 10490670',
+                       expected_type='TooManyHintsInFlight',
+                       expected_severity=Severity.ERROR)
 
-        _get_event(line='java.io.IOException: Operation x10 on key(s) [334f37384f4d32303430]: Error executing: '
-                        '(OverloadedException): Queried host (10.0.3.167/10.0.3.167:9042) was overloaded: Too many '
-                        'in flight hints: 10490670',
-                   expected_type='TooManyHintsInFlight',
-                   expected_severity=Severity.ERROR)
+        self.get_event(line='java.io.IOException: Operation x10 on key(s) [334f37384f4d32303430]: Error executing: '
+                       '(OverloadedException): Queried host (10.0.3.167/10.0.3.167:9042) ',
+                       expected_type='OperationOnKey',
+                       expected_severity=Severity.CRITICAL)
 
-        _get_event(line='java.io.IOException: Operation x10 on key(s) [334f37384f4d32303430]: Error executing: '
-                        '(OverloadedException): Queried host (10.0.3.167/10.0.3.167:9042) was overloaded: Too many '
-                        'hints in flight: 10490670',
-                   expected_type='TooManyHintsInFlight',
-                   expected_severity=Severity.ERROR)
+        self.get_event(line='java.io.IOException: Connection reset by peer',
+                       expected_type='IOException',
+                       expected_severity=Severity.ERROR)
 
-        _get_event(line='java.io.IOException: Operation x10 on key(s) [334f37384f4d32303430]: Error executing: '
-                        '(OverloadedException): Queried host (10.0.3.167/10.0.3.167:9042) ',
-                   expected_type='OperationOnKey',
-                   expected_severity=Severity.CRITICAL)
+        self.get_event(line='03:56:37.572 [cluster1-nio-worker-4] DEBUG com.datastax.driver.core.Connection - Connection['
+                       '/10.0.3.121:9042-11, inFlight=5, closed=false] Response received on stream 17856 but no '
+                       'handler set anymore (either the request has timed out or it was closed due to another error). '
+                       'Received message is ERROR UNAVAILABLE: Cannot achieve consistency level for cl QUORUM. '
+                       'Requires 2, alive 1',
+                       expected_type='ConsistencyError',
+                       expected_severity=Severity.ERROR)
 
-        _get_event(line='java.io.IOException: Connection reset by peer',
-                   expected_type='IOException',
-                   expected_severity=Severity.ERROR)
-
-        _get_event(line='03:56:37.572 [cluster1-nio-worker-4] DEBUG com.datastax.driver.core.Connection - Connection['
-                        '/10.0.3.121:9042-11, inFlight=5, closed=false] Response received on stream 17856 but no '
-                        'handler set anymore (either the request has timed out or it was closed due to another error). '
-                        'Received message is ERROR UNAVAILABLE: Cannot achieve consistency level for cl QUORUM. '
-                        'Requires 2, alive 1',
-                   expected_type='ConsistencyError',
-                   expected_severity=Severity.ERROR)
+    def test_cs_normal_shared_awarnes_event(self):
+        self.get_event(line='com.datastax.driver.core.Cluster - ===== Using optimized driver!!! =====',
+                       expected_type='ShardAwareDriver',
+                       expected_severity=Severity.NORMAL)
 
 
 class TestScyllaBenchLogEvent(unittest.TestCase):


### PR DESCRIPTION
Using prometheus query and parsing c-s log file check
whether c-s use shared-aware driver or not and add info
to summary email

Trello: https://trello.com/c/VrpxJLr4

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
