### PR TITLE
feature(operator): Add possibility to configure K8S perf tuning

### DIFF
--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -26,6 +26,10 @@ k8s_scylla_operator_chart_version: 'latest'
 k8s_cert_manager_version: '1.2.0'
 k8s_deploy_monitoring: true
 
+# NOTE: GKE requires 'k8s_scylla_utils_docker_image' be defined to enterprise Scylla version 2021+
+#       to have more performant configuration of disks.
+k8s_scylla_utils_docker_image: 'scylladb/scylla-enterprise:2021.1.6'
+
 k8s_scylla_datacenter: 'us-east1-b'
 k8s_scylla_rack: 'us-east1'
 k8s_scylla_cluster_name: 'sct-cluster'

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -158,6 +158,12 @@ max_events_severities: ""
 mgmt_docker_image: ''
 k8s_deploy_monitoring: false
 
+# NOTE: 'k8s_enable_performance_tuning' is alpha feature in operator-1.6 , so it is disabled by default
+k8s_enable_performance_tuning: false
+
+# NOTE: if 'k8s_scylla_utils_docker_image' is not specified then default values from operator-1.6+ will be used
+k8s_scylla_utils_docker_image: ''
+
 scylla_rsyslog_setup: false
 
 backup_bucket_region: ''  # use the same region as a cluster

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -156,6 +156,8 @@
 | **<a href="#user-content-gce_pd_ssd_disk_size_monitor" name="gce_pd_ssd_disk_size_monitor">gce_pd_ssd_disk_size_monitor</a>**  |  | N/A | SCT_GCE_SSD_DISK_SIZE_MONITOR
 | **<a href="#user-content-gke_cluster_version" name="gke_cluster_version">gke_cluster_version</a>**  |  | N/A | SCT_GKE_CLUSTER_VERSION
 | **<a href="#user-content-gke_k8s_release_channel" name="gke_k8s_release_channel">gke_k8s_release_channel</a>**  |  | N/A | SCT_GKE_K8S_RELEASE_CHANNEL
+| **<a href="#user-content-k8s_scylla_utils_docker_image" name="k8s_scylla_utils_docker_image">k8s_scylla_utils_docker_image</a>**  |  | N/A | SCT_K8S_SCYLLA_UTILS_DOCKER_IMAGE
+| **<a href="#user-content-k8s_enable_performance_tuning" name="k8s_enable_performance_tuning">k8s_enable_performance_tuning</a>**  |  | N/A | SCT_K8S_ENABLE_PERFORMANCE_TUNING
 | **<a href="#user-content-k8s_deploy_monitoring" name="k8s_deploy_monitoring">k8s_deploy_monitoring</a>**  |  | N/A | SCT_K8S_DEPLOY_MONITORING
 | **<a href="#user-content-k8s_scylla_operator_helm_repo" name="k8s_scylla_operator_helm_repo">k8s_scylla_operator_helm_repo</a>**  |  | N/A | SCT_K8S_SCYLLA_OPERATOR_HELM_REPO
 | **<a href="#user-content-k8s_scylla_operator_chart_version" name="k8s_scylla_operator_chart_version">k8s_scylla_operator_chart_version</a>**  |  | N/A | SCT_K8S_SCYLLA_OPERATOR_CHART_VERSION

