### PR TITLE
fix(artifact test): verify that 'housekeeping' attribute exists

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -37,7 +37,8 @@ class ArtifactsTest(ClusterTester):
         self.housekeeping.connect()
 
     def tearDown(self) -> None:
-        self.housekeeping.close()
+        if getattr(self, "housekeeping", None):
+            self.housekeeping.close()
 
         super().tearDown()
 

--- a/sdcm/utils/housekeeping.py
+++ b/sdcm/utils/housekeeping.py
@@ -61,10 +61,13 @@ class HousekeepingDB:
         return result
 
     def close(self) -> None:
-        self._cursor.close()
-        self._connection.close()
-        self._cursor = None
-        self._connection = None
+        if self._cursor:
+            self._cursor.close()
+            self._cursor = None
+
+        if self._connection:
+            self._connection.close()
+            self._connection = None
 
     def get_most_recent_record(self, query: str, args: Optional[Sequence[Any]] = None) -> Optional[Row]:
         result = self.execute(query + " ORDER BY -dt LIMIT 1", args)


### PR DESCRIPTION
Task:
https://trello.com/c/v204rFpm/4339-attributeerror-artifactstest-object-has-no-attribute-housekeeping

Failed test:
https://jenkins.scylladb.com/job/scylla-master/job/artifacts/job/artifacts-ubuntu2004-arm-test/61/execution/node/52/log/

Test failed because failed to create the node and actually the tes was not started.
As result the 'housekeeping' attribute wasn't created.
The fix is to check if the attribute exists

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
