### PR TITLE
test(function): override scylla.yaml

### DIFF
--- a/functional_tests/scylla_operator/conftest.py
+++ b/functional_tests/scylla_operator/conftest.py
@@ -174,3 +174,8 @@ def _bring_cluster_back_to_original_state(
 @pytest.fixture(name="cassandra_rackdc_properties")
 def fixture_cassandra_rackdc_properties(db_cluster: ScyllaPodCluster):
     return db_cluster.remote_cassandra_rackdc_properties
+
+
+@pytest.fixture(name="scylla_yaml")
+def fixture_scylla_yaml(db_cluster: ScyllaPodCluster):
+    return db_cluster.remote_scylla_yaml


### PR DESCRIPTION
Add a functional test that checks the ability to override scylla.yaml
Task: https://trello.com/c/ZgzgdjD5/3941-create-a-functional-test-that-checks-the-ability-to-
override-scyllayaml

Tested:
https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/yulia-functional-k8s-local-kind-aws/11/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
