### PR TITLE
fix(gemini-yaml): change oracle version

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -113,7 +113,8 @@ authenticator_password: ''
 gemini_version: '0.9.2'
 n_test_oracle_db_nodes: 1
 gemini_seed: 0
-oracle_scylla_version: ''
+oracle_scylla_version: '4.4.7'
+append_scylla_args_oracle: '--enable-cache false'
 
 # cassandra-stress defaults
 stress_multiplier: 1

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1433,7 +1433,8 @@ class SCTConfiguration(dict):
                                                               dist_version_loader)
 
         # 6.1) handle oracle_scylla_version if exists
-        if oracle_scylla_version := self.get('oracle_scylla_version'):  # pylint: disable=too-many-nested-blocks
+        if (oracle_scylla_version := self.get('oracle_scylla_version')) \
+           and self.get("db_type") == "mixed_scylla":  # pylint: disable=too-many-nested-blocks
             suffix = f" {oracle_scylla_version}"  # ami.name format example: ScyllaDB 4.4.0
             if not self.get('ami_id_db_oracle') and self.get('cluster_backend') == 'aws':
                 ami_list = []

--- a/test-cases/gemini/gemini-1tb-10h.yaml
+++ b/test-cases/gemini/gemini-1tb-10h.yaml
@@ -23,5 +23,3 @@ gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json'
 
 db_type: mixed_scylla
 instance_type_db_oracle: 'i3.16xlarge'
-oracle_scylla_version: '4.3.3'
-append_scylla_args_oracle: '--enable-cache false'

--- a/test-cases/gemini/gemini-3h-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nemesis.yaml
@@ -26,5 +26,3 @@ gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json'
 
 db_type: mixed_scylla
 instance_type_db_oracle: 'i3.8xlarge'
-oracle_scylla_version: '4.3.3'
-append_scylla_args_oracle: '--enable-cache false'

--- a/test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nondisruptive-nemesis.yaml
@@ -25,5 +25,3 @@ gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json'
 
 db_type: mixed_scylla
 instance_type_db_oracle: 'i3.8xlarge'
-oracle_scylla_version: '3.3.2'
-append_scylla_args_oracle: '--enable-cache false'

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -373,38 +373,53 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         target_upgrade_version = conf.get('target_upgrade_version')
         self.assertTrue(target_upgrade_version == '666.development' or target_upgrade_version.endswith(".dev"))
 
-    def test_16_oracle_scylla_version_us_east_1(self):
-        ami_3_0_11 = "ami-0a49c99b529429c18"
+    def test_16_default_oracle_scylla_version_eu_west_1(self):
+        ami_4_4_7 = "ami-0cac6b91be579df80"
 
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
-        os.environ['SCT_ORACLE_SCYLLA_VERSION'] = "3.0.11"
-        os.environ['SCT_REGION_NAME'] = 'us-east-1'
-        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-eae4f795'
-        os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/minimal_test_case.yaml'
-
-        conf = sct_config.SCTConfiguration()
-        conf.verify_configuration()
-
-        self.assertEqual(conf.get('ami_id_db_oracle'), ami_3_0_11)
-
-    def test_16_oracle_scylla_version_eu_west_1(self):
-        ami_3_0_11 = "ami-0535c88b85b914499"
-
-        os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
-        os.environ['SCT_ORACLE_SCYLLA_VERSION'] = "3.0.11"
         os.environ['SCT_REGION_NAME'] = 'eu-west-1'
         os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/minimal_test_case.yaml'
+        os.environ["SCT_DB_TYPE"] = "mixed_scylla"
 
         conf = sct_config.SCTConfiguration()
         conf.verify_configuration()
 
-        self.assertEqual(conf.get('ami_id_db_oracle'), ami_3_0_11)
+        self.assertEqual(conf.get('ami_id_db_oracle'), ami_4_4_7)
 
-    def test_16_oracle_scylla_version_wrong_region(self):
-        ami_3_0_11_eu_west_1 = "ami-0535c88b85b914499"
+    def test_16_oracle_scylla_version_us_east_1(self):
+        ami_4_5_2 = "ami-0e075abbcb95ac10a"
 
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
-        os.environ['SCT_ORACLE_SCYLLA_VERSION'] = "3.0.11"
+        os.environ['SCT_ORACLE_SCYLLA_VERSION'] = "4.5.2"
+        os.environ['SCT_REGION_NAME'] = 'us-east-1'
+        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-eae4f795'
+        os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/minimal_test_case.yaml'
+        os.environ["SCT_DB_TYPE"] = "mixed_scylla"
+
+        conf = sct_config.SCTConfiguration()
+        conf.verify_configuration()
+
+        self.assertEqual(conf.get('ami_id_db_oracle'), ami_4_5_2)
+
+    def test_16_oracle_scylla_version_eu_west_1(self):
+        ami_4_5_2 = "ami-057f1cfd8877782b2"
+
+        os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
+        os.environ['SCT_ORACLE_SCYLLA_VERSION'] = "4.5.2"
+        os.environ['SCT_REGION_NAME'] = 'eu-west-1'
+        os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/minimal_test_case.yaml'
+        os.environ["SCT_DB_TYPE"] = "mixed_scylla"
+
+        conf = sct_config.SCTConfiguration()
+        conf.verify_configuration()
+
+        self.assertEqual(conf.get('ami_id_db_oracle'), ami_4_5_2)
+
+    def test_16_oracle_scylla_version_wrong_region(self):
+        ami_4_5_2_eu_west_1 = "ami-057f1cfd8877782b2"
+
+        os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
+        os.environ['SCT_ORACLE_SCYLLA_VERSION'] = "4.5.2"
         os.environ['SCT_REGION_NAME'] = 'us-east-1'
         os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-eae4f795'
         os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/minimal_test_case.yaml'
