### PR TITLE
fix(event): not raise exception when begin event not found

### DIFF
--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -20,7 +20,8 @@ from sdcm.sct_events import Severity, SctEventProtocol
 from sdcm.sct_events.base import SctEvent, LogEvent, LogEventProtocol, T_log_event, InformationalEvent, \
     EventPeriod
 
-from sdcm.sct_events.continuous_event import ContinuousEventsRegistry, ContinuousEventRegistryException, ContinuousEvent
+from sdcm.sct_events.continuous_event import ContinuousEventsRegistry, ContinuousEvent
+from sdcm.sct_events.system import TestFrameworkEvent
 
 TOLERABLE_REACTOR_STALL: int = 1000  # ms
 
@@ -335,10 +336,14 @@ def get_pattern_to_event_to_func_mapping(node: str) \
         begun_events = event_filter.get_filtered()
 
         if not begun_events:
-            raise ContinuousEventRegistryException("Did not find any events of type {event_type}"
-                                                   "with period type {period_type}."
-                                                   .format(event_type=event_type,
-                                                           period_type=EventPeriod.BEGIN.value))
+            TestFrameworkEvent(
+                source=event_type.__name__,
+                message="Did not find any events of type {event_type}"
+                        "with period type {period_type}.".format(event_type=event_type,
+                                                                 period_type=EventPeriod.BEGIN.value),
+                severity=Severity.ERROR
+            ).publish_or_dump()
+
         if len(begun_events) > 1:
             LOGGER.debug("Found %s events of type %s with period %s. "
                          "Will apply the function to most recent event by default.",


### PR DESCRIPTION
If begin event for database continuous event is not found, exception is raised,
that caused to db log reader crash.
Publish TestFrameworkEvent instead.

Task: https://trello.com/c/qfnjQOD5/4174-continues-events-can-cause-db-log-reader-to-crash

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
