### PR TITLE
fix(JMXServiceEvent): fix evaluation of the end timestamp

### DIFF
--- a/sdcm/parallel_timeline_report/generate_pt_report.py
+++ b/sdcm/parallel_timeline_report/generate_pt_report.py
@@ -304,7 +304,7 @@ class ParallelTimelinesReportGenerator:
             # If endless events exist, evaluate end_timestamp for them
             endless_events = list(filter(lambda x: x.event_id in endless_event_id_set, begin_events))
             for event in endless_events:
-                if event.base == "ScyllaServerStatusEvent":
+                if event.base in ["ScyllaServerStatusEvent", "JMXServiceEvent"]:
                     event.end_timestamp = self.max_end_timestamp
                 else:
                     event.end_timestamp = event.begin_timestamp

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -274,7 +274,7 @@ class CompactionEvent(ScyllaDatabaseContinuousEvent):
 
 class JMXServiceEvent(ScyllaDatabaseContinuousEvent):
     begin_pattern = r'Starting the JMX server'
-    end_pattern = r'JMX is enabled to receive remote connections on port: \d+'
+    end_pattern = r'Stopped Scylla JMX'
 
     def __init__(self, node: str, severity=Severity.NORMAL, **__):
         super().__init__(node=node, severity=severity)


### PR DESCRIPTION
[Trello Task](https://trello.com/c/TV5a3akj/3944-jmxserviceevent-should-have-end-pattern-that-is-logged-when-the-service-is-stopped)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
