### PR TITLE
fix(artifactsPipeline): clean the old sct_runner_ip

### DIFF
--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -120,6 +120,9 @@ def call(Map pipelineParams) {
                                                 sctScript """
                                                     rm -fv ./latest
 
+                                                    # clean the old sct_runner_ip file
+                                                    rm -fv ./sct_runner_ip
+
                                                     export SCT_COLLECT_LOGS=false
                                                     export SCT_CONFIG_FILES=${test_config}
 


### PR DESCRIPTION
We don't want to use the SCT runner in artifact-tests, but the old
sct_runner_ip file might effect the tests.

This patch changed to clean the old sct_runner_ip file before running
the artifact-tests.

createSctRunner() was called for many pipelines, it's also helpful to
clean the old sct_runner_ip all the time.

Signed-off-by: Amos Kong <kongjianjun@gmail.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)

Fixes https://github.com/scylladb/scylla-cluster-tests/issues/3988
