### PR TITLE
fix(send email): separate uploaded SCT logs print

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -278,8 +278,8 @@ def get_latest_gemini_version():
 
 def list_logs_by_test_id(test_id):
     log_types = ['db-cluster', 'monitor-set', 'loader-set', 'sct-runner', 'jepsen-data', 'siren-manager-set',
-                 'prometheus', 'grafana', 'kubernetes',
-                 'job', 'monitoring_data_stack', 'events']
+                 'prometheus', 'grafana', 'kubernetes', 'job', 'monitoring_data_stack', 'event', 'output', 'error',
+                 'summary', 'warning', 'critical', 'normal', 'debug', 'left_processes', 'email_data']
 
     results = []
 


### PR DESCRIPTION
When SCT log files are too big, we create archive per file and uploading them separately
(introduced by PRs: https://github.com/scylladb/scylla-cluster-tests/pull/3734 and
https://github.com/scylladb/scylla-cluster-tests/pull/3795).
In the Jenkins console we see all logs, but in the email just part of them.
![Screenshot from 2021-08-29 11-03-17](https://user-images.githubusercontent.com/34435448/131243635-71d59594-83dc-443c-bdef-2ac4c514ff93.png)


This commit adds printing of all SCT logs in the email.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
