### PR TITLE
fix(data validator): prevent creation tables with same name

### DIFF
--- a/sdcm/utils/data_validator.py
+++ b/sdcm/utils/data_validator.py
@@ -205,10 +205,13 @@ class LongevityDataValidator:
         """
         if not self._mvs_for_updated_data:
             mvs_names = self.get_view_name_from_profile(self.SUFFIX_FOR_VIEW_AFTER_UPDATE, all_entries=True)
-            self._mvs_for_updated_data = [view_name.replace(self.SUFFIX_FOR_VIEW_AFTER_UPDATE, '')
-                                          for view_name in mvs_names]
-            return self._mvs_for_updated_data
-
+            # Cover the case when there are 2 MVs in the profile with same prefix in the name. After replacing of
+            # SUFFIX_FOR_VIEW_AFTER_UPDATE from the name, two views with same names will be in the list. In this case
+            # creation table failure will be received.
+            # Example:
+            # blogposts_update_one_column_lwt_indicator AND blogposts_update_one_column_lwt_indicator_after_update
+            self._mvs_for_updated_data = list(set(view_name.replace(self.SUFFIX_FOR_VIEW_AFTER_UPDATE, '')
+                                                  for view_name in mvs_names))
         return self._mvs_for_updated_data
 
     @property


### PR DESCRIPTION
Cover the case when there are 2 MVs in the profile with same prefix in the name. After replacing of
SUFFIX_FOR_VIEW_AFTER_UPDATE from the name, two views with same names will be in the list.
In this case creation table failure will be received.

Example:
blogposts_update_one_column_lwt_indicator AND blogposts_update_one_column_lwt_indicator_after_update

Error:
AlreadyExists: Table 'cqlstress_lwt_example.blogposts_update_one_column_lwt_indicator_expect'
already exists

Failed test:
https://jenkins.scylladb.com/job/scylla-4.4/job/longevity/job/longevity-lwt-500G-3d-test/3/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
