### PR TITLE
Nodetool stop nemesis

### DIFF
--- a/jenkins-pipelines/features-nodetool-stop-compaction.jenkinsfile
+++ b/jenkins-pipelines/features-nodetool-stop-compaction.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'stop_compaction_test.StopCompactionTest.test_stop_compaction',
+    test_config: '''["test-cases/features/stop-compaction.yaml"]'''
+)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -221,7 +221,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         self._containers = {}
         self.is_seed = False
 
-        self.remoter = None
+        self.remoter: Optional[RemoteCmdRunnerBase] = None
         self.is_scylla_bench_installed = False
         self.is_cassandra_harry_installed = False
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -443,30 +443,29 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.set_target_node()
         node = self.target_node
         compaction_ops = CompactionOps(cluster=self.cluster, node=node)
-        timeout = 120
+        timeout = 360
         trigger_func = partial(compaction_ops.trigger_major_compaction)
         watch_func = partial(compaction_ops.stop_on_user_compaction_logged,
                              node=node,
-                             mark=node.mark_log(),
-                             watch_for="User initiated compaction",
+                             mark=1,
+                             watch_for="User initiated compaction started on behalf of",
                              timeout=timeout,
                              stop_func=compaction_ops.stop_major_compaction)
-        # self.tester.wait_no_compactions_running()
+        self.tester.wait_no_compactions_running()
         ParallelObject(objects=[trigger_func, watch_func], timeout=timeout).call_objects()
 
     def disrupt_start_stop_scrub_compaction(self):
         self.set_target_node()
         node = self.target_node
         compaction_ops = CompactionOps(cluster=self.cluster, node=node)
-        timeout = 120
+        timeout = 360
         trigger_func = partial(compaction_ops.trigger_scrub_compaction)
         watch_func = partial(compaction_ops.stop_on_user_compaction_logged,
                              node=node,
-                             mark=node.mark_log(),
                              watch_for="Scrubbing",
                              timeout=timeout,
                              stop_func=compaction_ops.stop_scrub_compaction)
-        # self.tester.wait_no_compactions_running()
+        self.tester.wait_no_compactions_running()
         ParallelObject(objects=[trigger_func, watch_func], timeout=timeout).call_objects()
 
     def disrupt_start_stop_cleanup_compaction(self):
@@ -488,12 +487,12 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.set_target_node()
         node = self.target_node
         compaction_ops = CompactionOps(cluster=self.cluster, node=node)
-        timeout = 120
+        timeout = 360
         trigger_func = partial(compaction_ops.trigger_validation_compaction)
         watch_func = partial(compaction_ops.stop_on_user_compaction_logged,
                              node=node,
                              mark=node.mark_log(),
-                             watch_for="Scrubbing in validate mode",
+                             watch_for="Scrubbing ",
                              timeout=timeout,
                              stop_func=compaction_ops.stop_validation_compaction)
         # self.tester.wait_no_compactions_running()
@@ -3989,13 +3988,6 @@ class StartStopCleanupCompaction(Nemesis):
 
 
 class StartStopValidationCompaction(Nemesis):
-    disruptive = False
-
-    def disrupt(self):
-        self.disrupt_start_stop_validation_compaction()
-
-
-class StartStopCompactionMonkey(Nemesis):
     disruptive = False
 
     def disrupt(self):

--- a/sdcm/provision/scylla_yaml/scylla_yaml.py
+++ b/sdcm/provision/scylla_yaml/scylla_yaml.py
@@ -13,11 +13,15 @@
 from difflib import unified_diff
 from typing import List, Literal, Union
 
+import logging
 import yaml
 from pydantic import Field, validator, BaseModel  # pylint: disable=no-name-in-module
 
 from sdcm.provision.scylla_yaml.auxiliaries import RequestSchedulerOptions, EndPointSnitchType, SeedProvider, \
     ServerEncryptionOptions, ClientEncryptionOptions
+
+
+logger = logging.getLogger(__name__)
 
 
 class ScyllaYaml(BaseModel):  # pylint: disable=too-few-public-methods

--- a/sdcm/rest/remote_curl_client.py
+++ b/sdcm/rest/remote_curl_client.py
@@ -10,7 +10,7 @@ class RemoteCurlClient(RestClient):
         self._node = node
         self._remoter = self._node.remoter
 
-    def run_remoter_curl(self, method: Literal["GET", "POST"], path: str, params: dict[str, str], timeout: int = 30):
+    def run_remoter_curl(self, method: Literal["GET", "POST"], path: str, params: dict[str, str], timeout: int = 120):
         prepared_request = self._prepare_request(method=method, path=path, params=params)
 
         return self._remoter.run(f'curl -v -X {prepared_request.method} "{prepared_request.url}"', timeout=timeout)

--- a/sdcm/rest/remote_curl_client.py
+++ b/sdcm/rest/remote_curl_client.py
@@ -1,0 +1,16 @@
+from typing import Literal
+
+from sdcm.cluster import BaseNode
+from sdcm.rest.rest_client import RestClient
+
+
+class RemoteCurlClient(RestClient):
+    def __init__(self, host: str, endpoint: str, node: BaseNode):
+        super().__init__(host=host, endpoint=endpoint)
+        self._node = node
+        self._remoter = self._node.remoter
+
+    def run_remoter_curl(self, method: Literal["GET", "POST"], path: str, params: dict[str, str], timeout: int = 30):
+        prepared_request = self._prepare_request(method=method, path=path, params=params)
+
+        return self._remoter.run(f'curl -v -X {prepared_request.method} "{prepared_request.url}"', timeout=timeout)

--- a/sdcm/rest/rest_client.py
+++ b/sdcm/rest/rest_client.py
@@ -1,4 +1,6 @@
+from functools import cached_property
 from typing import Dict, Literal
+from urllib.parse import urljoin
 
 import requests
 from requests import Response
@@ -14,35 +16,23 @@ class RestClient:
         self._host = host
         self._endpoint = endpoint
 
-    def prepare_get_request(self, path: str, params: dict[str, str]):
-        prepared_request = self._prepare_request(method="GET", path=path, params=params)
-
-        return prepared_request
+    @cached_property
+    def _base_url(self) -> str:
+        return urljoin(f"{self._url_prefix}{self._host}", self._endpoint)
 
     def get(self, path: str, params: Dict[str, str] = None) -> Response:
-        url = self._get_full_url(path)
+        url = f"{self._base_url}/{path}"
         LOGGER.info("Sending a GET request for: %s", url)
 
         return requests.get(url=url, params=params)
 
-    def prepare_post_request(self, path: str, params: dict[str, str]):
-        prepared_request = self._prepare_request(method="POST", path=path, params=params)
-
-        return prepared_request
-
     def post(self, path: str, params: Dict[str, str] = None) -> Response:
-        url = self._get_full_url(path)
+        url = f"{self._base_url}/{path}"
         LOGGER.info("Sending a POST request for: %s", url)
-        requests.Request()
         return requests.post(url=url, params=params)
 
-    def _get_full_url(self, path: str) -> str:
-        full_url = f"{self._url_prefix}{self._host}/{self._endpoint}/{path}"
-
-        return full_url
-
     def _prepare_request(self, method: Literal["GET", "POST"], path: str, params: dict[str, str]):
-        full_url = f"{self._url_prefix}{self._host}/{self._endpoint}/{path}"
+        full_url = f"{self._base_url}/{path}"
         prepared_request = requests.Request(method=method, url=full_url, params=params).prepare()
 
         return prepared_request

