### PR TITLE
refactor(scylla setup): remove calls with args to config_setup

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3666,7 +3666,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         if new_params != old_params:
             self.params = new_params
             for node in self.nodes:
-                node.config_setup()
+                node.config_setup(append_scylla_args=self.get_scylla_args())
                 node.restart_scylla()
 
     def enable_client_encrypt(self):
@@ -4106,28 +4106,6 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             nemesis_thread.join(timeout)
         self.nemesis_threads = []
 
-    def node_config_setup(self, node, seed_address=None,  # pylint: disable=too-many-arguments,invalid-name
-                          endpoint_snitch=None, murmur3_partitioner_ignore_msb_bits=None, client_encrypt=None):
-        node.config_setup(seed_address=seed_address,
-                          cluster_name=self.name,  # pylint: disable=no-member
-                          enable_exp=self.params.get('experimental'),
-                          endpoint_snitch=endpoint_snitch,
-                          authenticator=self.params.get('authenticator'),
-                          server_encrypt=self.params.get('server_encrypt'),
-                          client_encrypt=client_encrypt if client_encrypt is not None else self.params.get(
-                              'client_encrypt'),
-                          append_scylla_yaml=self.params.get('append_scylla_yaml'),
-                          append_scylla_args=self.get_scylla_args(),
-                          hinted_handoff=self.params.get('hinted_handoff'),
-                          authorizer=self.params.get('authorizer'),
-                          alternator_port=self.params.get('alternator_port'),
-                          murmur3_partitioner_ignore_msb_bits=murmur3_partitioner_ignore_msb_bits,
-                          alternator_enforce_authorization=self.params.get('alternator_enforce_authorization'),
-                          internode_compression=self.params.get('internode_compression'),
-                          internode_encryption=self.params.get('internode_encryption'),
-                          ldap=self.params.get('use_ldap_authorization'),
-                          ms_ad_ldap=self.params.get('use_ms_ad_ldap'))
-
     def scylla_configure_non_root_installation(self, node, devname, verbose, timeout):
         node.stop_scylla_server(verify_down=False)
         node.remoter.run(f'{INSTALL_DIR}/sbin/scylla_setup --nic {devname} --no-raid-setup --no-io-setup',
@@ -4196,7 +4174,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
 
             if self.test_config.MULTI_REGION:
                 node.datacenter_setup(self.datacenter)  # pylint: disable=no-member
-            self.node_config_setup(node, ','.join(self.seed_nodes_ips), self.get_endpoint_snitch())
+            node.config_setup(append_scylla_args=self.get_scylla_args())
 
             self._scylla_post_install(node, install_scylla, nic_devname)
 

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -906,42 +906,6 @@ class ScyllaAWSCluster(cluster.BaseScyllaCluster, AWSCluster):
         )
         return added_nodes
 
-    def node_config_setup(self, node, seed_address=None, endpoint_snitch=None,
-                          murmur3_partitioner_ignore_msb_bits=None, client_encrypt=None):  # pylint: disable=too-many-arguments
-        setup_params = dict(
-            enable_exp=self.params.get('experimental'),
-            endpoint_snitch=endpoint_snitch,
-            authenticator=self.params.get('authenticator'),
-            server_encrypt=self.params.get('server_encrypt'),
-            client_encrypt=client_encrypt if client_encrypt is not None else self.params.get('client_encrypt'),
-            append_scylla_args=self.get_scylla_args(),
-            authorizer=self.params.get('authorizer'),
-            hinted_handoff=self.params.get('hinted_handoff'),
-            alternator_port=self.params.get('alternator_port'),
-            seed_address=seed_address,
-            append_scylla_yaml=self.params.get('append_scylla_yaml'),
-            murmur3_partitioner_ignore_msb_bits=murmur3_partitioner_ignore_msb_bits,
-            ip_ssh_connections=self.params.get('ip_ssh_connections'),
-            alternator_enforce_authorization=self.params.get('alternator_enforce_authorization'),
-            internode_compression=self.params.get('internode_compression'),
-            internode_encryption=self.params.get('internode_encryption'),
-            ldap=self.params.get('use_ldap_authorization'),
-            ms_ad_ldap=self.params.get('use_ms_ad_ldap'),
-        )
-        if self.test_config.INTRA_NODE_COMM_PUBLIC:
-            setup_params.update(dict(
-                broadcast=node.public_ip_address,
-            ))
-
-        if self.extra_network_interface:
-            setup_params.update(dict(
-                seed_address=seed_address,
-                broadcast=node.private_ip_address,
-                listen_on_all_interfaces=True,
-            ))
-
-        node.config_setup(**setup_params)
-
     @staticmethod
     def _wait_for_preinstalled_scylla(node):
         node.wait_for_machine_image_configured()

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -238,9 +238,6 @@ class ScyllaDockerCluster(cluster.BaseScyllaCluster, DockerCluster):  # pylint: 
                          params=params)
 
     def node_setup(self, node, verbose=False, timeout=3600):
