### PR TITLE
fix(scylla_yaml): expose parameters required by nodetool

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1629,7 +1629,13 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             scylla_yaml_object = ScyllaYaml(**scylla_yaml)
             yield scylla_yaml_object
             scylla_yaml.clear()
-            scylla_yaml.update(scylla_yaml_object.dict(exclude_defaults=True, exclude_unset=True))
+            scylla_yaml.update(scylla_yaml_object.dict(
+                exclude_defaults=True,
+                exclude_unset=True,
+                # NOTE: explicit fields included into yaml no matter what,
+                #  they are needed for nodetool to operate properly
+                explicit=['partitioner', 'commitlog_sync', 'commitlog_sync_period_in_ms']
+            ))
 
     def remote_manager_yaml(self):
         return self._remote_yaml(path=SCYLLA_MANAGER_YAML_PATH)

--- a/sdcm/provision/scylla_yaml/scylla_yaml.py
+++ b/sdcm/provision/scylla_yaml/scylla_yaml.py
@@ -305,6 +305,26 @@ class ScyllaYaml(BaseModel):  # pylint: disable=too-few-public-methods
     ldap_url_template: str = None
     saslauthd_socket_path: str = None
 
+    def dict(
+        self,
+        *,
+        include: Union['AbstractSetIntStr', 'MappingIntStrAny'] = None,
+        exclude: Union['AbstractSetIntStr', 'MappingIntStrAny'] = None,
+        by_alias: bool = False,
+        skip_defaults: bool = None,
+        exclude_unset: bool = False,
+        exclude_defaults: bool = False,
+        exclude_none: bool = False,
+        explicit: Union['AbstractSetIntStr', 'MappingIntStrAny'] = None,
+    ) -> 'DictStrAny':
+        to_dict = super().dict(
+            include=include, exclude=exclude, by_alias=by_alias, skip_defaults=skip_defaults,
+            exclude_unset=exclude_unset, exclude_defaults=exclude_defaults, exclude_none=exclude_none)
+        if explicit:
+            for required_attrs in explicit:
+                to_dict[required_attrs] = getattr(self, required_attrs)
+        return to_dict
+
     def _update_dict(self, obj: dict, fields_data: dict):
         for attr_name, attr_value in obj.items():
             attr_info = fields_data.get(attr_name, None)


### PR DESCRIPTION
nodetool cleanup requires following parameters (in scylla.yaml) to be set: `partitioner, commitlog_sync, commitlog_sync_period_in_ms`

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