--- a/jenkins-pipelines/operator/performance/perf-regression-latency-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/performance/perf-regression-latency-eks.jenkinsfile
@@ -10,6 +10,7 @@ perfRegressionParallelPipeline(
     test_config: "test-cases/performance/perf-regression-latency-500gb-30min.yaml",
     sub_tests: ["test_latency"],
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    k8s_enable_performance_tuning: true,
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',

--- a/jenkins-pipelines/operator/performance/perf-regression-throughput-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/performance/perf-regression-throughput-eks.jenkinsfile
@@ -10,6 +10,7 @@ perfRegressionParallelPipeline(
     test_config: "test-cases/performance/perf-regression.100threads.30M-keys.yaml",
     sub_tests: ["test_write", "test_read", "test_mixed"],
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    k8s_enable_performance_tuning: true,
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',

--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -346,9 +346,9 @@ class LocalKindCluster(LocalMinimalClusterBase):
     _target_user: str
     _create_kubectl_config_cmd: str = '/var/tmp/kind export kubeconfig'
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.allowed_labels_on_scylla_node = [
+    @cached_property
+    def allowed_labels_on_scylla_node(self) -> list:
+        return [
             ('k8s-app', 'kindnet'),
             ('k8s-app', 'kube-proxy'),
             ('scylla/cluster', self.k8s_scylla_cluster_name),

--- a/sdcm/k8s_configs/eks/scylla-node-prepare.yaml
+++ b/sdcm/k8s_configs/eks/scylla-node-prepare.yaml
@@ -173,8 +173,10 @@ spec:
       - name: node-setup
         image: scylladb/scylla-machine-image:k8s-aws-666.development-20201023.0c4dfa1
         imagePullPolicy: Always
-        args:
-          - --all
+        # NOTE: 'args' will be updated in the code
+        #        when perf tuning is disabled it is ['--all']
+        #        when perf tuning is enabled it is ['--setup-disks']
+        args: ${SCYLLA_MACHINE_IMAGE_ARGS}
         env:
           - name: ROOT_DISK
             value: /mnt/hostfs/mnt/raid-disks/disk0

--- a/sdcm/k8s_configs/loaders.yaml
+++ b/sdcm/k8s_configs/loaders.yaml
@@ -33,7 +33,9 @@ spec:
             - mountPath: /var/run/docker.sock
               name: docker-socket
           resources:
-            # NOTE: set only 'requests' and not 'limits' to reuse as many resources as possible
+            limits:
+              cpu: ${CPU_LIMIT}
+              memory: ${MEMORY_LIMIT}
             requests:
               cpu: ${CPU_LIMIT}
               memory: ${MEMORY_LIMIT}

--- a/sdcm/k8s_configs/node-config-crd.yaml
+++ b/sdcm/k8s_configs/node-config-crd.yaml
@@ -1,0 +1,12 @@
+apiVersion: scylla.scylladb.com/v1alpha1
+kind: NodeConfig
+metadata:
+  name: scylla-layout-nodes-tuning
+  labels:
+    app: scylla-node-config
+spec:
+  placement:
+    nodeSelector: {}
+    # NOTE: 'affinity' will be updated in the code
+    affinity: {}
+  disableOptimizations: false

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -700,6 +700,16 @@ class SCTConfiguration(dict):
                   "'rapid', 'regular', 'stable' and '' (static / No channel)."),
 
         # k8s options
+        dict(name="k8s_scylla_utils_docker_image",
+             env="SCT_K8S_SCYLLA_UTILS_DOCKER_IMAGE", type=str,
+             help=(
+                 "Docker image to be used by Scylla operator to tune K8S nodes for performance. "
+                 "Used when k8s_enable_performance_tuning' is defined to 'True'. "
+                 "If not set then the default from operator will be used.")),
+
+        dict(name="k8s_enable_performance_tuning", env="SCT_K8S_ENABLE_PERFORMANCE_TUNING",
+             type=boolean, help="Define whether performance tuning must run or not."),
+
         dict(name="k8s_deploy_monitoring", env="SCT_K8S_DEPLOY_MONITORING", type=str,
              help=""),
 

--- a/sdcm/utils/k8s.py
+++ b/sdcm/utils/k8s.py
@@ -689,7 +689,18 @@ def get_pool_affinity_modifiers(pool_label_name, pool_name):
                     pool_label_name,
                     pool_name)
 
-    return [add_statefulset_or_daemonset_pool_affinity, add_scylla_cluster_pool_affinity]
+    def add_node_config_pool_affinity(obj):
+        if obj['kind'] == 'NodeConfig':
+            obj['spec']['placement']['affinity'] = add_pool_node_affinity(
+                obj['spec']['placement'].get('affinity', {}),
+                pool_label_name,
+                pool_name)
+
+    return [
+        add_statefulset_or_daemonset_pool_affinity,
+        add_scylla_cluster_pool_affinity,
+        add_node_config_pool_affinity,
+    ]
 
 
 class HelmValues:

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -191,6 +191,12 @@ def call(Map pipelineParams) {
                                                         if [[ -n "${params.k8s_scylla_operator_docker_image ? params.k8s_scylla_operator_docker_image : ''}" ]] ; then
                                                             export SCT_K8S_SCYLLA_OPERATOR_DOCKER_IMAGE=${params.k8s_scylla_operator_docker_image}
                                                         fi
+                                                        if [[ -n "${pipelineParams.k8s_enable_performance_tuning ? pipelineParams.k8s_enable_performance_tuning : ''}" ]] ; then
+                                                            export SCT_K8S_ENABLE_PERFORMANCE_TUNING=${pipelineParams.k8s_enable_performance_tuning}
+                                                        fi
+                                                        if [[ -n "${pipelineParams.k8s_scylla_utils_docker_image ? pipelineParams.k8s_scylla_utils_docker_image : ''}" ]] ; then
+                                                            export SCT_K8S_SCYLLA_UTILS_DOCKER_IMAGE=${pipelineParams.k8s_scylla_utils_docker_image}
+                                                        fi
 
                                                         echo "start test ......."
                                                         ./docker/env/hydra.sh run-test ${perf_test} --backend ${params.backend}  --logdir "`pwd`"


### PR DESCRIPTION
Operator release 1.6 will have 2 new CRs (Custom Resources) for
handling of the K8S nodes performance tuning.
So, add support for it.

Following new configuration options are introduced:
- k8s_enable_performance_tuning. This one defines whether we should
  enable K8S nodes tuning or not.
- k8s_scylla_utils_docker_image. This one defines the Scylla docker
  image to be used as utils image for the tuning of K8S nodes.
  If not specified then the default value from the operator will be
  used.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