@@ -412,7 +427,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         conf = sct_config.SCTConfiguration()
         conf.verify_configuration()
 
-        self.assertNotEqual(conf.get('ami_id_db_oracle'), ami_3_0_11_eu_west_1)
+        self.assertNotEqual(conf.get('ami_id_db_oracle'), ami_4_5_2_eu_west_1)
 
     def test_16_oracle_scylla_version_and_oracle_ami_together(self):
 
@@ -420,6 +435,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         os.environ['SCT_REGION_NAME'] = 'eu-west-1'
         os.environ['SCT_ORACLE_SCYLLA_VERSION'] = '3.0.11'
         os.environ['SCT_AMI_ID_DB_ORACLE'] = 'ami-0535c88b85b914499'
+        os.environ["SCT_DB_TYPE"] = "mixed_scylla"
         os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/minimal_test_case.yaml'
 
         with self.assertRaises(ValueError) as context:

--- a/unit_tests/test_data/test_scylla_yaml_builders/PR-provision-test.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/PR-provision-test.yaml
@@ -22,7 +22,7 @@ instance_provision: 'spot'
 
 gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
 
-scylla_version: 4.4.1
+scylla_version: 4.4.7
 scylla_mgmt_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.3.repo'
 
 workaround_kernel_bug_for_iotune: true

--- a/unit_tests/test_scylla_yaml_builders.py
+++ b/unit_tests/test_scylla_yaml_builders.py
@@ -494,7 +494,7 @@ class DummyNode(BaseNode):  # pylint: disable=abstract-method
 class IntegrationTests(unittest.TestCase):
     get_scylla_ami_version_output = ObjectDict(**{
         'Architecture': 'x86_64', 'CreationDate': '2021-04-11T11:42:47.000Z',
-        'ImageId': 'ami-01717260ff878ed92', 'ImageLocation': '797456418907/ScyllaDB 4.4.1',
+        'ImageId': 'ami-01717260ff878ed92', 'ImageLocation': '797456418907/ScyllaDB 4.4.7',
         'ImageType': 'machine', 'Public': True, 'OwnerId': '797456418907',
         'PlatformDetails': 'Linux/UNIX', 'UsageOperation': 'RunInstances',
         'State': 'available', 'BlockDeviceMappings': [
@@ -520,18 +520,18 @@ class IntegrationTests(unittest.TestCase):
              'VirtualName': 'ephemeral6'},
             {'DeviceName': '/dev/sdi',
              'VirtualName': 'ephemeral7'}],
-        'Description': 'ScyllaDB 4.4.1', 'EnaSupport': True, 'Hypervisor': 'xen',
-        'Name': 'ScyllaDB 4.4.1', 'RootDeviceName': '/dev/sda1', 'RootDeviceType': 'ebs',
+        'Description': 'ScyllaDB 4.4.7', 'EnaSupport': True, 'Hypervisor': 'xen',
+        'Name': 'ScyllaDB 4.4.7', 'RootDeviceName': '/dev/sda1', 'RootDeviceType': 'ebs',
         'Tags': [
-            {'Key': 'ScyllaMachineImageVersion', 'Value': '4.4.1-20210407.3e5b0f86c2'},
-            {'Key': 'ScyllaPython3Version', 'Value': '4.4.1-0.20210406.00da6b5e9'},
+            {'Key': 'ScyllaMachineImageVersion', 'Value': '4.4.7-20210407.3e5b0f86c2'},
+            {'Key': 'ScyllaPython3Version', 'Value': '4.4.7-0.20210406.00da6b5e9'},
             {'Key': 'user_data_format_version', 'Value': '2'},
-            {'Key': 'ScyllaToolsVersion', 'Value': '4.4.1-0.20210406.00da6b5e9'},
-            {'Key': 'ScyllaJMXVersion', 'Value': '4.4.1-0.20210406.00da6b5e9'},
+            {'Key': 'ScyllaToolsVersion', 'Value': '4.4.7-0.20210406.00da6b5e9'},
+            {'Key': 'ScyllaJMXVersion', 'Value': '4.4.7-0.20210406.00da6b5e9'},
             {'Key': 'branch', 'Value': 'branch-4.4'},
             {'Key': 'scylla-git-commit', 'Value': '1439d48e2a2b5a3841a87b47f1f52d6fb904a902'},
             {'Key': 'build-tag', 'Value': 'jenkins-scylla-4.4-ami-52'},
-            {'Key': 'ScyllaVersion', 'Value': '4.4.1-0.20210406.00da6b5e9'},
+            {'Key': 'ScyllaVersion', 'Value': '4.4.7-0.20210406.00da6b5e9'},
             {'Key': 'build-id', 'Value': '52'}
         ], 'VirtualizationType': 'hvm'})
 


### PR DESCRIPTION
Change Oracle version for gemini tests to 4.4.7

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
