### PR TITLE
improvement(email): add link to the job that recreate a monitor

### DIFF
--- a/sdcm/report_templates/results_base.html
+++ b/sdcm/report_templates/results_base.html
@@ -282,11 +282,12 @@
 {% block hydra_commands %}
     {% if test_id %}
         <h3>
-            Hydra commands:
+            Restore commands:
         </h3>
         <div>
             <ul>
                 <li>Restore Monitor Stack command: $ hydra investigate show-monitor {{ test_id }}</li>
+                <li>Restore monitor on AWS instance using <a href="{{ restore_monitor_job_base_link }}test_id={{ test_id }}"> Jenkins job </a></li>
                 <li>Show all stored logs command: $ hydra investigate show-logs {{ test_id }}</li>
             </ul>
         </div>

--- a/sdcm/report_templates/results_base_new.html
+++ b/sdcm/report_templates/results_base_new.html
@@ -241,11 +241,12 @@
 
 {%- block hydra_commands -%}
     <h3>
-        Hydra commands:
+        Restore commands:
     </h3>
     <div>
         <ul>
             <li>Restore Monitor Stack command: $ hydra investigate show-monitor {{ current_main_test.test_id }}</li>
+            <li>Restore monitor on AWS instance using <a href="{{ restore_monitor_job_base_link }}test_id={{ test_id }}"> Jenkins job </a></li>
             <li>Show all stored logs command: $ hydra investigate show-logs {{ current_main_test.test_id }}</li>
         </ul>
     </div>

--- a/sdcm/report_templates/results_issue_template.html
+++ b/sdcm/report_templates/results_issue_template.html
@@ -93,6 +93,7 @@
     {% if test_id %}
     <div>
         Restore Monitor Stack command: `$ hydra investigate show-monitor {{ test_id }}`<br>
+        Restore monitor on AWS instance using [Jenkins job]({{ restore_monitor_job_base_link }}test_id={{ test_id }})<br>
         Show all stored logs command: `$ hydra investigate show-logs {{ test_id }}`<br>
         <br>
         Test id: `{{ test_id }}`<br>

--- a/sdcm/report_templates/results_jepsen.html
+++ b/sdcm/report_templates/results_jepsen.html
@@ -33,11 +33,12 @@
 {% block hydra_commands %}
     {% if test_id %}
         <h3>
-            Hydra commands:
+            Restore commands:
         </h3>
         <div>
             <ul>
                 <li>Restore Monitor Stack command: $ hydra investigate show-monitor {{ test_id }}</li>
+                <li>Restore monitor on AWS instance using <a href="{{ restore_monitor_job_base_link }}test_id={{ test_id }}"> Jenkins job </a></li>
                 <li>Show all stored logs command: $ hydra investigate show-logs {{ test_id }}</li>
                 <li>Run web server with Jepsen results: $ hydra investigate show-jepsen-results {{ test_id }}</li>
             </ul>

--- a/sdcm/send_email.py
+++ b/sdcm/send_email.py
@@ -150,6 +150,7 @@ class BaseEmailReporter:
         "test_status",
         "username",
         "shard_awareness_driver",
+        "restore_monitor_job_base_link",
     )
     _fields = ()
     email_template_file = 'results_base.html'

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2957,6 +2957,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             scylla_instance_type = "N/A"
 
         job_name = os.environ.get('JOB_NAME').split("/")[-1] if os.environ.get('JOB_NAME') else config_file_name
+        restore_monitor_job_base_link = \
+            "https://jenkins.scylladb.com/view/QA/job/QA-tools/job/hydra-show-monitor/parambuild/?"
 
         return {"backend": backend,
                 "build_id": os.environ.get('BUILD_NUMBER', ''),
@@ -2980,7 +2982,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 "test_name": self.id(),
                 "test_status": test_status,
                 "username": get_username(),
-                "shard_awareness_driver": self.is_shard_awareness_driver}
+                "shard_awareness_driver": self.is_shard_awareness_driver,
+                "restore_monitor_job_base_link": restore_monitor_job_base_link}
 
     @silence()
     def tag_ami_with_result(self):


### PR DESCRIPTION
This commit will improve our issues and do a life easier to developers.
Add to the issue link to the job that restore the monitor with it's parameters.

Task: https://trello.com/c/nHVX473v/3993-email-template-add-link-to-the-job-that-recreate-a-monitor


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