--- a/sdcm/rest/rest_client.py
+++ b/sdcm/rest/rest_client.py
@@ -1,0 +1,48 @@
+from typing import Dict, Literal
+
+import requests
+from requests import Response
+
+from sct import LOGGER
+
+
+class RestClient:
+    def __init__(self,
+                 host: str,
+                 endpoint: str):
+        self._url_prefix = "http://"
+        self._host = host
+        self._endpoint = endpoint
+
+    def prepare_get_request(self, path: str, params: dict[str, str]):
+        prepared_request = self._prepare_request(method="GET", path=path, params=params)
+
+        return prepared_request
+
+    def get(self, path: str, params: Dict[str, str] = None) -> Response:
+        url = self._get_full_url(path)
+        LOGGER.info("Sending a GET request for: %s", url)
+
+        return requests.get(url=url, params=params)
+
+    def prepare_post_request(self, path: str, params: dict[str, str]):
+        prepared_request = self._prepare_request(method="POST", path=path, params=params)
+
+        return prepared_request
+
+    def post(self, path: str, params: Dict[str, str] = None) -> Response:
+        url = self._get_full_url(path)
+        LOGGER.info("Sending a POST request for: %s", url)
+        requests.Request()
+        return requests.post(url=url, params=params)
+
+    def _get_full_url(self, path: str) -> str:
+        full_url = f"{self._url_prefix}{self._host}/{self._endpoint}/{path}"
+
+        return full_url
+
+    def _prepare_request(self, method: Literal["GET", "POST"], path: str, params: dict[str, str]):
+        full_url = f"{self._url_prefix}{self._host}/{self._endpoint}/{path}"
+        prepared_request = requests.Request(method=method, url=full_url, params=params).prepare()
+
+        return prepared_request

--- a/sdcm/rest/rest_client.py
+++ b/sdcm/rest/rest_client.py
@@ -1,3 +1,4 @@
+import logging
 from functools import cached_property
 from typing import Dict, Literal
 from urllib.parse import urljoin
@@ -5,7 +6,8 @@ from urllib.parse import urljoin
 import requests
 from requests import Response
 
-from sct import LOGGER
+
+LOGGER = logging.getLogger(__name__)
 
 
 class RestClient:

--- a/sdcm/rest/storage_service_client.py
+++ b/sdcm/rest/storage_service_client.py
@@ -10,19 +10,19 @@ class StorageServiceClient(RemoteCurlClient):
     def __init__(self, node: BaseNode):
         super().__init__(host="localhost:10000", endpoint="storage_service", node=node)
 
-    def compact_ks_cf(self, keyspace: str, cf: str) -> Result:
+    def compact_ks_cf(self, keyspace: str, cf: Optional[str] = None) -> Result:
         params = {"cf": cf} if cf else {}
         path = f"keyspace_compaction/{keyspace}"
 
         return self.run_remoter_curl(method="POST", path=path, params=params)
 
-    def cleanup_ks_cf(self, keyspace: str, cf: str) -> Result:
+    def cleanup_ks_cf(self, keyspace: str, cf: Optional[str] = None) -> Result:
         params = {"cf": cf} if cf else {}
         path = f"keyspace_cleanup/{keyspace}"
 
         return self.run_remoter_curl(method="POST", path=path, params=params)
 
-    def scrub_ks_cf(self, keyspace: str, cf: Optional[str], scrub_mode: Optional[str] = None) -> Result:
+    def scrub_ks_cf(self, keyspace: str, cf: Optional[str] = None, scrub_mode: Optional[str] = None) -> Result:
         params = {"cf": cf} if cf else {}
 
         if scrub_mode:
@@ -32,7 +32,7 @@ class StorageServiceClient(RemoteCurlClient):
 
         return self.run_remoter_curl(method="GET", path=path, params=params)
 
-    def upgrade_sstables(self, keyspace: str = "ks", cf: str = "cf"):
+    def upgrade_sstables(self, keyspace: str = "ks", cf: Optional[str] = None):
         params = {"cf": cf} if cf else {}
         path = f"keyspace_upgrade_sstables/{keyspace}"
 

--- a/sdcm/rest/storage_service_client.py
+++ b/sdcm/rest/storage_service_client.py
@@ -1,0 +1,56 @@
+from typing import Optional
+
+from fabric.runners import Result
+from requests import PreparedRequest
+
+from sdcm.cluster import BaseNode
+
+from sdcm.rest.rest_client import RestClient
+
+
+class StorageServiceClient:
+    def __init__(self, node: BaseNode):
+        self._node = node
+        self._host = "localhost:10000"
+        self._remoter = self._node.remoter
+        self._endpoint = "storage_service"
+        self.__client = RestClient(host=self._host, endpoint=self._endpoint)
+
+    def compact_ks_cf(self, keyspace: str, cf: str) -> Result:
+        params = {"cf": cf} if cf else {}
+        full_path = f"keyspace_compaction/{keyspace}"
+        prepared_request = self.__client.prepare_post_request(path=full_path, params=params)
+        response = self._run_remoter_curl(prepared_request)
+
+        return response
+
+    def cleanup_ks_cf(self, keyspace: str, cf: str) -> Result:
+        params = {"cf": cf} if cf else {}
+        full_path = f"keyspace_cleanup/{keyspace}"
+        prepared_request = self.__client.prepare_post_request(path=full_path, params=params)
+        response = self._run_remoter_curl(prepared_request)
+
+        return response
+
+    def scrub_ks_cf(self, keyspace: str, cf: Optional[str], scrub_mode: Optional[str] = None) -> Result:
+        params = {"cf": cf} if cf else {}
+
+        if scrub_mode:
+            params.update({"scrub_mode": scrub_mode})
+
+        full_path = f"keyspace_scrub/{keyspace}"
+        prepared_request = self.__client.prepare_get_request(path=full_path, params=params)
+        response = self._run_remoter_curl(prepared_request)
+
+        return response
+
+    def upgrade_sstables(self, keyspace: str = "ks", cf: str = "cf"):
+        params = {"cf": cf} if cf else {}
+        full_path = f"keyspace_upgrade_sstables/{keyspace}"
+        prepared_request = self.__client.prepare_get_request(path=full_path, params=params)
+        response = self._run_remoter_curl(prepared_request)
+
+        return response
+
+    def _run_remoter_curl(self, prepared_request: PreparedRequest, timeout: int = None):
+        return self._remoter.run(f'curl -v -X {prepared_request.method} "{prepared_request.url}"', timeout=timeout)

--- a/sdcm/rest/storage_service_client.py
+++ b/sdcm/rest/storage_service_client.py
@@ -14,7 +14,7 @@ class StorageServiceClient(RemoteCurlClient):
         params = {"cf": cf} if cf else {}
         path = f"keyspace_compaction/{keyspace}"
 
-        return self.run_remoter_curl(method="POST", path=path, params=params)
+        return self.run_remoter_curl(method="POST", path=path, params=params, timeout=360)
 
     def cleanup_ks_cf(self, keyspace: str, cf: Optional[str] = None) -> Result:
         params = {"cf": cf} if cf else {}

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -426,17 +426,25 @@ class ParallelObject:
             raise ParallelObjectException(results=results)
         return results
 
-    @classmethod
-    def run_once(cls,
-                 partial_funcs_w_args: list[Callable],
-                 timeout: int = 6,
-                 num_workers: Optional[int] = None,
-                 disable_logging: bool = False,
-                 ignore_exceptions: bool = False) -> "ParallelObjectResult":
-        po = cls(partial_funcs_w_args, num_workers=num_workers, timeout=timeout, disable_logging=disable_logging)
-        result = po.run(lambda x: x(), ignore_exceptions=ignore_exceptions)
+    def call_objects(self) -> "ParallelObjectResult":
+        """
+        Use the ParallelObject run() method to call a list of
+        callables in parallel. Rather than running a single function
+        with a number of objects as arguments in parallel, we're
+        calling a list of callables in parallel.
 
-        return result
+        If we need to run multiple callables with some arguments, one
+        solution is to use partial objects to pack the callable with
+        its arguments, e.g.:
+
+        partial_func_1 = partial(print, "lorem")
+        partial_func_2 = partial(sum, (2, 3))
+        ParallelObject(objects=[partial_func_1, partial_func_2]).call_objects()
+
+        This can be useful if we need to tightly synchronise the
+        execution of multiple functions.
+        """
+        return self.run(lambda x: x())
 
     def clean_up(self, futures):
         # if there are futures that didn't run  we cancel them

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -426,6 +426,18 @@ class ParallelObject:
             raise ParallelObjectException(results=results)
         return results
 
