### PR TITLE
fix(centos-manager-backup-gce): Removed duplicated scylla_version param

### DIFF
--- a/jenkins-pipelines/manager/centos-manager-backup-gce.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-backup-gce.jenkinsfile
@@ -10,8 +10,6 @@ managerPipeline(
     scylla_version: '',  // In the manager scylla_version has a value by default,  but hydra currently can't find gce images by specific version number.
     // Therefore, I set scylla_version to be empty for this run, and instead set a predetermined scylla machine image
 
-    scylla_version: '4.5',
-
     timeout: [time: 500, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
