### PR TITLE
fix(k8s-func): specify helm chart version in test which uses it

### DIFF
--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -462,6 +462,8 @@ def test_deploy_helm_with_default_values(db_cluster: ScyllaPodCluster):
     log.debug(db_cluster.k8s_cluster.helm_install(
         target_chart_name=target_chart_name,
         source_chart_name="scylla-operator/scylla",
+        version=db_cluster.k8s_cluster._scylla_operator_chart_version,  # pylint: disable=protected-access
+        use_devel=True,
         namespace=namespace,
     ))
 


### PR DESCRIPTION
Recently was added new K8S functional test that creates a Scylla
cluster using default values of a Scylla Helm chart.
If we use 'stable' repo then it works, but if we use 'latest' one
then it fails not being able to find any version, because
that repo contains only "dev" versions, not "stable" ones.
So, provide version explicitly to not only avoid this error, but
also for usage of the expected chart version.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
