### PR TITLE
fix(k8s-functional-tests): refer to correct object with scylla namespace

### DIFF
--- a/functional_tests/scylla_operator/libs/helpers.py
+++ b/functional_tests/scylla_operator/libs/helpers.py
@@ -65,7 +65,7 @@ def wait_for_resource_absence(db_cluster: ScyllaPodCluster,
     def resource_is_absent() -> bool:
         all_resources = db_cluster.k8s_cluster.kubectl(
             f"get {resource_type} -o=custom-columns=:.metadata.name",
-            namespace=db_cluster.k8s_cluster.SCYLLA_NAMESPACE,
+            namespace=SCYLLA_NAMESPACE,
         ).stdout.split()
         return resource_name not in all_resources
 


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
