### PR TITLE
fix(provision): make it work for ipv6

### DIFF
--- a/sdcm/provision/aws/provisioner.py
+++ b/sdcm/provision/aws/provisioner.py
@@ -119,7 +119,7 @@ class AWSInstanceProvisioner(InstanceProvisionerBase):  # pylint: disable=too-fe
             count: int,
             tags: List[TagsType]) -> List[Instance]:
         instance_parameters_dict = instance_parameters.dict(
-            exclude_none=True, exclude_defaults=True, exclude_unset=True)
+            exclude_none=True, exclude_defaults=True, exclude_unset=True, encode_user_data=False)
         LOGGER.info("[%s] Creating {count} on-demand instances using AMI id '%s' with following parameters:\n%s",
                     provision_parameters.region_name,
                     instance_parameters.ImageId,
@@ -133,7 +133,7 @@ class AWSInstanceProvisioner(InstanceProvisionerBase):  # pylint: disable=too-fe
                 instance_tags = tags.pop()
                 set_tags_on_instances(
                     region_name=provision_parameters.region_name,
-                    instance_ids=[instance.instance_id for instance in instances],
+                    instance_ids=[instance.instance_id],
                     tags={'Name': 'spot_fleet_{}_{}'.format(instance.instance_id, ind)} | instance_tags,
                 )
         return instances
@@ -179,7 +179,12 @@ class AWSInstanceProvisioner(InstanceProvisionerBase):  # pylint: disable=too-fe
             count=count,
             price=provision_parameters.price,
             fleet_role=self._iam_fleet_role,
-            instance_parameters=instance_parameters.dict(exclude_none=True, exclude_unset=True, exclude_defaults=True),
+            instance_parameters=instance_parameters.dict(
+                exclude_none=True,
+                exclude_unset=True,
+                exclude_defaults=True,
+                encode_user_data=True,
+            ),
         )
         instance_ids = wait_for_provision_request_done(
             region_name=provision_parameters.region_name,
@@ -266,7 +271,12 @@ class AWSInstanceProvisioner(InstanceProvisionerBase):  # pylint: disable=too-fe
             region_name=provision_parameters.region_name,
             count=count,
             price=getattr(provision_parameters, 'price', None),
-            instance_parameters=instance_parameters.dict(exclude_none=True, exclude_unset=True, exclude_defaults=True),
+            instance_parameters=instance_parameters.dict(
+                exclude_none=True,
+                exclude_unset=True,
+                exclude_defaults=True,
+                encode_user_data=True,
+            ),
             full_availability_zone=self._full_availability_zone_name(provision_parameters),
             valid_until=self._spot_valid_until,
             duration=self._spot_block_duration(provision_parameters),

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1649,7 +1649,8 @@ class SCTConfiguration(dict):
         self._verify_data_volume_configuration(backend)
 
         self._validate_seeds_number()
-        self._validate_nemesis_can_run_on_non_seed()
+        if self.get('n_db_nodes'):
+            self._validate_nemesis_can_run_on_non_seed()
         if 'extra_network_interface' in self and len(self.region_names) >= 2:
             raise ValueError("extra_network_interface isn't supported for multi region use cases")
         self._check_partition_range_with_data_validation_correctness()
@@ -1710,7 +1711,6 @@ class SCTConfiguration(dict):
             return
         seeds_num = self.get('seeds_num')
         num_of_db_nodes = sum([int(i) for i in str(self.get('n_db_nodes')).split(' ')]) + int(self.get('add_node_cnt'))
-
         assert num_of_db_nodes > seeds_num, \
             "Nemesis cannot run when 'nemesis_filter_seeds' is true and seeds number is equal to nodes number"
 

--- a/sdcm/sct_provision/aws/cluster.py
+++ b/sdcm/sct_provision/aws/cluster.py
@@ -203,6 +203,8 @@ class ClusterBase(BaseModel):
         return AWSInstanceParams(**params_builder.dict(exclude_none=True, exclude_unset=True, exclude_defaults=True))
 
     def provision(self):
+        if self._node_nums == [0]:
+            return []
         total_instances_provisioned = []
         for region_id in range(len(self._regions)):
             instance_parameters = self._instance_parameters(region_id=region_id)

--- a/sdcm/sct_provision/aws/instance_parameters_builder.py
+++ b/sdcm/sct_provision/aws/instance_parameters_builder.py
@@ -12,7 +12,6 @@
 # Copyright (c) 2021 ScyllaDB
 
 import abc
-import base64
 from functools import cached_property
 from typing import Union, List, Optional, Tuple
 
@@ -93,10 +92,8 @@ class AWSInstanceParamsBuilder(AWSInstanceParamsBuilderBase, metaclass=abc.ABCMe
         if not self.user_data_raw:
             return None
         if isinstance(self.user_data_raw, UserDataBuilderBase):
-            user_data = self.user_data_raw.to_string()
-        else:
-            user_data = self.user_data_raw
-        return base64.b64encode(user_data.encode('ascii')).decode("ascii")
+            return self.user_data_raw.to_string()
+        return self.user_data_raw
 
     @cached_property
     def _root_device_name(self):


### PR DESCRIPTION
https://trello.com/c/P7Eo1SdE/4446-provision-fix-issue-with-ipv6

Reason why IPV6 did on work on provisioned instances was that user-data was not executed on them.
There are two reasons for that :
1. We used scylla-based user data for loaders, which was wrong
2. Something in the scripts did not allow it to be executed properly

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
