### PR TITLE
fix(nemesis.py): toppartition supported version

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2010,8 +2010,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.log.debug(result)
 
     # NOTE: '2022.1.rc0' is set in advance, not guaranteed to match when appears
-    # NOTE: current variant of the toppartitions feature is supported since 4.5 OSS
-    @scylla_versions(("4.5.rc1", None), ("2022.1.rc0", None))
+    # NOTE: current variant of the toppartitions feature is supported since 4.6 OSS
+    @scylla_versions(("4.6.rc0", None), ("2022.1.rc0", None))
     def disrupt_show_toppartitions(self):
         result = self.target_node.run_nodetool(sub_cmd='help', args='toppartitions')
         if 'Unknown command toppartitions' in result.stdout:


### PR DESCRIPTION
Issue https://github.com/scylladb/scylla/issues/9268 was decided to be
fixed in version 4.6

Marking disrupt_show_toppartitions with 4.6rc0 scylla version

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
