### PR TITLE
fix(elasticsearch): handle elasticsearch connection exceptions

### DIFF
--- a/sdcm/results_analyze/test.py
+++ b/sdcm/results_analyze/test.py
@@ -475,11 +475,16 @@ class TestResultClass(ClassBase):
     def get_by_params(cls, es_index=es_index, **params):
         es_query = cls._get_es_query_from_instance_data(params)
         filter_path = cls._get_es_filters()
-        es_data = ES().search(
-            index=es_index,
-            q=es_query,
-            filter_path=filter_path,
-            size=10000)
+        try:
+            es_data = ES().search(
+                index=es_index,
+                q=es_query,
+                filter_path=filter_path,
+                size=10000)
+        except Exception as exc:  # pylint: disable=broad-except
+            LOGGER.warning("Unable to find ES data: %s", exc)
+            es_data = None
+
         if not es_data:
             return []
         es_data = es_data.get('hits', {}).get('hits', {})
@@ -538,10 +543,15 @@ class TestResultClass(ClassBase):
 
     def get_prior_tests(self, filter_path=None) -> typing.List['TestResultClass']:
         output = []
-        es_query = self.get_same_tests_query()
-        es_result = ES().search(index=self._es_data['_index'], q=es_query, filter_path=filter_path,
-                                size=10000)  # pylint: disable=unexpected-keyword-arg
-        es_result = es_result.get('hits', {}).get('hits', None) if es_result else None
+        try:
+            es_query = self.get_same_tests_query()
+            es_result = ES().search(index=self._es_data['_index'], q=es_query, filter_path=filter_path,
+                                    size=10000)  # pylint: disable=unexpected-keyword-arg
+            es_result = es_result.get('hits', {}).get('hits', None) if es_result else None
+        except Exception as exc:  # pylint: disable=broad-except
+            LOGGER.warning("Unable to find ES data: %s", exc)
+            es_result = None
+
         if not es_result:
             return output
         for es_data in es_result:  # pylint: disable=not-an-iterable


### PR DESCRIPTION
In certain cases inability to connect to the elasticsearch can
bring down the entire thread where it is not necessary, this pr
addresses those cases by adding a catch all exception to elasticsearch
calls

[Trello link](https://trello.com/c/anRlwIIL/3366-elasticsearch-updates-shouldnt-fail-tests)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
