### PR TITLE
fix(cdc-options): update supported values for preimage

### DIFF
--- a/sdcm/utils/cdc/options.py
+++ b/sdcm/utils/cdc/options.py
@@ -18,7 +18,7 @@ CDC_SETTINGS_NAMES_VALUES = {
 
 CDC_DELTA_REGEXP = r"delta.*?(?P<delta>(full|keys))"
 CDC_ENABLED_REGEXP = r"enabled.*?(?P<enabled>(true|false))"
-CDC_PREIMAGE_REGEXP = r"preimage.*?(?P<preimage>(full|on|off))"
+CDC_PREIMAGE_REGEXP = r"preimage.*?(?P<preimage>(full|false|true))"
 CDC_POSTIMAGE_REGEXP = r"postimage.*?(?P<postimage>(true|false))"
 CDC_TTL_REGEXP = r"ttl.*?(?P<ttl>\d+)"
 


### PR DESCRIPTION
https://docs.scylladb.com/using-scylla/cdc/cdc-intro/
Per documentation true|false|full are the only that supported

Recently the test failed with the following:

```
< t:2021-11-08 21:19:53,199       p:INFO  > sdcm.nemesis.ChaosMonkey: Apply new cdc settigs for table cdc_test.test_table: {'delta': 'full', 'enabled': True, 'preimage': 'on', 'postimage': False, 'ttl': '600'}
< t:2021-11-08 21:19:53,200       p:DEBUG > sdcm.nemesis.ChaosMonkey: Alter command: ALTER TABLE cdc_test.test_table WITH cdc = {'delta': 'full', 'enabled': True, 'preimage': 'on', 'postimage': False, 'ttl': '600'};
...
< t:2021-11-08 21:20:24,505       p:DEBUG > sdcm.nemesis.ChaosMonkey: Verify new cdc settings on table cdc_test.test_table
< t:2021-11-08 21:20:24,506       p:DEBUG > Running command "cqlsh --no-color   --request-timeout=120 --connect-timeout=60  -e "desc keyspace cdc_test" 10.0.0.204 9042"...
...
< t:2021-11-08 21:20:26,561        CREATE KEYSPACE cdc_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true;
< t:2021-11-08 21:20:26,561
< t:2021-11-08 21:20:26,561        CREATE TABLE cdc_test.test_table (
< t:2021-11-08 21:20:26,561            pkid text PRIMARY KEY,
< t:2021-11-08 21:20:26,561            boy boolean,
< t:2021-11-08 21:20:26,562            bvalue blob,
< t:2021-11-08 21:20:26,562            name text,
< t:2021-11-08 21:20:26,562            names_set set<text>,
< t:2021-11-08 21:20:26,562            number int,
< t:2021-11-08 21:20:26,562            nums_set set<int>,
< t:2021-11-08 21:20:26,562            starttime timestamp,
< t:2021-11-08 21:20:26,562            steps float,
< t:2021-11-08 21:20:26,562            t_num tinyint,
< t:2021-11-08 21:20:26,562            vage varint,
< t:2021-11-08 21:20:26,562            vname text,
< t:2021-11-08 21:20:26,562            weight decimal
< t:2021-11-08 21:20:26,562        ) WITH bloom_filter_fp_chance = 0.01
< t:2021-11-08 21:20:26,562            AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
< t:2021-11-08 21:20:26,562            AND comment = 'Request for unit level UIs'
< t:2021-11-08 21:20:26,562            AND compaction = {'class': 'SizeTieredCompactionStrategy'}
< t:2021-11-08 21:20:26,562            AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
< t:2021-11-08 21:20:26,562            AND crc_check_chance = 1.0
< t:2021-11-08 21:20:26,562            AND dclocal_read_repair_chance = 0.1
< t:2021-11-08 21:20:26,562            AND default_time_to_live = 0
< t:2021-11-08 21:20:26,562            AND gc_grace_seconds = 864000
< t:2021-11-08 21:20:26,563            AND max_index_interval = 2048
< t:2021-11-08 21:20:26,563            AND memtable_flush_period_in_ms = 0
< t:2021-11-08 21:20:26,563            AND min_index_interval = 128
< t:2021-11-08 21:20:26,563            AND read_repair_chance = 0.0
< t:2021-11-08 21:20:26,563            AND speculative_retry = '99.0PERCENTILE';
< t:2021-11-08 21:20:26,563
< t:2021-11-08 21:20:26,563        cdc = {'postimage': 'false', 'preimage': 'true', 'ttl': '600', 'enabled': 'true', 'delta': 'full'}
...
< t:2021-11-08 21:20:36,827 .utils.cdc.options p:DEBUG > Blob object with cdc settings: b'\x05\x00\x00\x00\x05\x00\x00\x00delta\x04\x00\x00\x00full\x07\x00\x00\x00enabled\x04\x00\x00\x00true\t\x00\x00\x00postimage\x05\x00\x00\x00false\x08\x00\x00\x00preimage\x04\x00\x00\x00true\x03\x00\x00\x00ttl\x03\x00\x00\x00600'
< t:2021-11-08 21:20:36,827 .utils.cdc.options p:DEBUG > CDC settings as dict: {'delta': 'full', 'enabled': True, 'preimage': False, 'postimage': False, 'ttl': '600'}
...
 t:2021-11-08 21:20:36,830 sdcmnemesis         p:ERROR > Traceback (most recent call last):
< t:2021-11-08 21:20:36,830 .nemesis         p:ERROR >   File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 2968, in wrapper
< t:2021-11-08 21:20:36,830 .nemesis         p:ERROR >     result = method(*args, **kwargs)
< t:2021-11-08 21:20:36,830 .nemesis         p:ERROR >   File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 3272, in disrupt
< t:2021-11-08 21:20:36,830 .nemesis         p:ERROR >     self.call_random_disrupt_method()
< t:2021-11-08 21:20:36,830 .nemesis         p:ERROR >   File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 1133, in call_random_disrupt_method
< t:2021-11-08 21:20:36,830 .nemesis         p:ERROR >     self.execute_disrupt_method(disrupt_method)
< t:2021-11-08 21:20:36,830 .nemesis         p:ERROR >   File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 1140, in execute_disrupt_method
< t:2021-11-08 21:20:36,830 .nemesis         p:ERROR >     disrupt_method()
< t:2021-11-08 21:20:36,830 .nemesis         p:ERROR >   File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 2858, in disrupt_toggle_cdc_feature_properties_on_table
< t:2021-11-08 21:20:36,830 .nemesis         p:ERROR >     self._verify_cdc_feature_status(ks, table, cdc_settings)
< t:2021-11-08 21:20:36,830 .nemesis         p:ERROR >   File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 2922, in _verify_cdc_feature_status
< t:2021-11-08 21:20:36,830 .nemesis         p:ERROR >     assert actual_cdc_settings == cdc_settings, \
< t:2021-11-08 21:20:36,830 .nemesis         p:ERROR > AssertionError: CDC extension settings are differs. Current: {'delta': 'full', 'enabled': True, 'preimage': False, 'postimage': False, 'ttl': '600'} expected: {'delta': 'full', 'enabled':True, 'preimage': 'on', 'postimage': False, 'ttl': '600'}

```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
