### PR TITLE
fix(RebuildStreamingErr): filter expected stream error

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2456,6 +2456,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                             node=self.target_node), \
             DbEventsFilter(db_event=DatabaseLogEvent.RUNTIME_ERROR,
                            line="Fail to send STREAM_MUTATION_DONE",
+                           node=self.target_node), \
+            DbEventsFilter(db_event=DatabaseLogEvent.DATABASE_ERROR,
+                           line="streaming::stream_exception",
                            node=self.target_node):
             self.target_node.reboot(hard=True, verify_ssh=True)
             streaming_thread.join(60)


### PR DESCRIPTION
during a gemini test, when this nemesis was run there
were few stream exception errors, but they are expected
as the node was rebooted while stream was running.
the message was:
```
Rebuild with 10.0.0.220 for keyspace=ks1 failed,
took 539.373 seconds: streaming::stream_exception (Stream failed)
```

these 2 entries in the target node's log created
2 `DATABASE_ERROR` events.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
