### PR TITLE
fix(start_events_device): ignore 'Exceptional future ignored'

### DIFF
--- a/sdcm/sct_events/setup.py
+++ b/sdcm/sct_events/setup.py
@@ -65,6 +65,7 @@ def start_events_device(log_dir: Optional[Union[str, Path]] = None,
                                 regex='cdc - Could not update CDC description table with generation').publish()
     DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line='Rate-limit: supressed').publish()
     DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line='Rate-limit: suppressed').publish()
+    DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line='Exceptional future ignored:').publish()
 
     atexit.register(stop_events_device, _registry=_registry)
 


### PR DESCRIPTION
https://trello.com/c/vNQcjg5r/4155-fixstarteventsdevice-ignore-exceptional-future-ignored

Ignore following events:

```
2021-11-11T04:56:35+00:00  rolling-upgrade-2021-1-centos-db-node-e91803c5-0-1 !WARNING | scylla: [shard 0] seastar - Exceptional future ignored: std::system_error (error system:32, sendmsg: Broken pipe), backtrace:    0x323fe9d#012   0x32400f0#012   0x3240539#012   0x2d8d0a7#012   0x2d8d1ec#012   0x318bfd9#012   /opt/scylladb/libreloc/libgnutls.so.30+0x43638#012   /opt/scylladb/libreloc/libgnutls.so.30+0x448ff#012   /opt/scylladb/libreloc/libgnutls.so.30+0x46977#012   /opt/scylladb/libreloc/libgnutls.so.30+0x96ffa#012   /opt/scylladb/libreloc/libgnutls.so.30+0x3f957#012   /opt/scylladb/libreloc/libgnutls.so.30+0x4b199#012   0x3186438#012   0x31872cf#012   0x2de3957#012   0x2de3c0e#012   0x2e22a85#012   0x2d76dfe#012   0x2d7788e#012   0xe03ff0#012   /opt/scylladb/libreloc/libc.so.6+0x27b74#012   0xcd986d#012   --------#012   seastar::continuation<seastar::internal::promise_base_with_type<void>, seastar::tls::session::do_handshake()::{lambda()#1}::operator()() const::{lambda()#1}, seastar::future<void>::then_impl_nrvo<{lambda()#1}, seastar::tls::session::do_handshake()::{lambda()#1}::operator()() const::{lambda()#1}>({lambda()#1}&&)::{lambda(seastar::internal::promise_base_with_type<void>&&, {lambda()#1}&, seastar::future_state<seastar::internal::monostate>&&)#1}, void>#012   --------#012   N7seastar12continuationINS_8internal22promise_base_with_typeIvEENS_6futureIvE12finally_bodyIZZNS_14with_semaphoreINS_35semaphore_default_exception_factoryEZZNS_3tls7session9handshakeEvENKUlvE0_clEvEUlvE_NSt6chrono3_V212steady_clockEEENS_8futurizeINSt9result_ofIFT0_vEE4typeEE4typeERNS_15basic_semaphoreIT_T1_EEmOSI_ENUlSP_E_clINS_15semaphore_unitsIS8_SF_EEEEDaSP_EUlvE_Lb0EEEZNS5_17then_wrapped_nrvoIS5_SZ_EENSG_ISP_E4typeEST_EUlOS3_RSZ_ONS_12future_stateINS1_9monostateEEEE_vEE#012   --------#012   N7seastar12continuationINS_8internal22promise_base_with_typeIvEENS_6futureIvE12finally_bodyIZZNS_14with_semaphoreINS_35semaphore_default_exception_factoryEZNS_3tls7session9handshakeEvEUlvE0_NSt6chrono3_V212steady_clockEEENS_8futurizeINSt9result_ofIFT0_vEE4typeEE4typeERNS_15basic_semaphoreIT_T1_EEmOSH_ENUlSO_E_clINS_15semaphore_unitsIS8_SE_EEEEDaSO_EUlvE_Lb0EEEZNS5_17then_wrapped_nrvoIS5_SY_EENSF_ISO_E4typeESS_EUlOS3_RSY_ONS_12future_stateINS1_9monostateEEEE_vEE#012   --------#012   seastar::continuation<seastar::internal::promise_base_with_type<seastar::temporary_buffer<char> >, std::_Bind<seastar::future<seastar::temporary_buffer<char> > (seastar::tls::session::*(seastar::tls::session*))()>, seastar::future<void>::then_impl_nrvo<std::_Bind<seastar::future<seastar::temporary_buffer<char> > (seastar::tls::session::*(seastar::tls::session*))()>, seastar::future<seastar::temporary_buffer<char> > >(std::_Bind<seastar::future<seastar::temporary_buffer<char> > (seastar::tls::session::*(seastar::tls::session*))()>&&)::{lambda(seastar::internal::promise_base_with_type<seastar::temporary_buffer<char> >&&, std::_Bind<seastar::future<seastar::temporary_buffer<char> > (seastar::tls::session::*(seastar::tls::session*))()>&, seastar::future_state<seastar::internal::monostate>&&)#1}, void>#012   --------#012   seastar::continuation<seastar::internal::promise_base_with_type<seastar::temporary_buffer<char> >, seastar::input_stream<char>::read_exactly(unsigned long)::{lambda(auto:1)#1}, seastar::future<seastar::temporary_buffer<char> >::then_impl_nrvo<{lambda(auto:1)#1}, seastar::future>({lambda(auto:1)#1}&&)::{lambda(seastar::internal::promise_base_with_type<seastar::temporary_buffer<char> >&&, {lambda(auto:1)#1}&, seastar::future_state<seastar::temporary_buffer<char> >&&)#1}, seastar::temporary_buffer<char> >#012   --------#012   seastar::continuation<seastar::internal::promise_base_with_type<std::map<seastar::rpc::protocol_features, seastar::basic_sstring<char, unsigned int, 15u, true>, std::less<seastar::rpc::protocol_features>, std::allocator<std::pair<seastar::rpc::protocol_features const, seastar::basic_sstring<char, unsigned int, 15u, true> > > > >, seastar::rpc::receive_negotiation_frame<seastar::rpc::client>(seastar::rpc::client&, seastar::input_stream<char>&)::{lambda(seastar::temporary_buffer<char>)#1}, seastar::future<seastar::temporary_buffer<char> >::then_impl_nrvo<{lambda(seastar::temporary_buffer<char>)#1}, seastar::future<std::map<seastar::rpc::protocol_features, seastar::basic_sstring<char, unsigned int, 15u, true>, std::less<seastar::rpc::protocol_features>, std::allocator<std::pair<seastar::rpc::protocol_features const, seastar::basic_sstring<char, unsigned int, 15u, true> > > > > >(seastar::rpc::client&&)::{lambda(seastar::internal::promise_base_with_type<std::map<seastar::rpc::protocol_features, seastar::basic_sstring<char, unsigned int, 15u, true>, std::less<seastar::rpc::protocol_features>, std::allocator<std::pair<seastar::rpc::protocol_features const, seastar::basic_sstring<char, unsigned int, 15u, true> > > > >&&, {lambda(seastar::temporary_buffer<char>)#1}&, seastar::future_state<seastar::temporary_buffer<char> >&&)#1}, seastar::temporary_buffer<char> >#012   --------#012   seastar::continuation<seastar::internal::promise_base_with_type<void>, seastar::rpc::client::negotiate_protocol(seastar::input_stream<char>&)::{lambda(std::map<seastar::rpc::protocol_features, seastar::basic_sstring<char, unsigned int, 15u, true>, std::less<seastar::rpc::protocol_features>, std::allocator<std::pair<seastar::rpc::protocol_features const, seastar::basic_sstring<char, unsigned int, 15u, true> > > >)#1}, seastar::future<std::map<seastar::rpc::protocol_features, seastar::basic_sstring<char, unsigned int, 15u, true>, std::less<seastar::rpc::protocol_features>, std::allocator<std::pair<seastar::rpc::protocol_features const, seastar::basic_sstring<char, unsigned int, 15u, true> > > > >::then_impl_nrvo<{lambda(std::map<seastar::rpc::protocol_features, seastar::basic_sstring<char, unsigned int, 15u, true>, std::less<seastar::rpc::protocol_features>, std::allocator<std::pair<seastar::rpc::protocol_features const, seastar::basic_sstring<char, unsigned int, 15u, true> > > >)#1}, seastar::rpc::client::negotiate_protocol(seastar::input_stream<char>&)::{lambda(std::map<seastar::rpc::protocol_features, seastar::basic_sstring<char, unsigned int, 15u, true>, std::less<seastar::rpc::protocol_features>, std::allocator<std::pair<seastar::rpc::protocol_features const, seastar::basic_sstring<char, unsigned int, 15u, true> > > >)#1}<void> >({lambda(std::map<seastar::rpc::protocol_features, seastar::basic_sstring<char, unsigned int, 15u, true>, std::less<seastar::rpc::protocol_features>, std::allocator<std::pair<seastar::rpc::protocol_features const, seastar::basic_sstring<char, unsigned int, 15u, true> > > >)#1}&&)::{lambda(seastar::internal::promise_base_with_type<void>&&, {lambda(std::map<seastar::rpc::protocol_features, seastar::basic_sstring<char, unsigned int, 15u, true>, std::less<seastar::rpc::protocol_features>, std::allocator<std::pair<seastar::rpc::protocol_features const, seastar::basic_sstring<char, unsigned int, 15u, true> > > >)#1}&, seastar::future_state<std::map<seastar::rpc::protocol_features, seastar::basic_sstring<char, unsigned int, 15u, true>, std::less<seastar::rpc::protocol_features>, std::allocator<std::pair<seastar::rpc::protocol_features const, seastar::basic_sstring<char, unsigned int, 15u, true> > > > >&&)#1}, std::map<seastar::rpc::protocol_features, seastar::basic_sstring<char, unsigned int, 15u, true>, std::less<seastar::rpc::protocol_features>, std::allocator<std::pair<seastar::rpc::protocol_features const, seastar::basic_sstring<char, unsigned int, 15u, true> > > > >#012   --------#012   seastar::continuation<seastar::internal::promise_base_with_type<void>, seastar::rpc::client::client(seastar::rpc::logger const&, void*, seastar::rpc::client_options, seastar::socket, seastar::socket_address const&, seastar::socket_address const&)::{lambda(seastar::connected_socket)#1}::operator()(seastar::connected_socket) const::{lambda()#2}, seastar::future<void>::then_impl_nrvo<{lambda(seastar::connected_socket)#1}, seastar::rpc::client::client(seastar::rpc::logger const&, void*, seastar::rpc::

```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
