### PR TITLE
fix(test_base_version): make pylint happy

### DIFF
--- a/unit_tests/test_base_version.py
+++ b/unit_tests/test_base_version.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from utils.get_supported_scylla_base_versions import UpgradeBaseVersion  # pylint: disable=no-name-in-module
+from utils.get_supported_scylla_base_versions import UpgradeBaseVersion  # pylint: disable=no-name-in-module, import-error
 
 
 def general_test(scylla_repo='', linux_distro=''):


### PR DESCRIPTION
Pylint fails with import-error, probably due to the module naming

```
15:52:21  ************* Module unit_tests.test_base_version
15:52:21  unit_tests/test_base_version.py:17:0: E0401: Unable to import 'utils.get_supported_scylla_base_versions' (import-error)
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
