### PR TITLE
fix(hydra.sh): allow to run hydra --help

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -47,7 +47,7 @@ while [[ $# -gt 0 ]]; do
             shift
             shift
             ;;
-        --install-bash-completion)
+        --install-bash-completion|--help)
             SCT_ARGUMENTS+=("$1")
             shift
             ;;


### PR DESCRIPTION
Before:

```sh
$ hydra --help
Unknown argument '--help'
```

After:

```sh
$ hydra --help
Docker version 20.10.8, build 3967b7d
There is scylladb/hydra:v0.93 in local cache, use it.
Obtaining QA SSH keys...
QA SSH keys obtained.
Making sure the ownerships of results directories are of the user
Going to run './sct.py --help '...
Obtaining QA SSH keys...
QA SSH keys obtained.
Usage: sct.py [OPTIONS] COMMAND [ARGS]...

Options:
  --install-bash-completion       Install completion for the current shell.
                                  Make sure to have psutil installed.
  --install-package-from-directory PATH
                                  Install paths for extra python pacakges to
                                  install, scylla-cluster-plugins for example
  --help                          Show this message and exit.
...
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
