### PR TITLE
Fix populate data parallel

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2396,7 +2396,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
         total_keys = size_in_gb * 1024 * 1024
         n_loaders = int(self.params.get('n_loaders'))
-        keys_per_node = total_keys / n_loaders
+        keys_per_node = total_keys // n_loaders
 
         write_queue = list()
         start = 1

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2383,13 +2383,14 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             errors=test_events['ERROR'] + test_events['CRITICAL'],
             coredumps=coredumps)
 
-    def populate_data_parallel(self, size_in_gb, blocking=True, read=False):
+    def populate_data_parallel(self, size_in_gb: int, replication_factor: int = 3, blocking=True, read=False):
 
         # pylint: disable=too-many-locals
         base_cmd = "cassandra-stress write cl=QUORUM "
         if read:
             base_cmd = "cassandra-stress read cl=ONE "
-        stress_fixed_params = " -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' " \
+        stress_fixed_params = f" -schema 'replication(factor={replication_factor}) " \
+                              "compaction(strategy=LeveledCompactionStrategy)' " \
                               "-port jmx=6868 -mode cql3 native -rate threads=200 -col 'size=FIXED(1024) n=FIXED(1)' "
         stress_keys = "n="
         population = " -pop seq="


### PR DESCRIPTION
The `populate_data_parallel` method is currently broken - it calculates the `keys_per_node` value as a float and inserts it into a cassandra-stress command string, which causes c-s to error out. This PR fixes that. It also adds the option to change the replication factor when using this command, as it was previously hardcoded to rf=3.

Trello task: https://trello.com/c/Zy1JIset

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
