### PR TITLE
fix(sdcm/*.py): fix duplicated code to make pylint happy

### DIFF
--- a/sdcm/remote/remote_base.py
+++ b/sdcm/remote/remote_base.py
@@ -570,13 +570,13 @@ class RemoteCmdRunnerBase(CommandRunner):  # pylint: disable=too-many-instance-a
     # pylint: disable=too-many-arguments
     def run(self,
             cmd: str,
-            timeout: Optional[float] = None,
+            timeout: float | None = None,
             ignore_status: bool = False,
             verbose: bool = True,
             new_session: bool = False,
-            log_file: Optional[str] = None,
+            log_file: str | None = None,
             retry: int = 1,
-            watchers: Optional[List[StreamWatcher]] = None,
+            watchers: List[StreamWatcher] | None = None,
             change_context: bool = False
             ) -> Result:
         """

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -2223,20 +2223,20 @@ def download_from_github(repo: str, tag: str, dst_dir: str):
 
 
 def walk_thru_data(data, path: str) -> Any:
-    current = data
+    current_value = data
     for name in path.split('/'):
-        if current is None:
+        if current_value is None:
             return None
         if not name:
             continue
-        if name.isalnum() and isinstance(current, (list, tuple, set)):
+        if name.isalnum() and isinstance(current_value, (list, tuple, set)):
             try:
-                current = current[int(name)]
+                current_value = current_value[int(name)]
             except Exception:  # pylint: disable=broad-except
-                current = None
+                current_value = None
             continue
-        current = current.get(name, None)
-    return current
+        current_value = current_value.get(name, None)
+    return current_value
 
 
 def update_authenticator(nodes, authenticator='AllowAllAuthenticator', restart=True):


### PR DESCRIPTION
Fixed following doubles:
sdcm.remote.base:[93:104] vs sdcm.remote.remote_base:[570:597]
sdcm.utils.common:[2231:2241] vs sdcm.utils.k8s:[865:874]

(cherry picked from commit a5fe3ac4531b952f8bd4b80ba9d23d1c36c76610)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
