### PR TITLE
fix(artifact test): nonroot install not support housekeeping

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -199,10 +199,11 @@ class ArtifactsTest(ClusterTester):
             # Scylla service is stopping/starting after installation and re-configuration.
             # To validate version after installation, we need to perform validation before re-config.
             # For that the test should be changed to be able to call "add_nodes" function from BaseCluster.
-            # self.log.info("Validate version after install")
-            # self.check_scylla_version_in_housekeepingdb(prev_id=0,
-            #                                             expected_status_code='i',
-            #                                             new_row_expected=False)
+            # if not self.node.is_nonroot_install:
+            #   self.log.info("Validate version after install")
+            #   self.check_scylla_version_in_housekeepingdb(prev_id=0,
+            #                                               expected_status_code='i',
+            #                                               new_row_expected=False)
 
         version_id_after_stop = 0
         with self.subTest("check Scylla server after stop/start"):
@@ -213,22 +214,24 @@ class ArtifactsTest(ClusterTester):
             # So we don't need to stop and to start it again
             self.check_scylla()
 
-            self.log.info("Validate version after stop/start")
-            version_id_after_stop = self.check_scylla_version_in_housekeepingdb(
-                prev_id=0,
-                expected_status_code=expected_housekeeping_status_code,
-                new_row_expected=False,
-                backend=backend)
+            if not self.node.is_nonroot_install:
+                self.log.info("Validate version after stop/start")
+                version_id_after_stop = self.check_scylla_version_in_housekeepingdb(
+                    prev_id=0,
+                    expected_status_code=expected_housekeeping_status_code,
+                    new_row_expected=False,
+                    backend=backend)
 
         with self.subTest("check Scylla server after restart"):
             self.node.restart_scylla(verify_up_after=True)
             self.check_scylla()
 
-            self.log.info("Validate version after restart")
-            self.check_scylla_version_in_housekeepingdb(prev_id=version_id_after_stop,
-                                                        expected_status_code=expected_housekeeping_status_code,
-                                                        new_row_expected=True,
-                                                        backend=backend)
+            if not self.node.is_nonroot_install:
+                self.log.info("Validate version after restart")
+                self.check_scylla_version_in_housekeepingdb(prev_id=version_id_after_stop,
+                                                            expected_status_code=expected_housekeeping_status_code,
+                                                            new_row_expected=True,
+                                                            backend=backend)
 
     def get_email_data(self):
         self.log.info("Prepare data for email")

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1269,7 +1269,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
     @property
     def uuid(self):
-        if not self._uuid:
+        if not self._uuid and not self.is_nonroot_install:
             uuid_path = '/var/lib/scylla-housekeeping/housekeeping.uuid'
             uuid_result = self.remoter.run('test -e %s' % uuid_path, ignore_status=True, verbose=True)
             uuid_exists = uuid_result.ok


### PR DESCRIPTION
Task:
https://trello.com/c/IkBtoQIi/4207-investigate-the-artifacts-tests-failures-related-to-housekeeping

According to https://github.com/scylladb/scylla/blob/965ea4a3facc50f337733349eba316e9e8b9b9ae/dist/common/scripts/scylla_setup#L371 and https://github.com/scylladb/scylla/blob/965ea4a3facc50f337733349eba316e9e8b9b9ae/install.sh#L293
housekeeping is not supported for nonroot installation

Test passed:
https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/yulia/job/yulia-artifacts-centos8-nonroot-test/6/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
