### PR TITLE
ci(perf-pipeline): use separate timeouts for different stages

### DIFF
--- a/jenkins-pipelines/operator/performance/perf-regression-latency-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/performance/perf-regression-latency-eks.jenkinsfile
@@ -13,6 +13,5 @@ perfRegressionParallelPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-    post_behavior_k8s_cluster: 'destroy',
-    timeout: [time: 480, unit: "MINUTES"]
+    post_behavior_k8s_cluster: 'destroy'
 )

--- a/jenkins-pipelines/operator/performance/perf-regression-throughput-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/performance/perf-regression-throughput-eks.jenkinsfile
@@ -13,6 +13,5 @@ perfRegressionParallelPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-    post_behavior_k8s_cluster: 'destroy',
-    timeout: [time: 420, unit: "MINUTES"]
+    post_behavior_k8s_cluster: 'destroy'
 )

--- a/vars/getJobTimeouts.groovy
+++ b/vars/getJobTimeouts.groovy
@@ -7,19 +7,6 @@ List<Integer> call(Map params, String region){
     #!/bin/bash
     export SCT_CLUSTER_BACKEND="${params.backend}"
     export SCT_CONFIG_FILES=${test_config}
-
-    if [[ -n "${params.k8s_scylla_operator_docker_image ? params.k8s_scylla_operator_docker_image : ''}" ]] ; then
-        export SCT_K8S_SCYLLA_OPERATOR_DOCKER_IMAGE=${params.k8s_scylla_operator_docker_image}
-    fi
-    if [[ -n "${params.k8s_scylla_operator_helm_repo ? params.k8s_scylla_operator_helm_repo : ''}" ]] ; then
-        export SCT_K8S_SCYLLA_OPERATOR_HELM_REPO=${params.k8s_scylla_operator_helm_repo}
-    fi
-    if [[ -n "${params.k8s_scylla_operator_chart_version ? params.k8s_scylla_operator_chart_version : ''}" ]] ; then
-        export SCT_K8S_SCYLLA_OPERATOR_CHART_VERSION=${params.k8s_scylla_operator_chart_version}
-    fi
-    if [[ -n "${params.scylla_mgmt_agent_version ? params.scylla_mgmt_agent_version : ''}" ]] ; then
-        export SCT_SCYLLA_MGMT_AGENT_VERSION=${params.scylla_mgmt_agent_version}
-    fi
     ./docker/env/hydra.sh output-conf -b "${params.backend}"
     """
     def testData = sh(script: cmd, returnStdout: true).trim()


### PR DESCRIPTION
For the moment we use one single timeout for whole performance
pipeline. It is not really correct because we can get successfully
finished test in time but timed out logs collection. Such a situation
leads to the false negative job results.
So, use separate timeouts for different stages in performance pipeline
the same way as we do it in longevity ones.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