+    @classmethod
+    def run_once(cls,
+                 partial_funcs_w_args: list[Callable],
+                 timeout: int = 6,
+                 num_workers: Optional[int] = None,
+                 disable_logging: bool = False,
+                 ignore_exceptions: bool = False) -> "ParallelObjectResult":
+        po = cls(partial_funcs_w_args, num_workers=num_workers, timeout=timeout, disable_logging=disable_logging)
+        result = po.run(lambda x: x(), ignore_exceptions=ignore_exceptions)
+
+        return result
+
     def clean_up(self, futures):
         # if there are futures that didn't run  we cancel them
         for future, _ in futures:

--- a/sdcm/utils/compaction_ops.py
+++ b/sdcm/utils/compaction_ops.py
@@ -1,0 +1,103 @@
+import time
+from typing import Callable, Optional, NamedTuple
+
+from fabric.runners import Result
+
+from sct import LOGGER
+from sdcm.cluster import BaseNode, BaseCluster
+from sdcm.rest.storage_service_client import StorageServiceClient
+
+
+class ScrubModes(NamedTuple):
+    ABORT: str = "ABORT"
+    SKIP: str = "SKIP"
+    SEGREGATE: str = "SEGREGATE"
+    VALIDATE: str = "VALIDATE"
+
+
+class NodetoolCommands(NamedTuple):
+    flush: str = "flush"
+    stop_major_compaction: str = "stop COMPACTION"
+    stop_scrub_compaction: str = "stop SCRUB"
+    stop_cleanup_compaction: str = "stop CLEANUP"
+    stop_upgrade_compaction: str = "stop UPGRADE"
+    stop_reshape_compaction: str = "stop RESHAPE"
+
+
+class CompactionOps:
+    NODETOOL_CMD = NodetoolCommands()
+    SCRUB_MODES = ScrubModes()
+
+    def __init__(self, cluster: BaseCluster):
+        self.cluster = cluster
+        self.node = self.cluster.nodes[0]
+        self.storage_service_client = StorageServiceClient(node=self.node)
+
+    def trigger_major_compaction(self, keyspace: str = "keyspace1", cf: str = "standard1") -> Result:
+        return self.storage_service_client.compact_ks_cf(keyspace=keyspace, cf=cf)
+
+    def trigger_scrub_compaction(self,
+                                 keyspace: str = "keyspace1",
+                                 cf: str = "standard1",
+                                 scrub_mode: Optional[str] = None) -> Result:
+        params = {"keyspace": keyspace, "cf": cf}
+
+        if scrub_mode:
+            params.update({"scrub_mode": scrub_mode})
+
+        return self.storage_service_client.scrub_ks_cf(**params)
+
+    def trigger_cleanup_compaction(self, keyspace: str = "keyspace1", cf: str = "standard1") -> Result:
+        return self.storage_service_client.cleanup_ks_cf(keyspace=keyspace, cf=cf)
+
+    def trigger_validation_compaction(self, keyspace: str = "keyspace1", cf: str = "standard1") -> Result:
+        return self.storage_service_client.scrub_ks_cf(keyspace=keyspace,
+                                                       cf=cf,
+                                                       scrub_mode=self.SCRUB_MODES.VALIDATE)
+
+    def trigger_upgrade_compaction(self, keyspace: str = "keyspace1", cf: str = "standard1") -> Result:
+        return self.storage_service_client.upgrade_sstables(keyspace=keyspace, cf=cf)
+
+    def trigger_flush(self):
+        self.node.run_nodetool(self.NODETOOL_CMD.flush)
+
+    def stop_major_compaction(self):
+        self._stop_compaction(self.NODETOOL_CMD.stop_major_compaction)
+
+    def stop_scrub_compaction(self):
+        self._stop_compaction(self.NODETOOL_CMD.stop_scrub_compaction)
+
+    def stop_cleanup_compaction(self):
+        self._stop_compaction(self.NODETOOL_CMD.stop_cleanup_compaction)
+
+    def stop_upgrade_compaction(self):
+        self._stop_compaction(self.NODETOOL_CMD.stop_upgrade_compaction)
+
+    def stop_reshape_compaction(self):
+        self._stop_compaction(self.NODETOOL_CMD.stop_reshape_compaction)
+
+    def stop_validation_compaction(self):
+        self.stop_scrub_compaction()
+
+    def disable_autocompaction_on_ks_cf(self, node: BaseNode,  keyspace: str = "", cf: Optional[str] = ""):
+        node = node if node else self.node
+        node.run_nodetool(f'disableautocompaction {keyspace} {cf}')
+
+    def _stop_compaction(self, nodetool_cmd: str):
+        LOGGER.info("Stopping compaction with nodetool %s", nodetool_cmd)
+        self.node.run_nodetool(nodetool_cmd)
+
+    @staticmethod
+    def stop_on_user_compaction_logged(node: BaseNode, watch_for: str, timeout: int,
+                                       stop_func: Callable, mark: Optional[int] = None):
+        start_time = time.time()
+        with open(node.system_log, "r") as log_file:
+            if mark:
+                log_file.seek(mark)
+
+            while time.time() - start_time < timeout:
+                line = log_file.readline()
+                if watch_for in line:
+                    stop_func()
+                    LOGGER.info("Watch for expression found %s in log line %s", watch_for, line)
+                    break

--- a/sdcm/utils/compaction_ops.py
+++ b/sdcm/utils/compaction_ops.py
@@ -28,9 +28,9 @@ class CompactionOps:
     NODETOOL_CMD = NodetoolCommands()
     SCRUB_MODES = ScrubModes()
 
-    def __init__(self, cluster: Union[BaseCluster, BaseScyllaCluster]):
+    def __init__(self, cluster: Union[BaseCluster, BaseScyllaCluster], node: Optional[BaseNode] = None):
         self.cluster = cluster
-        self.node = self.cluster.nodes[0]
+        self.node = node if node else self.cluster.nodes[0]
         self.storage_service_client = StorageServiceClient(node=self.node)
 
     def trigger_major_compaction(self, keyspace: str = "keyspace1", cf: str = "standard1") -> Result:
@@ -40,10 +40,7 @@ class CompactionOps:
                                  keyspace: str = "keyspace1",
                                  cf: str = "standard1",
                                  scrub_mode: Optional[str] = None) -> Result:
-        params = {"keyspace": keyspace, "cf": cf}
-
-        if scrub_mode:
-            params.update({"scrub_mode": scrub_mode})
+        params = {"keyspace": keyspace, "cf": cf, "scrub_mode": scrub_mode}
 
         return self.storage_service_client.scrub_ks_cf(**params)
 
@@ -99,5 +96,5 @@ class CompactionOps:
                 line = log_file.readline()
                 if watch_for in line:
                     stop_func()
-                    LOGGER.info("Grepped expression found %s in log line %s", watch_for, line)
+                    LOGGER.info("Grepped expression found: %s in log line %s", watch_for, line)
                     break

--- a/sdcm/utils/compaction_ops.py
+++ b/sdcm/utils/compaction_ops.py
@@ -1,10 +1,10 @@
 import time
-from typing import Callable, Optional, NamedTuple
+from typing import Callable, Optional, NamedTuple, Union
 
 from fabric.runners import Result
 
 from sct import LOGGER
-from sdcm.cluster import BaseNode, BaseCluster
+from sdcm.cluster import BaseNode, BaseCluster, BaseScyllaCluster
 from sdcm.rest.storage_service_client import StorageServiceClient
 
 
@@ -28,7 +28,7 @@ class CompactionOps:
     NODETOOL_CMD = NodetoolCommands()
     SCRUB_MODES = ScrubModes()
 
