### PR TITLE
feature(sct): Argus test run tracking

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,18 +104,19 @@ To run SCT tests locally run following::
     sudo ./install-prereqs.sh
     ./get-qa-ssh-keys.sh
 
-    # install python3.8 via pyenv
+    # install python3.10 via pyenv
     curl https://pyenv.run | bash
     exec $SHELL
     # go to: https://github.com/pyenv/pyenv/wiki/Common-build-problems#prerequisites
     # and follow the instructions for your distribution, to install the prerequisites
     # for compiling python from source
-    pyenv install 3.8.3
+    pyenv install 3.10.0
 
     # create a virtualenv for SCT
-    pyenv virtualenv 3.8.3 sct38
-    pyenv activate sct38
-    pip install -r requirements.txt
+    pyenv virtualenv 3.10.0 sct310
+    pyenv activate sct310
+    pip install -r requirements.in
+    pip install -e git+https://github.com/bentsi/argus#egg=argus
 
 
 Preparing AWS Cloud environment

--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -214,7 +214,7 @@ function run_in_docker () {
             --net=host \
             --name="${SCT_TEST_ID}_$(date +%s)" \
             ${DOCKER_REPO}:${VERSION} \
-            /bin/bash -c "sudo ln -s '${SCT_DIR}' '${WORK_DIR}'; /sct/get-qa-ssh-keys.sh; ${TERM_SET_SIZE} eval '${CMD_TO_RUN}'"
+            /bin/bash -c "sudo ln -s '${SCT_DIR}' '${WORK_DIR}'; /sct/get-qa-ssh-keys.sh; /sct/install_argus.sh; ${TERM_SET_SIZE} eval '${CMD_TO_RUN}'"
     else
         echo docker ${REMOTE_DOCKER_HOST} run --rm ${TTY_STDIN} --privileged \
             -h ${HOST_NAME} \
@@ -249,7 +249,7 @@ function run_in_docker () {
             --net=host \
             --name="${SCT_TEST_ID}_$(date +%s)" \
             ${DOCKER_REPO}:${VERSION} \
-            /bin/bash -c "sudo ln -s '${SCT_DIR}' '${WORK_DIR}'; /sct/get-qa-ssh-keys.sh; ${TERM_SET_SIZE} eval '${CMD_TO_RUN}'"
+            /bin/bash -c "sudo ln -s '${SCT_DIR}' '${WORK_DIR}'; /sct/get-qa-ssh-keys.sh; /sct/install_argus.sh; ${TERM_SET_SIZE} eval '${CMD_TO_RUN}'"
     fi
 }
 

--- a/install_argus.sh
+++ b/install_argus.sh
@@ -3,7 +3,11 @@ set -eu
 LOGFILE="/tmp/argus-install.log"
 echo "Installing Argus pip package..."
 echo "[TODO] Remove this once Argus stabilizes"
-sudo /usr/local/bin/pip3 install --force -e git+https://github.com/bentsi/argus#egg=argus >"$LOGFILE" 2>&1 && echo "Package installed." || (
+sudo /usr/local/bin/pip3 install --force -e git+https://github.com/bentsi/argus#egg=argus >"$LOGFILE" 2>&1 && (
+  echo "Package installed."
+  if [ -d "./src" ]; then sudo chown "$(whoami):$(whoami)" -R "./src"; fi
+  exit 0
+) || (
   env
   echo "Argus failed to install!"
   cat "$LOGFILE"

--- a/install_argus.sh
+++ b/install_argus.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+LOGFILE="/tmp/argus-install.log"
+echo "Installing Argus pip package..."
+echo "[TODO] Remove this once Argus stabilizes"
+sudo /usr/local/bin/pip3 install --force -e git+https://github.com/bentsi/argus#egg=argus >"$LOGFILE" 2>&1 && echo "Package installed." || (
+  env
+  echo "Argus failed to install!"
+  cat "$LOGFILE"
+  exit 1
+)

--- a/sct.py
+++ b/sct.py
@@ -34,8 +34,7 @@ import click
 import click_completion
 from prettytable import PrettyTable
 
-from sdcm.argus_test_run import ArgusTestRun, ArgusConfig
-from sdcm.keystore import KeyStore
+from sdcm.argus_test_run import ArgusTestRun
 from sdcm.remote import LOCALRUNNER
 from sdcm.results_analyze import PerformanceResultsAnalyzer, BaseResultsAnalyzer
 from sdcm.sct_config import SCTConfiguration
@@ -987,8 +986,7 @@ def collect_logs(test_id=None, logdir=None, backend=None, config_file=None):
 
 def store_logs_in_argus(test_id: UUID, logs: dict[str, list[list[str] | str]]):
     try:
-        test_run = ArgusTestRun.get(test_id=test_id, config=ArgusConfig(**KeyStore().get_argusdb_credentials(),
-                                                                        keyspace_name="argus"))
+        test_run = ArgusTestRun.get(test_id=test_id)
         for cluster_type, s3_links in logs.items():
             for link in s3_links:
                 test_run.run_info.logs.add_log(cluster_type, link)

--- a/sct.py
+++ b/sct.py
@@ -982,7 +982,7 @@ def collect_logs(test_id=None, logdir=None, backend=None, config_file=None):
     click.echo(table.get_string(title="Collected logs by test-id: {}".format(collector.test_id)))
 
     try:
-        test_run = ArgusTestRun.get(test_id=UUID(test_id))
+        test_run = ArgusTestRun.get(test_id=UUID(collector.test_id))
         if test_run:
             for cluster_type, s3_links in collected_logs.items():
                 for link in s3_links:

--- a/sct.py
+++ b/sct.py
@@ -34,7 +34,8 @@ import click
 import click_completion
 from prettytable import PrettyTable
 
-from sdcm.argus_test_run import ArgusTestRun
+from sdcm.argus_test_run import ArgusTestRun, ArgusConfig
+from sdcm.keystore import KeyStore
 from sdcm.remote import LOCALRUNNER
 from sdcm.results_analyze import PerformanceResultsAnalyzer, BaseResultsAnalyzer
 from sdcm.sct_config import SCTConfiguration
@@ -986,7 +987,8 @@ def collect_logs(test_id=None, logdir=None, backend=None, config_file=None):
 
 def store_logs_in_argus(test_id: UUID, logs: dict[str, list[list[str] | str]]):
     try:
-        test_run = ArgusTestRun.get(test_id=test_id)
+        test_run = ArgusTestRun.get(test_id=test_id, config=ArgusConfig(**KeyStore().get_argusdb_credentials(),
+                                                                        keyspace_name="argus"))
         for cluster_type, s3_links in logs.items():
             for link in s3_links:
                 test_run.run_info.logs.add_log(cluster_type, link)

