### PR TITLE
feature(scylla operator): add event for catching pods wrong scheduling

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -68,6 +68,7 @@ ScyllaOperatorLogEvent: ERROR
 ScyllaOperatorLogEvent.REAPPLY: WARNING
 ScyllaOperatorLogEvent.TLS_HANDSHAKE_ERROR: WARNING
 ScyllaOperatorLogEvent.OPERATOR_STARTED_INFO: NORMAL
+ScyllaOperatorLogEvent.WRONG_SCHEDULED_PODS: WARNING
 StartupTestEvent: NORMAL
 TestTimeoutEvent: CRITICAL
 TestFrameworkEvent: CRITICAL

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -76,7 +76,7 @@ from sdcm.utils.k8s import (
 from sdcm.utils.decorators import log_run_info, retrying
 from sdcm.utils.decorators import timeout as timeout_wrapper
 from sdcm.utils.remote_logger import get_system_logging_thread, CertManagerLogger, ScyllaOperatorLogger, \
-    KubectlClusterEventsLogger, ScyllaManagerLogger
+    KubectlClusterEventsLogger, ScyllaManagerLogger, KubernetesWrongSchedulingLogger
 from sdcm.utils.version_utils import get_git_tag_from_helm_chart_version
 from sdcm.wait import wait_for
 from sdcm.cluster_k8s.operator_monitoring import ScyllaOperatorLogMonitoring
@@ -234,6 +234,14 @@ class CloudK8sNodePool(metaclass=abc.ABCMeta):  # pylint: disable=too-many-insta
     def readiness_timeout(self) -> int:
         return 10 + (10 * self.num_nodes)
 
+    @property
+    def nodes(self):
+        try:
+            return self.k8s_cluster.k8s_core_v1_api.list_node(label_selector=f'{self.pool_label_name}={self.name}')
+        except Exception as details:  # pylint: disable=broad-except
+            LOGGER.debug("Failed to get nodes list: %s", str(details))
+            return {}
+
     def wait_for_nodes_readiness(self):
         readiness_timeout = self.readiness_timeout
 
@@ -270,6 +278,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
     _cert_manager_journal_thread: Optional[CertManagerLogger] = None
     _scylla_manager_journal_thread: Optional[ScyllaManagerLogger] = None
     _scylla_operator_journal_thread: Optional[ScyllaOperatorLogger] = None
+    _scylla_operator_scheduling_thread: Optional[KubernetesWrongSchedulingLogger] = None
     _scylla_cluster_events_thread: Optional[KubectlClusterEventsLogger] = None
 
     _scylla_operator_log_monitor_thread: Optional[ScyllaOperatorLogMonitoring] = None
@@ -288,6 +297,9 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
         self.name = '%s-%s' % (user_prefix, self.shortid)
         self.params = params
         self.api_call_rate_limiter = None
+        self.k8s_scylla_cluster_name = self.params.get('k8s_scylla_cluster_name')
+        # keep pods labels that are allowed to be scheduled on the Scylla node
+        self.allowed_labels_on_scylla_node = []
 
     # NOTE: Following class attr(s) are defined for consumers of this class
     #       such as 'sdcm.utils.remote_logger.ScyllaOperatorLogger'.
@@ -555,6 +567,8 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
     def start_scylla_operator_journal_thread(self) -> None:
         self._scylla_operator_journal_thread = ScyllaOperatorLogger(self, self.scylla_operator_log)
         self._scylla_operator_journal_thread.start()
+        self._scylla_operator_scheduling_thread = KubernetesWrongSchedulingLogger(self, self.scylla_operator_log)
+        self._scylla_operator_scheduling_thread.start()
         self._scylla_operator_log_monitor_thread = ScyllaOperatorLogMonitoring(self)
         self._scylla_operator_log_monitor_thread.start()
 
@@ -1075,6 +1089,8 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
             self._scylla_operator_log_monitor_thread.stop()
         if self._scylla_operator_journal_thread:
             self._scylla_operator_journal_thread.stop(timeout)
+        if self._scylla_operator_scheduling_thread:
+            self._scylla_operator_scheduling_thread.stop(timeout)
         if self._scylla_cluster_events_thread:
             self._scylla_cluster_events_thread.stop(timeout)
 

--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -239,6 +239,11 @@ class EksCluster(KubernetesCluster, EksClusterCleanupMixin):
         self.ec2_subnet_ids = ec2_subnet_ids
         self.service_ipv4_cidr = service_ipv4_cidr
         self.vpc_cni_version = vpc_cni_version
+        self.allowed_labels_on_scylla_node = [('name', 'node-setup'),
+                                              ('k8s-app', 'aws-node'),
+                                              ('app', 'local-volume-provisioner'),
+                                              ('k8s-app', 'kube-proxy'),
+                                              ('scylla/cluster', self.k8s_scylla_cluster_name)]
 
     def create_eks_cluster(self, wait_till_functional=True):
         self.eks_client.create_cluster(

--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -175,6 +175,14 @@ class GkeCluster(KubernetesCluster):
         self.gce_user = services[0].key
         self.gce_zone = gce_datacenter[0]
         self.gke_cluster_created = False
+        self.allowed_labels_on_scylla_node = [('name', 'cpu-policy'),
+                                              ('app', 'local-volume-provisioner'),
+                                              ('name', 'raid-local-disks'),
+                                              ('k8s-app', 'fluentbit-gke'),
+                                              ('k8s-app', 'gke-metrics-agent'),
+                                              ('component', 'kube-proxy'),
+                                              ('k8s-app', 'gcp-compute-persistent-disk-csi-driver'),
+                                              ('scylla/cluster', self.k8s_scylla_cluster_name)]
 
         self.api_call_rate_limiter = ApiCallRateLimiter(
             rate_limit=GKE_API_CALL_RATE_LIMIT,

--- a/sdcm/sct_events/filters.py
+++ b/sdcm/sct_events/filters.py
@@ -43,7 +43,7 @@ class DbEventsFilter(BaseFilter):
         result = bool(self.filter_type) and self.filter_type == event.type
 
         if self.filter_line:
-            result &= self.filter_line in getattr(event, "line", "")
+            result &= self.filter_line in (getattr(event, "line", "") or "")
 
         if self.filter_node:
             result &= self.filter_node == getattr(event, "node", "")

--- a/sdcm/sct_events/operator.py
+++ b/sdcm/sct_events/operator.py
@@ -18,6 +18,7 @@ import time
 from typing import List, Tuple, Type
 
 from sdcm.sct_events import Severity
+from sdcm.utils.remote_logger import KubernetesWrongSchedulingLogger
 from sdcm.sct_events.base import LogEvent, LogEventProtocol, T_log_event
 
 
@@ -28,13 +29,10 @@ class ScyllaOperatorLogEvent(LogEvent):
     REAPPLY: Type[LogEventProtocol]
     TLS_HANDSHAKE_ERROR: Type[LogEventProtocol]
     OPERATOR_STARTED_INFO: Type[LogEventProtocol]
-    message: str
-    source: str
+    WRONG_SCHEDULED_PODS: Type[LogEventProtocol]
 
-    def __init__(self, message: str = '', source: str = '', regex: str = None, severity=Severity.NORMAL):
+    def __init__(self, regex: str = None, severity=Severity.NORMAL):
         super().__init__(regex=regex, severity=severity)
-        self.message = message
-        self.source = source
         self.line_number = None
 
     # pylint: disable=too-many-locals
@@ -46,7 +44,7 @@ class ScyllaOperatorLogEvent(LogEvent):
         splits = line.split(maxsplit=4)
         if len(splits) != 5 or len(splits[0]) != 5:
             return self
-        type_month_date, time_string, _, self.source, self.message = splits
+        type_month_date, time_string, *_ = splits
         try:
             hour_minute_second, milliseconds = time_string.split('.')
             hour, minute, second = hour_minute_second.split(':')
@@ -58,11 +56,12 @@ class ScyllaOperatorLogEvent(LogEvent):
                 microsecond=int(milliseconds), tzinfo=datetime.timezone.utc).timestamp()
         except Exception:  # pylint: disable=broad-except
             self.timestamp = time.time()
-        return self
 
-    @property
-    def msgfmt(self):
-        return super().msgfmt + ": {0.source} {0.message}"
+        self.node = str(node)
+        self.line = line
+        self._ready_to_publish = True
+
+        return self
 
 
 ScyllaOperatorLogEvent.add_subevent_type(
@@ -74,12 +73,16 @@ ScyllaOperatorLogEvent.add_subevent_type(
 ScyllaOperatorLogEvent.add_subevent_type(
     "OPERATOR_STARTED_INFO", severity=Severity.NORMAL,
     regex='"Starting controller" controller="ScyllaCluster"')
+ScyllaOperatorLogEvent.add_subevent_type(
+    "WRONG_SCHEDULED_PODS", severity=Severity.WARNING,
+    regex=KubernetesWrongSchedulingLogger.WRONG_SCHEDULED_PODS_MESSAGE)
 
 
 SCYLLA_OPERATOR_EVENTS = [
     ScyllaOperatorLogEvent.REAPPLY(),
     ScyllaOperatorLogEvent.TLS_HANDSHAKE_ERROR(),
     ScyllaOperatorLogEvent.OPERATOR_STARTED_INFO(),
+    ScyllaOperatorLogEvent.WRONG_SCHEDULED_PODS(),
 ]
 
 

--- a/unit_tests/test_sct_events_operator.py
+++ b/unit_tests/test_sct_events_operator.py
@@ -20,17 +20,7 @@ from sdcm.sct_events.operator import ScyllaOperatorLogEvent
 
 
 class TestOperatorEvents(unittest.TestCase):
-    def test_scylla_operator_log_event(self):
-        event = ScyllaOperatorLogEvent(message="tid1 scylla/c1: m1, e1")
-        event.event_id = "9bb2980a-5940-49a7-8b08-d5c323b46aa9"
-        self.assertEqual(
-            '(ScyllaOperatorLogEvent Severity.NORMAL) period_type=one-time '
-            'event_id=9bb2980a-5940-49a7-8b08-d5c323b46aa9::  tid1 scylla/c1: m1, e1',
-            str(event)
-        )
-        self.assertEqual(event, pickle.loads(pickle.dumps(event)))
-        self.assertTrue(hasattr(event, "TLS_HANDSHAKE_ERROR"))
-        self.assertTrue(hasattr(event, "OPERATOR_STARTED_INFO"))
+    maxDiff = None
 
     def test_scylla_operator_log_event_tls_handshake_error(self):
         log_record = "I0628 15:53:02.269804       1 operator/operator.go:133] http: " \
@@ -47,9 +37,10 @@ class TestOperatorEvents(unittest.TestCase):
         assert event.timestamp == 1624895582.269804
         self.assertEqual(
             '(ScyllaOperatorLogEvent Severity.WARNING) period_type=one-time '
-            'event_id=9bb2980a-5940-49a7-8b08-d5c323b46aa9: '
-            'type=TLS_HANDSHAKE_ERROR regex=TLS handshake error from .*:'
-            ' operator/operator.go:133] http: TLS handshake error from 172.17.0.1:50882: EOF',
+            'event_id=9bb2980a-5940-49a7-8b08-d5c323b46aa9: type=TLS_HANDSHAKE_ERROR regex=TLS handshake error '
+            'from .* node=N/A\n'
+            'I0628 15:53:02.269804       1 operator/operator.go:133] http: TLS handshake error from 172.17.0.1:50882: '
+            'EOF',
             str(event),
         )
 
@@ -69,8 +60,32 @@ class TestOperatorEvents(unittest.TestCase):
         assert event.timestamp == 1624896463.572294
         self.assertEqual(
             '(ScyllaOperatorLogEvent Severity.NORMAL) period_type=one-time '
-            'event_id=9bb2980a-5940-49a7-8b08-d5c323b46aa9: type=OPERATOR_STARTED_INFO '
-            'regex="Starting controller" controller="ScyllaCluster": scyllacluster/controller.go:203] '
-            '"Starting controller" controller="ScyllaCluster"',
+            'event_id=9bb2980a-5940-49a7-8b08-d5c323b46aa9: type=OPERATOR_STARTED_INFO regex="Starting controller" '
+            'controller="ScyllaCluster" node=N/A\n'
+            'I0628 16:07:43.572294       1 scyllacluster/controller.go:203] "Starting controller" '
+            'controller="ScyllaCluster"',
+            str(event),
+        )
+
+    def test_scylla_operator_log_event_wrong_scheduled_info(self):
+        log_record = (
+            "I0830 12:35:39              Not allowed pods are scheduled on Scylla node found: kube-proxy-7kjnf "
+            "(ip-10-0-1-200.eu-north-1.compute.internal node)"
+        )
+        event = ScyllaOperatorLogEvent.WRONG_SCHEDULED_PODS()
+        pattern = re.compile(event.regex, re.IGNORECASE)
+
+        self.assertTrue(isinstance(event, LogEvent))
+        self.assertTrue(pattern.search(log_record))
+        event.add_info(node="N/A", line=log_record, line_number=0)
+
+        self.assertEqual(event, pickle.loads(pickle.dumps(event)))
+        event.event_id = "9bb2980a-5940-49a7-8b08-d5c323b46aa9"
+        self.assertEqual(
+            '(ScyllaOperatorLogEvent Severity.WARNING) period_type=one-time '
+            'event_id=9bb2980a-5940-49a7-8b08-d5c323b46aa9: type=WRONG_SCHEDULED_PODS '
+            'regex=Not allowed pods are scheduled on Scylla node found node=N/A\n'
+            'I0830 12:35:39              Not allowed pods are scheduled on Scylla node found: kube-proxy-7kjnf '
+            '(ip-10-0-1-200.eu-north-1.compute.internal node)',
             str(event),
         )


### PR DESCRIPTION
We have fixed a lot of bugs related to the wrong scheduling of non-Scylla pods on K8S.
Main problem: we can get some non-Scylla pods be scheduled onto Scylla nodes and it may
lead to unpredictable errors when we run different nemesis'.

So, we should not only fix but also keep an eye on the non-Scylla pods that must not be placed
on Scylla nodes.

As a result, need to create event(s) that will periodically check pods on Scylla nodes and verify
that there are only allowed ones.

This commit introduce an error event.

Task: https://trello.com/c/cqx1W4c6/3359-k8s-add-events-for-catching-wrong-scheduling-of-non-scylla-pods


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
