### PR TITLE
fix(longevity-1tb): Decrease stress duration in order to meet timeout

### DIFF
--- a/test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml
@@ -4,12 +4,12 @@ prepare_write_cmd: ["cassandra-stress write cl=QUORUM n=275050075 -schema 'repli
                     "cassandra-stress write cl=QUORUM n=275050075 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=150 -col 'size=FIXED(200) n=FIXED(5)' -pop seq=550100151..825150225",
                     "cassandra-stress write cl=QUORUM n=275050075 -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=150 -col 'size=FIXED(200) n=FIXED(5)' -pop seq=825150226..1100200300"]
 
-stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=7000m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=1..550100150  -log interval=5 -col 'size=FIXED(200) n=FIXED(5)'",
-             "cassandra-stress mixed cl=QUORUM duration=7000m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=550100151..1100200300  -log interval=5 -col 'size=FIXED(200) n=FIXED(5)'",
-             "cassandra-stress user profile=/tmp/cs_mv_profile.yaml ops'(insert=3,read1=1,read2=1,read3=1)' cl=QUORUM duration=7000m -port jmx=6868 -mode cql3 native -rate threads=10"]
+stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=6800m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=1..550100150  -log interval=5 -col 'size=FIXED(200) n=FIXED(5)'",
+             "cassandra-stress mixed cl=QUORUM duration=6800m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=550100151..1100200300  -log interval=5 -col 'size=FIXED(200) n=FIXED(5)'",
+             "cassandra-stress user profile=/tmp/cs_mv_profile.yaml ops'(insert=3,read1=1,read2=1,read3=1)' cl=QUORUM duration=6800m -port jmx=6868 -mode cql3 native -rate threads=10"]
 
 
-stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=7000m -port jmx=6868 -mode cql3 native  -rate threads=10 -pop seq=1..1100200300  -log interval=5 -col 'size=FIXED(200) n=FIXED(5)'" ]
+stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=6800m -port jmx=6868 -mode cql3 native  -rate threads=10 -pop seq=1..1100200300  -log interval=5 -col 'size=FIXED(200) n=FIXED(5)'" ]
 
 
 run_fullscan: 'random, 120'  # 'ks.cf|random, interval(min)''


### PR DESCRIPTION
The previous stress duration of 7000 minutes is too long to fit
the 7200 timeout including the prepare phase.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