--- a/sct.py
+++ b/sct.py
@@ -66,8 +66,8 @@ from sdcm.utils.common import (
     list_logs_by_test_id,
     list_resources_docker,
     search_test_id_in_latest,
-    get_sct_runner_ip,
 )
+from sdcm.utils.net import get_sct_runner_ip
 from sdcm.utils.jepsen import JepsenResults
 from sdcm.utils.docker_utils import docker_hub_login
 from sdcm.monitorstack import (restore_monitoring_stack, get_monitoring_stack_services,

--- a/sct.py
+++ b/sct.py
@@ -66,6 +66,7 @@ from sdcm.utils.common import (
     list_logs_by_test_id,
     list_resources_docker,
     search_test_id_in_latest,
+    get_sct_runner_ip,
 )
 from sdcm.utils.jepsen import JepsenResults
 from sdcm.utils.docker_utils import docker_hub_login
@@ -84,7 +85,7 @@ from utils.get_supported_scylla_base_versions import UpgradeBaseVersion  # pylin
 SUPPORTED_CLOUDS = ("aws", "gce", "azure",)
 DEFAULT_CLOUD = SUPPORTED_CLOUDS[0]
 
-SCT_RUNNER_HOST = os.environ.get("RUNNER_IP", "localhost")  # TODO: replace with get_runner_ip (check "localhost" usage)
+SCT_RUNNER_HOST = get_sct_runner_ip()
 
 LOGGER = setup_stdout_logger()
 
@@ -784,7 +785,7 @@ def show_jepsen_results(test_id):
         click.secho(message=f"\nJepsen data restored, starting web server on "
                             f"http://{SCT_RUNNER_HOST}:{jepsen.jepsen_results_port}/",
                     fg="green")
-        detach = SCT_RUNNER_HOST != "localhost"
+        detach = SCT_RUNNER_HOST != "127.0.0.1"
         if not detach:
             click.secho(message="Press Ctrl-C to stop the server.", fg="green")
         click.echo("")

--- a/sct.py
+++ b/sct.py
@@ -82,7 +82,7 @@ from utils.get_supported_scylla_base_versions import UpgradeBaseVersion  # pylin
 SUPPORTED_CLOUDS = ("aws", "gce", "azure",)
 DEFAULT_CLOUD = SUPPORTED_CLOUDS[0]
 
-SCT_RUNNER_HOST = os.environ.get("RUNNER_IP", "localhost")
+SCT_RUNNER_HOST = os.environ.get("RUNNER_IP", "localhost")  # TODO: replace with get_runner_ip (check "localhost" usage)
 
 LOGGER = setup_stdout_logger()
 

--- a/sdcm/argus_test_run.py
+++ b/sdcm/argus_test_run.py
@@ -187,7 +187,7 @@ class ArgusTestRun:
         backend = sct_config.get("cluster_backend")
         regions = sct_config.region_names
 
-        sct_runner_info = CloudInstanceDetails(ip=get_sct_runner_ip(), provider=backend,
+        sct_runner_info = CloudInstanceDetails(public_ip=get_sct_runner_ip(), provider=backend,
                                                region=regions[0], private_ip=get_my_ip())
 
         cloud_setup = cls.BACKEND_MAP.get(backend, _prepare_unknown_resource_setup)(sct_config)

--- a/sdcm/argus_test_run.py
+++ b/sdcm/argus_test_run.py
@@ -12,10 +12,10 @@ from argus.db.config import Config
 
 from sdcm.keystore import KeyStore
 from sdcm.sct_config import SCTConfiguration
-from sdcm.utils.common import get_test_name, get_sct_runner_ip, get_my_ip
+from sdcm.utils.net import get_my_ip, get_sct_runner_ip
 from sdcm.utils.get_username import get_username
 from sdcm.utils.git import get_git_current_branch, get_git_commit_id
-from sdcm.utils.ci_tools import get_job_url, get_job_name
+from sdcm.utils.ci_tools import get_job_url, get_job_name, get_test_name
 
 LOGGER = logging.getLogger(__name__)
 

--- a/sdcm/argus_test_run.py
+++ b/sdcm/argus_test_run.py
@@ -161,6 +161,7 @@ class ArgusTestRun:
         "docker": _prepare_docker_resource_setup,
         "unknown": _prepare_unknown_resource_setup,
     }
+    CONFIG = ArgusConfig(**KeyStore().get_argusdb_credentials(), keyspace_name="argus")
 
     def __init__(self):
         pass
@@ -212,15 +213,14 @@ class ArgusTestRun:
         cls.TESTRUN_INSTANCE = TestRunWithHeartbeat(test_id=test_id, group=test_group, release_name=release_name,
                                                     assignee="",
                                                     run_info=run_info,
-                                                    config=ArgusConfig(**KeyStore().get_argusdb_credentials(),
-                                                                       keyspace_name="argus"))
+                                                    config=cls.CONFIG)
 
         return cls.TESTRUN_INSTANCE
 
     @classmethod
-    def get(cls, test_id: UUID = None, config: ArgusConfig = None) -> TestRunWithHeartbeat:
-        if test_id and not cls.TESTRUN_INSTANCE and config:
-            cls.TESTRUN_INSTANCE = TestRunWithHeartbeat.from_id(test_id, config=config)
+    def get(cls, test_id: UUID = None) -> TestRunWithHeartbeat:
+        if test_id and not cls.TESTRUN_INSTANCE:
+            cls.TESTRUN_INSTANCE = TestRunWithHeartbeat.from_id(test_id, config=cls.CONFIG)
 
         if not cls.TESTRUN_INSTANCE:
             cls.warn_once("Returning MagicMock from ArgusTestRun.get() as we are unable to acquire Argus connection")

--- a/sdcm/argus_test_run.py
+++ b/sdcm/argus_test_run.py
@@ -15,7 +15,7 @@ from sdcm.sct_config import SCTConfiguration
 from sdcm.utils.common import get_test_name, get_sct_runner_ip, get_my_ip
 from sdcm.utils.get_username import get_username
 from sdcm.utils.git import get_git_current_branch, get_git_commit_id
-from utils.build_system import get_job_url, get_job_name
+from sdcm.utils.ci_tools import get_job_url, get_job_name
 
 LOGGER = logging.getLogger(__name__)
 

--- a/sdcm/argus_test_run.py
+++ b/sdcm/argus_test_run.py
@@ -12,9 +12,10 @@ from argus.db.config import Config
 
 from sdcm.keystore import KeyStore
 from sdcm.sct_config import SCTConfiguration
-from sdcm.utils.common import get_job_name, get_job_url, get_test_name, get_git_commit_id, get_git_current_branch, \
+from sdcm.utils.common import get_test_name, get_git_commit_id, get_git_current_branch, \
     get_sct_runner_ip, get_my_ip
 from sdcm.utils.get_username import get_username
