### PR TITLE
improvement(clean-runner-instances): add timeout to the pipeline job

### DIFF
--- a/jenkins-pipelines/hydra-clean-runner-instances.jenkinsfile
+++ b/jenkins-pipelines/hydra-clean-runner-instances.jenkinsfile
@@ -48,9 +48,11 @@ pipeline {
         }
         stage('Run hydra clean-runner-instances') {
             steps {
-                sctScript """
-                    ./docker/env/hydra.sh clean-runner-instances ${params.dryRun ? '--dry-run' : ''}
-                """
+                   timeout(time: 15, unit: 'MINUTES') {
+                        sctScript """
+                            ./docker/env/hydra.sh clean-runner-instances ${params.dryRun ? '--dry-run' : ''}
+                        """
+                   }
             }
         }
     }


### PR DESCRIPTION
Recently the job was stuck due to some builder connectivity issues. Hence added a timeout.
```
13:44:28  Docker version 19.03.11, build 42e35e61f3
13:44:28  Pull version v0.99 from Docker Hub...
19:26:02  Cannot contact gce4-qavpc: java.lang.InterruptedException
```
![image](https://user-images.githubusercontent.com/5269241/141677148-b19b7e4c-01c5-495d-b792-5a84ed916388.png)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
