### PR TITLE
fix(aws_pricing): price i4 as i3

### DIFF
--- a/sdcm/utils/pricing.py
+++ b/sdcm/utils/pricing.py
@@ -17,7 +17,7 @@ class AWSPricing:
         self.pricing_client: PricingClient = boto3.client('pricing', region_name='us-east-1')
 
     @lru_cache(maxsize=None)
-    def get_on_demand_instance_price(self, region_name, instance_type):
+    def get_on_demand_instance_price(self, region_name: str, instance_type: str):
         regions_names_map = {
             'us-east-2': 'US East (Ohio)',
             'us-east-1': 'US East (N. Virginia)',
@@ -77,6 +77,9 @@ class AWSPricing:
 
     def get_instance_price(self, region, instance_type, state, lifecycle):
         if state == "running":
+            if instance_type.startswith("i4"):
+                LOGGER.warning("AWSPricing: i4 instance type is not generally available")
+                return 0
             if lifecycle == InstanceLifecycle.ON_DEMAND:
                 return self.get_on_demand_instance_price(region_name=region, instance_type=instance_type)
             if lifecycle == InstanceLifecycle.SPOT:


### PR DESCRIPTION
since i4 is still no generally available there are
no prices for i4 family in AWS pricing API

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
