### PR TITLE
fix(byolongevity): delete pipelineParams from byolongevity

### DIFF
--- a/vars/byoLongevityPipeline.groovy
+++ b/vars/byoLongevityPipeline.groovy
@@ -41,8 +41,8 @@ def call() {
             string(defaultValue: "eu-west-1",
                description: 'Supported: us-east-1|eu-west-1|eu-west-2|eu-north-1|random (randomly select region)',
                name: 'aws_region')
-            string(defaultValue: "${pipelineParams.get('gce_datacenter', 'us-east1')}",
-                   description: 'GCE datacenter',
+            string(defaultValue: "us-east1",
+                   description: 'GCE datacenter supported: us-east1',
                    name: 'gce_datacenter')
             string(defaultValue: "a",
                description: 'Availability zone',


### PR DESCRIPTION
byolongevity pipeline doesn't support pipelineParams parameter
 and cause issue:
hudson.remoting.ProxyException: groovy.lang.MissingPropertyException:
 No such property: pipelineParams for class: byoLongevityPipeline
   at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:53)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
