### PR TITLE
fix(perfRegressionParallelPipeline): remove cleanSCTRunners step

### DIFF
--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -218,19 +218,6 @@ def call(Map pipelineParams) {
                                                 }
                                             }
                                         }
-                                        stage('Clean SCT Runners') {
-                                            steps {
-                                                catchError(stageResult: 'FAILURE') {
-                                                    script {
-                                                        wrap([$class: 'BuildUser']) {
-                                                            dir('scylla-cluster-tests') {
-                                                                cleanSctRunners(params, currentBuild)
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
Remove it for following reasons:
- This CI job doesn't create SCT runner, so such step becomes redundant.
- Jenkins fails with following error:

    java.lang.NoSuchMethodError: No such DSL method 'steps' found among
        steps [addEmbeddableBadgeConfiguration, ...]

  When it tries to run 'cleanSCTRunners' step.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
