### PR TITLE
improvement(perf report): add `append_scylla_args` to email report

### DIFF
--- a/sdcm/utils/es_queries.py
+++ b/sdcm/utils/es_queries.py
@@ -11,7 +11,7 @@ class QueryFilter:
     Definition of query filtering parameters
     """
     SETUP_PARAMS = ['n_db_nodes', 'n_loaders', 'n_monitor_nodes']
-    SETUP_INSTANCE_PARAMS = ['instance_type_db', 'instance_type_loader', 'instance_type_monitor']
+    SETUP_INSTANCE_PARAMS = ['instance_type_db', 'instance_type_loader', 'instance_type_monitor', 'append_scylla_args']
 
     def __init__(self, test_doc, is_gce=False, use_wide_query=False, lastyear=False):
         self.test_doc = test_doc


### PR DESCRIPTION
this is an information is meant to help analyze
performance jobs, and understand if we are having
more than usual `reactor stalls` when for example,
decreasing the `blocked-reactor-notify-ms` parameter

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
