### PR TITLE
fix(logcollector): fix names in case archive per file

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -982,7 +982,15 @@ def collect_logs(test_id=None, logdir=None, backend=None, config_file=None):
     table.align = 'l'
     for cluster_type, s3_links in collected_logs.items():
         for link in s3_links:
-            table.add_row([cluster_type, link])
+            current_cluster_type = cluster_type
+            # Cover case when archive is created per log file not all logs in one archive.
+            # Here log name is extracted from archive name. For example:
+            # for link https://cloudius-jenkins-test.s3.amazonaws.com/c63a6913-6253-45a0-b5cf-d553f713fe81/20211222_
+            # 101636/warning-c63a6913.log.tar.gz
+            #  current_cluster_type will be "warning"
+            if cluster_type == 'sct-runner' and cluster_type not in link:
+                current_cluster_type = link.split("/")[-1].split("-")[0]
+            table.add_row([current_cluster_type, link])
 
     click.echo(table.get_string(title="Collected logs by test-id: {}".format(collector.test_id)))
     store_logs_in_argus(test_id=UUID(collector.test_id), logs=collected_logs)


### PR DESCRIPTION
This commit presents 2 fixes for case when a log archive is created per file:
1. add test_id to archive name how it's done for all other archives
2. when list of archive links is printed on console, set link name according to the
log file, like:
`warning` for link of warning.log (and not 'sct-runner' like it is printed now)


Test result:
```
14:27:57  +---------------------------------------------------------------------------------------------------------------------------------------------------------+
14:27:57  |                                             Collected logs by test-id: a656ccff-c8d0-4fb1-9204-4a9100d8d127                                             |
14:27:57  +----------------+----------------------------------------------------------------------------------------------------------------------------------------+
14:27:57  | Cluster set    | Link                                                                                                                                   |
14:27:57  +----------------+----------------------------------------------------------------------------------------------------------------------------------------+
14:27:57  | db-cluster     | https://cloudius-jenkins-test.s3.amazonaws.com/a656ccff-c8d0-4fb1-9204-4a9100d8d127/20211222_122344/db-cluster-a656ccff.tar.gz         |
14:27:57  | monitor-set    | https://cloudius-jenkins-test.s3.amazonaws.com/a656ccff-c8d0-4fb1-9204-4a9100d8d127/20211222_122344/monitor-set-a656ccff.tar.gz        |
14:27:57  | loader-set     | https://cloudius-jenkins-test.s3.amazonaws.com/a656ccff-c8d0-4fb1-9204-4a9100d8d127/20211222_122344/loader-set-a656ccff.tar.gz         |
14:27:57  | normal         | https://cloudius-jenkins-test.s3.amazonaws.com/a656ccff-c8d0-4fb1-9204-4a9100d8d127/20211222_122344/normal-a656ccff.log.tar.gz         |
14:27:57  | summary        | https://cloudius-jenkins-test.s3.amazonaws.com/a656ccff-c8d0-4fb1-9204-4a9100d8d127/20211222_122344/summary-a656ccff.log.tar.gz        |
14:27:57  | events         | https://cloudius-jenkins-test.s3.amazonaws.com/a656ccff-c8d0-4fb1-9204-4a9100d8d127/20211222_122344/events-a656ccff.log.tar.gz         |
14:27:57  | output         | https://cloudius-jenkins-test.s3.amazonaws.com/a656ccff-c8d0-4fb1-9204-4a9100d8d127/20211222_122344/output-a656ccff.log.tar.gz         |
14:27:57  | debug          | https://cloudius-jenkins-test.s3.amazonaws.com/a656ccff-c8d0-4fb1-9204-4a9100d8d127/20211222_122344/debug-a656ccff.log.tar.gz          |
14:27:57  | sct            | https://cloudius-jenkins-test.s3.amazonaws.com/a656ccff-c8d0-4fb1-9204-4a9100d8d127/20211222_122344/sct-a656ccff.log.tar.gz            |
14:27:57  | error          | https://cloudius-jenkins-test.s3.amazonaws.com/a656ccff-c8d0-4fb1-9204-4a9100d8d127/20211222_122344/error-a656ccff.log.tar.gz          |
14:27:57  | critical       | https://cloudius-jenkins-test.s3.amazonaws.com/a656ccff-c8d0-4fb1-9204-4a9100d8d127/20211222_122344/critical-a656ccff.log.tar.gz       |
14:27:57  | raw_events     | https://cloudius-jenkins-test.s3.amazonaws.com/a656ccff-c8d0-4fb1-9204-4a9100d8d127/20211222_122344/raw_events-a656ccff.log.tar.gz     |
14:27:57  | warning        | https://cloudius-jenkins-test.s3.amazonaws.com/a656ccff-c8d0-4fb1-9204-4a9100d8d127/20211222_122344/warning-a656ccff.log.tar.gz        |
14:27:57  | email_data     | https://cloudius-jenkins-test.s3.amazonaws.com/a656ccff-c8d0-4fb1-9204-4a9100d8d127/20211222_122344/email_data-a656ccff.json.tar.gz    |
14:27:57  | left_processes | https://cloudius-jenkins-test.s3.amazonaws.com/a656ccff-c8d0-4fb1-9204-4a9100d8d127/20211222_122344/left_processes-a656ccff.log.tar.gz |
14:27:57  +----------------+----------------------------------------------------------------------------------------------------------------------------------------+
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