-        endpoint_snitch = self.params.get('endpoint_snitch')
-        seed_address = ','.join(self.seed_nodes_ips)
-
         node.wait_ssh_up(verbose=verbose)
 
         node.is_scylla_installed(raise_if_not_installed=True)
@@ -250,7 +247,7 @@ class ScyllaDockerCluster(cluster.BaseScyllaCluster, DockerCluster):  # pylint: 
         if self.test_config.BACKTRACE_DECODING:
             node.install_scylla_debuginfo()
 
-        self.node_config_setup(node, seed_address, endpoint_snitch)
+        node.config_setup(append_scylla_args=self.get_scylla_args())
 
         node.stop_scylla_server(verify_down=False)
         node.remoter.sudo('rm -Rf /var/lib/scylla/data/*')  # Clear data folder to drop wrong cluster name data.

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2051,17 +2051,8 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
 
         if self.test_config.MULTI_REGION:
             node.datacenter_setup(self.datacenter)  # pylint: disable=no-member
-        try:
-            # NOTE: case of seedful scylla (operator v1.3.0-)
-            seed_nodes = ','.join(self.seed_nodes_ips)
-        except AssertionError:
-            # NOTE: case of seedless scylla (operator v1.4.0+)
-            seed_nodes = None
-        self.node_config_setup(
-            node,
-            seed_address=seed_nodes,
-            endpoint_snitch=self.get_endpoint_snitch(),
-        )
+
+        self.node_config_setup()
 
     @cached_property
     def scylla_manager_cluster_name(self):  # pylint: disable=invalid-overridden-method
@@ -2080,10 +2071,6 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
         raise NotImplementedError('Scylla manager should not be manipulated on kubernetes manually')
 
     def node_config_setup(self,
-                          node,
-                          seed_address=None,
-                          endpoint_snitch=None,
-                          murmur3_partitioner_ignore_msb_bits=None,
                           client_encrypt=None):  # pylint: disable=too-many-arguments,invalid-name
         if client_encrypt is None:
             client_encrypt = self.params.get("client_encrypt")

--- a/unit_tests/test_scylla_yaml_builders.py
+++ b/unit_tests/test_scylla_yaml_builders.py
@@ -387,7 +387,7 @@ class DummyCluster(BaseScyllaCluster, BaseCluster):  # pylint: disable=too-few-p
 
     def init_nodes(self):
         for node in self.nodes:
-            self.node_config_setup(node, ','.join(self.seed_nodes_ips), self.get_endpoint_snitch())
+            node.config_setup(append_scylla_args=self.get_scylla_args())
 
     # pylint: disable=too-many-arguments
     def add_nodes(self, count, ec2_user_data='', dc_idx=0, rack=0, enable_auto_bootstrap=False):


### PR DESCRIPTION
Task: https://trello.com/c/fNFNZmN9/3934-refactor-remove-calls-with-args-to-configsetup?
filter=member:juliayakovlev1

Continue to task: https://trello.com/c/63iLEnOC/3589-create-scyllayaml-class

After adding ScyllaYaml class all calls with args to config_setup are not needed.
This commit remove args from config_setup calls

Tested configurations:
1. AWS - longevity 3h (https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/staging-10gb-3h/272)
2. GCE - longevity 3h (https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/yulia-longevity-10gb-3h-gce-test/3)
3. docker - artifacts-docker-test (https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/yulia-artifacts-docker-test/5)
4. multidc (AWS) - longevity-lwt-24h-multidc (https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/staging-longevity-lwt-24h-multidc/8)
5. multi seed (AWS) - longevity-100gb-4h (https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/staging-longevity-100gb-4h/63)
6. append_scylla_args_oracle - gemini-3h-test (https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/yulia-gemini-3h-test/9)
7. append_scylla_args - longevity-cdc-100gb-4h-test (https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/yulis-longevity-cdc-100gb-4h-test/2/)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
