### PR TITLE
Fix get testrun status

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1765,7 +1765,7 @@ def get_post_behavior_actions(config):
 
 
 def clean_resources_according_post_behavior(params, config, logdir, dry_run=False):
-    success = get_testrun_status(params.get('TestId'), logdir, only_critical=True)
+    critical_events = get_testrun_status(params.get('TestId'), logdir, only_critical=True)
     actions_per_type = get_post_behavior_actions(config)
     LOGGER.debug(actions_per_type)
 
@@ -1781,7 +1781,7 @@ def clean_resources_according_post_behavior(params, config, logdir, dry_run=Fals
             LOGGER.info("Post behavior %s for %s. Clean resources", action_type["action"], cluster_nodes_type)
             clean_cloud_resources({**params, "NodeType": action_type["NodeType"]}, dry_run=dry_run)
             continue
-        elif action_type["action"] == "keep-on-failure" and not success:
+        elif action_type["action"] == "keep-on-failure" and not critical_events:
             LOGGER.info("Post behavior %s for %s. Test run Successful. Clean resources",
                         action_type["action"], cluster_nodes_type)
             clean_cloud_resources({**params, "NodeType": action_type["NodeType"]}, dry_run=dry_run)
@@ -1831,12 +1831,12 @@ def get_testrun_status(test_id=None, logdir=None, only_critical=False):
     error_log = os.path.join(testrun_dir, 'events_log/error.log')
 
     if os.path.exists(critical_log):
-        with open(critical_log) as f:  # pylint: disable=invalid-name
-            status = f.readlines()
+        with open(critical_log) as file:
+            status = file.readlines()
 
     if not only_critical and os.path.exists(error_log):
-        with open(error_log) as f:  # pylint: disable=invalid-name
-            status += f.readlines()
+        with open(error_log) as file:
+            status += file.readlines()
 
     return status
 


### PR DESCRIPTION
Make it not to fail if file is not there :

```
15:41:45  ['/home/ubuntu/sct-results/20211013-122151-427103/test_id', '/home/ubuntu/sct-results/20211013-122217-538468/test_id']
15:41:45  Traceback (most recent call last):
15:41:45    File "/home/ubuntu/scylla-cluster-tests/./sct.py", line 1195, in <module>
15:41:45      cli()
15:41:45    File "/usr/local/lib/python3.9/site-packages/click/core.py", line 764, in __call__
15:41:45      return self.main(*args, **kwargs)
15:41:45    File "/usr/local/lib/python3.9/site-packages/click/core.py", line 717, in main
15:41:45      rv = self.invoke(ctx)
15:41:45    File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1137, in invoke
15:41:45      return _process_result(sub_ctx.command.invoke(sub_ctx))
15:41:45    File "/usr/local/lib/python3.9/site-packages/click/core.py", line 956, in invoke
15:41:45      return ctx.invoke(self.callback, **ctx.params)
15:41:45    File "/usr/local/lib/python3.9/site-packages/click/core.py", line 555, in invoke
15:41:45      return callback(*args, **kwargs)
15:41:45    File "/usr/local/lib/python3.9/site-packages/click/decorators.py", line 17, in new_func
15:41:45      return f(get_current_context(), *args, **kwargs)
15:41:45    File "/home/ubuntu/scylla-cluster-tests/./sct.py", line 261, in clean_resources
15:41:45      clean_func(param, dry_run=dry_run)
15:41:45    File "/home/ubuntu/scylla-cluster-tests/sdcm/utils/common.py", line 1822, in clean_resources_according_post_behavior
15:41:45      success = get_testrun_status(params.get('TestId'), logdir, only_critical=True)
15:41:45    File "/home/ubuntu/scylla-cluster-tests/sdcm/utils/common.py", line 1883, in get_testrun_status
15:41:45      with open(os.path.join(testrun_dir, 'events_log/critical.log')) as f:  # pylint: disable=invalid-name
15:41:45  FileNotFoundError: [Errno 2] No such file or directory: '/home/ubuntu/sct-results/20211013-122151-427103/events_log/critical.log'
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
