### PR TITLE
fix(perf pipelines): changing region didn't take effect

### DIFF
--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -97,7 +97,11 @@ def call(Map pipelineParams) {
                                                         rm -fv ./latest
 
                                                         export SCT_CLUSTER_BACKEND=${params.backend}
-                                                        export SCT_REGION_NAME=${pipelineParams.aws_region}
+                                                        if [[ -n "${params.aws_region}" ]]; then
+                                                            export SCT_REGION_NAME=${params.aws_region}
+                                                        else
+                                                            export SCT_REGION_NAME=${pipelineParams.aws_region}
+                                                        fi
                                                         export SCT_CONFIG_FILES=${pipelineParams.test_config}
                                                         export SCT_SCYLLA_MGMT_AGENT_REPO=${pipelineParams.mgmt_agent_repo}
                                                         export SCT_EMAIL_RECIPIENTS="${email_recipients}"


### PR DESCRIPTION
happened that changing in the job's pipeline call
the region did not take effect.
after this change, there is a running job with
the correct region (see PR's previous comment).

this is a back port PR from #3995

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
