### PR TITLE
fix(base node): read scylla-server file with sudo

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -586,7 +586,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             return ''
 
         try:
-            grep_result = self.remoter.run(f'grep "^SCYLLA_ARGS=" {self.scylla_server_sysconfig_path}')
+            grep_result = self.remoter.sudo(f'grep "^SCYLLA_ARGS=" {self.scylla_server_sysconfig_path}')
         except Exception as exc:  # pylint: disable=broad-except
             self.log.error(f"Failed to get SCYLLA_ARGS. Error: {exc}")
             return ''


### PR DESCRIPTION
Task: https://trello.com/c/MyT25VCr/4263-cloud-longevity-fail-to-get-scyllaargs

To find 'SMP' property we read 'scylla-server' file. When a test run on AWS this file
has read permission for root user only. Use sudo

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
