### PR TITLE
fix(manager): separating manager installation to server and client

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2264,7 +2264,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         self.log.debug("Upgrade scylla-manager via repo: %s", scylla_mgmt_repo)
         self.download_scylla_manager_repo(scylla_mgmt_repo)
         if self.distro.is_rhel_like:
-            self.remoter.sudo("yum update scylla-manager -y")
+            self.remoter.sudo("yum update scylla-manager-server scylla-manager-client -y")
         else:
             self.remoter.sudo("apt-get update", ignore_status=True)
             # Upgrade should update packages of:
@@ -2304,7 +2304,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             package_names = f"{package_url}scylla-manager-server* {package_url}scylla-manager-client*"
         else:
             self.download_scylla_manager_repo(scylla_mgmt_repo)
-            package_names = "scylla-manager"
+            package_names = "scylla-manager-server scylla-manager-client"
         self.install_package(package_names)
 
         self.log.debug("Copying TLS files from data_dir to the node")


### PR DESCRIPTION
Due to recent changes in the manager package, the manager cannot be installed by
simplpy installing the 'scylla-manager' package, but instead one must install
both 'scylla-manager-server' and 'scylla-manager-client'.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
