### PR TITLE
refactor(manager tests): manager tests use scylla 4.5 instead of 4.4

### DIFF
--- a/jenkins-pipelines/manager/centos-manager-backup-200gb.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-backup-200gb.jenkinsfile
@@ -10,7 +10,7 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_backup_feature',
     test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/200gb_dataset.yaml"]''',
 
-    scylla_version: '4.4',
+    scylla_version: '4.5',
 
     timeout: [time: 1400, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',

--- a/jenkins-pipelines/manager/centos-manager-backup-azure.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-backup-azure.jenkinsfile
@@ -11,7 +11,7 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_backup_feature',
     test_config: 'test-cases/manager/manager-regression-multiDC-set-distro.yaml',
 
-    scylla_version: '4.4',
+    scylla_version: '4.5',
 
     timeout: [time: 500, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',

--- a/jenkins-pipelines/manager/centos-manager-backup-gce.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-backup-gce.jenkinsfile
@@ -8,7 +8,7 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_backup_feature',
     test_config: 'test-cases/manager/manager-regression-gce.yaml',
 
-    scylla_version: '4.4',
+    scylla_version: '4.5',
 
     timeout: [time: 500, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',

--- a/jenkins-pipelines/manager/centos-manager-backup.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-backup.jenkinsfile
@@ -10,7 +10,7 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_backup_feature',
     test_config: 'test-cases/manager/manager-regression-multiDC-set-distro.yaml',
 
-    scylla_version: '4.4',
+    scylla_version: '4.5',
 
     timeout: [time: 500, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',

--- a/jenkins-pipelines/manager/centos-manager-repair-control.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-repair-control.jenkinsfile
@@ -11,7 +11,7 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_repair_control',
     test_config: 'test-cases/manager/manager-repair-control.yaml',
 
-    scylla_version: '4.4',
+    scylla_version: '4.5',
 
     timeout: [time: 1260, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',

--- a/jenkins-pipelines/manager/centos-manager-repair-intensity-multiple-repaired-nodes.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-repair-intensity-multiple-repaired-nodes.jenkinsfile
@@ -11,7 +11,7 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_repair_intensity_feature_on_multiple_node',
     test_config: 'test-cases/manager/manager-repair-intensity-multiple-repaired-nodes.yaml',
 
-    scylla_version: '4.4',
+    scylla_version: '4.5',
 
     timeout: [time: 1260, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',

--- a/jenkins-pipelines/manager/centos-manager-repair-intensity-single-repaired-nodes.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-repair-intensity-single-repaired-nodes.jenkinsfile
@@ -11,7 +11,7 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_repair_intensity_feature_on_single_node',
     test_config: 'test-cases/manager/manager-repair-intensity-single-repaired-nodes.yaml',
 
-    scylla_version: '4.4',
+    scylla_version: '4.5',
 
     timeout: [time: 1620, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',

--- a/jenkins-pipelines/manager/centos-manager-sanity-ipv6.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-sanity-ipv6.jenkinsfile
@@ -10,7 +10,7 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: 'test-cases/manager/manager-regression-ipv6.yaml',
 
-    scylla_version: '4.4',
+    scylla_version: '4.5',
 
     timeout: [time: 120, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',

--- a/jenkins-pipelines/manager/centos-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-sanity.jenkinsfile
@@ -11,7 +11,7 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: 'test-cases/manager/manager-regression-multiDC-set-distro.yaml',
 
-    scylla_version: '4.4',
+    scylla_version: '4.5',
 
     timeout: [time: 120, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',

--- a/jenkins-pipelines/manager/centos-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-upgrade.jenkinsfile
@@ -11,7 +11,7 @@ managerPipeline(
     target_manager_version: 'master_latest',
 
     manager_version: '2.5',
-    scylla_version: '4.4',
+    scylla_version: '4.5',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: 'test-cases/upgrades/manager-upgrade.yaml',

--- a/jenkins-pipelines/manager/debian10-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/debian10-manager-sanity.jenkinsfile
@@ -10,7 +10,7 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/debian10.yaml"]''',
 
-    scylla_version: '4.4',
+    scylla_version: '4.5',
 
     timeout: [time: 120, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',

--- a/jenkins-pipelines/manager/debian10-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian10-manager-upgrade.jenkinsfile
@@ -11,7 +11,7 @@ managerPipeline(
     target_manager_version: 'master_latest',
 
     manager_version: '2.5',
-    scylla_version: '4.4',
+    scylla_version: '4.5',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/debian10.yaml"]''',

--- a/jenkins-pipelines/manager/debian9-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/debian9-manager-sanity.jenkinsfile
@@ -10,7 +10,7 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/debian9.yaml"]''',
 
-    scylla_version: '4.4',
+    scylla_version: '4.5',
 
     timeout: [time: 120, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',

--- a/jenkins-pipelines/manager/debian9-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian9-manager-upgrade.jenkinsfile
@@ -11,7 +11,7 @@ managerPipeline(
     target_manager_version: 'master_latest',
 
     manager_version: '2.5',
-    scylla_version: '4.4',
+    scylla_version: '4.5',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/debian9.yaml"]''',

--- a/jenkins-pipelines/manager/ubuntu16-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu16-manager-sanity.jenkinsfile
@@ -10,7 +10,7 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/ubuntu16.yaml"]''',
 
-    scylla_version: '4.4',
+    scylla_version: '4.5',
 
     timeout: [time: 120, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',

--- a/jenkins-pipelines/manager/ubuntu16-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu16-manager-upgrade.jenkinsfile
@@ -11,7 +11,7 @@ managerPipeline(
     target_manager_version: 'master_latest',
 
     manager_version: '2.5',
-    scylla_version: '4.4',
+    scylla_version: '4.5',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/ubuntu16.yaml"]''',

--- a/jenkins-pipelines/manager/ubuntu18-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu18-manager-sanity.jenkinsfile
@@ -9,7 +9,7 @@ managerPipeline(
     aws_region: '''["us-east-1", "us-west-2"]''',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/ubuntu18.yaml"]''',
-    scylla_version: '4.4',
+    scylla_version: '4.5',
 
     timeout: [time: 120, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',

--- a/jenkins-pipelines/manager/ubuntu18-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu18-manager-upgrade.jenkinsfile
@@ -11,7 +11,7 @@ managerPipeline(
     target_manager_version: 'master_latest',
 
     manager_version: '2.5',
-    scylla_version: '4.4',
+    scylla_version: '4.5',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/ubuntu18.yaml"]''',

--- a/jenkins-pipelines/manager/ubuntu20-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu20-manager-sanity.jenkinsfile
@@ -9,7 +9,7 @@ managerPipeline(
     aws_region: '''["us-east-1", "us-west-2"]''',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/ubuntu20.yaml"]''',
-    scylla_version: '4.4',
+    scylla_version: '4.5',
 
     timeout: [time: 120, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',

--- a/jenkins-pipelines/manager/ubuntu20-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu20-manager-upgrade.jenkinsfile
@@ -11,7 +11,7 @@ managerPipeline(
     target_manager_version: 'master_latest',
 
     manager_version: '2.5',
-    scylla_version: '4.4',
+    scylla_version: '4.5',
 
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/ubuntu20.yaml"]''',


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
