### PR TITLE
improvement(events): set log level per event

### DIFF
--- a/sdcm/sct_events/base.py
+++ b/sdcm/sct_events/base.py
@@ -107,6 +107,7 @@ class SctEvent:
         self.severity = severity
         self._ready_to_publish = True
         self.event_id = str(uuid.uuid4())
+        self.log_level = logging.INFO
 
     @classmethod
     def is_abstract(cls) -> bool:

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -261,6 +261,7 @@ class CompactionEvent(ScyllaDatabaseContinuousEvent):
         super().__init__(node=node, shard=shard, severity=severity)
         self.table = table
         self.compaction_process_id = compaction_process_id
+        self.log_level = logging.DEBUG
 
     @property
     def msgfmt(self):

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -248,6 +248,7 @@ class RepairEvent(ScyllaDatabaseContinuousEvent):
 
     def __init__(self, node: str, shard: int, severity=Severity.NORMAL, **__):
         super().__init__(node=node, shard=shard, severity=severity)
+        self.log_level = logging.DEBUG
 
 
 class CompactionEvent(ScyllaDatabaseContinuousEvent):

--- a/sdcm/sct_events/file_logger.py
+++ b/sdcm/sct_events/file_logger.py
@@ -71,13 +71,15 @@ class EventsFileLogger(BaseEventsProcess[Tuple[str, Any], None], multiprocessing
         for event_tuple in self.inbound_events():
             with verbose_suppress("EventsFileLogger failed to process %s", event_tuple):
                 _, event = event_tuple  # try to unpack event from EventsDevice
-                self.write_event(event=event, tee=LOGGER.info)
+                self.write_event(event=event)
 
-    def write_event(self, event: SctEvent, tee: Optional[Callable[[str], Any]] = None) -> None:
+    def write_event(self, event: SctEvent) -> None:
         if event.source_timestamp:
             message = f"{event.formatted_event_timestamp} <{event.formatted_source_timestamp}>: {str(event).strip()}"
         else:
             message = f"{event.formatted_event_timestamp}: {str(event).strip()}"
+
+        tee = getattr(LOGGER, logging.getLevelName(event.log_level).lower())
         if tee and not isinstance(event, TestResultEvent):
             with verbose_suppress("%s: failed to tee %s to %s", self, event, tee):
                 tee(message)

--- a/unit_tests/test_sct_events_base.py
+++ b/unit_tests/test_sct_events_base.py
@@ -155,7 +155,7 @@ class TestSctEvent(SctEventTestCase):
         self.assertEqual(
             y.to_json(),
             f'{{"base": "Y", "type": null, "subtype": null, "event_timestamp": {y.event_timestamp}, "source_timestamp": null, '
-            f'"severity": "UNKNOWN", "event_id": "fa4a84a2-968b-474c-b188-b3bac4be8527"}}'
+            f'"severity": "UNKNOWN", "event_id": "fa4a84a2-968b-474c-b188-b3bac4be8527", "log_level": 20}}'
         )
 
     def test_publish(self):


### PR DESCRIPTION
Now log level of all events is INFO. It cause to problem when a lot of
events are printed on the console. Even those that we son't need to see them there.
This commit add possibility to set log level for every event separately.

To change log level: set 'self.log_level' to wished value:
logging.DEBUG, logging.WARNING..

Default is INFO

Changed log level to DEBUG for:
- CompactionEvent
- RepairEvent

```
< t:2021-11-14 17:04:10,925 f:file_logger.py  l:85   c:sdcm.sct_events.file_logger p:DEBUG > 2021-11-14 17:04:10.921: (RepairEvent Severity.NORMAL) period_type=begin event_id=38d56eaa-9dd6-421e-8fa9-571928dca3f6 node=longevity-10gb-3h-compacti-db-node-a7af6e98-1 shard=0
```

```
< t:2021-11-14 17:04:10,920 f:file_logger.py  l:85   c:sdcm.sct_events.file_logger p:DEBUG > 2021-11-14 17:04:10.908: (CompactionEvent Severity.NORMAL) period_type=end event_id=e428d6ba-06e9-4673-bc38-f9618331a5
b6 duration=0s node=longevity-10gb-3h-compacti-db-node-a7af6e98-1 shard=0 table=system_schema.keyspaces compaction_process_id=dfc50ba0-456c-11ec-a234-98009f2563c3
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
