### PR TITLE
feature(cdcmultidc): New job 8h-cdc-multidc-topology-changes

### DIFF
--- a/data_dir/cdc_profile.yaml
+++ b/data_dir/cdc_profile.yaml
@@ -23,7 +23,7 @@ table_definition: |
     nums_set set<int>,
     names_set set<text>
   ) WITH bloom_filter_fp_chance = 0.01
-    AND cdc = {'enabled': true, 'preimage': false, 'postimage': false, 'ttl': 600}
+    AND cdc = {'enabled': true, 'preimage': false, 'postimage': false, 'ttl': 3600}
     AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
     AND comment = 'Request for unit level UIs'
     AND compaction = {'class': 'SizeTieredCompactionStrategy'}
@@ -31,7 +31,7 @@ table_definition: |
     AND crc_check_chance = 1.0
     AND dclocal_read_repair_chance = 0.1
     AND default_time_to_live = 0
-    AND gc_grace_seconds = 864000
+    AND gc_grace_seconds = 1800
     AND max_index_interval = 2048
     AND memtable_flush_period_in_ms = 0
     AND min_index_interval = 128

--- a/data_dir/cdc_profile_multidc.yaml
+++ b/data_dir/cdc_profile_multidc.yaml
@@ -2,13 +2,13 @@ keyspace: cdc_test
 
 keyspace_definition: |
 
-  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true;
+  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-westscylla_node_west': 3, 'us-eastscylla_node_east': 2}  AND durable_writes = true;
 
-table: test_table_preimage
+table: test_table
 
 table_definition: |
 
