### PR TITLE
Provision: localize provisioner plan and plan builder

### DIFF
--- a/sdcm/provision/aws/provisioner.py
+++ b/sdcm/provision/aws/provisioner.py
@@ -26,12 +26,12 @@ from sdcm.provision.aws.utils import ec2_services, ec2_clients, find_instance_by
     create_spot_instance_request
 from sdcm.provision.aws.constants import SPOT_CNT_LIMIT, SPOT_FLEET_LIMIT, SPOT_REQUEST_TIMEOUT, STATUS_FULFILLED, \
     SPOT_STATUS_UNEXPECTED_ERROR, FLEET_LIMIT_EXCEEDED_ERROR, SPOT_CAPACITY_NOT_AVAILABLE_ERROR, MAX_SPOT_DURATION_TIME
-from sdcm.provision.common.provisioner import TagsType, ProvisionParameters, ProvisionerBase
+from sdcm.provision.common.provisioner import TagsType, ProvisionParameters, InstanceProvisionerBase
 
 LOGGER = logging.getLogger(__name__)
 
 
-class AWSProvisioner(ProvisionerBase):  # pylint: disable=too-few-public-methods
+class AWSInstanceProvisioner(InstanceProvisionerBase):  # pylint: disable=too-few-public-methods
     # TODO: Make them configurable
     _wait_interval = 5
     _iam_fleet_role = 'arn:aws:iam::797456418907:role/aws-ec2-spot-fleet-role'

--- a/sdcm/provision/common/provision_plan.py
+++ b/sdcm/provision/common/provision_plan.py
@@ -1,0 +1,47 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2021 ScyllaDB
+
+import logging
+from typing import List
+
+from pydantic import BaseModel
+
+from sdcm.provision.common.provisioner import ProvisionParameters, InstanceProvisionerBase, InstanceParamsBase, TagsType
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ProvisionPlan(BaseModel):
+    provision_steps: List[ProvisionParameters]
+    provisioner: InstanceProvisionerBase
+
+    @property
+    def name(self):
+        return self.__class__.__name__
+
+    def provision_instances(self, instance_parameters: InstanceParamsBase, node_count: int, node_tags: List[TagsType],
+                            node_names: List[str]):
+        for provision_parameters in self.provision_steps:
+            if instances := self.provisioner.provision(
+                    provision_parameters=provision_parameters,
+                    instance_parameters=instance_parameters,
+                    count=node_count,
+                    tags=node_tags,
+                    names=node_names,
+            ):
+                LOGGER.info('%s: Instances has been provisioned using "%s":\n%s', self.name,
+                            provision_parameters.name, instances)
+                return instances
+            else:
+                LOGGER.error('%s: Failed to provision instances using "%s"', self.name, provision_parameters.name)
+        return []

