### PR TITLE
fix(mgmt_cli_test): wait for any final task status instead of DONE

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -493,7 +493,9 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
             or manager_tool.add_cluster(name=self.CLUSTER_NAME, db_cluster=self.db_cluster,
                                         auth_token=self.monitors.mgmt_auth_token)
         backup_task = mgr_cluster.create_backup_task(location_list=self.locations)
-        backup_task.wait_for_status(list_status=[TaskStatus.DONE])
+        backup_task_status = backup_task.wait_and_get_final_status(timeout=1500)
+        assert backup_task_status == TaskStatus.DONE, \
+            f"Backup task ended in {backup_task_status} instead of {TaskStatus.DONE}"
         self.verify_backup_success(mgr_cluster=mgr_cluster, backup_task=backup_task)
 
         mgr_cluster.delete()  # remove cluster at the end of the test
@@ -509,7 +511,9 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
         self.log.debug('tables list = {}'.format(tables))
         # TODO: insert data to those tables
         backup_task = mgr_cluster.create_backup_task(location_list=self.locations)
-        backup_task.wait_for_status(list_status=[TaskStatus.DONE], timeout=10800)
+        backup_task_status = backup_task.wait_and_get_final_status(timeout=1500)
+        assert backup_task_status == TaskStatus.DONE, \
+            f"Backup task ended in {backup_task_status} instead of {TaskStatus.DONE}"
         self.verify_backup_success(mgr_cluster=mgr_cluster, backup_task=backup_task)
         self.log.info('finishing test_backup_multiple_ks_tables')
 


### PR DESCRIPTION
In some of the tests in the mgmt_cli_test, the tests wait for the manager
task to reach the status of 'DONE' alone. And if there was an error,
the wait_for function will just wait until timeout is reached.
As such, I used wait_and_get_final_status instead

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
