### PR TITLE
fix(longevity-10gb-3h-gce): specify proper region

### DIFF
--- a/jenkins-pipelines/longevity-10gb-3h-gce.jenkinsfile
+++ b/jenkins-pipelines/longevity-10gb-3h-gce.jenkinsfile
@@ -5,6 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'gce',
+    aws_region: 'us-east1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-10gb-3h.yaml',
 )


### PR DESCRIPTION
Pipeline that is used by "longevity-10gb-3h-gce" CI job doesn't
specify region for GCE backend and it leads to the situation where
default name from AWS backend gets picked up.
It leads to the following error:

    AssertionError: only `us-east1' region is supported

So, specify correct and supported GCE backend to make this job work.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
