### PR TITLE
feature(sct-runner): allow to define instance type

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1117,9 +1117,11 @@ def create_runner_image(cloud_provider, region, availability_zone):
               help="Name of the region")
 @click.option("-z", "--availability-zone", required=False, default="", type=str,
               help="Name of availability zone, ex. 'a'")
+@click.option("-i", "--instance-type", required=False, type=str, default="", help="Instance type")
 @click.option("-t", "--test-id", required=True, type=str, help="Test ID")
 @click.option("-d", "--duration", required=True, type=int, help="Test duration in MINUTES")
-def create_runner_instance(cloud_provider, region, availability_zone, test_id, duration):
+def create_runner_instance(cloud_provider, region, availability_zone, instance_type,
+                           test_id, duration):
     cloud_provider = cloud_provider.lower()
     if cloud_provider == 'aws' and availability_zone != "":
         assert len(availability_zone) == 1, f"Invalid AZ: {availability_zone}, availability-zone is one-letter a-z."
@@ -1135,7 +1137,12 @@ def create_runner_instance(cloud_provider, region, availability_zone, test_id, d
     else:
         raise Exception('Unsupported Cloud provider')
 
-    instance = sct_runner.create_instance(test_id=test_id, test_duration=duration, region_az=region + availability_zone)
+    instance = sct_runner.create_instance(
+        instance_type=instance_type,
+        test_id=test_id,
+        test_duration=duration,
+        region_az=region + availability_zone,
+    )
     if cloud_provider == 'aws':
         runner_public_ip = instance.public_ip_address
     elif cloud_provider == 'gce':

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -152,7 +152,7 @@ class SctRunner(ABC):
     def _get_base_image(self, image=None):
         ...
 
-    def create_instance(self, test_id: str, test_duration: int, region_az: str):
+    def create_instance(self, test_id: str, test_duration: int, region_az: str, instance_type: str = ''):
         """
             :param test_duration: used to set keep-alive flags, measured in MINUTES
         """
@@ -165,7 +165,7 @@ class SctRunner(ABC):
             sys.exit(1)
         lt_datetime = datetime.datetime.now(tz=pytz.utc)
         return self._create_instance(
-            instance_type=self.instance_type(test_duration=test_duration),
+            instance_type=instance_type or self.instance_type(test_duration=test_duration),
             base_image=self._get_base_image(self.image),
             tags_list=[
                 {"Key": "Name", "Value": self.RUNNER_NAME},
@@ -506,4 +506,5 @@ if __name__ == "__main__":
     TEST_ZONE = "a"
     SCT_RUNNER = AwsSctRunner(region_name=TEST_REGION, availability_zone=TEST_ZONE)
     SCT_RUNNER.create_image()
-    SCT_RUNNER.create_instance(test_id="byakabuka", test_duration=60, region_az=f"{TEST_REGION}{TEST_ZONE}")
+    SCT_RUNNER.create_instance(
+        instance_type="", test_id="byakabuka", test_duration=60, region_az=f"{TEST_REGION}{TEST_ZONE}")

--- a/vars/createSctRunner.groovy
+++ b/vars/createSctRunner.groovy
@@ -9,7 +9,7 @@ def call(Map params, Integer test_duration, String region) {
     set -xe
     env
 
-    if [[ "$cloud_provider" == "aws" || "$cloud_provider" == "gce" || "$cloud_provider" == "k8s-local-kind-aws" || "$cloud_provider" == "k8s-local-kind-gce" ]]; then
+    if [[ "$cloud_provider" == "aws" || "$cloud_provider" == "gce" ]]; then
         rm -fv sct_runner_ip
         ./docker/env/hydra.sh create-runner-instance --cloud-provider ${cloud_provider} --region ${region} --availability-zone ${params.availability_zone} --test-id \${SCT_TEST_ID} --duration ${test_duration}
     else

--- a/vars/createSctRunner.groovy
+++ b/vars/createSctRunner.groovy
@@ -2,6 +2,12 @@
 
 def call(Map params, Integer test_duration, String region) {
     def cloud_provider = getCloudProviderFromBackend(params.backend)
+    def instance_type_arg = ""
+    if ( params.backend == "k8s-local-kind-aws" ) {
+        instance_type_arg = "--instance-type c5.xlarge"
+    } else if ( params.backend == "k8s-local-kind-gce" ) {
+        instance_type_arg = "--instance-type e2-standard-4"
+    }
 
     println(params)
     sh """
@@ -11,7 +17,13 @@ def call(Map params, Integer test_duration, String region) {
 
     if [[ "$cloud_provider" == "aws" || "$cloud_provider" == "gce" ]]; then
         rm -fv sct_runner_ip
-        ./docker/env/hydra.sh create-runner-instance --cloud-provider ${cloud_provider} --region ${region} --availability-zone ${params.availability_zone} --test-id \${SCT_TEST_ID} --duration ${test_duration}
+        ./docker/env/hydra.sh create-runner-instance \
+            --cloud-provider ${cloud_provider} \
+            --region ${region} \
+            --availability-zone ${params.availability_zone} \
+            $instance_type_arg \
+            --test-id \${SCT_TEST_ID} \
+            --duration ${test_duration}
     else
         echo "Currently, <$cloud_provider> not supported to. Will run on regular builder."
     fi

--- a/vars/runCleanupResource.groovy
+++ b/vars/runCleanupResource.groovy
@@ -32,7 +32,7 @@ def call(Map params, String region){
     fi
 
     echo "Starting to clean resources ..."
-    if [[ "$cloud_provider" == "aws" || "$cloud_provider" == "gce" || "$cloud_provider" == "k8s-local-kind-aws" || "$cloud_provider" == "k8s-local-kind-gce" ]]; then
+    if [[ "$cloud_provider" == "aws" || "$cloud_provider" == "gce" ]]; then
         RUNNER_IP=\$(cat sct_runner_ip||echo "")
         if [[ -n "\${RUNNER_IP}" ]] ; then
             ./docker/env/hydra.sh --execute-on-runner \${RUNNER_IP} clean-resources --post-behavior --test-id \$SCT_TEST_ID

--- a/vars/runCollectLogs.groovy
+++ b/vars/runCollectLogs.groovy
@@ -17,7 +17,7 @@ def call(Map params, String region){
     export SCT_CONFIG_FILES=${test_config}
 
     echo "start collect logs ..."
-    if [[ "$cloud_provider" == "aws" || "$cloud_provider" == "gce" || "$cloud_provider" == "k8s-local-kind-aws" || "$cloud_provider" == "k8s-local-kind-gce" ]]; then
+    if [[ "$cloud_provider" == "aws" || "$cloud_provider" == "gce" ]]; then
         RUNNER_IP=\$(cat sct_runner_ip||echo "")
         if [[ -n "\${RUNNER_IP}" ]] ; then
             ./docker/env/hydra.sh --execute-on-runner \${RUNNER_IP} collect-logs

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -130,7 +130,7 @@ def call(Map params, String region, functional_test = false){
     fi
 
     echo "start test ......."
-    if [[ "$cloud_provider" == "aws" || "$cloud_provider" == "gce" || "$cloud_provider" == "k8s-local-kind-aws" || "$cloud_provider" == "k8s-local-kind-gce" ]]; then
+    if [[ "$cloud_provider" == "aws" || "$cloud_provider" == "gce" ]]; then
         RUNNER_IP=\$(cat sct_runner_ip||echo "")
         if [[ -n "\${RUNNER_IP}" ]] ; then
             ./docker/env/hydra.sh --execute-on-runner \${RUNNER_IP} ${test_cmd} ${params.test_name} --backend ${params.backend}

--- a/vars/runSendEmail.groovy
+++ b/vars/runSendEmail.groovy
@@ -20,7 +20,7 @@ def call(Map params, RunWrapper currentBuild){
     set -xe
     env
     echo "Start send email ..."
-    if [[ "$cloud_provider" == "aws" || "$cloud_provider" == "gce" || "$cloud_provider" == "k8s-local-kind-aws" || "$cloud_provider" == "k8s-local-kind-gce" ]]; then
+    if [[ "$cloud_provider" == "aws" || "$cloud_provider" == "gce" ]]; then
         RUNNER_IP=\$(cat sct_runner_ip||echo "")
         if [[ -n "\${RUNNER_IP}" ]] ; then
             ./docker/env/hydra.sh --execute-on-runner \${RUNNER_IP} send-email ${test_status} ${start_time} \


### PR DESCRIPTION
Also, update vars/createSctRunner.groovy with the logic
where we reuse this feature and set non-default instance types
for the "k8s-local-kind-aws" and "k8s-local-kind-gce" backends.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
