### PR TITLE
improvement(k8s-gke): update cpu-policy daemonset

### DIFF
--- a/sdcm/k8s_configs/gke/scylla-node-prepare.yaml
+++ b/sdcm/k8s_configs/gke/scylla-node-prepare.yaml
@@ -74,19 +74,56 @@ spec:
       serviceAccountName: cpu-policy-daemonset
       containers:
       - name: cpu-policy
-        image: scylladb/kubectl:1.11.5
+        image: bitnami/kubectl:1.21.4
         imagePullPolicy: Always
         env:
           - name: NODE
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: HOSTFS
+            value: /mnt/hostfs
+          - name: KUBELET_CONFIG_PATH
+            value: /home/kubernetes/kubelet-config.yaml
         securityContext:
           privileged: true
+          runAsUser: 0
         volumeMounts:
           - name: hostfs
             mountPath: /mnt/hostfs
             mountPropagation: Bidirectional
+        command:
+          - "/bin/bash"
+          - "-c"
+          - "--"
+        args:
+          - |
+            set -ex
+            if [ ! -f "$HOSTFS$KUBELET_CONFIG_PATH" ]; then
+                echo "Kublet config not found"
+                exit 1
+            fi
+
+            TOKEN_PATH=$(find / -name token | grep cpu-policy-daemonset -m1)
+            TOKEN=$(cat $TOKEN_PATH)
+            CA_CRT=$TOKEN_PATH/../ca.crt
+            kubectl config set-cluster scylla --server=https://kubernetes.default --certificate-authority=$CA_CRT
+            kubectl config set-credentials qa@scylladb.com --token=$TOKEN
+            kubectl config set-context scylla --cluster=scylla --user=qa@scylladb.com
+            kubectl config use-context scylla
+
+            if grep "cpuManagerPolicy" $HOSTFS$KUBELET_CONFIG_PATH | grep "static" ; then
+                echo "cpu-manager-policy is already set to be static"
+                echo "uncordoning the node"
+                kubectl uncordon $NODE || true
+                while true; do sleep infinity; done
+            fi
+
+            echo "Change kubelet config and restart it's service"
+            kubectl drain $NODE --force --ignore-daemonsets --delete-local-data --grace-period=60
+            echo cpuManagerPolicy: static | tee -a $HOSTFS$KUBELET_CONFIG_PATH
+            rm $HOSTFS/var/lib/kubelet/cpu_manager_state
+            kill -9 $(pidof kubelet)
       volumes:
         - name: hostfs
           hostPath:


### PR DESCRIPTION
For the moment we update cpu-policy-manager config on GKE using
docker image for which we do not have source code and where the
used script is built-in. To be able to update the logic for it
we need either to update the image or redefine the script for it.

So, stop using that obsolete image replacing it with upstream actual
one and also specify the script explicitly in the daemonset
configuration to be able to change it easily anytime later not
depending on an image built-ins.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
