### PR TITLE
improvement(config): select Scylla version for GCE image

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -38,13 +38,31 @@ from sdcm.results_analyze import PerformanceResultsAnalyzer
 from sdcm.sct_config import SCTConfiguration
 from sdcm.sct_runner import AwsSctRunner, GceSctRunner
 from sdcm.utils.cloud_monitor import cloud_report, cloud_qa_report
-from sdcm.utils.common import (list_instances_aws, list_instances_gce, list_resources_docker, clean_cloud_resources,
-                               all_aws_regions, get_scylla_ami_versions, get_s3_scylla_repos_mapping,
-                               list_logs_by_test_id, get_branched_ami, gce_meta_to_dict,
-                               aws_tags_to_dict, list_elastic_ips_aws, get_builder_by_test_id,
-                               clean_resources_according_post_behavior, clean_sct_runners,
-                               search_test_id_in_latest, get_testrun_dir, format_timestamp, list_clusters_gke,
-                               list_clusters_eks, get_all_gce_regions)
+from sdcm.utils.common import (
+    all_aws_regions,
+    aws_tags_to_dict,
+    clean_cloud_resources,
+    clean_resources_according_post_behavior,
+    clean_sct_runners,
+    format_timestamp,
+    gce_meta_to_dict,
+    get_all_gce_regions,
+    get_branched_ami,
+    get_branched_gce_images,
+    get_builder_by_test_id,
+    get_s3_scylla_repos_mapping,
+    get_scylla_ami_versions,
+    get_scylla_gce_images_versions,
+    get_testrun_dir,
+    list_clusters_eks,
+    list_clusters_gke,
+    list_elastic_ips_aws,
+    list_instances_aws,
+    list_instances_gce,
+    list_logs_by_test_id,
+    list_resources_docker,
+    search_test_id_in_latest,
+)
 from sdcm.utils.jepsen import JepsenResults
 from sdcm.monitorstack import (restore_monitoring_stack, get_monitoring_stack_services,
                                kill_running_monitoring_stack_services)
@@ -369,14 +387,9 @@ def list_resources(ctx, user, test_id, get_all, get_all_running, verbose):
 def list_ami_versions(region):
     add_file_logger()
 
-    amis = get_scylla_ami_versions(region)
-
-    tbl = PrettyTable(["Name", "ImageId", "CreationDate"])
-    tbl.align = "l"
-
-    for ami in amis:
-        tbl.add_row([ami['Name'], ami['ImageId'], ami['CreationDate']])
-
+    tbl = PrettyTable(field_names=["Name", "ImageId", "CreationDate"], align="l")
+    for ami in get_scylla_ami_versions(region_name=region):
+        tbl.add_row([ami.name, ami.image_id, ami.creation_date])
     click.echo(tbl.get_string(title="Scylla AMI versions"))
 
 
@@ -393,19 +406,46 @@ def list_ami_branch(region, version):
     if ":" not in version:
         version += ":all"
 
-    amis = get_branched_ami(version, region_name=region)
-    tbl = PrettyTable(["Name", "ImageId", "CreationDate", "BuildId", "Test Status"])
-    tbl.align = "l"
-
-    for ami in amis:
+    tbl = PrettyTable(field_names=["Name", "ImageId", "CreationDate", "BuildId", "Test Status"], align="l")
+    for ami in get_branched_ami(scylla_version=version, region_name=region):
         tags = get_tags(ami)
         test_status = [(k, v) for k, v in tags.items() if k.startswith('JOB:')]
         test_status = [click.style(k, fg='green') for k, v in test_status if v == 'PASSED'] + \
                       [click.style(k, fg='red') for k, v in test_status if not v == 'PASSED']
         test_status = ", ".join(test_status) if test_status else click.style('Unknown', fg='yellow')
