### PR TITLE
fix(FullScanThread): Fix bad handling of 'random' option for fullscan

### DIFF
--- a/sdcm/full_scan_thread.py
+++ b/sdcm/full_scan_thread.py
@@ -36,8 +36,9 @@ class FullScanThread:
     def get_ks_cs(self, db_node: BaseNode):
         ks_cf_list = self.db_cluster.get_non_system_ks_cf_list(db_node)
         if self.ks_cf not in ks_cf_list:
-            return 'random'
-        elif 'random' in self.ks_cf.lower():
+            self.ks_cf = 'random'
+
+        if 'random' in self.ks_cf.lower():
             return random.choice(ks_cf_list)
         return self.ks_cf
 


### PR DESCRIPTION
The fullscan parameter has an option to get 'random' as the ks.cf for
the full scan query.
However, this one got broken as part of the previous changes.

In runs of  4.5  and 2021.1 I see the followings errors when running fullscan for "random" option:
(I don't know how people didn't see it before or maybe we just recently backported this breakage)

FullScanEvent Severity.ERROR): type=finish select_from=random on db_node=10.0.3.217 message=Error from server: code=2200 [Invalid query] message="No keyspace has been specified. USE a keyspace, or explicitly specify keyspace.tablename"