### PR TITLE
fix(kubernetes): suppress absence of seed nodes

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2104,6 +2104,14 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
     def install_scylla_manager(self, node):
         pass
 
+    @property
+    def seed_nodes_ips(self):
+        return []
+
+    @property
+    def seed_nodes(self):
+        return []
+
     def node_setup(self, node: BaseScyllaPodContainer, verbose: bool = False, timeout: int = 3600):
         if self.test_config.BACKTRACE_DECODING:
             node.install_scylla_debuginfo()


### PR DESCRIPTION
After merge of [1] K8S deployment started failing with following error:

    AssertionError: We should have at least one selected seed by now

The reason for it is that operator-1.4+ stopped using seed nodes and
reuses seedless approach. So, check for seeeds is not relevant to K8S
backends.
So, fix it by redefining 'seed_nodes_ips' and 'seed_nodes' properties
with empty values.

[1] https://github.com/scylladb/scylla-cluster-tests/pull/3882

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
