### PR TITLE
fix(rolling-upgrade-with-null-inserts): typo user profile

### DIFF
--- a/configurations/rolling-upgrade-with-null-inserts.yaml
+++ b/configurations/rolling-upgrade-with-null-inserts.yaml
@@ -1,6 +1,6 @@
 # workloads
-stress_before_upgrade: cassandra-stress user profile=/tmp/c-s_null_insert.yaml 'ops(null-insert=1)' no-warmup cl=ONE n=60000000 -port jmx=6868 -mode cql3 native -rate threads=1000
-stress_during_entire_upgrade: cassandra-stress user profile=/tmp/c-s_null_insert.yaml 'ops(insert=1)' no-warmup cl=QUORUM duration=30m -port jmx=6868 -mode cql3 native -rate threads=200
-stress_after_cluster_upgrade: cassandra-stress user profile=/tmp/c-s_null_insert.yaml 'ops(pk-select=1)' no-warmup cl=QUORUM n=60000000 -port jmx=6868 -mode cql3 native -rate threads=200
+stress_before_upgrade: cassandra-stress user profile=/tmp/c-s_null_inserts.yaml 'ops(null-insert=1)' no-warmup cl=ONE n=60000000 -port jmx=6868 -mode cql3 native -rate threads=1000
+stress_during_entire_upgrade: cassandra-stress user profile=/tmp/c-s_null_inserts.yaml 'ops(insert=1)' no-warmup cl=QUORUM duration=30m -port jmx=6868 -mode cql3 native -rate threads=200
+stress_after_cluster_upgrade: cassandra-stress user profile=/tmp/c-s_null_inserts.yaml 'ops(pk-select=1)' no-warmup cl=QUORUM n=60000000 -port jmx=6868 -mode cql3 native -rate threads=200
 
 upgrade_sstables: false


### PR DESCRIPTION
the user profile path/name had a typo (it was missing
the "s" in the end of the file.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
