### PR TITLE
fix(test_master): master is on 4.6

### DIFF
--- a/unit_tests/test_base_version.py
+++ b/unit_tests/test_base_version.py
@@ -33,7 +33,7 @@ class TestBaseVersion(unittest.TestCase):
         scylla_repo = self.url_base + 'unstable/scylla/master/rpm/centos/2021-08-29T00:58:58Z/scylla.repo'
         linux_distro = 'centos'
         version_list = general_test(scylla_repo, linux_distro)
-        self.assertEqual(version_list, ['4.5'])
+        self.assertEqual(version_list, ['4.6'])
 
     def test_4_5_with_centos8(self):
         scylla_repo = self.url_base + 'unstable/scylla/branch-4.5/rpm/centos/2021-08-29T00:58:58Z/scylla.repo'


### PR DESCRIPTION
Fixes following error:

```
20:24:46  
20:24:46  self = <unit_tests.test_base_version.TestBaseVersion testMethod=test_master>
20:24:46  
20:24:46      def test_master(self):
20:24:46          scylla_repo = self.url_base + 'unstable/scylla/master/rpm/centos/2021-08-29T00:58:58Z/scylla.repo'
20:24:46          linux_distro = 'centos'
20:24:46          version_list = general_test(scylla_repo, linux_distro)
20:24:46  >       self.assertEqual(version_list, ['4.5'])
20:24:46  E       AssertionError: Lists differ: ['4.6'] != ['4.5']
20:24:46  E       
20:24:46  E       First differing element 0:
20:24:46  E       '4.6'
20:24:46  E       '4.5'
20:24:46  E       
20:24:46  E       - ['4.6']
20:24:46  E       ?     ^
20:24:46  E       
20:24:46  E       + ['4.5']
20:24:46  E       ?   
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
