### PR TITLE
fix(kubernetes): specify affinity rules for webhook-server pods

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -64,6 +64,7 @@ from sdcm.utils.k8s import (
     convert_memory_value_from_k8s_to_units,
     get_helm_pool_affinity_values,
     get_pool_affinity_modifiers,
+    get_preferred_pod_anti_affinity_values,
     ApiCallRateLimiter,
     CordonNodes,
     JSON_PATCH_TYPE,
@@ -582,7 +583,15 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
             if pool_name is None:
                 pool_name = self.AUXILIARY_POOL_NAME
 
-            values = HelmValues(**get_helm_pool_affinity_values(self.POOL_LABEL_NAME, pool_name) if pool_name else {})
+            affinity_rules = {
+                "affinity": get_preferred_pod_anti_affinity_values("scylla-operator"),
+                "webhookServerAffinity": get_preferred_pod_anti_affinity_values("webhook-server"),
+            }
+            if pool_name:
+                add_pool_node_affinity(affinity_rules["affinity"], self.POOL_LABEL_NAME, pool_name)
+                affinity_rules["webhookServerAffinity"]["nodeAffinity"] = (
+                    affinity_rules["affinity"]["nodeAffinity"])
+            values = HelmValues(**affinity_rules)
             if version.parse(self._scylla_operator_chart_version.split("-")[0]) > version.parse("v1.3.0"):
                 # NOTE: following is supported starting with operator-1.4
                 values.set("logLevel", 4)

--- a/sdcm/utils/k8s.py
+++ b/sdcm/utils/k8s.py
@@ -813,6 +813,19 @@ def add_pool_node_affinity(value, pool_label_name, pool_name):
     return value
 
 
+def get_preferred_pod_anti_affinity_values(name: str) -> dict:
+    return {"podAntiAffinity": {"preferredDuringSchedulingIgnoredDuringExecution": [{
+        "weight": 1,
+        "podAffinityTerm": {
+            "topologyKey": "kubernetes.io/hostname",
+            "labelSelector": {"matchLabels": {
+                "app.kubernetes.io/name": name,
+                "app.kubernetes.io/instance": name,
+            }},
+        },
+    }]}}
+
+
 def get_helm_pool_affinity_values(pool_label_name, pool_name):
     return {'affinity': add_pool_node_affinity({}, pool_label_name, pool_name)}
 


### PR DESCRIPTION
In operator-1.5 was added separate helm chart option for affinity rules
of webhook-server pods. So, to make it be scheduled as expected,
specify additional helm chart option with affinity rules for it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
