### PR TITLE
Fix rolling upgrade

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1677,7 +1677,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                     exclude_none=True, exclude_unset=True, exclude_defaults=True,
                     # NOTE: explicit fields included into yaml no matter what,
                     #  they are needed for nodetool to operate properly
-                    explicit=['partitioner', 'commitlog_sync', 'commitlog_sync_period_in_ms']
+                    explicit=['partitioner', 'commitlog_sync', 'commitlog_sync_period_in_ms', 'endpoint_snitch']
                 )
             )
             LOGGER.debug("%s: scylla.yaml will be updated to:\n%s", self, scylla_yaml)


### PR DESCRIPTION
Based on https://github.com/scylladb/scylla-cluster-tests/pull/4115

Make endpoint_snitch be always present in scylla_yaml to make `/usr/bin/nodetool upgradesstables -a` work

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
