### PR TITLE
test(manager): testing upgrade from meta installation

### DIFF
--- a/configurations/manager/meta-installation.yaml
+++ b/configurations/manager/meta-installation.yaml
@@ -1,0 +1,1 @@
+use_mgmt_meta_installation: true

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -101,6 +101,7 @@ use_legacy_cluster_init: false
 internode_encryption: 'all'
 
 use_mgmt: true
+use_mgmt_meta_installation: false
 manager_prometheus_port: 5090
 scylla_mgmt_pkg: ''
 

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -45,6 +45,7 @@
 | **<a href="#user-content-stress_cmd_lwt_mixed_baseline" name="stress_cmd_lwt_mixed_baseline">stress_cmd_lwt_mixed_baseline</a>**  | Stress command for LWT performance test for mixed lwt load baseline | N/A | SCT_STRESS_CMD_LWT_MIXED_BASELINE
 | **<a href="#user-content-use_cloud_manager" name="use_cloud_manager">use_cloud_manager</a>**  | When define true, will install scylla cloud manager | N/A | SCT_USE_CLOUD_MANAGER
 | **<a href="#user-content-use_ldap_authorization" name="use_ldap_authorization">use_ldap_authorization</a>**  | When defined true, will create a docker container with LDAP and configure scylla.yaml to use it | N/A | SCT_USE_LDAP_AUTHORIZATION
+| **<a href="#user-content-use_mgmt_meta_installation" name="use_mgmt">use_mgmt_meta_installation</a>**  | When define true, the manager server will be installed using meta-installation | N/A | SCT_USE_MGMT_META_INSTALLATION
 | **<a href="#user-content-use_mgmt" name="use_mgmt">use_mgmt</a>**  | When define true, will install scylla management | N/A | SCT_USE_MGMT
 | **<a href="#user-content-manager_prometheus_port" name="manager_prometheus_port">manager_prometheus_port</a>**  | Port to be used by the manager to contact Prometheus | 5090 | SCT_MANAGER_PROMETHEUS_PORT
 | **<a href="#user-content-target_scylla_mgmt_server_address" name="target_scylla_mgmt_server_address">target_scylla_mgmt_server_address</a>**  | Url to the repo of scylla manager version used to upgrade the manager server | N/A | SCT_TARGET_SCYLLA_MGMT_SERVER_ADDRESS

--- a/jenkins-pipelines/manager/centos-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-sanity.jenkinsfile
@@ -16,5 +16,5 @@ managerPipeline(
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
 
-    downstream_jobs_to_run: 'centos-upgrade-test, centos-sanity-ipv6-test, sct-feature-test-backup, sct-feature-test-backup-azure, sct-feature-test-backup-gce'
+    downstream_jobs_to_run: 'centos-upgrade-test, centos-sanity-ipv6-test, sct-feature-test-backup, sct-feature-test-backup-azure, sct-feature-test-backup-gce, centos-upgrade-meta-installation-test'
 )

--- a/jenkins-pipelines/manager/centos-manager-upgrade-meta-installation.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-upgrade-meta-installation.jenkinsfile
@@ -1,0 +1,23 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+managerPipeline(
+    manager: true,
+    backend: 'aws',
+    aws_region: 'us-east-1',
+
+    target_manager_version: 'master_latest',
+
+    manager_version: '2.5',
+    //TODO: Should be deprecated once 2.6 is no longer tested, since 2.6 doesn't even support meta installation anymore.
+
+    test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
+    test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/meta-installation.yaml"]''',
+
+    timeout: [time: 360, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy'
+)

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -296,6 +296,9 @@ class SCTConfiguration(dict):
         dict(name="use_ms_ad_ldap", env="SCT_USE_MS_AD_LDAP", type=boolean,
              help="This option will use ldap server of QA MS Active Directory, not default openldap"),
 
+        dict(name="use_mgmt_meta_installation", env="SCT_USE_MGMT_META_INSTALLATION", type=boolean,
+             help="When define true, the manager server and backend will be installed using a meta installation"),
+
         dict(name="use_mgmt", env="SCT_USE_MGMT", type=boolean,
              help="When define true, will install scylla management"),
 


### PR DESCRIPTION
Since meta-installation is no longer supported in manager 2.6,
I created a new test that makes sure that a meta installed
manager server can be upgraded to a version that does not support
meta-installation with no issue.

Should be deprecated once 2.6 is no longer tested,
since 2.6 doesn't even support meta installation anymore.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
