### PR TITLE
ci(k8s-gke): fix region setting for the k8s-gke backend

### DIFF
--- a/jenkins-pipelines/operator/upgrade/upgrade-major-scylla-k8s-gke.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-major-scylla-k8s-gke.jenkinsfile
@@ -4,6 +4,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingOperatorUpgradePipeline(
     backend: 'k8s-gke',
+    aws_region: 'us-east1',
     base_versions: '["4.1.5"]',
     new_version: '4.2.1',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_scylla_upgrade',

--- a/jenkins-pipelines/operator/upgrade/upgrade-operator-k8s-gke.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-operator-k8s-gke.jenkinsfile
@@ -4,6 +4,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingOperatorUpgradePipeline(
     backend: 'k8s-gke',
+    aws_region: 'us-east1',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_operator_upgrade',
     test_config: 'test-cases/scylla-operator/kubernetes-operator-upgrade.yaml',
 )

--- a/jenkins-pipelines/operator/upgrade/upgrade-scylla-k8s-gke.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-scylla-k8s-gke.jenkinsfile
@@ -4,6 +4,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingOperatorUpgradePipeline(
     backend: 'k8s-gke',
+    aws_region: 'us-east1',
     base_versions: '["4.2.0"]',
     new_version: '4.2.1',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_scylla_upgrade',

--- a/vars/rollingOperatorUpgradePipeline.groovy
+++ b/vars/rollingOperatorUpgradePipeline.groovy
@@ -14,10 +14,11 @@ def call(Map pipelineParams) {
             SCT_TEST_ID = UUID.randomUUID().toString()
         }
         parameters {
-            choice(choices: ["${pipelineParams.get('backend', 'k8s-gke')}", 'k8s-gke', 'k8s-gce-minikube'],
+            choice(choices: ["${pipelineParams.get('backend', 'k8s-gke')}", 'k8s-eks', 'k8s-gke'],
                    name: 'backend')
-            choice(choices: ["${pipelineParams.get('aws_region', '')}", 'eu-north-1', 'eu-west-1', 'eu-central-1', 'us-east-1'],
-                   name: 'aws_region')
+            string(defaultValue: "${pipelineParams.get('aws_region', '')}",
+               description: 'Supported: us-east-1|eu-west-1|eu-west-2|eu-north-1|random (randomly select region)',
+               name: 'aws_region')
             string(defaultValue: "a",
                description: 'Availability zone',
                name: 'availability_zone')


### PR DESCRIPTION
For the moment 'rollingOperatorUpgradePipeline' pipeline uses
'aws_region' var for both backends - 'k8s-eks' and 'k8s-gke'.
But it doesn't allow to specify k8s-gke specific ones.
So, fix it by removing 'choice' and adding possibility to set any
region.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
