### PR TITLE
fix(ScyllaYaml): support values defined in ScyllaCloud's yaml config

### DIFF
--- a/sdcm/provision/scylla_yaml/cluster_builder.py
+++ b/sdcm/provision/scylla_yaml/cluster_builder.py
@@ -30,9 +30,10 @@ class ScyllaYamlClusterAttrBuilder(ScyllaYamlAttrBuilderBase):
 
     @property
     def hinted_handoff_enabled(self) -> Optional[str]:
-        if self.params.get('hinted_handoff') == 'enabled':
+        param_hinted_handoff = str(self.params.get('hinted_handoff')).lower()
+        if param_hinted_handoff in ('enabled', 'true', '1'):
             return 'enabled'
-        if self.params.get('hinted_handoff') == 'disabled':
+        if param_hinted_handoff in ('disabled', 'false', '0'):
             return 'disabled'
         return None
 

--- a/sdcm/provision/scylla_yaml/scylla_yaml.py
+++ b/sdcm/provision/scylla_yaml/scylla_yaml.py
@@ -156,7 +156,10 @@ class ScyllaYaml(BaseModel):  # pylint: disable=too-few-public-methods
     dynamic_snitch_badness_threshold: int = 0
     dynamic_snitch_reset_interval_in_ms: int = 60000
     dynamic_snitch_update_interval_in_ms: int = 100
-    hinted_handoff_enabled: Literal['enabled', 'disabled'] = 'enabled'
+    hinted_handoff_enabled: Literal[
+        'enabled', 'true', 'True', '1', True,
+        'disabled', 'false', 'False', '0', False,
+    ] = 'enabled'
     hinted_handoff_throttle_in_kb: int = 1024
     max_hint_window_in_ms: int = 10800000
     max_hints_delivery_threads: int = 2

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -87,10 +87,12 @@ from sdcm.utils.gce_utils import get_gce_services
 from sdcm.keystore import KeyStore
 from sdcm.utils.latency import calculate_latency
 
+CLUSTER_CLOUD_IMPORT_ERROR = ""
 try:
     import cluster_cloud
-except ImportError:
+except ImportError as exc:
     cluster_cloud = None
+    CLUSTER_CLOUD_IMPORT_ERROR = str(exc)
 
 configure_logging(exception_handler=handle_exception, variables={'log_dir': TestConfig().logdir()})
 
@@ -717,7 +719,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 params=self.params,
             )
             if not cluster_cloud:
-                raise ImportError("cluster_cloud isn't installed")
+                raise ImportError(f"cluster_cloud isn't installed. {CLUSTER_CLOUD_IMPORT_ERROR}")
             self.db_cluster = cluster_cloud.ScyllaCloudCluster(**params)
         else:
             self.db_cluster = ScyllaGCECluster(gce_image=gce_image_db,
@@ -844,7 +846,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                     params=self.params,
                 )
                 if not cluster_cloud:
-                    raise ImportError("cluster_cloud isn't installed")
+                    raise ImportError(f"cluster_cloud isn't installed. {CLUSTER_CLOUD_IMPORT_ERROR}")
                 return cluster_cloud.ScyllaCloudCluster(**params)
             return None
 

--- a/unit_tests/test_scylla_yaml_builders.py
+++ b/unit_tests/test_scylla_yaml_builders.py
@@ -191,6 +191,7 @@ class ScyllaYamlClusterAttrBuilderTest(ScyllaYamlClusterAttrBuilderBase):
                 'authorizer': 'CassandraAuthorizer',
                 'enable_ipv6_dns_lookup': False,
                 'endpoint_snitch': 'org.apache.cassandra.locator.GossipingPropertyFileSnitch',
+                'hinted_handoff_enabled': 'enabled',
                 'ldap_attr_role': 'cn', 'ldap_bind_dn': 'SOMEDN', 'ldap_bind_passwd': 'PASSWORD',
                 'ldap_url_template': 'ldap://3.3.3.3:389/dc=scylla-qa,dc=com?cn?sub?(member=CN={USER},dc=scylla-qa,dc=com)',
                 'saslauthd_socket_path': '/run/saslauthd/mux',


### PR DESCRIPTION
Recently was merged feature with new logic for handling of the Scylla foncfiguration [1].
It changed the behavior of "hinted_handoff" option from
'"disabled" is False and all other mean True' to
'only "disabled" and "enabled" values are allowed'.
The problem with it is that scylla.yaml file that SCT reads from
cluster created by siren-tests returns boolean-like value, not 'disabled' or 'enabled' ones.
So, add support for such values too to unblock usage of ScyllaCloud clusters.
    
[1] https://github.com/scylladb/scylla-cluster-tests/pull/3882

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
