### PR TITLE
fix(k8s-functional): define and use fixtures properly

### DIFF
--- a/functional_tests/scylla_operator/pytest.ini
+++ b/functional_tests/scylla_operator/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 markers =
-    require_node_terminate: test require certain node terminate method, if backend does not support it, test will be skipped
-    require_mgmt: test require scylla manager to be provisioned, set "use_mgmt: true" to enable it
+    requires_node_termination_support: test gets skipped if backend doesn't support specified K8S node termination method
+    requires_mgmt: test requires scylla manager to exist, set "use_mgmt: true" to enable it

--- a/functional_tests/scylla_operator/pytest.ini
+++ b/functional_tests/scylla_operator/pytest.ini
@@ -2,3 +2,4 @@
 markers =
     requires_node_termination_support: test gets skipped if backend doesn't support specified K8S node termination method
     requires_mgmt: test requires scylla manager to exist, set "use_mgmt: true" to enable it
+    readonly: test that does not make any changes to cluster, only reads. Useful for running fast subset of tests

--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -123,7 +123,7 @@ def test_rolling_restart_cluster(db_cluster):
         f"'{old_force_redeployment_reason}' must be different than '{new_force_redeployment_reason}'")
 
 
-@pytest.mark.require_node_terminate('drain_k8s_node')
+@pytest.mark.requires_node_termination_support('drain_k8s_node')
 def test_drain_and_replace_node_kubernetes(db_cluster):
     target_node = random.choice(db_cluster.non_seed_nodes)
     old_uid = target_node.k8s_pod_uid
@@ -136,7 +136,7 @@ def test_drain_and_replace_node_kubernetes(db_cluster):
     target_node.refresh_ip_address()
 
 
-@pytest.mark.require_node_terminate('drain_k8s_node')
+@pytest.mark.requires_node_termination_support('drain_k8s_node')
 def test_drain_wait_and_replace_node_kubernetes(db_cluster):
     target_node = random.choice(db_cluster.non_seed_nodes)
     old_uid = target_node.k8s_pod_uid
@@ -152,7 +152,7 @@ def test_drain_wait_and_replace_node_kubernetes(db_cluster):
     target_node.refresh_ip_address()
 
 
-@pytest.mark.require_node_terminate('drain_k8s_node')
+@pytest.mark.requires_node_termination_support('drain_k8s_node')
 def test_drain_terminate_decommission_add_node_kubernetes(db_cluster):
     target_rack = random.choice([*db_cluster.racks])
     target_node = db_cluster.get_rack_nodes(target_rack)[-1]
@@ -162,7 +162,7 @@ def test_drain_terminate_decommission_add_node_kubernetes(db_cluster):
     db_cluster.wait_for_pods_readiness(pods_to_wait=1, total_pods=len(db_cluster.nodes))
 
 
-@pytest.mark.require_mgmt()
+@pytest.mark.requires_mgmt
 def test_mgmt_repair(db_cluster):
     mgr_cluster = db_cluster.get_cluster_manager()
     mgr_task = mgr_cluster.create_repair_task()
@@ -172,7 +172,7 @@ def test_mgmt_repair(db_cluster):
         mgr_task.id, str(mgr_task.status))
 
 
-@pytest.mark.require_mgmt()
+@pytest.mark.requires_mgmt
 def test_mgmt_backup(db_cluster):
     mgr_cluster = db_cluster.get_cluster_manager()
     backup_bucket_location = db_cluster.params.get('backup_bucket_location')
@@ -415,7 +415,7 @@ def test_startup_probe_exists_in_scylla_pods(db_cluster: ScyllaPodCluster):
     assert not pods, f"startupProbe is not found in the following pods: {pods}"
 
 
-@pytest.mark.require_mgmt()
+@pytest.mark.requires_mgmt
 def test_readiness_probe_exists_in_mgmt_pods(db_cluster: ScyllaPodCluster):
     """
     PR: https://github.com/scylladb/scylla-operator/pull/725

--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -39,6 +39,7 @@ from functional_tests.scylla_operator.libs.helpers import (
 log = logging.getLogger()
 
 
+@pytest.mark.readonly
 def test_single_operator_image_tag_is_everywhere(db_cluster):
     expected_operator_tag = db_cluster.k8s_cluster.get_operator_image().split(":")[-1]
     pods_with_wrong_image_tags = []
@@ -183,6 +184,7 @@ def test_mgmt_backup(db_cluster):
     assert TaskStatus.DONE == status
 
 
+@pytest.mark.readonly
 def test_listen_address(db_cluster):
     """
     Issues: https://github.com/scylladb/scylla-operator/issues/484
@@ -397,6 +399,7 @@ def test_ha_update_spec_while_rollout_restart(db_cluster: ScyllaPodCluster):
                 "\n".join(crd_update_errors)))
 
 
+@pytest.mark.readonly
 def test_scylla_operator_pods(db_cluster: ScyllaPodCluster):
     scylla_operator_pods = scylla_operator_pods_and_statuses(db_cluster)
 
@@ -406,6 +409,7 @@ def test_scylla_operator_pods(db_cluster: ScyllaPodCluster):
     assert not not_running_pods, f'There are pods in state other than running: {not_running_pods}'
 
 
+@pytest.mark.readonly
 def test_startup_probe_exists_in_scylla_pods(db_cluster: ScyllaPodCluster):
     pods = get_pods_without_probe(
         db_cluster=db_cluster,
@@ -415,6 +419,7 @@ def test_startup_probe_exists_in_scylla_pods(db_cluster: ScyllaPodCluster):
     assert not pods, f"startupProbe is not found in the following pods: {pods}"
 
 
+@pytest.mark.readonly
 @pytest.mark.requires_mgmt
 def test_readiness_probe_exists_in_mgmt_pods(db_cluster: ScyllaPodCluster):
     """


### PR DESCRIPTION
Apply following fixes for the pytest fixtures used for operator testing:
- Use "fixture_" prefix in functions names which are defined as
  fixtures to avoid following pylint rule violation:
      W0621: Redefining name %r from outer scope (line %s)
  It appears if we reuse fixtures in scope of one single module.
- Split 'skip_if_cluster_requirements_not_met' function that
  must have been defined as fixture into 2 new functions and
  define both as fixtures with 'autouse=True' argument which makes
  it run against each relevant test.
- Add 'autouse=True' key for the "change_test_dir" fixture to make it
  be applied for each of the tests. Without it is not used at all.
- Rename 'require_mgmt' marker to the 'requires_mgmt'
  to be more grammatically correct.
- Rename 'require_node_terminate' marker
  to the 'requires_node_termination_support' to be more correct too.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
