### PR TITLE
fix(k8s-functional): disable logging configuration as redundant

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5495,3 +5495,8 @@ class LocalNode(BaseNode):
 
     def check_spot_termination(self):
         pass
+
+
+class LocalK8SHostNode(LocalNode):
+    def configure_remote_logging(self):
+        self.log.debug("No need to configure remote logging on k8s")

--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -20,7 +20,7 @@ from functools import cached_property
 from invoke.exceptions import UnexpectedExit
 
 from sdcm import cluster
-from sdcm.cluster import LocalNode
+from sdcm.cluster import LocalK8SHostNode
 from sdcm.remote import LOCALRUNNER
 from sdcm.remote.base import CommandRunner
 from sdcm.cluster_k8s import (
@@ -312,7 +312,7 @@ class LocalMinimalClusterBase(MinimalClusterBase):
     # pylint: disable=invalid-overridden-method
     @cached_property
     def host_node(self):
-        node = LocalNode(
+        node = LocalK8SHostNode(
             name=f"{self.node_prefix}-1",
             parent_cluster=self,
             base_logdir=self.logdir,


### PR DESCRIPTION
K8S functional tests do not work on local K8S backend anymore after
merge of the [1] change where was added configuration of logging
sub-system.
It must not run on any part of the K8S test run, including host
machine for a local K8S cluster.
So, stop configuring logging on K8S backends.

[1] https://github.com/scylladb/scylla-cluster-tests/commit/a321ad25

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
