### PR TITLE
fix(ManagerTask.status): Added considation for 'ERROR (4/4)' status

### DIFF
--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -156,7 +156,7 @@ class ManagerTask:
         # The manager will sometimes retry a task a few times if it's defined this way, and so in the case of
         # a failure in the task the manager can present the task's status as 'ERROR (#/4)'
         tmp = str_status.split()
-        if ' '.join(tmp[0:1]) == 'ERROR (4/4)':
+        if ' '.join(tmp) == 'ERROR (4/4)':
             return TaskStatus.ERROR_FINAL
         return TaskStatus.from_str(tmp[0])
 

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -156,7 +156,8 @@ class ManagerTask:
         # The manager will sometimes retry a task a few times if it's defined this way, and so in the case of
         # a failure in the task the manager can present the task's status as 'ERROR (#/4)'
         tmp = str_status.split()
-        if ' '.join(tmp) == 'ERROR (4/4)':
+        # We don't examine the whole string, since sometimes error messages can appear after the status
+        if ' '.join(tmp[0:2]) == 'ERROR (4/4)':
             return TaskStatus.ERROR_FINAL
         return TaskStatus.from_str(tmp[0])
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1757,7 +1757,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         status = mgr_task.wait_and_get_final_status(timeout=54000, step=5, only_final=True)
         if status == TaskStatus.DONE:
             self.log.info("Task: %s is done.", mgr_task.id)
-        elif status == TaskStatus.ERROR:
+        elif status in (TaskStatus.ERROR, TaskStatus.ERROR_FINAL):
             assert False, f'Backup task {mgr_task.id} failed'
         else:
             mgr_task.stop()


### PR DESCRIPTION
The status string of a manager task, when splited based on spaces, can
be two items long (like 'ERROR (1/4)'). As such, when we examine if
the manager status is ERROR_FINAL ('ERROR (4/4)') we need to examine
the entire list, and not just its first value.

Also, broadened Nemesis._mgmt_backup to look for ERROR_FINAL status at the
end of the backup task.

Fixes #3902 

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
