### PR TITLE
improvement(siren-tests): stop depending on the '*-siren' backend names

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3598,7 +3598,6 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
     def set_seeds(self, wait_for_timeout=300, first_only=False):
         seeds_selector = self.params.get('seeds_selector')
         seeds_num = self.params.get('seeds_num')
-        cluster_backend = self.params.get('cluster_backend')
 
         seed_nodes_ips = None
         if first_only:
@@ -3606,7 +3605,9 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             node.wait_ssh_up()
             seed_nodes_ips = [node.ip_address]
 
-        elif seeds_selector == 'reflector' or self.test_config.REUSE_CLUSTER or cluster_backend == 'aws-siren':
+        elif (seeds_selector == 'reflector'
+                or self.test_config.REUSE_CLUSTER
+                or self.params.get('db_type') == 'cloud_scylla'):
             node = self.nodes[0]
             node.wait_ssh_up()
             # When cluster just started, seed IP in the scylla.yaml may be like '127.0.0.1'

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2120,7 +2120,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         3.Nodetool removenode
         4.Add new node
         """
-        if self.cluster.params.get("cluster_backend") == 'aws-siren':
+        if self.cluster.params.get("db_type") == 'cloud_scylla':
             raise UnsupportedNemesis("Skipping this nemesis due this job run from Siren cloud with 2019 version!")
 
         node_to_remove = self.target_node

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -102,6 +102,9 @@ class SCTConfiguration(dict):
     available_backends = [
         'baremetal',
         'docker',
+        # TODO: remove 'aws-siren' and 'gce-siren' backends completely when
+        #       'siren-tests' project gets switched to the 'aws' and 'gce' ones.
+        #       Such a switch must be fast change.
         'aws', 'aws-siren', 'k8s-local-kind-aws', 'k8s-eks',
         'gce', 'gce-siren', 'k8s-local-kind-gce', 'k8s-gke', 'k8s-gce-minikube',
         'k8s-local-minikube', 'k8s-local-kind',

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -580,7 +580,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     def set_system_auth_rf(self):
         # No need to change system tables when running via scylla-cloud
         # Also, when running a Alternator via scylla-cloud, we don't have CQL access to the cluster
-        if self.params.get("cluster_backend") == 'aws-siren':
+        if self.params.get('db_type') == 'cloud_scylla':
             # TODO: move this skip to siren-tools when possible
             self.log.warning("Skipping this function due this job run from Siren cloud!")
             return


### PR DESCRIPTION
We have lots of backends supported among which we have 'aws-siren' and
'gce-siren' ones.
These two kind of duplicates of the 'aws' and 'gce' ones.
So, remove the difference between these pairs by reusing
"db_type" SCT option instead of the "cluster_backend" one for getting to
know that we use Scylla cloud kind of a cluster.
'db_type' option has 'scylla' value in common case and
'cloud_scylla' in case of the cloud variant.

Positive side effect of this change is that we make logic work
the expected way when we run 'gce-siren' kind of tests,
which didn't fit the conditions fixed here.

With this change we don't have any difference between 'aws' and
'aws-siren' backends. The same for 'gce*' ones.
So, '*-siren' ones may be removed when it is not used anymore
by 'siren-tests'.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
