### PR TITLE
fix(nemesis-on-k8s): disable methods which don't work on scylla 4.4

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3721,6 +3721,11 @@ class KubernetesScyllaOperatorMonkey(Nemesis):
             # So, skip it until it gets stabilized.
             "disrupt_nodetool_refresh",
             "disrupt_restart_with_resharding",
+            # NOTE: skip following methods because operator uses only
+            # stable scylla versions and these methods cover features in un-released scylla versions
+            # such as 4.5-rc.x . Remove following when operator's minimum scylla version becomes 4.5
+            "disrupt_load_and_stream",
+            "show_toppartitions",
         )
         self.disrupt_methods_list = list(
             set(self.get_list_of_methods_compatible_with_backend()) - set(ignore_methods))


### PR DESCRIPTION
Disable 'load_and_stream' and 'show_toppartitions' nemesis methods
for running against K8S backends because it's support available only
only Scylla-4.5, which is unreleased yet. But operator uses only stable
Scylla versions.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
