### PR TITLE
fix(argus): make it be compatible with K8S backends

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5426,7 +5426,7 @@ class LocalNode(BaseNode):
 
     @property
     def region(self):
-        pass
+        return "local"
 
     def set_keep_alive(self):
         pass

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -281,6 +281,10 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
     _scylla_manager_namespace = SCYLLA_MANAGER_NAMESPACE
     _scylla_namespace = SCYLLA_NAMESPACE
 
+    @cached_property
+    def cluster_backend(self):
+        return self.params.get("cluster_backend")
+
     @property
     def k8s_server_url(self) -> Optional[str]:
         return None
@@ -1407,7 +1411,8 @@ class BasePodContainer(cluster.BaseNode):  # pylint: disable=too-many-public-met
 
     @property
     def region(self):
-        return self.parent_cluster.k8s_cluster.datacenter[0]  # TODO: find the node and return it's region.
+        # TODO: make it be multi-dc aware when multi-dc support gets added
+        return self.parent_cluster.k8s_cluster.params.get('k8s_scylla_datacenter')
 
     def start_journal_thread(self):
         self._journal_thread = get_system_logging_thread(logs_transport="kubectl",

--- a/sdcm/utils/docker_remote.py
+++ b/sdcm/utils/docker_remote.py
@@ -94,7 +94,7 @@ class RemoteDocker(BaseNode):
 
     @property
     def region(self):
-        pass
+        return "docker"
 
     def restart(self):
         pass


### PR DESCRIPTION
Fix following exception:
```    
  File "%path%/sdcm/cluster.py", line 295, in
    provider=self.parent_cluster.cluster_backend,
  AttributeError: 'LocalKindCluster' object has no attribute 'cluster_backend'
```
    
By adding missing 'cluster_backend' attribute for K8S classes.
    
then, fix following exception:
```
  File "%path%/sdcm/cluster.py", line 294, in
    instance_details = CloudInstanceDetails(public_ip=self.public_ip_address,
  File "<string>", line 10, in __init__
  File "%path%/pydantic/dataclasses.py", line 99, in
    raise validation_error
  pydantic.error_wrappers.ValidationError: 1 validation error for CloudInstanceDetails
  region
    none is not an allowed value (type=type_error.none.not_allowed)
```

By making RemoteDocker and LocalNode provide non-empty strings as values
for the 'region' attribute instead of None which is not expected by Argus.
    
Finally fix following exception:
```    
  File "%path%/sdcm/cluster.py", line 294, in _init_argus_resource
    instance_details = CloudInstanceDetails(public_ip=self.public_ip_address, region=self.region,
  File "%path%/sdcm/cluster_k8s/__init__.py", line 1414, in region
    return self.parent_cluster.k8s_cluster.datacenter[0]
  IndexError: tuple index out of range
```

By properly getting datacenter value.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
