### PR TITLE
fix(requirements): Change back to official ssh2-python release

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -30,9 +30,7 @@ selenium==3.141.0
 mysql-connector-python==8.0.26
 docker==4.4.4  # can't use >=5 because of tcconfig==0.26.0
 python-jenkins==1.7.0
-# ssh2-python==0.22.0
-# fix segmentation fault with ssh2-python
-https://github.com/enaydanov/ssh2-python/archive/fix_segmentation_plus_3_10.zip  # based on 0.26.0
+ssh2-python==0.27.0
 parameterized==0.8.1
 pylint==2.11.1  # Needed for pre-commit hooks
 autopep8==1.5.7  # Needed for pre-commit hooks


### PR DESCRIPTION
The fix of seg fault is part of 0.27.0.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
