### PR TITLE
Events publisher for NoSQLBench

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -59,6 +59,9 @@ KclStressEvent.failure: ERROR
 KclStressEvent.start: NORMAL
 KclStressEvent.finish: NORMAL
 NoSQLBenchStressEvent: CRITICAL
+NoSQLBenchStressLogEvents.ProgressIndicatorRunningEvent: DEBUG
+NoSQLBenchStressLogEvents.ProgressIndicatorFinishedEvent: NORMAL
+NoSQLBenchStressLogEvents.ProgressIndicatorStoppedEvent: CRITICAL
 CassandraStressLogEvent.IOException: ERROR
 CassandraStressLogEvent.ConsistencyError: ERROR
 CassandraStressLogEvent.OperationOnKey: CRITICAL

--- a/sdcm/sct_events/loaders.py
+++ b/sdcm/sct_events/loaders.py
@@ -273,3 +273,37 @@ class GeminiStressLogEvent(LogEvent[T_log_event], abstract=True):  # pylint: dis
 
 
 GeminiStressLogEvent.add_subevent_type("GeminiEvent")
+
+
+class NoSQLBenchStressLogEvents(LogEvent, abstract=True):
+    ProgressIndicatorStoppedEvent: Type[LogEventProtocol]
+    ProgressIndicatorRunningEvent: Type[LogEventProtocol]
+    ProgressIndicatorFinishedEvent: Type[LogEventProtocol]
+
+
+NoSQLBenchStressLogEvents.add_subevent_type(
+    "ProgressIndicatorStoppedEvent",
+    severity=Severity.CRITICAL,
+    regex=r'\d*\s+INFO\s+\[ProgressIndicator/logonly:\ds\]\s+PROGRESS\s+\w+:\s+\d{2}.\d{2}%/Stopped.*'
+)
+
+NoSQLBenchStressLogEvents.add_subevent_type(
+    "ProgressIndicatorRunningEvent",
+    severity=Severity.DEBUG,
+    regex=r'\d*\s+INFO\s+\[ProgressIndicator/logonly:\ds\]\s+PROGRESS\s+\w+:\s+\d{2}.\d{2}%/Running.*'
+)
+
+NoSQLBenchStressLogEvents.add_subevent_type(
+    "ProgressIndicatorFinishedEvent",
+    severity=Severity.NORMAL,
+    regex=r'\d*\s+INFO\s+\[ProgressIndicator/logonly:\ds\]\s+PROGRESS\s+\w+:\s+100.0%/Stopped\s+.*'
+)
+
+
+NOSQLBENCH_LOG_EVENTS = (
+    NoSQLBenchStressLogEvents.ProgressIndicatorStoppedEvent(),
+    NoSQLBenchStressLogEvents.ProgressIndicatorFinishedEvent(),
+    NoSQLBenchStressLogEvents.ProgressIndicatorRunningEvent()
+)
+
+NOSQLBENCH_EVENT_PATTERNS = [(re.compile(event.regex), event) for event in NOSQLBENCH_LOG_EVENTS]


### PR DESCRIPTION
Introducing an events publisher context manager for the NoSQLBench thread. This will allow us to monitor far the progress of NoSQLBench being stopped (e.g. when running a Nemesis).

Example log for stopped progress of NoSQLBench:

```
12:19:26  ======================================================================
12:19:26  FAIL: test_custom_time (longevity_test.LongevityTest)
12:19:26  Run cassandra-stress with params defined in data_dir/scylla.yaml
12:19:26  ----------------------------------------------------------------------
12:19:26  Traceback (most recent call last):
12:19:26    File "/home/ubuntu/scylla-cluster-tests/sdcm/sct_events/events_analyzer.py", line 50, in run
12:19:26      raise TestFailure(f"Got critical event: {event}")
12:19:26  sdcm.sct_events.events_analyzer.TestFailure: Got critical event: (NoSQLBenchStressLogEvents Severity.CRITICAL) period_type=one-time event_id=d88dc6db-6ece-4cde-988c-7cb1ea53474c: type=ProgressIndicatorStoppedEvent regex=\d*\s+INFO\s+\[ProgressIndicator/logonly:\ds\]\s+PROGRESS\s+\w+:\s+\d{2}.\d{2}%/Stopped.* line_number=965 node=Node longevity-10gb-3h-nosql-st-loader-node-4a80f103-1 [16.170.155.250 | 10.0.3.120] (seed: False)
12:19:26  2930971 INFO  [ProgressIndicator/logonly:5s] PROGRESS     cqltabular2_default_main: 51.94%/Stopped (details: min=0 cycle=51944610 max=100000000)
```

Example Jenkins run: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/maciej/job/mc-longevity/job/mc-byo-nosql-bench/78/

Trello task: https://trello.com/c/POVq13n0

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
