### PR TITLE
fix(static_ips): display instance name if ip's name is empty

### DIFF
--- a/sdcm/utils/cloud_monitor/resources/static_ips.py
+++ b/sdcm/utils/cloud_monitor/resources/static_ips.py
@@ -67,8 +67,12 @@ class StaticIPs(CloudResources):
         # identify user by the owner of the resource
         cloud_instances_by_id = {instance.instance_id: instance for instance in self.cloud_instances["aws"]}
         for eip in self["aws"]:
-            if eip.owner == NA and eip.used_by != NA and cloud_instances_by_id.get(eip.used_by):
-                eip.owner = cloud_instances_by_id[eip.used_by].owner
+            if eip.used_by != NA and cloud_instances_by_id.get(eip.used_by):
+                if eip.owner == NA:
+                    eip.owner = cloud_instances_by_id[eip.used_by].owner
+                if eip.name == NA:
+                    # display the used instance name if ip's name is empty
+                    eip.name = f"{NA} ({cloud_instances_by_id[eip.used_by].name})"
         self.all.extend(self["aws"])
 
     def get_gce_static_ips(self):


### PR DESCRIPTION
Currently we only display the used instance ID, it's difficult to know
the purpose of the ip when the ip'name is empty. This patch changed to
display the instance name additionally.

Signed-off-by: Amos Kong <amos@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
