### PR TITLE
fix(mgmt.common.py): add OEL and Amazon2 defaults

### DIFF
--- a/sdcm/mgmt/common.py
+++ b/sdcm/mgmt/common.py
@@ -12,13 +12,16 @@ LOGGER = logging.getLogger(__name__)
 
 def get_distro_name(distro_object):
     known_distro_dict = {
+        Distro.AMAZON2: "centos7",
         Distro.CENTOS7: "centos7",
         Distro.CENTOS8: "centos8",
         Distro.DEBIAN9: "debian9",
         Distro.DEBIAN10: "debian10",
         Distro.UBUNTU16: "ubuntu16",
         Distro.UBUNTU18: "ubuntu18",
-        Distro.UBUNTU20: "ubuntu20"
+        Distro.UBUNTU20: "ubuntu20",
+        Distro.OEL7: "centos7",
+        Distro.OEL8: "centos8"
     }
     distro_name = known_distro_dict.get(distro_object, None)
     assert distro_name, f"Unfamiliar distribution: {distro_object}"


### PR DESCRIPTION
Small fix for `get_distro_name` compatibility with our artifact jobs. We're using OEL7/8 and AMAZON2 distros there, so we need to pair them with the correct manager repo (centos in this case).

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
