### PR TITLE
fix(test_events): fix continues event tests

### DIFF
--- a/unit_tests/test_events.py
+++ b/unit_tests/test_events.py
@@ -10,7 +10,6 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2020 ScyllaDB
-
 import time
 import logging
 import unittest
@@ -66,8 +65,8 @@ class SctEventsTests(BaseEventsTest):  # pylint: disable=too-many-public-methods
     maxDiff = None
 
     def test_disruption_skipped_event(self):
-        with DisruptionEvent(nemesis_name="DeleteByRowsRange",
-                             node="target_node", publish_event=False) as nemesis_event:
+        with self.assertRaises(UnsupportedNemesis), DisruptionEvent(
+                nemesis_name="DeleteByRowsRange", node="target_node", publish_event=False) as nemesis_event:
             try:
                 raise UnsupportedNemesis("This nemesis can run on scylla_bench test only")
             except UnsupportedNemesis as exc:
@@ -84,8 +83,8 @@ class SctEventsTests(BaseEventsTest):  # pylint: disable=too-many-public-methods
         )
 
     def test_disruption_raised_critical_event(self):
-        with DisruptionEvent(nemesis_name="DeleteByRowsRange",
-                             node="target_node", publish_event=False) as nemesis_event:
+        with self.assertRaises(ZeroDivisionError), DisruptionEvent(
+                nemesis_name="DeleteByRowsRange", node="target_node", publish_event=False) as nemesis_event:
             nemesis_event.event_id = "c2561d8b-97ca-44fb-b5b1-8bcc0d437318"
             self.assertEqual(
                 str(nemesis_event),
@@ -107,8 +106,8 @@ class SctEventsTests(BaseEventsTest):  # pylint: disable=too-many-public-methods
         self.assertEqual(nemesis_event.duration_formatted, '15s')
 
     def test_disruption_raised_error_event(self):
-        with DisruptionEvent(nemesis_name="DeleteByRowsRange",
-                             node="target_node", publish_event=False) as nemesis_event:
+        with self.assertRaises(ZeroDivisionError), DisruptionEvent(
+                nemesis_name="DeleteByRowsRange", node="target_node", publish_event=False) as nemesis_event:
             nemesis_event.event_id = "c2561d8b-97ca-44fb-b5b1-8bcc0d437318"
             self.assertEqual(
                 str(nemesis_event),
@@ -129,8 +128,8 @@ class SctEventsTests(BaseEventsTest):  # pylint: disable=too-many-public-methods
         self.assertEqual(nemesis_event.duration_formatted, '15s')
 
     def test_disruption_error_event(self):
-        with DisruptionEvent(nemesis_name="DeleteByRowsRange",
-                             node="target_node", publish_event=False) as nemesis_event:
+        with DisruptionEvent(nemesis_name="DeleteByRowsRange", node="target_node",
+                             publish_event=False) as nemesis_event:
             nemesis_event.event_id = "c2561d8b-97ca-44fb-b5b1-8bcc0d437318"
             self.assertEqual(
                 str(nemesis_event),
@@ -146,11 +145,10 @@ class SctEventsTests(BaseEventsTest):  # pylint: disable=too-many-public-methods
                 nemesis_event.duration = 15
                 nemesis_event.severity = Severity.ERROR
 
-        self.assertEqual(
-            str(nemesis_event),
+        self.assertIn(
             '(DisruptionEvent Severity.ERROR) period_type=end event_id=c2561d8b-97ca-44fb-b5b1-8bcc0d437318 '
-            'duration=15s: nemesis_name=DeleteByRowsRange target_node=target_node errors=division by zero\n'
-            'traceback.format_exc()'
+            'duration=15s: nemesis_name=DeleteByRowsRange target_node=target_node errors=division by zero\n',
+            str(nemesis_event),
         )
 
     def test_disruption_normal_event(self):


### PR DESCRIPTION
There is regression in tests after fa5c1b4ae103088282447d208ecbb4110eba623e
Amend tests to match new behavior

https://trello.com/c/6EwNnFKB/3898-unit-tests-fix-testeventsscteventstests

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
