### PR TITLE
Fix poweroff

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -35,7 +35,7 @@ DatabaseLogEvent.BOOT: NORMAL
 DatabaseLogEvent.STOP: NORMAL
 DatabaseLogEvent.SUPPRESSED_MESSAGES: WARNING
 DatabaseLogEvent.stream_exception: ERROR
-DatabaseLogEvent.POWER_OFF: CRITICAL
+DatabaseLogEvent.POWER_OFF: WARNING
 IndexSpecialColumnErrorEvent: ERROR
 YcsbStressEvent.failure: CRITICAL
 YcsbStressEvent.error: ERROR

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4483,8 +4483,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             raise NodeStayInClusterAfterDecommission(error_msg)
 
         LOGGER.info('Decommission %s PASS', node)
-        with DbEventsFilter(db_event=DatabaseLogEvent.POWER_OFF, node=node):
-            self.terminate_node(node)  # pylint: disable=no-member
+        self.terminate_node(node)  # pylint: disable=no-member
         self.test_config.tester_obj().monitors.reconfigure_scylla_monitoring()
 
     def decommission(self, node):

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -87,10 +87,9 @@ from sdcm.sct_events import Severity
 from sdcm.sct_events.base import LogEvent
 from sdcm.sct_events.health import ClusterHealthValidatorEvent
 from sdcm.sct_events.system import TestFrameworkEvent
-from sdcm.sct_events.filters import DbEventsFilter
 from sdcm.sct_events.grafana import set_grafana_url
-from sdcm.sct_events.database import SYSTEM_ERROR_EVENTS_PATTERNS, BACKTRACE_RE, DatabaseLogEvent, \
-    ScyllaHelpErrorEvent, get_pattern_to_event_to_func_mapping
+from sdcm.sct_events.database import SYSTEM_ERROR_EVENTS_PATTERNS, BACKTRACE_RE, ScyllaHelpErrorEvent, \
+    get_pattern_to_event_to_func_mapping
 from sdcm.sct_events.nodetool import NodetoolEvent
 from sdcm.sct_events.decorators import raise_event_on_failure
 from sdcm.utils.auto_ssh import AutoSshContainerMixin

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -783,8 +783,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                                  f"does not support node termination")
 
     def _terminate_cluster_node(self, node):
-        with DbEventsFilter(db_event=DatabaseLogEvent.POWER_OFF, node=node):
-            self.cluster.terminate_node(node)
+        self.cluster.terminate_node(node)
         self.monitoring_set.reconfigure_scylla_monitoring()
 
     def disrupt_nodetool_decommission(self, add_node=True, disruption_name=None):

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -146,19 +146,9 @@ class TestBaseNode(unittest.TestCase, EventsUtilsMixin):
         ).publish()
 
         time.sleep(0.1)
-        with self.get_events_logger().events_logs_by_severity[Severity.CRITICAL].open() as events_file:
+        with self.get_events_logger().events_logs_by_severity[Severity.WARNING].open() as events_file:
             events = [line for line in events_file if 'Powering Off' in line]
             assert events
-
-    def test_ignore_power_off(self):
-        self.node.system_log = os.path.join(os.path.dirname(__file__), 'test_data', 'power_off.log')
-        with DbEventsFilter(db_event=DatabaseLogEvent.POWER_OFF, node=self.node):
-            self.node._read_system_log_and_publish_events(start_from_beginning=True)
-
-            time.sleep(0.1)
-            with self.get_events_logger().events_logs_by_severity[Severity.CRITICAL].open() as events_file:
-                events = [line for line in events_file if 'Powering Off' in line]
-                assert not events
 
     def test_search_system_suppressed_messages(self):
         self.node.system_log = os.path.join(os.path.dirname(


### PR DESCRIPTION
https://trello.com/c/OXsjoWby/3779-events-missing-when-monitoring-stack-is-restored

Make poweroff event WARNING, instead of CRITICAL.
Also get rid of poweroff filters and fix tests accordingly.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
