### PR TITLE
fix(nemesis): add 'limited' filter for nosqlbench test case

### DIFF
--- a/test-cases/longevity/longevity-nosqlbench-3h.yaml
+++ b/test-cases/longevity/longevity-nosqlbench-3h.yaml
@@ -14,7 +14,7 @@ gce_instance_type_loader: 'e2-standard-4'
 
 ssh_transport: 'libssh2'
 
-nemesis_class_name: 'SisyphusMonkey'
+nemesis_class_name: 'ChaosMonkey'
 nemesis_interval: 10
 
 user_prefix: 'longevity-nosqlbench-3h'


### PR DESCRIPTION
Small fix for the nosqlbench longevity test case.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
