### PR TITLE
fix(pylint): remove the basis for the duplicate-code error

### DIFF
--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -71,10 +71,10 @@ class EksNodePool(CloudK8sNodePool):
             k8s_cluster=k8s_cluster,
             name=name,
             num_nodes=num_nodes,
+            instance_type=instance_type,
+            image_type=image_type,
             disk_size=disk_size,
             disk_type=disk_type,
-            image_type=image_type,
-            instance_type=instance_type,
             labels=labels,
             is_deployed=is_deployed,
         )


### PR DESCRIPTION
Calling super's method with the same attributes from 2 different
child classes is not a code duplication, but not for pylint.

So, update code in the 'sdcm/cluster_k8s/eks.py' a bit to avoid following
occassional pylint error:

    ************* Module sdcm.utils.remotewebbrowser
    sdcm/utils/remotewebbrowser.py:1:0: R0801: Similar lines in 2 files
    ==sdcm.cluster_k8s.eks:[68:80]
    ==sdcm.cluster_k8s.gke:[55:67]
        ):
            super().__init__(
                k8s_cluster=k8s_cluster,
                name=name,
                num_nodes=num_nodes,
                disk_size=disk_size,
                disk_type=disk_type,
                image_type=image_type,
                instance_type=instance_type,
                labels=labels,
                is_deployed=is_deployed,
            ) (duplicate-code)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