+from utils.build_system import get_job_url, get_job_name
 
 LOGGER = logging.getLogger(__name__)
 

--- a/sdcm/argus_test_run.py
+++ b/sdcm/argus_test_run.py
@@ -1,3 +1,15 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2021 ScyllaDB
 import time
 import logging
 import unittest.mock

--- a/sdcm/argus_test_run.py
+++ b/sdcm/argus_test_run.py
@@ -3,6 +3,7 @@ import logging
 import unittest.mock
 from uuid import UUID
 
+from cassandra import ConsistencyLevel
 from argus.db.db_types import TestStatus
 from argus.db.testrun import TestRunWithHeartbeat, TestRunInfo, TestDetails, TestResources, TestLogs, TestResults, \
     TestResourcesSetup
@@ -173,7 +174,8 @@ class ArgusTestRun:
             return
         LOGGER.info("Initializing ScyllaDB connection session...")
         ks = KeyStore()
-        ArgusDatabase.from_config(Config(**ks.get_argusdb_credentials(), keyspace_name="argus"))
+        database = ArgusDatabase.from_config(Config(**ks.get_argusdb_credentials(), keyspace_name="argus"))
+        database.session.default_consistency_level = ConsistencyLevel.QUORUM
         cls.db_init = True
 
     @classmethod

