### PR TITLE
fix(sct_config.py): return back support for 2-digit versions

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1395,14 +1395,15 @@ class SCTConfiguration(dict):
             if self.get("cluster_backend") in ["docker", "k8s-gce-minikube", "k8s-gke"]:
                 self.log.info("Assume that Scylla Docker image has repo file pre-installed.")
             elif not self.get('ami_id_db_scylla') and self.get('cluster_backend') == 'aws':
-                suffix = f" {scylla_version}"  # ami.name format example: ScyllaDB 4.4.0
+                # ami.name format examples: ScyllaDB 4.4.0 or ScyllaDB Enterprise 2019.1.1
+                scylla_version_substr = f" {scylla_version}"
                 ami_list = []
                 for region in region_names:
                     if ':' in scylla_version:
                         ami = get_branched_ami(scylla_version=scylla_version, region_name=region)[0]
                     else:
                         for ami in get_scylla_ami_versions(region_name=region):
-                            if ami.name.endswith(suffix):
+                            if scylla_version_substr in ami.name:
                                 break
                         else:
                             raise ValueError(f"AMIs for {scylla_version=} not found in {region}")
@@ -1414,9 +1415,9 @@ class SCTConfiguration(dict):
                     gce_image = get_branched_gce_images(scylla_version=scylla_version)[0]
                 else:
                     # gce_image.name format examples: scylla-4-3-6 or scylla-enterprise-2021-1-2
-                    suffix = f"-{scylla_version.replace('.', '-')}"
+                    scylla_version_substr = f"scylla-{scylla_version.replace('.', '-')}"
                     for gce_image in get_scylla_gce_images_versions():
-                        if gce_image.name.endswith(suffix):
+                        if gce_image.name.replace("-enterprise", "").startswith(scylla_version_substr):
                             break
                     else:
                         raise ValueError(f"GCE images for {scylla_version=} not found")


### PR DESCRIPTION
I've slightly changed the logic of AMI selection in https://github.com/scylladb/scylla-cluster-tests/commit/01bcc064624508177a591fa11133118d75e5ade5

This change caused failures of https://jenkins.scylladb.com/job/scylla-master/job/rolling-upgrade/job/rolling-upgrade-ami-test/

This PR will return ability to use versions like 4.5 or 2020.1

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
