### PR TITLE
improvement(k8s-logs): gather also logs for previous containers in pods

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1133,9 +1133,12 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
                         continue
                     os.makedirs(resource_dir / res, exist_ok=True)
                     for container_name in container_names:
-                        logfile = resource_dir / res / f"{container_name}.log"
+                        logfile = resource_dir / res / f"{container_name}"
                         # NOTE: ignore status because it may fail when pod is not ready/running
-                        self.kubectl(f"logs pod/{res} -c={container_name} > {logfile}",
+                        self.kubectl(f"logs pod/{res} -c={container_name} > {logfile}.log",
+                                     namespace=namespace, ignore_status=True)
+                        self.kubectl(f"logs pod/{res} -c={container_name} --previous=true > "
+                                     f"{logfile}-previous.log",
                                      namespace=namespace, ignore_status=True)
 
     @log_run_info


### PR DESCRIPTION
There are cases when we may want to see all logs of containers that were restarted/recreated.
For the moment we get logs of only current instances of containers.
"kubectl logs" supports getting logs of previous containers using "--previous=true" flag. So, use it when we gather pods logs.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
