### PR TITLE
fix(artifacts pipeline): disable sct runner

### DIFF
--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -115,17 +115,6 @@ def call(Map pipelineParams) {
                                                     checkout scm
                                                 }
                                             }
-                                            stage('Create SCT Runner') {
-                                                catchError(stageResult: 'FAILURE') {
-                                                    wrap([$class: 'BuildUser']) {
-                                                        dir('scylla-cluster-tests') {
-                                                            timeout(time: 5, unit: 'MINUTES') {
-                                                                createSctRunner(params, pipelineParams.timeout.time, builder.region)
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
                                             stage("Run SCT Test (${instance_type})") {
                                                 def cloud_provider = getCloudProviderFromBackend(params.backend)
                                                 sctScript """
@@ -195,12 +184,7 @@ def call(Map pipelineParams) {
                                                     export SCT_INSTANCE_PROVISION="${params.provision_type}"
 
                                                     echo "start test ......."
-                                                    RUNNER_IP=\$(cat sct_runner_ip||echo "")
-                                                    if [[ -n "\${RUNNER_IP}" ]] ; then
-                                                        ./docker/env/hydra.sh --execute-on-runner \${RUNNER_IP} run-test artifacts_test --backend ${params.backend}
-                                                    else
-                                                        ./docker/env/hydra.sh run-test artifacts_test --backend ${params.backend} --logdir "`pwd`"
-                                                    fi
+                                                    ./docker/env/hydra.sh run-test artifacts_test --backend ${params.backend} --logdir "`pwd`"
                                                     echo "end test ....."
                                                 """
                                             }
@@ -232,15 +216,6 @@ def call(Map pipelineParams) {
                                                             timeout(time: 10, unit: 'MINUTES') {
                                                                 runSendEmail(params, currentBuild)
                                                             }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                            stage('Clean SCT Runners') {
-                                                catchError(stageResult: 'FAILURE') {
-                                                    wrap([$class: 'BuildUser']) {
-                                                        dir('scylla-cluster-tests') {
-                                                            cleanSctRunners(params, currentBuild)
                                                         }
                                                     }
                                                 }


### PR DESCRIPTION
The test duration of artifacts-test jobs are always very short, the
test isn't heavy, and the problems are easy to reproduce.

It's waste of resource to use SCT runner for artifacts-test jobs.
This patch disabled it.

Signed-off-by: Amos Kong <kongjianjun@gmail.com>
Reported-by: Bentsi Magidovich <bentsi@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
