### PR TITLE
fix(k8s-functional): avoid races restarting Scylla pods

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2289,6 +2289,10 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
             f"patch scyllacluster {scyllacluster_name} --type merge -p '{json.dumps(patch_data)}'",
             namespace=self.namespace)
 
+        # NOTE: sleep for some time to avoid races.
+        #       We do not waste time here, because waiting for Scylla pods restart takes minutes.
+        time.sleep(10)
+
         readiness_timeout = self.get_nodes_reboot_timeout(len(self.nodes))
         statefulsets = self.statefulsets
         if random_order:


### PR DESCRIPTION
It happens that running 'restart_scylla' method on K8S may
face race condition where we do not wait for the restart to happen.
And it causes incorrect behavior of the 'test_scylla_yaml_override'
functional test.
So, fix it by adding additional sleep between restart operation
and attempt to wait for it's rollout tracking resource appearence.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
