### PR TITLE
fix(artifacts_test): ignore absence of perftune.yaml

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -94,7 +94,10 @@ class ArtifactsTest(ClusterTester):
 
     @cached_property
     def write_back_cache(self) -> int | None:
-        return yaml.safe_load(self.node.remoter.run("cat /etc/scylla.d/perftune.yaml").stdout).get("write_back_cache")
+        res = self.node.remoter.run("cat /etc/scylla.d/perftune.yaml", ignore_status=True)
+        if res.ok:
+            return yaml.safe_load(res.stdout).get("write_back_cache")
+        return None
 
     def check_cluster_name(self):
         with self.node.remote_scylla_yaml() as scylla_yaml:


### PR DESCRIPTION
There is no perftune.yaml on Docker image, so, return None (unset) for
write_back_cache setting in that case.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
