### PR TITLE
refactor(test_default): Set master branch to use manager 2.5

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -6,7 +6,7 @@ ip_ssh_connections: 'private'
 
 scylla_repo: ''
 
-manager_version: 'master_latest'
+manager_version: '2.5'
 manager_scylla_backend_version: '2021'  # Notice: that centos, ubuntu 20 and debian 10 monitors use 2021, while debian 9, ubuntu 16 and ubuntu 18 use 2020, since we support both
 
 scylla_repo_loader: ''


### PR DESCRIPTION
Manager mastr isn't stable and changes aren't communicated well to
the QA team. Hence, I decided to test scylla master with a "Fixed"
latest released manager version.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
