### PR TITLE
fix(operator_monitoring): fix log parsing

### DIFF
--- a/sdcm/utils/file.py
+++ b/sdcm/utils/file.py
@@ -121,5 +121,11 @@ class File:
                         break
         return ReiterableGenerator(generator=generator)
 
+    def iterate_lines(self) -> Iterable[str]:
+        def generator():
+            for line in self._io:
+                yield line
+        return ReiterableGenerator(generator=generator)
+
     def __getattr__(self, item):
         return getattr(self._io, item)


### PR DESCRIPTION
Operator 1.4 changed it's logging fix log monitoring
 to match new style

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
