### PR TITLE
fix(k8s): skip logging configuration

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1436,6 +1436,9 @@ class BasePodContainer(cluster.BaseNode):  # pylint: disable=too-many-public-met
     def pod_replace_timeout(self) -> int:
         return self.pod_terminate_timeout + self.pod_readiness_timeout
 
+    def configure_remote_logging(self):
+        self.log.debug("No need to configure remote logging on k8s")
+
     @staticmethod
     def is_docker() -> bool:
         return True


### PR DESCRIPTION
Fixes regression after https://github.com/scylladb/scylla-cluster-tests/commit/a321ad252865ea3988ad10335003a667200b70f7
https://trello.com/c/Gs7ZRFB5/4215-make-syslog-ng-work-on-k8s-backends

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
