### PR TITLE
refactor(cluster.py): convert scylla_version to the property

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3470,7 +3470,7 @@ def wait_for_init_wrap(method):
         node_list = kwargs.get('node_list', None) or cl_inst.nodes
         timeout = kwargs.get('timeout', None)
         # remove all arguments which is not supported by BaseScyllaCluster.node_setup method
-        setup_kwargs = {k: kwargs[k] for k in kwargs if k not in ["node_list", "check_node_health"]}
+        setup_kwargs = {k: v for k, v in kwargs.items() if k not in ["node_list", "check_node_health"]}
 
         _queue = queue.Queue()
 

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2024,7 +2024,6 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
         pass
 
     def node_setup(self, node: BaseScyllaPodContainer, verbose: bool = False, timeout: int = 3600):
-        self.get_scylla_version()
         if self.test_config.BACKTRACE_DECODING:
             node.install_scylla_debuginfo()
 

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1300,6 +1300,7 @@ class BasePodContainer(cluster.BaseNode):  # pylint: disable=too-many-public-met
     def is_docker() -> bool:
         return True
 
+    @cached_property
     def tags(self) -> Dict[str, str]:
         return {**super().tags,
                 "NodeIndex": str(self.node_index), }

--- a/sdcm/utils/decorators.py
+++ b/sdcm/utils/decorators.py
@@ -15,7 +15,7 @@ import sys
 import time
 import logging
 import datetime
-from functools import wraps, partial
+from functools import wraps, partial, cached_property
 
 LOGGER = logging.getLogger(__name__)
 
@@ -192,3 +192,21 @@ def latency_calculator_decorator(func):
         return res
 
     return wrapped
+
+
+class NoValue(Exception):
+    ...
+
+
+class optional_cached_property(cached_property):  # pylint: disable=invalid-name,too-few-public-methods
+    """Extension for cached_property from Lib/functools.py with ability to ignore calculated result.
+
+    To make it to not cache a value on a property call raise NoValue exception: it will be ignored and
+    None will be returned as a result.
+    """
+
+    def __get__(self, instance, owner=None):
+        try:
+            return super().__get__(instance=instance, owner=owner)
+        except NoValue:
+            return None


### PR DESCRIPTION
Trello: https://trello.com/c/mfHdGjxO/3300-convert-getscyllaversion-to-scyllaversion-property

- Add `optional_cached_property` decorator
- Introduce a method to clean cached Scylla version
- `node.scylla_version` always should be a short (like `4.4.dev`)


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
