### PR TITLE
improvement(hydra.sh): create a new runner and run command

### DIFF
--- a/sdcm/monitorstack/__init__.py
+++ b/sdcm/monitorstack/__init__.py
@@ -21,9 +21,9 @@ GRAFANA_DOCKER_NAME = "agraf"
 PROMETHEUS_DOCKER_NAME = "aprom"
 ALERT_DOCKER_NAME = "aalert"
 
-GRAFANA_DOCKER_PORT = get_free_port()
-ALERT_DOCKER_PORT = get_free_port()
-PROMETHEUS_DOCKER_PORT = get_free_port()
+GRAFANA_DOCKER_PORT = get_free_port(ports_to_try=(3000, 0, ))
+ALERT_DOCKER_PORT = get_free_port(ports_to_try=(9093, 0, ))
+PROMETHEUS_DOCKER_PORT = get_free_port(ports_to_try=(9090, 0, ))
 COMMAND_TIMEOUT = 1800
 
 

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1863,9 +1863,8 @@ def get_post_behavior_actions(config):
         "k8s_cluster": {"NodeType": "k8s", "action": None},
     }
 
-    for key in action_per_type:
-        config_key = 'post_behavior_{}'.format(key)
-        action_per_type[key]["action"] = config.get(config_key)
+    for key, value in action_per_type.items():
+        value["action"] = config.get(f"post_behavior_{key}")
 
     return action_per_type
 

