### PR TITLE
improvement(Jenkins): add job for removing SCT runners

### DIFF
--- a/jenkins-pipelines/hydra-clean-runner-instances.jenkinsfile
+++ b/jenkins-pipelines/hydra-clean-runner-instances.jenkinsfile
@@ -1,0 +1,57 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+pipeline {
+    agent {
+        label {
+            label 'sct-builders'
+        }
+    }
+    environment {
+        AWS_ACCESS_KEY_ID     = credentials('qa-aws-secret-key-id')
+        AWS_SECRET_ACCESS_KEY = credentials('qa-aws-secret-access-key')
+    }
+    parameters {
+        booleanParam(
+            defaultValue: false,
+            description: 'do not execute commands, just print out',
+            name: 'dryRun'
+        )
+    }
+    options {
+        timestamps()
+        disableConcurrentBuilds()
+        buildDiscarder(logRotator(numToKeepStr: '50'))
+    }
+    stages {
+        stage('Skip build#1') {  // Because this: https://issues.jenkins-ci.org/browse/JENKINS-41929
+            when { expression { env.BUILD_NUMBER == '1' } }
+            steps {
+                script {
+                    if (currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause') != null) {
+                        currentBuild.description = ('Aborted build#1 not having parameters loaded.\n' +
+                                                    'Build#2 is ready to run')
+                        currentBuild.result = 'ABORTED'
+                        error('Abort build#1 which only loads params')
+                    }
+                }
+            }
+        }
+        stage('Checkout') {
+            steps {
+                dir('scylla-cluster-tests') {
+                    checkout scm
+                }
+            }
+        }
+        stage('Run hydra clean-runner-instances') {
+            steps {
+                sctScript """
+                    ./docker/env/hydra.sh clean-runner-instances ${params.dryRun ? '--dry-run' : ''}
+                """
+            }
+        }
+    }
+}


### PR DESCRIPTION
Trello: https://trello.com/c/9sKBqVL0/4094-clean-forgotten-gce-runner-instances

New job: https://jenkins.scylladb.com/view/QA/job/QA-tools/job/hydra-clean-runner-instances/

Plan to run it every 3h

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
