### PR TITLE
[branch-perf-v8] fix(cluster.py): set prometheus_address to 0.0.0.0

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1617,6 +1617,10 @@ class BaseNode():  # pylint: disable=too-many-instance-attributes,too-many-publi
         with open(yaml_dst_path, 'r') as scylla_yaml_file:
             scylla_yaml_contents = scylla_yaml_file.read()
 
+        # Set prometheus_address to 0.0.0.0
+        pattern = re.compile('\n[# ]*prometheus_address:.*')
+        scylla_yaml_contents = pattern.sub('\nprometheus_address: 0.0.0.0', scylla_yaml_contents)
+
         if seed_address:
             # Set seeds
             pattern = re.compile('seeds:.*')


### PR DESCRIPTION
It's a kind of backport of https://github.com/scylladb/scylla-cluster-tests/pull/4188 to branch-perf-v8

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
