### PR TITLE
fix(create_runner_instance): check az for AWS even if not provided

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1159,7 +1159,7 @@ def create_runner_image(cloud_provider, region, availability_zone):
 @click.option("-t", "--test-id", required=True, type=str, help="Test ID")
 @click.option("-d", "--duration", required=True, type=int, help="Test duration in MINUTES")
 def create_runner_instance(cloud_provider, region, availability_zone, instance_type, test_id, duration):
-    if cloud_provider == "aws" and availability_zone != "":
+    if cloud_provider == "aws":
         assert len(availability_zone) == 1, f"Invalid AZ: {availability_zone}, availability-zone is one-letter a-z."
     add_file_logger()
     sct_runner_ip_path = Path("sct_runner_ip")


### PR DESCRIPTION
When empty az is provided create_runner_instance fails
```
(sct) ✘-2 ~/devel/scylladb/scylla-cluster-tests [master ↑·976|…23⚑ 4] 
20:34 $ hydra create-runner-instance -r us-east-1 -t bentsi -d 2
Docker version 20.10.8, build 3967b7d
There is scylladb/hydra:v0.96 in local cache, use it.
Obtaining QA SSH keys...
QA SSH keys obtained.
Making sure the ownerships of results directories are of the user
Going to run './sct.py  create-runner-instance -r us-east-1 -t bentsi -d 2'...
Obtaining QA SSH keys...
QA SSH keys obtained.
Docker daemon is already logged in as `scyllaqatest'.
New directory created: /home/bentsi/sct-results/20211004-173507-418744-create-runner-instance
Creating SCT Runner instance...
Traceback (most recent call last):
  File "/home/bentsi/devel/scylladb/scylla-cluster-tests/./sct.py", line 1198, in <module>
    cli()
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/bentsi/devel/scylladb/scylla-cluster-tests/./sct.py", line 1168, in create_runner_instance
    instance = sct_runner.create_instance(
  File "/home/bentsi/devel/scylladb/scylla-cluster-tests/sdcm/sct_runner.py", line 342, in create_instance
    return self._create_instance(
  File "/home/bentsi/devel/scylladb/scylla-cluster-tests/sdcm/sct_runner.py", line 437, in _create_instance
    assert subnet, f"No SCT subnet found in the source region. " \
AssertionError: No SCT subnet found in the source region. Use `hydra prepare-region --cloud-provider aws --region-name us-east-1' to create cloud env!
```
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
