### PR TITLE
improvement(functional): make webhook-server rollout test more stable

### DIFF
--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -260,6 +260,7 @@ def test_orphaned_services_multi_rack(db_cluster):
     assert not get_orphaned_services(db_cluster), "Orphaned services were found after decommission"
 
 
+# NOTE: may fail from time to time due to the https://github.com/scylladb/scylla-operator/issues/791
 def test_ha_update_spec_while_rollout_restart(db_cluster: ScyllaPodCluster):
     """
     Cover the issue https://github.com/scylladb/scylla-operator/issues/410
@@ -332,8 +333,8 @@ def test_ha_update_spec_while_rollout_restart(db_cluster: ScyllaPodCluster):
         log.info("Bring back scylla-operator pods to life")
         db_cluster.k8s_cluster.kubectl(
             patch_operator_replicas_cmd % 2, namespace=SCYLLA_OPERATOR_NAMESPACE)
-        db_cluster.k8s_cluster.kubectl(
-            "wait -l app.kubernetes.io/name=scylla-operator --for=condition=Ready pod",
+        db_cluster.k8s_cluster.kubectl_wait(
+            "--for=condition=Ready pod -l app.kubernetes.io/name=scylla-operator",
             namespace=SCYLLA_OPERATOR_NAMESPACE, timeout=300)
 
     try:


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