--- a/sdcm/argus_test_run.py
+++ b/sdcm/argus_test_run.py
@@ -1,0 +1,222 @@
+import time
+import logging
+from uuid import UUID
+
+from argus.db.db_types import TestStatus
+from argus.db.testrun import TestRun, TestRunInfo, TestDetails, TestResources, TestLogs, TestResults, \
+    TestResourcesSetup
+from argus.db.cloud_types import CloudInstanceDetails, AWSSetupDetails, GCESetupDetails, BaseCloudSetupDetails, \
+    CloudNodesInfo
+from argus.db.interface import ArgusDatabase
+from argus.db.config import Config
+
+from sdcm.keystore import KeyStore
+from sdcm.sct_config import SCTConfiguration
+from sdcm.utils.common import get_job_name, get_job_url, get_test_name, get_git_commit_id, get_git_current_branch, \
+    get_sct_runner_ip, get_my_ip
+from sdcm.utils.get_username import get_username
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ArgusTestRunError(Exception):
+    pass
+
+
+def _prepare_aws_resource_setup(sct_config: SCTConfiguration):
+    db_node_setup = CloudNodesInfo(image_id=sct_config.get("ami_id_db_scylla"),
+                                   instance_type=sct_config.get("instance_type_db"),
+                                   node_amount=sct_config.get("n_db_nodes"),
+                                   post_behaviour=sct_config.get("post_behavior_db_nodes"))
+    loader_node_setup = CloudNodesInfo(image_id=sct_config.get("ami_id_loader"),
+                                       instance_type=sct_config.get("instance_type_loader"),
+                                       node_amount=sct_config.get("n_loaders"),
+                                       post_behaviour=sct_config.get("post_behavior_loader_nodes"))
+    monitor_node_setup = CloudNodesInfo(image_id=sct_config.get("ami_id_monitor"),
+                                        instance_type=sct_config.get("instance_type_monitor"),
+                                        node_amount=sct_config.get("n_monitor_nodes"),
+                                        post_behaviour=sct_config.get("post_behavior_monitor_nodes"))
+    cloud_setup = AWSSetupDetails(db_node=db_node_setup, loader_node=loader_node_setup,
+                                  monitor_node=monitor_node_setup)
+
+    return cloud_setup
+
+
+def _prepare_gce_resource_setup(sct_config: SCTConfiguration):
+    db_node_setup = CloudNodesInfo(image_id=sct_config.get("gce_image_db"),
+                                   instance_type=sct_config.get("gce_instance_type_db"),
+                                   node_amount=sct_config.get("n_db_nodes"),
+                                   post_behaviour=sct_config.get("post_behavior_db_nodes"))
+    loader_node_setup = CloudNodesInfo(image_id=sct_config.get("gce_image_loader"),
+                                       instance_type=sct_config.get("gce_instance_type_loader"),
+                                       node_amount=sct_config.get("n_loaders"),
+                                       post_behaviour=sct_config.get("post_behavior_loader_nodes"))
+    monitor_node_setup = CloudNodesInfo(image_id=sct_config.get("gce_image_monitor"),
+                                        instance_type=sct_config.get("gce_instance_type_monitor"),
+                                        node_amount=sct_config.get("n_monitor_nodes"),
+                                        post_behaviour=sct_config.get("post_behavior_monitor_nodes"))
+    cloud_setup = GCESetupDetails(db_node=db_node_setup, loader_node=loader_node_setup,
+                                  monitor_node=monitor_node_setup)
+
+    return cloud_setup
+
+
+def _prepare_unknown_resource_setup(sct_config: SCTConfiguration):
+    LOGGER.error("Unknown backend encountered: %s", sct_config.get("cluster_backend"))
+    db_node_setup = CloudNodesInfo(image_id="UNKNOWN",
+                                   instance_type="UNKNOWN",
+                                   node_amount=-1,
+                                   post_behaviour="UNKNOWN")
+    loader_node_setup = CloudNodesInfo(image_id="UNKNOWN",
+                                       instance_type="UNKNOWN",
+                                       node_amount=-1,
+                                       post_behaviour="UNKNOWN")
+    monitor_node_setup = CloudNodesInfo(image_id="UNKNOWN",
+                                        instance_type="UNKNOWN",
+                                        node_amount=-1,
+                                        post_behaviour="UNKNOWN")
+    cloud_setup = BaseCloudSetupDetails(db_node=db_node_setup, loader_node=loader_node_setup,
+                                        monitor_node=monitor_node_setup, backend=sct_config.get("cluster_backend"))
+
+    return cloud_setup
+
+
+def _prepare_bare_metal_resource_setup(sct_config: SCTConfiguration):
+    db_node_setup = CloudNodesInfo(image_id="bare_metal",
+                                   instance_type="bare_metal",
+                                   node_amount=sct_config.get("n_db_nodes"),
+                                   post_behaviour=sct_config.get("post_behavior_db_nodes"))
+    loader_node_setup = CloudNodesInfo(image_id="bare_metal",
+                                       instance_type="bare_metal",
+                                       node_amount=sct_config.get("n_loaders"),
+                                       post_behaviour=sct_config.get("post_behavior_loader_nodes"))
+    monitor_node_setup = CloudNodesInfo(image_id="bare_metal",
+                                        instance_type="bare_metal",
+                                        node_amount=sct_config.get("n_monitor_nodes"),
+                                        post_behaviour=sct_config.get("post_behavior_monitor_nodes"))
+    cloud_setup = BaseCloudSetupDetails(db_node=db_node_setup, loader_node=loader_node_setup,
+                                        monitor_node=monitor_node_setup, backend=sct_config.get("cluster_backend"))
+
+    return cloud_setup
+
+
+def _prepare_k8s_gce_minikube_resource_setup(sct_config: SCTConfiguration):
+    cloud_setup = _prepare_gce_resource_setup(sct_config)
+
+    image_id = sct_config.get("scylla_version")
+    cloud_setup.db_node.image_id = f"scylladb/scylladb:{image_id}"
+    cloud_setup.db_node.instance_type = sct_config.get("gce_instance_type_minikube")
+
+    return cloud_setup
+
+
+def _prepare_k8s_gke_resource_setup(sct_config: SCTConfiguration):
+    cloud_setup = _prepare_gce_resource_setup(sct_config)
+    image_id = sct_config.get("scylla_version")
+    cloud_setup.db_node.image_id = f"scylladb/scylladb:{image_id}"
+    cloud_setup.monitor_node.image_id = sct_config.get("mgmt_docker_image")
+    cloud_setup.loader_node.image_id = f"scylladb/scylladb:{image_id}"
+
+    return cloud_setup
+
+
+def _prepare_k8s_eks_resource_setup(sct_config: SCTConfiguration):
+    cloud_setup = _prepare_aws_resource_setup(sct_config)
+
+    return cloud_setup
+
+
+def _prepare_docker_resource_setup(sct_config: SCTConfiguration):
+    db_node_setup = CloudNodesInfo(image_id=sct_config.get('docker_image'),
+                                   instance_type="docker",
+                                   node_amount=sct_config.get("n_db_nodes"),
+                                   post_behaviour=sct_config.get("post_behavior_db_nodes"))
+    loader_node_setup = CloudNodesInfo(image_id=sct_config.get('docker_image'),
+                                       instance_type="docker",
+                                       node_amount=sct_config.get("n_loaders"),
+                                       post_behaviour=sct_config.get("post_behavior_loader_nodes"))
+    monitor_node_setup = CloudNodesInfo(image_id=sct_config.get('docker_image'),
+                                        instance_type="docker",
+                                        node_amount=sct_config.get("n_monitor_nodes"),
+                                        post_behaviour=sct_config.get("post_behavior_monitor_nodes"))
+    cloud_setup = BaseCloudSetupDetails(db_node=db_node_setup, loader_node=loader_node_setup,
+                                        monitor_node=monitor_node_setup, backend=sct_config.get("cluster_backend"))
+
+    return cloud_setup
+
+
+class ArgusTestRun:
+    TESTRUN_INSTANCE = None
+    BACKEND_MAP = {
+        "aws": _prepare_aws_resource_setup,
+        "aws-siren": _prepare_aws_resource_setup,
+        "gce": _prepare_gce_resource_setup,
+        "gce-siren": _prepare_gce_resource_setup,
+        "k8s-eks": _prepare_k8s_eks_resource_setup,
+        "k8s-gke": _prepare_k8s_gke_resource_setup,
+        "k8s-gce-minikube": _prepare_k8s_gce_minikube_resource_setup,
+        "baremetal": _prepare_bare_metal_resource_setup,
+        "docker": _prepare_docker_resource_setup,
+        "unknown": _prepare_unknown_resource_setup,
+    }
+
+    def __init__(self):
+        pass
+
+    @classmethod
+    def from_sct_config(cls, test_id: UUID, test_module_path: str, sct_config: SCTConfiguration) -> TestRun:  # pylint: disable=too-many-locals
+        if cls.TESTRUN_INSTANCE:
+            raise ArgusTestRunError("Instance already initialized")
+
+        LOGGER.info("Initializing ScyllaDB connection session...")
+        ks = KeyStore()
+        ArgusDatabase.from_config(Config(**ks.get_argusdb_credentials(), keyspace_name="argus"))
+        LOGGER.info("Preparing Test Details...")
+        test_group, *_ = test_module_path.split(".")
+        config_files = sct_config.get("config_files")
+        job_name = get_job_name()
+        job_url = get_job_url()
+        started_by = get_username()
+        release_name = sct_config.environment.get("release_name", get_git_current_branch())
+
+        details = TestDetails(name=get_test_name(), scm_revision_id=get_git_commit_id(), started_by=started_by,
+                              build_job_name=job_name, build_job_url=job_url,
+                              yaml_test_duration=sct_config.get("test_duration"), start_time=int(time.time()),
+                              config_files=config_files, packages=[])
+        LOGGER.info("Preparing Resource Setup...")
+        backend = sct_config.get("cluster_backend")
+        regions = sct_config.region_names
+
+        sct_runner_info = CloudInstanceDetails(ip=get_sct_runner_ip(), provider=backend,
+                                               region=regions[0], private_ip=get_my_ip())
+
+        cloud_setup = cls.BACKEND_MAP.get(backend, _prepare_unknown_resource_setup)(sct_config)
+
+        setup_details = TestResourcesSetup(sct_runner_host=sct_runner_info, region_name=regions,
+                                           cloud_setup=cloud_setup)
+
+        logs = TestLogs()
+        resources = TestResources()
+        results = TestResults(status=TestStatus.CREATED)
+
+        run_info = TestRunInfo(details=details, setup=setup_details, resources=resources, logs=logs, results=results)
+        LOGGER.info("Initializing TestRun...")
+        cls.TESTRUN_INSTANCE = TestRun(test_id=test_id, group=test_group, release_name=release_name, assignee="",
+                                       run_info=run_info)
+
+        return cls.TESTRUN_INSTANCE
+
+    @classmethod
+    def get(cls) -> TestRun:
+        if not cls.TESTRUN_INSTANCE:
+            raise ArgusTestRunError("No instance configured")
+
+        return cls.TESTRUN_INSTANCE
+
+    @classmethod
+    def destroy(cls):
+        if not cls.TESTRUN_INSTANCE:
+            raise ArgusTestRunError("No instance configured")
+
+        cls.TESTRUN_INSTANCE = None
+        ArgusDatabase.destroy()

--- a/sdcm/argus_test_run.py
+++ b/sdcm/argus_test_run.py
@@ -1,5 +1,6 @@
 import time
 import logging
+import unittest.mock
 from uuid import UUID
 
 from argus.db.db_types import TestStatus
@@ -227,7 +228,7 @@ class ArgusTestRun:
             cls.TESTRUN_INSTANCE = TestRunWithHeartbeat.from_id(test_id)
 
         if not cls.TESTRUN_INSTANCE:
-            raise ArgusTestRunError("No instance available")
+            return unittest.mock.MagicMock()
 
         return cls.TESTRUN_INSTANCE
 

