### PR TITLE
fix(kubernetes): place kube-system's deployments in default node pool

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1081,8 +1081,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         # NOTE: between GKE cluster creation and addition of new node pools we need
         # several minutes gap to avoid "repair" status of a cluster when API server goes down.
         # So, deploy apps specific to default-pool in between above mentioned deployment steps.
-        self.k8s_cluster.set_nodeselector_for_kubedns(
-            pool_name=self.k8s_cluster.AUXILIARY_POOL_NAME)
+        self.k8s_cluster.set_nodeselector_for_deployments(
+            pool_name=self.k8s_cluster.AUXILIARY_POOL_NAME, namespace="kube-system")
         self.k8s_cluster.deploy_cert_manager(pool_name=self.k8s_cluster.AUXILIARY_POOL_NAME)
         self.k8s_cluster.deploy_scylla_operator()
         if self.params.get('use_mgmt'):
@@ -1204,8 +1204,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
         self.k8s_cluster.deploy()
         self.k8s_cluster.tune_network()
-        self.k8s_cluster.set_nodeselector_for_kubedns(
-            pool_name=self.k8s_cluster.AUXILIARY_POOL_NAME)
+        self.k8s_cluster.set_nodeselector_for_deployments(
+            pool_name=self.k8s_cluster.AUXILIARY_POOL_NAME, namespace="kube-system")
 
         self.k8s_cluster.deploy_node_pool(
             eks.EksNodePool(


### PR DESCRIPTION
Deploying Scylla cluster on EKS or GKE backends we don't want to have
unexpected pods be placed onto Scylla K8S nodes (scylla-pool).
'kube-system' namespace has some platform-specific apps which,
by default, get deployed onto any node in a cluster.
So, specify nodeSelector field for all deployments in this namespace
explicitly to make it be deployed on proper nodes.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
