### PR TITLE
refactor(FullScanEvent): change to continuous

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -11,8 +11,7 @@ DataValidatorEvent.UpdatedRowsValidator: WARNING
 DataValidatorEvent.DeletedRowsValidator: ERROR
 ScyllaHelpErrorEvent.duplicate: ERROR
 ScyllaHelpErrorEvent.filtered: ERROR
-FullScanEvent.start: NORMAL
-FullScanEvent.finish: ERROR
+FullScanEvent: ERROR
 DatabaseLogEvent.NO_SPACE_ERROR: ERROR
 DatabaseLogEvent.UNKNOWN_VERB: WARNING
 DatabaseLogEvent.CLIENT_DISCONNECT: WARNING

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -172,34 +172,6 @@ ScyllaHelpErrorEvent.add_subevent_type("duplicate")
 ScyllaHelpErrorEvent.add_subevent_type("filtered")
 
 
-class FullScanEvent(SctEvent, abstract=True):
-    start: Type[SctEventProtocol]
-    finish: Type[SctEventProtocol]
-
-    message: str
-
-    def __init__(self, db_node_ip: str, ks_cf, message: Optional[str] = None, severity=Severity.NORMAL):
-        super().__init__(severity=severity)
-
-        self.db_node_ip = db_node_ip
-        self.ks_cf = ks_cf
-
-        # Don't include `message' to the state if it's None.
-        if message is not None:
-            self.message = message
-
-    @property
-    def msgfmt(self):
-        fmt = super().msgfmt + ": type={0.type} select_from={0.ks_cf} on db_node={0.db_node_ip}"
-        if hasattr(self, "message"):
-            fmt += " message={0.message}"
-        return fmt
-
-
-FullScanEvent.add_subevent_type("start")
-FullScanEvent.add_subevent_type("finish")
-
-
 class IndexSpecialColumnErrorEvent(InformationalEvent):
     def __init__(self, message: str, severity: Severity = Severity.ERROR):
         super().__init__(severity=severity)
@@ -254,6 +226,20 @@ class BootstrapEvent(ScyllaDatabaseContinuousEvent):
 
     def __init__(self, node: str, severity=Severity.NORMAL, **__):
         super().__init__(node=node, severity=severity)
+
+
+class FullScanEvent(ScyllaDatabaseContinuousEvent):
+    def __init__(self, node: str, ks_cf: str, message: Optional[str] = None, severity=Severity.NORMAL, **__):
+        super().__init__(node=node, severity=severity)
+        self.ks_cf = ks_cf
+        self.message = message
+
+    @property
+    def msgfmt(self):
+        fmt = super().msgfmt + " select_from={0.ks_cf}"
+        if self.message:
+            fmt += " message={0.message}"
+        return fmt
 
 
 class RepairEvent(ScyllaDatabaseContinuousEvent):

--- a/test-cases/longevity/longevity-10gb-3h.yaml
+++ b/test-cases/longevity/longevity-10gb-3h.yaml
@@ -10,6 +10,7 @@ instance_type_db: 'i3.4xlarge'
 gce_instance_type_db: 'n1-highmem-16'
 gce_instance_type_loader: 'e2-standard-4'
 scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-4.3.repo'
+run_fullscan: 'keyspace1.standard1, 5' # 'ks.cf|random, interval(min)''
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '111'

--- a/unit_tests/test_sct_events_continuous_events_registry.py
+++ b/unit_tests/test_sct_events_continuous_events_registry.py
@@ -9,9 +9,10 @@ import pytest
 from sdcm.sct_events import Severity
 from sdcm.sct_events.base import EventPeriod
 from sdcm.sct_events.continuous_event import ContinuousEventsRegistry, ContinuousEventRegistryException
-from sdcm.sct_events.database import FullScanEvent, get_pattern_to_event_to_func_mapping
+from sdcm.sct_events.database import get_pattern_to_event_to_func_mapping
 from sdcm.sct_events.loaders import GeminiStressEvent
 from sdcm.sct_events.nodetool import NodetoolEvent
