### PR TITLE
fix(longevity_test): Skip paxos error/warning messages (#8706)

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -168,3 +168,26 @@ def ignore_scrub_invalid_errors():
             line="Skipping invalid partition",
         ))
         yield
+
+
+@contextmanager
+def catch_all_errors():
+    yield
+
+
+@contextmanager
+def skip_paxos_warnings_errors():
+    with ExitStack() as stack:
+        stack.enter_context(DbEventsFilter(
+            db_event=DatabaseLogEvent.DATABASE_ERROR,
+            line="mutation_write_timeout_exception (Operation timed out for system.paxos"
+        ))
+        stack.enter_context(DbEventsFilter(
+            db_event=DatabaseLogEvent.DATABASE_ERROR,
+            line="Operation timed out for system.paxos"
+        ))
+        stack.enter_context(DbEventsFilter(
+            db_event=DatabaseLogEvent.DATABASE_ERROR,
+            line="Operation failed for system.paxos"
+        ))
+        yield


### PR DESCRIPTION
on branch 4.4 alternator tests usually set as failed due
paxos/errors messages described in issue #8706.
Ingore this messages for alternator tests globally.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
