### PR TITLE
fix(show-monitor): make it pass ip via command line when runner is used

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -82,6 +82,8 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+COMMAND=${HYDRA_COMMAND[0]}
+
 if [[ -n "${CREATE_RUNNER_INSTANCE}" ]]; then
     if [[ -n "${SCT_RUNNER_IP}" ]]; then
         echo "Can't use '--execute-on-new-runner' and '--execute-on-runner IP' options simultaneously"
@@ -327,6 +329,10 @@ if [[ -n "$SCT_RUNNER_IP" ]]; then
         done
     fi
 
+    if [[ "$COMMAND" == "show-monitor" ]]; then
+        HYDRA_COMMAND[0]="$COMMAND --ip-to-show ${SCT_RUNNER_IP}"
+    fi
+
     DOCKER_HOST="-H ssh://ubuntu@${SCT_RUNNER_IP}"
 else
     if [ -z "${DOCKER_GROUP_ARGS[@]}" ]; then
@@ -336,7 +342,6 @@ else
     fi
 fi
 
-COMMAND=${HYDRA_COMMAND[0]}
 
 if [[ "$COMMAND" == *'bash'* ]] || [[ "$COMMAND" == *'python'* ]]; then
     CMD=${HYDRA_COMMAND[@]}

--- a/sct.py
+++ b/sct.py
@@ -603,7 +603,8 @@ def show_log(test_id, output_format):
 @click.argument('test_id')
 @click.option("--date-time", type=str, required=False, help='Datetime of monitor-set archive is collected')
 @click.option("--kill", type=bool, required=False, help='Kill and remove containers')
-def show_monitor(test_id, date_time, kill):
+@click.option("--ip-to-show", type=str, required=False, help='Ip of the monitoring stack', default='localhost')
+def show_monitor(test_id, date_time, kill, ip_to_show):
     add_file_logger()
 
     click.echo('Search monitoring stack archive files for test id {} and restoring...'.format(test_id))
@@ -615,10 +616,9 @@ def show_monitor(test_id, date_time, kill):
 
     table = PrettyTable(['Service', 'Container', 'Link'], align="l")
     if status:
-        host = os.environ.get("SCT_RUNNER_IP", "localhost")
         click.echo('Monitoring stack restored')
         for docker in get_monitoring_stack_services():
-            table.add_row([docker["service"], docker["name"], f"http://{host}:{docker['port']}"])
+            table.add_row([docker["service"], docker["name"], f"http://{ip_to_show}:{docker['port']}"])
         click.echo(table.get_string(title='Monitoring stack services'))
         if kill:
             kill_running_monitoring_stack_services()


### PR DESCRIPTION
Address https://github.com/scylladb/scylla-cluster-tests/issues/3909
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