--- a/sdcm/argus_test_run.py
+++ b/sdcm/argus_test_run.py
@@ -12,9 +12,9 @@ from argus.db.config import Config
 
 from sdcm.keystore import KeyStore
 from sdcm.sct_config import SCTConfiguration
-from sdcm.utils.common import get_test_name, get_git_commit_id, get_git_current_branch, \
-    get_sct_runner_ip, get_my_ip
+from sdcm.utils.common import get_test_name, get_sct_runner_ip, get_my_ip
 from sdcm.utils.get_username import get_username
+from sdcm.utils.git import get_git_current_branch, get_git_commit_id
 from utils.build_system import get_job_url, get_job_name
 
 LOGGER = logging.getLogger(__name__)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -77,11 +77,11 @@ from sdcm.utils.common import (
     normalize_ipv6_url,
     download_dir_from_cloud,
     generate_random_string,
-    get_test_name,
     update_authenticator,
     prepare_and_start_saslauthd_service,
     change_default_password,
 )
+from sdcm.utils.ci_tools import get_test_name
 from sdcm.utils.distro import Distro
 from sdcm.utils.install import InstallMode
 from sdcm.utils.docker_utils import ContainerManager, NotFound, docker_hub_login

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -48,7 +48,7 @@ from cassandra.policies import RetryPolicy
 from cassandra.policies import WhiteListRoundRobinPolicy
 
 from argus.db.cloud_types import ResourceState, CloudInstanceDetails, CloudResource
-from sdcm.argus_test_run import ArgusTestRun, ArgusTestRunError
+from sdcm.argus_test_run import ArgusTestRun
 from sdcm.collectd import ScyllaCollectdSetup
 from sdcm.mgmt import AnyManagerCluster, ScyllaManagerError
 from sdcm.mgmt.common import get_manager_repo_from_defaults, get_manager_scylla_backend
@@ -298,8 +298,6 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             run.run_info.resources.attach_resource(resource)
 
             run.save()
-        except ArgusTestRunError:
-            LOGGER.error("Unable to init Argus Resource - skipping...", exc_info=True)
         except Exception:  # pylint: disable=broad-except
             LOGGER.error("Encountered an unhandled exception while interacting with Argus", exc_info=True)
 
@@ -1118,8 +1116,6 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                     if self.running_nemesis else "GracefulShutdown"
                 run.run_info.resources.detach_resource(self.argus_resource)
                 run.save()
-        except ArgusTestRunError:
-            LOGGER.error("Unable to init argus - skipping...", exc_info=True)
         except Exception:  # pylint: disable=broad-except
             self.log.error("Error saving resource state to Argus", exc_info=True)
 

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -289,10 +289,10 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
         try:
             run = ArgusTestRun.get()
