### PR TITLE
feature(Jenkins): a job for show-monitor

### DIFF
--- a/jenkins-pipelines/hydra-show-monitor.jenkinsfile
+++ b/jenkins-pipelines/hydra-show-monitor.jenkinsfile
@@ -1,0 +1,70 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+pipeline {
+    agent {
+        label {
+            label 'sct-builders'
+        }
+    }
+    environment {
+        AWS_ACCESS_KEY_ID     = credentials('qa-aws-secret-key-id')
+        AWS_SECRET_ACCESS_KEY = credentials('qa-aws-secret-access-key')
+    }
+    parameters {
+        string(defaultValue: '',
+               description: 'ID of a SCT test to restore the monitoring stack',
+               name: 'test_id')
+        string(defaultValue: '1440',
+               description: 'how long to keep an AWS instance with the restored monitoring stack (in minutes)',
+               name: 'duration')
+        string(defaultValue: 'us-east-1',
+               description: 'a region where to deploy an AWS instance',
+               name: 'aws_region')
+        string(defaultValue: 'a',
+               description: 'an availability zone where to deploy an AWS instance',
+               name: 'availability_zone')
+    }
+    options {
+        timestamps()
+        disableConcurrentBuilds()
+        buildDiscarder(logRotator(numToKeepStr: '50'))
+    }
+    stages {
+        stage('Skip build#1') {  // Because this: https://issues.jenkins-ci.org/browse/JENKINS-41929
+            when { expression { env.BUILD_NUMBER == '1' } }
+            steps {
+                script {
+                    if (currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause') != null) {
+                        currentBuild.description = ('Aborted build#1 not having parameters loaded.\n' +
+                                                    'Build#2 is ready to run')
+                        currentBuild.result = 'ABORTED'
+                        error('Abort build#1 which only loads params')
+                    }
+                }
+            }
+        }
+        stage('Checkout') {
+            steps {
+                dir('scylla-cluster-tests') {
+                    checkout scm
+                }
+            }
+        }
+        stage('Run hydra investigate show-monitor') {
+            steps {
+                sctScript """
+                    rm -fv sct_runner_ip
+
+                    export RUNNER_DURATION="${params.duration}"
+                    export RUNNER_REGION="${params.aws_region}"
+                    export RUNNER_AZ="${params.availability_zone}"
+
+                    ./docker/env/hydra.sh --execute-on-new-runner investigate show-monitor "${params.test_id}"
+                """
+            }
+        }
+    }
+}


### PR DESCRIPTION
Trello: https://trello.com/c/xhpATopG/3883-jenkins-self-service-job-for-running-hydra-investigate-show-monitor-command

The new job has following parameters:

![image](https://user-images.githubusercontent.com/63434/133962853-0ee6fa39-dbe3-433e-945d-fc3306846b95.png)

And at the bottom of the Console Output of a build you will see the links to Grafana:

![image](https://user-images.githubusercontent.com/63434/133963451-6504f423-bed3-4e3f-8f0e-bbbbddba5a2c.png)


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