-    def __init__(self, cluster: BaseCluster):
+    def __init__(self, cluster: Union[BaseCluster, BaseScyllaCluster]):
         self.cluster = cluster
         self.node = self.cluster.nodes[0]
         self.storage_service_client = StorageServiceClient(node=self.node)
@@ -99,5 +99,5 @@ class CompactionOps:
                 line = log_file.readline()
                 if watch_for in line:
                     stop_func()
-                    LOGGER.info("Watch for expression found %s in log line %s", watch_for, line)
+                    LOGGER.info("Grepped expression found %s in log line %s", watch_for, line)
                     break

--- a/sdcm/utils/compaction_ops.py
+++ b/sdcm/utils/compaction_ops.py
@@ -59,6 +59,7 @@ class CompactionOps:
         self.node.run_nodetool(self.NODETOOL_CMD.flush)
 
     def stop_major_compaction(self):
+        LOGGER.info("Stopping major compaction with <nodetool stop>")
         self._stop_compaction(self.NODETOOL_CMD.stop_major_compaction)
 
     def stop_scrub_compaction(self):
@@ -87,6 +88,7 @@ class CompactionOps:
     @staticmethod
     def stop_on_user_compaction_logged(node: BaseNode, watch_for: str, timeout: int,
                                        stop_func: Callable, mark: Optional[int] = None):
+        LOGGER.info("Starting to watch for user compaction logged...")
         start_time = time.time()
         with open(node.system_log, "r") as log_file:
             if mark:
@@ -94,6 +96,7 @@ class CompactionOps:
 
             while time.time() - start_time < timeout:
                 line = log_file.readline()
+
                 if watch_for in line:
                     stop_func()
                     LOGGER.info("Grepped expression found: %s in log line %s", watch_for, line)

--- a/stop_compaction_test.py
+++ b/stop_compaction_test.py
@@ -12,38 +12,181 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2021 ScyllaDB
-import time
+import re
 
+from sdcm.cluster import BaseNode
+from sdcm.nemesis import StartStopMajorCompaction, StartStopScrubCompaction, StartStopCleanupCompaction, \
+    StartStopValidationCompaction, StartStopUpgradeCompaction, StartStopReshapeCompaction
+from sdcm.rest.storage_service_client import StorageServiceClient
 from sdcm.tester import ClusterTester
+from sdcm.utils.compaction_ops import CompactionOps
 
 
 class StopCompactionTest(ClusterTester):
+    GREP_PATTERN = r'Compaction for keyspace1/standard1 was stopped due to: user request'
+
     def setUp(self):
         super().setUp()
+        self.node1: BaseNode = self.db_cluster.nodes[0]
+        self.storage_service_client = StorageServiceClient(self.node1)
+        self.populate_data_parallel(size_in_gb=10, blocking=True, replication_factor=1)
         self.disable_autocompaction_on_all_nodes()
-        self.populate_data_parallel(size_in_gb=100, blocking=False)
 
     def disable_autocompaction_on_all_nodes(self):
-        for node in self.db_cluster.nodes:
-            cmd = "disableautocompaction"
-            node.run_nodetool(sub_cmd=cmd)
+        compaction_ops = CompactionOps(cluster=self.db_cluster)
+        compaction_ops.disable_autocompaction_on_ks_cf(node=self.node1)
 
-    def test_stop_major_compaction(self):  # pylint: disable=invalid-name
-        # populates 100GB
-        # write_queue = self.populate_data_parallel(100, blocking=False)
-        #
-        # self.db_cluster.wait_total_space_used_per_node(50 * (1024 ** 3))  # calculates 50gb in bytes
-        #
-        # # run rebuild
-        # current_nemesis = nemesis.CorruptThenRepairMonkey(
-        #     tester_obj=self, termination_event=self.db_cluster.nemesis_termination_event)
-        # current_nemesis.disrupt()
-        #
-        # for stress in write_queue:
-        #     self.verify_stress_thread(cs_thread_pool=stress)
-        # self.populate_data_parallel(100, blocking=False, read=True)
-        start_time = time.time()
-        stress_queue = self.run_stress_thread(stress_cmd=self.params.get('stress_cmd')[0])
-        self.verify_stress_thread(cs_thread_pool=stress_queue)
-        self.verify_no_drops_and_errors(starting_from=start_time)
+    def test_stop_major_compaction(self):
+        """
+        Test that we can stop a major compaction with <nodetool stop COMPACTION>.
+        1. Use the StopStartMajorCompaction nemesis to trigger the
+        major compaction and stop it mid-flight with <nodetool stop
+        COMPACTION>.
+        2. Grep the logs for a line informing of the major compaction being
+        stopped due to a user request.
+        3. Assert that we found the line we were grepping for.
+        """
+        self._stop_compaction_base_test_scenario(
+            compaction_nemesis=StartStopMajorCompaction(tester_obj=self,
+                                                        termination_event=self.db_cluster.nemesis_termination_event),
+            grep_pattern=self.GREP_PATTERN)
 
