### PR TITLE
fix(provision): do not create test_id

### DIFF
--- a/sdcm/sct_provision/common/layout.py
+++ b/sdcm/sct_provision/common/layout.py
@@ -64,5 +64,5 @@ class SCTProvisionLayout:
 def create_sct_configuration(test_name: str):
     sct_configuration = init_and_verify_sct_config()
     TestConfig().set_test_name(test_name)
-    TestConfig().set_test_id(sct_configuration.get('test_id'))
+    TestConfig().set_test_id_only(sct_configuration.get('test_id'))
     return sct_configuration

--- a/sdcm/test_config.py
+++ b/sdcm/test_config.py
@@ -53,14 +53,19 @@ class TestConfig(metaclass=Singleton):  # pylint: disable=too-many-public-method
         return cls._test_id
 
     @classmethod
-    def set_test_id(cls, test_id):
+    def set_test_id_only(cls, test_id) -> bool:
         if not cls._test_id:
             cls._test_id = str(test_id)
+            return True
+        LOGGER.warning("TestID already set!")
+        return False
+
+    @classmethod
+    def set_test_id(cls, test_id):
+        if cls.set_test_id_only(test_id):
             test_id_file_path = os.path.join(cls.logdir(), "test_id")
             with open(test_id_file_path, "w") as test_id_file:
                 test_id_file.write(str(test_id))
-        else:
-            LOGGER.warning("TestID already set!")
 
     @classmethod
     def tester_obj(cls):


### PR DESCRIPTION
With current logic we create folder with test_id in it
As result in the pipelines where both provision step and test run step
 exists, all steps that are using get_testrun_dir are getting two folder

fixes (https://github.com/scylladb/scylla-cluster-tests/issues/4100)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
