### PR TITLE
improvement(unit-tests): print slowest 20 unit tests

### DIFF
--- a/unit_tests/pytest.ini
+++ b/unit_tests/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --durations=20


### PR DESCRIPTION
Add pytest.ini file specifying there option that allows us to
get list of the slowest tests we run there.
Useful for further debugging of slow tests.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