+    def test_stop_scrub_compaction(self):
+        """
+        Test that we can stop a scurb compaction with <nodetool stop SCRUB>.
+        1. Use the StopStartScrubCompaction nemesis to trigger the
+        major compaction and stop it mid-flight with <nodetool stop
+        SCRUB>.
+        2. Grep the logs for a line informing of the scrub compaction being
+        stopped due to a user request.
+        3. Assert that we found the line we were grepping for.
+        """
+        self._stop_compaction_base_test_scenario(
+            compaction_nemesis=StartStopScrubCompaction(tester_obj=self,
+                                                        termination_event=self.db_cluster.nemesis_termination_event),
+            grep_pattern=self.GREP_PATTERN)
+
+    def test_stop_cleanup_compaction(self):
+        """
+        Test that we can stop a cleanup compaction with <nodetool stop CLEANUP>.
+        1. Use the StopStartCleanupCompaction nemesis to trigger the
+        major compaction and stop it mid-flight with <nodetool stop
+        CLEANUP>.
+        2. Grep the logs for a line informing of the cleanup compaction being
+        stopped due to a user request.
+        3. Assert that we found the line we were grepping for.
+        """
+        self._stop_compaction_base_test_scenario(
+            compaction_nemesis=StartStopCleanupCompaction(tester_obj=self,
+                                                          termination_event=self.db_cluster.nemesis_termination_event),
+            grep_pattern=self.GREP_PATTERN)
+
+    def test_stop_validation_compaction(self):
+        """
+        Test that we can stop a validation compaction with
+        <nodetool stop VALIDATION>.
+        1. Use the StopStartValidationCompaction nemesis to trigger the
+        major compaction and stop it mid-flight with <nodetool stop
+        CLEANUP>.
+        2. Grep the logs for a line informing of the validation
+        compaction being stopped due to a user request.
+        3. Assert that we found the line we were grepping for.
+        """
+        self._stop_compaction_base_test_scenario(
+            compaction_nemesis=StartStopValidationCompaction(
+                tester_obj=self,
+                termination_event=self.db_cluster.nemesis_termination_event),
+            grep_pattern=self.GREP_PATTERN)
+
+    def test_stop_upgrade_compaction(self):
+        """
+        Test that we can stop an upgrade compaction with <nodetool stop UPGRADE>.
+        1. Flush the memtable data to sstables to make sure the data
+        is persisted in the default format.
+        2. Stop the Scylla server on the target node.
+        3. Reset the configurations options for the cluster to include:
+        "enable_sstables_mc_format" set to True and
+        "enable_sstables_md_format" set to False.
+        4. Restart the Scylla server.
+        5. Trigger the upgrade sstables compaction.
+        6. Stop the update sstables compaction mid-flight.
+        7. Grep the logs for a line informing of the validation
+        compaction being stopped due to a user request.
+        8. Assert that we found the line we were grepping for.
+        """
+        self._stop_compaction_base_test_scenario(
+            compaction_nemesis=StartStopUpgradeCompaction(tester_obj=self,
+                                                          termination_event=self.db_cluster.nemesis_termination_event),
+            grep_pattern=self.GREP_PATTERN)
+
+    def test_stop_reshape_compaction(self):
+        """
+        Test that we can stop a reshape compaction with <nodetool stop RESHAPE>.
+        1. Initialize cluster with 1 node.
+        2. Running in parallel:
+            2.1 Run refresh and restart. This will populate the db with data
+            and flush to sstables using STCS as the compaction mode. Then it
+            will alter the compaction mode to TWCS and refresh to trigger the
+            reshape compaction.
+            2.2 Watch for the first line indicating reshaping to show up in the
+            logs and then issue the nodetool stop RESHAPE command.
+        3. Grep the logs for a line informing of the compaction being stopped
+        due to a user request.
+        4. Assert that according to the logs scrubbing was stopped due to a
+        user request.
+        """
+        self._stop_compaction_base_test_scenario(
+            compaction_nemesis=StartStopReshapeCompaction(tester_obj=self,
+                                                          termination_event=self.db_cluster.nemesis_termination_event),
+            grep_pattern=self.GREP_PATTERN)
+    #     compaction_ops = CompactionOps(self.db_cluster)
+    #     trigger_func = {"func": self._reshape_scenario, "kwargs": {}}
+    #     watch_func = {"func": compaction_ops.stop_on_user_compaction_logged,
+    #                   "kwargs": {"node": self.node1,
+    #                              "watch_for": "Reshape",
+    #                              "timeout": 300,
+    #                              "stop_func": compaction_ops.stop_reshape_compaction}}
+    #     grep_pattern = r'Compaction for keyspace1/standard1 was stopped due to: user request'
+    #     self._stop_compaction_base_test_scenario(
+    #         trigger_func=trigger_func,
+    #         watch_func=watch_func,
+    #         grep_pattern=grep_pattern)
+    #
+    # def _reshape_scenario(self):
+    #     twcs = {'class': 'TimeWindowCompactionStrategy', 'compaction_window_size': 1,
+    #             'compaction_window_unit': 'MINUTES', 'max_threshold': 1, 'min_threshold': 1}
+    #     self.node1.run_nodetool(sub_cmd="flush")
+    #     self.wait_no_compactions_running()
+    #     self._copy_files()
+    #     cmd = f"ALTER TABLE standard1 WITH compaction={twcs}"
+    #     self.node1.run_cqlsh(cmd=cmd, keyspace="keyspace1")
+    #     self.node1.run_nodetool("refresh -- keyspace1 standard1")
+
+    # def _copy_files(self, keyspace: str = "keyspace1"):
+    #     LOGGER.info("Copying data files to ./staging and ./upload directories...")
+    #     keyspace_dir = f'/var/lib/scylla/data/{keyspace}'
+    #     cf_data_dir = self.node1.remoter.run(f"ls {keyspace_dir}").stdout.splitlines()[0]
+    #     full_dir_path = f"{keyspace_dir}/{cf_data_dir}"
+    #     upload_dir = f"{full_dir_path}/upload"
+    #     staging_dir = f"{full_dir_path}/staging"
+    #     cp_cmd_upload = f"cp -p {full_dir_path}/md-* {upload_dir}"
+    #     cp_cmd_staging = f"cp -p {full_dir_path}/md-* {staging_dir}"
+    #     self.node1.remoter.sudo(cp_cmd_staging)
+    #     self.node1.remoter.sudo(cp_cmd_upload)
+    #     LOGGER.info("Finished copying data files to ./staging and ./upload directories.")
+
+    def _stop_compaction_base_test_scenario(self,
+                                            compaction_nemesis,
+                                            # trigger_func: dict[str, Any],
+                                            # watch_func: dict[str, Any],
+                                            grep_pattern: str,):
+        compaction_nemesis.disrupt()
+        found_grepped_expression = False
+        with open(self.node1.system_log, "r") as logfile:
+            pattern = re.compile(grep_pattern)
+            for line in logfile.readlines():
+                if pattern.findall(line):
+                    found_grepped_expression = True
+
+        self.assertTrue(found_grepped_expression, msg=f'Did not find the expected "{grep_pattern}" '
+                                                      f'expression in the logs.')

--- a/stop_compaction_test.py
+++ b/stop_compaction_test.py
@@ -14,7 +14,6 @@
 # Copyright (c) 2021 ScyllaDB
 import re
 
-from sdcm.cluster import BaseNode
 from sdcm.nemesis import StartStopMajorCompaction, StartStopScrubCompaction, StartStopCleanupCompaction, \
     StartStopValidationCompaction, StartStopUpgradeCompaction, StartStopReshapeCompaction
 from sdcm.rest.storage_service_client import StorageServiceClient
@@ -27,14 +26,14 @@ class StopCompactionTest(ClusterTester):
 
     def setUp(self):
         super().setUp()
-        self.node1: BaseNode = self.db_cluster.nodes[0]
-        self.storage_service_client = StorageServiceClient(self.node1)
-        self.populate_data_parallel(size_in_gb=10, blocking=True, replication_factor=1)
+        self.node = self.db_cluster.nodes[0]
+        self.storage_service_client = StorageServiceClient(self.node)
+        self.populate_data_parallel(size_in_gb=10, blocking=True)
         self.disable_autocompaction_on_all_nodes()
 
     def disable_autocompaction_on_all_nodes(self):
         compaction_ops = CompactionOps(cluster=self.db_cluster)
-        compaction_ops.disable_autocompaction_on_ks_cf(node=self.node1)
+        compaction_ops.disable_autocompaction_on_ks_cf(node=self.node)
 
     def test_stop_major_compaction(self):
         """
@@ -47,9 +46,9 @@ class StopCompactionTest(ClusterTester):
         3. Assert that we found the line we were grepping for.
         """
         self._stop_compaction_base_test_scenario(
-            compaction_nemesis=StartStopMajorCompaction(tester_obj=self,
-                                                        termination_event=self.db_cluster.nemesis_termination_event),
-            grep_pattern=self.GREP_PATTERN)
+            compaction_nemesis=StartStopMajorCompaction(
+                tester_obj=self,
+                termination_event=self.db_cluster.nemesis_termination_event))
 
     def test_stop_scrub_compaction(self):
         """
@@ -62,9 +61,9 @@ class StopCompactionTest(ClusterTester):
         3. Assert that we found the line we were grepping for.
         """
         self._stop_compaction_base_test_scenario(
-            compaction_nemesis=StartStopScrubCompaction(tester_obj=self,
-                                                        termination_event=self.db_cluster.nemesis_termination_event),
-            grep_pattern=self.GREP_PATTERN)
+            compaction_nemesis=StartStopScrubCompaction(
+                tester_obj=self,
+                termination_event=self.db_cluster.nemesis_termination_event))
 
     def test_stop_cleanup_compaction(self):
         """
@@ -77,9 +76,9 @@ class StopCompactionTest(ClusterTester):
         3. Assert that we found the line we were grepping for.
         """
         self._stop_compaction_base_test_scenario(
-            compaction_nemesis=StartStopCleanupCompaction(tester_obj=self,
-                                                          termination_event=self.db_cluster.nemesis_termination_event),
-            grep_pattern=self.GREP_PATTERN)
+            compaction_nemesis=StartStopCleanupCompaction(
+                tester_obj=self,
+                termination_event=self.db_cluster.nemesis_termination_event))
 
     def test_stop_validation_compaction(self):
         """
@@ -95,98 +94,47 @@ class StopCompactionTest(ClusterTester):
         self._stop_compaction_base_test_scenario(
             compaction_nemesis=StartStopValidationCompaction(
                 tester_obj=self,
-                termination_event=self.db_cluster.nemesis_termination_event),
-            grep_pattern=self.GREP_PATTERN)
+                termination_event=self.db_cluster.nemesis_termination_event))
 
     def test_stop_upgrade_compaction(self):
         """
         Test that we can stop an upgrade compaction with <nodetool stop UPGRADE>.
