### PR TITLE
fix(k8s-eks): use --setup-disks option for scylla-machine-image pods

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -822,7 +822,11 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
         affinity_modifiers = node_pool.affinity_modifiers
         if node_prepare_config:
             LOGGER.info("Install DaemonSets required by scylla nodes")
-            scylla_machine_image_args = ['--setup-disks'] if self.is_performance_tuning_enabled else ['--all']
+            scylla_machine_image_args = ['--all']
+            if version.parse(self._scylla_operator_chart_version) > version.parse("v1.5.0"):
+                # NOTE: operator versions newer than v1.5.0 have it's own perf tuning,
+                #       so, we should not do anything else than disk setup in such a case.
+                scylla_machine_image_args = ['--setup-disks']
 
             def scylla_machine_image_args_modifier(obj):
                 if obj["kind"] != "DaemonSet":


### PR DESCRIPTION
Do it using latest operator versions to avoid possible failures
of setup-node pods which will cause Scylla pods failures.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
