### PR TITLE
improvement(continuous event): convert PrometheusAlertManagerEvent

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -64,8 +64,7 @@ CassandraStressLogEvent.OperationOnKey: CRITICAL
 CassandraStressLogEvent.TooManyHintsInFlight: ERROR
 ScyllaBenchLogEvent.ConsistencyError: ERROR
 GeminiStressLogEvent.GeminiEvent: CRITICAL
-PrometheusAlertManagerEvent.start: WARNING
-PrometheusAlertManagerEvent.end: WARNING
+PrometheusAlertManagerEvent: CRITICAL
 ScyllaOperatorLogEvent: ERROR
 ScyllaOperatorLogEvent.REAPPLY: WARNING
 ScyllaOperatorLogEvent.TLS_HANDSHAKE_ERROR: WARNING

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -54,6 +54,7 @@ from sdcm.log import SDCMAdapter
 from sdcm.remote import RemoteCmdRunnerBase, LOCALRUNNER, NETWORK_EXCEPTIONS, shell_script_cmd
 from sdcm.remote.remote_file import remote_file, yaml_file_to_dict, dict_to_yaml_file
 from sdcm import wait, mgmt
+from sdcm.sct_events.continuous_event import ContinuousEventsRegistry
 from sdcm.utils import alternator, properties
 from sdcm.utils.common import (
     S3Storage,
@@ -81,7 +82,7 @@ from sdcm.utils.remotewebbrowser import WebDriverContainerMixin
 from sdcm.test_config import TestConfig
 from sdcm.utils.version_utils import SCYLLA_VERSION_RE, get_gemini_version, get_systemd_version
 from sdcm.sct_events import Severity
-from sdcm.sct_events.base import LogEvent, ContinuousEventsRegistry
+from sdcm.sct_events.base import LogEvent
 from sdcm.sct_events.health import ClusterHealthValidatorEvent
 from sdcm.sct_events.system import TestFrameworkEvent
 from sdcm.sct_events.filters import DbEventsFilter

--- a/sdcm/sct_events/base.py
+++ b/sdcm/sct_events/base.py
@@ -47,9 +47,16 @@ LOGGER = logging.getLogger(__name__)
 
 
 class ContinuousRegistryFilter:
-    def __init__(self, registry: List[Any]):
-        self._registry = registry
-        self._output = registry.copy()
+    def __init__(self, registry: List[Any], by_base: str = None):
+        """
+        str by_base: return events only with event.base value = by_base.
+                     For example: NodetoolEvent.base = "NodetoolEvent"
+        """
+        if not by_base:
+            self._registry = registry
+        else:
+            self._registry = [event for event in registry if event.base == by_base]
+        self._output = self._registry.copy()
 
     def filter_by_id(self, event_id: str) -> ContinuousRegistryFilter:
         self._output = [event for event in self._output if event.event_id == event_id]
@@ -73,6 +80,16 @@ class ContinuousRegistryFilter:
 
     def filter_by_shard(self, shard: int) -> ContinuousRegistryFilter:
         self._output = [item for item in self._output if item.shard == shard]
+
+        return self
+
+    def filter_by_alert(self, alert: str) -> ContinuousRegistryFilter:
+        self._output = [item for item in self._output if item.alert_name == alert]
+
+        return self
+
+    def filter_by_starts_at(self, starts_at: str) -> ContinuousRegistryFilter:
+        self._output = [item for item in self._output if item.starts_at == starts_at]
 
         return self
 
@@ -150,8 +167,8 @@ class ContinuousEventsRegistry(metaclass=Singleton):
 
         return found_events
 
-    def get_registry_filter(self) -> ContinuousRegistryFilter:
-        registry_filter = ContinuousRegistryFilter(registry=self.continuous_events)
+    def get_registry_filter(self, by_base=None) -> ContinuousRegistryFilter:
+        registry_filter = ContinuousRegistryFilter(registry=self.continuous_events, by_base=by_base)
 
         return registry_filter
 

--- a/sdcm/sct_events/base.py
+++ b/sdcm/sct_events/base.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import json
 import time
-import traceback
 import uuid
 import pickle
 import fnmatch
@@ -26,7 +25,7 @@ from enum import Enum
 from json import JSONEncoder
 from types import new_class
 from typing import \
-    Any, Optional, Type, Dict, List, Tuple, Callable, Generic, TypeVar, Protocol, runtime_checkable, Union
+    Any, Optional, Type, Dict, List, Tuple, Callable, Generic, TypeVar, Protocol, runtime_checkable
 from keyword import iskeyword
 from weakref import proxy as weakproxy
 from datetime import datetime
@@ -34,149 +33,14 @@ from functools import partialmethod
 
 import yaml
 import dateutil.parser
-from dateutil.relativedelta import relativedelta
 
 from sdcm import sct_abs_path
 from sdcm.sct_events import Severity, SctEventProtocol
 from sdcm.sct_events.events_processes import EventsProcessesRegistry
-from sdcm.utils.metaclasses import Singleton
 
 DEFAULT_SEVERITIES = sct_abs_path("defaults/severities.yaml")
 
 LOGGER = logging.getLogger(__name__)
-
-
-class ContinuousRegistryFilter:
-    def __init__(self, registry: List[Any], by_base: str = None):
-        """
-        str by_base: return events only with event.base value = by_base.
-                     For example: NodetoolEvent.base = "NodetoolEvent"
-        """
-        if not by_base:
-            self._registry = registry
-        else:
-            self._registry = [event for event in registry if event.base == by_base]
-        self._output = self._registry.copy()
-
-    def filter_by_id(self, event_id: str) -> ContinuousRegistryFilter:
-        self._output = [event for event in self._output if event.event_id == event_id]
-
-        return self
-
-    def filter_by_node(self, node: str) -> ContinuousRegistryFilter:
-        self._output = [item for item in self._output if item.node == node]
-
-        return self
-
-    def filter_by_type(self, event_type: Type[ContinuousEvent]) -> ContinuousRegistryFilter:
-        self._output = [item for item in self._output if isinstance(item, event_type)]
-
-        return self
-
-    def filter_by_period(self, period_type: EventPeriod) -> ContinuousRegistryFilter:
-        self._output = [item for item in self._output if item.period_type == period_type]
-
-        return self
-
-    def filter_by_shard(self, shard: int) -> ContinuousRegistryFilter:
-        self._output = [item for item in self._output if item.shard == shard]
-
-        return self
-
-    def filter_by_alert(self, alert: str) -> ContinuousRegistryFilter:
-        self._output = [item for item in self._output if item.alert_name == alert]
-
-        return self
-
-    def filter_by_starts_at(self, starts_at: str) -> ContinuousRegistryFilter:
-        self._output = [item for item in self._output if item.starts_at == starts_at]
-
-        return self
-
-    def get_filtered(self) -> List[Any]:
-        return self._output
-
-
-class ContinuousEventRegistryException(BaseException):
-    pass
-
-
-class ContinuousEventsRegistry(metaclass=Singleton):
-    def __init__(self):
-        self._continuous_events: List[ContinuousEvent] = []
-
-    @property
-    def continuous_events(self):
-        return self._continuous_events
-
-    def add_event(self, event: ContinuousEvent):
-        if not issubclass(type(event), ContinuousEvent):
-            msg = f"Event: {event} is not a ContinuousEvent"
-            raise ContinuousEventRegistryException(msg)
-
-        if self._find_event_by_id(event.event_id):
-            msg = f"Event with id: {event.event_id} is already present. Event ids in the registry must be unique."
-            raise ContinuousEventRegistryException(msg)
-
-        self.continuous_events.append(event)
-
-    def get_event_by_id(self, event_id: Union[uuid.UUID, str]) -> Optional[ContinuousEvent]:
-        found_events = self._find_event_by_id(event_id)
-
-        if not found_events:
-            LOGGER.warning("Couldn't find continuous event with id: {event_id} in registry.".format(event_id=event_id))
-
-            return None
-
-        return found_events[0]
-
-    def get_events_by_type(self, event_type: Type[ContinuousEvent]) -> List[ContinuousEvent]:
-        event_filter = self.get_registry_filter()
-        found_events = event_filter \
-            .filter_by_type(event_type=event_type) \
-            .get_filtered()
-
-        if not found_events:
-            LOGGER.warning("No continuous events of type: {event_type} found in registry."
-                           .format(event_type=event_type))
-
-        return found_events
-
-    def get_events_by_period(self,
-                             period_type: EventPeriod) -> List[ContinuousEvent]:
-        event_filter = self.get_registry_filter()
-        found_events = event_filter \
-            .filter_by_period(period_type=period_type.value) \
-            .get_filtered()
-
-        if not found_events:
-            LOGGER.warning("No continuous events with period type: {period_type} found in registry."
-                           .format(period_type=period_type))
-
-        return found_events
-
-    def get_events_by_node(self, node: str) -> List[ContinuousEvent]:
-        event_filter = self.get_registry_filter()
-        found_events = event_filter \
-            .filter_by_node(node=node) \
-            .get_filtered()
-
-        if not found_events:
-            LOGGER.warning("No continuous event with associated with node: {node_name} found in registry"
-                           .format(node_name=node))
-
-        return found_events
-
-    def get_registry_filter(self, by_base=None) -> ContinuousRegistryFilter:
-        registry_filter = ContinuousRegistryFilter(registry=self.continuous_events, by_base=by_base)
-
-        return registry_filter
-
-    def _find_event_by_id(self, event_id: Union[uuid.UUID, str]) -> List[ContinuousEvent]:
-        event_filter = self.get_registry_filter()
-        found_events = event_filter.filter_by_id(event_id).get_filtered()
-
-        return found_events
 
 
 class SctEventTypesRegistry(Dict[str, Type["SctEvent"]]):  # pylint: disable=too-few-public-methods
@@ -366,130 +230,6 @@ class InformationalEvent(SctEvent, abstract=True):
         self.period_type = EventPeriod.INFORMATIONAL.value
 
 
-class ContinuousEvent(SctEvent, abstract=True):
-    # Event filter does not create object of the class (not initialize it), so "_duration" attribute should
-    # exist without initialization
-    _duration: Optional[int] = None
-
-    def __init__(self,
-                 severity: Severity = Severity.UNKNOWN,
-                 publish_event: bool = True):
-        super().__init__(severity=severity)
-        self.log_file_name = None
-        self.errors = []
-        self.publish_event = publish_event
-        self._ready_to_publish = publish_event
-        self.begin_timestamp = None
-        self.end_timestamp = None
-        self.is_skipped = False
-        self.skip_reason = ""
-        self._continuous_event_registry = ContinuousEventsRegistry()
-        self.register_event()
-
-    def __enter__(self):
-        event = self.begin_event()
-        return event
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        if exc_tb is not None:
-            if not isinstance(self.errors, list):
-                self.errors = []
-
-            if self.is_skipped:
-                self.severity = Severity.NORMAL
-            else:
-                self.severity = Severity.ERROR if self.severity.value <= Severity.ERROR.value else self.severity
-                self.errors.append(traceback.format_exc(limit=None, chain=True))
-
-        self.end_event()
-        return self
-
-    def skip(self, skip_reason):
-        self.is_skipped = True
-        self.skip_reason = skip_reason
-
-    @property
-    def msgfmt(self):
-        fmt = super().msgfmt
-        if self.duration is not None:
-            fmt += " duration={0.duration_formatted}"
-        return fmt
-
-    @property
-    def errors_formatted(self):
-        return "\n".join(self.errors) if self.errors is not None else ""
-
-    @property
-    def duration(self):
-        if self._duration is None:
-            if self.begin_timestamp is not None and self.end_timestamp is not None:
-                self._duration = int(self.end_timestamp - self.begin_timestamp)
-        return self._duration
-
-    @duration.setter
-    def duration(self, duration: int):
-        self._duration = duration
-
-    @property
-    def duration_formatted(self):
-        duration = ''
-        if self.duration is None:
-            return duration
-
-        delta = relativedelta(seconds=self.duration)
-        days, hours, minutes, sec = (int(delta.days), int(delta.hours), int(delta.minutes), delta.seconds)
-        if days:
-            duration += f"{days}d"
-
-        if days or hours:
-            duration += f"{hours}h"
-
-        if (hours or days) or (not hours and minutes > 0):
-            duration += f"{minutes}m"
-
-        duration += f"{sec}s"
-
-        return duration
-
-    # TODO: rename function to "begin" after the refactor will be done
-    def begin_event(self) -> ContinuousEvent:
-        self.timestamp = time.time()
-        self.begin_timestamp = self.timestamp
-        self.period_type = EventPeriod.BEGIN.value
-        self.severity = Severity.NORMAL
-        if self.publish_event:
-            self._ready_to_publish = True
-            self.publish()
-        return self
-
-    # TODO: rename function to "end" after the refactor will be done
-    def end_event(self) -> None:
-        self.timestamp = time.time()
-        self.end_timestamp = self.timestamp
-        self.period_type = EventPeriod.END.value
-        if self.publish_event:
-            self._ready_to_publish = True
-            self.publish()
-
-    def add_error(self, errors: Optional[List[str]]) -> None:
-        if not isinstance(self.errors, list):
-            self.errors = []
-
-        self.errors.extend(errors)
-
-    # TODO: rename function to "error" after the refactor will be done
-    def event_error(self):
-        self.timestamp = time.time()
-        self.period_type = EventPeriod.INFORMATIONAL.value
-        self.duration = None
-        if self.publish_event:
-            self._ready_to_publish = True
-            self.publish()
-
-    def register_event(self):
-        self._continuous_event_registry.add_event(self)
-
-
 def add_severity_limit_rules(rules: List[str]) -> None:
     for rule in rules:
         if not rule:
@@ -643,74 +383,7 @@ class LogEvent(Generic[T_log_event], InformationalEvent, abstract=True):
         return fmt
 
 
-class BaseStressEvent(ContinuousEvent, abstract=True):
-    # pylint: disable=too-many-arguments
-    @classmethod
-    def add_stress_subevents(cls,
-                             failure: Optional[Severity] = None,
-                             error: Optional[Severity] = None,
-                             timeout: Optional[Severity] = None,
-                             start: Optional[Severity] = Severity.NORMAL,
-                             finish: Optional[Severity] = Severity.NORMAL,
-                             warning: Optional[Severity] = None) -> None:
-        if failure is not None:
-            cls.add_subevent_type("failure", severity=failure)
-        if error is not None:
-            cls.add_subevent_type("error", severity=error)
-        if warning is not None:
-            cls.add_subevent_type("warning", severity=warning)
-        if timeout is not None:
-            cls.add_subevent_type("timeout", severity=timeout)
-        if start is not None:
-            cls.add_subevent_type("start", severity=start)
-        if finish is not None:
-            cls.add_subevent_type("finish", severity=finish)
-
-
-class StressEventProtocol(SctEventProtocol, Protocol):
-    node: str
-    stress_cmd: Optional[str]
-    log_file_name: Optional[str]
-    errors: Optional[List[str]]
-
-    @property
-    def errors_formatted(self):
-        ...
-
-
-class StressEvent(BaseStressEvent, abstract=True):
-    # pylint: disable=too-many-arguments
-    def __init__(self,
-                 node: Any,
-                 stress_cmd: Optional[str] = None,
-                 log_file_name: Optional[str] = None,
-                 errors: Optional[List[str]] = None,
-                 severity: Severity = Severity.NORMAL,
-                 publish_event: bool = True):
-        super().__init__(severity=severity, publish_event=publish_event)
-
-        self.node = str(node)
-        self.stress_cmd = stress_cmd
-        self.log_file_name = log_file_name
-        self.errors = errors
-
-    @property
-    def msgfmt(self):
-        fmt = super().msgfmt + ":"
-        if self.type:
-            fmt += " type={0.type}"
-        if self.node:
-            fmt += " node={0.node}"
-        if self.stress_cmd:
-            fmt += "\nstress_cmd={0.stress_cmd}"
-        if self.errors:
-            fmt += "\nerrors:\n\n{0.errors_formatted}"
-        return fmt
-
-
 __all__ = ("SctEvent", "SctEventProtocol", "SystemEvent", "BaseFilter",
            "LogEvent", "LogEventProtocol", "T_log_event",
-           "BaseStressEvent", "StressEvent", "StressEventProtocol",
            "add_severity_limit_rules", "max_severity", "print_critical_events",
-           "ContinuousEvent", "InformationalEvent", "ContinuousEventsRegistry",
-           "ContinuousEventRegistryException", "EventPeriod")
+           "InformationalEvent", "EventPeriod")

