### PR TITLE
fix(artifactsPipeline): make region parameter to be matched

### DIFF
--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -1,7 +1,7 @@
 #! groovy
 
 def call(Map pipelineParams) {
-    def builder = getJenkinsLabels(params.backend, params.region_name, params.gce_datacenter)
+    def builder = getJenkinsLabels(params.backend, params.aws_region, params.gce_datacenter)
 
     pipeline {
         agent {
@@ -43,7 +43,7 @@ def call(Map pipelineParams) {
                    name: 'gce_image_db')
             string(defaultValue: "${pipelineParams.get('region_name', '')}",
                    description: 'AWS region with Scylla AMI (for AMI test, ignored otherwise)',
-                   name: 'region_name')
+                   name: 'aws_region')
             string(defaultValue: "${pipelineParams.get('gce_datacenter', 'us-east1')}",
                    description: 'GCE datacenter',
                    name: 'gce_datacenter')
@@ -128,7 +128,7 @@ def call(Map pipelineParams) {
 
                                                     if [[ ! -z "${params.scylla_ami_id}" ]]; then
                                                         export SCT_AMI_ID_DB_SCYLLA="${params.scylla_ami_id}"
-                                                        export SCT_REGION_NAME="${params.region_name}"
+                                                        export SCT_REGION_NAME="${params.aws_region}"
                                                     elif [[ ! -z "${params.gce_image_db}" ]]; then
                                                         export SCT_GCE_IMAGE_DB="${params.gce_image_db}"
                                                         if [[ -n "${params.gce_datacenter ? params.gce_datacenter : ''}" ]] ; then


### PR DESCRIPTION
Our SCT parameter of aws region is region_name (SCT_REGION_NAME), but we
used aws_region in yaml config and some vars functions.

Artifacts Pipeline and yaml configs use matched region_name, but it
called the shared functions (eg: runCollectLogs).

The grace change should change all the parameter in yaml config and
vars functions to `region_name`, but it's too big change.

This patch only changed the parameter name in artifacts pipeline to
match with runCollectLogs().

Signed-off-by: Amos Kong <kongjianjun@gmail.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
