### PR TITLE
fix(scylla_bench_version): adding to test_default.py

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -158,3 +158,5 @@ k8s_deploy_monitoring: false
 
 scylla_rsyslog_setup: false
 events_limit_in_email: 10
+
+scylla_bench_version: v0.1.3

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -366,6 +366,9 @@ class SCTConfiguration(dict):
         dict(name="server_encrypt", env="SCT_SERVER_ENCRYPT", type=boolean,
              help="when enable scylla will use encryption on the server side"),
 
+        dict(name="scylla_bench_version", env="SCT_SCYLLA_BENCH_VERSION", type=str,
+             help="A valid tag under the scylla bench repo: https://github.com/scylladb/scylla-bench"),
+
         dict(name="client_encrypt", env="SCT_CLIENT_ENCRYPT", type=boolean,
              help="when enable scylla will use encryption on the client side"),
 


### PR DESCRIPTION
another commit missed this back port.
this commit is a specific back port to branch-4.5
as it broke the get_scylla_bench on all 4.5 jobs.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
