### PR TITLE
fix(scylla-service-name): in 4.6 it was renamed to scylla-server

### DIFF
--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -101,7 +101,8 @@ class DockerNode(cluster.BaseNode, NodeContainerMixin):  # pylint: disable=abstr
     def start_scylla_server(self, verify_up=True, verify_down=False, timeout=300, verify_up_timeout=300):
         if verify_down:
             self.wait_db_down(timeout=timeout)
-        self.remoter.sudo('supervisorctl start scylla', timeout=timeout)
+        self.remoter.sudo('sh -c "{0} || {0}-server"'.format("supervisorctl start scylla"),
+                          timeout=timeout)
         if verify_up:
             self.wait_db_up(timeout=verify_up_timeout)
 
@@ -112,7 +113,8 @@ class DockerNode(cluster.BaseNode, NodeContainerMixin):  # pylint: disable=abstr
     def stop_scylla_server(self, verify_up=False, verify_down=True, timeout=300, ignore_status=False):
         if verify_up:
             self.wait_db_up(timeout=timeout)
-        self.remoter.sudo('supervisorctl stop scylla', timeout=timeout)
+        self.remoter.sudo('sh -c "{0} || {0}-server"'.format("supervisorctl stop scylla"),
+                          timeout=timeout)
         if verify_down:
             self.wait_db_down(timeout=timeout)
 
@@ -123,7 +125,8 @@ class DockerNode(cluster.BaseNode, NodeContainerMixin):  # pylint: disable=abstr
     def restart_scylla_server(self, verify_up_before=False, verify_up_after=True, timeout=300, ignore_status=False):
         if verify_up_before:
             self.wait_db_up(timeout=timeout)
-        self.remoter.sudo("supervisorctl restart scylla", timeout=timeout)
+        self.remoter.sudo('sh -c "{0} || {0}-server"'.format("supervisorctl restart scylla"),
+                          timeout=timeout)
         if verify_up_after:
             self.wait_db_up(timeout=timeout)
 

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1571,7 +1571,8 @@ class BaseScyllaPodContainer(BasePodContainer):  # pylint: disable=abstract-meth
                             timeout=500, verify_up_timeout=300):
         if verify_down:
             self.wait_db_down(timeout=timeout)
-        self.remoter.run('supervisorctl start scylla', timeout=timeout)
+        self.remoter.run('sh -c "{0} || {0}-server"'.format("supervisorctl start scylla"),
+                         timeout=timeout)
         if verify_up:
             self.wait_db_up(timeout=verify_up_timeout)
 
@@ -1582,7 +1583,7 @@ class BaseScyllaPodContainer(BasePodContainer):  # pylint: disable=abstract-meth
                            ignore_status=False):
         if verify_up:
             self.wait_db_up(timeout=timeout)
-        self.remoter.run('supervisorctl stop scylla',
+        self.remoter.run('sh -c "{0} || {0}-server"'.format("supervisorctl stop scylla"),
                          timeout=timeout, ignore_status=ignore_status)
         if verify_down:
             self.wait_db_down(timeout=timeout)
@@ -1598,7 +1599,8 @@ class BaseScyllaPodContainer(BasePodContainer):  # pylint: disable=abstract-meth
     def restart_scylla_server(self, verify_up_before=False, verify_up_after=True, timeout=300, ignore_status=False):
         if verify_up_before:
             self.wait_db_up(timeout=timeout)
-        self.remoter.run("supervisorctl restart scylla", timeout=timeout)
+        self.remoter.run('sh -c "{0} || {0}-server"'.format("supervisorctl restart scylla"),
+                         timeout=timeout)
         if verify_up_after:
             self.wait_db_up(timeout=timeout)
 


### PR DESCRIPTION
"scylla" service was renamed to "scylla-server" in 4.6
So, we should support both now in places where we touch it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
