### PR TITLE
fix(pricing): ap-northeast-3 renamed to Osaka

### DIFF
--- a/sdcm/utils/pricing.py
+++ b/sdcm/utils/pricing.py
@@ -24,7 +24,7 @@ class AWSPricing:
             'us-west-1': 'US West (N. California)',
             'us-west-2': 'US West (Oregon)',
             'ap-south-1': 'Asia Pacific (Mumbai)',
-            'ap-northeast-3': 'Asia Pacific (Osaka-Local)',
+            'ap-northeast-3': 'Asia Pacific (Osaka)',
             'ap-northeast-2': 'Asia Pacific (Seoul)',
             'ap-southeast-1': 'Asia Pacific (Singapore)',
             'ap-southeast-2': 'Asia Pacific (Sydney)',


### PR DESCRIPTION
Osaka-Local was renamed to Osaka
Fixes:
```
10:23:07 Found total of 353 instances.
10:23:07 Traceback (most recent call last):
10:23:07   File "/jenkins/slave/workspace/devops-cloud-resources-report/./sct.py", line 1279, in <module>
10:23:07     cli()
10:23:07   File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1137, in __call__
10:23:07     return self.main(*args, **kwargs)
10:23:07   File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1062, in main
10:23:07     rv = self.invoke(ctx)
10:23:07   File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1668, in invoke
10:23:07     return _process_result(sub_ctx.command.invoke(sub_ctx))
10:23:07   File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
10:23:07     return ctx.invoke(self.callback, **ctx.params)
10:23:07   File "/usr/local/lib/python3.10/site-packages/click/core.py", line 763, in invoke
10:23:07     return __callback(*args, **kwargs)
10:23:07   File "/jenkins/slave/workspace/devops-cloud-resources-report/./sct.py", line 935, in cloud_usage_report
10:23:07     cloud_report(mail_to=email_list)
10:23:07   File "/jenkins/slave/workspace/devops-cloud-resources-report/sdcm/utils/cloud_monitor/cloud_monitor.py", line 38, in cloud_report
10:23:08     cloud_instances = CloudInstances()
10:23:08   File "/jenkins/slave/workspace/devops-cloud-resources-report/sdcm/utils/cloud_monitor/resources/__init__.py", line 48, in __init__
10:23:08     self.get_all()
10:23:08   File "/jenkins/slave/workspace/devops-cloud-resources-report/sdcm/utils/cloud_monitor/resources/instances.py", line 110, in get_all
10:23:08     self.get_aws_instances()
10:23:08   File "/jenkins/slave/workspace/devops-cloud-resources-report/sdcm/utils/cloud_monitor/resources/instances.py", line 100, in get_aws_instances
10:23:08     self["aws"] = [AWSInstance(instance) for instance in aws_instances]
10:23:08   File "/jenkins/slave/workspace/devops-cloud-resources-report/sdcm/utils/cloud_monitor/resources/instances.py", line 100, in <listcomp>
10:23:08     self["aws"] = [AWSInstance(instance) for instance in aws_instances]
10:23:08   File "/jenkins/slave/workspace/devops-cloud-resources-report/sdcm/utils/cloud_monitor/resources/instances.py", line 19, in __init__
10:23:08     super().__init__(
10:23:08   File "/jenkins/slave/workspace/devops-cloud-resources-report/sdcm/utils/cloud_monitor/resources/__init__.py", line 21, in __init__
10:23:08     self.price = self.pricing.get_instance_price(region=self.region, instance_type=self.instance_type,
10:23:08   File "/jenkins/slave/workspace/devops-cloud-resources-report/sdcm/utils/pricing.py", line 81, in get_instance_price
10:23:08     return self.get_on_demand_instance_price(region_name=region, instance_type=instance_type)
10:23:08   File "/jenkins/slave/workspace/devops-cloud-resources-report/sdcm/utils/pricing.py", line 53, in get_on_demand_instance_price
10:23:08     assert response['PriceList'], "failed to get price for {instance_type} in {region_name}".format(
10:23:08 AssertionError: failed to get price for t2.micro in ap-northeast-3
```
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
