### PR TITLE
improvement(sct.py): move ArgusTestRun import to the func that uses it

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -34,7 +34,6 @@ import click
 import click_completion
 from prettytable import PrettyTable
 
-from sdcm.argus_test_run import ArgusTestRun
 from sdcm.remote import LOCALRUNNER
 from sdcm.results_analyze import PerformanceResultsAnalyzer, BaseResultsAnalyzer
 from sdcm.sct_config import SCTConfiguration
@@ -987,6 +986,7 @@ def collect_logs(test_id=None, logdir=None, backend=None, config_file=None):
 
 def store_logs_in_argus(test_id: UUID, logs: dict[str, list[list[str] | str]]):
     try:
+        from sdcm.argus_test_run import ArgusTestRun  # pylint: disable=import-outside-toplevel
         test_run = ArgusTestRun.get(test_id=test_id)
         for cluster_type, s3_links in logs.items():
             for link in s3_links:


### PR DESCRIPTION
since we use it only in the collect logs we don't want this
import happen every time we run other sct.py commands

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
