### PR TITLE
fix(kernel callstack) remove from email attachment:

### DIFF
--- a/sdcm/report_templates/results_reactor_stall_events_list.html
+++ b/sdcm/report_templates/results_reactor_stall_events_list.html
@@ -16,8 +16,10 @@
                 {{ severity }} - [{{ debug_events_summary.get(severity, 0) }}]
                 </h4>
                 {% for event in events %}
-                    <pre>{{event}}</pre>
-                    <hr>
+                    {% if "Reactor stalled" in event %}
+                        <pre>{{event}}</pre>
+                        <hr>
+                    {% endif %}
                 {% endfor %}
             {% endfor %}
         {% endif %}


### PR DESCRIPTION
after the new events were added, they are now
flooding the DEBUG events and hence emails are not
able to be sent (there is a limit, and we might not
be able to change it, or we don't want to change it).
with this change, the kernel callstacks will not be
shown in the email attachment (that now is called
`reactor_stall_events_list`, and maybe a new
attachment file will be added with these kernel
events, but for now, removing it to have the test
passing (and sending the emails).

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
