### PR TITLE
fix(cluster.py): fix a call to scylla_packages_installed()

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3866,19 +3866,16 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             elif node.distro.is_ubuntu:
                 check_package_suites_distro(node, 'deb')
 
-                def list_installed_packages():
-                    node.scylla_packages_installed()
-
                 @retrying(n=6, sleep_time=10, allowed_exceptions=(UnexpectedExit,))
                 def dpkg_force_install():
                     node.remoter.sudo(shell_script_cmd("yes Y | dpkg --force-depends -i /tmp/scylla/scylla*"),
                                       ignore_status=False, verbose=True)
 
                 node.log.info('Installed .deb packages before replacing with new .DEB files')
-                list_installed_packages()
+                node.log.info(node.scylla_packages_installed)
                 dpkg_force_install()
                 node.log.info('Installed .deb packages after replacing with new .DEB files')
-                list_installed_packages()
+                node.log.info(node.scylla_packages_installed)
             _queue.put(node)
             _queue.task_done()
 


### PR DESCRIPTION
	It should be called as a property without parenthases.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