--- a/sdcm/sct_events/continuous_event.py
+++ b/sdcm/sct_events/continuous_event.py
@@ -1,0 +1,286 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2021 ScyllaDB
+from __future__ import annotations
+
+import logging
+import time
+import traceback
+import uuid
+from typing import Optional, List, Union, Type, Any
+
+from dateutil.relativedelta import relativedelta
+
+from sdcm.sct_events import Severity
+from sdcm.sct_events.base import SctEvent, EventPeriod
+from sdcm.utils.metaclasses import Singleton
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ContinuousEventRegistryException(BaseException):
+    pass
+
+
+class ContinuousEventsRegistry(metaclass=Singleton):
+    def __init__(self):
+        self._continuous_events: List[ContinuousEvent] = []
+
+    @property
+    def continuous_events(self):
+        return self._continuous_events
+
+    def add_event(self, event: ContinuousEvent):
+        if not issubclass(type(event), ContinuousEvent):
+            msg = f"Event: {event} is not a ContinuousEvent"
+            raise ContinuousEventRegistryException(msg)
+
+        if self._find_event_by_id(event.event_id):
+            msg = f"Event with id: {event.event_id} is already present. Event ids in the registry must be unique."
+            raise ContinuousEventRegistryException(msg)
+
+        self.continuous_events.append(event)
+
+    def get_event_by_id(self, event_id: Union[uuid.UUID, str]) -> Optional[ContinuousEvent]:
+        found_events = self._find_event_by_id(event_id)
+
+        if not found_events:
+            LOGGER.warning("Couldn't find continuous event with id: {event_id} in registry.".format(event_id=event_id))
+
+            return None
+
+        return found_events[0]
+
+    def get_events_by_type(self, event_type: Type[ContinuousEvent]) -> List[ContinuousEvent]:
+        event_filter = self.get_registry_filter()
+        found_events = event_filter \
+            .filter_by_type(event_type=event_type) \
+            .get_filtered()
+
+        if not found_events:
+            LOGGER.warning("No continuous events of type: {event_type} found in registry."
+                           .format(event_type=event_type))
+
+        return found_events
+
+    def get_events_by_period(self,
+                             period_type: EventPeriod) -> List[ContinuousEvent]:
+        event_filter = self.get_registry_filter()
+        found_events = event_filter \
+            .filter_by_period(period_type=period_type.value) \
+            .get_filtered()
+
+        if not found_events:
+            LOGGER.warning("No continuous events with period type: {period_type} found in registry."
+                           .format(period_type=period_type))
+
+        return found_events
+
+    def get_events_by_node(self, node: str) -> List[ContinuousEvent]:
+        event_filter = self.get_registry_filter()
+        found_events = event_filter \
+            .filter_by_node(node=node) \
+            .get_filtered()
+
+        if not found_events:
+            LOGGER.warning("No continuous event with associated with node: {node_name} found in registry"
+                           .format(node_name=node))
+
+        return found_events
+
+    def get_registry_filter(self) -> ContinuousRegistryFilter:
+        registry_filter = ContinuousRegistryFilter(registry=self.continuous_events)
+
+        return registry_filter
+
+    def _find_event_by_id(self, event_id: Union[uuid.UUID, str]) -> List[ContinuousEvent]:
+        event_filter = self.get_registry_filter()
+        found_events = event_filter.filter_by_id(event_id).get_filtered()
+
+        return found_events
+
+
+# pylint: disable=too-many-instance-attributes
+class ContinuousEvent(SctEvent, abstract=True):
+    # Event filter does not create object of the class (not initialize it), so "_duration" attribute should
+    # exist without initialization
+    _duration: Optional[int] = None
+
+    def __init__(self,
+                 severity: Severity = Severity.UNKNOWN,
+                 publish_event: bool = True):
+        super().__init__(severity=severity)
+        self.log_file_name = None
+        self.errors = []
+        self.publish_event = publish_event
+        self._ready_to_publish = publish_event
+        self.begin_timestamp = None
+        self.end_timestamp = None
+        self.is_skipped = False
+        self.skip_reason = ""
+        self._continuous_event_registry = ContinuousEventsRegistry()
+        self.register_event()
+
+    def __enter__(self):
+        event = self.begin_event()
+        return event
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_tb is not None:
+            if not isinstance(self.errors, list):
+                self.errors = []
+
+            if self.is_skipped:
+                self.severity = Severity.NORMAL
+            else:
+                self.severity = Severity.ERROR if self.severity.value <= Severity.ERROR.value else self.severity
+                self.errors.append(traceback.format_exc(limit=None, chain=True))
+
+        self.end_event()
+        return self
+
+    def skip(self, skip_reason):
+        self.is_skipped = True
+        self.skip_reason = skip_reason
+
+    @property
+    def msgfmt(self):
+        fmt = super().msgfmt
+        if self.duration is not None:
+            fmt += " duration={0.duration_formatted}"
+        return fmt
+
+    @property
+    def errors_formatted(self):
+        return "\n".join(self.errors) if self.errors is not None else ""
+
+    @property
+    def duration(self):
+        if self._duration is None:
+            if self.begin_timestamp is not None and self.end_timestamp is not None:
+                self._duration = int(self.end_timestamp - self.begin_timestamp)
+        return self._duration
+
+    @duration.setter
+    def duration(self, duration: int):
+        self._duration = duration
+
+    @property
+    def duration_formatted(self):
+        duration = ''
+        if self.duration is None:
+            return duration
+
+        delta = relativedelta(seconds=self.duration)
+        days, hours, minutes, sec = (int(delta.days), int(delta.hours), int(delta.minutes), delta.seconds)
+        if days:
+            duration += f"{days}d"
+
+        if days or hours:
+            duration += f"{hours}h"
+
+        if (hours or days) or (not hours and minutes > 0):
+            duration += f"{minutes}m"
+
+        duration += f"{sec}s"
+
+        return duration
+
+    # TODO: rename function to "begin" after the refactor will be done
+    def begin_event(self) -> ContinuousEvent:
+        self.timestamp = time.time()
+        self.begin_timestamp = self.timestamp
+        self.period_type = EventPeriod.BEGIN.value
+        self.severity = Severity.NORMAL
+        if self.publish_event:
+            self._ready_to_publish = True
+            self.publish()
+        return self
+
+    # TODO: rename function to "end" after the refactor will be done
+    def end_event(self) -> None:
+        self.timestamp = time.time()
+        self.end_timestamp = self.timestamp
+        self.period_type = EventPeriod.END.value
+        if self.publish_event:
+            self._ready_to_publish = True
+            self.publish()
+
+    def add_error(self, errors: Optional[List[str]]) -> None:
+        if not isinstance(self.errors, list):
+            self.errors = []
+
+        self.errors.extend(errors)
+
+    # TODO: rename function to "error" after the refactor will be done
+    def event_error(self):
+        self.timestamp = time.time()
+        self.period_type = EventPeriod.INFORMATIONAL.value
+        self.duration = None
+        if self.publish_event:
+            self._ready_to_publish = True
+            self.publish()
+
+    def register_event(self):
+        self._continuous_event_registry.add_event(self)
+
+
+class ContinuousRegistryFilter:
+    def __init__(self, registry: List[Any]):
+        self._registry = registry
+        self._output = registry.copy()
+
+    def filter_by_id(self, event_id: str) -> ContinuousRegistryFilter:
+        self._output = [event for event in self._output if event.event_id == event_id]
+
+        return self
+
+    def filter_by_node(self, node: str) -> ContinuousRegistryFilter:
+        self._output = [item for item in self._output if item.node == node]
+
+        return self
+
+    def filter_by_type(self, event_type: Type[ContinuousEvent]) -> ContinuousRegistryFilter:
+        self._output = [item for item in self._output if isinstance(item, event_type)]
+
+        return self
+
+    def filter_by_period(self, period_type: EventPeriod) -> ContinuousRegistryFilter:
+        self._output = [item for item in self._output if item.period_type == period_type]
+
+        return self
+
+    def filter_by_shard(self, shard: int) -> ContinuousRegistryFilter:
+        self._output = [item for item in self._output if item.shard == shard]
+
+        return self
+
+    def filter_by_attr(self, **kwargs) -> ContinuousRegistryFilter:
+        output = []
+        for event in self._output:
+            selected = False
+            for attr, value in kwargs.items():
+                if getattr(event, attr, None) == value:
+                    selected = True
+                else:
+                    selected = False
+                    break
+
+            if selected:
+                output.append(event)
+
+        self._output = output
+
+        return self
+
+    def get_filtered(self) -> List[Any]:
+        return self._output

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -17,8 +17,10 @@ from functools import partial
 from typing import Type, List, Tuple, Generic, Optional, NamedTuple, Pattern, Callable, Match
 
 from sdcm.sct_events import Severity, SctEventProtocol
