### PR TITLE
fix(ubuntu Dockerfile): wrong call to bashrc

### DIFF
--- a/docker/scylla-sct/ubuntu/Dockerfile
+++ b/docker/scylla-sct/ubuntu/Dockerfile
@@ -37,5 +37,4 @@ stdout_logfile_maxbytes=0\n\
 stderr_logfile=/dev/stderr\n\
 stderr_logfile_maxbytes=0' > /etc/supervisord.conf.d/scylla-manager.conf && \
     echo "autostart=false" >> /etc/supervisord.conf.d/scylla-server.conf && \
-    echo "autostart=false" >> /etc/supervisord.conf.d/scylla-housekeeping.conf && \
-    sed -i "\:/dev/stderr:d" /etc/bashrc
+    echo "autostart=false" >> /etc/supervisord.conf.d/scylla-housekeeping.conf


### PR DESCRIPTION
PR #3865 changed the default docker to be
ubuntu (instead of centos), but ubuntu has
no `/etc/bashrc` and instead it has
`/etc/bash.bashrc`, so last runs for
4.6 are failing due to this sed command
failing.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