-  CREATE TABLE cdc_test.test_table_preimage (
+  CREATE TABLE cdc_test.test_table (
     pkid text PRIMARY KEY,
     name text,
     number int,
@@ -23,7 +23,7 @@ table_definition: |
     nums_set set<int>,
     names_set set<text>
   ) WITH bloom_filter_fp_chance = 0.01
-    AND cdc = {'enabled': true, 'preimage': true, 'postimage': false, 'ttl': 600}
+    AND cdc = {'enabled': true, 'preimage': false, 'postimage': false, 'ttl': 3600}
     AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
     AND comment = 'Request for unit level UIs'
     AND compaction = {'class': 'SizeTieredCompactionStrategy'}
@@ -31,7 +31,7 @@ table_definition: |
     AND crc_check_chance = 1.0
     AND dclocal_read_repair_chance = 0.1
     AND default_time_to_live = 0
-    AND gc_grace_seconds = 14400
+    AND gc_grace_seconds = 1800
     AND max_index_interval = 2048
     AND memtable_flush_period_in_ms = 0
     AND min_index_interval = 128
@@ -56,14 +56,14 @@ insert:
 
 queries:
   read1:
-    cql: select * from cdc_test.test_table_preimage where pkid = ?
+    cql: select * from cdc_test.test_table where pkid = ?
     fields: samerow
   update_name:
-    cql: update cdc_test.test_table_preimage set name = ? where pkid = ?
+    cql: update cdc_test.test_table set name = ? where pkid = ?
     fields: samerow
   update_number:
-    cql: update cdc_test.test_table_preimage set number = ? where pkid = ?
+    cql: update cdc_test.test_table set number = ? where pkid = ?
     fields: samerow
   delete1:
-    cql: delete from cdc_test.test_table_preimage where pkid = ?
+    cql: delete from cdc_test.test_table where pkid = ?
     fields: samerow

--- a/data_dir/cdc_profile_multidc_postimage.yaml
+++ b/data_dir/cdc_profile_multidc_postimage.yaml
@@ -2,13 +2,13 @@ keyspace: cdc_test
 
 keyspace_definition: |
 
-  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true;
+  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-westscylla_node_west': 2, 'us-eastscylla_node_east': 3}  AND durable_writes = true;
 
-table: test_table_preimage
+table: test_table_postimage
 
 table_definition: |
 
-  CREATE TABLE cdc_test.test_table_preimage (
+  CREATE TABLE cdc_test.test_table_postimage (
     pkid text PRIMARY KEY,
     name text,
     number int,
@@ -23,7 +23,7 @@ table_definition: |
     nums_set set<int>,
     names_set set<text>
   ) WITH bloom_filter_fp_chance = 0.01
-    AND cdc = {'enabled': true, 'preimage': true, 'postimage': false, 'ttl': 600}
+    AND cdc = {'enabled': true, 'preimage': false, 'postimage': true, 'ttl': 600}
     AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
     AND comment = 'Request for unit level UIs'
     AND compaction = {'class': 'SizeTieredCompactionStrategy'}
@@ -31,7 +31,7 @@ table_definition: |
     AND crc_check_chance = 1.0
     AND dclocal_read_repair_chance = 0.1
     AND default_time_to_live = 0
-    AND gc_grace_seconds = 14400
+    AND gc_grace_seconds = 3600
     AND max_index_interval = 2048
     AND memtable_flush_period_in_ms = 0
     AND min_index_interval = 128
@@ -56,14 +56,14 @@ insert:
 
 queries:
   read1:
-    cql: select * from cdc_test.test_table_preimage where pkid = ?
+    cql: select * from cdc_test.test_table_postimage where pkid = ?
     fields: samerow
   update_name:
-    cql: update cdc_test.test_table_preimage set name = ? where pkid = ?
+    cql: update cdc_test.test_table_postimage set name = ? where pkid = ?
     fields: samerow
   update_number:
-    cql: update cdc_test.test_table_preimage set number = ? where pkid = ?
+    cql: update cdc_test.test_table_postimage set number = ? where pkid = ?
     fields: samerow
   delete1:
-    cql: delete from cdc_test.test_table_preimage where pkid = ?
+    cql: delete from cdc_test.test_table_postimage where pkid = ?
     fields: samerow

--- a/data_dir/cdc_profile_multidc_preimage.yaml
+++ b/data_dir/cdc_profile_multidc_preimage.yaml
@@ -2,7 +2,7 @@ keyspace: cdc_test
 
 keyspace_definition: |
 
-  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true;
+  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-westscylla_node_west': 2, 'us-eastscylla_node_east': 3}  AND durable_writes = true;
 
 table: test_table_preimage
 

--- a/data_dir/cdc_profile_multidc_preimage_postimage.yaml
+++ b/data_dir/cdc_profile_multidc_preimage_postimage.yaml
@@ -2,13 +2,13 @@ keyspace: cdc_test
 
 keyspace_definition: |
 
-  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true;
+  CREATE KEYSPACE IF NOT EXISTS cdc_test WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-westscylla_node_west': 3, 'us-eastscylla_node_east': 2}  AND durable_writes = true;
 
-table: test_table_preimage
+table: test_table_preimage_postimage
 
 table_definition: |
 
-  CREATE TABLE cdc_test.test_table_preimage (
+  CREATE TABLE cdc_test.test_table_preimage_postimage (
     pkid text PRIMARY KEY,
     name text,
     number int,
@@ -23,7 +23,7 @@ table_definition: |
     nums_set set<int>,
     names_set set<text>
   ) WITH bloom_filter_fp_chance = 0.01
-    AND cdc = {'enabled': true, 'preimage': true, 'postimage': false, 'ttl': 600}
+    AND cdc = {'enabled': true, 'preimage': true, 'postimage': true, 'ttl': 1800}
     AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
     AND comment = 'Request for unit level UIs'
     AND compaction = {'class': 'SizeTieredCompactionStrategy'}
@@ -56,14 +56,14 @@ insert:
 
 queries:
   read1:
-    cql: select * from cdc_test.test_table_preimage where pkid = ?
+    cql: select * from cdc_test.test_table_preimage_postimage where pkid = ?
     fields: samerow
   update_name:
-    cql: update cdc_test.test_table_preimage set name = ? where pkid = ?
+    cql: update cdc_test.test_table_preimage_postimage set name = ? where pkid = ?
     fields: samerow
   update_number:
-    cql: update cdc_test.test_table_preimage set number = ? where pkid = ?
+    cql: update cdc_test.test_table_preimage_postimage set number = ? where pkid = ?
     fields: samerow
   delete1:
-    cql: delete from cdc_test.test_table_preimage where pkid = ?
+    cql: delete from cdc_test.test_table_preimage_postimage where pkid = ?
     fields: samerow

--- a/data_dir/cdc_profile_postimage.yaml
+++ b/data_dir/cdc_profile_postimage.yaml
@@ -31,7 +31,7 @@ table_definition: |
     AND crc_check_chance = 1.0
     AND dclocal_read_repair_chance = 0.1
     AND default_time_to_live = 0
-    AND gc_grace_seconds = 864000
+    AND gc_grace_seconds = 3600
     AND max_index_interval = 2048
     AND memtable_flush_period_in_ms = 0
     AND min_index_interval = 128

--- a/data_dir/cdc_profile_preimage_postimage.yaml
+++ b/data_dir/cdc_profile_preimage_postimage.yaml
@@ -23,7 +23,7 @@ table_definition: |
     nums_set set<int>,
     names_set set<text>
   ) WITH bloom_filter_fp_chance = 0.01
-    AND cdc = {'enabled': true, 'preimage': true, 'postimage': true, 'ttl': 600}
+    AND cdc = {'enabled': true, 'preimage': true, 'postimage': true, 'ttl': 1800}
     AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
     AND comment = 'Request for unit level UIs'
     AND compaction = {'class': 'SizeTieredCompactionStrategy'}
@@ -31,7 +31,7 @@ table_definition: |
     AND crc_check_chance = 1.0
     AND dclocal_read_repair_chance = 0.1
     AND default_time_to_live = 0
-    AND gc_grace_seconds = 864000
+    AND gc_grace_seconds = 14400
     AND max_index_interval = 2048
     AND memtable_flush_period_in_ms = 0
     AND min_index_interval = 128

--- a/jenkins-pipelines/longevity-cdc-8h-multi-dc-topology-changes.jenkinsfile
+++ b/jenkins-pipelines/longevity-cdc-8h-multi-dc-topology-changes.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: '''["eu-west-1", "us-east-1"]''',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-topology-changes.yaml',
+
+    timeout: [time: 560, unit: 'MINUTES']
+)

--- a/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-topology-changes.yaml
+++ b/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-topology-changes.yaml
@@ -1,0 +1,27 @@
+test_duration: 500
+
+stress_cmd: [ "cassandra-stress user no-warmup profile=/tmp/cdc_profile_multidc.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=480m -port jmx=6868 -mode cql3 native -rate threads=75",
+              "cassandra-stress user no-warmup profile=/tmp/cdc_profile_multidc_preimage.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=480m -port jmx=6868 -mode cql3 native -rate threads=75",
+              "cassandra-stress user no-warmup profile=/tmp/cdc_profile_multidc_postimage.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=480m -port jmx=6868 -mode cql3 native -rate threads=75",
+              "cassandra-stress user no-warmup profile=/tmp/cdc_profile_multidc_preimage_postimage.yaml ops'(insert=2,read1=1,update_number=1,update_name=1,delete1=1)' cl=QUORUM duration=480m -port jmx=6868 -mode cql3 native -rate threads=75"
+             ]
+
+n_db_nodes: '4 4'
+instance_type_db: 'i3.4xlarge'
+n_loaders: '2 2'
+region_aware_loader: true
+n_monitor_nodes: 1
+
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_include_filter: ['topology_changes']
+nemesis_seed: '032'
+nemesis_interval: 5
+nemesis_add_node_cnt: 2
+
+round_robin: true
+
+user_prefix: 'longevity-cdc-100gb-8h-multi-dc-tpch'
+space_node_threshold: 64424
+
+ip_ssh_connections: 'public'
+intra_node_comm_public: true


### PR DESCRIPTION
Starting from branch-4.6 new system_distributed_everywhere keyspace was added. 
Data of this keyspace replicated to each node in cluster. First consumer of the keyspace
is cdc. It stores there new cdc_generation_description table. It is system table and not 
should be used by user. Regular tests for cdc + multi dc should be enough for testing.

Add new job for testing cdc in multi dc cluster configuration with new nemesis
Update c-s profiles for cdc to support multi dc.
Change replication class to NetworkTopology

Trello: https://trello.com/c/3xwu3ugW

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
