### PR TITLE
refactor(jenkins): rename aws-region to region

### DIFF
--- a/docs/sct-pipelines.md
+++ b/docs/sct-pipelines.md
@@ -15,7 +15,7 @@
 
 ```groovy
 longevityPipeline(
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.py:LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-10gb-3h.yaml',
 

--- a/jenkins-pipelines/EaR-longevity-kmip-200gb-6h.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-kmip-200gb-6h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml", "configurations/hytrust-kmip-ear.yaml"]''',
 

--- a/jenkins-pipelines/EaR-longevity-kmip-50gb-4d.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-kmip-50gb-4d.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "configurations/hytrust-kmip-ear.yaml"]''',
 

--- a/jenkins-pipelines/EaR-longevity-local-200gb-6h.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-local-200gb-6h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml", "configurations/local-ear.yaml"]''',
 

--- a/jenkins-pipelines/EaR-longevity-local-50gb-4d.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-local-50gb-4d.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "configurations/local-ear.yaml"]''',
 

--- a/jenkins-pipelines/EaR-longevity-replicated-200gb-6h.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-replicated-200gb-6h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml", "configurations/replicated-ear.yaml"]''',
 

--- a/jenkins-pipelines/EaR-longevity-replicated-50gb-4d.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-replicated-50gb-4d.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "configurations/replicated-ear.yaml"]''',
 

--- a/jenkins-pipelines/admission_control_overload.jenkinsfile
+++ b/jenkins-pipelines/admission_control_overload.jenkinsfile
@@ -4,7 +4,7 @@
 def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'admission_control_overload_test.AdmissionControlOverloadTest',
     test_config: 'test-cases/load/admission_control_overload_test.yaml',
 

--- a/jenkins-pipelines/feature-cdc-replication-gemini-postimage.jenkinsfile
+++ b/jenkins-pipelines/feature-cdc-replication-gemini-postimage.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 cdcReplicationPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'cdc_replication_test.CDCReplicationTest.test_replication_gemini_postimage',
     test_config: 'test-cases/cdc/cdc-15m-replication-postimage.yaml',
 

--- a/jenkins-pipelines/feature-cdc-replication-gemini-preimage.jenkinsfile
+++ b/jenkins-pipelines/feature-cdc-replication-gemini-preimage.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 cdcReplicationPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'cdc_replication_test.CDCReplicationTest.test_replication_gemini_preimage',
     test_config: 'test-cases/cdc/cdc-15m-replication-preimage.yaml',
 

--- a/jenkins-pipelines/feature-cdc-replication-gemini.jenkinsfile
+++ b/jenkins-pipelines/feature-cdc-replication-gemini.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 cdcReplicationPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'cdc_replication_test.CDCReplicationTest.test_replication_gemini_delta',
     test_config: 'test-cases/cdc/cdc-15m-replication-gemini.yaml',
 

--- a/jenkins-pipelines/feature-cdc-replication-longevity.jenkinsfile
+++ b/jenkins-pipelines/feature-cdc-replication-longevity.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 cdcReplicationPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'cdc_replication_test.CDCReplicationTest.test_replication_longevity',
     test_config: 'test-cases/cdc/cdc-replication-longevity.yaml',
 

--- a/jenkins-pipelines/feature-cdc-replication.jenkinsfile
+++ b/jenkins-pipelines/feature-cdc-replication.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 cdcReplicationPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'cdc_replication_test.CDCReplicationTest.test_replication_cs',
     test_config: 'test-cases/cdc/cdc-15m-replication.yaml',
 

--- a/jenkins-pipelines/feature-ldap-authorization-and-audit-longevity-100gb-4h.jenkinsfile
+++ b/jenkins-pipelines/feature-ldap-authorization-and-audit-longevity-100gb-4h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/ldap-authorization.yaml", "configurations/audit.yaml"]''',
 

--- a/jenkins-pipelines/feature-ldap-authorization-longevity-100gb-4h.jenkinsfile
+++ b/jenkins-pipelines/feature-ldap-authorization-longevity-100gb-4h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/ldap-authorization.yaml"]''',
 

--- a/jenkins-pipelines/feature-ldap-authorization-longevity-200gb-48h.jenkinsfile
+++ b/jenkins-pipelines/feature-ldap-authorization-longevity-200gb-48h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml", "configurations/ldap-authorization.yaml"]''',
 

--- a/jenkins-pipelines/feature-ldap-authorization-longevity-50gb-3days.jenkinsfile
+++ b/jenkins-pipelines/feature-ldap-authorization-longevity-50gb-3days.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "configurations/ldap-authorization.yaml"]''',
 

--- a/jenkins-pipelines/feature-ms-ad-ldap-longevity-100gb-4h.jenkinsfile
+++ b/jenkins-pipelines/feature-ms-ad-ldap-longevity-100gb-4h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-north-1',
+    region: 'eu-north-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/ms-ad-ldap.yaml"]''',
 

--- a/jenkins-pipelines/features-2mv-backpressure-4days.jenkinsfile
+++ b/jenkins-pipelines/features-2mv-backpressure-4days.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/features/2mv-backpressure-4d.yaml',
 

--- a/jenkins-pipelines/features-corrupt-then-rebuild-7days.jenkinsfile
+++ b/jenkins-pipelines/features-corrupt-then-rebuild-7days.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'corrupt_then_rebuild.CorruptThenRebuildTest.test_corrupt_then_rebuild_nodes',
     test_config: 'test-cases/features/corrupt-then-rebuild.yaml',
 

--- a/jenkins-pipelines/features-destroy-data-then-repair-7days.jenkinsfile
+++ b/jenkins-pipelines/features-destroy-data-then-repair-7days.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'destroy_data_then_repair_test.CorruptThenRepair.test_destroy_data_then_repair_test_nodes',
     test_config: 'test-cases/destroy-data-then-repair.yaml',
 

--- a/jenkins-pipelines/features-dns-cluster-5min.jenkinsfile
+++ b/jenkins-pipelines/features-dns-cluster-5min.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'build_cluster_test.BuildClusterTest.test_use_public_dns_names',
     test_config: 'test-cases/features/dns-cluster-5min.yaml',
 

--- a/jenkins-pipelines/features-enospc-30min.jenkinsfile
+++ b/jenkins-pipelines/features-enospc-30min.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'enospc_test.EnospcTest.test_enospc_nodes',
     test_config: 'test-cases/features/enospc-30min.yaml',
 

--- a/jenkins-pipelines/features-full-cluster-stop-start.jenkinsfile
+++ b/jenkins-pipelines/features-full-cluster-stop-start.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'full_cluster_stop_start_test.FullClusterStopStart.test_full_cluster_stop_start',
     test_config: 'test-cases/features/full-cluster-stop-start.yaml',
 

--- a/jenkins-pipelines/features-ics-space-amplification-goal-test.jenkinsfile
+++ b/jenkins-pipelines/features-ics-space-amplification-goal-test.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'ics_space_amplification_goal_test.IcsSpaceAmplificationTest.test_ics_space_amplification_goal',
     test_config: 'test-cases/features/ics_space_amplification_goal_test.yaml',
 

--- a/jenkins-pipelines/features-ics-space-amplification-test-sag.jenkinsfile
+++ b/jenkins-pipelines/features-ics-space-amplification-test-sag.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'ics_space_amplification_test.IcsSpaceAmplificationTest.test_ics_space_amplification_with_goal',
     test_config: 'test-cases/features/ics_space_amplification_test.yaml',
 

--- a/jenkins-pipelines/features-refresh-120gb-30min.jenkinsfile
+++ b/jenkins-pipelines/features-refresh-120gb-30min.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'refresh_test.RefreshTest.test_refresh_node',
     test_config: 'test-cases/features/refresh-30mins-120gb.yaml',
 

--- a/jenkins-pipelines/features-scale-180-200-cluster-test.jenkinsfile
+++ b/jenkins-pipelines/features-scale-180-200-cluster-test.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     post_behavior_db_nodes: 'destroy',
     test_name: 'grow_cluster_test.GrowClusterTest.test_grow_x_to_y',
     test_config: '''["test-cases/features/scale-cluster.yaml", "configurations/scale-180-200.yaml"]''',

--- a/jenkins-pipelines/features-scale-450-500-cluster-test.jenkinsfile
+++ b/jenkins-pipelines/features-scale-450-500-cluster-test.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     post_behavior_db_nodes: 'destroy',
     test_name: 'grow_cluster_test.GrowClusterTest.test_grow_x_to_y',
     test_config: '''["test-cases/features/scale-cluster.yaml", "configurations/scale-450-500.yaml"]''',

--- a/jenkins-pipelines/features-sla-read-50perc-write-50perc-load.jenkinsfile
+++ b/jenkins-pipelines/features-sla-read-50perc-write-50perc-load.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'sla_per_user_system_test.SlaPerUserTest.test_read_50perc_write_50perc_load',
     test_config: 'test-cases/features/system-sla-test.yaml',
 

--- a/jenkins-pipelines/features-sla-read-throughput-1to5-ratio.jenkinsfile
+++ b/jenkins-pipelines/features-sla-read-throughput-1to5-ratio.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'sla_per_user_system_test.SlaPerUserTest.test_read_throughput_1to5_ratio',
     test_config: 'test-cases/features/system-sla-test.yaml',
 

--- a/jenkins-pipelines/features-sla-read-throughput-vs-latency-cache-and-disk.jenkinsfile
+++ b/jenkins-pipelines/features-sla-read-throughput-vs-latency-cache-and-disk.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'sla_per_user_system_test.SlaPerUserTest.test_read_throughput_vs_latency_cache_and_disk',
     test_config: 'test-cases/features/system-sla-test.yaml',
 

--- a/jenkins-pipelines/features-sla-read-throughput-vs-latency-cache-only.jenkinsfile
+++ b/jenkins-pipelines/features-sla-read-throughput-vs-latency-cache-only.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'sla_per_user_system_test.SlaPerUserTest.test_read_throughput_vs_latency_cache_only',
     test_config: 'test-cases/features/system-sla-test.yaml',
 

--- a/jenkins-pipelines/features-sla-read-throughput-vs-latency-disk-only.jenkinsfile
+++ b/jenkins-pipelines/features-sla-read-throughput-vs-latency-disk-only.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'sla_per_user_system_test.SlaPerUserTest.test_read_throughput_vs_latency_disk_only',
     test_config: 'test-cases/features/system-sla-test.yaml',
 

--- a/jenkins-pipelines/gemini-1tb-10h.jenkinsfile
+++ b/jenkins-pipelines/gemini-1tb-10h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'gemini_test.GeminiTest.test_load_random_with_nemesis',
     test_config: 'test-cases/gemini/gemini-1tb-10h.yaml',
 

--- a/jenkins-pipelines/gemini-3h-cdc-preimage-write.jenkinsfile
+++ b/jenkins-pipelines/gemini-3h-cdc-preimage-write.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'gemini_test.GeminiTest.test_random_load',
     test_config: 'test-cases/gemini/gemini-3h-cdc-preimage-write.yaml',
 

--- a/jenkins-pipelines/gemini-3h-cdc-write.jenkinsfile
+++ b/jenkins-pipelines/gemini-3h-cdc-write.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'gemini_test.GeminiTest.test_random_load',
     test_config: 'test-cases/gemini/gemini-3h-cdc-write.yaml',
 

--- a/jenkins-pipelines/gemini-3h-ics-cdc-with-nemesis.jenkinsfile
+++ b/jenkins-pipelines/gemini-3h-ics-cdc-with-nemesis.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'gemini_test.GeminiTest.test_load_random_with_nemesis_cdc_reader',
     test_config: 'test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml',
 

--- a/jenkins-pipelines/gemini-3h-ics-nondisruptive-nemesis.jenkinsfile
+++ b/jenkins-pipelines/gemini-3h-ics-nondisruptive-nemesis.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'gemini_test.GeminiTest.test_load_random_with_nemesis',
     test_config: 'test-cases/gemini/gemini-3h-ics-with-nondisruptive-nemesis.yaml',
 

--- a/jenkins-pipelines/gemini-3h-ics.jenkinsfile
+++ b/jenkins-pipelines/gemini-3h-ics.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'gemini_test.GeminiTest.test_random_load',
     test_config: 'test-cases/gemini/gemini-basic-3h-ics.yaml',
 

--- a/jenkins-pipelines/gemini-3h-nondisruptive-nemesis.jenkinsfile
+++ b/jenkins-pipelines/gemini-3h-nondisruptive-nemesis.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'gemini_test.GeminiTest.test_load_random_with_nemesis',
     test_config: 'test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml',
 

--- a/jenkins-pipelines/gemini-3h-with-nemesis.jenkinsfile
+++ b/jenkins-pipelines/gemini-3h-with-nemesis.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'us-east-1',
+    region: 'us-east-1',
     test_name: 'gemini_test.GeminiTest.test_load_random_with_nemesis',
     test_config: 'test-cases/gemini/gemini-3h-with-nemesis.yaml',
 

--- a/jenkins-pipelines/gemini-3h.jenkinsfile
+++ b/jenkins-pipelines/gemini-3h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'gemini_test.GeminiTest.test_random_load',
     test_config: 'test-cases/gemini/gemini-basic-3h.yaml',
 

--- a/jenkins-pipelines/gemini-8h-large-num-columns.jenkinsfile
+++ b/jenkins-pipelines/gemini-8h-large-num-columns.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'gemini_test.GeminiTest.test_load_random_with_nemesis',
     test_config: 'test-cases/gemini/gemini-8h-large-num-columns.yaml',
 

--- a/jenkins-pipelines/hydra-show-jepsen-results.jenkinsfile
+++ b/jenkins-pipelines/hydra-show-jepsen-results.jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
                name: 'duration')
         string(defaultValue: 'us-east-1',
                description: 'a region where to deploy an AWS instance',
-               name: 'aws_region')
+               name: 'region')
         string(defaultValue: 'a',
                description: 'an availability zone where to deploy an AWS instance',
                name: 'availability_zone')
@@ -59,7 +59,7 @@ pipeline {
                     rm -fv sct_runner_ip
 
                     export RUNNER_DURATION="${params.duration}"
-                    export RUNNER_REGION="${params.aws_region}"
+                    export RUNNER_REGION="${params.region}"
                     export RUNNER_AZ="${params.availability_zone}"
 
                     ./docker/env/hydra.sh --execute-on-new-runner investigate show-jepsen-results "${params.test_id}"

--- a/jenkins-pipelines/hydra-show-monitor.jenkinsfile
+++ b/jenkins-pipelines/hydra-show-monitor.jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
                name: 'duration')
         string(defaultValue: 'us-east-1',
                description: 'a region where to deploy an AWS instance',
-               name: 'aws_region')
+               name: 'region')
         string(defaultValue: 'a',
                description: 'an availability zone where to deploy an AWS instance',
                name: 'availability_zone')
@@ -59,7 +59,7 @@ pipeline {
                     rm -fv sct_runner_ip
 
                     export RUNNER_DURATION="${params.duration}"
-                    export RUNNER_REGION="${params.aws_region}"
+                    export RUNNER_REGION="${params.region}"
                     export RUNNER_AZ="${params.availability_zone}"
 
                     ./docker/env/hydra.sh --execute-on-new-runner investigate show-monitor "${params.test_id}"

--- a/jenkins-pipelines/ics-longevity-100gb-4h.jenkinsfile
+++ b/jenkins-pipelines/ics-longevity-100gb-4h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "test-cases/enterprise-features/ics/longevity/ics-longevity-100gb-4h.yaml"]''',
 

--- a/jenkins-pipelines/ics-longevity-10gb-3h.jenkinsfile
+++ b/jenkins-pipelines/ics-longevity-10gb-3h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-10gb-3h.yaml", "test-cases/enterprise-features/ics/longevity/ics-longevity-10gb-3h.yaml"]''',
 

--- a/jenkins-pipelines/ics-longevity-1tb-7days.jenkinsfile
+++ b/jenkins-pipelines/ics-longevity-1tb-7days.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml", "test-cases/enterprise-features/ics/longevity/ics-longevity-1TB-7days-authorization-and-tls-ssl.yaml"]''',
 

--- a/jenkins-pipelines/ics-longevity-200gb-48h.jenkinsfile
+++ b/jenkins-pipelines/ics-longevity-200gb-48h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml", "test-cases/enterprise-features/ics/longevity/ics-longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml"]''',
 

--- a/jenkins-pipelines/ics-longevity-50gb-4days.jenkinsfile
+++ b/jenkins-pipelines/ics-longevity-50gb-4days.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "test-cases/enterprise-features/ics/longevity/ics-longevity-50GB-4days-authorization-and-tls-ssl.yaml"]''',
 

--- a/jenkins-pipelines/ics-longevity-large-partition-4days.jenkinsfile
+++ b/jenkins-pipelines/ics-longevity-large-partition-4days.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
     test_config: '''["test-cases/longevity/longevity-large-partition-4days.yaml", "test-cases/enterprise-features/ics/longevity/ics-longevity-large-partition-4days.yaml"]''',
 

--- a/jenkins-pipelines/ics-longevity-mv-si-4days.jenkinsfile
+++ b/jenkins-pipelines/ics-longevity-mv-si-4days.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-mv-si-4days.yaml", "test-cases/enterprise-features/ics/longevity/ics-longevity-mv-si-4days.yaml"]''',
 

--- a/jenkins-pipelines/ics-longevity-toggle-strategy-large-partitions-24h.jenkinsfile
+++ b/jenkins-pipelines/ics-longevity-toggle-strategy-large-partitions-24h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
     test_config: '''["test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml", "test-cases/enterprise-features/ics/longevity/ics-longevity-toggle-strategy-large-partitions-24h.yaml"]''',
     timeout: [time: 6540, unit: 'MINUTES'],

--- a/jenkins-pipelines/longevity-100gb-4h-ebs-gp3.jenkinsfile
+++ b/jenkins-pipelines/longevity-100gb-4h-ebs-gp3.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml","configurations/ebs/ebs-gp3-2v-4tb-16k-iops.yaml"]''',
 

--- a/jenkins-pipelines/longevity-100gb-4h-ldap-authorization-authenticator-ms-ad.jenkinsfile
+++ b/jenkins-pipelines/longevity-100gb-4h-ldap-authorization-authenticator-ms-ad.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/ms-ad-ldap-authorization-and-authentication.yaml"]''',
 

--- a/jenkins-pipelines/longevity-100gb-4h-ldap-authorization-authenticator.jenkinsfile
+++ b/jenkins-pipelines/longevity-100gb-4h-ldap-authorization-authenticator.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/ldap-authorization-and-authentication.yaml"]''',
 

--- a/jenkins-pipelines/longevity-100gb-4h.jenkinsfile
+++ b/jenkins-pipelines/longevity-100gb-4h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-100gb-4h.yaml',
 

--- a/jenkins-pipelines/longevity-10gb-3h-gce.jenkinsfile
+++ b/jenkins-pipelines/longevity-10gb-3h-gce.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'gce',
-    aws_region: 'us-east1',
+    region: 'us-east1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-10gb-3h.yaml',
 )

--- a/jenkins-pipelines/longevity-10gb-3h-ipv6.jenkinsfile
+++ b/jenkins-pipelines/longevity-10gb-3h-ipv6.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     ip_ssh_connections: 'ipv6',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-10gb-3h.yaml',

--- a/jenkins-pipelines/longevity-10gb-3h-nosqlbench.jenkinsfile
+++ b/jenkins-pipelines/longevity-10gb-3h-nosqlbench.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-nosqlbench-3h.yaml',
 )

--- a/jenkins-pipelines/longevity-10gb-3h-saslauthd-authenticator-ms-ad.jenkinsfile
+++ b/jenkins-pipelines/longevity-10gb-3h-saslauthd-authenticator-ms-ad.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-10gb-3h.yaml", "configurations/ms-ad-ldap-authenticator.yaml"]''',
 

--- a/jenkins-pipelines/longevity-10gb-3h-saslauthd-authenticator.jenkinsfile
+++ b/jenkins-pipelines/longevity-10gb-3h-saslauthd-authenticator.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-10gb-3h.yaml", "configurations/ldap-authenticator.yaml"]''',
 

--- a/jenkins-pipelines/longevity-10gb-3h.jenkinsfile
+++ b/jenkins-pipelines/longevity-10gb-3h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-10gb-3h.yaml',
 

--- a/jenkins-pipelines/longevity-1tb-7days.jenkinsfile
+++ b/jenkins-pipelines/longevity-1tb-7days.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml',
 

--- a/jenkins-pipelines/longevity-200gb-48h-network-monkey.jenkinsfile
+++ b/jenkins-pipelines/longevity-200gb-48h-network-monkey.jenkinsfile
@@ -5,8 +5,8 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
     ip_ssh_connections: 'public',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-200GB-48h-network-monkey.yaml',
 

--- a/jenkins-pipelines/longevity-200gb-48h.jenkinsfile
+++ b/jenkins-pipelines/longevity-200gb-48h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml',
 

--- a/jenkins-pipelines/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.jenkinsfile
+++ b/jenkins-pipelines/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml',
 

--- a/jenkins-pipelines/longevity-5000-tables.jenkinsfile
+++ b/jenkins-pipelines/longevity-5000-tables.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_user_batch_custom_time',
     test_config: 'test-cases/longevity/longevity-5000-tables.yaml',
 

--- a/jenkins-pipelines/longevity-50gb-3days-ebs-gp3.jenkinsfile
+++ b/jenkins-pipelines/longevity-50gb-3days-ebs-gp3.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml","configurations/ebs/ebs-gp3-2v-4tb-16k-iops.yaml"]''',
 

--- a/jenkins-pipelines/longevity-50gb-3days.jenkinsfile
+++ b/jenkins-pipelines/longevity-50gb-3days.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml',
 

--- a/jenkins-pipelines/longevity-50gb-asymmetric-cluster-12h.jenkinsfile
+++ b/jenkins-pipelines/longevity-50gb-asymmetric-cluster-12h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-50GB-12h-verifier-LimitedMonkey-tls.yaml", "configurations/db-nodes-shards-random.yaml"]'''
 )

--- a/jenkins-pipelines/longevity-alternator-200gb-48h.jenkinsfile
+++ b/jenkins-pipelines/longevity-alternator-200gb-48h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-alternator-200GB-48h.yaml',
 

--- a/jenkins-pipelines/longevity-alternator-3h-multidc.jenkinsfile
+++ b/jenkins-pipelines/longevity-alternator-3h-multidc.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: '''["eu-west-1", "us-east-1"]''',
+    region: '''["eu-west-1", "us-east-1"]''',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-alternator-3h-multidc.yaml',
 

--- a/jenkins-pipelines/longevity-alternator-3h.jenkinsfile
+++ b/jenkins-pipelines/longevity-alternator-3h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-alternator-3h.yaml',
 

--- a/jenkins-pipelines/longevity-alternator-streams-12h.jenkinsfile
+++ b/jenkins-pipelines/longevity-alternator-streams-12h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-alternator-streams-100gb-12h.yaml',
 )

--- a/jenkins-pipelines/longevity-alternator-streams-4h-nemesis.jenkinsfile
+++ b/jenkins-pipelines/longevity-alternator-streams-4h-nemesis.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-alternator-streams-100gb-4h.yaml", "configurations/alternator/streams-with-nemesis.yaml"]''',
 )

--- a/jenkins-pipelines/longevity-cdc-3d-400gb.jenkinsfile
+++ b/jenkins-pipelines/longevity-cdc-3d-400gb.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-cdc-3d-400gb.yaml',
 

--- a/jenkins-pipelines/longevity-cdc-4h.jenkinsfile
+++ b/jenkins-pipelines/longevity-cdc-4h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-cdc-100gb-4h.yaml',
 

--- a/jenkins-pipelines/longevity-counters-3h.jenkinsfile
+++ b/jenkins-pipelines/longevity-counters-3h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-counters-3h.yaml',
 

--- a/jenkins-pipelines/longevity-counters-multidc.jenkinsfile
+++ b/jenkins-pipelines/longevity-counters-multidc.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: '''["eu-west-1", "us-west-2", "us-east-1"]''',
+    region: '''["eu-west-1", "us-west-2", "us-east-1"]''',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-counters-multidc.yaml',
 

--- a/jenkins-pipelines/longevity-harry-2h.jenkinsfile
+++ b/jenkins-pipelines/longevity-harry-2h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-harry-2h.yaml',
 

--- a/jenkins-pipelines/longevity-in-memory-36gb-1d.jenkinsfile
+++ b/jenkins-pipelines/longevity-in-memory-36gb-1d.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_in_memory_test.InMemoryLongevityTest.test_in_mem_longevity',
     test_config: 'test-cases/longevity/longevity-in-memory-36GB-1day.yaml',
 

--- a/jenkins-pipelines/longevity-large-collections-12h.jenkinsfile
+++ b/jenkins-pipelines/longevity-large-collections-12h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-large-collections-12h.yaml',
 

--- a/jenkins-pipelines/longevity-large-partition-200k-pks-4days.jenkinsfile
+++ b/jenkins-pipelines/longevity-large-partition-200k-pks-4days.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
     test_config: 'test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml',
 

--- a/jenkins-pipelines/longevity-large-partition-4days.jenkinsfile
+++ b/jenkins-pipelines/longevity-large-partition-4days.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
     test_config: 'test-cases/longevity/longevity-large-partition-4days.yaml',
 

--- a/jenkins-pipelines/longevity-large-partition-8h-ebs-gp3.jenkinsfile
+++ b/jenkins-pipelines/longevity-large-partition-8h-ebs-gp3.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
     test_config: '''["test-cases/longevity/longevity-large-partition-8h.yaml","configurations/ebs/ebs-gp3-2v-4tb-16k-iops.yaml"]''',
 

--- a/jenkins-pipelines/longevity-large-partition-8h.jenkinsfile
+++ b/jenkins-pipelines/longevity-large-partition-8h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
     test_config: 'test-cases/longevity/longevity-large-partition-8h.yaml',
 

--- a/jenkins-pipelines/longevity-large-partition-asymmetric-cluster-3h.jenkinsfile
+++ b/jenkins-pipelines/longevity-large-partition-asymmetric-cluster-3h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
     test_config: '''["test-cases/longevity/longevity-large-partition-3h.yaml", "configurations/db-nodes-shards-random.yaml"]''',
 

--- a/jenkins-pipelines/longevity-lwt-1loader-3h.jenkinsfile
+++ b/jenkins-pipelines/longevity-lwt-1loader-3h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_lwt_test.LWTLongevityTest.test_lwt_longevity',
     test_config: 'test-cases/longevity/longevity-lwt-1loader-3h.yaml',
 

--- a/jenkins-pipelines/longevity-lwt-24h-1dis-2nondis.jenkinsfile
+++ b/jenkins-pipelines/longevity-lwt-24h-1dis-2nondis.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_lwt_test.LWTLongevityTest.test_lwt_longevity',
     test_config: 'test-cases/longevity/longevity-lwt-basic-24h-1dis-2nondis.yaml',
 

--- a/jenkins-pipelines/longevity-lwt-24h-multidc.jenkinsfile
+++ b/jenkins-pipelines/longevity-lwt-24h-multidc.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: '''["eu-west-1", "us-west-2", "us-east-1"]''',
+    region: '''["eu-west-1", "us-west-2", "us-east-1"]''',
     test_name: 'longevity_lwt_test.LWTLongevityTest.test_lwt_longevity',
     test_config: 'test-cases/longevity/longevity-lwt-24h-multidc.yaml',
 

--- a/jenkins-pipelines/longevity-lwt-24h.jenkinsfile
+++ b/jenkins-pipelines/longevity-lwt-24h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_lwt_test.LWTLongevityTest.test_lwt_longevity',
     test_config: 'test-cases/longevity/longevity-lwt-basic-24h.yaml',
 

--- a/jenkins-pipelines/longevity-lwt-3h.jenkinsfile
+++ b/jenkins-pipelines/longevity-lwt-3h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_lwt_test.LWTLongevityTest.test_lwt_longevity',
     test_config: 'test-cases/longevity/longevity-lwt-basic-3h.yaml',
 

--- a/jenkins-pipelines/longevity-lwt-500G-3d.jenkinsfile
+++ b/jenkins-pipelines/longevity-lwt-500G-3d.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_lwt_test.LWTLongevityTest.test_lwt_longevity',
     test_config: 'test-cases/longevity/longevity-lwt-500G-3d.yaml',
 

--- a/jenkins-pipelines/longevity-lwt-parallel-schema-changes-with-disruptive-24h.jenkinsfile
+++ b/jenkins-pipelines/longevity-lwt-parallel-schema-changes-with-disruptive-24h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_lwt_test.LWTLongevityTest.test_lwt_longevity',
     test_config: 'test-cases/longevity/longevity-lwt-parallel-24h.yaml',
 

--- a/jenkins-pipelines/longevity-mini-test-1h.jenkinsfile
+++ b/jenkins-pipelines/longevity-mini-test-1h.jenkinsfile
@@ -7,7 +7,7 @@ longevityPipeline(
     params: params,
 
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-mini-test-1h.yaml',
 

--- a/jenkins-pipelines/longevity-multi-keyspaces-60h.jenkinsfile
+++ b/jenkins-pipelines/longevity-multi-keyspaces-60h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_batch_custom_time',
     test_config: 'test-cases/longevity/longevity-multi-keyspaces.yaml',
 

--- a/jenkins-pipelines/longevity-mv-si-4days.jenkinsfile
+++ b/jenkins-pipelines/longevity-mv-si-4days.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-mv-si-4days.yaml',
 

--- a/jenkins-pipelines/longevity-ndbench-12-nodes-multidc-4h.jenkinsfile
+++ b/jenkins-pipelines/longevity-ndbench-12-nodes-multidc-4h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: '''["eu-west-1", "us-east-1"]''',
+    region: '''["eu-west-1", "us-east-1"]''',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-ndbench-12-nodes-multidc-4h.yaml'
 )

--- a/jenkins-pipelines/longevity-ndbench-192-nodes-multidc-4h.jenkinsfile
+++ b/jenkins-pipelines/longevity-ndbench-192-nodes-multidc-4h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: '''["eu-west-1", "us-east-1"]''',
+    region: '''["eu-west-1", "us-east-1"]''',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-ndbench-192-nodes-multidc-4h.yaml'
 )

--- a/jenkins-pipelines/longevity-twcs-3h.jenkinsfile
+++ b/jenkins-pipelines/longevity-twcs-3h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_twcs_test.TWCSLongevityTest.test_twcs_longevity',
     test_config: 'test-cases/longevity/longevity-twcs-3h.yaml',
 

--- a/jenkins-pipelines/longevity-twcs-48h.jenkinsfile
+++ b/jenkins-pipelines/longevity-twcs-48h.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'longevity_twcs_test.TWCSLongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-twcs-48h.yaml',
 

--- a/jenkins-pipelines/manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager-sanity.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 managerPipeline(
     backend: 'aws',
     ip_ssh_connections: 'public',
-    aws_region: '''["us-east-1", "us-west-2"]''',
+    region: '''["us-east-1", "us-west-2"]''',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: 'test-cases/manager/manager-regression-multiDC-set-distro.yaml',
 

--- a/jenkins-pipelines/manager/centos-manager-backup-200gb.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-backup-200gb.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 managerPipeline(
     backend: 'aws',
     ip_ssh_connections: 'public',
-    aws_region: '''["us-east-1", "us-west-2"]''',
+    region: '''["us-east-1", "us-west-2"]''',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_backup_feature',
     test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/200gb_dataset.yaml"]''',
 

--- a/jenkins-pipelines/manager/centos-manager-backup-azure.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-backup-azure.jenkinsfile
@@ -7,7 +7,7 @@ managerPipeline(
     backup_bucket_backend: 'azure',
     backend: 'aws',
     ip_ssh_connections: 'public',
-    aws_region: '''["us-east-1", "us-west-2"]''',
+    region: '''["us-east-1", "us-west-2"]''',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_backup_feature',
     test_config: 'test-cases/manager/manager-regression-multiDC-set-distro.yaml',
 

--- a/jenkins-pipelines/manager/centos-manager-backup.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-backup.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 managerPipeline(
     backend: 'aws',
     ip_ssh_connections: 'public',
-    aws_region: '''["us-east-1", "us-west-2"]''',
+    region: '''["us-east-1", "us-west-2"]''',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_backup_feature',
     test_config: 'test-cases/manager/manager-regression-multiDC-set-distro.yaml',
 

--- a/jenkins-pipelines/manager/centos-manager-sanity-ipv6.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-sanity-ipv6.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 managerPipeline(
     backend: 'aws',
     ip_ssh_connections: 'ipv6',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: 'test-cases/manager/manager-regression-ipv6.yaml',
 

--- a/jenkins-pipelines/manager/centos-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-sanity.jenkinsfile
@@ -7,7 +7,7 @@ managerPipeline(
     manager: true,
     backend: 'aws',
     ip_ssh_connections: 'public',
-    aws_region: '''["us-east-1", "us-west-2"]''',
+    region: '''["us-east-1", "us-west-2"]''',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: 'test-cases/manager/manager-regression-multiDC-set-distro.yaml',
 

--- a/jenkins-pipelines/manager/centos-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-upgrade.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 managerPipeline(
     manager: true,
     backend: 'aws',
-    aws_region: 'us-east-1',
+    region: 'us-east-1',
 
     target_manager_version: 'master_latest',
 

--- a/jenkins-pipelines/manager/debian10-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/debian10-manager-sanity.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 managerPipeline(
     backend: 'aws',
     ip_ssh_connections: 'public',
-    aws_region: '''["us-east-1", "us-west-2"]''',
+    region: '''["us-east-1", "us-west-2"]''',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/debian10.yaml"]''',
 

--- a/jenkins-pipelines/manager/debian10-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian10-manager-upgrade.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 managerPipeline(
     manager: true,
     backend: 'aws',
-    aws_region: 'us-east-1',
+    region: 'us-east-1',
 
     target_manager_version: 'master_latest',
 

--- a/jenkins-pipelines/manager/debian9-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/debian9-manager-sanity.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 managerPipeline(
     backend: 'aws',
     ip_ssh_connections: 'public',
-    aws_region: '''["us-east-1", "us-west-2"]''',
+    region: '''["us-east-1", "us-west-2"]''',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/debian9.yaml"]''',
 

--- a/jenkins-pipelines/manager/debian9-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian9-manager-upgrade.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 managerPipeline(
     manager: true,
     backend: 'aws',
-    aws_region: 'us-east-1',
+    region: 'us-east-1',
 
     target_manager_version: 'master_latest',
 

--- a/jenkins-pipelines/manager/ubuntu16-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu16-manager-sanity.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 managerPipeline(
     backend: 'aws',
     ip_ssh_connections: 'public',
-    aws_region: '''["us-east-1", "us-west-2"]''',
+    region: '''["us-east-1", "us-west-2"]''',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/ubuntu16.yaml"]''',
 

--- a/jenkins-pipelines/manager/ubuntu16-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu16-manager-upgrade.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 managerPipeline(
     manager: true,
     backend: 'aws',
-    aws_region: 'us-east-1',
+    region: 'us-east-1',
 
     target_manager_version: 'master_latest',
 

--- a/jenkins-pipelines/manager/ubuntu18-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu18-manager-sanity.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 managerPipeline(
     backend: 'aws',
     ip_ssh_connections: 'public',
-    aws_region: '''["us-east-1", "us-west-2"]''',
+    region: '''["us-east-1", "us-west-2"]''',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/ubuntu18.yaml"]''',
 

--- a/jenkins-pipelines/manager/ubuntu18-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu18-manager-upgrade.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 managerPipeline(
     manager: true,
     backend: 'aws',
-    aws_region: 'us-east-1',
+    region: 'us-east-1',
 
     target_manager_version: 'master_latest',
 

--- a/jenkins-pipelines/manager/ubuntu20-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu20-manager-sanity.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 managerPipeline(
     backend: 'aws',
     ip_ssh_connections: 'public',
-    aws_region: '''["us-east-1", "us-west-2"]''',
+    region: '''["us-east-1", "us-west-2"]''',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/ubuntu20.yaml"]''',
 

--- a/jenkins-pipelines/manager/ubuntu20-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu20-manager-upgrade.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 managerPipeline(
     manager: true,
     backend: 'aws',
-    aws_region: 'us-east-1',
+    region: 'us-east-1',
 
     target_manager_version: 'master_latest',
 

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-add-remove-rack.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-add-remove-rack.jenkinsfile
@@ -4,7 +4,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-eks',
-    aws_region: 'eu-north-1',
+    region: 'eu-north-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-add-remove-rack.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-backup.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-backup.jenkinsfile
@@ -4,7 +4,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-eks',
-    aws_region: 'eu-north-1',
+    region: 'eu-north-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-backup.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-cluster-rolling.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-cluster-rolling.jenkinsfile
@@ -4,7 +4,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-eks',
-    aws_region: 'eu-north-1',
+    region: 'eu-north-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-cluster-rolling.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-grow-shrink.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-grow-shrink.jenkinsfile
@@ -4,7 +4,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-eks',
-    aws_region: 'eu-north-1',
+    region: 'eu-north-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-grow-shrink.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-repair.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-repair.jenkinsfile
@@ -4,7 +4,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-eks',
-    aws_region: 'eu-north-1',
+    region: 'eu-north-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-repair.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-replace.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-replace.jenkinsfile
@@ -4,7 +4,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-eks',
-    aws_region: 'eu-north-1',
+    region: 'eu-north-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-replace.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-scylla-enterprise.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-scylla-enterprise.jenkinsfile
@@ -4,7 +4,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-eks',
-    aws_region: 'eu-north-1',
+    region: 'eu-north-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-stop-start.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-stop-start.jenkinsfile
@@ -4,7 +4,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-eks',
-    aws_region: 'eu-north-1',
+    region: 'eu-north-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-stop-start.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-terminate-decommission-add.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-terminate-decommission-add.jenkinsfile
@@ -4,7 +4,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-eks',
-    aws_region: 'eu-north-1',
+    region: 'eu-north-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-terminate-decommission-add.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-terminate-replace.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-terminate-replace.jenkinsfile
@@ -4,7 +4,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-eks',
-    aws_region: 'eu-north-1',
+    region: 'eu-north-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-terminate-replace.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks.jenkinsfile
@@ -4,7 +4,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-eks',
-    aws_region: 'eu-north-1',
+    region: 'eu-north-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-basic-3h-eks-scylla-enterprise.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-basic-3h-eks-scylla-enterprise.jenkinsfile
@@ -4,7 +4,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-eks',
-    aws_region: 'eu-north-1',
+    region: 'eu-north-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-basic-3h.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-basic-3h-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-basic-3h-eks.jenkinsfile
@@ -4,7 +4,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-eks',
-    aws_region: 'eu-north-1',
+    region: 'eu-north-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-basic-3h.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',

--- a/jenkins-pipelines/operator/functional/functional-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/functional/functional-eks.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 longevityPipeline(
     backend: 'k8s-eks',
     functional_test: true,
-    aws_region: 'eu-north-1',
+    region: 'eu-north-1',
     test_name: 'functional_tests/scylla_operator',
     test_config: 'test-cases/scylla-operator/functional.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',

--- a/jenkins-pipelines/operator/functional/functional-k8s-local-kind-aws.jenkinsfile
+++ b/jenkins-pipelines/operator/functional/functional-k8s-local-kind-aws.jenkinsfile
@@ -4,7 +4,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-local-kind-aws',
-    aws_region: 'eu-north-1',
+    region: 'eu-north-1',
     functional_test: true,
     test_name: 'functional_tests/scylla_operator',
     test_config: 'test-cases/scylla-operator/functional.yaml',

--- a/jenkins-pipelines/operator/functional/functional-k8s-local-kind-gce.jenkinsfile
+++ b/jenkins-pipelines/operator/functional/functional-k8s-local-kind-gce.jenkinsfile
@@ -4,7 +4,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'k8s-local-kind-gce',
-    aws_region: 'us-east1',
+    region: 'us-east1',
     functional_test: true,
     test_name: 'functional_tests/scylla_operator',
     test_config: 'test-cases/scylla-operator/functional.yaml',

--- a/jenkins-pipelines/operator/performance/perf-regression-latency-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/performance/perf-regression-latency-eks.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "k8s-eks",
-    aws_region: 'us-east-1',
+    region: 'us-east-1',
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: "test-cases/performance/perf-regression-latency-500gb-30min.yaml",
     sub_tests: ["test_latency"],

--- a/jenkins-pipelines/operator/performance/perf-regression-throughput-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/performance/perf-regression-throughput-eks.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "k8s-eks",
-    aws_region: 'us-east-1',
+    region: 'us-east-1',
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: "test-cases/performance/perf-regression.100threads.30M-keys.yaml",
     sub_tests: ["test_write", "test_read", "test_mixed"],

--- a/jenkins-pipelines/operator/upgrade/upgrade-major-scylla-k8s-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-major-scylla-k8s-eks.jenkinsfile
@@ -4,7 +4,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingOperatorUpgradePipeline(
     backend: 'k8s-eks',
-    aws_region: 'eu-north-1',
+    region: 'eu-north-1',
     base_versions: '["4.3.2"]',
     new_version: '4.4.1',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_scylla_upgrade',

--- a/jenkins-pipelines/operator/upgrade/upgrade-major-scylla-k8s-gke.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-major-scylla-k8s-gke.jenkinsfile
@@ -4,7 +4,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingOperatorUpgradePipeline(
     backend: 'k8s-gke',
-    aws_region: 'us-east1',
+    region: 'us-east1',
     base_versions: '["4.1.5"]',
     new_version: '4.2.1',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_scylla_upgrade',

--- a/jenkins-pipelines/operator/upgrade/upgrade-operator-k8s-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-operator-k8s-eks.jenkinsfile
@@ -4,7 +4,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingOperatorUpgradePipeline(
     backend: 'k8s-eks',
-    aws_region: 'eu-north-1',
+    region: 'eu-north-1',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_operator_upgrade',
     test_config: 'test-cases/scylla-operator/kubernetes-operator-upgrade.yaml',
 )

--- a/jenkins-pipelines/operator/upgrade/upgrade-operator-k8s-gke.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-operator-k8s-gke.jenkinsfile
@@ -4,7 +4,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingOperatorUpgradePipeline(
     backend: 'k8s-gke',
-    aws_region: 'us-east1',
+    region: 'us-east1',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_operator_upgrade',
     test_config: 'test-cases/scylla-operator/kubernetes-operator-upgrade.yaml',
 )

--- a/jenkins-pipelines/operator/upgrade/upgrade-platform-k8s-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-platform-k8s-eks.jenkinsfile
@@ -4,7 +4,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingOperatorUpgradePipeline(
     backend: 'k8s-eks',
-    aws_region: 'eu-north-1',
+    region: 'eu-north-1',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_platform_upgrade',
     test_config: 'test-cases/scylla-operator/kubernetes-platform-upgrade.yaml',
 )

--- a/jenkins-pipelines/operator/upgrade/upgrade-platform-k8s-gke.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-platform-k8s-gke.jenkinsfile
@@ -4,7 +4,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingOperatorUpgradePipeline(
     backend: 'k8s-gke',
-    aws_region: 'us-east1',
+    region: 'us-east1',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_platform_upgrade',
     test_config: 'test-cases/scylla-operator/kubernetes-platform-upgrade.yaml',
 )

--- a/jenkins-pipelines/operator/upgrade/upgrade-scylla-k8s-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-scylla-k8s-eks.jenkinsfile
@@ -4,7 +4,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingOperatorUpgradePipeline(
     backend: 'k8s-eks',
-    aws_region: 'eu-north-1',
+    region: 'eu-north-1',
     base_versions: '["4.4.0"]',
     new_version: '4.4.1',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_scylla_upgrade',

--- a/jenkins-pipelines/operator/upgrade/upgrade-scylla-k8s-gke.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-scylla-k8s-gke.jenkinsfile
@@ -4,7 +4,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingOperatorUpgradePipeline(
     backend: 'k8s-gke',
-    aws_region: 'us-east1',
+    region: 'us-east1',
     base_versions: '["4.2.0"]',
     new_version: '4.2.1',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_scylla_upgrade',

--- a/jenkins-pipelines/perf-regression-cdc-mixed-latency-60min.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-cdc-mixed-latency-60min.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_cdc_test.PerformanceRegressionCDCTest",
     test_config: "test-cases/performance/perf-regression-latency-cdc-mixed-poll-batching.yaml",
     sub_tests: ["test_mixed_latency"],

--- a/jenkins-pipelines/perf-regression-cdc-mixed-throughput-60min.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-cdc-mixed-throughput-60min.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_cdc_test.PerformanceRegressionCDCTest",
     test_config: "test-cases/performance/perf-regression-throughput-cdc-mixed-poll-batching.yaml",
     sub_tests: ["test_mixed_throughput"],

--- a/jenkins-pipelines/perf-regression-cdc-write-latency-60min.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-cdc-write-latency-60min.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_cdc_test.PerformanceRegressionCDCTest",
     test_config: "test-cases/performance/perf-regression-write-latency-cdc.yaml",
     sub_tests: ["test_write_latency"],

--- a/jenkins-pipelines/perf-regression-cdc-write-throughput-60min.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-cdc-write-throughput-60min.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_cdc_test.PerformanceRegressionCDCTest",
     test_config: "test-cases/performance/perf-regression-write-throughput-cdc.yaml",
     sub_tests: ["test_write_throughput"],

--- a/jenkins-pipelines/perf-regression-latency-125gb-with-ebs-gp3-volume.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-125gb-with-ebs-gp3-volume.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: '''["test-cases/performance/perf-regression-latency-125gb.yaml","configurations/ebs/ebs-gp3-2v-4tb-16k-iops.yaml"]'''
     sub_tests: ["test_latency"],

--- a/jenkins-pipelines/perf-regression-latency-125gb-with-ebs-volume.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-125gb-with-ebs-volume.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: '''["test-cases/performance/perf-regression-latency-125gb.yaml","configurations/ebs/ebs-gp2-2v-4tb.yaml"]'''
     sub_tests: ["test_latency"],

--- a/jenkins-pipelines/perf-regression-latency-125gb.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-125gb.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: "test-cases/performance/perf-regression-latency-125gb.yaml",
     sub_tests: ["test_latency"],

--- a/jenkins-pipelines/perf-regression-latency-1TB-ebs-gp3-volumes.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-1TB-ebs-gp3-volumes.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: '''["test-cases/performance/perf-regression-latency-1TB.yaml", "configurations/ebs/ebs-gp3-2v-4tb-16k-iops.yaml"]''',
     sub_tests: ["test_latency"],

--- a/jenkins-pipelines/perf-regression-latency-1TB-ebs-volumes.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-1TB-ebs-volumes.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: '''["test-cases/performance/perf-regression-latency-1TB.yaml", "configurations/ebs/ebs-gp2-2v-4tb.yaml"]''',
     sub_tests: ["test_latency"],

--- a/jenkins-pipelines/perf-regression-latency-1TB.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-1TB.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: "test-cases/performance/perf-regression-latency-1TB.yaml",
     sub_tests: ["test_latency"],

--- a/jenkins-pipelines/perf-regression-latency-30min.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-30min.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: "test-cases/performance/perf-regression-latency-500gb-30min.yaml",
     sub_tests: ["test_latency"],

--- a/jenkins-pipelines/perf-regression-latency-30min.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-30min.jenkinsfile
@@ -9,6 +9,5 @@ perfRegressionParallelPipeline(
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: "test-cases/performance/perf-regression-latency-500gb-30min.yaml",
     sub_tests: ["test_latency"],
-
     timeout: [time: 420, unit: "MINUTES"]
 )

--- a/jenkins-pipelines/perf-regression-latency-lwt-big.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-lwt-big.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'performance_regression_lwt_test.PerformanceRegressionLWTTest',
     test_config: 'test-cases/performance/perf-regression-latency-lwt-big.yaml',
     sub_tests: ["test_latency"],

--- a/jenkins-pipelines/perf-regression-latency-lwt-small.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-lwt-small.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'performance_regression_lwt_test.PerformanceRegressionLWTTest',
     test_config: 'test-cases/performance/perf-regression-latency-lwt-small.yaml',
     sub_tests: ["test_latency"],

--- a/jenkins-pipelines/perf-regression-throughput-125gb-with-ebs-gp3-volume.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-throughput-125gb-with-ebs-gp3-volume.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: '''["test-cases/performance/perf-regression-throughput-125gb.yaml", "configurations/ebs/ebs-gp3-2v-4tb-16k-iops.yaml"]''',
     sub_tests: ["test_write", "test_read", "test_mixed"],

--- a/jenkins-pipelines/perf-regression-throughput-125gb-with-ebs-volume.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-throughput-125gb-with-ebs-volume.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: '''["test-cases/performance/perf-regression-throughput-125gb.yaml", "configurations/ebs/ebs-gp2-6v-1800gb.yaml"]''',
     sub_tests: ["test_write", "test_read", "test_mixed"],

--- a/jenkins-pipelines/perf-regression-throughput-125gb.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-throughput-125gb.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: "test-cases/performance/perf-regression-throughput-125gb.yaml",
     sub_tests: ["test_write", "test_read", "test_mixed"],

--- a/jenkins-pipelines/perf-regression-throughput-30min-ebs-volumes.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-throughput-30min-ebs-volumes.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: '''["test-cases/performance/perf-regression.100threads.30M-keys.yaml", "configurations/ebs/ebs-gp2-2v-4tb.yaml"]'''
     sub_tests: ["test_write", "test_read", "test_mixed"],

--- a/jenkins-pipelines/perf-regression-throughput-30min.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-throughput-30min.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    aws_region: "us-east-1",
+    region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: "test-cases/performance/perf-regression.100threads.30M-keys.yaml",
     sub_tests: ["test_write", "test_read", "test_mixed"],

--- a/jenkins-pipelines/perf-regression-throughput-lwt-big.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-throughput-lwt-big.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'performance_regression_lwt_test.PerformanceRegressionLWTTest',
     test_config: 'test-cases/performance/perf-regression-throughput-lwt-big.yaml',
     sub_tests: ["test_throughput"],

--- a/jenkins-pipelines/perf-regression-throughput-lwt-small.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-throughput-lwt-small.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'performance_regression_lwt_test.PerformanceRegressionLWTTest',
     test_config: 'test-cases/performance/perf-regression-throughput-lwt-small.yaml',
     sub_tests: ["test_throughput"],

--- a/jenkins-pipelines/perf-row-level-repair.jenkinsfile
+++ b/jenkins-pipelines/perf-row-level-repair.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'performance_regression_row_level_repair_test.PerformanceRegressionRowLevelRepairTest.test_row_level_repair_large_partitions',
     test_config: 'test-cases/performance/perf-row-level-repair-1TB.yaml',
 

--- a/jenkins-pipelines/rolling-upgrade-multidc.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-multidc.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'aws',
-    aws_region: '["eu-west-1", "eu-west-2"]',
+    region: '["eu-west-1", "eu-west-2"]',
     base_versions: ['2021.1', '4.5'],
     linux_distro: 'ubuntu-focal',
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2992,7 +2992,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         test_result = 'PASSED' if self.get_test_status() == 'SUCCESS' else 'ERROR'
         job_base_name = os.environ.get('JOB_BASE_NAME', 'UnknownJob')
         ami_id = self.params.get('ami_id_db_scylla').split()[0]
-        region_name = self.params.get('aws_region').split()[0]
+        region_name = self.params.region_names[0]
 
         tag_ami(ami_id=ami_id, region_name=region_name, tags_dict={"JOB:{}".format(job_base_name): test_result})
 

--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -1,7 +1,7 @@
 #! groovy
 
 def call(Map pipelineParams) {
-    def builder = getJenkinsLabels(params.backend, params.aws_region, params.gce_datacenter)
+    def builder = getJenkinsLabels(params.backend, params.region, params.gce_datacenter)
 
     pipeline {
         agent {
@@ -41,9 +41,9 @@ def call(Map pipelineParams) {
             string(defaultValue: '',
                    description: 'a GCE Image to run against',
                    name: 'gce_image_db')
-            string(defaultValue: "${pipelineParams.get('region_name', '')}",
+            string(defaultValue: "${pipelineParams.get('region', '')}",
                    description: 'AWS region with Scylla AMI (for AMI test, ignored otherwise)',
-                   name: 'aws_region')
+                   name: 'region')
             string(defaultValue: "${pipelineParams.get('gce_datacenter', 'us-east1')}",
                    description: 'GCE datacenter',
                    name: 'gce_datacenter')
@@ -128,7 +128,7 @@ def call(Map pipelineParams) {
 
                                                     if [[ ! -z "${params.scylla_ami_id}" ]]; then
                                                         export SCT_AMI_ID_DB_SCYLLA="${params.scylla_ami_id}"
-                                                        export SCT_REGION_NAME="${params.aws_region}"
+                                                        export SCT_REGION_NAME="${params.region}"
                                                     elif [[ ! -z "${params.gce_image_db}" ]]; then
                                                         export SCT_GCE_IMAGE_DB="${params.gce_image_db}"
                                                         if [[ -n "${params.gce_datacenter ? params.gce_datacenter : ''}" ]] ; then

--- a/vars/byoLongevityPipeline.groovy
+++ b/vars/byoLongevityPipeline.groovy
@@ -3,7 +3,7 @@
 
 def call() {
 
-    def builder = getJenkinsLabels(params.backend, params.aws_region, params.gce_datacenter)
+    def builder = getJenkinsLabels(params.backend, params.region, params.gce_datacenter)
 
     pipeline {
 
@@ -40,7 +40,7 @@ def call() {
                name: 'backend')
             string(defaultValue: "eu-west-1",
                description: 'Supported: us-east-1|eu-west-1|eu-west-2|eu-north-1|random (randomly select region)',
-               name: 'aws_region')
+               name: 'region')
             string(defaultValue: "us-east1",
                    description: 'GCE datacenter supported: us-east1',
                    name: 'gce_datacenter')

--- a/vars/cdcReplicationPipeline.groovy
+++ b/vars/cdcReplicationPipeline.groovy
@@ -3,7 +3,7 @@
 def completed_stages = [:]
 
 def runSctTest(Map params, String region){
-    def region = initAwsRegionParam(params.region, region)
+    def current_region = initAwsRegionParam(params.region, region)
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)
     def cloud_provider = params.backend.trim().toLowerCase()
 
@@ -15,7 +15,7 @@ def runSctTest(Map params, String region){
     rm -fv ./latest
 
     export SCT_CLUSTER_BACKEND="${params.backend}"
-    export SCT_REGION_NAME=${region}
+    export SCT_REGION_NAME=${current_region}
     if [[ -n "${params.gce_datacenter ? params.gce_datacenter : ''}" ]] ; then
         export SCT_GCE_DATACENTER=${params.gce_datacenter}
     fi

--- a/vars/cdcReplicationPipeline.groovy
+++ b/vars/cdcReplicationPipeline.groovy
@@ -3,7 +3,7 @@
 def completed_stages = [:]
 
 def runSctTest(Map params, String region){
-    def aws_region = initAwsRegionParam(params.aws_region, region)
+    def region = initAwsRegionParam(params.region, region)
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)
     def cloud_provider = params.backend.trim().toLowerCase()
 
@@ -15,7 +15,7 @@ def runSctTest(Map params, String region){
     rm -fv ./latest
 
     export SCT_CLUSTER_BACKEND="${params.backend}"
-    export SCT_REGION_NAME=${aws_region}
+    export SCT_REGION_NAME=${region}
     if [[ -n "${params.gce_datacenter ? params.gce_datacenter : ''}" ]] ; then
         export SCT_GCE_DATACENTER=${params.gce_datacenter}
     fi
@@ -71,7 +71,7 @@ def runSctTest(Map params, String region){
 
 def call(Map pipelineParams) {
 
-    def builder = getJenkinsLabels(params.backend, params.aws_region, params.gce_datacenter)
+    def builder = getJenkinsLabels(params.backend, params.region, params.gce_datacenter)
 
     pipeline {
         agent {
@@ -89,9 +89,9 @@ def call(Map pipelineParams) {
                description: 'aws|gce',
                name: 'backend')
 
-            string(defaultValue: "${pipelineParams.get('aws_region', 'eu-west-1')}",
+            string(defaultValue: "${pipelineParams.get('region', 'eu-west-1')}",
                description: 'Supported: us-east-1|eu-west-1|eu-west-2|eu-north-1|random (randomly select region)',
-               name: 'aws_region')
+               name: 'region')
             string(defaultValue: "${pipelineParams.get('gce_datacenter', 'us-east1')}",
                    description: 'GCE datacenter',
                    name: 'gce_datacenter')

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -5,7 +5,7 @@ def (testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCl
 
 def call(Map pipelineParams) {
 
-    def builder = getJenkinsLabels(params.backend, params.aws_region, params.gce_datacenter)
+    def builder = getJenkinsLabels(params.backend, params.region, params.gce_datacenter)
     def functional_test = pipelineParams.functional_test
 
     pipeline {
@@ -24,9 +24,9 @@ def call(Map pipelineParams) {
                description: 'aws|gce',
                name: 'backend')
 
-            string(defaultValue: "${pipelineParams.get('aws_region', 'eu-west-1')}",
+            string(defaultValue: "${pipelineParams.get('region', 'eu-west-1')}",
                description: 'Supported: us-east-1|eu-west-1|eu-west-2|eu-north-1|random (randomly select region)',
-               name: 'aws_region')
+               name: 'region')
             string(defaultValue: "${pipelineParams.get('gce_datacenter', 'us-east1')}",
                    description: 'GCE datacenter',
                    name: 'gce_datacenter')

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -37,7 +37,7 @@ def (testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCl
 
 def call(Map pipelineParams) {
 
-    def builder = getJenkinsLabels(params.backend, params.aws_region, params.gce_datacenter)
+    def builder = getJenkinsLabels(params.backend, params.region, params.gce_datacenter)
 
     pipeline {
         agent {
@@ -57,9 +57,9 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('backend', 'aws')}",
                description: 'aws|gce',
                name: 'backend')
-            string(defaultValue: "${pipelineParams.get('aws_region', 'eu-west-1')}",
+            string(defaultValue: "${pipelineParams.get('region', 'eu-west-1')}",
                description: 'Supported: us-east-1|eu-west-1|eu-west-2|eu-north-1|random (randomly select region)',
-               name: 'aws_region')
+               name: 'region')
             string(defaultValue: "${pipelineParams.get('gce_datacenter', 'us-east1')}",
                    description: 'GCE datacenter',
                    name: 'gce_datacenter')
@@ -208,7 +208,7 @@ def call(Map pipelineParams) {
                                     dir('scylla-cluster-tests') {
 
                                         // handle params which can be a json list
-                                        def aws_region = initAwsRegionParam(params.aws_region, builder.region)
+                                        def region = initAwsRegionParam(params.region, builder.region)
                                         def test_config = groovy.json.JsonOutput.toJson(params.test_config)
                                         def cloud_provider = params.backend.trim().toLowerCase()
 
@@ -219,7 +219,7 @@ def call(Map pipelineParams) {
                                         rm -fv ./latest
 
                                         export SCT_CLUSTER_BACKEND="${params.backend}"
-                                        export SCT_REGION_NAME=${aws_region}
+                                        export SCT_REGION_NAME=${region}
                                         if [[ -n "${params.gce_datacenter ? params.gce_datacenter : ''}" ]] ; then
                                             export SCT_GCE_DATACENTER=${params.gce_datacenter}
                                         fi

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -5,7 +5,7 @@ def (testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCl
 
 def call(Map pipelineParams) {
 
-    def builder = getJenkinsLabels(params.backend, params.aws_region, params.gce_datacenter)
+    def builder = getJenkinsLabels(params.backend, params.region, params.gce_datacenter)
 
     pipeline {
         agent {
@@ -22,9 +22,9 @@ def call(Map pipelineParams) {
                description: 'aws|gce',
                name: 'backend')
 
-            string(defaultValue: "${pipelineParams.get('aws_region', 'eu-west-1')}",
+            string(defaultValue: "${pipelineParams.get('region', 'eu-west-1')}",
                description: 'us-east-1|eu-west-1',
-               name: 'aws_region')
+               name: 'region')
 
             string(defaultValue: "${pipelineParams.get('gce_datacenter', 'us-east1')}",
                    description: 'GCE datacenter',
@@ -148,10 +148,10 @@ def call(Map pipelineParams) {
                                                         rm -fv ./latest
 
                                                         export SCT_CLUSTER_BACKEND=${params.backend}
-                                                        if [[ -n "${params.aws_region}" ]]; then
-                                                            export SCT_REGION_NAME=${params.aws_region}
+                                                        if [[ -n "${params.region}" ]]; then
+                                                            export SCT_REGION_NAME=${params.region}
                                                         else
-                                                            export SCT_REGION_NAME=${pipelineParams.aws_region}
+                                                            export SCT_REGION_NAME=${pipelineParams.region}
                                                         fi
                                                         export SCT_CONFIG_FILES=${test_config}
 
@@ -211,7 +211,7 @@ def call(Map pipelineParams) {
                                                         env
 
                                                         export SCT_CLUSTER_BACKEND="${params.backend}"
-                                                        export SCT_REGION_NAME=${aws_region}
+                                                        export SCT_REGION_NAME=${region}
                                                         if [[ -n "${params.gce_datacenter ? params.gce_datacenter : ''}" ]] ; then
                                                             export SCT_GCE_DATACENTER=${params.gce_datacenter}
                                                         fi
@@ -230,7 +230,7 @@ def call(Map pipelineParams) {
                                                 timeout(time: resourceCleanupTimeout, unit: 'MINUTES') { script {
                                                     wrap([$class: 'BuildUser']) {
                                                         dir('scylla-cluster-tests') {
-                                                            def aws_region = groovy.json.JsonOutput.toJson(params.aws_region)
+                                                            def region = groovy.json.JsonOutput.toJson(params.region)
                                                             def test_config = groovy.json.JsonOutput.toJson(pipelineParams.test_config)
 
                                                             sh """
@@ -241,7 +241,7 @@ def call(Map pipelineParams) {
 
                                                             export SCT_CONFIG_FILES=${test_config}
                                                             export SCT_CLUSTER_BACKEND="${params.backend}"
-                                                            export SCT_REGION_NAME=${aws_region}
+                                                            export SCT_REGION_NAME=${region}
                                                             export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
                                                             export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
                                                             export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"

--- a/vars/provisionResources.groovy
+++ b/vars/provisionResources.groovy
@@ -1,7 +1,7 @@
 #!groovy
 
 def call(Map params, String region){
-    def region = initAwsRegionParam(params.region, region)
+    def current_region = initAwsRegionParam(params.region, region)
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)
     def cloud_provider = getCloudProviderFromBackend(params.backend)
 
@@ -16,7 +16,7 @@ def call(Map params, String region){
     export SCT_COLLECT_LOGS=false
 
     if [[ -n "${params.region ? params.region : ''}" ]] ; then
-        export SCT_REGION_NAME=${region}
+        export SCT_REGION_NAME=${current_region}
     fi
     if [[ -n "${params.gce_datacenter ? params.gce_datacenter : ''}" ]] ; then
         export SCT_GCE_DATACENTER=${params.gce_datacenter}

--- a/vars/provisionResources.groovy
+++ b/vars/provisionResources.groovy
@@ -1,7 +1,7 @@
 #!groovy
 
 def call(Map params, String region){
-    def aws_region = initAwsRegionParam(params.aws_region, region)
+    def region = initAwsRegionParam(params.region, region)
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)
     def cloud_provider = getCloudProviderFromBackend(params.backend)
 
@@ -15,8 +15,8 @@ def call(Map params, String region){
     export SCT_CONFIG_FILES=${test_config}
     export SCT_COLLECT_LOGS=false
 
-    if [[ -n "${params.aws_region ? params.aws_region : ''}" ]] ; then
-        export SCT_REGION_NAME=${aws_region}
+    if [[ -n "${params.region ? params.region : ''}" ]] ; then
+        export SCT_REGION_NAME=${region}
     fi
     if [[ -n "${params.gce_datacenter ? params.gce_datacenter : ''}" ]] ; then
         export SCT_GCE_DATACENTER=${params.gce_datacenter}

--- a/vars/rollingOperatorUpgradePipeline.groovy
+++ b/vars/rollingOperatorUpgradePipeline.groovy
@@ -1,7 +1,7 @@
 #!groovy
 
 def call(Map pipelineParams) {
-    def builder = getJenkinsLabels(pipelineParams.backend, pipelineParams.aws_region)
+    def builder = getJenkinsLabels(pipelineParams.backend, pipelineParams.region)
     pipeline {
         agent {
             label {
@@ -16,9 +16,9 @@ def call(Map pipelineParams) {
         parameters {
             choice(choices: ["${pipelineParams.get('backend', 'k8s-gke')}", 'k8s-eks', 'k8s-gke'],
                    name: 'backend')
-            string(defaultValue: "${pipelineParams.get('aws_region', '')}",
+            string(defaultValue: "${pipelineParams.get('region', '')}",
                description: 'Supported: us-east-1|eu-west-1|eu-west-2|eu-north-1|random (randomly select region)',
-               name: 'aws_region')
+               name: 'region')
             string(defaultValue: "a",
                description: 'Availability zone',
                name: 'availability_zone')

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -2,7 +2,7 @@
 
 def call(Map pipelineParams) {
 
-    def builder = getJenkinsLabels(params.backend, params.aws_region, params.gce_datacenter)
+    def builder = getJenkinsLabels(params.backend, params.region, params.gce_datacenter)
 
     pipeline {
         agent {
@@ -19,9 +19,9 @@ def call(Map pipelineParams) {
                description: 'aws|gce',
                name: 'backend')
 
-            string(defaultValue: "${pipelineParams.get('aws_region', 'eu-west-1')}",
+            string(defaultValue: "${pipelineParams.get('region', 'eu-west-1')}",
                description: 'Supported: us-east-1|eu-west-1|eu-west-2|eu-north-1|random (randomly select region)',
-               name: 'aws_region')
+               name: 'region')
             string(defaultValue: "${pipelineParams.get('gce_datacenter', 'us-east1')}",
                    description: 'GCE datacenter',
                    name: 'gce_datacenter')
@@ -123,8 +123,8 @@ def call(Map pipelineParams) {
 
                                                         export SCT_CLUSTER_BACKEND=${params.backend}
 
-                                                        if [[ -n "${params.aws_region ? params.aws_region : ''}" ]] ; then
-                                                            export SCT_REGION_NAME='${params.aws_region}'
+                                                        if [[ -n "${params.region ? params.region : ''}" ]] ; then
+                                                            export SCT_REGION_NAME='${params.region}'
                                                         fi
                                                         if [[ -n "${params.gce_datacenter ? params.gce_datacenter : ''}" ]] ; then
                                                             export SCT_GCE_DATACENTER=${params.gce_datacenter}

--- a/vars/runCleanupResource.groovy
+++ b/vars/runCleanupResource.groovy
@@ -1,7 +1,7 @@
 #!groovy
 
 def call(Map params, String region){
-    def region = initAwsRegionParam(params.region, region)
+    def current_region = initAwsRegionParam(params.region, region)
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)
     def cloud_provider = getCloudProviderFromBackend(params.backend)
 
@@ -15,7 +15,7 @@ def call(Map params, String region){
     export SCT_CLUSTER_BACKEND="${params.backend}"
 
     if [[ -n "${params.region ? params.region : ''}" ]] ; then
-        export SCT_REGION_NAME=${region}
+        export SCT_REGION_NAME=${current_region}
     fi
     if [[ -n "${params.gce_datacenter ? params.gce_datacenter : ''}" ]] ; then
         export SCT_GCE_DATACENTER=${params.gce_datacenter}

--- a/vars/runCleanupResource.groovy
+++ b/vars/runCleanupResource.groovy
@@ -1,7 +1,7 @@
 #!groovy
 
 def call(Map params, String region){
-    def aws_region = initAwsRegionParam(params.aws_region, region)
+    def region = initAwsRegionParam(params.region, region)
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)
     def cloud_provider = getCloudProviderFromBackend(params.backend)
 
@@ -14,8 +14,8 @@ def call(Map params, String region){
     export SCT_CONFIG_FILES=${test_config}
     export SCT_CLUSTER_BACKEND="${params.backend}"
 
-    if [[ -n "${params.aws_region ? params.aws_region : ''}" ]] ; then
-        export SCT_REGION_NAME=${aws_region}
+    if [[ -n "${params.region ? params.region : ''}" ]] ; then
+        export SCT_REGION_NAME=${region}
     fi
     if [[ -n "${params.gce_datacenter ? params.gce_datacenter : ''}" ]] ; then
         export SCT_GCE_DATACENTER=${params.gce_datacenter}

--- a/vars/runCollectLogs.groovy
+++ b/vars/runCollectLogs.groovy
@@ -2,7 +2,7 @@
 
 
 def call(Map params, String region){
-    def region = initAwsRegionParam(params.region, region)
+    def current_region = initAwsRegionParam(params.region, region)
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)
     def cloud_provider = getCloudProviderFromBackend(params.backend)
     sh """
@@ -13,7 +13,7 @@ def call(Map params, String region){
 
     echo "${params.test_config}"
     export SCT_CLUSTER_BACKEND="${params.backend}"
-    export SCT_REGION_NAME=${region}
+    export SCT_REGION_NAME=${current_region}
     if [[ -n "${params.gce_datacenter ? params.gce_datacenter : ''}" ]] ; then
         export SCT_GCE_DATACENTER=${params.gce_datacenter}
     fi

--- a/vars/runCollectLogs.groovy
+++ b/vars/runCollectLogs.groovy
@@ -2,7 +2,7 @@
 
 
 def call(Map params, String region){
-    def aws_region = initAwsRegionParam(params.aws_region, region)
+    def region = initAwsRegionParam(params.region, region)
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)
     def cloud_provider = getCloudProviderFromBackend(params.backend)
     sh """
@@ -13,7 +13,7 @@ def call(Map params, String region){
 
     echo "${params.test_config}"
     export SCT_CLUSTER_BACKEND="${params.backend}"
-    export SCT_REGION_NAME=${aws_region}
+    export SCT_REGION_NAME=${region}
     if [[ -n "${params.gce_datacenter ? params.gce_datacenter : ''}" ]] ; then
         export SCT_GCE_DATACENTER=${params.gce_datacenter}
     fi

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -2,7 +2,7 @@
 
 def call(Map params, String region, functional_test = false){
     // handle params which can be a json list
-    def region = initAwsRegionParam(params.region, region)
+    def current_region = initAwsRegionParam(params.region, region)
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)
     def cloud_provider = getCloudProviderFromBackend(params.backend)
     def test_cmd
@@ -25,7 +25,7 @@ def call(Map params, String region, functional_test = false){
     export SCT_COLLECT_LOGS=false
 
     if [[ -n "${params.region ? params.region : ''}" ]] ; then
-        export SCT_REGION_NAME=${region}
+        export SCT_REGION_NAME=${current_region}
     fi
     if [[ -n "${params.gce_datacenter ? params.gce_datacenter : ''}" ]] ; then
         export SCT_GCE_DATACENTER=${params.gce_datacenter}

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -2,7 +2,7 @@
 
 def call(Map params, String region, functional_test = false){
     // handle params which can be a json list
-    def aws_region = initAwsRegionParam(params.aws_region, region)
+    def region = initAwsRegionParam(params.region, region)
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)
     def cloud_provider = getCloudProviderFromBackend(params.backend)
     def test_cmd
@@ -24,8 +24,8 @@ def call(Map params, String region, functional_test = false){
     export SCT_CONFIG_FILES=${test_config}
     export SCT_COLLECT_LOGS=false
 
-    if [[ -n "${params.aws_region ? params.aws_region : ''}" ]] ; then
-        export SCT_REGION_NAME=${aws_region}
+    if [[ -n "${params.region ? params.region : ''}" ]] ; then
+        export SCT_REGION_NAME=${region}
     fi
     if [[ -n "${params.gce_datacenter ? params.gce_datacenter : ''}" ]] ; then
         export SCT_GCE_DATACENTER=${params.gce_datacenter}


### PR DESCRIPTION
Ranme `aws_region` to `region` in our jenkins-pipelines and related code.


Trello task: https://trello.com/c/Gk4IC83w

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
