### PR TITLE
fix(common.py): start use build-id label for GCE

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1373,8 +1373,7 @@ def get_branched_gce_images(scylla_version: str, project: str = SCYLLA_GCE_IMAGE
     filters = f"(family eq scylla)(labels.branch eq {branch})(name ne debug-image-.*)"
 
     if build_id not in ("latest", "all", ):
-        # filters += f"(labels.build-id eq {build_id})"  # asked releng to add `build-id' label too, but
-        filters += f"(name eq .+-build-{build_id})"      # use BUILD_ID from an image name for now
+        filters += f"(labels.build-id eq {build_id})"
 
     LOGGER.info("Looking for GCE images match [%s]", scylla_version)
     compute_engine = get_gce_driver()


### PR DESCRIPTION
Since https://github.com/scylladb/scylla-machine-image/pull/169 was merged we can switch to `build-id` label

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
