### PR TITLE
fix(scylla-bench-thread): Run sb read cmd with timestamp from sb write

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4383,6 +4383,7 @@ class BaseLoaderSet():
         self.params = params
         self._gemini_version = None
         self._gemini_base_path = None
+        self.sb_write_timeseries_ts = None
 
     @property
     def gemini_version(self):

--- a/test-cases/longevity/longevity-twcs-3h.yaml
+++ b/test-cases/longevity/longevity-twcs-3h.yaml
@@ -1,10 +1,13 @@
 test_duration: 210
 bench_run: true
 
-stress_cmd: ["scylla-bench -workload=timeseries -mode=write -replication-factor=3 -partition-count=400 -clustering-row-count=10000000 -clustering-row-size=200 -concurrency=100 -rows-per-request=100  -connection-count 100 -max-rate 50000 --timeout 120s -duration=170m"]
+stress_cmd: ["scylla-bench -workload=timeseries -mode=write -replication-factor=3 -partition-count=400 -clustering-row-count=10000000 -clustering-row-size=200 -concurrency=100 -rows-per-request=100 -start-timestamp=SET_WRITE_TIMESTAMP -connection-count 100 -max-rate 50000 --timeout 120s -duration=170m"]
+# write-rate with timeseries workload for read mode
+# calculated from timeseries workload for write mode by formula:
+# write-rate = -max-rate / -partition-count = 50000 / 400 = 125
 stress_read_cmd: [
-    "scylla-bench -workload=timeseries -mode=read -partition-count=20000 -concurrency=100 -replication-factor=3 -clustering-row-count=10000000 -clustering-row-size=200  -rows-per-request=100 -start-timestamp=SCT_TIME -write-rate 125 -duration=10m -distribution hnormal --connection-count 100 -duration=170m",
-    "scylla-bench -workload=timeseries -mode=read -partition-count=20000 -concurrency=100 -replication-factor=3 -clustering-row-count=10000000 -clustering-row-size=200  -rows-per-request=100 -start-timestamp=SCT_TIME -write-rate 125 -duration=10m -distribution uniform --connection-count 100 -duration=170m"
+    "scylla-bench -workload=timeseries -mode=read -partition-count=20000 -concurrency=100 -replication-factor=3 -clustering-row-count=10000000 -clustering-row-size=200  -rows-per-request=100 -start-timestamp=GET_WRITE_TIMESTAMP -write-rate 125 -distribution hnormal --connection-count 100 -duration=170m",
+    "scylla-bench -workload=timeseries -mode=read -partition-count=20000 -concurrency=100 -replication-factor=3 -clustering-row-count=10000000 -clustering-row-size=200  -rows-per-request=100 -start-timestamp=GET_WRITE_TIMESTAMP -write-rate 125 -distribution uniform --connection-count 100 -duration=170m"
     ]
 
 n_db_nodes: 5
@@ -21,3 +24,5 @@ nemesis_during_prepare: false
 space_node_threshold: 64424
 
 user_prefix: 'longevity-twcs-3h'
+
+post_prepare_cql_cmds: "ALTER TABLE scylla_bench.test with gc_grace_seconds = 300;"

--- a/test-cases/longevity/longevity-twcs-48h.yaml
+++ b/test-cases/longevity/longevity-twcs-48h.yaml
@@ -1,10 +1,13 @@
 test_duration: 3000
 bench_run: true
 
-stress_cmd: ["scylla-bench -workload=timeseries -mode=write -replication-factor=3 -partition-count=400 -clustering-row-count=10000000 -clustering-row-size=200 -concurrency=100 -rows-per-request=100  -connection-count 100 -max-rate 50000 --timeout 120s -duration=2880m"]
+stress_cmd: ["scylla-bench -workload=timeseries -mode=write -replication-factor=3 -partition-count=400 -clustering-row-count=10000000 -clustering-row-size=200 -concurrency=100 -rows-per-request=100 -start-timestamp=SET_WRITE_TIMESTAMP -connection-count 100 -max-rate 50000 --timeout 120s -duration=2880m"]
+# write-rate with timeseries workload for read mode
+# calculated from timeseries workload for write mode by formula:
+# write-rate = -max-rate / -partition-count = 50000 / 400 = 125
 stress_read_cmd: [
-    "scylla-bench -workload=timeseries -mode=read -partition-count=20000 -concurrency=100 -replication-factor=3 -clustering-row-count=10000000 -clustering-row-size=200  -rows-per-request=100 -start-timestamp=SCT_TIME -write-rate 125 -duration=10m -distribution hnormal --connection-count 100 -duration=2880m",
-    "scylla-bench -workload=timeseries -mode=read -partition-count=20000 -concurrency=100 -replication-factor=3 -clustering-row-count=10000000 -clustering-row-size=200  -rows-per-request=100 -start-timestamp=SCT_TIME -write-rate 125 -duration=10m -distribution uniform --connection-count 100 -duration=2880m"
+    "scylla-bench -workload=timeseries -mode=read -partition-count=20000 -concurrency=100 -replication-factor=3 -clustering-row-count=10000000 -clustering-row-size=200  -rows-per-request=100 -start-timestamp=GET_WRITE_TIMESTAMP -write-rate 125 -distribution hnormal --connection-count 100 -duration=2880m",
+    "scylla-bench -workload=timeseries -mode=read -partition-count=20000 -concurrency=100 -replication-factor=3 -clustering-row-count=10000000 -clustering-row-size=200  -rows-per-request=100 -start-timestamp=GET_WRITE_TIMESTAMP -write-rate 125 -distribution uniform --connection-count 100 -duration=2880m"
     ]
 
 
@@ -21,3 +24,5 @@ nemesis_during_prepare: false
 space_node_threshold: 64424
 
 user_prefix: 'longevity-twcs-48h'
+
+post_prepare_cql_cmds: "ALTER TABLE scylla_bench.test with gc_grace_seconds = 300 and default_time_to_live = 21600 and compaction = {'class':'TimeWindowCompactionStrategy', 'compaction_window_size': 60, 'compaction_window_unit': 'MINUTES'};"


### PR DESCRIPTION
Scylla-bench with workload=timeseries in read mode should use
start timestamp from scylla-bench command in write mode.

In case of fix Issue 4241 to scylla_bench_thread was added
file log reader which parse output from write command with
timeserieis workload and pass it to read command

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
