### PR TITLE
fix(argus_test_run.py): Fix multi-dc node amounts

### DIFF
--- a/sdcm/argus_test_run.py
+++ b/sdcm/argus_test_run.py
@@ -37,14 +37,24 @@ class ArgusTestRunError(Exception):
     pass
 
 
+def _get_node_amounts(config: SCTConfiguration) -> tuple[int, int]:
+    num_db_node = config.get("n_db_nodes")
+    num_db_node = sum([int(i) for i in num_db_node.split()]) if isinstance(num_db_node, str) else num_db_node
+    num_loaders = config.get("n_loaders")
+    num_loaders = sum([int(i) for i in num_loaders.split()]) if isinstance(num_loaders, str) else num_loaders
+
+    return num_db_node, num_loaders
+
+
 def _prepare_aws_resource_setup(sct_config: SCTConfiguration):
+    num_db_nodes, n_loaders = _get_node_amounts(sct_config)
     db_node_setup = CloudNodesInfo(image_id=sct_config.get("ami_id_db_scylla"),
                                    instance_type=sct_config.get("instance_type_db"),
-                                   node_amount=sct_config.get("n_db_nodes"),
+                                   node_amount=num_db_nodes,
                                    post_behaviour=sct_config.get("post_behavior_db_nodes"))
     loader_node_setup = CloudNodesInfo(image_id=sct_config.get("ami_id_loader"),
                                        instance_type=sct_config.get("instance_type_loader"),
-                                       node_amount=sct_config.get("n_loaders"),
+                                       node_amount=n_loaders,
                                        post_behaviour=sct_config.get("post_behavior_loader_nodes"))
     monitor_node_setup = CloudNodesInfo(image_id=sct_config.get("ami_id_monitor"),
                                         instance_type=sct_config.get("instance_type_monitor"),
@@ -57,13 +67,14 @@ def _prepare_aws_resource_setup(sct_config: SCTConfiguration):
 
 
 def _prepare_gce_resource_setup(sct_config: SCTConfiguration):
+    num_db_nodes, n_loaders = _get_node_amounts(sct_config)
     db_node_setup = CloudNodesInfo(image_id=sct_config.get("gce_image_db"),
                                    instance_type=sct_config.get("gce_instance_type_db"),
-                                   node_amount=sct_config.get("n_db_nodes"),
+                                   node_amount=num_db_nodes,
                                    post_behaviour=sct_config.get("post_behavior_db_nodes"))
     loader_node_setup = CloudNodesInfo(image_id=sct_config.get("gce_image_loader"),
                                        instance_type=sct_config.get("gce_instance_type_loader"),
-                                       node_amount=sct_config.get("n_loaders"),
+                                       node_amount=n_loaders,
                                        post_behaviour=sct_config.get("post_behavior_loader_nodes"))
     monitor_node_setup = CloudNodesInfo(image_id=sct_config.get("gce_image_monitor"),
                                         instance_type=sct_config.get("gce_instance_type_monitor"),


### PR DESCRIPTION
Multi-DC configuration uses strings for specifying node amounts, which
is not supported by Argus' CloudNodesInfo. For now, those amounts will
be summed into a single number and saved this way.

[Trello](https://trello.com/c/dUaQq5nc/4438-argusdb-failed-to-setup-connection)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [x] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [x] All new and existing unit tests passed (CI)
- [x] ~I have updated the Readme/doc folder accordingly (if needed)~
