### PR TITLE
feature(artifacts test): add test for web installer

### DIFF
--- a/configurations/web_install.yaml
+++ b/configurations/web_install.yaml
@@ -1,0 +1,3 @@
+# Install Scylla by Web Installer script
+# https://github.com/scylladb/scylla-web-install
+install_mode: 'web'

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -170,3 +170,5 @@ data_volume_disk_num: 0
 data_volume_disk_type: ''
 data_volume_disk_size: 0
 data_volume_disk_iops: 0 # depend on type iops could be 100-16000 for io2|io3 and 3000-16000 for gp3
+
+install_mode: 'repo'  # install from scylla_repo

--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -206,6 +206,7 @@ function run_in_docker () {
             ${BUILD_OPTIONS} \
             ${JENKINS_OPTIONS} \
             ${AWS_OPTIONS} \
+            --env GIT_BRANCH \
             --net=host \
             --name="${SCT_TEST_ID}_$(date +%s)" \
             ${DOCKER_REPO}:${VERSION} \
@@ -239,6 +240,7 @@ function run_in_docker () {
             ${BUILD_OPTIONS} \
             ${JENKINS_OPTIONS} \
             ${AWS_OPTIONS} \
+            --env GIT_BRANCH \
             --net=host \
             --name="${SCT_TEST_ID}_$(date +%s)" \
             ${DOCKER_REPO}:${VERSION} \

--- a/jenkins-pipelines/artifacts-centos8-web.jenkinsfile
+++ b/jenkins-pipelines/artifacts-centos8-web.jenkinsfile
@@ -1,0 +1,14 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: '''["test-cases/artifacts/centos8.yaml", "configurations/web_install.yaml"]''',
+    backend: 'gce',
+    provision_type: 'spot',
+    scylla_mgmt_repo: '',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/jenkins-pipelines/artifacts-ubuntu2004-web.jenkinsfile
+++ b/jenkins-pipelines/artifacts-ubuntu2004-web.jenkinsfile
@@ -1,0 +1,14 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: '''["test-cases/artifacts/ubuntu2004.yaml", "configurations/web_install.yaml"]''',
+    backend: 'gce',
+    provision_type: 'spot',
+    scylla_mgmt_repo: '',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -74,6 +74,7 @@ from sdcm.utils.common import (
     change_default_password,
 )
 from sdcm.utils.distro import Distro
+from sdcm.utils.install import InstallMode
 from sdcm.utils.docker_utils import ContainerManager, NotFound, docker_hub_login
 from sdcm.utils.health_checker import check_nodes_status, check_node_status_in_gossip_and_nodetool_status, \
     check_schema_version, check_nulls_in_peers, check_schema_agreement_in_gossip_and_peers, \
@@ -2146,6 +2147,27 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 rm -f /tmp/scylla.yaml
             """)
             self.remoter.run('sudo bash -cxe "%s"' % install_cmds)
+
+    def web_install_scylla(self, scylla_version: Optional[str] = None) -> None:
+        """
+        Install scylla by Scylla Web Installer Script. Try to use install the latest
+        unstable build for the test branch, generally it should install same version
+        as the unstable scylla_repo.
+
+        https://github.com/scylladb/scylla-web-install
+        """
+
+        # Try to get the major version from the branch name, it will only be used when scylla_version isn't assigned.
+        # It can be switched to RELEASE_BRANCH from upstream job
+        git_branch = os.environ.get('GIT_BRANCH')  # origin/branch-4.5
+        self.log.debug("scylla_version: %s, git_branch: %s", scylla_version, git_branch)
+
+        if match := re.match(r'\D*(\d+\.\d+)', scylla_version or git_branch):
+            version = f"nightly-{match.group(1)}"
+        else:
+            raise Exception("Scylla version for web install isn't identified")
+
+        self.remoter.run(f"curl -sSf get.scylladb.com/server | sudo bash -s -- --scylla-version {version}")
 
     def install_scylla_debuginfo(self) -> None:
         if self.distro.is_rhel_like:
@@ -4235,6 +4257,16 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
     def _scylla_install(self, node):
         node.update_repo_cache()
         node.clean_scylla()
+
+        install_mode = self.params.get('install_mode')
+        try:
+            mode = InstallMode(install_mode)
+        except Exception as ex:
+            raise ValueError(f'Invalid install mode: {install_mode}, err: {ex}') from ex
+
+        if mode == InstallMode.WEB:
+            node.web_install_scylla(scylla_version=self.params.get('scylla_version'))
+
         if self.params.get('unified_package'):
             node.offline_install_scylla(unified_package=self.params.get('unified_package'),
                                         nonroot=self.params.get('nonroot_offline_install'))

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -184,6 +184,9 @@ class SCTConfiguration(dict):
         dict(name="nonroot_offline_install", env="SCT_NONROOT_OFFLINE_INSTALL", type=boolean,
              help="Install Scylla without required root priviledge"),
 
+        dict(name="install_mode", env="SCT_INSTALL_MODE", type=str,
+             help="Scylla install mode, repo/offline/web"),
+
         dict(name="scylla_version", env="SCT_SCYLLA_VERSION",
              type=str,
              help="""Version of scylla to install, ex. '2.3.1'

--- a/sdcm/utils/install.py
+++ b/sdcm/utils/install.py
@@ -1,0 +1,20 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2020 ScyllaDB
+
+import enum
+
+
+class InstallMode(enum.Enum):
+    REPO = "repo"
+    OFFLINE = "offline"
+    WEB = "web"


### PR DESCRIPTION
Currently we always passed the unstable scylla_repo to artifacts-test
jobs. But the web installer won't use it.

web_install_scylla() tries to use install the latest unstable build for
the current test branch, generally it should install same version as the
unstable scylla_repo.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)


#### Test jobs

https://jenkins.scylladb.com/job/scylla-master/job/artifacts/job/artifacts-centos8-web-test/
https://jenkins.scylladb.com/job/scylla-master/job/artifacts/job/artifacts-ubuntu2004-web-test/
