### PR TITLE
improvement(run_pytest): allow to provide additional pytest params in CI

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -164,6 +164,9 @@ fi
 # export all SCT_* env vars into the docker run
 SCT_OPTIONS=$(env | grep SCT_ | cut -d "=" -f 1 | xargs -i echo "--env {}")
 
+# export all PYTEST_* env vars into the docker run
+PYTEST_OPTIONS=$(env | grep PYTEST_ | cut -d "=" -f 1 | xargs -i echo "--env {}")
+
 # export all BUILD_* env vars into the docker run
 BUILD_OPTIONS=$(env | grep BUILD_ | cut -d "=" -f 1 | xargs -i echo "--env {}")
 
@@ -203,6 +206,7 @@ function run_in_docker () {
             -u ${USER_ID} \
             ${DOCKER_GROUP_ARGS[@]} \
             ${SCT_OPTIONS} \
+            ${PYTEST_OPTIONS} \
             ${BUILD_OPTIONS} \
             ${JENKINS_OPTIONS} \
             ${AWS_OPTIONS} \
@@ -236,6 +240,7 @@ function run_in_docker () {
             -u ${USER_ID} \
             ${DOCKER_GROUP_ARGS[@]} \
             ${SCT_OPTIONS} \
+            ${PYTEST_OPTIONS} \
             ${BUILD_OPTIONS} \
             ${JENKINS_OPTIONS} \
             ${AWS_OPTIONS} \

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -91,6 +91,15 @@ def call(Map pipelineParams) {
                    description: 'Name of the test to run',
                    name: 'test_name')
 
+            string(defaultValue: "${pipelineParams.get('pytest_addopts', '')}",
+                   description: (
+                        '"pytest_addopts" is used by "run_pytest" hydra command. \n' +
+                        'Useful for K8S functional tests which run using pytest. \n' +
+                        'PyTest runner allows to provide any options using "PYTEST_ADDOPTS" ' +
+                        'env var which gets set here if value is provided. \n' +
+                        'Example: "--maxfail=1" - it will stop test run after first failure.'),
+                   name: 'pytest_addopts')
+
             string(defaultValue: "${pipelineParams.get('k8s_scylla_operator_helm_repo', 'https://storage.googleapis.com/scylla-operator-charts/latest')}",
                    description: 'Scylla Operator helm repo',
                    name: 'k8s_scylla_operator_helm_repo')

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -125,6 +125,10 @@ def call(Map params, String region, functional_test = false){
         export SCT_MANAGER_VERSION="${params.manager_version}"
     fi
 
+    if [[ -n "${params.pytest_addopts ? params.pytest_addopts : ''}" ]] ; then
+        export PYTEST_ADDOPTS="${params.pytest_addopts}"
+    fi
+
     echo "start test ......."
     if [[ "$cloud_provider" == "aws" || "$cloud_provider" == "gce" || "$cloud_provider" == "k8s-local-kind-aws" || "$cloud_provider" == "k8s-local-kind-gce" ]]; then
         RUNNER_IP=\$(cat sct_runner_ip||echo "")


### PR DESCRIPTION
In hydra we have "run-pytest" command which is used for K8S functional
tests. And we may want to provide different set of options for it
from time to time. So, add such possibility to provide pytest options
by adding new pipeline parameter called 'pytest_addopts'.
Under the hood it utilizes 'PYTEST_ADDOPTS' env var.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
