### PR TITLE
fix(manager sanity): skip test_healthcheck_change_max_timeout for ipv6

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -372,8 +372,11 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
             self.test_mgmt_cluster_crud()
         with self.subTest('Mgmt cluster Health Check'):
             self.test_mgmt_cluster_healthcheck()
-        with self.subTest('Basic test healthcheck change max timeout'):
-            self.test_healthcheck_change_max_timeout()
+        # test_healthcheck_change_max_timeout requires a multi dc run. And since ipv6 cannot run in multi dc, this test
+        # function will be skipped for ipv6 runs.
+        if self.db_cluster.nodes[0].test_config.IP_SSH_CONNECTIONS != "ipv6":
+            with self.subTest('Basic test healthcheck change max timeout'):
+                self.test_healthcheck_change_max_timeout()
         with self.subTest('Basic test suspend and resume'):
             self.test_suspend_and_resume()
         with self.subTest('Client Encryption'):


### PR DESCRIPTION
Since test_healthcheck_change_max_timeout requires a multi dc cluster,
and sct can't create an ipv6 multi dc cluster, I skipped the test for
ipv6 runs.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