-        1. Flush the memtable data to sstables to make sure the data
-        is persisted in the default format.
-        2. Stop the Scylla server on the target node.
-        3. Reset the configurations options for the cluster to include:
-        "enable_sstables_mc_format" set to True and
-        "enable_sstables_md_format" set to False.
-        4. Restart the Scylla server.
-        5. Trigger the upgrade sstables compaction.
-        6. Stop the update sstables compaction mid-flight.
-        7. Grep the logs for a line informing of the validation
-        compaction being stopped due to a user request.
-        8. Assert that we found the line we were grepping for.
+        1. Use the StartStopUpgradeCompaction nemesis to trigger the sstables
+        upgrade compaction.
+        2. Stop the compaction mid-flight with <nodetool stop UPGRADE>.
+        3. Grep the logs for a line informing of the upgrade compaction being
+        stopped due to a user request.
+        4. Assert that we found the line we were grepping for.
         """
         self._stop_compaction_base_test_scenario(
-            compaction_nemesis=StartStopUpgradeCompaction(tester_obj=self,
-                                                          termination_event=self.db_cluster.nemesis_termination_event),
-            grep_pattern=self.GREP_PATTERN)
+            compaction_nemesis=StartStopUpgradeCompaction(
+                tester_obj=self,
+                termination_event=self.db_cluster.nemesis_termination_event))
 
     def test_stop_reshape_compaction(self):
         """
         Test that we can stop a reshape compaction with <nodetool stop RESHAPE>.
-        1. Initialize cluster with 1 node.
-        2. Running in parallel:
-            2.1 Run refresh and restart. This will populate the db with data
-            and flush to sstables using STCS as the compaction mode. Then it
-            will alter the compaction mode to TWCS and refresh to trigger the
-            reshape compaction.
-            2.2 Watch for the first line indicating reshaping to show up in the
-            logs and then issue the nodetool stop RESHAPE command.
-        3. Grep the logs for a line informing of the compaction being stopped
-        due to a user request.
-        4. Assert that according to the logs scrubbing was stopped due to a
-        user request.
+        1. Use the StartStopReshapeCompaction nemesis to trigger the reshape
+        compaction.
+        2. Stop the compaction mid-flight with <nodetool stop RESHAPE>.
+        3. Grep the logs for a line informing of the reshape compaction
+        being stopped due to a user request.
+        4. Assert that we found the line we were grepping for.
         """
         self._stop_compaction_base_test_scenario(
-            compaction_nemesis=StartStopReshapeCompaction(tester_obj=self,
-                                                          termination_event=self.db_cluster.nemesis_termination_event),
-            grep_pattern=self.GREP_PATTERN)
-    #     compaction_ops = CompactionOps(self.db_cluster)
-    #     trigger_func = {"func": self._reshape_scenario, "kwargs": {}}
-    #     watch_func = {"func": compaction_ops.stop_on_user_compaction_logged,
-    #                   "kwargs": {"node": self.node1,
-    #                              "watch_for": "Reshape",
-    #                              "timeout": 300,
-    #                              "stop_func": compaction_ops.stop_reshape_compaction}}
-    #     grep_pattern = r'Compaction for keyspace1/standard1 was stopped due to: user request'
-    #     self._stop_compaction_base_test_scenario(
-    #         trigger_func=trigger_func,
-    #         watch_func=watch_func,
-    #         grep_pattern=grep_pattern)
-    #
-    # def _reshape_scenario(self):
-    #     twcs = {'class': 'TimeWindowCompactionStrategy', 'compaction_window_size': 1,
-    #             'compaction_window_unit': 'MINUTES', 'max_threshold': 1, 'min_threshold': 1}
-    #     self.node1.run_nodetool(sub_cmd="flush")
-    #     self.wait_no_compactions_running()
-    #     self._copy_files()
-    #     cmd = f"ALTER TABLE standard1 WITH compaction={twcs}"
-    #     self.node1.run_cqlsh(cmd=cmd, keyspace="keyspace1")
-    #     self.node1.run_nodetool("refresh -- keyspace1 standard1")
-
-    # def _copy_files(self, keyspace: str = "keyspace1"):
-    #     LOGGER.info("Copying data files to ./staging and ./upload directories...")
-    #     keyspace_dir = f'/var/lib/scylla/data/{keyspace}'
-    #     cf_data_dir = self.node1.remoter.run(f"ls {keyspace_dir}").stdout.splitlines()[0]
-    #     full_dir_path = f"{keyspace_dir}/{cf_data_dir}"
-    #     upload_dir = f"{full_dir_path}/upload"
-    #     staging_dir = f"{full_dir_path}/staging"
-    #     cp_cmd_upload = f"cp -p {full_dir_path}/md-* {upload_dir}"
-    #     cp_cmd_staging = f"cp -p {full_dir_path}/md-* {staging_dir}"
-    #     self.node1.remoter.sudo(cp_cmd_staging)
-    #     self.node1.remoter.sudo(cp_cmd_upload)
-    #     LOGGER.info("Finished copying data files to ./staging and ./upload directories.")
+            compaction_nemesis=StartStopReshapeCompaction(
+                tester_obj=self,
+                termination_event=self.db_cluster.nemesis_termination_event))
 
     def _stop_compaction_base_test_scenario(self,
-                                            compaction_nemesis,
-                                            # trigger_func: dict[str, Any],
-                                            # watch_func: dict[str, Any],
-                                            grep_pattern: str,):
+                                            compaction_nemesis):
         compaction_nemesis.disrupt()
         found_grepped_expression = False
-        with open(self.node1.system_log, "r") as logfile:
-            pattern = re.compile(grep_pattern)
+        with open(self.node.system_log, "r") as logfile:
+            pattern = re.compile(self.GREP_PATTERN)
             for line in logfile.readlines():
                 if pattern.findall(line):
                     found_grepped_expression = True
 
-        self.assertTrue(found_grepped_expression, msg=f'Did not find the expected "{grep_pattern}" '
+        self.assertTrue(found_grepped_expression, msg=f'Did not find the expected "{self.GREP_PATTERN}" '
                                                       f'expression in the logs.')

--- a/stop_compaction_test.py
+++ b/stop_compaction_test.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2021 ScyllaDB
+import time
+
+from sdcm.tester import ClusterTester
+
+
+class StopCompactionTest(ClusterTester):
+    def setUp(self):
+        super().setUp()
+        self.disable_autocompaction_on_all_nodes()
+        self.populate_data_parallel(size_in_gb=100, blocking=False)
+
+    def disable_autocompaction_on_all_nodes(self):
+        for node in self.db_cluster.nodes:
+            cmd = "disableautocompaction"
+            node.run_nodetool(sub_cmd=cmd)
+
+    def test_stop_major_compaction(self):  # pylint: disable=invalid-name
+        # populates 100GB
+        # write_queue = self.populate_data_parallel(100, blocking=False)
+        #
+        # self.db_cluster.wait_total_space_used_per_node(50 * (1024 ** 3))  # calculates 50gb in bytes
+        #
+        # # run rebuild
+        # current_nemesis = nemesis.CorruptThenRepairMonkey(
+        #     tester_obj=self, termination_event=self.db_cluster.nemesis_termination_event)
+        # current_nemesis.disrupt()
+        #
+        # for stress in write_queue:
+        #     self.verify_stress_thread(cs_thread_pool=stress)
+        # self.populate_data_parallel(100, blocking=False, read=True)
+        start_time = time.time()
+        stress_queue = self.run_stress_thread(stress_cmd=self.params.get('stress_cmd')[0])
+        self.verify_stress_thread(cs_thread_pool=stress_queue)
+        self.verify_no_drops_and_errors(starting_from=start_time)
+

--- a/stop_compaction_test.py
+++ b/stop_compaction_test.py
@@ -12,13 +12,20 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2021 ScyllaDB
+import logging
 import re
+from functools import partial
 
+from sdcm.cluster import BaseNode
 from sdcm.nemesis import StartStopMajorCompaction, StartStopScrubCompaction, StartStopCleanupCompaction, \
-    StartStopValidationCompaction, StartStopUpgradeCompaction, StartStopReshapeCompaction
+    StartStopValidationCompaction
 from sdcm.rest.storage_service_client import StorageServiceClient
 from sdcm.tester import ClusterTester
+from sdcm.utils.common import ParallelObject
 from sdcm.utils.compaction_ops import CompactionOps
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 class StopCompactionTest(ClusterTester):
@@ -35,7 +42,26 @@ class StopCompactionTest(ClusterTester):
         compaction_ops = CompactionOps(cluster=self.db_cluster)
         compaction_ops.disable_autocompaction_on_ks_cf(node=self.node)
 
-    def test_stop_major_compaction(self):
+    def test_stop_compaction(self):
+        with self.subTest("Stop upgrade compaction test"):
+            self.stop_upgrade_compaction()
+
+        with self.subTest("Stop major compaction test"):
+            self.stop_major_compaction()
+
+        with self.subTest("Stop scrub compaction test"):
+            self.stop_scrub_compaction()
+
+        with self.subTest("Stop cleanup compaction test"):
+            self.stop_cleanup_compaction()
+
+        with self.subTest("Stop validation compaction test"):
+            self.stop_validation_compaction()
+
+        with self.subTest("Stop reshape compaction test"):
+            self.stop_reshape_compaction()
+
+    def stop_major_compaction(self):
         """
         Test that we can stop a major compaction with <nodetool stop COMPACTION>.
         1. Use the StopStartMajorCompaction nemesis to trigger the
