### PR TITLE
improvement(sdcm/sct_config.py): perform repo checks for proper backends

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1696,9 +1696,14 @@ class SCTConfiguration(dict):
         """
         Check if ami_id and repo urls are valid
         """
+        backend = self.get('cluster_backend')
+        if backend in ("k8s-eks", "k8s-gke"):
+            return
+
         self._get_target_upgrade_version()
+
         # verify that the AMIs used all have 'user_data_format_version' tag
-        if 'aws' in self.get('cluster_backend'):
+        if backend == 'aws':
             ami_id_db_scylla = self.get('ami_id_db_scylla').split()
             region_names = self.region_names
             ami_id_db_oracle = self.get('ami_id_db_oracle').split()
@@ -1714,9 +1719,16 @@ class SCTConfiguration(dict):
                             f"tags: {tags}"
         # For each Scylla repo file we will check that there is at least one valid URL through which to download a
         # version of SCYLLA, otherwise we will get an error.
-        get_branch_version_for_multiple_repositories(urls=(self.get(url) for url in [
-            'new_scylla_repo', 'scylla_repo_m', 'scylla_repo_loader', 'scylla_mgmt_repo', 'scylla_mgmt_agent_repo',
-            'scylla_mgmt_agent_repo'] if self.get(url)))
+        repos_to_validate = ['scylla_repo_loader']
+        if backend in ("aws", "gce", "baremetal"):
+            repos_to_validate.extend([
+                'new_scylla_repo',
+                'scylla_repo_m',
+                'scylla_mgmt_repo',
+                'scylla_mgmt_agent_repo',
+            ])
+        get_branch_version_for_multiple_repositories(
+            urls=(self.get(url) for url in repos_to_validate if self.get(url)))
 
     def dump_config(self):
         """


### PR DESCRIPTION
Do not verify config options values that are related to package repos
on the backends which do not use these options such as "K8S" and "siren"-based.
So, it will allow us to avoid false negative results of checks.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
