### PR TITLE
fix(get_db_tables): iterate over copy of tables keys

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1494,7 +1494,7 @@ def get_db_tables(session, ks, with_compact_storage=True):
 
     """
     output = []
-    for table in session.cluster.metadata.keyspaces[ks].tables.keys():
+    for table in list(session.cluster.metadata.keyspaces[ks].tables.keys()):
         table_code = session.cluster.metadata.keyspaces[ks].tables[table].as_cql_query()
         if with_compact_storage is None:
             output.append(table)


### PR DESCRIPTION
while iterating over session.cluster.metadata.keyspaces[ks].tables.keys()
we can get into situation when new table is added or the structure
is altered by the driver in background, hence we need to iterate
over the copy of the keys otherwize we can get
'RuntimeError: dictionary changed size during iteration'

More infor about an Exception can be found here:
https://stackoverflow.com/questions/11941817/how-to-avoid-runtimeerror-dictionary-changed-size-during-iteration-error

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
