### PR TITLE
fix(sdcm/argus_test_run.py): Check list length before usage

### DIFF
--- a/sdcm/argus_test_run.py
+++ b/sdcm/argus_test_run.py
@@ -218,9 +218,10 @@ class ArgusTestRun:
         LOGGER.info("Preparing Resource Setup...")
         backend = sct_config.get("cluster_backend")
         regions = sct_config.region_names
+        primary_region = regions[0] if len(regions) > 0 else "unknown"
 
         sct_runner_info = CloudInstanceDetails(public_ip=get_sct_runner_ip(), provider=backend,
-                                               region=regions[0], private_ip=get_my_ip())
+                                               region=primary_region, private_ip=get_my_ip())
 
         cloud_setup = cls.BACKEND_MAP.get(backend, _prepare_unknown_resource_setup)(sct_config)
 

--- a/sdcm/argus_test_run.py
+++ b/sdcm/argus_test_run.py
@@ -217,8 +217,9 @@ class ArgusTestRun:
                               config_files=config_files, packages=[])
         LOGGER.info("Preparing Resource Setup...")
         backend = sct_config.get("cluster_backend")
-        regions = sct_config.region_names
-        primary_region = regions[0] if len(regions) > 0 else "unknown"
+        raw_regions = sct_config.get("region_name") or sct_config.get("gce_datacenter") or "undefined_region"
+        regions = raw_regions.split()
+        primary_region = regions[0]
 
         sct_runner_info = CloudInstanceDetails(public_ip=get_sct_runner_ip(), provider=backend,
                                                region=primary_region, private_ip=get_my_ip())


### PR DESCRIPTION
There is a possibility sct_config.region_names can be an empty list,
this ensures an out of bounds access doesn't happen

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [x] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [x] All new and existing unit tests passed (CI)
- [x] ~I have updated the Readme/doc folder accordingly (if needed)~
