### PR TITLE
fix(cluster.py): add scylla_help_seastar to scylla_help

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1765,7 +1765,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         if append_scylla_args:
             scylla_help = self.remoter.run(
                 f"{self.add_install_prefix('/usr/bin/scylla')} --help", ignore_status=True).stdout
-            scylla_arg_parser = ScyllaArgParser.from_scylla_help(scylla_help)
+            scylla_help_seastar = self.remoter.run(
+                f"{self.add_install_prefix('/usr/bin/scylla')} --help-seastar", ignore_status=True).stdout
+            scylla_arg_parser = ScyllaArgParser.from_scylla_help(f"{scylla_help}\n{scylla_help_seastar}")
             append_scylla_args = scylla_arg_parser.filter_args(append_scylla_args)
 
         if append_scylla_args:


### PR DESCRIPTION
following PR #4003 this commit will back port this
change to `branch-perf-v10`

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