@@ -50,9 +76,9 @@ class StopCompactionTest(ClusterTester):
                 tester_obj=self,
                 termination_event=self.db_cluster.nemesis_termination_event))
 
-    def test_stop_scrub_compaction(self):
+    def stop_scrub_compaction(self):
         """
-        Test that we can stop a scurb compaction with <nodetool stop SCRUB>.
+        Test that we can stop a scrub compaction with <nodetool stop SCRUB>.
         1. Use the StopStartScrubCompaction nemesis to trigger the
         major compaction and stop it mid-flight with <nodetool stop
         SCRUB>.
@@ -65,7 +91,7 @@ class StopCompactionTest(ClusterTester):
                 tester_obj=self,
                 termination_event=self.db_cluster.nemesis_termination_event))
 
-    def test_stop_cleanup_compaction(self):
+    def stop_cleanup_compaction(self):
         """
         Test that we can stop a cleanup compaction with <nodetool stop CLEANUP>.
         1. Use the StopStartCleanupCompaction nemesis to trigger the
@@ -80,7 +106,7 @@ class StopCompactionTest(ClusterTester):
                 tester_obj=self,
                 termination_event=self.db_cluster.nemesis_termination_event))
 
-    def test_stop_validation_compaction(self):
+    def stop_validation_compaction(self):
         """
         Test that we can stop a validation compaction with
         <nodetool stop VALIDATION>.
@@ -96,41 +122,123 @@ class StopCompactionTest(ClusterTester):
                 tester_obj=self,
                 termination_event=self.db_cluster.nemesis_termination_event))
 
-    def test_stop_upgrade_compaction(self):
+    def stop_upgrade_compaction(self):
         """
         Test that we can stop an upgrade compaction with <nodetool stop UPGRADE>.
-        1. Use the StartStopUpgradeCompaction nemesis to trigger the sstables
-        upgrade compaction.
-        2. Stop the compaction mid-flight with <nodetool stop UPGRADE>.
-        3. Grep the logs for a line informing of the upgrade compaction being
-        stopped due to a user request.
-        4. Assert that we found the line we were grepping for.
-        """
-        self._stop_compaction_base_test_scenario(
-            compaction_nemesis=StartStopUpgradeCompaction(
-                tester_obj=self,
-                termination_event=self.db_cluster.nemesis_termination_event))
 
-    def test_stop_reshape_compaction(self):
+        Prerequisite:
+        The initial setup in scylla.yaml must include 2 settings:
+            enable_sstables_mc_format: true
+            enable_sstables_md_format: false
+        This is necessary for the test to be able to go from the legacy
+        "mc" sstable format to the newer "md" format.
+
+        1. Flush the data from memtables to sstables.
+        2. Stop scylla on a given node.
+        3. Update the scylla.yaml configuration to enable the mc
+        sstable format.
+        4. Restart scylla.
+        5. Trigger the upgrade compaction using the API request.
+        6. Stop the compaction mid-flight with <nodetool stop UPGRADE>.
+        7. Grep the logs for a line informing of the upgrade compaction being
+        stopped due to a user request.
+        8. Assert that we found the line we were grepping for.
+        """
+        compaction_ops = CompactionOps(cluster=self.db_cluster, node=self.node)
+        timeout = 300
+        upgraded_configuration_options = {"enable_sstables_mc_format": False,
+                                          "enable_sstables_md_format": True}
+        trigger_func = partial(compaction_ops.trigger_upgrade_compaction)
+        watch_func = partial(compaction_ops.stop_on_user_compaction_logged,
+                             node=self.node,
+                             mark=self.node.mark_log(),
+                             watch_for="Upgrade keyspace1.standard1",
+                             timeout=timeout,
+                             stop_func=compaction_ops.stop_upgrade_compaction)
+
+        def _upgrade_sstables_format(node: BaseNode):
+            LOGGER.info("Upgrading sstables format...")
+            with node.remote_scylla_yaml() as scylla_yaml:
+                scylla_yaml.update(upgraded_configuration_options)
+
+        try:
+            compaction_ops.trigger_flush()
+            self.node.stop_scylla()
+            _upgrade_sstables_format(self.node)
+            self.node.start_scylla()
+            self.wait_no_compactions_running()
+            ParallelObject(objects=[trigger_func, watch_func], timeout=timeout).call_objects()
+            self._grep_log_and_assert(self.node)
+        finally:
+            self.node.running_nemesis = False
+
+    def stop_reshape_compaction(self):
         """
         Test that we can stop a reshape compaction with <nodetool stop RESHAPE>.
-        1. Use the StartStopReshapeCompaction nemesis to trigger the reshape
-        compaction.
-        2. Stop the compaction mid-flight with <nodetool stop RESHAPE>.
-        3. Grep the logs for a line informing of the reshape compaction
+        To trigger a reshape compaction, the current CompactionStrategy
+        must not be aligned with the shape of the stored sstables. In
+        this case we're setting the new strategy to
+        TimeWindowCompactionStrategy with a very small time window.
+
+        1. Flush the memtable data to sstables.
+        2. Copy sstable files to the upload and staging dirs.
+        3. Change the compaction strategy to TimeWindowCompactionStrategy.
+        4. Run <nodetool refresh> command to trigger the compaction.
+        5. Stop the compaction mid-flight with <nodetool stop RESHAPE>.
+        6. Grep the logs for a line informing of the reshape compaction
         being stopped due to a user request.
-        4. Assert that we found the line we were grepping for.
+        7. Assert that we found the line we were grepping for.
         """
