### PR TITLE
fix(sct-runner-usage): allow SCT_RUNNER_IP env var to be set

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -301,6 +301,8 @@ class SCTConfiguration(dict):
                 for the monitoring of the Nemesis.
                 can only work out of the box in AWS
              """),
+        dict(name="sct_runner_ip", env="SCT_RUNNER_IP", type=str,
+             help="IP address of an SCT runner VM"),
         dict(name="sct_ngrok_name", env="SCT_NGROK_NAME", type=str,
              help="""
             Override the default hostname address of the sct test runner,


### PR DESCRIPTION
To avoid following error:

    ValueError: Unsupported environment variables were used:
     - SCT_RUNNER_IP=34.138.242.64

Such error started appearing after merge of the following PR:
- https://github.com/scylladb/scylla-cluster-tests/pull/3901

Where previously local env var called "SCT_RUNNER_IP" started
being exported.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
