### PR TITLE
fix(configure_scylla_monitoring): check stress_cmd is not in config file

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5078,7 +5078,8 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
                 scrape_configs.append(dict(job_name="gemini_metrics", honor_labels=True,
                                            static_configs=[dict(targets=gemini_loader_targets_list)]))
 
-            if "nosqlbench" in self.params.get('stress_cmd')[0]:
+            nosqlbench_cmds = self.params.get('stress_cmd')
+            if nosqlbench_cmds and "nosqlbench" in nosqlbench_cmds[0]:
                 graphite_exporter_target_list = [f"{node.ip_address}:9108" for node in self.targets["loaders"].nodes]
                 scrape_configs.append(dict(job_name="nosqlbench_metrics", honor_labels=True,
                                            static_configs=[dict(targets=graphite_exporter_target_list)]))


### PR DESCRIPTION
if test config file doesn't contain stress_cmd parameter, ex. gemini*.yaml
next error failed the job:
File "/home/ubuntu/scylla-cluster-tests/sdcm/cluster.py", line 5081, in configure_scylla_monitoring
if "nosqlbench" in self.params.get('stress_cmd')[0]:
TypeError: 'NoneType' object is not subscriptable

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
