### PR TITLE
test(manager): testing healthcheck's max_timeout parameter

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -30,7 +30,7 @@ from pkg_resources import parse_version
 from sdcm import mgmt
 from sdcm.mgmt import ScyllaManagerError, TaskStatus, HostStatus, HostSsl, HostRestStatus
 from sdcm.mgmt.cli import ScyllaManagerTool
-from sdcm.mgmt.common import alter_manager_yaml_and_restart
+from sdcm.mgmt.common import reconfigure_scylla_manager
 from sdcm.remote import shell_script_cmd
 from sdcm.tester import ClusterTester
 from sdcm.cluster import TestConfig
@@ -711,8 +711,8 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
             name=self.CLUSTER_NAME, db_cluster=self.db_cluster, auth_token=self.monitors.mgmt_auth_token)
 
         try:
-            alter_manager_yaml_and_restart(manager_node=manager_node, logger=self.log,
-                                           values_to_update=[{"healthcheck": {"max_timeout": "20ms"}}])
+            reconfigure_scylla_manager(manager_node=manager_node, logger=self.log,
+                                       values_to_update=[{"healthcheck": {"max_timeout": "20ms"}}])
             sleep = 40
             self.log.debug('Sleep %s seconds, waiting for health-check task to rerun', sleep)
             time.sleep(sleep)
@@ -728,7 +728,7 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
                     f'the healthcheck status of {node.ip_address} is not {HostStatus.UP} as expected, but ' \
                     f'instead it was {dict_host_health[node.ip_address].status}'
         finally:
-            alter_manager_yaml_and_restart(manager_node=manager_node, logger=self.log, values_to_remove=['healthcheck'])
+            reconfigure_scylla_manager(manager_node=manager_node, logger=self.log, values_to_remove=['healthcheck'])
             mgr_cluster.delete()  # remove cluster at the end of the test
         self.log.info('finishing test_healthcheck_change_max_timeout')
 

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -12,6 +12,7 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2016 ScyllaDB
+# pylint: disable=too-many-lines
 
 from random import randint
 from pathlib import Path
@@ -29,6 +30,7 @@ from pkg_resources import parse_version
 from sdcm import mgmt
 from sdcm.mgmt import ScyllaManagerError, TaskStatus, HostStatus, HostSsl, HostRestStatus
 from sdcm.mgmt.cli import ScyllaManagerTool
+from sdcm.mgmt.common import alter_manager_yaml_and_restart
 from sdcm.remote import shell_script_cmd
 from sdcm.tester import ClusterTester
 from sdcm.cluster import TestConfig
@@ -356,7 +358,10 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
             self.test_mgmt_cluster_crud()
         with self.subTest('Mgmt cluster Health Check'):
             self.test_mgmt_cluster_healthcheck()
-        self.test_suspend_and_resume()
+        with self.subTest('Basic test healthcheck change max timeout'):
+            self.test_healthcheck_change_max_timeout()
+        with self.subTest('Basic test suspend and resume'):
+            self.test_suspend_and_resume()
         with self.subTest('Client Encryption'):
             # Since this test activates encryption, it has to be the last test in the sanity
             self.test_client_encryption()
@@ -680,6 +685,52 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
 
         mgr_cluster.delete()  # remove cluster at the end of the test
         self.log.info('finishing test_mgmt_cluster_healthcheck')
+
+    def test_healthcheck_change_max_timeout(self):
+        """
+        New in manager 2.6
+        'max_timeout' is new parameter in the scylla manager yaml. It decides the maximum
+        amount of time the manager healthcheck function will wait for a ping response before
+        it will announce the node as timed out.
+
+        The test sets the timeout as such that the latency of the nodes that exist in the
+        local region (us-east-1) will not be longer than the set timeout, and therefore
+        will appear as UP in the healthcheck, while the latency of the node that is the
+        distant region (us-west-2) will be longer than the set timeout, and therefore the
+        healthcheck will report it as TIMEOUT.
+
+        The test makes sure that the healthcheck reports those statuses correctly.
+        """
+        self.log.info('starting test_healthcheck_change_max_timeout')
+
+        nodes_from_local_dc = self.db_cluster.nodes[:2]
+        nodes_from_distant_dc = self.db_cluster.nodes[2:]
+        manager_node = self.monitors.nodes[0]
+        manager_tool = mgmt.get_scylla_manager_tool(manager_node=manager_node)
+        mgr_cluster = manager_tool.get_cluster(cluster_name=self.CLUSTER_NAME) or manager_tool.add_cluster(
+            name=self.CLUSTER_NAME, db_cluster=self.db_cluster, auth_token=self.monitors.mgmt_auth_token)
+
+        try:
+            alter_manager_yaml_and_restart(manager_node=manager_node, logger=self.log,
+                                           values_to_update=[{"healthcheck": {"max_timeout": "20ms"}}])
+            sleep = 40
+            self.log.debug('Sleep %s seconds, waiting for health-check task to rerun', sleep)
+            time.sleep(sleep)
+            dict_host_health = mgr_cluster.get_hosts_health()
+            for node in nodes_from_distant_dc:
+                assert dict_host_health[node.ip_address].status == HostStatus.TIMEOUT, \
+                    f'After setting "max_timeout" to a value shorter than the latency of the distant dc nodes, ' \
+                    f'the healthcheck status of {node.ip_address} was not {HostStatus.TIMEOUT} as expected, but ' \
+                    f'instead it was {dict_host_health[node.ip_address].status}'
+            for node in nodes_from_local_dc:
+                assert dict_host_health[node.ip_address].status == HostStatus.UP, \
+                    f'After setting "max_timeout" to a value longer than the latency of the local dc nodes, ' \
+                    f'the healthcheck status of {node.ip_address} is not {HostStatus.UP} as expected, but ' \
+                    f'instead it was {dict_host_health[node.ip_address].status}'
+        finally:
+            alter_manager_yaml_and_restart(manager_node=manager_node, logger=self.log, values_to_remove=['healthcheck'])
+            mgr_cluster.delete()  # remove cluster at the end of the test
+        self.log.info('finishing test_healthcheck_change_max_timeout')
 
     def test_ssh_setup_script(self):
         self.log.info('starting test_ssh_setup_script')

