### PR TITLE
fix(upgrade_test.py): Create Alternator tables once in all session

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -24,7 +24,7 @@ import unittest.mock
 import warnings
 from typing import NamedTuple, Optional, Union, List, Dict, Any
 from uuid import uuid4, UUID
-from functools import wraps, cached_property
+from functools import wraps, cached_property, cache
 import threading
 import signal
 import sys
@@ -669,6 +669,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self.log.info('repair system_auth keyspace ...')
             node.run_nodetool(sub_cmd="repair", args="-- system_auth")
 
+    @cache
     def pre_create_alternator_tables(self):
         node = self.db_cluster.nodes[0]
         if self.params.get('alternator_port'):


### PR DESCRIPTION
* The problem:
   The `pre_create_alternator_tables` creates the tables needed to run alternator tests.
   The problem that the method is called several times during the rolling upgrade test. 
   To avoid this problem does not happen again, I change the method to "call" one time in the
     session.
* Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/4133

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
