### PR TITLE
fix(k8s-mgmt): increase RAM for manager agent container

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -124,7 +124,7 @@ COMMON_CONTAINERS_RESOURCES = {
 
 SCYLLA_MANAGER_AGENT_RESOURCES = {
     'cpu': 0.2,
-    'memory': 0.098,  # 0.098 will give 100Mb as a result
+    'memory': 0.489,  # 0.489 will give 500Mb as a result
 }
 
 LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
We need to increase RAM that we provide for Scylla manager agents,
because we get it OOMkilled lots of times.

Observed peak value is about 400Mb.
So, increase it to be 500Mb instead of 100Mb to make sure we do not
exceed it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
