### PR TITLE
fix(duplication): reuse walk_thru_data func in HelmValues.get method

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -2222,13 +2222,33 @@ def download_from_github(repo: str, tag: str, dst_dir: str):
             os.rename(os.path.join(base_dir, file), os.path.join(dst_dir, file))
 
 
-def walk_thru_data(data, path: str) -> Any:
+def walk_thru_data(data, path: str, separator: str = '/') -> Any:
+    """Allows to get a value of an element in some data structure.
+
+    Example from K8S API:
+    object_dict = {
+        "spec": {
+            "automaticOrphanedNodeCleanup": True,
+            "datacenter": {
+                "name": "dc-1",
+                racks: [...],
+            },
+        },
+    }
+
+    And to get the DC name out of it we can call this function like following:
+
+        walk_thru_data(data=object_dict, path='spec.datacenter.name', separator=".")
+
+    """
     current_value = data
-    for name in path.split('/'):
+    for name in path.split(separator):
         if current_value is None:
             return None
         if not name:
             continue
+        if name[0] == '[' and name[-1] == ']':
+            name = name[1:-1]
         if name.isalnum() and isinstance(current_value, (list, tuple, set)):
             try:
                 current_value = current_value[int(name)]

--- a/sdcm/utils/k8s.py
+++ b/sdcm/utils/k8s.py
@@ -34,6 +34,7 @@ from urllib3.util.retry import Retry
 
 from sdcm import sct_abs_path
 from sdcm.remote import LOCALRUNNER
+from sdcm.utils.common import walk_thru_data
 from sdcm.utils.decorators import timeout as timeout_decor, retrying
 from sdcm.utils.docker_utils import ContainerManager, DockerException, Container
 from sdcm.wait import wait_for
@@ -699,20 +700,7 @@ class HelmValues:
             self._data = dict(**kwargs)
 
     def get(self, path):
-        current = self._data
-        for name in path.split('.'):
-            if current is None:
-                return None
-            if name[0] == '[' and name[-1] == ']':
-                name = name[1:-1]
-            if name.isalnum() and isinstance(current, (list, tuple, set)):
-                try:
-                    current = current[int(name)]
-                except Exception:  # pylint: disable=broad-except
-                    current = None
-                continue
-            current = current.get(name, None)
-        return current
+        return walk_thru_data(data=self._data, path=path, separator=".")
 
     def _path_to_dict(self, path, value):
         keys = path.split(".")


### PR DESCRIPTION
'walk_thru_data' function located at sdcm/utils/common.py module
has the same logic as 'HelmValues.get' method in the sdcm/utils/k8s.py

So, update the first one to be compatible with the needs of the second
one and reuse it to remove code duplication.
Also, add docstring to the reused function with the description of it's
usage.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
