### PR TITLE
Fix missing emails for cdc performance tests

### DIFF
--- a/docker/cdcstressor/image
+++ b/docker/cdcstressor/image
@@ -1,1 +1,1 @@
-scylladb/hydra-loaders:cdc-stresser-20200430
+scylladb/hydra-loaders:cdc-stresser-20210630

--- a/sdcm/results_analyze/__init__.py
+++ b/sdcm/results_analyze/__init__.py
@@ -409,7 +409,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
         elif test_doc['_source']['test_details'].get('ycsb'):
             return PerformanceFilterYCSB(test_doc, is_gce)()
         elif "cdc" in test_doc['_source']['test_details'].get('sub_type'):
-            return CDCQueryFilterCS(test_doc, is_gce)()
+            return CDCQueryFilterCS(test_doc, is_gce, use_wide_query=True)()
         else:
             return PerformanceFilterCS(test_doc, is_gce)()
 

--- a/sdcm/utils/es_queries.py
+++ b/sdcm/utils/es_queries.py
@@ -251,7 +251,8 @@ class CDCQueryFilter(QueryFilter):
     def filter_test_details(self):
         test_details = 'test_details.job_name: \"{}\" '.format(
             self.test_doc['_source']['test_details']['job_name'].split('/')[0])
-        test_details += self.test_cmd_details()
+        if not self.use_wide_query:
+            test_details += self.test_cmd_details()
         test_details += ' AND test_details.time_completed: {}'.format(self.date_re)
         test_details += r' AND test_details.sub_type: cdc* '
         return test_details


### PR DESCRIPTION
PR contains 3 commits.
1. Retry to create/update document if Readtimeouterr happened for ES.
2. Update docker image for cdc stressor tool
3. Switch to use wide query for cdc performance tests

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
