### PR TITLE
fix(wait_for_init_wrap): wait timeout only for scylla db nodes

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3466,14 +3466,14 @@ class NodeSetupTimeout(Exception):
     pass
 
 
-def wait_for_init_wrap(method):
+def wait_for_init_wrap(method):  # pylint: disable=too-many-statements
     """
     Wraps wait_for_init class method.
     Run setup of nodes simultaneously and wait for all the setups finished.
     Raise exception if setup failed or timeout expired.
     """
     @wraps(method)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args, **kwargs):  # pylint: disable=too-many-statements
         cl_inst = args[0]
         LOGGER.debug('Class instance: %s', cl_inst)
         LOGGER.debug('Method kwargs: %s', kwargs)
@@ -3531,7 +3531,9 @@ def wait_for_init_wrap(method):
                 setup_thread = threading.Thread(target=node_setup, name='NodeSetupThread',
                                                 args=(node,), daemon=True)
                 setup_thread.start()
-                time.sleep(120)
+                if isinstance(cl_inst, BaseScyllaCluster):
+                    cl_inst.log.info("Wait 120 seconds before next node setup")
+                    time.sleep(120)
 
         while len(results) != len(node_list):
             verify_node_setup(start_time)


### PR DESCRIPTION
Loaderset uses same wrapper for waiting node initialization.
And parallel initialization is used with same timeout 120 seconds
for Loaderset and scylladb set.  In this case, loader nodes wait not
needed 2 minutes to start next node setup.
Use timeout with 2 minutes only for scylla db nodes

Trello: https://trello.com/c/MWv3aKlQ

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
