### PR TITLE
fix(disrupt_method_wrapper): Convert exception to str

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2848,9 +2848,9 @@ def disrupt_method_wrapper(method):  # pylint: disable=too-many-statements
                 nemesis_event.add_error([str(details)])
                 nemesis_event.full_traceback = traceback.format_exc()
                 nemesis_event.severity = Severity.ERROR
-                args[0].error_list.append(details)
+                args[0].error_list.append(str(details))
                 args[0].log.error('Unhandled exception in method %s', method, exc_info=True)
-                log_info.update({'error': details, 'full_traceback': traceback.format_exc()})
+                log_info.update({'error': str(details), 'full_traceback': traceback.format_exc()})
                 status = False
 
             finally:


### PR DESCRIPTION
If nemesis raises the exception during disrupt methond,
in disrupt_method_wrapper, adding such exception to
log_info["error"] dict sometimes add as py object
and not converted to str. This could trigger 'Circular reference detected'
exception during save email data with test result to json file

convert Exception object to string.
 
The issue reproduced during job: https://jenkins.scylladb.com/job/scylla-master/job/longevity/job/longevity-200gb-48h/133/
Testid : 9c20da8f-f455-4c3a-b333-3ef70ee52c66

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