--- a/mgmt_upgrade_test.py
+++ b/mgmt_upgrade_test.py
@@ -70,8 +70,7 @@ class ManagerUpgradeTest(BackupFunctionsMixIn, ClusterTester):
             scylla_manager_yaml["http"] = f"{node_ip}:{new_manager_http_port}"
             scylla_manager_yaml["prometheus"] = f"{node_ip}:{self.params['manager_prometheus_port']}"
             LOGGER.info("The new Scylla Manager is:\n{}".format(scylla_manager_yaml))
-        manager_node.remoter.sudo("systemctl restart scylla-manager")
-        manager_node.wait_manager_server_up(port=new_manager_http_port)
+        manager_node.restart_manager_server(port=new_manager_http_port)
         manager_tool = get_scylla_manager_tool(manager_node=manager_node)
         manager_tool.add_cluster(name="cluster_under_test", db_cluster=self.db_cluster,
                                  auth_token=self.monitors.mgmt_auth_token)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1274,6 +1274,10 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             wait.wait_for(func=self.is_manager_server_up, port=self.OLD_MANAGER_PORT,
                           step=10, text=text, timeout=timeout, throw_exc=True)
 
+    def restart_manager_server(self, port=None):
+        self.remoter.sudo("systemctl restart scylla-manager")
+        self.wait_manager_server_up(port=port)
+
     # Configuration node-exporter.service when use IPv6
 
     def set_web_listen_address(self):

--- a/sdcm/mgmt/common.py
+++ b/sdcm/mgmt/common.py
@@ -76,7 +76,7 @@ def get_manager_scylla_backend(scylla_backend_version_name, distro):
     return backend_repo_address
 
 
-def alter_manager_yaml_and_restart(manager_node, logger, values_to_update=(), values_to_remove=()):
+def reconfigure_scylla_manager(manager_node, logger, values_to_update=(), values_to_remove=()):
     with manager_node.remote_manager_yaml() as scylla_manager_yaml:
         for value in values_to_update:
             scylla_manager_yaml.update(value)

--- a/sdcm/mgmt/common.py
+++ b/sdcm/mgmt/common.py
@@ -76,6 +76,17 @@ def get_manager_scylla_backend(scylla_backend_version_name, distro):
     return backend_repo_address
 
 
+def alter_manager_yaml_and_restart(manager_node, logger, values_to_update=(), values_to_remove=()):
+    with manager_node.remote_manager_yaml() as scylla_manager_yaml:
+        for value in values_to_update:
+            scylla_manager_yaml.update(value)
+        for value in values_to_remove:
+            del scylla_manager_yaml[value]
+        logger.info("The new Scylla Manager is:\n%s", scylla_manager_yaml)
+    manager_node.remoter.sudo("systemctl restart scylla-manager")
+    manager_node.wait_manager_server_up()
+
+
 class ScyllaManagerError(Exception):
     """
     A custom exception for Manager related errors

--- a/sdcm/mgmt/common.py
+++ b/sdcm/mgmt/common.py
@@ -83,8 +83,7 @@ def reconfigure_scylla_manager(manager_node, logger, values_to_update=(), values
         for value in values_to_remove:
             del scylla_manager_yaml[value]
         logger.info("The new Scylla Manager is:\n%s", scylla_manager_yaml)
-    manager_node.remoter.sudo("systemctl restart scylla-manager")
-    manager_node.wait_manager_server_up()
+    manager_node.restart_manager_server()
 
 
 class ScyllaManagerError(Exception):


### PR DESCRIPTION
New in manager 2.6
'max_timeout' is new parameter in the scylla manager yaml. It decides the maximum
amount of time the manager healthcheck function will wait for a ping response before
it will announce the node as timed out.
The new test in the manager sanity, test_healthcheck_change_max_timeout, sets the
timeout as such that the latency of the nodes that exist in the
local region (us-east-1) will not be longer than the set timeout, and therefore
will appear as UP in the healthcheck, while the latency of the node that is the
distant region (us-west-2) will be longer than the set timeout, and therefore the
healthcheck will report it as TIMEOUT.
The test makes sure that the healthcheck reports those statuses correctly.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
