### PR TITLE
fix(upgrade test): change regex in ignore_ycsb_connection_refused filter

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -148,7 +148,7 @@ def ignore_mutation_write_errors():
 
 @contextmanager
 def ignore_ycsb_connection_refused():
-    with EventsFilter(event_class=YcsbStressEvent, regex='.*Unable to execute HTTP request: Connection refused.*'):
+    with EventsFilter(event_class=YcsbStressEvent, regex='Unable to execute HTTP request: .*Connection refused'):
         yield
 
 


### PR DESCRIPTION
'Connection refused' YcsbStressEvent is filtered in upgrade test when an upgraded node is
restarted and it's unable to connect to alternator.
In the test https://jenkins.scylladb.com/job/scylla-master/job/rolling-upgrade/job/rolling-upgrade-alternator-test/63/ another wording of this error was received:

```
Unable to execute HTTP request: Connect to alternator:8080 [alternator/10.142.0.127] failed: Connection refused (Connection refused)
```

Change the regex for the filter accordingly

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
