### PR TITLE
improvement(tox-pyenv): add support for python 3.10

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,3 +35,10 @@ commands =
     {[testenv]commands}
     mkdir -p {envdir}/lib/python3.9/site-packages
     bash -c "{posargs:echo 'No commands have been specified. Exiting.'}"
+
+[testenv:py310]
+basepython = python3.10
+commands =
+    {[testenv]commands}
+    mkdir -p {envdir}/lib/python3.10/site-packages
+    bash -c "{posargs:echo 'No commands have been specified. Exiting.'}"


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
