### PR TITLE
fix(k8s-remote-scylla-yaml): reuse proper parent_cluster attributes

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2139,10 +2139,10 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
         return self.k8s_cluster.scylla_config_map
 
     def remote_scylla_yaml(self) -> ContextManager:
-        return self.k8s_cluster.manage_file_in_scylla_config_map()
+        return self.k8s_cluster.remote_scylla_yaml()
 
     def remote_cassandra_rackdc_properties(self) -> ContextManager:
-        return self.k8s_cluster.manage_file_in_scylla_config_map(filename='cassandra-rackdc.properties')
+        return self.k8s_cluster.remote_cassandra_rackdc_properties()
 
     def update_seed_provider(self):
         pass


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
