### PR TITLE
fix(helm-versions): make 'latest' helm charts work again

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -474,7 +474,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
         all_versions = yaml.safe_load(self.helm(
             f"search repo {local_chart_path} --devel --versions -o yaml"))
         assert isinstance(all_versions, list), f"Expected list of data, got: {type(all_versions)}"
-        return str(max((version.parse(chart_data["version"]) for chart_data in all_versions)))
+        return str(max((version.LegacyVersion(chart_data["version"]) for chart_data in all_versions)))
 
     @cached_property
     def _scylla_operator_chart_version(self):


### PR DESCRIPTION
If we specify 'latest' as a version for the operator Helm charts then
we get following error:

    chart "scylla-operator" version "1.6.0a0" not found ...

The reason for it is that real chart version that is '1.6.0-alpha.0'
gets transformed to the '1.6.0a0' and since we need direct matching of
strings we fail to match any helm version here.
So, switch to usage of the 'LegavyVersion' class instead of 'Version'
one processing list of Helm charts versions to get not transformed
strings.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
