### PR TITLE
fix(dashboard): Use $test_name template for grafana dashboard

### DIFF
--- a/data_dir/scylla-dash-per-server-nemesis.master.json
+++ b/data_dir/scylla-dash-per-server-nemesis.master.json
@@ -6516,8 +6516,7 @@
     "schemaVersion": 31,
     "style": "dark",
     "tags": [
-      "master",
-      "longevity-twcs-3h"
+      "master"
     ],
     "templating": {
       "list": [
@@ -6792,8 +6791,7 @@
       ]
     },
     "timezone": "utc",
-    "title": "[longevity-twcs-3h] Scylla Per Server Metrics Nemesis Master",
-    "uid": "J1T2FZ57za",
+    "title": "[$test_name] Scylla Per Server Metrics Nemesis Master",
     "version": 1
   }
 }


### PR DESCRIPTION
Set $test_name template parameter to use test/job name for
scylla-dash-per-server-nemesis dashboard

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
