### PR TITLE
test(functional_test): deploy helm chart with all default values

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -799,7 +799,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
                 self.api_call_rate_limiter.wait_till_api_become_stable(self)
         self.wait_all_node_pools_to_be_ready()
 
-    def create_scylla_manager_agent_config(self):
+    def create_scylla_manager_agent_config(self, namespace=SCYLLA_NAMESPACE):
         data = {}
         if self.params['use_mgmt']:
             data["s3"] = {
@@ -810,7 +810,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
             }
 
         # Create kubernetes secret that holds scylla manager agent configuration
-        self.update_secret_from_data(SCYLLA_AGENT_CONFIG_NAME, SCYLLA_NAMESPACE, {
+        self.update_secret_from_data(SCYLLA_AGENT_CONFIG_NAME, namespace, {
             'scylla-manager-agent.yaml': data,
         })
 


### PR DESCRIPTION
Task: https://trello.com/c/612dSiAU/3576-check-that-default-scylla-storage-capacity-is-set-to-10gb

Issue: https://github.com/scylladb/scylla-operator/issues/501
Fix: https://github.com/scylladb/scylla-operator/pull/502

Test passed: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/yulia/job/yulia-functional-k8s-local-kind-aws/6/console

```
System under test
ScyllaDB version: 4.4.4-0.20210801.69daa9fd0 with build-id eb11cddd30e88ef39c32c847e70181b5cf786355
Instance type: N/A
Number of ScyllaDB nodes: 3
Test statuses
test_functional.py::test_single_operator_image_tag_is_everywhere - SUCCESS
test_functional.py::test_rolling_restart_cluster - SUCCESS
test_functional.py::test_drain_and_replace_node_kubernetes - SUCCESS
test_functional.py::test_drain_wait_and_replace_node_kubernetes - SUCCESS
test_functional.py::test_drain_terminate_decommission_add_node_kubernetes - SUCCESS
test_functional.py::test_mgmt_repair - SUCCESS
test_functional.py::test_mgmt_backup - SUCCESS
test_functional.py::test_listen_address - SUCCESS
test_functional.py::test_check_operator_operability_when_scylla_crd_is_incorrect - SUCCESS
test_functional.py::test_orphaned_services_after_shrink_cluster - SUCCESS
test_functional.py::test_orphaned_services_multi_rack - SUCCESS
test_functional.py::test_ha_update_spec_while_rollout_restart - SUCCESS
test_functional.py::test_scylla_operator_pods - SUCCESS
test_functional.py::test_startup_probe_exists_in_scylla_pods - SUCCESS
test_functional.py::test_readiness_probe_exists_in_mgmt_pods - SUCCESS
test_functional.py::test_deploy_helm_with_default_values - SUCCESS
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
