### PR TITLE
fix(nemesis): Use proper values for the 'preimage' CDC option

### DIFF
--- a/sdcm/utils/cdc/options.py
+++ b/sdcm/utils/cdc/options.py
@@ -11,7 +11,7 @@ CDC_LOGTABLE_SUFFIX = "_scylla_cdc_log"
 CDC_SETTINGS_NAMES_VALUES = {
     "enabled": [True, False],
     "delta": ["full", "keys"],
-    "preimage": ["full", "on", "off"],
+    "preimage": ["full", "true", "false"],
     "postimage": [True, False],
     "ttl": "86400"
 }


### PR DESCRIPTION
Support of the 'on' and 'off' values for the 'preimage' CDC option
was recently removed [1].
So, switch to the documented 'true' and 'false' values to make
'ToggleCdcFeaturePropertiesOnTable' nemesis work.

[1] https://github.com/scylladb/scylla/pull/9639

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
