### PR TITLE
improvement(k8s-eks-perf): allow Scylla pods to get guaranteed CPU bind

### DIFF
--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -240,6 +240,7 @@ class EksCluster(KubernetesCluster, EksClusterCleanupMixin):
         self.service_ipv4_cidr = service_ipv4_cidr
         self.vpc_cni_version = vpc_cni_version
         self.allowed_labels_on_scylla_node = [('name', 'node-setup'),
+                                              ('name', 'cpu-policy'),
                                               ('k8s-app', 'aws-node'),
                                               ('app', 'local-volume-provisioner'),
                                               ('k8s-app', 'kube-proxy'),

--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -32,8 +32,6 @@ GKE_URLLIB_RETRY = 5  # How many times api request is retried before reporting f
 GKE_URLLIB_BACKOFF_FACTOR = 0.1
 
 LOADER_CLUSTER_CONFIG = sct_abs_path("sdcm/k8s_configs/gke-loaders.yaml")
-CPU_POLICY_DAEMONSET = sct_abs_path("sdcm/k8s_configs/cpu-policy-daemonset.yaml")
-RAID_DAEMONSET = sct_abs_path("sdcm/k8s_configs/raid-daemonset.yaml")
 LOGGER = logging.getLogger(__name__)
 
 

--- a/sdcm/k8s_configs/eks/scylla-node-prepare.yaml
+++ b/sdcm/k8s_configs/eks/scylla-node-prepare.yaml
@@ -55,6 +55,102 @@ subjects:
   name: node-setup-daemonset
   namespace: default
 ---
+# Daemonset that will change cpuManagerPolicy to static.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cpu-policy
+spec:
+  selector:
+    matchLabels:
+      name: cpu-policy
+  template:
+    metadata:
+      labels:
+        name: cpu-policy
+    spec:
+      hostPID: true
+      hostIPC: true
+      serviceAccountName: node-setup-daemonset
+      containers:
+      - name: cpu-policy
+        image: bitnami/kubectl:1.21.4
+        imagePullPolicy: Always
+        env:
+          - name: NODE
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: HOSTFS
+            value: /mnt/hostfs
+          - name: KUBELET_CONFIG_PATH
+            value: /etc/kubernetes/kubelet/kubelet-config.json
+        securityContext:
+          privileged: true
+          runAsUser: 0
+        volumeMounts:
+          - name: hostfs
+            mountPath: /mnt/hostfs
+            mountPropagation: Bidirectional
+        command:
+          - "/bin/bash"
+          - "-c"
+          - "--"
+        args:
+          - |
+            set -ex
+            if [ ! -f "$HOSTFS$KUBELET_CONFIG_PATH" ]; then
+                echo "Kublet config not found"
+                exit 1
+            fi
+
+            TOKEN_PATH=$(find / -name token | grep node-setup-daemonset -m1)
+            TOKEN=$(cat $TOKEN_PATH)
+            CA_CRT=$TOKEN_PATH/../ca.crt
+            kubectl config set-cluster scylla --server=https://kubernetes.default --certificate-authority=$CA_CRT
+            kubectl config set-credentials qa@scylladb.com --token=$TOKEN
+            kubectl config set-context scylla --cluster=scylla --user=qa@scylladb.com
+            kubectl config use-context scylla
+
+            if grep "cpuManagerPolicy" $HOSTFS$KUBELET_CONFIG_PATH | grep "static" ; then
+                echo "cpu-manager-policy is already set to be static"
+                echo "uncordoning the node"
+                kubectl uncordon $NODE || true
+                while true; do sleep infinity; done
+            fi
+
+            echo "Change kubelet config and restart it's service"
+            kubectl drain $NODE --force --ignore-daemonsets --delete-local-data --grace-period=60
+            awk 'NR==2{print "  \"cpuManagerPolicy\": \"static\","}1' $HOSTFS$KUBELET_CONFIG_PATH > \
+                tmp-kubelet-config.json && cat tmp-kubelet-config.json > $HOSTFS$KUBELET_CONFIG_PATH
+            rm $HOSTFS/var/lib/kubelet/cpu_manager_state
+            kill -9 $(pidof kubelet)
+      volumes:
+        - name: hostfs
+          hostPath:
+            path: /
+        - name: dbus
+          hostPath:
+            path: /var/run/dbus
+        - name: systemd
+          hostPath:
+            path: /run/systemd
+        - name: systemctl
+          hostPath:
+            path: /bin/systemctl
+        - name: system
+          hostPath:
+            path: /etc/systemd/system
+        - name: usr
+          hostPath:
+            path: /usr
+        - name: lib
+          hostPath:
+            path: /lib/systemd
+        - name: lib-linux
+          hostPath:
+            path: /lib/systemd
+---
 # Daemonset that will configure disks and networking interfaces on node.
 apiVersion: apps/v1
 kind: DaemonSet


### PR DESCRIPTION
To improve Scylla's performance we should run it's pods dedicating CPUs
to it exclusively ('Guaranteed' QoS class).
So, to be able to do it define 'cpuManagerPolicy=static' option
for kubelet on K8S nodes which are going to host Scylla.

Details: https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
