### PR TITLE
fix(node_setup): ignore status of iptables stop

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4199,8 +4199,8 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
     def node_setup(self, node: BaseNode, verbose: bool = False, timeout: int = 3600):  # pylint: disable=too-many-branches
         node.wait_ssh_up(verbose=verbose, timeout=timeout)
         if node.distro.is_centos8 or node.distro.is_rhel8 or node.distro.is_oel8:
-            node.remoter.sudo('systemctl stop iptables')
-            node.remoter.sudo('systemctl disable iptables')
+            node.remoter.sudo('systemctl stop iptables', ignore_status=True)
+            node.remoter.sudo('systemctl disable iptables', ignore_status=True)
         node.update_repo_cache()
 
         install_scylla = True


### PR DESCRIPTION
on latest job for 4.5.rc7 offline installer failed
because Centos8 image doesn't have iptables service.

Job: https://jenkins.scylladb.com/job/scylla-4.5/job/artifacts-offline-install/job/artifacts-centos8-nonroot-test/119/execution/node/48/log/

Add ignore status to command execution

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
