### PR TITLE
feature(py-env-manager): add config for the 'tox' python env manager

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,37 @@
+# If "pip" is not installed, install it running following command:
+#   $ yum install python-pip
+#
+# If "tox" is not installed, install it running following command:
+#   $ pip install -e git://github.com/tox-dev/tox.git@3.23.1#egg=tox
+#
+# After it you can use "tox" command. Example:
+#   $ tox -e py39 -- pwd
+
+[tox]
+# With version 1.6.0 'skipsdist' config option was added. It allows to skip
+# installation of current project to 'sdist' (no req to define setup.py file).
+minversion = 1.6.0
+skipsdist = True
+sitepackages = False
+
+[testenv]
+envdir = {toxworkdir}/{envname}
+passenv = PYTEST_* SCT_*
+whitelist_externals = *
+commands =
+    python -m pip install --upgrade pip>=9.0.0 setuptools wheel
+    pip install -r requirements.in
+
+[testenv:py38]
+basepython = python3.8
+commands =
+    {[testenv]commands}
+    mkdir -p {envdir}/lib/python3.8/site-packages
+    bash -c "{posargs:echo 'No commands have been specified. Exiting.'}"
+
+[testenv:py39]
+basepython = python3.9
+commands =
+    {[testenv]commands}
+    mkdir -p {envdir}/lib/python3.9/site-packages
+    bash -c "{posargs:echo 'No commands have been specified. Exiting.'}"


### PR DESCRIPTION
Just having this config it is possible to run SCT in the venv just using
following command:

    tox -e py39 -- ./sct.py %other-options%

This command will also propagate all SCT_* and PYTEST_* options
to the env from the current shell.

Details about 'tox' python env manager:

    https://tox.readthedocs.io/en/latest/install.html

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
