### PR TITLE
improvement(k8s-gke): deploy 2 nodes in the default node pool

### DIFF
--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -151,12 +151,12 @@ class GkeCluster(KubernetesCluster):
                  gce_image_size,
                  gce_network,
                  services,
-                 gce_instance_type='n1-standard-4',
+                 gce_instance_type='n1-standard-2',
                  user_prefix=None,
                  params=None,
                  gce_datacenter=None,
                  cluster_uuid=None,
-                 n_nodes=1
+                 n_nodes=2,
                  ):
         super().__init__(
             params=params,

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1073,7 +1073,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                           gce_network=self.params.get("gce_network"),
                                           services=services,
                                           user_prefix=self.params.get("user_prefix"),
-                                          n_nodes=1,
+                                          gce_instance_type='n1-standard-2',
+                                          n_nodes=2,
                                           params=self.params,
                                           gce_datacenter=gce_datacenter)
         self.k8s_cluster.deploy()


### PR DESCRIPTION
Deploy 2 nodes of 'n1-standard-2' type instead of
1 node of 'n1-standard-4' type running tests on GKE backend.
The prices will be equal, so expanses will stay the same.
The reason to do so is to have more than 1 node for HA pods such
as 'scylla-operator' and 'webhook-server' which better to schedule
on different nodes.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
