### PR TITLE
refactor(k8s-rackdc-update): make rackdc props file be updated correctly

### DIFF
--- a/functional_tests/scylla_operator/conftest.py
+++ b/functional_tests/scylla_operator/conftest.py
@@ -156,9 +156,11 @@ def _bring_cluster_back_to_original_state(
 
         if restart:
             db_cluster.restart_scylla()
+        db_cluster.wait_for_nodes_up_and_normal(
+            nodes=db_cluster.nodes, verification_node=db_cluster.nodes[0])
     except Exception as exc:  # pylint: disable=broad-except
         tester.healthy_flag = False
-        pytest.fail("Failed to bring cluster nodes back to original number due to :\n" +
+        pytest.fail("Failed to bring cluster nodes back to original state due to :\n" +
                     "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)))
 
 

--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -86,6 +86,7 @@ def test_drain_and_replace_node_kubernetes(db_cluster):
     target_node.wait_till_k8s_pod_get_uid(ignore_uid=old_uid)
     target_node.wait_for_pod_readiness()
     db_cluster.wait_for_pods_readiness(pods_to_wait=1, total_pods=len(db_cluster.nodes))
+    target_node.refresh_ip_address()
 
 
 @pytest.mark.require_node_terminate('drain_k8s_node')
@@ -101,6 +102,7 @@ def test_drain_wait_and_replace_node_kubernetes(db_cluster):
     target_node.wait_till_k8s_pod_get_uid(ignore_uid=old_uid)
     target_node.wait_for_pod_readiness()
     db_cluster.wait_for_pods_readiness(pods_to_wait=1, total_pods=len(db_cluster.nodes))
+    target_node.refresh_ip_address()
 
 
 @pytest.mark.require_node_terminate('drain_k8s_node')

--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -537,8 +537,8 @@ class LocalMinimalClusterBase(MinimalClusterBase):
 
     @cached_property
     def k8s_server_url(self):
-        host, port = MinimalK8SOps.get_local_kubectl_proxy()
-        return f"http://{host}:{port}"
+        # NOTE: there is no need to use kubectl proxy running only on local machine
+        return ""
 
     def deploy_node_pool(self, pool, wait_till_ready=True) -> None:
         pass


### PR DESCRIPTION
For the moment, we have 2 different methods which update
'scylla-config' configMap that is used to store 'scylla.yaml'
and 'cassandra-rackdc.properties' files. Their logic is not
aligned with each other and one of them doesn't consider changes from
another and make inconsistent changes.
We didn't face such problem just because the only place where we update
'cassandra-rackdc.properties' file is K8S functional test, which is
skipped now due to the bug in operator.

So, refactor the approach with update of mentioned configs files on K8S
backends making both be consistent.

Also, update related K8S functional test (test_cassandra_rackdc)
by doing following:
- Add waiters for the 'UN' status of scylla members calling 'nodetool
  status' command. It will allow us to fail test correctly
  when we face https://github.com/scylladb/scylla-operator/issues/797
- Reuse refactored logic and remove config option that we added in test
  instead of defining it with default value.
  Doing it we avoid redundant scylla rollout after the test end.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
