### PR TITLE
fix(syslog-ng): wait for dpkg lock before install

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -915,9 +915,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         return self._init_system
 
     def start_journal_thread(self):
-        log_transport = self.parent_cluster.params.get("logs_transport")
+        logs_transport = self.parent_cluster.params.get("logs_transport")
         self._journal_thread = get_system_logging_thread(
-            logs_transport=log_transport,
+            logs_transport=logs_transport,
             node=self,
             target_log_file=self.system_log,
         )
@@ -925,9 +925,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             self.log.info("Use %s as logging daemon", type(self._journal_thread).__name__)
             self._journal_thread.start()
         else:
-            if log_transport == 'rsyslog':
+            if logs_transport == 'rsyslog':
                 self.log.info("Use no logging daemon since log transport is rsyslog")
-            elif log_transport == 'syslog-ng':
+            elif logs_transport == 'syslog-ng':
                 self.log.info("Use no logging daemon since log transport is syslog-ng")
             else:
                 TestFrameworkEvent(
@@ -2971,7 +2971,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             use_rsyslog = True
         elif self.parent_cluster.params.get('logs_transport') == 'syslog-ng':
             self.log.info("Log transport is syslog-ng. Try to install it.")
-            if self.remoter.sudo(f"bash -cxe '{install_syslogng_service(return_status=True)}'", ignore_status=True).ok:
+            if self.remoter.sudo(shell_script_cmd(install_syslogng_service(), quote="'"), ignore_status=True).ok:
                 script += self.test_config.get_syslogng_configuration_script(hostname=self.name)
                 script += restart_syslogng_service()
             else:
@@ -2982,7 +2982,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             script += self.test_config.get_rsyslog_configuration_script()
             script += restart_rsyslog_service()
         if script:
-            self.remoter.sudo(f"bash -cxe '{script}'")
+            self.remoter.sudo(shell_script_cmd(script, quote="'"))
         else:
             self.log.warning('Logging configuration is not needed')
 

--- a/sdcm/test_config.py
+++ b/sdcm/test_config.py
@@ -233,7 +233,7 @@ class TestConfig(metaclass=Singleton):  # pylint: disable=too-many-public-method
         script += restart_sshd_service()
         if cls._tester_obj and cls._tester_obj.params.get('logs_transport') == 'syslog-ng':
             script += install_syslogng_service()
-            script += '\nif [ -z "$SYSLOGNG_INSTALLED" ]; then\n'
+            script += '\nif [ $? -ne 0 ]; then\n'
             script += cls.get_rsyslog_configuration_script()
             script += restart_rsyslog_service()
             script += '\nelse\n'


### PR DESCRIPTION
Fix syslog-ng installation on Debian.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x]  I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
