### PR TITLE
feature(perf_event_paranoid): changing value to get kernal stack

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -286,6 +286,15 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         self._init_port_mapping()
 
         self.set_keep_alive()
+        if self.node_type == "db":
+            try:
+                self.remoter.sudo(shell_script_cmd("""\
+                echo 'kernel.perf_event_paranoid = 0' >> /etc/sysctl.conf
+                sysctl -p
+                """), verbose=True)
+            except Exception:  # pylint: disable=broad-except
+                LOGGER.error("Encountered an unhadled exception while changing 'perf_event_paranoid' value",
+                             exc_info=True)
         self._init_argus_resource()
 
     def _init_argus_resource(self):

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -786,7 +786,9 @@ class ScyllaLogCollector(LogCollector):
                     CommandLog(name='io-properties.yaml',
                                command='cat /etc/scylla.d/io_properties.yaml'),
                     CommandLog(name='dmesg.log',
-                               command='dmesg -P')
+                               command='dmesg -P'),
+                    CommandLog(name='kallsyms',
+                               command='sudo cat /proc/kallsyms')
                     ]
     cluster_log_type = "db-cluster"
     cluster_dir_prefix = "db-cluster"


### PR DESCRIPTION
from Avi's patch on Seastar, now we will get the stack traces
from the kernel for our reactor stall back traces.
this is only an experiment to see if we will indeed get
the desired results, but we might want to place this
command somewhere else (or only for perf jobs), or even
to add a new parameter on sct_config, to control it
from test .yaml configuration file.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