-            instance_details = CloudInstanceDetails(ip=self.public_ip_address, region=self.region,
+            instance_details = CloudInstanceDetails(public_ip=self.public_ip_address, region=self.region,
                                                     provider=self.parent_cluster.cluster_backend,
                                                     private_ip=self.ip_address)
-            resource = CloudResource(name=self.name, resource_state=ResourceState.RUNNING,
+            resource = CloudResource(name=self.name, state=ResourceState.RUNNING,
                                      instance_info=instance_details)
             self.argus_resource = resource
             run.run_info.resources.attach_resource(resource)
@@ -1114,7 +1114,6 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             run = ArgusTestRun.get()
             if self.argus_resource in run.run_info.resources.leftover_resources:
                 run.run_info.resources.detach_resource(self.argus_resource)
-                self.argus_resource.resource_state = ResourceState.TERMINATED
                 run.save()
         except ArgusTestRunError:
             LOGGER.error("Unable to init argus - skipping...", exc_info=True)
@@ -3121,7 +3120,6 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
         self.use_saslauthd_authenticator = self.params.get('use_saslauthd_authenticator')
         # default 'cassandra' password is weak password, MS AD doesn't allow to use it.
         self.added_password_suffix = False
-        self._cluster_backend = self.params.get("cluster_backend")
 
         if self.test_config.REUSE_CLUSTER:
             # get_node_ips_param should be defined in child
@@ -3493,7 +3491,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
 
     @property
     def cluster_backend(self):
-        return self._cluster_backend
+        return self.params.get("cluster_backend")
 
 
 class NodeSetupFailed(Exception):

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -50,6 +50,7 @@ from sdcm.sct_events.system import SpotTerminationEvent
 from sdcm.sct_events.filters import DbEventsFilter
 from sdcm.sct_events.database import DatabaseLogEvent
 
+
 LOGGER = logging.getLogger(__name__)
 
 INSTANCE_PROVISION_ON_DEMAND = 'on_demand'

--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -31,10 +31,10 @@ import requests
 
 from sdcm.es import ES
 from sdcm.test_config import TestConfig
-from sdcm.utils.common import get_job_name, normalize_ipv6_url, get_git_commit_id, get_job_url
+from sdcm.utils.common import normalize_ipv6_url, get_git_commit_id
 from sdcm.utils.decorators import retrying
 from sdcm.sct_events.system import ElasticsearchEvent
-
+from utils.build_system import get_job_name, get_job_url
 
 LOGGER = logging.getLogger(__name__)
 

--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -15,7 +15,6 @@ import re
 import datetime
 import time
 import os
-import subprocess
 import platform
 import logging
 import json
@@ -32,7 +31,7 @@ import requests
 
 from sdcm.es import ES
 from sdcm.test_config import TestConfig
-from sdcm.utils.common import get_job_name, normalize_ipv6_url
+from sdcm.utils.common import get_job_name, normalize_ipv6_url, get_git_commit_id, get_job_url
 from sdcm.utils.decorators import retrying
 from sdcm.sct_events.system import ElasticsearchEvent
 
@@ -539,9 +538,9 @@ class TestStatsMixin(Stats):
 
     def get_test_details(self):
         test_details = {}
-        test_details['sct_git_commit'] = subprocess.check_output(['git', 'rev-parse', 'HEAD'], text=True).strip()
+        test_details['sct_git_commit'] = get_git_commit_id()
         test_details['job_name'] = get_job_name()
-        test_details['job_url'] = os.environ.get('BUILD_URL', '')
+        test_details['job_url'] = get_job_url()
         test_details['start_host'] = platform.node()
         test_details['test_duration'] = self.params.get(key='test_duration')
         test_details['start_time'] = time.time()

--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -35,7 +35,7 @@ from sdcm.utils.common import normalize_ipv6_url
 from sdcm.utils.git import get_git_commit_id
 from sdcm.utils.decorators import retrying
 from sdcm.sct_events.system import ElasticsearchEvent
-from utils.build_system import get_job_name, get_job_url
+from sdcm.utils.ci_tools import get_job_name, get_job_url
 
 LOGGER = logging.getLogger(__name__)
 

--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -31,7 +31,8 @@ import requests
 
 from sdcm.es import ES
 from sdcm.test_config import TestConfig
-from sdcm.utils.common import normalize_ipv6_url, get_git_commit_id
+from sdcm.utils.common import normalize_ipv6_url
+from sdcm.utils.git import get_git_commit_id
 from sdcm.utils.decorators import retrying
 from sdcm.sct_events.system import ElasticsearchEvent
 from utils.build_system import get_job_name, get_job_url

--- a/sdcm/monitorstack/ui.py
+++ b/sdcm/monitorstack/ui.py
@@ -8,7 +8,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webelement import WebElement
 from selenium.common import exceptions
 
-from sdcm.utils.common import get_test_name
+from sdcm.utils.ci_tools import get_test_name
 
 
 LOGGER = logging.getLogger(__name__)

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -69,7 +69,7 @@ from sdcm.utils.version_utils import MethodVersionNotFound, scylla_versions
 from sdcm.remote.libssh2_client.exceptions import UnexpectedExit as Libssh2UnexpectedExit
 from sdcm.cluster_k8s import PodCluster, ScyllaPodCluster
 from sdcm.nemesis_publisher import NemesisElasticSearchPublisher
-from sdcm.argus_test_run import ArgusTestRun, ArgusTestRunError
+from sdcm.argus_test_run import ArgusTestRun
 from test_lib.compaction import CompactionStrategy, get_compaction_strategy, get_compaction_random_additional_params
 from test_lib.cql_types import CQLTypeBuilder
 from argus.db.db_types import NemesisStatus, NemesisRunInfo, NodeDescription
@@ -2861,8 +2861,6 @@ def disrupt_method_wrapper(method):  # pylint: disable=too-many-statements
                                               status=NemesisStatus.RUNNING)
                 run.run_info.results.add_nemesis(nemesis_info)
                 run.save()  # TODO: Thread Safety
-            except ArgusTestRunError:
-                args[0].log.error("Argus failed to initialize!", exc_info=True)
             except Exception:  # pylint: disable=broad-except
                 args[0].log.error("Error saving nemesis_info to Argus", exc_info=True)
             try:

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2834,7 +2834,7 @@ def disrupt_method_wrapper(method):  # pylint: disable=too-many-statements
                 nemesis_info.status = NemesisStatus.SKIPPED
             else:
                 nemesis_info.complete()
-            nemesis_info.duration = nemesis_info.start_time - nemesis_info.end_time
+            nemesis_info.duration = nemesis_info.end_time - nemesis_info.start_time
             run.save()
         except Exception:  # pylint: disable=broad-except
             nemesis.log.error("Error saving nemesis_info to Argus", exc_info=True)

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1505,6 +1505,10 @@ class SCTConfiguration(dict):
         return output
 
     @property
+    def environment(self) -> dict:
+        return self._env
+
+    @property
     def _env(self) -> dict:
         return self._load_environment_variables()
 

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -343,7 +343,8 @@ class SCTConfiguration(dict):
         dict(name="instance_provision", env="SCT_INSTANCE_PROVISION", type=str,
              help="instance_provision: spot|on_demand|spot_fleet"),
 
-        dict(name="instance_provision_fallback_on_demand", env="SCT_INSTANCE_PROVISION_FALLBACK_ON_DEMAND", type=boolean,
+        dict(name="instance_provision_fallback_on_demand", env="SCT_INSTANCE_PROVISION_FALLBACK_ON_DEMAND",
+             type=boolean,
              help="instance_provision_fallback_on_demand: create instance on_demand provision type if instance with selected "
                   "'instance_provision' type creation failed. "
                   "Expected values: true|false (default - false"),
@@ -1452,7 +1453,7 @@ class SCTConfiguration(dict):
                 self['new_scylla_repo'] = find_scylla_repo(new_scylla_version, dist_type, dist_version)
 
         # 8) resolve repo symlinks
-        for repo_key in ("scylla_repo", "scylla_repo_loader", "new_scylla_repo", ):
+        for repo_key in ("scylla_repo", "scylla_repo_loader", "new_scylla_repo",):
             if self.get(repo_key):
                 self[repo_key] = resolve_latest_repo_symlink(self[repo_key])
 
@@ -1492,7 +1493,7 @@ class SCTConfiguration(dict):
 
     @property
     def region_names(self) -> List[str]:
-        region_names = self._env.get('region_name')
+        region_names = self.environment.get('region_name')
         if region_names is None:
             region_names = self.get('region_name')
         if region_names is None:
@@ -1506,10 +1507,6 @@ class SCTConfiguration(dict):
 
     @property
     def environment(self) -> dict:
-        return self._env
-
-    @property
-    def _env(self) -> dict:
         return self._load_environment_variables()
 
     @classmethod

--- a/sdcm/test_config.py
+++ b/sdcm/test_config.py
@@ -9,7 +9,7 @@ import requests
 from sdcm.keystore import KeyStore
 from sdcm.provision.common.utils import configure_sshd_script, configure_rsyslog_rate_limits_script, \
     configure_rsyslog_target_script, restart_sshd_service, restart_rsyslog_service
-from sdcm.utils.common import get_my_ip
+from sdcm.utils.net import get_my_ip
 from sdcm.utils.decorators import retrying
 from sdcm.utils.docker_utils import ContainerManager
 from sdcm.utils.get_username import get_username

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -366,10 +366,11 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     def argus_test_run(self):
         if not self._argus_test_run:
             try:
-                self._argus_test_run = ArgusTestRun.from_sct_config(test_id=UUID(self.test_id),
-                                                                    test_module_path=self.test_config.test_name(),
-                                                                    sct_config=self.params)
-                self._argus_test_run.save()
+                argus_test_run = ArgusTestRun.from_sct_config(test_id=UUID(self.test_id),
+                                                              test_module_path=self.test_config.test_name(),
+                                                              sct_config=self.params)
+                argus_test_run.save()
+                self._argus_test_run = argus_test_run
             except Exception:  # pylint: disable=broad-except
                 self.log.error("Error setting up argus connection", exc_info=True)
         return self._argus_test_run

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -414,16 +414,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         except Exception:  # pylint: disable=broad-except
             self.log.error("Error committing test events to Argus", exc_info=True)
 
-    def argus_collect_logs(self, log_links: dict[str, list[str] | str]):
+    def argus_collect_logs(self, log_links: dict[str, list[list[str] | str]]):
         try:
             for name, link in log_links.items():
-                if isinstance(link, str):
-                    self.argus_test_run.run_info.logs.add_log(name, link)
-                elif isinstance(link, list):
-                    for log_inner_link in link:
-                        self.argus_test_run.run_info.logs.add_log(name, log_inner_link)
-                else:
-                    self.log.warning("Unknown log type encountered: %s", link)
+                self.argus_test_run.run_info.logs.add_log(name, link)
             self.argus_test_run.save()
         except Exception:  # pylint: disable=broad-except
             self.log.error("Error saving logs to Argus", exc_info=True)

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -309,6 +309,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                              self.params.get('email_recipients'),
                                              self.logdir)
         self._argus_test_run = None
+        self._use_argus = True
         self.log.info("Initializing Argus TestRun with test id %s", self.argus_test_run.id)
         self._move_kubectl_config()
         self.localhost = self._init_localhost()
@@ -364,7 +365,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
     @property
     def argus_test_run(self):
-        if not self._argus_test_run:
+        if not self._argus_test_run and self._use_argus:
             try:
                 argus_test_run = ArgusTestRun.from_sct_config(test_id=UUID(self.test_id),
                                                               test_module_path=self.test_config.test_name(),
@@ -372,6 +373,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 argus_test_run.save()
                 self._argus_test_run = argus_test_run
             except Exception:  # pylint: disable=broad-except
+                self._use_argus = False
                 self.log.error("Error setting up argus connection", exc_info=True)
         return self._argus_test_run
 

--- a/sdcm/utils/ci_tools.py
+++ b/sdcm/utils/ci_tools.py
@@ -13,3 +13,16 @@ def get_job_name() -> str:
 
 def get_job_url() -> str:
     return os.environ.get('BUILD_URL', '')
+
+
+def get_test_name() -> str:
+    job_name = get_job_name()
+    if job_name and job_name != 'local_run':
+        return job_name.split("/")[-1]
+
+    if config_files := os.environ.get("SCT_CONFIG_FILES"):
+        # Example: 'test-cases/gemini/gemini-1tb-10h.yaml,test-cases/gemini/gemini-10tb-10h.yaml'
+        config_file = config_files[0] if isinstance(config_files, list) else config_files.split(",")[0].strip()
+        return config_file.split("/")[-1].replace('.yaml', '').replace('"', '').replace("'", "").rstrip("]")
+
+    return "#TEST_NAME_NOT_FOUND"

--- a/sdcm/utils/ci_tools.py
+++ b/sdcm/utils/ci_tools.py
@@ -1,0 +1,15 @@
+"""
+Functions related to CI pipelines (Jenkins/GH Actions)
+"""
+import logging
+import os
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get_job_name() -> str:
+    return os.environ.get('JOB_NAME', 'local_run')
+
+
+def get_job_url() -> str:
+    return os.environ.get('BUILD_URL', '')

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -74,7 +74,7 @@ from sdcm.utils.docker_utils import ContainerManager
 from sdcm.utils.gce_utils import GcloudContainerMixin
 from sdcm.remote import LocalCmdRunner
 from sdcm.remote import RemoteCmdRunnerBase
-from utils.build_system import get_job_name
+from sdcm.utils.ci_tools import get_job_name
 
 LOGGER = logging.getLogger('utils')
 DEFAULT_AWS_REGION = "eu-west-1"

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -75,6 +75,7 @@ from sdcm.utils.docker_utils import ContainerManager
 from sdcm.utils.gce_utils import GcloudContainerMixin
 from sdcm.remote import LocalCmdRunner
 from sdcm.remote import RemoteCmdRunnerBase
+from utils.build_system import get_job_name
 
 LOGGER = logging.getLogger('utils')
 DEFAULT_AWS_REGION = "eu-west-1"
@@ -152,16 +153,8 @@ def get_sct_root_path():
     return os.path.abspath(sct_root_dir)
 
 
-def get_sct_runner_ip() -> str:  # TODO: Replace all occurences of env variable
+def get_sct_runner_ip() -> str:
     return os.environ.get("RUNNER_IP", "127.0.0.1")
-
-
-def get_job_name() -> str:  # TODO: Move to build_system module
-    return os.environ.get('JOB_NAME', 'local_run')
-
-
-def get_job_url() -> str:  # TODO: Move to build_system module
-    return os.environ.get('BUILD_URL', '')
 
 
 def get_git_commit_id() -> str:
@@ -175,7 +168,7 @@ def get_git_commit_id() -> str:
 
 def get_git_current_branch() -> str:
     try:
-        proc = subprocess.run(args=["git", "branch", "--show-current"], check=True, capture_output=True)
+        proc = subprocess.run(args=["git", "rev-parse", "--abbrev-ref=loose", "HEAD"], check=True, capture_output=True)
     except subprocess.CalledProcessError:
         LOGGER.warning("Error running git command", exc_info=True)
         return "#ERROR"

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -21,7 +21,6 @@ import os
 import logging
 import random
 import socket
-import subprocess
 import time
 import datetime
 import errno
@@ -155,24 +154,6 @@ def get_sct_root_path():
 
 def get_sct_runner_ip() -> str:
     return os.environ.get("RUNNER_IP", "127.0.0.1")
-
-
-def get_git_commit_id() -> str:
-    try:
-        proc = subprocess.run(args=["git", "rev-parse", "HEAD"], check=True, capture_output=True)
-    except subprocess.CalledProcessError:
-        LOGGER.warning("Error running git command", exc_info=True)
-        return ""
-    return proc.stdout.decode(encoding="utf-8").strip()
-
-
-def get_git_current_branch() -> str:
-    try:
-        proc = subprocess.run(args=["git", "rev-parse", "--abbrev-ref=loose", "HEAD"], check=True, capture_output=True)
-    except subprocess.CalledProcessError:
-        LOGGER.warning("Error running git command", exc_info=True)
-        return "#ERROR"
-    return proc.stdout.decode(encoding="utf-8").strip()
 
 
 def get_test_name() -> str:

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -178,7 +178,7 @@ def get_git_current_branch() -> str:
         proc = subprocess.run(args=["git", "branch", "--show-current"], check=True, capture_output=True)
     except subprocess.CalledProcessError:
         LOGGER.warning("Error running git command", exc_info=True)
-        return ""
+        return "#ERROR"
     return proc.stdout.decode(encoding="utf-8").strip()
 
 

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -74,7 +74,6 @@ from sdcm.utils.docker_utils import ContainerManager
 from sdcm.utils.gce_utils import GcloudContainerMixin
 from sdcm.remote import LocalCmdRunner
 from sdcm.remote import RemoteCmdRunnerBase
-from sdcm.utils.ci_tools import get_job_name
 
 LOGGER = logging.getLogger('utils')
 DEFAULT_AWS_REGION = "eu-west-1"
@@ -150,23 +149,6 @@ def get_sct_root_path():
     sdcm_path = os.path.realpath(sdcm.__path__[0])
     sct_root_dir = os.path.join(sdcm_path, "..")
     return os.path.abspath(sct_root_dir)
-
-
-def get_sct_runner_ip() -> str:
-    return os.environ.get("RUNNER_IP", "127.0.0.1")
-
-
-def get_test_name() -> str:
-    job_name = get_job_name()
-    if job_name and job_name != 'local_run':
-        return job_name.split("/")[-1]
-
-    if config_files := os.environ.get("SCT_CONFIG_FILES"):
-        # Example: 'test-cases/gemini/gemini-1tb-10h.yaml,test-cases/gemini/gemini-10tb-10h.yaml'
-        config_file = config_files[0] if isinstance(config_files, list) else config_files.split(",")[0].strip()
-        return config_file.split("/")[-1].replace('.yaml', '').replace('"', '').replace("'", "").rstrip("]")
-
-    return ""
 
 
 def verify_scylla_repo_file(content, is_rhel_like=True):
@@ -1284,14 +1266,6 @@ def get_free_port(address: str = '', ports_to_try: Iterable[int] = (0,)) -> int:
         except OSError:
             pass
     raise RuntimeError("Can't allocate a free port")
-
-
-def get_my_ip():
-    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    sock.connect(("8.8.8.8", 80))
-    ip = sock.getsockname()[0]
-    sock.close()
-    return ip
 
 
 @retrying(n=60, sleep_time=5, allowed_exceptions=(OSError,))

--- a/sdcm/utils/git.py
+++ b/sdcm/utils/git.py
@@ -1,0 +1,25 @@
+"""
+Simple git wrappers that provide useful information about current repository
+"""
+import subprocess
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get_git_commit_id() -> str:
+    try:
+        proc = subprocess.run(args=["git", "rev-parse", "HEAD"], check=True, capture_output=True)
+    except subprocess.CalledProcessError:
+        LOGGER.warning("Error running git command", exc_info=True)
+        return ""
+    return proc.stdout.decode(encoding="utf-8").strip()
+
+
+def get_git_current_branch() -> str:
+    try:
+        proc = subprocess.run(args=["git", "rev-parse", "--abbrev-ref=loose", "HEAD"], check=True, capture_output=True)
+    except subprocess.CalledProcessError:
+        LOGGER.warning("Error running git command", exc_info=True)
+        return "#ERROR"
+    return proc.stdout.decode(encoding="utf-8").strip()

--- a/sdcm/utils/net.py
+++ b/sdcm/utils/net.py
@@ -1,0 +1,17 @@
+"""
+Utility functions related to network information
+"""
+import os
+import socket
+
+
+def get_sct_runner_ip() -> str:
+    return os.environ.get("RUNNER_IP", "127.0.0.1")
+
+
+def get_my_ip():
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.connect(("8.8.8.8", 80))
+    ip = sock.getsockname()[0]
+    sock.close()
+    return ip

--- a/unit_tests/test_tester.py
+++ b/unit_tests/test_tester.py
@@ -17,6 +17,7 @@ import logging
 import tempfile
 import time
 import unittest.mock
+from unittest.mock import MagicMock
 from time import sleep
 
 from sdcm.tester import ClusterTester, silence, TestResultEvent
@@ -62,6 +63,10 @@ class ClusterTesterForTests(ClusterTester):
             variables={'log_dir': self.logdir}
         )
         super().__init__(*args)
+
+    @property
+    def argus_test_run(self):
+        return MagicMock()
 
     def _init_params(self):
         self.log = logging.getLogger(self.__class__.__name__)

--- a/unit_tests/test_tester.py
+++ b/unit_tests/test_tester.py
@@ -17,6 +17,7 @@ import logging
 import tempfile
 import time
 import unittest.mock
+from functools import cached_property
 from unittest.mock import MagicMock
 from time import sleep
 
@@ -64,7 +65,7 @@ class ClusterTesterForTests(ClusterTester):
         )
         super().__init__(*args)
 