+from sdcm.sct_events.system import InfoEvent
 
 
 class TestContinuousEventsRegistry:
@@ -28,9 +29,8 @@ class TestContinuousEventsRegistry:
         yield GeminiStressEvent(node="mock_node", cmd="gemini mock cmd", publish_event=False)
 
     @pytest.fixture(scope="function")
-    def full_scan_event(self) -> Generator[FullScanEvent, None, None]:
-        full_scan_event = FullScanEvent
-        yield full_scan_event.start(db_node_ip="124.5.2.1", ks_cf="mock_cf")
+    def info_event(self) -> Generator[InfoEvent, None, None]:
+        yield InfoEvent(message="This is a mock InfoEvent")
 
     @pytest.fixture(scope="function")
     def populated_registry(self,
@@ -58,9 +58,9 @@ class TestContinuousEventsRegistry:
 
     def test_adding_a_non_continuous_event_raises_error(self,
                                                         registry: ContinuousEventsRegistry,
-                                                        full_scan_event: FullScanEvent):
+                                                        info_event):
         with pytest.raises(ContinuousEventRegistryException):
-            registry.add_event(full_scan_event)
+            registry.add_event(info_event)
 
     def test_get_event_by_id(self,
                              populated_registry: ContinuousEventsRegistry):

--- a/unit_tests/test_sct_events_database.py
+++ b/unit_tests/test_sct_events_database.py
@@ -66,24 +66,25 @@ class TestDatabaseLogEvent(unittest.TestCase):
 
 
 class TestFullScanEvent(unittest.TestCase):
+    NODE_NAME = "db-node-1"
+    KS_CF = "ks_cf"
+    MSG = "msg"
+
     def test_no_message(self):
-        event = FullScanEvent.start(db_node_ip="127.0.0.1", ks_cf="ks")
-        self.assertFalse(hasattr(event, "message"))
-        event.event_id = "743c4ad7-7d83-4b07-9602-120bb6c98fd6"
-        self.assertEqual(str(event),
-                         "(FullScanEvent Severity.NORMAL) period_type=not-set "
-                         "event_id=743c4ad7-7d83-4b07-9602-120bb6c98fd6: type=start select_from=ks on "
-                         "db_node=127.0.0.1")
+        event = FullScanEvent(node=self.NODE_NAME, ks_cf=self.KS_CF)
+        self.assertIsNone(event.message)
+        self.assertRegex(
+            str(event),
+            r"\(FullScanEvent Severity\.NORMAL\) period_type=not-set event_id=([\d\w-]{36}) "
+            f"node={self.NODE_NAME} select_from={self.KS_CF}")
 
     def test_with_message(self):
-        event = FullScanEvent.finish(db_node_ip="127.0.0.1", ks_cf="ks", message="m1")
-        self.assertEqual(event.message, "m1")
-        event.event_id = "743c4ad7-7d83-4b07-9602-120bb6c98fd6"
-        self.assertEqual(
+        event = FullScanEvent(node=self.NODE_NAME, ks_cf=self.KS_CF, message=self.MSG)
+        self.assertEqual(event.message, self.MSG)
+        self.assertRegex(
             str(event),
-            "(FullScanEvent Severity.NORMAL) period_type=not-set event_id=743c4ad7-7d83-4b07-9602-120bb6c98fd6: "
-            "type=finish select_from=ks on db_node=127.0.0.1 message=m1"
-        )
+            r"\(FullScanEvent Severity\.NORMAL\) period_type=not-set event_id=([\d\w-]{36}) "
+            f"node={self.NODE_NAME} select_from={self.KS_CF} message={self.MSG}")
 
 
 class TestIndexSpecialColumnErrorEvent(unittest.TestCase):


### PR DESCRIPTION
Modify FullScanEvent to be a continuous event.

Example log output:

