### PR TITLE
improvement(YCSB_docker): introduce version support scylla command

### DIFF
--- a/docker/ycsb/Dockerfile
+++ b/docker/ycsb/Dockerfile
@@ -11,6 +11,9 @@ RUN cd /YCSB/dynamodb/target && mkdir -p YCSB && tar xvvf ycsb-dynamo*.tar.gz -C
 RUN cd YCSB; mvn -pl cassandra -am clean package -DskipTests
 RUN cd /YCSB/cassandra/target && mkdir -p YCSB && tar xvvf ycsb-cassandra-*.tar.gz -C YCSB --strip-components 1
 
+RUN cd YCSB; mvn -pl scylla -am clean package -DskipTests
+RUN cd /YCSB/scylla/target && mkdir -p YCSB && tar xvvf ycsb-scylla-*.tar.gz -C YCSB --strip-components 1
+
 
 FROM openjdk:8 as app
 RUN echo 'networkaddress.cache.ttl=0' >> $JAVA_HOME/jre/lib/security/java.security
@@ -18,3 +21,4 @@ RUN echo 'networkaddress.cache.negative.ttl=0' >> $JAVA_HOME/jre/lib/security/ja
 COPY java.policy $JAVA_HOME/jre/lib/security/java.policy
 COPY --from=builder /YCSB/dynamodb/target/YCSB /YCSB
 COPY --from=builder /YCSB/cassandra/target/YCSB /YCSB
+COPY --from=builder /YCSB/scylla/target/YCSB /YCSB

--- a/docker/ycsb/image
+++ b/docker/ycsb/image
@@ -1,1 +1,1 @@
-scylladb/hydra-loaders:ycsb-jdk8-20200326
+scylladb/hydra-loaders:ycsb-jdk8-20211104

--- a/sdcm/utils/docker_remote.py
+++ b/sdcm/utils/docker_remote.py
@@ -43,7 +43,7 @@ class RemoteDocker(BaseNode):
         :return: the external port automatically open by docker
         """
         external_port = self.node.remoter.run(f"docker port {self.docker_id} {internal_port}").stdout.strip()
-        return external_port
+        return external_port.splitlines()[0]
 
     def get_log(self):
         return self.node.remoter.run(f"docker logs {self.docker_id}").stdout.strip()

--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -224,7 +224,7 @@ class YcsbStressThread(DockerBasedStressThread):  # pylint: disable=too-many-ins
         if self.stress_num > 1:
             cpu_options = '--cpuset-cpus="{cpu_idx}"'
 
-        docker = RemoteDocker(loader, "scylladb/hydra-loaders:ycsb-jdk8-20200326",
+        docker = RemoteDocker(loader, "scylladb/hydra-loaders:ycsb-jdk8-20211104",
                               extra_docker_opts=f'{dns_options} {cpu_options} --label shell_marker={self.shell_marker}')
         self.copy_template(docker)
         stress_cmd = self.build_stress_cmd()

--- a/unit_tests/test_ycsb_thread.py
+++ b/unit_tests/test_ycsb_thread.py
@@ -167,8 +167,8 @@ def test_02_dynamodb_api_dataintegrity(request, docker_scylla, prom_address, eve
 def test_03_cql(request, docker_scylla, prom_address):
     loader_set = LocalLoaderSetDummy()
 
-    cmd = 'bin/ycsb load cassandra-cql -P workloads/workloada -threads 5 -p recordcount=1000000 ' \
-          '-p fieldcount=10 -p fieldlength=1024 -p operationcount=200200300 -s'
+    cmd = 'bin/ycsb load scylla -P workloads/workloada -threads 5 -p recordcount=1000000 ' \
+          f'-p fieldcount=10 -p fieldlength=1024 -p operationcount=200200300 -p scylla.hosts={docker_scylla.ip_address} -s'
     ycsb_thread = YcsbStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=5, params=TEST_PARAMS)
 
     def cleanup_thread():


### PR DESCRIPTION
build new docker image that has https://github.com/brianfrankcooper/YCSB/pull/1507
and enable shard aware by default

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
