### PR TITLE
feature(raid_support): Support raid configuration

### DIFF
--- a/configurations/raid/raid5.yaml
+++ b/configurations/raid/raid5.yaml
@@ -1,0 +1,1 @@
+raid_level: 5

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -186,3 +186,5 @@ scylla_apt_keys:
   - '17723034C56D4B19'  # ScyllaDB Package Signing Key 2018 <security@scylladb.com>
   - '5E08FBD8B5D6EC9C'  # ScyllaDB Package Signing Key 2020 <security@scylladb.com>
   - 'D0A112E067426AB2'  # ScyllaDB Package Signing Key 2022 <security@scylladb.com>
+
+raid_level: 0

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -287,3 +287,4 @@
 | **<a href="#user-content-data_volume_disk_iops" name="data_volume_disk_iops">data_volume_disk_iops</a>**  | Number of iops for ebs type io2|io3|gp3 | N/A | SCT_DATA_VOLUME_DISK_IOPS
 | **<a href="#user-content-scylla_bench_version" name="scylla_bench_version">scylla_bench_version</a>**  | A valid tag under the scylla bench repo: https://github.com/scylladb/scylla-bench | N/A | SCT_SCYLLA_BENCH_VERSION
 | **<a href="#user-content-nosqlbench_image" name="nosqlbench_image">nosqlbench_image</a>**  | A docker image of NoSQLBench | N/A | SCT_NOSQLBENCH_IMAGE
+| **<a href="#user-content-raid_level" name="raid_level">raid_level</a>**  | Configure RAID0 or RAID5 on instance | N/A | SCT_RAID_LEVEL

--- a/jenkins-pipelines/longevity-10gb-3h-gce-raid-5.jenkinsfile
+++ b/jenkins-pipelines/longevity-10gb-3h-gce-raid-5.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'gce',
+    region: 'us-east1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-10gb-3h.yaml", "configurations/raid/raid5.yaml"]'''
+)

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -788,11 +788,13 @@ class ScyllaAWSCluster(cluster.BaseScyllaCluster, AWSCluster):
         user_data_format_version = ami_tags.get('user_data_format_version', user_data_format_version)
 
         data_device_type = EBS_VOLUME if params.get("data_volume_disk_num") > 0 else INSTANCE_STORE
+        raid_level = params.get("raid_level")
 
         if parse_version(user_data_format_version) >= parse_version('2'):
             user_data = dict(scylla_yaml=dict(cluster_name=name),
                              start_scylla_on_first_boot=False,
-                             data_device=data_device_type)
+                             data_device=data_device_type,
+                             raid_level=raid_level)
         else:
             user_data = ('--clustername %s '
                          '--totalnodes %s' % (name, sum(n_nodes)))

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -332,6 +332,7 @@ class GCECluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
             """)
         username = self.params.get("gce_image_username")
         public_key = pub_key_from_private_key_file(self.params.get("user_credentials_path"))
+        raid_level = self.params.get("raid_level")
         create_node_params = dict(name=name,
                                   size=self._gce_instance_type,
                                   image=self._gce_image,
@@ -342,7 +343,8 @@ class GCECluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
                                                "NodeIndex": node_index,
                                                "startup-script": startup_script,
                                                "user-data": json.dumps(dict(scylla_yaml=dict(cluster_name=self.name),
-                                                                            start_scylla_on_first_boot=False)),
+                                                                            start_scylla_on_first_boot=False,
+                                                                            raid_level=raid_level)),
                                                "block-project-ssh-keys": "true",
                                                "ssh-keys": f"{username}:ssh-rsa {public_key}", },
                                   ex_service_accounts=self._service_accounts,

--- a/sdcm/provision/common/user_data.py
+++ b/sdcm/provision/common/user_data.py
@@ -22,6 +22,11 @@ class DataDeviceType(str, Enum):
     INSTANCE_STORE = 'instance_store'
 
 
+class RaidLevelType(int, Enum):
+    RAID0 = 0
+    RAID5 = 5
+
+
 class UserDataBuilderBase(AttrBuilder, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def to_string(self) -> str:
@@ -59,3 +64,10 @@ class ScyllaUserDataBuilderBase(UserDataBuilderBase, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def to_string(self) -> str:
         pass
+
+    @property
+    @abc.abstractmethod
+    def raid_level(self) -> RaidLevelType:
+        """
+        Tell scylla setup which raid to build RAID0 or RAID5
+        """

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1233,6 +1233,9 @@ class SCTConfiguration(dict):
              type=int,
              help="Multiply the list of nemesis to execute by the specified factor"),
 
+        dict(name="raid_level", env="SCT_RAID_LEVEL",
+             type=int,
+             help="Number of of raid level: 0 - RAID0, 5 - RAID5"),
     ]
 
     required_params = ['cluster_backend', 'test_duration', 'n_db_nodes', 'n_loaders', 'use_preinstalled_scylla',

--- a/sdcm/sct_provision/aws/user_data.py
+++ b/sdcm/sct_provision/aws/user_data.py
@@ -5,7 +5,7 @@ from typing import Union
 from pydantic import Field
 
 from sdcm.provision.aws.configuration_script import AWSConfigurationScriptBuilder
-from sdcm.provision.common.user_data import UserDataBuilderBase, DataDeviceType, ScyllaUserDataBuilderBase
+from sdcm.provision.common.user_data import UserDataBuilderBase, DataDeviceType, ScyllaUserDataBuilderBase, RaidLevelType
 from sdcm.provision.scylla_yaml import ScyllaYaml
 from sdcm.sct_config import SCTConfiguration
 
@@ -39,6 +39,13 @@ class ScyllaUserDataBuilder(ScyllaUserDataBuilderBase):
         if self.params.get("data_volume_disk_num") > 0:
             return DataDeviceType.ATTACHED.value
         return DataDeviceType.INSTANCE_STORE.value
+
+    @property
+    def raid_level(self) -> RaidLevelType:
+        """
+        Tell scylla setup to create RAID0 or RAID5 on disks
+        """
+        return self.params.get("raid_level") or RaidLevelType.RAID0
 
     @property
     def post_configuration_script(self) -> str:


### PR DESCRIPTION
scylla-4.6 have support to create 2 kind of
raid configuration: RAID0 and RAID5.
Scylla: https://github.com/scylladb/scylla/commit/42fd73d0332d034809c6cd228785bff82e1845aa
Feature: https://github.com/scylladb/scylla/pull/9093

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