--- a/vars/cdcReplicationPipeline.groovy
+++ b/vars/cdcReplicationPipeline.groovy
@@ -53,9 +53,9 @@ def runSctTest(Map params, String region){
 
     echo "start test ......."
     if [[ "$cloud_provider" == "aws" ]]; then
-        SCT_RUNNER_IP=\$(cat sct_runner_ip||echo "")
-        if [[ ! -z "\${SCT_RUNNER_IP}" ]] ; then
-            ./docker/env/hydra.sh --execute-on-runner \${SCT_RUNNER_IP} run-test ${params.test_name} --backend ${params.backend}
+        RUNNER_IP=\$(cat sct_runner_ip||echo "")
+        if [[ ! -z "\${RUNNER_IP}" ]] ; then
+            ./docker/env/hydra.sh --execute-on-runner \${RUNNER_IP} run-test ${params.test_name} --backend ${params.backend}
         else
             echo "SCT runner IP file is empty. Probably SCT Runner was not created."
             exit 1

--- a/vars/cleanSctRunners.groovy
+++ b/vars/cleanSctRunners.groovy
@@ -16,8 +16,8 @@ def call(Map params, RunWrapper currentBuild){
 
     echo "Starting to clean runner instances"
     if [[ "$cloud_provider" == "aws" || "$cloud_provider" == "gce" ]]; then
-        export SCT_RUNNER_IP=\$(cat sct_runner_ip||echo "")
-        ./docker/env/hydra.sh clean-runner-instances --test-status "$test_status" --runner-ip \${SCT_RUNNER_IP}
+        export RUNNER_IP=\$(cat sct_runner_ip||echo "")
+        ./docker/env/hydra.sh clean-runner-instances --test-status "$test_status" --runner-ip \${RUNNER_IP}
 
     else
         echo "Not running on AWS or GCP. Skipping cleaning runner instances."

--- a/vars/jepsenPipeline.groovy
+++ b/vars/jepsenPipeline.groovy
@@ -154,9 +154,9 @@ def call(Map pipelineParams) {
                                 export SCT_INSTANCE_PROVISION_FALLBACK_ON_DEMAND="${params.instance_provision_fallback_on_demand ? params.instance_provision_fallback_on_demand : ''}"
 
                                 echo "start test ......."
-                                SCT_RUNNER_IP=\$(cat sct_runner_ip||echo "")
-                                if [[ -n "\${SCT_RUNNER_IP}" ]] ; then
-                                    ./docker/env/hydra.sh --execute-on-runner \${SCT_RUNNER_IP} run-test jepsen_test --backend gce
+                                RUNNER_IP=\$(cat sct_runner_ip||echo "")
+                                if [[ -n "\${RUNNER_IP}" ]] ; then
+                                    ./docker/env/hydra.sh --execute-on-runner \${RUNNER_IP} run-test jepsen_test --backend gce
                                 else
                                     echo "SCT runner IP file is empty. Probably SCT Runner was not created."
                                     exit 1

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -258,9 +258,9 @@ def call(Map pipelineParams) {
 
                                         echo "start test ......."
                                         if [[ "$cloud_provider" == "aws" ]]; then
-                                            SCT_RUNNER_IP=\$(cat sct_runner_ip||echo "")
-                                            if [[ ! -z "\${SCT_RUNNER_IP}" ]] ; then
-                                                ./docker/env/hydra.sh --execute-on-runner \${SCT_RUNNER_IP} run-test ${params.test_name} --backend ${params.backend}
+                                            RUNNER_IP=\$(cat sct_runner_ip||echo "")
+                                            if [[ ! -z "\${RUNNER_IP}" ]] ; then
+                                                ./docker/env/hydra.sh --execute-on-runner \${RUNNER_IP} run-test ${params.test_name} --backend ${params.backend}
                                             else
                                                 echo "SCT runner IP file is empty. Probably SCT Runner was not created."
                                                 exit 1

--- a/vars/runCleanupResource.groovy
+++ b/vars/runCleanupResource.groovy
@@ -33,9 +33,9 @@ def call(Map params, String region){
 
     echo "Starting to clean resources ..."
     if [[ "$cloud_provider" == "aws" || "$cloud_provider" == "gce" || "$cloud_provider" == "k8s-local-kind-aws" || "$cloud_provider" == "k8s-local-kind-gce" ]]; then
-        SCT_RUNNER_IP=\$(cat sct_runner_ip||echo "")
-        if [[ -n "\${SCT_RUNNER_IP}" ]] ; then
-            ./docker/env/hydra.sh --execute-on-runner \${SCT_RUNNER_IP} clean-resources --post-behavior --test-id \$SCT_TEST_ID
+        RUNNER_IP=\$(cat sct_runner_ip||echo "")
+        if [[ -n "\${RUNNER_IP}" ]] ; then
+            ./docker/env/hydra.sh --execute-on-runner \${RUNNER_IP} clean-resources --post-behavior --test-id \$SCT_TEST_ID
         else
             echo "SCT runner IP file is empty. Probably SCT Runner was not created."
             exit 1

--- a/vars/runCollectLogs.groovy
+++ b/vars/runCollectLogs.groovy
@@ -18,9 +18,9 @@ def call(Map params, String region){
 
     echo "start collect logs ..."
     if [[ "$cloud_provider" == "aws" || "$cloud_provider" == "gce" || "$cloud_provider" == "k8s-local-kind-aws" || "$cloud_provider" == "k8s-local-kind-gce" ]]; then
-        SCT_RUNNER_IP=\$(cat sct_runner_ip||echo "")
-        if [[ -n "\${SCT_RUNNER_IP}" ]] ; then
-            ./docker/env/hydra.sh --execute-on-runner \${SCT_RUNNER_IP} collect-logs
+        RUNNER_IP=\$(cat sct_runner_ip||echo "")
+        if [[ -n "\${RUNNER_IP}" ]] ; then
+            ./docker/env/hydra.sh --execute-on-runner \${RUNNER_IP} collect-logs
         else
             echo "SCT runner IP file is empty. Probably SCT Runner was not created."
             exit 1

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -123,9 +123,9 @@ def call(Map params, String region, functional_test = false){
 
     echo "start test ......."
     if [[ "$cloud_provider" == "aws" || "$cloud_provider" == "gce" || "$cloud_provider" == "k8s-local-kind-aws" || "$cloud_provider" == "k8s-local-kind-gce" ]]; then
-        SCT_RUNNER_IP=\$(cat sct_runner_ip||echo "")
-        if [[ -n "\${SCT_RUNNER_IP}" ]] ; then
-            ./docker/env/hydra.sh --execute-on-runner \${SCT_RUNNER_IP} ${test_cmd} ${params.test_name} --backend ${params.backend}
+        RUNNER_IP=\$(cat sct_runner_ip||echo "")
+        if [[ -n "\${RUNNER_IP}" ]] ; then
+            ./docker/env/hydra.sh --execute-on-runner \${RUNNER_IP} ${test_cmd} ${params.test_name} --backend ${params.backend}
         else
             echo "SCT runner IP file is empty. Probably SCT Runner was not created."
             exit 1

--- a/vars/runSendEmail.groovy
+++ b/vars/runSendEmail.groovy
@@ -21,10 +21,10 @@ def call(Map params, RunWrapper currentBuild){
     env
     echo "Start send email ..."
     if [[ "$cloud_provider" == "aws" || "$cloud_provider" == "gce" || "$cloud_provider" == "k8s-local-kind-aws" || "$cloud_provider" == "k8s-local-kind-gce" ]]; then
-        SCT_RUNNER_IP=\$(cat sct_runner_ip||echo "")
-        if [[ -n "\${SCT_RUNNER_IP}" ]] ; then
-            ./docker/env/hydra.sh --execute-on-runner \${SCT_RUNNER_IP} send-email ${test_status} ${start_time} \
-            --runner-ip \${SCT_RUNNER_IP} --email-recipients "${email_recipients}"
+        RUNNER_IP=\$(cat sct_runner_ip||echo "")
+        if [[ -n "\${RUNNER_IP}" ]] ; then
+            ./docker/env/hydra.sh --execute-on-runner \${RUNNER_IP} send-email ${test_status} ${start_time} \
+            --runner-ip \${RUNNER_IP} --email-recipients "${email_recipients}"
         else
             echo "SCT runner IP file is empty. Probably SCT Runner was not created."
             ./docker/env/hydra.sh send-email ${test_status} ${start_time} --logdir "`pwd`" --email-recipients "${email_recipients}"


### PR DESCRIPTION
Trello: https://trello.com/c/jnwsZVHb/2658-hydra-show-monitor-on-sct-runner

Second attempt to put this code into SCT. Tested more carefully this time.

- Add new option for hydra: --execute-on-new-runner
- Refactor `get_free_port()`
- Rename `SCT_RUNNER_IP` to `RUNNER_IP`
- Export `RUNNER_IP` env variable
- Modify `show-monitor` and `show-jepsen-results` commands to use the new feature
- Try to use default ports for monitoring stack and Jepsen results server first

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
