### PR TITLE
fix(k8s-functional-tests): correctly wait for the restored cluster state

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2026,8 +2026,6 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
                     metadata={'name': SCYLLA_CONFIG_NAME}
                 )
             )
-        self.restart_scylla()
-        self.wait_for_nodes_up_and_normal()
 
     @contextlib.contextmanager
     def remote_cassandra_rackdc_properties(self) -> ContextManager:
@@ -2059,6 +2057,8 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
                 diff = "".join(unified_diff(original, changed))
                 LOGGER.debug("%s: cassandra-rackdc.properties has been updated:\n%s", self, diff)
                 scylla_config_map['cassandra-rackdc.properties'] = changed_bare
+                self.restart_scylla()
+                self.wait_for_nodes_up_and_normal()
 
     def update_seed_provider(self):
         pass


### PR DESCRIPTION
In operator 1.4 was changed the approach for reconciliation and
now spec update of a ScyllaCluster CRD causes rollout restart
automatically. So, having this new logic we have redundant rollouts
in our restore cluster for functional tests.
So, update it to be compatible with lateset operator logic avoiding
redundant restarts.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
