### PR TITLE
fix(typos): use correct info in some typo'ed log messages

### DIFF
--- a/sdcm/sct_events/filters.py
+++ b/sdcm/sct_events/filters.py
@@ -58,7 +58,7 @@ class DbEventsFilter(BaseFilter):
         if self.filter_line:
             output.append('line={0.filter_line}')
         if self.filter_node:
-            output.append('type={0.filter_node}')
+            output.append('node={0.filter_node}')
         return '(' + (' '.join(output)) + ')'
 
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -271,7 +271,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         self.log.debug('Post behavior for db nodes %s', post_behavior_db_nodes)
         self.test_config.keep_cluster(node_type='db_nodes', val=post_behavior_db_nodes)
         post_behavior_monitor_nodes = self.params.get('post_behavior_monitor_nodes')
-        self.log.debug('Post behavior for loader nodes %s', post_behavior_monitor_nodes)
+        self.log.debug('Post behavior for monitor nodes %s', post_behavior_monitor_nodes)
         self.test_config.keep_cluster(node_type='monitor_nodes', val=post_behavior_monitor_nodes)
         post_behavior_loader_nodes = self.params.get('post_behavior_loader_nodes')
         self.log.debug('Post behavior for loader nodes %s', post_behavior_loader_nodes)


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