-from sdcm.sct_events.base import SctEvent, LogEvent, LogEventProtocol, T_log_event, InformationalEvent, ContinuousEvent, \
-    ContinuousEventsRegistry, ContinuousEventRegistryException, EventPeriod
+from sdcm.sct_events.base import SctEvent, LogEvent, LogEventProtocol, T_log_event, InformationalEvent, \
+    EventPeriod
+
+from sdcm.sct_events.continuous_event import ContinuousEventsRegistry, ContinuousEventRegistryException, ContinuousEvent
 
 TOLERABLE_REACTOR_STALL: int = 1000  # ms
 

--- a/sdcm/sct_events/loaders.py
+++ b/sdcm/sct_events/loaders.py
@@ -21,8 +21,8 @@ import dateutil.parser
 from invoke.runners import Result
 
 from sdcm.sct_events import Severity
-from sdcm.sct_events.base import \
-    SctEvent, LogEvent, LogEventProtocol, T_log_event, BaseStressEvent, StressEvent, StressEventProtocol
+from sdcm.sct_events.base import SctEvent, LogEvent, LogEventProtocol, T_log_event
+from sdcm.sct_events.stress_events import BaseStressEvent, StressEvent, StressEventProtocol
 
 LOGGER = logging.getLogger(__name__)
 

