### PR TITLE
fix(scylla repos): Validating siren backend only relevant repos

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1698,7 +1698,8 @@ class SCTConfiguration(dict):
         """
         self._get_target_upgrade_version()
         # verify that the AMIs used all have 'user_data_format_version' tag
-        if 'aws' in self.get('cluster_backend'):
+        backend = self.get('cluster_backend')
+        if backend == 'aws':
             ami_id_db_scylla = self.get('ami_id_db_scylla').split()
             region_names = self.region_names
             ami_id_db_oracle = self.get('ami_id_db_oracle').split()
@@ -1714,9 +1715,11 @@ class SCTConfiguration(dict):
                             f"tags: {tags}"
         # For each Scylla repo file we will check that there is at least one valid URL through which to download a
         # version of SCYLLA, otherwise we will get an error.
-        get_branch_version_for_multiple_repositories(urls=(self.get(url) for url in [
-            'new_scylla_repo', 'scylla_repo_m', 'scylla_repo_loader', 'scylla_mgmt_repo', 'scylla_mgmt_agent_repo',
-            'scylla_mgmt_agent_repo'] if self.get(url)))
+        repos_to_validate = ['scylla_repo_loader']
+        non_siren_repos = ['new_scylla_repo', 'scylla_repo_m', 'scylla_mgmt_repo', 'scylla_mgmt_agent_repo']
+        if 'siren' not in backend:
+            repos_to_validate += non_siren_repos
+        get_branch_version_for_multiple_repositories(urls=(self.get(url) for url in repos_to_validate if self.get(url)))
 
     def dump_config(self):
         """


### PR DESCRIPTION
	For a siren backend - only the loader repository is relevant.
	all other repos should be ignored.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
