### PR TITLE
fix(verify config): mandatory variables for siren tests

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -168,8 +168,9 @@ class CloudRegion(click.ParamType):
               envvar="PACKAGES_PATHS",
               type=click.Path(),
               expose_value=False,
-              help="Install paths for extra python pacakges to install, scylla-cluster-plugins for example")
+              help="Install paths for extra python packages to install, scylla-cluster-plugins for example")
 def cli():
+    LOGGER.info("install-bash-completion current path: %s", os.getcwd())
     docker_hub_login(remoter=LOCALRUNNER)
 
 

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1619,8 +1619,9 @@ class SCTConfiguration(dict):
         self._check_unexpected_sct_variables()
         self._validate_sct_variable_values()
         backend = self.get('cluster_backend')
+        db_type = self.get('db_type')
         self._check_per_backend_required_values(backend)
-        if backend in ['aws']:
+        if backend in ['aws'] and db_type != 'cloud_scylla':
             self._check_aws_multi_region_params()
 
         self._verify_data_volume_configuration(backend)
@@ -1693,6 +1694,8 @@ class SCTConfiguration(dict):
 
     def _check_per_backend_required_values(self, backend: str):
         if backend in self.available_backends:
+            if backend in ('aws', 'gce') and self.get("db_type") == "cloud_scylla":
+                backend += "-siren"
             self._check_backend_defaults(backend, self.backend_required_params[backend])
         else:
             raise ValueError("Unsupported backend [{}]".format(backend))

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -316,7 +316,8 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         self.assertEqual(conf['store_perf_results'], False)
 
     def test_14_aws_siren_from_env(self):
-        os.environ['SCT_CLUSTER_BACKEND'] = 'aws-siren'
+        os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
+        os.environ['SCT_DB_TYPE'] = 'cloud_scylla'
         os.environ['SCT_REGION_NAME'] = 'us-east-1'
         os.environ['SCT_N_DB_NODES'] = '2'
         os.environ['SCT_INSTANCE_TYPE_DB'] = 'i3.large'


### PR DESCRIPTION
Follow to https://github.com/scylladb/scylla-cluster-tests/pull/4013.
This commit present two fixes:

1. not verify aws multi region params for siren tests. 'ami_id_db_scylla' is mandatory for not
siren tests and it causes to failure of siren tests

2. check backend defaults for siren tests. Siren tests has its own default mandatory variables
and we need to validate them before running the test

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
