### PR TITLE
fix(alternator-3h): increase test_duration by 60 minutes

### DIFF
--- a/test-cases/longevity/longevity-alternator-3h.yaml
+++ b/test-cases/longevity/longevity-alternator-3h.yaml
@@ -1,4 +1,4 @@
-test_duration: 300
+test_duration: 360
 prepare_write_cmd:
   - >-
     bin/ycsb load dynamodb -P workloads/workloadc -threads 80 -p recordcount=6990500


### PR DESCRIPTION
Time to time teardown takes 40 minutes and test setup takes 1h
 in such case test is running out of time and getting killed

Example killed runs:
https://jenkins.scylladb.com/job/scylla-master/job/longevity/job/longevity-alternator-3h-test/313/
https://jenkins.scylladb.com/job/scylla-master/job/longevity/job/longevity-alternator-3h-test/309/
https://jenkins.scylladb.com/job/scylla-master/job/longevity/job/longevity-alternator-3h-test/306/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
