### PR TITLE
improvement(local-k8s): run scylla with disabled developer mode

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -793,7 +793,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
             )
         else:
             cpu_limit = 1
-            memory_limit = 2
+            memory_limit = 2.5
 
         cpu_limit = int(cpu_limit)
         memory_limit = convert_memory_units_to_k8s_value(memory_limit)

--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -309,7 +309,7 @@ class MinimalClusterBase(KubernetesCluster, metaclass=abc.ABCMeta):  # pylint: d
         values = super().get_scylla_cluster_helm_values(cpu_limit, memory_limit, pool_name)
         values.delete('racks.[0].storage.storageClassName')
         values.set('cpuset', False)
-        values.set('developerMode', True)
+        values.set('developerMode', False)
         values.set('hostNetworking', False)
         return values
 


### PR DESCRIPTION
Do it to be able to test things which require developer mode be disabled
Also, increase dedicated memory for Scylla pods from 2Gi to 2.5Gi
to satisfy 1Gi requirement per 1 lcore (2Gi was enough for dev mode).
2.5Gi is the minimum we can set, if we set 2.4Gi then
following error appears:

    ERROR <time> [shard 0] init - Only 920 MiB per shard;
      this is below the recommended minimum of 1 GiB/shard;
      terminating.Configure more memory (--memory option) or
      decrease shard count (--smp option).

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
