### PR TITLE
improvement(keystore): add method for argus db credentials

### DIFF
--- a/sdcm/keystore.py
+++ b/sdcm/keystore.py
@@ -94,6 +94,9 @@ class KeyStore:
     def get_azure_credentials(self):
         return self.get_json("azure.json")
 
+    def get_argusdb_credentials(self):
+        return self.get_json("argusdb_config.json")
+
 
 def pub_key_from_private_key_file(key_file):
     return paramiko.rsakey.RSAKey.from_private_key_file(os.path.expanduser(key_file)).get_base64()


### PR DESCRIPTION
Now the instance of KeyStore is able to work with creds for Argus DB.

https://trello.com/c/71AsWPqo/3966-create-argus-db-cluster

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] ~~I added the relevant `backport` labels~~
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
