### PR TITLE
fix(pyyaml): use safe load functions when Loader isn't specified

### DIFF
--- a/functional_tests/scylla_operator/libs/helpers.py
+++ b/functional_tests/scylla_operator/libs/helpers.py
@@ -60,7 +60,7 @@ def get_pods_without_probe(db_cluster: ScyllaPodCluster,
                            probe_type: str, selector: str, container_name: str) -> list:
     pods = db_cluster.k8s_cluster.kubectl(f'get pods -A -l "{selector}" -o yaml')
     pods_without_probes = []
-    for pod in yaml.load(pods.stdout)["items"]:
+    for pod in yaml.safe_load(pods.stdout)["items"]:
         for container in pod.get("spec", {}).get("containers", []):
             if container['name'] == container_name and not container.get(probe_type):
                 pods_without_probes.append(
@@ -103,14 +103,14 @@ def wait_for_resource_absence(db_cluster: ScyllaPodCluster,
 def get_pods_and_statuses(db_cluster: ScyllaPodCluster, namespace: str, label: str = None):
     pods = db_cluster.k8s_cluster.kubectl(f"get pods {'-l ' + label if label else ''} -o yaml", namespace=namespace)
     return [{"name": pod["metadata"]["name"], "status": pod["status"]["phase"]} for pod in
-            yaml.load(pods.stdout)["items"] if pod]
+            yaml.safe_load(pods.stdout)["items"] if pod]
 
 
 def get_pod_storage_capacity(db_cluster: ScyllaPodCluster, namespace: str, pod_name: str = None, label: str = None):
     pods_storage_capacity = []
     label = " -l " + label if label else ''
     persistent_volume_info = db_cluster.k8s_cluster.kubectl(f"get pvc {label} -o yaml", namespace=namespace)
-    for pod in yaml.load(persistent_volume_info.stdout)["items"]:
+    for pod in yaml.safe_load(persistent_volume_info.stdout)["items"]:
         if pod_name and pod_name not in pod["metadata"]["name"]:
             continue
 

--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -451,7 +451,7 @@ def test_deploy_helm_with_default_values(db_cluster: ScyllaPodCluster):
 
     log.info("Create %s namespace", namespace)
 
-    namespaces = yaml.load(db_cluster.k8s_cluster.kubectl("get namespaces -o yaml").stdout)
+    namespaces = yaml.safe_load(db_cluster.k8s_cluster.kubectl("get namespaces -o yaml").stdout)
 
     if not [ns["metadata"]["name"] for ns in namespaces["items"] if ns["metadata"]["name"] == namespace]:
         db_cluster.k8s_cluster.kubectl(f"create namespace {namespace}")

--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -109,7 +109,7 @@ class GkeNodePool(CloudK8sNodePool):
     @property
     def instance_group_name(self) -> str:
         try:
-            group_link = yaml.load(
+            group_link = yaml.safe_load(
                 self.k8s_cluster.gcloud.run(
                     f'container node-pools describe {self.name} '
                     f'--zone {self.gce_zone} --project {self.gce_project} '
@@ -257,7 +257,7 @@ class GkeCluster(KubernetesCluster):
 
     def get_instance_group_name_for_pool(self, pool_name: str, default=None) -> str:
         try:
-            group_link = yaml.load(
+            group_link = yaml.safe_load(
                 self.gcloud.run(
                     f'container node-pools describe {pool_name} '
                     f'--zone {self.gce_zone} --project {self.gce_project} '

--- a/sdcm/mgmt/common.py
+++ b/sdcm/mgmt/common.py
@@ -47,7 +47,7 @@ def duration_to_timedelta(duration_string):
 
 def get_manager_repo_from_defaults(manager_version_name, distro):
     with open("defaults/manager_versions.yaml", 'r') as mgmt_config:
-        manager_repos_by_version_dict = yaml.load(mgmt_config, Loader=yaml.BaseLoader)["manager_repos_by_version"]
+        manager_repos_by_version_dict = yaml.safe_load(mgmt_config)["manager_repos_by_version"]
 
     version_specific_repos = manager_repos_by_version_dict.get(manager_version_name, None)
     assert version_specific_repos, f"Couldn't find manager version {manager_version_name} in manager defaults"
@@ -62,8 +62,7 @@ def get_manager_repo_from_defaults(manager_version_name, distro):
 
 def get_manager_scylla_backend(scylla_backend_version_name, distro):
     with open("defaults/manager_versions.yaml", 'r') as mgmt_config:
-        scylla_backend_repos_by_version_dict = yaml.load(mgmt_config,
-                                                         Loader=yaml.BaseLoader)["scylla_backend_repo_by_version"]
+        scylla_backend_repos_by_version_dict = yaml.safe_load(mgmt_config)["scylla_backend_repo_by_version"]
 
     version_specific_repos = scylla_backend_repos_by_version_dict.get(scylla_backend_version_name, None)
     assert version_specific_repos, f"Couldn't find scylla version {scylla_backend_version_name} in manager defaults"

--- a/sdcm/utils/k8s.py
+++ b/sdcm/utils/k8s.py
@@ -330,7 +330,7 @@ class KubernetesOps:  # pylint: disable=too-many-public-methods
             else:
                 with open(config_path, 'r') as config_file_stream:
                     data = config_file_stream.read()
-            file_content = yaml.load_all(data)
+            file_content = yaml.safe_load_all(data)
 
             for doc in file_content:
                 if modifiers:


### PR DESCRIPTION
Use safe_load and safe_load_all instead of plain loads when Loader isn't
specified. Also makes pylint on 3.10 happy.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [ ] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [x] All new and existing unit tests passed (CI)
- [ ] ~I have updated the Readme/doc folder accordingly (if needed)~

[Trello](https://trello.com/c/Y21ag8HC/4048-specify-loader-or-use-safeload-for-yamlload-calls)