### PR TITLE
fix(email): print link for archive of sct.log

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -259,7 +259,7 @@ def get_latest_gemini_version():
 
 
 def list_logs_by_test_id(test_id):
-    log_types = ['db-cluster', 'monitor-set', 'loader-set', 'sct-runner', 'jepsen-data', 'siren-manager-set',
+    log_types = ['db-cluster', 'monitor-set', 'loader-set', 'sct', 'jepsen-data', 'siren-manager-set',
                  'prometheus', 'grafana', 'kubernetes', 'job', 'monitoring_data_stack', 'event', 'output', 'error',
                  'summary', 'warning', 'critical', 'normal', 'debug', 'left_processes', 'email_data']
 


### PR DESCRIPTION
Task: https://trello.com/c/4PeL1Tke/4199-link-to-sctlog-is-missing-in-the-email

If sct.log size is big, we create logs archive not as single archive but per file.
In this case the link for sct.log archive can be found on the job run console, but missed in the email
and issue template.

Example of fixed email:
```
Logs:
grafana - [https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101240/grafana-screenshot-overview-20211222_101240-longevity-10gb-3h-archive--monitor-node-c63a6913-1.png](https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101240/grafana-screenshot-overview-20211222_101240-longevity-10gb-3h-archive--monitor-node-c63a6913-1.png)
grafana - [https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101240/grafana-screenshot-staging-10gb-3h-scylla-per-server-metrics-nemesis-20211222_101403-longevity-10gb-3h-archive--monitor-node-c63a6913-1.png](https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101240/grafana-screenshot-staging-10gb-3h-scylla-per-server-metrics-nemesis-20211222_101403-longevity-10gb-3h-archive--monitor-node-c63a6913-1.png)
critical - [https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/critical-c63a6913.log.tar.gz](https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/critical-c63a6913.log.tar.gz)
db-cluster - [https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/db-cluster-c63a6913.tar.gz](https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/db-cluster-c63a6913.tar.gz)
debug - [https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/debug-c63a6913.log.tar.gz](https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/debug-c63a6913.log.tar.gz)
email_data - [https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/email_data.json.tar.gz](https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/email_data.json.tar.gz)
error - [https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/error-c63a6913.log.tar.gz](https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/error-c63a6913.log.tar.gz)
event - [https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/events-c63a6913.log.tar.gz](https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/events-c63a6913.log.tar.gz)
left_processes - [https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/left_processes-c63a6913.log.tar.gz](https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/left_processes-c63a6913.log.tar.gz)
loader-set - [https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/loader-set-c63a6913.tar.gz](https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/loader-set-c63a6913.tar.gz)
monitor-set - [https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/monitor-set-c63a6913.tar.gz](https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/monitor-set-c63a6913.tar.gz)
normal - [https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/normal-c63a6913.log.tar.gz](https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/normal-c63a6913.log.tar.gz)
output - [https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/output-c63a6913.log.tar.gz](https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/output-c63a6913.log.tar.gz)
event - [https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/raw_events-c63a6913.log.tar.gz](https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/raw_events-c63a6913.log.tar.gz)
sct - [https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/sct-c63a6913.log.tar.gz](https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/sct-c63a6913.log.tar.gz)
summary - [https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/summary-c63a6913.log.tar.gz](https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/summary-c63a6913.log.tar.gz)
warning - [https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/warning-c63a6913.log.tar.gz](https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_101636/warning-c63a6913.log.tar.gz)
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
