### PR TITLE
fix(install_cassandra_harry): Change from Amos fork to official

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -472,8 +472,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             """))
         self.remoter.run(shell_script_cmd("""\
             rm -rf cassandra-harry
-            git clone -b scylla-branch https://github.com/apache/cassandra-harry
+            git clone https://github.com/apache/cassandra-harry
             cd cassandra-harry
+            git checkout 26bb6696ba1b18ff5c062d780a9360e750691052
             make mvn
         """))
         result = self.remoter.run('realpath ~/cassandra-harry/scripts/cassandra-harry')

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -472,7 +472,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             """))
         self.remoter.run(shell_script_cmd("""\
             rm -rf cassandra-harry
-            git clone -b scylla-branch https://github.com/amoskong/cassandra-harry
+            git clone -b scylla-branch https://github.com/apache/cassandra-harry
             cd cassandra-harry
             make mvn
         """))


### PR DESCRIPTION
Amos's PR (https://github.com/apache/cassandra-harry/pull/10) to
cassandra-harry was merged, so we can change this to the official
repo.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
