### PR TITLE
fix(test_timeout): make start_time to be in sync

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -442,10 +442,11 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                       start_time, self.test_duration, end_time)
         self.argus_update_status(TestStatus.RUNNING)
 
-        def kill_the_test():
-            TestTimeoutEvent(start_time=self.start_time, duration=self.test_duration).publish()
+        def kill_the_test(start: float, duration: int):
+            TestTimeoutEvent(start_time=start, duration=duration).publish()
 
-        thread = threading.Timer(60 * int(self.test_duration), kill_the_test)
+        thread = threading.Timer(60 * int(self.test_duration), kill_the_test,
+                                 kwargs={'start': self.start_time, 'duration': self.test_duration})
         thread.daemon = True
         thread.start()
         return thread


### PR DESCRIPTION
https://trello.com/c/YHyn6Dur/4154-testtimeoutevent-start-time-is-drifted

test_id: 8000967e-91e8-4ed9-ad47-ffabc4b1d3aa

```
< t:2021-11-08 20:53:46,391 f:tester.py       l:346  c:LongevityTest        p:INFO  > Test start time 2021-11-08 20:53:45, duration is 240 and timeout set to 2021-11-09 00:53:45
< t:2021-11-09 00:53:46,394 f:file_logger.py  l:78   c:sdcm.sct_events.file_logger p:INFO  > 2021-11-09 00:53:46.392: (TestTimeoutEvent Severity.CRITICAL), Test started at 2021-11-08 21:27:57, reached it's timeo
ut (240 minute)
```


Test start time **2021-11-08 20:53:45**, duration is 240 and timeout set to 2021-(TestTimeoutEvent Severity.CRITICAL), Test started at **2021-11-08 21:27:57**, reached it's timeout (240 minute)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
