### PR TITLE
test(lwt longevity): using non-deterministic function in PK

### DIFF
--- a/data_dir/lwt_builtin_functions.yaml
+++ b/data_dir/lwt_builtin_functions.yaml
@@ -1,0 +1,71 @@
+# LWT test: create and update data using LWT.
+### DML ###
+
+# Keyspace Name
+keyspace: lwt_builtin_function_test
+
+# The CQL for creating a keyspace (optional if it already exists)
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS lwt_builtin_function_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};
+
+# Table name
+table: blogposts
+
+# The CQL for creating a table you wish to stress (optional if it already exists)
+table_definition: |
+  CREATE TABLE IF NOT EXISTS blogposts (
+        domain uuid,
+        published_date timestamp,
+        lwt_indicator date,
+        url text,
+        author text,
+        title text,
+        PRIMARY KEY((domain, published_date), lwt_indicator)
+  ) WITH compaction = { 'class':'LeveledCompactionStrategy' }
+    AND comment='A table to hold blog posts'
+
+
+### Column Distribution Specifications ###
+
+columnspec:
+  - name: domain
+    population: seq(1..10000000)  #10M possible domains to pick from
+
+  - name: published_date
+    cluster: uniform(1..1001000)         #under each domain we will have max 1000 posts
+
+  - name: lwt_indicator
+    population: seq(1..1001000)
+
+  - name: url
+    size: uniform(30..30)
+
+  - name: title                  #titles shouldn't go beyond 200 chars
+    size: gaussian(10..20)
+
+  - name: author
+    size: uniform(5..20)         #author names should be short
+
+### Batch Ratio Distribution Specifications ###
+
+insert:
+  partitions: fixed(1)            # Our partition key is the domain so only insert one per batch
+
+  select:    fixed(1)/1000        # We have 1000 posts per domain so 1/1000 will allow 1 post per batch
+
+  batchtype: UNLOGGED             # Unlogged batches
+
+
+#
+# A list of queries you wish to run against the schema
+#
+queries:
+   insert_query:
+      cql: insert into blogposts (domain, published_date, lwt_indicator, url, author, title) values (uuid(),currentTimestamp(),currentDate(),?,?,?) if not exists
+      fields: samerow
+   lwt_update_by_pk:
+      cql: update blogposts set url = ? where domain = ? and published_date = ? and lwt_indicator = ? if exists
+      fields: samerow
+   lwt_update_by_ck:
+      cql: update blogposts set url = ? where domain = ? and published_date = ? and lwt_indicator = ? if exists
+      fields: samerow

--- a/test-cases/longevity/longevity-lwt-500G-3d.yaml
+++ b/test-cases/longevity/longevity-lwt-500G-3d.yaml
@@ -1,10 +1,16 @@
 test_duration: 4450
 prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml n=133333333 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=100 -pop seq=1..133333333",
                     "cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml n=133333333 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=100 -pop seq=133333334..266666666",
-                    "cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml n=133333333 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=100 -pop seq=266666667..400000000"
+                    "cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml n=133333333 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=100 -pop seq=266666667..400000000",
+                    "cassandra-stress user profile=/tmp/lwt_builtin_functions.yaml n=33333333 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=50 -pop seq=1..33333333",
+                    "cassandra-stress user profile=/tmp/lwt_builtin_functions.yaml n=33333333 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=50 -pop seq=33333334..66666666",
+                    "cassandra-stress user profile=/tmp/lwt_builtin_functions.yaml n=33333333 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=50 -pop seq=66666667..100000000",
                    ]
 stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1,lwt_deletes=1)' cl=QUORUM duration=3600m -mode native cql3 -rate threads=10" ,
-             "cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1,lwt_deletes=1)' cl=QUORUM duration=3600m -mode native cql3 -rate threads=10"
+             "cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1,lwt_deletes=1)' cl=QUORUM duration=3600m -mode native cql3 -rate threads=10",
+             "cassandra-stress user profile=/tmp/lwt_builtin_functions.yaml ops'(lwt_update_by_pk=1,lwt_update_by_ck=1)' cl=QUORUM duration=3600m -mode native cql3 -rate threads=10 -pop seq=1..33333333",
+             "cassandra-stress user profile=/tmp/lwt_builtin_functions.yaml ops'(lwt_update_by_pk=1,lwt_update_by_ck=1)' cl=QUORUM duration=3600m -mode native cql3 -rate threads=10 -pop seq=33333334..66666666",
+             "cassandra-stress user profile=/tmp/lwt_builtin_functions.yaml ops'(lwt_update_by_pk=1,lwt_update_by_ck=1)' cl=QUORUM duration=3600m -mode native cql3 -rate threads=10 -pop seq=66666667..100000000"
             ]
 stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml ops'(select=1)' cl=SERIAL duration=3600m -mode native cql3 -rate threads=10" ]
 

--- a/test-cases/longevity/longevity-lwt-basic-3h.yaml
+++ b/test-cases/longevity/longevity-lwt-basic-3h.yaml
@@ -1,7 +1,9 @@
 test_duration: 300
-prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml n=10000000 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=30"]
+prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml n=10000000 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=30",
+                    "cassandra-stress user profile=/tmp/lwt_builtin_functions.yaml n=1000000 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=20"]
 stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=QUORUM duration=160m -mode native cql3 -rate threads=20",
-             "cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=QUORUM duration=160m -mode native cql3 -rate threads=20"
+             "cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=QUORUM duration=160m -mode native cql3 -rate threads=20",
+             "cassandra-stress user profile=/tmp/lwt_builtin_functions.yaml ops'(lwt_update_by_pk=1,lwt_update_by_ck=1)' cl=QUORUM duration=160m -mode native cql3 -rate threads=10"
             ]
 stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(select=1)' cl=SERIAL duration=160m -mode native cql3 -rate threads=20" ]
 


### PR DESCRIPTION
Issue: https://github.com/scylladb/scylla/issues/8604
Task: https://trello.com/c/N9mTs8tp/4382-sct-using-non-deterministic-functions-in-partition-
keys-issue-8604

When type of PK column is non-determenistic function (like, uuid, currentTimestamp), LWT queries
sporadic fail.

Run this queries with multiple threads and long time to increase chance to get failure 

Fix: https://github.com/scylladb/scylla/commit/0876248c2b4296295fbd28c536b606bb0398c3fa

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
