### PR TITLE
fix(is_scylla_bench_installed): make flag out of it

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -206,6 +206,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         self.is_seed = False
 
         self.remoter = None
+        self.is_scylla_bench_installed = False
 
         self._spot_monitoring_thread = None
         self._journal_thread = None
@@ -361,6 +362,26 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
     @property
     def continuous_events_registry(self) -> ContinuousEventsRegistry:
         return self._continuous_events_registry
+
+    @retrying(n=5)
+    def install_scylla_bench(self):
+        if self.distro.is_rhel_like:
+            self.remoter.sudo("yum install -y git")
+        else:
+            self.remoter.sudo(shell_script_cmd("""\
+                apt-get update
+                apt-get install -y git
+            """))
+        self.remoter.sudo(shell_script_cmd(f"""\
+            rm -rf /usr/local/go
+            curl -LO https://storage.googleapis.com/golang/go1.16.3.linux-amd64.tar.gz
+            tar -C /usr/local -xvzf go1.16.3.linux-amd64.tar.gz
+            echo 'export GOPATH=$HOME/go' >> $HOME/.bash_profile
+            echo 'export PATH=$PATH:/usr/local/go/bin' >> $HOME/.bash_profile
+            source $HOME/.bash_profile
+            GO111MODULE=on go get -v github.com/scylladb/scylla-bench@{self.parent_cluster.params.get('scylla_bench_version')}
+        """))
+        self.is_scylla_bench_installed = True
 
     @property
     def cassandra_stress_version(self):
@@ -4506,15 +4527,17 @@ class BaseLoaderSet():
         if self.params.get('client_encrypt'):
             node.config_client_encrypt()
 
+        if 'scylla-bench' in self.params.list_of_stress_tools:
+            # Update existing scylla-bench to latest
+            if not node.is_scylla_bench_installed:
+                node.install_scylla_bench()
+
         result = node.remoter.run('test -e ~/PREPARED-LOADER', ignore_status=True)
         node.remoter.sudo("bash -cxe \"echo '*\t\thard\tcore\t\tunlimited\n*\t\tsoft\tcore\t\tunlimited' "
                           ">> /etc/security/limits.d/20-coredump.conf\"")
         if result.exit_status == 0:
-            # Update existing scylla-bench to latest
-            if 'scylla-bench' in self.params.list_of_stress_tools:
-                self.install_scylla_bench(node)
-                self.log.debug('Skip loader setup for using a prepared AMI')
-                return
+            self.log.debug('Skip loader setup for using a prepared AMI')
+            return
 
         if node.is_ubuntu14():
             install_java_script = dedent("""
@@ -4567,7 +4590,8 @@ class BaseLoaderSet():
         node.wait_cs_installed(verbose=verbose)
 
         if 'scylla-bench' in self.params.list_of_stress_tools:
-            self.install_scylla_bench(node)
+            if not node.is_scylla_bench_installed:
+                node.install_scylla_bench()
 
         # install docker
         docker_install = dedent("""
@@ -4734,29 +4758,6 @@ class BaseLoaderSet():
                 kill_result = loader.remoter.run('pkill -f -SIGINT gemini', ignore_status=True)
                 if kill_result.exit_status != 0:
                     self.log.warning('Terminate gemini on node %s:\n%s', loader, kill_result)
-
-    @staticmethod
-    def is_scylla_bench_installed(node: BaseNode):
-        return node.remoter.run('ls /$HOME/go/bin/scylla-bench', ignore_status=True).ok
-
-    @retrying(n=5)
-    def install_scylla_bench(self, node):
-        if node.distro.is_rhel_like:
-            node.remoter.sudo("yum install -y git")
-        else:
-            node.remoter.sudo(shell_script_cmd("""\
-                apt-get update
-                apt-get install -y git
-            """))
-        node.remoter.sudo(shell_script_cmd(f"""\
-            rm -rf /usr/local/go
-            curl -LO https://storage.googleapis.com/golang/go1.16.3.linux-amd64.tar.gz
-            tar -C /usr/local -xvzf go1.16.3.linux-amd64.tar.gz
-            echo 'export GOPATH=$HOME/go' >> $HOME/.bash_profile
-            echo 'export PATH=$PATH:/usr/local/go/bin' >> $HOME/.bash_profile
-            source $HOME/.bash_profile
-            GO111MODULE=on go get -v github.com/scylladb/scylla-bench@{self.params.get('scylla_bench_version')}
-        """))
 
 
 class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instance-attributes

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -311,7 +311,8 @@ class LoaderSetDocker(cluster.BaseLoaderSet, DockerCluster):
         self.install_gemini(node=node)
 
         if 'scylla-bench' in self.params.list_of_stress_tools:
-            self.install_scylla_bench(node)
+            if not node.is_scylla_bench_installed:
+                node.install_scylla_bench()
 
         if self.params.get('client_encrypt'):
             node.config_client_encrypt()

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2306,7 +2306,8 @@ class LoaderPodCluster(cluster.BaseLoaderSet, PodCluster):
                    **kwargs) -> None:
 
         if 'scylla-bench' in self.params.list_of_stress_tools:
-            self.install_scylla_bench(node)
+            if not node.is_scylla_bench_installed:
+                node.install_scylla_bench()
 
         if self.params.get('client_encrypt'):
             node.config_client_encrypt()

--- a/sdcm/scylla_bench_thread.py
+++ b/sdcm/scylla_bench_thread.py
@@ -183,8 +183,8 @@ class ScyllaBenchThread:  # pylint: disable=too-many-instance-attributes
         LOGGER.debug("Round-Robin through loaders, Selected loader is {} ".format(loaders))
 
         for loader in loaders:
-            if not self.loader_set.is_scylla_bench_installed(loader):
-                self.loader_set.install_scylla_bench(loader)
+            if not loader.is_scylla_bench_installed:
+                loader.install_scylla_bench()
 
         self.max_workers = (os.cpu_count() or 1) * 5
         LOGGER.debug("Starting %d scylla-bench Worker threads", self.max_workers)


### PR DESCRIPTION
https://trello.com/c/gkrn14EX/3780-unknown-flag-when-running-scylla-bench

s-b is not getting installed in some cases.

Currently we relay on s-b existance, but since default loaders have
outdated version of it this approach does not work.
Also go does not have ability to check on it too.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