--- a/sdcm/sct_events/nemesis.py
+++ b/sdcm/sct_events/nemesis.py
@@ -11,7 +11,7 @@
 #
 # Copyright (c) 2020 ScyllaDB
 from sdcm.sct_events import Severity
-from sdcm.sct_events.base import ContinuousEvent
+from sdcm.sct_events.continuous_event import ContinuousEvent
 
 
 class DisruptionEvent(ContinuousEvent):

--- a/sdcm/sct_events/nodetool.py
+++ b/sdcm/sct_events/nodetool.py
@@ -15,7 +15,7 @@ from json import JSONEncoder
 from typing import Any, Type
 
 from sdcm.sct_events import Severity
-from sdcm.sct_events.base import ContinuousEvent
+from sdcm.sct_events.continuous_event import ContinuousEvent
 
 
 @dataclass

--- a/sdcm/sct_events/stress_events.py
+++ b/sdcm/sct_events/stress_events.py
@@ -1,0 +1,81 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2021 ScyllaDB
+from typing import Any, Optional, List, Protocol
+
+from sdcm.sct_events import Severity, SctEventProtocol
+from sdcm.sct_events.continuous_event import ContinuousEvent
+
+
+class BaseStressEvent(ContinuousEvent, abstract=True):
+    # pylint: disable=too-many-arguments
+    @classmethod
+    def add_stress_subevents(cls,
+                             failure: Optional[Severity] = None,
+                             error: Optional[Severity] = None,
+                             timeout: Optional[Severity] = None,
+                             start: Optional[Severity] = Severity.NORMAL,
+                             finish: Optional[Severity] = Severity.NORMAL,
+                             warning: Optional[Severity] = None) -> None:
+        if failure is not None:
+            cls.add_subevent_type("failure", severity=failure)
+        if error is not None:
+            cls.add_subevent_type("error", severity=error)
+        if warning is not None:
+            cls.add_subevent_type("warning", severity=warning)
+        if timeout is not None:
+            cls.add_subevent_type("timeout", severity=timeout)
+        if start is not None:
+            cls.add_subevent_type("start", severity=start)
+        if finish is not None:
+            cls.add_subevent_type("finish", severity=finish)
+
+
+class StressEventProtocol(SctEventProtocol, Protocol):
+    node: str
+    stress_cmd: Optional[str]
+    log_file_name: Optional[str]
+    errors: Optional[List[str]]
+
+    @property
+    def errors_formatted(self):
+        ...
+
+
+class StressEvent(BaseStressEvent, abstract=True):
+    # pylint: disable=too-many-arguments
+    def __init__(self,
+                 node: Any,
+                 stress_cmd: Optional[str] = None,
+                 log_file_name: Optional[str] = None,
+                 errors: Optional[List[str]] = None,
+                 severity: Severity = Severity.NORMAL,
+                 publish_event: bool = True):
+        super().__init__(severity=severity, publish_event=publish_event)
+
+        self.node = str(node)
+        self.stress_cmd = stress_cmd
+        self.log_file_name = log_file_name
+        self.errors = errors
+
+    @property
+    def msgfmt(self):
+        fmt = super().msgfmt + ":"
+        if self.type:
+            fmt += " type={0.type}"
+        if self.node:
+            fmt += " node={0.node}"
+        if self.stress_cmd:
+            fmt += "\nstress_cmd={0.stress_cmd}"
+        if self.errors:
+            fmt += "\nerrors:\n\n{0.errors_formatted}"
+        return fmt

