### PR TITLE
fix(defaults): Fixing artifacts jobs to work with manager2.5

### DIFF
--- a/test-cases/artifacts/debian10.yaml
+++ b/test-cases/artifacts/debian10.yaml
@@ -15,6 +15,8 @@ nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'debian-buster'
 scylla_repo: 'http://downloads.scylladb.com/unstable/scylla/master/deb/unified/latest/scylladb-master/scylla.list'
 scylla_apt_keys:
+  # When will use manager 2.6, need to remove this commit because it's a workaround to make artifacts works
+  - '5E08FBD8B5D6EC9C'  # ScyllaDB Package Signing Key 2020 <security@scylladb.com>
   - 'D0A112E067426AB2'  # ScyllaDB Package Signing Key 2022 <security@scylladb.com>
 test_duration: 60
 user_prefix: 'artifacts-debian10'

--- a/test-cases/artifacts/debian11.yaml
+++ b/test-cases/artifacts/debian11.yaml
@@ -15,6 +15,8 @@ nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'debian-bullseye'
 scylla_repo: 'http://downloads.scylladb.com/unstable/scylla/master/deb/unified/latest/scylladb-master/scylla.list'
 scylla_apt_keys:
+  # When will use manager 2.6, need to remove this commit because it's a workaround to make artifacts works
+  - '5E08FBD8B5D6EC9C'  # ScyllaDB Package Signing Key 2020 <security@scylladb.com>
   - 'D0A112E067426AB2'  # ScyllaDB Package Signing Key 2022 <security@scylladb.com>
 test_duration: 60
 user_prefix: 'artifacts-debian11'

--- a/test-cases/artifacts/debian9.yaml
+++ b/test-cases/artifacts/debian9.yaml
@@ -15,6 +15,8 @@ nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'debian-stretch'
 scylla_repo: 'http://downloads.scylladb.com/unstable/scylla/master/deb/unified/latest/scylladb-master/scylla.list'
 scylla_apt_keys:
+  # When will use manager 2.6, need to remove this commit because it's a workaround to make artifacts works
+  - '5E08FBD8B5D6EC9C'  # ScyllaDB Package Signing Key 2020 <security@scylladb.com>
   - 'D0A112E067426AB2'  # ScyllaDB Package Signing Key 2022 <security@scylladb.com>
 test_duration: 60
 user_prefix: 'artifacts-debian9'

--- a/test-cases/artifacts/ubuntu1604.yaml
+++ b/test-cases/artifacts/ubuntu1604.yaml
@@ -15,6 +15,8 @@ nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'ubuntu-xenial'
 scylla_repo: 'http://downloads.scylladb.com/unstable/scylla/master/deb/unified/latest/scylladb-master/scylla.list'
 scylla_apt_keys:
+  # When will use manager 2.6, need to remove this commit because it's a workaround to make artifacts works
+  - '5E08FBD8B5D6EC9C'  # ScyllaDB Package Signing Key 2020 <security@scylladb.com>
   - 'D0A112E067426AB2'  # ScyllaDB Package Signing Key 2022 <security@scylladb.com>
 test_duration: 60
 user_prefix: 'artifacts-ubuntu1604'

--- a/test-cases/artifacts/ubuntu1804.yaml
+++ b/test-cases/artifacts/ubuntu1804.yaml
@@ -15,6 +15,8 @@ nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'ubuntu-bionic'
 scylla_repo: 'http://downloads.scylladb.com/unstable/scylla/master/deb/unified/latest/scylladb-master/scylla.list'
 scylla_apt_keys:
+  # When will use manager 2.6, need to remove this commit because it's a workaround to make artifacts works
+  - '5E08FBD8B5D6EC9C'  # ScyllaDB Package Signing Key 2020 <security@scylladb.com>
   - 'D0A112E067426AB2'  # ScyllaDB Package Signing Key 2022 <security@scylladb.com>
 test_duration: 60
 user_prefix: 'artifacts-ubuntu1804'

--- a/test-cases/artifacts/ubuntu2004.yaml
+++ b/test-cases/artifacts/ubuntu2004.yaml
@@ -15,6 +15,8 @@ nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'ubuntu-focal'
 scylla_repo: 'http://downloads.scylladb.com/unstable/scylla/master/deb/unified/latest/scylladb-master/scylla.list'
 scylla_apt_keys:
+  # When will use manager 2.6, need to remove this commit because it's a workaround to make artifacts works
+  - '5E08FBD8B5D6EC9C'  # ScyllaDB Package Signing Key 2020 <security@scylladb.com>
   - 'D0A112E067426AB2'  # ScyllaDB Package Signing Key 2022 <security@scylladb.com>
 test_duration: 60
 user_prefix: 'artifacts-ubuntu2004'


### PR DESCRIPTION
* Adding `5E08FBD8B5D6EC9C` to run scylla4.7 with manager2.5
* Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/4272

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