-        self._stop_compaction_base_test_scenario(
-            compaction_nemesis=StartStopReshapeCompaction(
-                tester_obj=self,
-                termination_event=self.db_cluster.nemesis_termination_event))
+        node = self.node
+        compaction_ops = CompactionOps(cluster=self.db_cluster, node=node)
+        timeout = 600
+
+        def _trigger_reshape(node: BaseNode, tester, keyspace: str = "keyspace1"):
+            twcs = {'class': 'TimeWindowCompactionStrategy', 'compaction_window_size': 1,
+                    'compaction_window_unit': 'MINUTES', 'max_threshold': 1, 'min_threshold': 1}
+            compaction_ops.trigger_flush()
+            tester.wait_no_compactions_running()
+            LOGGER.info("Copying data files to ./staging and ./upload directories...")
+            keyspace_dir = f'/var/lib/scylla/data/{keyspace}'
+            cf_data_dir = node.remoter.run(f"ls {keyspace_dir}").stdout.splitlines()[0]
+            full_dir_path = f"{keyspace_dir}/{cf_data_dir}"
+            upload_dir = f"{full_dir_path}/upload"
+            staging_dir = f"{full_dir_path}/staging"
+            cp_cmd_upload = f"cp -p {full_dir_path}/m* {upload_dir}"
+            cp_cmd_staging = f"cp -p {full_dir_path}/m* {staging_dir}"
+            node.remoter.sudo(cp_cmd_staging)
+            node.remoter.sudo(cp_cmd_upload)
+            LOGGER.info("Finished copying data files to ./staging and ./upload directories.")
+            cmd = f"ALTER TABLE standard1 WITH compaction={twcs}"
+            node.run_cqlsh(cmd=cmd, keyspace="keyspace1")
+            node.run_nodetool("refresh -- keyspace1 standard1")
+
+        trigger_func = partial(_trigger_reshape,
+                               node=node,
+                               tester=self)
+        watch_func = partial(compaction_ops.stop_on_user_compaction_logged,
+                             node=node,
+                             mark=node.mark_log(),
+                             watch_for="Reshape keyspace1.standard1",
+                             timeout=timeout,
+                             stop_func=compaction_ops.stop_reshape_compaction)
+        try:
+            ParallelObject(objects=[trigger_func, watch_func], timeout=timeout).call_objects()
+        finally:
+            self._grep_log_and_assert(node)
 
     def _stop_compaction_base_test_scenario(self,
                                             compaction_nemesis):
-        compaction_nemesis.disrupt()
+        try:
+            compaction_nemesis.disrupt()
+            node = compaction_nemesis.target_node
+            self._grep_log_and_assert(node)
+        finally:
+            node.running_nemesis = False
+
+    def _grep_log_and_assert(self, node: BaseNode):
         found_grepped_expression = False
-        with open(self.node.system_log, "r") as logfile:
+        with open(node.system_log, "r") as logfile:
             pattern = re.compile(self.GREP_PATTERN)
             for line in logfile.readlines():
                 if pattern.findall(line):

--- a/stop_compaction_test.py
+++ b/stop_compaction_test.py
@@ -29,7 +29,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 class StopCompactionTest(ClusterTester):
-    GREP_PATTERN = r'Compaction for keyspace1/standard1 was stopped due to: user request'
+    GREP_PATTERN = r"Compaction for ([\w/\d]+) was stopped"
 
     def setUp(self):
         super().setUp()
@@ -241,7 +241,7 @@ class StopCompactionTest(ClusterTester):
         with open(node.system_log, "r") as logfile:
             pattern = re.compile(self.GREP_PATTERN)
             for line in logfile.readlines():
-                if pattern.findall(line):
+                if pattern.search(line):
                     found_grepped_expression = True
 
         self.assertTrue(found_grepped_expression, msg=f'Did not find the expected "{self.GREP_PATTERN}" '

--- a/test-cases/features/stop-compaction.yaml
+++ b/test-cases/features/stop-compaction.yaml
@@ -1,0 +1,13 @@
+test_duration: 30
+
+stress_cmd: ["cassandra-stress write cl=ONE duration=20m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..10000000 -log interval=60"]
+
+n_db_nodes: 3
+n_loaders: 1
+n_monitor_nodes: 1
+
+instance_type_db: 'i3.large'
+
+nemesis_class_name: 'NoOpMonkey'
+
+user_prefix: 'stop-compaction'

--- a/test-cases/features/stop-compaction.yaml
+++ b/test-cases/features/stop-compaction.yaml
@@ -1,7 +1,5 @@
 test_duration: 60
 
-stress_cmd: ["cassandra-stress write cl=ONE duration=20m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..10000000 -log interval=60"]
-
 n_db_nodes: 3
 n_loaders: 1
 n_monitor_nodes: 1

--- a/test-cases/features/stop-compaction.yaml
+++ b/test-cases/features/stop-compaction.yaml
@@ -1,4 +1,4 @@
-test_duration: 30
+test_duration: 60
 
 stress_cmd: ["cassandra-stress write cl=ONE duration=20m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..10000000 -log interval=60"]
 
@@ -8,6 +8,9 @@ n_monitor_nodes: 1
 
 instance_type_db: 'i3.large'
 
-nemesis_class_name: 'NoOpMonkey'
+backtrace_decoding: true
 
 user_prefix: 'stop-compaction'
+append_scylla_yaml: |
+  enable_sstables_mc_format: true
+  enable_sstables_md_format: false

--- a/test-cases/features/stop-compaction.yaml
+++ b/test-cases/features/stop-compaction.yaml
@@ -11,4 +11,4 @@ backtrace_decoding: true
 user_prefix: 'stop-compaction'
 append_scylla_yaml: |
   enable_sstables_mc_format: true
-  enable_sstables_md_format: false
+  enable_sstables_md_format: true

--- a/test-cases/longevity/longevity-10gb-3h.yaml
+++ b/test-cases/longevity/longevity-10gb-3h.yaml
@@ -1,9 +1,9 @@
-test_duration: 255
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5"
+test_duration: 120
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=30m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5"
              ]
 
-n_db_nodes: 6
-n_loaders: 2
+n_db_nodes: 3
+n_loaders: 1
 n_monitor_nodes: 1
 
 instance_type_db: 'i3.4xlarge'
@@ -12,8 +12,7 @@ gce_instance_type_loader: 'e2-standard-4'
 scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-4.3.repo'
 run_fullscan: 'keyspace1.standard1, 5' # 'ks.cf|random, interval(min)''
 
-nemesis_class_name: 'SisyphusMonkey'
-nemesis_seed: '111'
+nemesis_class_name: 'StartStopCompactionMonkey'
 nemesis_interval: 2
 ssh_transport: 'libssh2'
 

--- a/test-cases/longevity/longevity-10gb-3h.yaml
+++ b/test-cases/longevity/longevity-10gb-3h.yaml
@@ -1,9 +1,9 @@
-test_duration: 120
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=30m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5"
+test_duration: 255
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5"
              ]
 
-n_db_nodes: 3
-n_loaders: 1
+n_db_nodes: 6
+n_loaders: 2
 n_monitor_nodes: 1
 
 instance_type_db: 'i3.4xlarge'
@@ -12,7 +12,8 @@ gce_instance_type_loader: 'e2-standard-4'
 scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-4.3.repo'
 run_fullscan: 'keyspace1.standard1, 5' # 'ks.cf|random, interval(min)''
 
-nemesis_class_name: 'StartStopCompactionMonkey'
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_seed: '111'
 nemesis_interval: 2
 ssh_transport: 'libssh2'
 


### PR DESCRIPTION
The PR introduces a set of new tests and related nemesis methods for starting and stopping different types of compaction. The general flow of these is:
1. Meet the prerequisites for a given compaction type.
2. Trigger a given compaction type.
3. Watch the logs for a line informing about the compaction type being run.
4. Stop the compaction with a `nodetool stop <COMPACTION TYPE>` command.
5. Grep the logs for lines informing of the compaction being stopped.

There are 6 compaction types covered in total: MAJOR, SCRUB, CLEANUP, VALIDATION, UPGRADE, RESHAPE. There are relevant nemesis classes, methods and test cases for each of them.
Due to the fact that I trigger the compactions via API, I introduced a general RestClient class and subclasses for running the REST calls on a remoter via `curl` and a specific class for the StorageService (used for compaction-related API calls).

Trello tasks:
https://trello.com/c/13ghBL9F
https://trello.com/c/cScsE9vT

Example Jenkiks run:
https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/maciej/job/mc-longevity/job/mc-longevity-nodetool-stop-nemesis/22/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