--- a/sdcm/provision/common/provision_plan_builder.py
+++ b/sdcm/provision/common/provision_plan_builder.py
@@ -1,0 +1,122 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2021 ScyllaDB
+
+import logging
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+from sdcm.provision.aws.provisioner import AWSInstanceProvisioner
+from sdcm.provision.common.provision_plan import ProvisionPlan
+from sdcm.provision.common.provisioner import ProvisionParameters, InstanceProvisionerBase
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ProvisionType(str, Enum):
+    ON_DEMAND = 'on_demand'
+    SPOT_LOW_PRICE = 'spot_low_price'
+    SPOT_DURATION = 'spot_duration'
+    SPOT = 'spot'
+
+
+class ProvisionPlanBuilder(BaseModel):
+    initial_provision_type: ProvisionType
+    duration: int = None
+    fallback_provision_on_demand: bool
+    region_name: str
+    availability_zone: str
+    spot_low_price: float = None
+    provisioner: InstanceProvisionerBase
+
+    @property
+    def _provision_request_on_demand(self) -> Optional[ProvisionParameters]:
+        return ProvisionParameters(
+            name='On Demand',
+            spot=False,
+            region_name=self.region_name,
+            availability_zone=self.availability_zone,
+        )
+
+    @property
+    def _provision_request_spot(self) -> ProvisionParameters:
+        return ProvisionParameters(
+            name='Spot',
+            spot=True,
+            region_name=self.region_name,
+            availability_zone=self.availability_zone,
+        )
+
+    @property
+    def _provision_request_spot_low_price(self) -> ProvisionParameters:
+        return ProvisionParameters(
+            name='Spot(Low Price)',
+            spot=True,
+            region_name=self.region_name,
+            availability_zone=self.availability_zone,
+            price=self.spot_low_price
+        )
+
+    @property
+    def _provision_request_spot_duration(self) -> Optional[ProvisionParameters]:
+        if self.duration is None:
+            return None
+        return ProvisionParameters(
+            name='Spot(Duration)',
+            spot=True,
+            region_name=self.region_name,
+            availability_zone=self.availability_zone,
+            duration=self.duration
+        )
+
+    @property
+    def _provision_request_spot_duration_low_price(self) -> Optional[ProvisionParameters]:
+        if self.duration is None:
+            return None
+        return ProvisionParameters(
+            name='Spot(Duration, Low Price)',
+            spot=True,
+            region_name=self.region_name,
+            availability_zone=self.availability_zone,
+            price=self.spot_low_price,
+            duration=self.duration
+        )
+
+    @property
+    def _provision_steps(self) -> List[ProvisionParameters]:
+        if self.initial_provision_type == ProvisionType.ON_DEMAND:
+            return [self._provision_request_on_demand]
+        provision_plan = []
+        if self.initial_provision_type == ProvisionType.SPOT:
+            provision_plan.extend([
+                self._provision_request_spot,
+                self._provision_request_spot_duration
+            ])
+        elif self.initial_provision_type == ProvisionType.SPOT_LOW_PRICE:
+            provision_plan.extend([
+                self._provision_request_spot_low_price,
+                self._provision_request_spot_duration_low_price,
+                self._provision_request_spot,
+            ])
+        elif self.initial_provision_type == ProvisionType.SPOT_DURATION:
+            provision_plan.extend([
+                self._provision_request_spot,
+            ])
+        if self.fallback_provision_on_demand:
+            provision_plan.append(self._provision_request_on_demand)
+        return provision_plan
+
+    @property
+    def provision_plan(self):
+        return ProvisionPlan(provision_steps=self._provision_steps, provisioner=AWSInstanceProvisioner())

--- a/sdcm/provision/common/provisioner.py
+++ b/sdcm/provision/common/provisioner.py
@@ -23,7 +23,7 @@ class InstanceParamsBase(BaseModel):  # pylint: disable=too-few-public-methods
     """
 
 
-class ProvisionerBase(metaclass=abc.ABCMeta):  # pylint: disable=too-few-public-methods
+class InstanceProvisionerBase(BaseModel, metaclass=abc.ABCMeta):  # pylint: disable=too-few-public-methods
     """
     Base class for provisioner - a class that provide API to provision instances
     """

--- a/sdcm/sct_provision/common/layout.py
+++ b/sdcm/sct_provision/common/layout.py
@@ -29,7 +29,7 @@ class SCTProvisionLayout:
         backend = params.get('cluster_backend')
         try:
             importlib.import_module(cls.__module__.replace('.common.', f'.{backend}.'), package=None)
-        except Exception:  # pylint: disable=broad-except
+        except ModuleNotFoundError:
             pass
         target_class = cls._cluster_backend_mapping.get(backend, SCTProvisionLayout)
         return object.__new__(target_class)


### PR DESCRIPTION
Based on: https://github.com/scylladb/scylla-cluster-tests/pull/4098

Purpose is to localize logic regarding provisioning and generalize it.
Preparation for https://trello.com/c/EyP2J8ig/1290-microsoft-azure-as-a-new-backend


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
