### PR TITLE
fix(monitorstack/ui): change xpath for panel searching

### DIFF
--- a/sdcm/monitorstack/ui.py
+++ b/sdcm/monitorstack/ui.py
@@ -55,7 +55,7 @@ class Login:
 
 
 class Panel:
-    xpath_tmpl = """//header[contains(@aria-label,'{name}') and contains(@class, 'panel-title-container')]"""
+    xpath_tmpl = """//header[contains(@*,'{name}') and contains(@class, 'panel-title-container')]"""
 
     def __init__(self, name):
         self.name = name


### PR DESCRIPTION
Grafana changed the header element attributes.
This was found in branch-3.9 (monitoring version 3.9.1)

Fix xpath for searching panel on dashboard

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
