### PR TITLE
fix(artifacts): Remove manager agent from arm artifacts

### DIFF
--- a/jenkins-pipelines/artifacts-debian10-arm.jenkinsfile
+++ b/jenkins-pipelines/artifacts-debian10-arm.jenkinsfile
@@ -8,7 +8,7 @@ artifactsPipeline(
     backend: 'aws',
     region_name: 'eu-west-1',
     provision_type: 'spot_low_price',
-    scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/buster/master/latest/scylladb-manager-master/scylla-manager.list',
+    scylla_mgmt_repo: '',
 
     timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'

--- a/jenkins-pipelines/artifacts-ubuntu1804.jenkinsfile
+++ b/jenkins-pipelines/artifacts-ubuntu1804.jenkinsfile
@@ -7,7 +7,7 @@ artifactsPipeline(
     test_config: 'test-cases/artifacts/ubuntu1804.yaml',
     backend: 'gce',
     provision_type: 'spot',
-    scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/bionic/master/latest/scylladb-manager-master/scylla-manager.list',
+    scylla_mgmt_repo: '',
 
     timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'

--- a/jenkins-pipelines/artifacts-ubuntu2004-arm.jenkinsfile
+++ b/jenkins-pipelines/artifacts-ubuntu2004-arm.jenkinsfile
@@ -9,7 +9,6 @@ artifactsPipeline(
     region_name: 'eu-west-1',
     provision_type: 'spot_low_price',
 
-    // scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/focal/master/latest/scylladb-manager-master/scylla-manager.list',
     scylla_mgmt_repo: '',
 
     timeout: [time: 30, unit: 'MINUTES'],


### PR DESCRIPTION
After backporting the artifacts tests of ARM to 2021.1, I need this PR Since manager doesn't support arm instances yet.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
