### PR TITLE
feature(sct_config): add scylla_bench_version

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -156,3 +156,4 @@ mgmt_docker_image: ''
 k8s_deploy_monitoring: false
 
 scylla_rsyslog_setup: false
+scylla_bench_version: v0.1.3

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -366,6 +366,9 @@ class SCTConfiguration(dict):
         dict(name="server_encrypt", env="SCT_SERVER_ENCRYPT", type=boolean,
              help="when enable scylla will use encryption on the server side"),
 
+        dict(name="scylla_bench_version", env="SCT_SCYLLA_BENCH_VERSION", type=str,
+             help="A valid tag under the scylla bench repo: https://github.com/scylladb/scylla-bench"),
+
         dict(name="client_encrypt", env="SCT_CLIENT_ENCRYPT", type=boolean,
              help="when enable scylla will use encryption on the client side"),
 


### PR DESCRIPTION
Original commit cbdab37e116d29abfcf9bee66d61d18f2fc63791 was backported in a wrong way as result some changes did not endup in the `branch-2021.1`
This PR is to merge rest of the changes back to `branch-2021.1`

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
