### PR TITLE
fix(cloud 48h longevity yaml): Fix and update parameters of yaml

### DIFF
--- a/test-cases/longevity/longevity-100GB-48h-cloud.yaml
+++ b/test-cases/longevity/longevity-100GB-48h-cloud.yaml
@@ -1,29 +1,21 @@
-test_duration: 2880
+test_duration: 2960
 prepare_write_cmd: "cassandra-stress write cl=ALL n=100100150  -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=1000 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..100100150 -log interval=15"
 
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=2860m  -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=250  -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=400200300..500200300 -log interval=15"]
 stress_read_cmd: ["cassandra-stress read cl=ONE duration=2860m -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=250  -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..100100150 -log interval=5"]
-run_fullscan: 'keyspace1.standard1, 5' # 'ks.cf|random, interval(min)''
+run_fullscan: 'keyspace1.standard1, 15' # 'ks.cf|random, interval(min)''
 
 n_db_nodes: 4
 n_loaders: 1
 n_monitor_nodes: 1
 
-instance_type_db: 'i3.large' # instance type is defined in the jenkins job (with default value in the jenkinsfile for the cloud longevity
-
-post_behavior_db_nodes: "destroy"
-post_behavior_loader_nodes: "destroy"
-post_behavior_monitor_nodes: "destroy"
-
-nemesis_class_name: 'LimitedChaosMonkey'
 nemesis_interval: 30
 nemesis_during_prepare: false
 
-user_prefix: 'longevity-100gb-48h-cloud-limited-tls'
+user_prefix: 'longevity-100gb-48h-cloud'
 
 space_node_threshold: 644245094
 
-server_encrypt: true
 authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra
 authenticator_password: cassandra


### PR DESCRIPTION
	1) Test duration was set too short for load to finish, increasing it.
	2) Updated other minor parameters in yaml
	3) renamed yaml file to be more accurate.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
