### PR TITLE
fix(test-cases): remove scylla_mgmt_agent_repo which is not existing anymore

### DIFF
--- a/test-cases/artifacts/sles15.yaml
+++ b/test-cases/artifacts/sles15.yaml
@@ -17,4 +17,3 @@ scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-
 test_duration: 60
 user_prefix: 'artifacts-sles15'
 system_auth_rf: 1
-scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo'

--- a/unit_tests/test_data/test_scylla_yaml_builders/PR-provision-test.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/PR-provision-test.yaml
@@ -24,7 +24,6 @@ gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/globa
 
 scylla_version: 4.4.1
 scylla_mgmt_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.3.repo'
-scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.3.repo'
 
 workaround_kernel_bug_for_iotune: true
 

--- a/unit_tests/test_data/test_scylla_yaml_builders/artifact_amazon2.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/artifact_amazon2.yaml
@@ -18,4 +18,3 @@ system_auth_rf: 1
 test_duration: 60
 use_preinstalled_scylla: false
 user_prefix: 'artifacts-amazon2'
-scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo'

--- a/unit_tests/test_data/test_scylla_yaml_builders/manager-backup-1TB-gce.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/manager-backup-1TB-gce.yaml
@@ -30,7 +30,6 @@ nemesis_filter_seeds: false
 
 gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-1804-lts'
 scylla_linux_distro: 'ubuntu-bionic'
-scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/bionic/master/latest/scylladb-manager-master/scylla-manager.list'
 
 scylla_linux_distro_loader: 'centos'
 scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo'


### PR DESCRIPTION
https://trello.com/c/ij87eqF0/4059-fix-arifact-sles15-tests

scylla_mgmt_agent_repo was removed from sctconfiguration, but some test files are still having it.
We need to remove this option from these files to make them operational

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
