### PR TITLE
fix(siren backends): Adjust siren backens for sct cloud-provider option

### DIFF
--- a/vars/getCloudProviderFromBackend.groovy
+++ b/vars/getCloudProviderFromBackend.groovy
@@ -6,6 +6,8 @@ def call(String backend) {
         'k8s-local-kind-aws': 'aws',
         'k8s-local-kind-gce': 'gce',
         'k8s-gce-minikube': 'gce',
+        'aws-siren': 'aws',
+        'gce-siren': 'gce',
         ]
     if (!backend) {
         return backend


### PR DESCRIPTION
	'aws-siren' and 'gce-siren' values were added as new backends.
	Thus it should be adjusted when cloud-provider value is requested.

siren-tests corresponding PR is: https://github.com/scylladb/siren-tests/pull/713
Trello: https://trello.com/c/MAjHqcc3

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
