### PR TITLE
scy.py:list-ami-branch:ignore images with debug-image prefix

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -425,7 +425,9 @@ def list_ami_branch(region, version):
         test_status = [click.style(k, fg='green') for k, v in test_status if v == 'PASSED'] + \
                       [click.style(k, fg='red') for k, v in test_status if not v == 'PASSED']
         test_status = ", ".join(test_status) if test_status else click.style('Unknown', fg='yellow')
-        tbl.add_row([ami.name, ami.image_id, ami.creation_date, tags['build-id'], test_status])
+        if not ami.name.startswith('debug-image'):
+            tbl.add_row([ami.name, ami.image_id, ami.creation_date, tags['build-id'], test_status])
+
     click.echo(tbl.get_string(title="Scylla AMI branch versions"))
 
 


### PR DESCRIPTION
Today when using the command `hydra list-ami-branch master:latest` we
get latest master AMI.
In https://github.com/scylladb/scylla-pkg/pull/2396 and
https://github.com/scylladb/scylla-machine-image/pull/203 we added a prefix to identify the releng testing debug AMIs. 
**(Need to merge only after those 2 are merged)**

Let's make sure we ignore those images here

Fixes: 	https://github.com/scylladb/scylla-cluster-tests/issues/3950
