### PR TITLE
fix(common:get_branched_ami): filter out debug-image AMIs

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1508,6 +1508,7 @@ def get_branched_ami(scylla_version: str, region_name: str) -> list[EC2Image]:
         key=lambda x: x.creation_date,
         reverse=True,
     )
+    images = [image for image in images if not image.name.startswith('debug-image')]
 
     assert images, f"AMIs for {scylla_version=} not found in {region_name}"
     if build_id == "all":


### PR DESCRIPTION
Recently a debug prefix was introduced for images that are not "production" and used for debugging.
We need to ignore them for all the cloud providers (AWS, GCP)

Trello: https://trello.com/c/EUlhMsPK
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
