### PR TITLE
revert(health_checker): removing removed_nodes_list check

### DIFF
--- a/unit_tests/test_utils_health_checker.py
+++ b/unit_tests/test_utils_health_checker.py
@@ -94,7 +94,7 @@ class TestHealthChecker(unittest.TestCase):
         event = next(check_nodes_status(NODES_STATUS, Node, ["127.0.0.2", ]), None)
         self.assertIsNotNone(event)
         self.assertEqual(event.type, "NodeStatus")
-        self.assertEqual(event.severity, Severity.ERROR)
+        self.assertEqual(event.severity, Severity.CRITICAL)
         self.assertEqual(event.node, "node-0")
         self.assertEqual(event.message, "")
         self.assertNotEqual(event.error, "")


### PR DESCRIPTION
Due to https://github.com/scylladb/scylla-enterprise/issues/1419 being resloved, I removed
the changes that were inserted in https://github.com/scylladb/scylla-cluster-tests/pull/2383
As of now, ANY node that will not appear as UN during the health check will
trigger a critical event

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
