### PR TITLE
fix(unit-tests): mock all cleanup functions for cleanup resources tests

### DIFF
--- a/unit_tests/test_clean_cloud_resources_func.py
+++ b/unit_tests/test_clean_cloud_resources_func.py
@@ -126,6 +126,7 @@ class CleanCloudResourcesTest(unittest.TestCase):
         "sdcm.utils.common.clean_instances_aws",
         "sdcm.utils.common.clean_elastic_ips_aws",
         "sdcm.utils.common.clean_clusters_gke",
+        "sdcm.utils.common.clean_clusters_eks",
         "sdcm.utils.common.clean_instances_gce",
         "sdcm.utils.common.clean_resources_docker",
     )


### PR DESCRIPTION
Mock missing 'sdcm.utils.common.clean_clusters_eks' function in the
'unit_tests/test_clean_cloud_resources_func.py' test module to avoid
unexpected real attempts to make API calls.
At first it is incorrect, at second it takes a lot of time and,
at third, it is unexpected.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
