### PR TITLE
improvement(tox-venv-mgr): pass through 'HOME" env var needed by git

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ sitepackages = False
 
 [testenv]
 envdir = {toxworkdir}/{envname}
-passenv = PYTEST_* SCT_*
+passenv = HOME PYTEST_* SCT_*
 whitelist_externals = *
 commands =
     python -m pip install --upgrade pip>=9.0.0 setuptools wheel


### PR DESCRIPTION
To be able to run "git" commands in virtual environment we need to
have "HOME" env var be defined. So, pass through it to the tox
environment.

With this change following command starts working:

    $ tox -e py310 -- git commit

Such a command is needed to avoid skipping of pylint checks for
some of the files when we have default python version be incompatible.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
