### PR TITLE
improvement(event): print 'timestamp' event property to raw_event.log

### DIFF
--- a/sdcm/sct_events/base.py
+++ b/sdcm/sct_events/base.py
@@ -221,6 +221,7 @@ class SctEvent:
             "base": self.base,
             "type": self.type,
             "subtype": self.subtype,
+            "timestamp": self.timestamp,
             **self.__getstate__(),
         }, cls=encoder)
 

--- a/unit_tests/test_sct_events_base.py
+++ b/unit_tests/test_sct_events_base.py
@@ -154,7 +154,8 @@ class TestSctEvent(SctEventTestCase):
         y.event_id = "fa4a84a2-968b-474c-b188-b3bac4be8527"
         self.assertEqual(
             y.to_json(),
-            f'{{"base": "Y", "type": null, "subtype": null, "event_timestamp": {y.event_timestamp}, "source_timestamp": null, '
+            f'{{"base": "Y", "type": null, "subtype": null, "timestamp": {y.timestamp}, '
+            f'"event_timestamp": {y.event_timestamp}, "source_timestamp": null, '
             f'"severity": "UNKNOWN", "event_id": "fa4a84a2-968b-474c-b188-b3bac4be8527", "log_level": 20}}'
         )
 


### PR DESCRIPTION
Task: https://trello.com/c/fSEopNe6/4000-save-timestamp-events-property-to-rawevents

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
