### PR TITLE
fix(manager pipeline): Added the option to use gce scylla image

### DIFF
--- a/jenkins-pipelines/manager/centos-manager-backup-gce.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-backup-gce.jenkinsfile
@@ -7,6 +7,8 @@ managerPipeline(
     backend: 'gce',
     test_name: 'mgmt_cli_test.MgmtCliTest.test_backup_feature',
     test_config: 'test-cases/manager/manager-regression-gce.yaml',
+    scylla_version: '',  // In the manager scylla_version has a value by default,  but hydra currently can't find gce images by specific version number.
+    // Therefore, I set scylla_version to be empty for this run, and instead set a predetermined scylla machine image
 
     timeout: [time: 500, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',

--- a/test-cases/manager/manager-regression-gce.yaml
+++ b/test-cases/manager/manager-regression-gce.yaml
@@ -9,6 +9,8 @@ n_monitor_nodes: 1
 post_behavior_db_nodes: "destroy"
 post_behavior_loader_nodes: "destroy"
 post_behavior_monitor_nodes: "destroy"
+use_preinstalled_scylla: true
+scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-4.3.repo'
 
 user_prefix: manager-regression
 space_node_threshold: 6442

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -72,6 +72,9 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('scylla_version', 'master:latest')}", description: '', name: 'scylla_version')
             // When branching to manager version branch, set scylla_version to the latest release
             string(defaultValue: '', description: '', name: 'scylla_repo')
+            string(defaultValue: "https://www.googleapis.com/compute/alpha/projects/scylla-images/global/images/7436007548560002989",  // scylla 4.5.2
+                   description: "gce image of scylla (since scylla_version doesn't work with gce)",
+                   name: 'gce_image_db')  // TODO: remove setting once hydra is able to discover scylla images in gce from scylla_version
             string(defaultValue: "${pipelineParams.get('provision_type', 'spot')}",
                    description: 'spot|on_demand|spot_fleet',
                    name: 'provision_type')
@@ -232,12 +235,14 @@ def call(Map pipelineParams) {
 
                                         if [[ ! -z "${params.scylla_ami_id}" ]] ; then
                                             export SCT_AMI_ID_DB_SCYLLA="${params.scylla_ami_id}"
+                                        elif [[ ! -z "${params.gce_image_db}" ]] ; then
+                                            export SCT_GCE_IMAGE_DB="${params.gce_image_db}"  #TODO: remove it once scylla_version supports gce image detection
                                         elif [[ ! -z "${params.scylla_version}" ]] ; then
                                             export SCT_SCYLLA_VERSION="${params.scylla_version}"
                                         elif [[ ! -z "${params.scylla_repo}" ]] ; then
                                             export SCT_SCYLLA_REPO="${params.scylla_repo}"
                                         else
-                                            echo "need to choose one of SCT_AMI_ID_DB_SCYLLA | SCT_SCYLLA_VERSION | SCT_SCYLLA_REPO"
+                                            echo "need to choose one of SCT_AMI_ID_DB_SCYLLA | SCT_GCE_IMAGE_DB | SCT_SCYLLA_VERSION | SCT_SCYLLA_REPO"
                                             exit 1
                                         fi
 


### PR DESCRIPTION
Since SCT can't detect scylla db images when choosing scylla_version,
I modified the default in manager tests to use scylla 4.5.2 for gce_image_db
and set use_preinstalled_scylla to true, so sct will not try to install scylla
on the existing image.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
