### PR TITLE
fix(sct_config): fail fast when no available non-seed nodes for nemesis

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1707,8 +1707,7 @@ class SCTConfiguration(dict):
             f"Seeds number ({seeds_num}) should be not more then nodes number ({num_of_db_nodes})"
 
     def _validate_nemesis_can_run_on_non_seed(self) -> None:
-        nemesis_filter_seeds = self.get('nemesis_filter_seeds')
-        if nemesis_filter_seeds is False:
+        if self.get('nemesis_filter_seeds') is False or self.get('nemesis_class_name') == "NoOpMonkey":
             return
         seeds_num = self.get('seeds_num')
         num_of_db_nodes = sum([int(i) for i in str(self.get('n_db_nodes')).split(' ')])


### PR DESCRIPTION
When running sct with 'nemesis_filter_seeds' set to true and when 'n_db_nodes' count is equal to 'seeds_num'
nemesis cannot find node to run causing errors.
Change prevents from setting n_db_nodes equal to seeds_num when nemesis_filter_seeds is set to true
trello card: https://trello.com/c/5rp4gDLq
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
