### PR TITLE
fix(events): set debug level when more than 2 events found

### DIFF
--- a/sdcm/prometheus.py
+++ b/sdcm/prometheus.py
@@ -200,12 +200,9 @@ class PrometheusAlertManagerListener(threading.Thread):
                 new_event.period_type = EventPeriod.INFORMATIONAL.value
                 new_event.end_event()
             if len(begun_events) > 1:
-                LOGGER.warning("Found {event_count} events of type '{alert}' started at {starts_at} with period "
-                               "{event_period}. Will apply the function to most recent event by default."
-                               .format(event_count=len(begun_events),
-                                       alert=alert_name,
-                                       starts_at=alert.get("startsAt"),
-                                       event_period=EventPeriod.BEGIN.value))
+                LOGGER.debug("Found %s events of type '%s' started at %s with period %s. "
+                             "Will apply the function to most recent event by default.",
+                             len(begun_events), alert_name, alert.get("startsAt"), EventPeriod.BEGIN.value)
             if begun_events:
                 event = begun_events[-1]
                 event.end_event()

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -334,11 +334,9 @@ def get_pattern_to_event_to_func_mapping(node: str) \
                                                    .format(event_type=event_type,
                                                            period_type=EventPeriod.BEGIN.value))
         if len(begun_events) > 1:
-            LOGGER.warning("Found {event_count} events of type {event_type} with period {event_period}. "
-                           "Will apply the function to most recent event by default."
-                           .format(event_count=len(begun_events),
-                                   event_type=event_type,
-                                   event_period=EventPeriod.BEGIN.value))
+            LOGGER.debug("Found %s events of type %s with period %s. "
+                         "Will apply the function to most recent event by default.",
+                         len(begun_events), event_type, EventPeriod.BEGIN.value)
         event = begun_events[-1]
         event.end_event()
 


### PR DESCRIPTION
prevent tons of warnings that appear in console log. Example:
Found 5 events of type <class sdcm.sct_events.database.RepairEvent>
with period begin. Will apply the function

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
