### PR TITLE
fix(filters): use node name for filtering

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -935,7 +935,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         self._db_log_reader_thread = DbLogReader(
             system_log=self.system_log,
             remoter=self.remoter,
-            node_name=str(self),
+            node_name=str(self.name),
             system_event_patterns=SYSTEM_ERROR_EVENTS_PATTERNS,
             decoding_queue=self.test_config.DECODING_QUEUE,
             log_lines=self.parent_cluster.params.get('logs_transport') in ['rsyslog', 'syslog-ng']

--- a/sdcm/sct_events/filters.py
+++ b/sdcm/sct_events/filters.py
@@ -29,7 +29,7 @@ class DbEventsFilter(BaseFilter):
 
         self.filter_type = db_event.type
         self.filter_line = line
-        self.filter_node = str(node) if node else None
+        self.filter_node = str(node.name if hasattr(node, "name") else node) if node else None
 
     def eval_filter(self, event: LogEventProtocol) -> bool:
         if not isinstance(event, LogEventProtocol):
@@ -44,7 +44,7 @@ class DbEventsFilter(BaseFilter):
             result &= self.filter_line in (getattr(event, "line", "") or "")
 
         if self.filter_node:
-            result &= self.filter_node == getattr(event, "node", "")
+            result &= self.filter_node in (getattr(event, "node", "") or "").split()
 
         return result
 


### PR DESCRIPTION
Trello: https://trello.com/c/pigJaXBg/4379-event-filters-use-node-name-instead-of-strnode

Fixes #4217 

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
