### PR TITLE
fix(cluster.py): process args from --help-seastar

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1751,8 +1751,10 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         if append_scylla_args:
             scylla_help = self.remoter.run(
                 f"{self.add_install_prefix('/usr/bin/scylla')} --help", ignore_status=True).stdout
+            scylla_help_seastar = self.remoter.run(
+                f"{self.add_install_prefix('/usr/bin/scylla')} --help-seastar", ignore_status=True).stdout
             scylla_arg_parser = ScyllaArgParser.from_scylla_help(
-                scylla_help,
+                help_text=f"{scylla_help}\n{scylla_help_seastar}",
                 duplicate_cb=lambda dups: ScyllaHelpErrorEvent.duplicate(
                     message=f"Scylla help contains duplicate for the following arguments: {','.join(dups)}"
                 ).publish()


### PR DESCRIPTION
Trello: https://trello.com/c/5TyHBmbP/3968-processscyllaargs-failed-when-seastar-arguments-were-split-to-help-seastar-option

Fixes #4000 

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
