### PR TITLE
fix(s3-minio): increase size of the storage used by minio service

### DIFF
--- a/sdcm/k8s_configs/minio/values.yaml
+++ b/sdcm/k8s_configs/minio/values.yaml
@@ -74,7 +74,7 @@ persistence:
   storageClass: ""
   VolumeName: ""
   accessMode: ReadWriteOnce
-  size: 10Gi
+  size: 60Gi
 
   ## If subPath is set mount a sub folder of a volume instead of the root of the volume.
   ## This is especially handy for volume plugins that don't natively support sub mounting (like glusterfs).


### PR DESCRIPTION
Testing Scylla manager backups on K8S fails with following error:

  We encountered an internal error, please try again.:
    cause(mkdir /export/.minio.sys/buckets/minio-bucket/\
    scylla-manager-agent-826638828: no space left on device)

On EKS manager utilizes about 47Gb making 28 backups.
GKE uses less than EKS.
So, increase the storage size making it be 60Gb instead of 10Gb
to satisfy backups needs.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
