### PR TITLE
fix(remote-runner): define 'gateway' field explicitely

### DIFF
--- a/sdcm/remote/remote_cmd_runner.py
+++ b/sdcm/remote/remote_cmd_runner.py
@@ -45,7 +45,10 @@ class RemoteCmdRunner(RemoteCmdRunnerBase, ssh_transport='fabric', default=True)
             'load_ssh_config': False,
             'UserKnownHostsFile': self.known_hosts_file,
             'ServerAliveInterval': 300,
-            'StrictHostKeyChecking': 'no'})
+            'StrictHostKeyChecking': 'no',
+            # NOTE: 'gateway' define explicitely to avoid errors reaching the 'gateway' config attr
+            'gateway': None,
+        })
         self.start_ssh_up_thread()
         super()._prepare()
 


### PR DESCRIPTION
Do it to avoid following error:

    File ".../site-packages/invoke/config.py", line 176, in _get
      value = self._config[key]
    KeyError: 'gateway'

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
