### PR TITLE
fix(show_alive_threads): make it safe

### DIFF
--- a/sdcm/utils/threads_and_processes_alive.py
+++ b/sdcm/utils/threads_and_processes_alive.py
@@ -4,20 +4,33 @@ import multiprocessing
 import sys
 import threading
 import traceback
+from typing import Any
 
 
 LOGGER = logging.getLogger(__name__)
 
 
 def get_thread_stacktrace(thread):  # pylint: disable=no-self-use
-    frame = sys._current_frames().get(thread.ident, None)  # pylint: disable=protected-access
-    output = []
-    for filename, lineno, name, line in traceback.extract_stack(frame):
-        output.append('File: "%s", line %d, in %s' % (filename,
-                                                      lineno, name))
-        if line:
-            output.append("  %s" % (line.strip()))
-    return '\n'.join(output)
+    try:
+        frame = sys._current_frames().get(thread.ident, None)  # pylint: disable=protected-access
+        output = []
+        for filename, lineno, name, line in traceback.extract_stack(frame):
+            output.append('File: "%s", line %d, in %s' % (filename,
+                                                          lineno, name))
+            if line:
+                output.append("  %s" % (line.strip()))
+        return '\n'.join(output)
+    except Exception as exc:  # pylint: disable=broad-except
+        LOGGER.error('Failed to get stack trace due to the: %s', exc)
+        return 'FAILED TO GET STACKTRACE'
+
+
+def get_source(source: Any):
+    try:
+        return inspect.getsource(source)
+    except Exception as exc:  # pylint: disable=broad-except
+        LOGGER.error('Failed to source due to the: %s', exc)
+        return 'NO SOURCE AVAILABLE'
 
 
 def gather_live_threads_and_dump_to_file(dump_file_path: str) -> bool:
@@ -35,13 +48,13 @@ def gather_live_threads_and_dump_to_file(dump_file_path: str) -> bool:
             if thread.__class__ is threading.Thread:
                 if thread.run.__func__ is not threading.Thread.run:
                     module = thread.run.__module__
-                    source = inspect.getsource(thread.run)
+                    source = get_source(thread.run)
                 elif getattr(thread, '_target', None):
                     module = thread._target.__module__  # pylint: disable=protected-access
-                    source = inspect.getsource(thread._target)  # pylint: disable=protected-access
+                    source = get_source(thread._target)  # pylint: disable=protected-access
             else:
                 module = thread.__module__
-                source = inspect.getsource(thread.__class__)
+                source = get_source(thread.__class__)
             if module not in source_modules:
                 source_modules.append(module)
             daemonic = getattr(thread, '_daemonic', getattr(thread, 'daemon', False))
@@ -65,10 +78,10 @@ def gather_live_processes_and_dump_to_file(dump_file_path: str) -> bool:
             if proc.__class__ is multiprocessing.Process:
                 if proc.run.__func__ != multiprocessing.Process.run:
                     module = proc.run.__module__
-                    source = inspect.getsource(proc.run)
+                    source = get_source(proc.run)
             else:
                 module = proc.__module__
-                source = inspect.getsource(proc.__class__)
+                source = get_source(proc.__class__)
             if module not in source_modules:
                 source_modules.append(module)
             daemonic = getattr(proc, '_daemonic', getattr(proc, 'daemon', False))


### PR DESCRIPTION
inspect routines we are using can raise Exceptions in some cases
lets catch and log them, and return placeholder in such case

https://trello.com/c/oRgLrYqm/4069-showalivethreads-can-fail-with-source-code-not-available

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
