### PR TITLE
fix(list-gce-images-branch): filter out debug-images for GCP

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1524,7 +1524,7 @@ def get_branched_gce_images(scylla_version: str, project: str = SCYLLA_GCE_IMAGE
     #   RE2 syntax: https://github.com/google/re2/blob/master/doc/syntax.txt
     # or you can see brief explanation here:
     #   https://github.com/apache/libcloud/blob/trunk/libcloud/compute/drivers/gce.py#L274
-    filters = f"(family eq scylla)(labels.branch eq {branch})"
+    filters = f"(family eq scylla)(labels.branch eq {branch})(name ne debug-image-.*)"
 
     if build_id not in ("latest", "all", ):
         # filters += f"(labels.build-id eq {build_id})"  # asked releng to add `build-id' label too, but


### PR DESCRIPTION
Recently a debug prefix was introduced for images that are not "production" and used for debugging.
We need to ignore them also for GCP

Trello: https://trello.com/c/EUlhMsPK

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
