### PR TITLE
fix(sct_config.py): typo within fstring param

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1393,7 +1393,7 @@ class SCTConfiguration(dict):
                             if ami.name.endswith(suffix):
                                 break
                         else:
-                            raise ValueError(f"AMIs for {scylla_version=} not found in {region}")
+                            raise ValueError(f"AMIs for {scylla_version} not found in {region}")
                     self.log.debug("Found AMI %s for scylla_version='%s' in %s", ami.image_id, scylla_version, region)
                     ami_list.append(ami)
                 self['ami_id_db_scylla'] = " ".join(ami.image_id for ami in ami_list)
@@ -1407,7 +1407,7 @@ class SCTConfiguration(dict):
                         if gce_image.name.endswith(suffix):
                             break
                     else:
-                        raise ValueError(f"GCE images for {scylla_version=} not found")
+                        raise ValueError(f"GCE images for {scylla_version} not found")
                 self.log.debug("Found GCE image %s for scylla_version='%s'", gce_image.name, scylla_version)
                 self["gce_image_db"] = gce_image.extra["selfLink"]
             elif not self.get('scylla_repo'):


### PR DESCRIPTION
	it had: {scylla_version=} inside fstring.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
