### PR TITLE
fix(base cloud_monitor report template): Change link description

### DIFF
--- a/sdcm/utils/cloud_monitor/templates/base.html
+++ b/sdcm/utils/cloud_monitor/templates/base.html
@@ -41,6 +41,6 @@
 </head>
 <body>
 {{ body|safe }}
-<a href="https://docs.google.com/document/d/1gb8-K6RmlOypezcYB7ca7TnfuxuEoON87epUxOYorZk/edit#heading=h.mhz4o9ik7vhe">Procedure of using cloud resources</a>
+<a href="https://docs.google.com/document/d/1gb8-K6RmlOypezcYB7ca7TnfuxuEoON87epUxOYorZk/edit#heading=h.mhz4o9ik7vhe">Procedure of using the cloud</a>
 </body>
 </html>


### PR DESCRIPTION
Removing the word resourcers from the link description.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
