### PR TITLE
improvement(mgmt-agent-on-k8s): set dedicated resources explicitely

### DIFF
--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -30,6 +30,7 @@ from sdcm.cluster_k8s import (
     ScyllaPodCluster,
     COMMON_CONTAINERS_RESOURCES,
     OPERATOR_CONTAINERS_RESOURCES,
+    SCYLLA_MANAGER_AGENT_RESOURCES,
 )
 from sdcm.cluster_k8s.iptables import IptablesPodPortsRedirectMixin, IptablesClusterOpsMixin
 from sdcm.cluster_gce import MonitorSetGCE
@@ -62,8 +63,12 @@ class MinimalK8SNodePool(CloudK8sNodePool):
     @cached_property
     def cpu_and_memory_capacity(self) -> Tuple[float, float]:
         return (
-            1 + COMMON_CONTAINERS_RESOURCES['cpu'] + OPERATOR_CONTAINERS_RESOURCES['cpu'],
-            2.5 + COMMON_CONTAINERS_RESOURCES['memory'] + OPERATOR_CONTAINERS_RESOURCES['memory'],
+            1 + COMMON_CONTAINERS_RESOURCES['cpu']
+            + OPERATOR_CONTAINERS_RESOURCES['cpu']
+            + SCYLLA_MANAGER_AGENT_RESOURCES['cpu'],
+            2.5 + COMMON_CONTAINERS_RESOURCES['memory']
+            + OPERATOR_CONTAINERS_RESOURCES['memory']
+            + SCYLLA_MANAGER_AGENT_RESOURCES['memory'],
         )
 
 


### PR DESCRIPTION
Set CPU=200m and RAM=100M for the scylla manager agent containers
as one additional step for scylla performance improvement.
Default values are CPU=50m and RAM=10m and not limited.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
