### PR TITLE
fix(upgrade conf): set maxPending=1024 to increase the requests limit

### DIFF
--- a/test-cases/upgrades/rolling-upgrade.yaml
+++ b/test-cases/upgrades/rolling-upgrade.yaml
@@ -3,16 +3,16 @@
 test_duration: 250
 
 # workloads
-write_stress_during_entire_test: cassandra-stress write no-warmup cl=QUORUM n=20100200 -schema 'keyspace=keyspace_entire_test replication(factor=3) compression=LZ4Compressor compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=lz4 -rate threads=100 -pop seq=1..20100200 -log interval=5
-verify_stress_after_cluster_upgrade: cassandra-stress read no-warmup cl=QUORUM n=20100200 -schema 'keyspace=keyspace_entire_test replication(factor=3) compression=LZ4Compressor' -port jmx=6868 -mode cql3 native compression=lz4 -rate threads=1000 -pop seq=1..20100200 -log interval=5
-prepare_write_stress: cassandra-stress write no-warmup cl=QUORUM n=10100200 -schema 'replication(factor=3) compression=LZ4Compressor compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=lz4 -rate threads=1000 -pop seq=1..10100200 -log interval=5
-stress_cmd_read_cl_quorum: cassandra-stress read no-warmup cl=QUORUM n=10100200 -schema 'replication(factor=3) compression=DeflateCompressor' -port jmx=6868 -mode cql3 native compression=none -rate threads=1000 -pop seq=1..10100200 -log interval=5
-stress_cmd_read_10m: cassandra-stress read no-warmup cl=QUORUM duration=10m -schema 'replication(factor=3) compression=SnappyCompressor' -port jmx=6868 -mode cql3 native compression=snappy -rate threads=1000 -pop seq=1..10100200 -log interval=5
-stress_cmd_read_60m: cassandra-stress read no-warmup cl=QUORUM duration=60m -schema 'replication(factor=3) compression=LZ4Compressor' -port jmx=6868 -mode cql3 native compression=lz4 -rate threads=1000 -pop seq=1..10100200 -log interval=5
-stress_cmd_complex_prepare: cassandra-stress user no-warmup profile=/tmp/complex_schema.yaml  ops'(insert=1)' cl=ALL n=5000000 -mode cql3 native -rate threads=1000 -pop seq=1..5000000
-stress_cmd_complex_verify_read: cassandra-stress user no-warmup profile=/tmp/complex_schema.yaml  ops'(read1=1,read3=1)' cl=ONE n=5000000 -mode cql3 native -rate threads=1000 -pop seq=1..5000000
-stress_cmd_complex_verify_more: cassandra-stress user no-warmup profile=/tmp/complex_schema.yaml  ops'(read1=1,read2=1,read3=1,update_static=1,update_ttl=1,update_diff1_ts=1,update_diff2_ts=1,update_same1_ts=1,update_same2_ts=1)' cl=ALL n=5000000 -mode cql3 native -rate threads=200 -pop seq=1..5000000
-stress_cmd_complex_verify_delete: cassandra-stress user no-warmup profile=/tmp/complex_schema.yaml  ops'(delete_row=1)' cl=ALL n=500000 -mode cql3 native -rate threads=200 -pop seq=1..500000
+write_stress_during_entire_test: cassandra-stress write no-warmup cl=QUORUM n=20100200 -schema 'keyspace=keyspace_entire_test replication(factor=3) compression=LZ4Compressor compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native maxPending=1024 compression=lz4 -rate threads=100 -pop seq=1..20100200 -log interval=5
+verify_stress_after_cluster_upgrade: cassandra-stress read no-warmup cl=QUORUM n=20100200 -schema 'keyspace=keyspace_entire_test replication(factor=3) compression=LZ4Compressor' -port jmx=6868 -mode cql3 native maxPending=1024 compression=lz4 -rate threads=1000 -pop seq=1..20100200 -log interval=5
+prepare_write_stress: cassandra-stress write no-warmup cl=QUORUM n=10100200 -schema 'replication(factor=3) compression=LZ4Compressor compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native maxPending=1024 compression=lz4 -rate threads=1000 -pop seq=1..10100200 -log interval=5
+stress_cmd_read_cl_quorum: cassandra-stress read no-warmup cl=QUORUM n=10100200 -schema 'replication(factor=3) compression=DeflateCompressor' -port jmx=6868 -mode cql3 native maxPending=1024 compression=none -rate threads=1000 -pop seq=1..10100200 -log interval=5
+stress_cmd_read_10m: cassandra-stress read no-warmup cl=QUORUM duration=10m -schema 'replication(factor=3) compression=SnappyCompressor' -port jmx=6868 -mode cql3 native maxPending=1024 compression=snappy -rate threads=1000 -pop seq=1..10100200 -log interval=5
+stress_cmd_read_60m: cassandra-stress read no-warmup cl=QUORUM duration=60m -schema 'replication(factor=3) compression=LZ4Compressor' -port jmx=6868 -mode cql3 native maxPending=1024 compression=lz4 -rate threads=1000 -pop seq=1..10100200 -log interval=5
+stress_cmd_complex_prepare: cassandra-stress user no-warmup profile=/tmp/complex_schema.yaml  ops'(insert=1)' cl=ALL n=5000000 -mode cql3 native maxPending=1024 -rate threads=1000 -pop seq=1..5000000
+stress_cmd_complex_verify_read: cassandra-stress user no-warmup profile=/tmp/complex_schema.yaml  ops'(read1=1,read3=1)' cl=ONE n=5000000 -mode cql3 native maxPending=1024 -rate threads=1000 -pop seq=1..5000000
+stress_cmd_complex_verify_more: cassandra-stress user no-warmup profile=/tmp/complex_schema.yaml  ops'(read1=1,read2=1,read3=1,update_static=1,update_ttl=1,update_diff1_ts=1,update_diff2_ts=1,update_same1_ts=1,update_same2_ts=1)' cl=ALL n=5000000 -mode cql3 native maxPending=1024 -rate threads=200 -pop seq=1..5000000
+stress_cmd_complex_verify_delete: cassandra-stress user no-warmup profile=/tmp/complex_schema.yaml  ops'(delete_row=1)' cl=ALL n=500000 -mode cql3 native maxPending=1024 -rate threads=200 -pop seq=1..500000
 
 n_db_nodes: 4
 n_loaders: 1


### PR DESCRIPTION
Currently the default maxPendingPerConnection of cassandra-stress
doesn't match with driver v3. The default value had been removed from
cassandra-stress in scylla-master, but the fix isn't backported to 4.5

This patch set a bigger maxPending to cs workloads to avoid a
BusyPoolException in upgrade test.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
