### PR TITLE
feature(k8s-local-kind): separate K8S nodes for db and common types

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -811,8 +811,9 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
                 LOGGER.info("Install DaemonSets required by scylla nodes")
                 self.apply_file(node_prepare_config, modifiers=affinity_modifiers, envsubst=False)
 
-            LOGGER.info("Install local volume provisioner")
-            self.helm(f"install local-provisioner {LOCAL_PROVISIONER_DIR}", values=node_pool.helm_affinity_values)
+                LOGGER.info("Install local volume provisioner")
+                self.helm(f"install local-provisioner {LOCAL_PROVISIONER_DIR}",
+                          values=node_pool.helm_affinity_values)
 
             # Calculate cpu and memory limits to occupy all available amounts by scylla pods
             cpu_limit, memory_limit = node_pool.cpu_and_memory_capacity
@@ -822,7 +823,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
                 - OPERATOR_CONTAINERS_RESOURCES['cpu']
                 - COMMON_CONTAINERS_RESOURCES['cpu']
             )
-            memory_limit = int(
+            memory_limit = (
                 memory_limit
                 - OPERATOR_CONTAINERS_RESOURCES['memory']
                 - COMMON_CONTAINERS_RESOURCES['memory']
@@ -831,7 +832,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
             cpu_limit = 1
             memory_limit = 2.5
 
-        cpu_limit = int(cpu_limit)
+        cpu_limit = convert_cpu_units_to_k8s_value(cpu_limit)
         memory_limit = convert_memory_units_to_k8s_value(memory_limit)
 
         # Deploy scylla cluster

--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -541,7 +541,13 @@ class LocalMinikubeCluster(MinikubeK8sMixin, LocalMinimalClusterBase):
 
 
 class LocalKindCluster(KindK8sMixin, LocalMinimalClusterBase):
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.allowed_labels_on_scylla_node = [
+            ('k8s-app', 'kindnet'),
+            ('k8s-app', 'kube-proxy'),
+            ('scylla/cluster', self.k8s_scylla_cluster_name),
+        ]
 
 
 class RemoteMinimalClusterBase(MinimalClusterBase, metaclass=abc.ABCMeta):

--- a/sdcm/k8s_configs/minio/values.yaml
+++ b/sdcm/k8s_configs/minio/values.yaml
@@ -129,6 +129,15 @@ affinity:
             values:
             - auxiliary-pool
             - default-pool
+      # Minimal K8S (kind, minikube)
+      - weight: 100
+        preference:
+          matchExpressions:
+          - key: minimal-k8s-nodepool
+            operator: In
+            values:
+            - auxiliary-pool
+            - default-pool
 
 ## Add stateful containers to have security context, if enabled MinIO will run as this
 ## user and group NOTE: securityContext is only enabled if persistence.enabled=true

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -948,6 +948,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             params=self.params,
         )
         self.k8s_cluster.deploy()
+        for namespace in ('kube-system', 'local-path-storage'):
+            self.k8s_cluster.set_nodeselector_for_deployments(
+                pool_name=self.k8s_cluster.AUXILIARY_POOL_NAME, namespace=namespace)
         self.k8s_cluster.deploy_cert_manager(pool_name=self.k8s_cluster.AUXILIARY_POOL_NAME)
         self.k8s_cluster.deploy_scylla_operator(pool_name=self.k8s_cluster.AUXILIARY_POOL_NAME)
         if self.params.get('use_mgmt'):


### PR DESCRIPTION
We need to have dedicated K8S nodes for Scylla pods to be able
to perform various disruptions not making other services suffer
and provide unexpected failures.
So, configure kind nodes the way that we will have following set:
- 1 control plane node for K8S pods
- 2 default nodes for operator, manager and cert manager pods
- x (n_db_nodes + 1) scylla nodes for scylla pods

Also, fail early running with 'minikube' backend while we do not
add multi-node support for it.
It is low priority having 'kind' backend working.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
