### PR TITLE
fix(show_top_partition): disable new toppartition api

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2055,7 +2055,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         ks_cf_list = self.cluster.get_any_ks_cf_list(self.target_node)
         if not ks_cf_list:
             raise UnsupportedNemesis('User-defined Keyspace and ColumnFamily are not found.')
-        top_partition_api = random.choice([NewApiTopPartitionCmd, OldApiTopPartitionCmd])(ks_cf_list)
+        top_partition_api = OldApiTopPartitionCmd(ks_cf_list)
         # workaround for issue #4519
         self.target_node.run_nodetool('cfstats')
         top_partition_api.generate_cmd_arg_values()


### PR DESCRIPTION
Feature new toppartition api was disabled on branch-4.5
Left only old toppartition api

Trello: https://trello.com/c/71AMcRLj

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
