### PR TITLE
fix(show-monitor): unset dashboard.id field for the restored dashboard

### DIFF
--- a/sdcm/monitorstack/__init__.py
+++ b/sdcm/monitorstack/__init__.py
@@ -293,6 +293,14 @@ def restore_sct_dashboards(monitoring_dockers_dir, scylla_version):
     dashboard_url = f'http://localhost:{GRAFANA_DOCKER_PORT}/api/dashboards/db'
     with open(sct_dashboard_file, "r") as f:  # pylint: disable=invalid-name
         dashboard_config = json.load(f)
+        # NOTE: remove value from the 'dashboard.id' field to avoid following error:
+        #
+        #       Error message {"message":"Dashboard not found","status":"not-found"}
+        #
+        #       Creating dashboard from scratch we should not have 'id', because Grafana will try
+        #       to 'update' existing one which is absent in such a case.
+        if dashboard_config.get('dashboard', {}).get('id'):
+            dashboard_config['dashboard']['id'] = None
 
     try:
         res = requests.post(dashboard_url,


### PR DESCRIPTION
Having 'dashboard.id' field be set we get following error:

    Error message {"message":"Dashboard not found","status":"not-found"}

So, unset it to make Grafana understand that we create dashboard from
scratch and not update "existing' one.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
