### PR TITLE
fix(manager suspension tests): make sure to resume after suspending

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -1029,12 +1029,13 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
             raise ValueError(f"Not familiar with task type: {task_type}")
         assert suspendable_task.wait_for_status(list_status=[TaskStatus.RUNNING], timeout=300, step=5), \
             f"task {suspendable_task.id} failed to reach status {TaskStatus.RUNNING}"
-        mgr_cluster.suspend()
-        assert suspendable_task.wait_for_status(list_status=[TaskStatus.STOPPED], timeout=300, step=10), \
-            f"task {suspendable_task.id} failed to reach status {TaskStatus.STOPPED}"
-        mgr_cluster.resume(start_tasks=True)
-        assert suspendable_task.wait_for_status(list_status=[TaskStatus.DONE], timeout=1200, step=10), \
-            f"task {suspendable_task.id} failed to reach status {TaskStatus.DONE}"
+        with mgr_cluster.suspend_manager_then_resume(start_tasks=False):
+            mgr_cluster.suspend()
+            assert suspendable_task.wait_for_status(list_status=[TaskStatus.STOPPED], timeout=300, step=10), \
+                f"task {suspendable_task.id} failed to reach status {TaskStatus.STOPPED}"
+            mgr_cluster.resume(start_tasks=True)
+            assert suspendable_task.wait_for_status(list_status=[TaskStatus.DONE], timeout=1200, step=10), \
+                f"task {suspendable_task.id} failed to reach status {TaskStatus.DONE}"
         self.log.info('finishing test_suspend_and_resume_{}'.format(task_type))
 
     def test_suspend_and_resume_without_starting_tasks(self):
@@ -1046,14 +1047,15 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         suspendable_task = mgr_cluster.create_backup_task(location_list=self.locations)
         assert suspendable_task.wait_for_status(list_status=[TaskStatus.RUNNING], timeout=300, step=5), \
             f"task {suspendable_task.id} failed to reach status {TaskStatus.RUNNING}"
-        mgr_cluster.suspend()
-        assert suspendable_task.wait_for_status(list_status=[TaskStatus.STOPPED], timeout=300, step=10), \
-            f"task {suspendable_task.id} failed to reach status {TaskStatus.STOPPED}"
-        mgr_cluster.resume(start_tasks=False)
-        self.log.info("Waiting a little time to make sure the task isn't started")
-        time.sleep(60)
-        current_task_status = suspendable_task.status
-        assert current_task_status == TaskStatus.STOPPED, \
-            f'Task {current_task_status} did not remain in "{TaskStatus.STOPPED}" status, but instead ' \
-            f'reached "{current_task_status}" status'
+        with mgr_cluster.suspend_manager_then_resume(start_tasks=False):
+            mgr_cluster.suspend()
+            assert suspendable_task.wait_for_status(list_status=[TaskStatus.STOPPED], timeout=300, step=10), \
+                f"task {suspendable_task.id} failed to reach status {TaskStatus.STOPPED}"
+            mgr_cluster.resume(start_tasks=False)
+            self.log.info("Waiting a little time to make sure the task isn't started")
+            time.sleep(60)
+            current_task_status = suspendable_task.status
+            assert current_task_status == TaskStatus.STOPPED, \
+                f'Task {current_task_status} did not remain in "{TaskStatus.STOPPED}" status, but instead ' \
+                f'reached "{current_task_status}" status'
         self.log.info('finishing test_suspend_and_resume_without_starting_tasks')

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -20,6 +20,7 @@ import datetime
 from re import findall
 from textwrap import dedent
 from statistics import mean
+from contextlib import contextmanager
 
 import requests
 from invoke.exceptions import UnexpectedExit, Failure
@@ -720,6 +721,14 @@ class ManagerCluster(ScyllaManagerBase):
         if start_tasks:
             cmd += " --start-tasks"
         self.sctool.run(cmd=cmd)
+
+    @contextmanager
+    def suspend_manager_then_resume(self, start_tasks=True):
+        self.suspend()
+        try:
+            yield
+        finally:
+            self.resume(start_tasks=start_tasks)
 
 
 def verify_errorless_result(cmd, res):


### PR DESCRIPTION
In certain circumstances, during manager suspension tests, the cluster can
remain suspended at the end of the function.
To remedy this, I made sure that the manager is resumed in the end.

DO NODE: the option to resume an already resumed cluster was introduced
only in manager 2.6. Using it in earlier versions will result in errors.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