--- a/unit_tests/test_sct_events_monitors.py
+++ b/unit_tests/test_sct_events_monitors.py
@@ -38,27 +38,33 @@ RAW_ALERT = dict(
 
 class TestPrometheusAlertManagerEvent(unittest.TestCase):
     def test_msgfmt(self):
-        event = PrometheusAlertManagerEvent.start(raw_alert=RAW_ALERT)
+        event = PrometheusAlertManagerEvent(raw_alert=RAW_ALERT)
         event.event_id = "536eaf22-3d8f-418a-9381-fe0bcdce7ad9"
+        event.publish_event = False
+        event.begin_event()
         self.assertEqual(
             str(event),
-            "(PrometheusAlertManagerEvent Severity.WARNING) period_type=not-set "
-            "event_id=536eaf22-3d8f-418a-9381-fe0bcdce7ad9: alert_name=InstanceDown type=start"
-            " start=2019-12-24T17:00:09.591Z end=2019-12-26T06:21:09.591Z"
-            " description=[10.0.201.178] has been down for more than 30 seconds. updated=2019-12-26T06:18:09.593Z"
-            " state= fingerprint=None labels={'alertname': 'InstanceDown', 'instance': '[10.0.201.178]',"
-            " 'job': 'scylla', 'monitor': 'scylla-monitor', 'severity': '2'}"
+            "(PrometheusAlertManagerEvent Severity.NORMAL) period_type=begin "
+            "event_id=536eaf22-3d8f-418a-9381-fe0bcdce7ad9: alert_name=InstanceDown node=[10.0.201.178] "
+            "start=2019-12-24T17:00:09.591Z end=2019-12-26T06:21:09.591Z "
+            "description=[10.0.201.178] has been down for more than 30 seconds. updated=2019-12-26T06:18:09.593Z "
+            "state= fingerprint=None labels={'alertname': 'InstanceDown', 'instance': '[10.0.201.178]', 'job': 'scylla'"
+            ", 'monitor': 'scylla-monitor', 'severity': '2'}"
         )
         self.assertEqual(event, pickle.loads(pickle.dumps(event)))
 
     def test_sct_severity(self):
-        event = PrometheusAlertManagerEvent.end(raw_alert=dict(labels=dict(sct_severity="CRITICAL")))
+        event = PrometheusAlertManagerEvent(raw_alert=dict(labels=dict(sct_severity="CRITICAL")))
+        event.publish_event = False
+        event.end_event()
         self.assertEqual(event.severity, Severity.CRITICAL)
         self.assertTrue(str(event).startswith("(PrometheusAlertManagerEvent Severity.CRITICAL)"))
         self.assertEqual(event, pickle.loads(pickle.dumps(event)))
 
     def test_sct_severity_wrong(self):
-        event = PrometheusAlertManagerEvent.end(raw_alert=dict(labels=dict(sct_severity="WRONG")))
+        event = PrometheusAlertManagerEvent(raw_alert=dict(labels=dict(sct_severity="WRONG")))
+        event.publish_event = False
+        event.end_event()
         self.assertEqual(event.severity, Severity.WARNING)
         self.assertTrue(str(event).startswith("(PrometheusAlertManagerEvent Severity.WARNING)"))
         self.assertEqual(event, pickle.loads(pickle.dumps(event)))


### PR DESCRIPTION
Convert PrometheusAlertManagerEvent to be continuous event.

1. Add 'node' paameter to PrometheusAlertManagerEvent to do it compatible
with other events, despite maybe the event won't have a node information always.
In this case 'N/A' will be printed.

2. PrometheusAlertManagerEvent has 'stars_at' and 'alert_name' parameters that
are not supported by other events. Due this fact and for prevent the failures,
added possibility to filter all registered events by its base name
('PrometheusAlertManagerEvent' for example).

[Test](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/yulia/job/staging-longevity-100gb-4h/62/console) passed

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
