### PR TITLE
improvement(events): convert ClusterHealthValidator to continuous

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -4,8 +4,7 @@ ClusterHealthValidatorEvent.NodePeersNulls: ERROR
 ClusterHealthValidatorEvent.NodeSchemaVersion: ERROR
 ClusterHealthValidatorEvent.NodesNemesis: WARNING
 ClusterHealthValidatorEvent.ScyllaCloudClusterServerDiagnostic: CRITICAL
-ClusterHealthValidatorEvent.Done: NORMAL
-ClusterHealthValidatorEvent.Info: NORMAL
+ClusterHealthValidatorEvent: NORMAL
 DataValidatorEvent.DataValidator: ERROR
 DataValidatorEvent.ImmutableRowsValidator: ERROR
 DataValidatorEvent.UpdatedRowsValidator: WARNING

--- a/unit_tests/test_sct_events_health.py
+++ b/unit_tests/test_sct_events_health.py
@@ -33,12 +33,16 @@ class TestValidators(unittest.TestCase):
             ClusterHealthValidatorEvent.ScyllaCloudClusterServerDiagnostic,
             ClusterHealthValidatorEvent
         ))
-        self.assertTrue(hasattr(ClusterHealthValidatorEvent, "Info"))
-        self.assertTrue(issubclass(ClusterHealthValidatorEvent.Info, ClusterHealthValidatorEvent))
-        self.assertTrue(hasattr(ClusterHealthValidatorEvent, "Done"))
-        self.assertTrue(issubclass(ClusterHealthValidatorEvent.Done, ClusterHealthValidatorEvent))
 
     def test_cluster_health_validator_event_msgfmt(self):
+        chc_event = ClusterHealthValidatorEvent()
+        chc_event.publish_event = False
+        chc_event.event_id = "7208cfbb-a083-4b7a-b0db-1982d88f6da0"
+        chc_event.begin_event()
+        self.assertEqual(str(chc_event),
+                         "(ClusterHealthValidatorEvent Severity.NORMAL) period_type=begin "
+                         "event_id=7208cfbb-a083-4b7a-b0db-1982d88f6da0")
+
         critical_event = ClusterHealthValidatorEvent.NodeStatus(severity=Severity.CRITICAL, node="n1", error="e1")
         critical_event.event_id = "712128d0-4837-4213-8a60-d6e2ec106c52"
         self.assertEqual(
@@ -76,23 +80,14 @@ class TestValidators(unittest.TestCase):
         )
         self.assertEqual(info_event, pickle.loads(pickle.dumps(info_event)))
 
-        info_event = ClusterHealthValidatorEvent.Info(node="n4", message="m4")
-        info_event.event_id = "712128d0-4837-4213-8a60-d6e2ec106c52"
+        chc_event.message = "Cluster health check finished"
+        chc_event.duration = 5
+        chc_event.end_event()
         self.assertEqual(
-            str(info_event),
-            "(ClusterHealthValidatorEvent Severity.NORMAL) period_type=one-time "
-            "event_id=712128d0-4837-4213-8a60-d6e2ec106c52: type=Info node=n4 message=m4"
+            str(chc_event),
+            "(ClusterHealthValidatorEvent Severity.NORMAL) period_type=end "
+            "event_id=7208cfbb-a083-4b7a-b0db-1982d88f6da0 duration=5s message=Cluster health check finished"
         )
-        self.assertEqual(info_event, pickle.loads(pickle.dumps(info_event)))
-
-        info_event = ClusterHealthValidatorEvent.Done(node="n4", message="m4")
-        info_event.event_id = "712128d0-4837-4213-8a60-d6e2ec106c52"
-        self.assertEqual(
-            str(info_event),
-            "(ClusterHealthValidatorEvent Severity.NORMAL) period_type=one-time "
-            "event_id=712128d0-4837-4213-8a60-d6e2ec106c52: type=Done node=n4 message=m4"
-        )
-        self.assertEqual(info_event, pickle.loads(pickle.dumps(info_event)))
 
     def test_data_validator_event(self):
         self.assertTrue(hasattr(DataValidatorEvent, "DataValidator"))


### PR DESCRIPTION
Convert ClusterHealthValidator event to be continuous events and subevents to
Informational.

Example:
```
2021-08-29 16:22:47.408: (ClusterHealthValidatorEvent Severity.NORMAL) period_type=begin event_id=8ef83194-fc37-4a62-ba28-bb4734ae4f69
2021-08-29 16:24:42.450: (ClusterHealthValidatorEvent Severity.CRITICAL) period_type=one-time event_id=4891e18d-a199-4aed-b920-1164e2798c16: type=NodeStatus node=longevity-10gb-3h-convert--db-node-e5ac27be-1 error=Current node 10.0.1.129. Node with 10.0.2.23 (not target node) status is DN
2021-08-29 16:26:40.718: (ClusterHealthValidatorEvent Severity.CRITICAL) period_type=one-time event_id=10756144-7fb1-4836-a5ff-c181ff0d5518: type=NodeStatus node=longevity-10gb-3h-convert--db-node-e5ac27be-2 error=Current node 10.0.3.254. Node with 10.0.2.23 (not target node) status is DN
2021-08-29 16:26:58.739: (ClusterHealthValidatorEvent Severity.WARNING) period_type=one-time event_id=60078450-6f79-4348-8092-7a2fe2214069: type=NodeStatus node=longevity-10gb-3h-convert--db-node-e5ac27be-4 message=Unable to get nodetool status from `longevity-10gb-3h-convert--db-node-e5ac27be-4': 'NoneType' object has no attribute 'stdout'
2021-08-29 16:28:18.824: (ClusterHealthValidatorEvent Severity.NORMAL) period_type=end event_id=8ef83194-fc37-4a62-ba28-bb4734ae4f69 duration=5m31s message=Cluster health check finished
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