-    @property
+    @cached_property
     def argus_test_run(self):
         return MagicMock()
 

--- a/utils/build_system/__init__.py
+++ b/utils/build_system/__init__.py
@@ -12,3 +12,15 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2021 ScyllaDB
+import logging
+import os
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get_job_name() -> str:
+    return os.environ.get('JOB_NAME', 'local_run')
+
+
+def get_job_url() -> str:
+    return os.environ.get('BUILD_URL', '')

--- a/utils/build_system/__init__.py
+++ b/utils/build_system/__init__.py
@@ -12,15 +12,3 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2021 ScyllaDB
-import logging
-import os
-
-LOGGER = logging.getLogger(__name__)
-
-
-def get_job_name() -> str:
-    return os.environ.get('JOB_NAME', 'local_run')
-
-
-def get_job_url() -> str:
-    return os.environ.get('BUILD_URL', '')

--- a/vars/jepsenPipeline.groovy
+++ b/vars/jepsenPipeline.groovy
@@ -93,7 +93,7 @@ def call(Map pipelineParams) {
             stage('Get test duration') {
                 steps {
                     catchError(stageResult: 'FAILURE') {
-                        timeout(time: 1, unit: 'MINUTES') {
+                        timeout(time: 2, unit: 'MINUTES') {
                             script {
                                 wrap([$class: 'BuildUser']) {
                                     dir('scylla-cluster-tests') {

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -159,7 +159,7 @@ def call(Map pipelineParams) {
             stage('Get test duration') {
                 steps {
                     catchError(stageResult: 'FAILURE') {
-                        timeout(time: 1, unit: 'MINUTES') {
+                        timeout(time: 2, unit: 'MINUTES') {
                             script {
                                 wrap([$class: 'BuildUser']) {
                                     dir('scylla-cluster-tests') {

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -169,7 +169,7 @@ def call(Map pipelineParams) {
             }
             stage('Get test duration') {
                 options {
-                    timeout(time: 1, unit: 'MINUTES')
+                    timeout(time: 2, unit: 'MINUTES')
                 }
                 steps {
                     catchError(stageResult: 'FAILURE') {

--- a/vars/rollingOperatorUpgradePipeline.groovy
+++ b/vars/rollingOperatorUpgradePipeline.groovy
@@ -92,7 +92,7 @@ def call(Map pipelineParams) {
             stage('Get test duration') {
                 steps {
                     catchError(stageResult: 'FAILURE') {
-                        timeout(time: 1, unit: 'MINUTES') {
+                        timeout(time: 2, unit: 'MINUTES') {
                             script {
                                 wrap([$class: 'BuildUser']) {
                                     dir('scylla-cluster-tests') {


### PR DESCRIPTION
This PR adds argus test run tracking, intended to track changes to
test runs in real-time - Resource allocation/deallocation, status
changes, nemeses starts/successes/failures, and to track test
information such as test name, group, release name and test
configuration

[Trello link](https://trello.com/c/J7XlShSk/3956-integrate-argusdb-with-sct)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