-        tbl.add_row([ami.name, ami.id, ami.creation_date, tags['build-id'], test_status])
-
+        tbl.add_row([ami.name, ami.image_id, ami.creation_date, tags['build-id'], test_status])
     click.echo(tbl.get_string(title="Scylla AMI branch versions"))
+
+
+@cli.command("list-gce-images-versions", help="list Scylla formal GCE images versions")
+def list_gce_images_versions():
+    add_file_logger()
+
+    tbl = PrettyTable(field_names=["Name", "ImageId", "CreationDate"], align="l")
+    for image in get_scylla_gce_images_versions():
+        tbl.add_row([image.name, image.extra["selfLink"], image.extra["creationTimestamp"]])
+    click.echo(tbl.get_string(title="Scylla GCE images versions"))
+
+
+@cli.command("list-gce-images-branch", help="""list Scylla branched GCE images versions
+    \n\n[VERSION] is a branch version to look for, ex. 'branch-2019.1:latest', 'branch-3.1:all'""")
+@click.argument("version", type=str, default="branch-3.1:all")
+def list_gce_images_branch(version):
+    add_file_logger()
+
+    if ":" not in version:
+        version += ":all"
+
+    tbl = PrettyTable(field_names=["Name", "ImageId", "CreationDate", "BuildId", "Test Status"], align="l")
+    for image in get_branched_gce_images(scylla_version=version):
+        tbl.add_row([
+            image.name,
+            image.extra["selfLink"],
+            image.extra["creationTimestamp"],
+            image.extra["labels"].get("build-id") or image.name.rsplit("-build-", maxsplit=1)[-1],
+            click.style("Unknown", fg="yellow"),
+        ])
+    click.echo(tbl.get_string(title="Scylla GCE images branch versions"))
 
 
 @cli.command('list-repos', help='List repos url of Scylla formal versions')

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -36,7 +36,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
 
         cls.conf = sct_config.SCTConfiguration()
 
-        for k, _ in os.environ.items():
+        for k in os.environ:
             if k.startswith('SCT_'):
                 del os.environ[k]
 
@@ -45,7 +45,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/minimal_test_case.yaml'
 
     def tearDown(self):
-        for k, _ in os.environ.items():
+        for k in os.environ:
             if k.startswith('SCT_'):
                 del os.environ[k]
         os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/minimal_test_case.yaml'
@@ -178,7 +178,8 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
         os.environ['SCT_SCYLLA_VERSION'] = '99.0.3'
         os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/multi_region_dc_test_case.yaml'
-        self.assertRaisesRegex(ValueError, r"AMI for scylla version 99.0.3 wasn't found", sct_config.SCTConfiguration)
+        self.assertRaisesRegex(
+            ValueError, "AMIs for scylla_version='99.0.3' not found in eu-west-1", sct_config.SCTConfiguration)
 
     @staticmethod
     def test_12_scylla_version_repo():
@@ -423,7 +424,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         with self.assertRaises(ValueError) as context:
             sct_config.SCTConfiguration()
 
-        self.assertIn("oracle_scylla_version and ami_id_db_oracle can't used together", str(context.exception))
+        self.assertIn("'oracle_scylla_version' and 'ami_id_db_oracle' can't used together", str(context.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Trello: https://trello.com/c/CSz9X3uB/3030-support-selecting-scylla-version-for-gce-image

This is SCT part of https://github.com/scylladb/scylla-machine-image/pull/169

- Add 2 new functions to sdcm.common.utils:
  - get_scylla_gce_images_versions()
  - get_branched_gce_images(scylla_version)
- Refactor get_scylla_ami_versions() and get get_branched_ami()
- Add support for selecting GCE image by Scylla branch or version
  (e.g., `master:latest` or `4.4.0`)
- Refactor handling of scylla_version and oracle_scylla_version (AMI part)
- Add 2 new hydra commands: list-gce-images-versions and list-gce-images-branch
- Refactor list-ami-versions and list-ami-branch hydra commands

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
