### PR TITLE
fix(manager gce): Changed gce image to ubuntu 20

### DIFF
--- a/test-cases/manager/manager-regression-gce.yaml
+++ b/test-cases/manager/manager-regression-gce.yaml
@@ -2,6 +2,8 @@ test_duration: 360
 
 stress_cmd: "cassandra-stress write cl=QUORUM n=1200300 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -pop seq=400200300..600200300"
 
+gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2004-lts'
+
 n_db_nodes: 3
 n_loaders: 1
 n_monitor_nodes: 1


### PR DESCRIPTION
Since all of the manager tests use ubuntu clusters, I set the gce db image
to use ubuntu 20 as well, so they will fall in line with the rest.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
