### PR TITLE
fix(manager_versions): changed master_latest deb urls to unified build

### DIFF
--- a/defaults/manager_versions.yaml
+++ b/defaults/manager_versions.yaml
@@ -2,11 +2,11 @@ manager_repos_by_version:
   "master_latest":
     centos7: 'http://downloads.scylladb.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo'
     centos8: 'http://downloads.scylladb.com/manager/rpm/unstable/centos/master/latest/scylla-manager.repo'
-    debian9: 'http://downloads.scylladb.com/manager/deb/unstable/stretch/master/latest/scylladb-manager-master/scylla-manager.list'
-    debian10: 'http://downloads.scylladb.com/manager/deb/unstable/buster/master/latest/scylladb-manager-master/scylla-manager.list'
-    ubuntu16: 'http://downloads.scylladb.com/manager/deb/unstable/xenial/master/latest/scylla-manager-master/scylla-manager.list'
-    ubuntu18: 'http://downloads.scylladb.com/manager/deb/unstable/bionic/master/latest/scylladb-manager-master/scylla-manager.list'
-    ubuntu20: 'http://downloads.scylladb.com/manager/deb/unstable/focal/master/latest/scylla-manager-master/scylla-manager.list'
+    debian9: 'http://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
+    debian10: 'http://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
+    ubuntu16: 'http://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
+    ubuntu18: 'http://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
+    ubuntu20: 'http://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
   "2.5":
     centos7: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.5.repo'
     centos8: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.5.repo'


### PR DESCRIPTION
Since individuals packackes are not created for different deb distributions,
I modified all of the master urls in manager_versions.yaml to the unified deb build.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