```
11:03:12  < t:2021-10-07 09:03:11,891 f:file_logger.py  l:83   c:sdcm.sct_events.file_logger p:INFO  > 2021-10-07 09:03:11.889: (FullScanEvent Severity.NORMAL) period_type=begin event_id=0e6b7dae-709c-4c6f-a6e2-859fb1507149 node=longevity-10gb-3h-fullscan-db-node-14af46e5-1: select_from=keyspace1.standard1 message=None
11:03:12  < t:2021-10-07 09:03:12,109 f:full_scan_thread.py l:75   c:FullScanThread       p:INFO  > Will run command "select * from keyspace1.standard1 USING TIMEOUT 30s"
11:03:13  < t:2021-10-07 09:03:12,805 f:file_logger.py  l:83   c:sdcm.sct_events.file_logger p:INFO  > 2021-10-07 09:03:12.804: (NodetoolEvent Severity.NORMAL) period_type=begin event_id=b67a1bcc-d9fa-4e90-95cd-424272b1d2b4: nodetool_command=flush node=longevity-10gb-3h-fullscan-db-node-14af46e5-1
11:03:16  < t:2021-10-07 09:03:15,812 f:file_logger.py  l:83   c:sdcm.sct_events.file_logger p:INFO  > 2021-10-07 09:03:15.810: (NodetoolEvent Severity.NORMAL) period_type=end event_id=b67a1bcc-d9fa-4e90-95cd-424272b1d2b4 duration=3s: nodetool_command=flush node=longevity-10gb-3h-fullscan-db-node-14af46e5-1
11:03:16  < t:2021-10-07 09:03:15,813 f:file_logger.py  l:83   c:sdcm.sct_events.file_logger p:INFO  > 2021-10-07 09:03:15.810: (NodetoolEvent Severity.NORMAL) period_type=begin event_id=6510522f-4bd2-4d0e-9f27-1d61dab9e750: nodetool_command=cfstats node=longevity-10gb-3h-fullscan-db-node-14af46e5-1
11:03:19  < t:2021-10-07 09:03:19,276 f:file_logger.py  l:83   c:sdcm.sct_events.file_logger p:INFO  > 2021-10-07 09:03:19.274: (NodetoolEvent Severity.NORMAL) period_type=end event_id=6510522f-4bd2-4d0e-9f27-1d61dab9e750 duration=3s: nodetool_command=cfstats node=longevity-10gb-3h-fullscan-db-node-14af46e5-1
11:03:22  < t:2021-10-07 09:03:22,854 f:cluster.py      l:4086 c:sdcm.cluster         p:INFO  > Cluster longevity-10gb-3h-fullscan-db-cluster-14af46e5 (AMI: ['ami-0f5b034e5c8122817'] Type: i3.4xlarge): Clear _nemesis_termination_event
11:03:23  /usr/local/lib/python3.9/site-packages/elasticsearch/connection/http_urllib3.py:209: UserWarning: Connecting to https://746f0ad652a3447d83b1572f657c67cb.us-east-1.aws.found.io:9243 using SSL with verify_certs=False is insecure.
11:03:23    warnings.warn(
11:03:23  < t:2021-10-07 09:03:23,349 f:nemesis.py      l:291  c:sdcm.nemesis         p:INFO  > sdcm.nemesis.NoOpMonkey: Interval: 300 s
11:52:23  < t:2021-10-07 09:52:14,445 f:file_logger.py  l:83   c:sdcm.sct_events.file_logger p:INFO  > 2021-10-07 09:52:14.443: (FullScanEvent Severity.NORMAL) period_type=end event_id=0e6b7dae-709c-4c6f-a6e2-859fb1507149 duration=49m2s node=longevity-10gb-3h-fullscan-db-node-14af46e5-1: select_from=keyspace1.standard1 message=None
```

Example longevity run on Jenkins: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/maciej/job/mc-longevity/job/mc-byo-longevity-test/225

Trello task: https://trello.com/c/IHGIJmGh

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
