### PR TITLE
fix(sdcm/mgmt/cli.py): Fixing "delete_task" method

### DIFF
--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -553,7 +553,7 @@ class ManagerCluster(ScyllaManagerBase):
         self.sctool.run(cmd=cmd, is_verify_errorless_result=True)
 
     def delete_task(self, task_id):
-        cmd = "-c {} task delete {}".format(self.id, task_id)
+        cmd = "-c {} stop --delete {}".format(self.id, task_id)
         LOGGER.debug("Task Delete command to execute is: {}".format(cmd))
         self.sctool.run(cmd=cmd, parse_table_res=False)
         LOGGER.debug("Deleted the task '{}' successfully!". format(task_id))


### PR DESCRIPTION
The command syntax was changed from `task delete` to `stop --delete`

Error traceback
```
Command: 'sudo sctool -c 9c77396a-7ae6-4d5c-b832-6907fe2e963f task delete repair/all-weekly'
Exit code: 1
Stdout:
Stderr:
Command "delete" is deprecated, use sctool stop --delete instead
```