### PR TITLE
improvement(hydra.sh): show monitor on SCT Runner

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -607,20 +607,18 @@ def show_monitor(test_id, date_time, kill):
     add_file_logger()
 
     click.echo('Search monitoring stack archive files for test id {} and restoring...'.format(test_id))
-    # if debug_log:
-    #     LOGGER.setLevel(logging.DEBUG)
     try:
         status = restore_monitoring_stack(test_id, date_time)
     except Exception as details:  # pylint: disable=broad-except
-        LOGGER.error("%s", details)
+        LOGGER.error(details)
         status = False
 
-    table = PrettyTable(['Service', 'Container', 'Link'])
-    table.align = 'l'
+    table = PrettyTable(['Service', 'Container', 'Link'], align="l")
     if status:
+        host = os.environ.get("SCT_RUNNER_IP", "localhost")
         click.echo('Monitoring stack restored')
         for docker in get_monitoring_stack_services():
-            table.add_row([docker['service'], docker["name"], 'http://localhost:{}'.format(docker["port"])])
+            table.add_row([docker["service"], docker["name"], f"http://{host}:{docker['port']}"])
         click.echo(table.get_string(title='Monitoring stack services'))
         if kill:
             kill_running_monitoring_stack_services()

--- a/sdcm/monitorstack/__init__.py
+++ b/sdcm/monitorstack/__init__.py
@@ -21,9 +21,9 @@ GRAFANA_DOCKER_NAME = "agraf"
 PROMETHEUS_DOCKER_NAME = "aprom"
 ALERT_DOCKER_NAME = "aalert"
 
-GRAFANA_DOCKER_PORT = get_free_port()
-ALERT_DOCKER_PORT = get_free_port()
-PROMETHEUS_DOCKER_PORT = get_free_port()
+GRAFANA_DOCKER_PORT = get_free_port(ports_to_try=(3000, 0, ))
+ALERT_DOCKER_PORT = get_free_port(ports_to_try=(9093, 0, ))
+PROMETHEUS_DOCKER_PORT = get_free_port(ports_to_try=(9090, 0, ))
 COMMAND_TIMEOUT = 1800
 
 

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1863,9 +1863,8 @@ def get_post_behavior_actions(config):
         "k8s_cluster": {"NodeType": "k8s", "action": None},
     }
 
-    for key in action_per_type:
-        config_key = 'post_behavior_{}'.format(key)
-        action_per_type[key]["action"] = config.get(config_key)
+    for key, value in action_per_type.items():
+        value["action"] = config.get(f"post_behavior_{key}")
 
     return action_per_type
 


### PR DESCRIPTION
Trello: https://trello.com/c/jnwsZVHb/2658-hydra-show-monitor-on-sct-runner

- Add new option for hydra: `--execute-on-new-runner`
- Refactor `get_free_port()`
- Try to use default ports for monitoring stack first
- Export `SCT_RUNNER_IP` env variable

New runner region, AZ and duration can be controlled using env variables `RUNNER_REGION`, `RUNNER_AZ` and `RUNNER_DURATION` correspondingly. 

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
