### PR TITLE
improvement(large partitions): Set random clustering order for s-b table

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -97,6 +97,7 @@
 | **<a href="#user-content-nemesis_sequence_sleep_between_ops" name="nemesis_sequence_sleep_between_ops">nemesis_sequence_sleep_between_ops</a>**  | Sleep interval between nemesis operations for use in unique_sequence nemesis kind of tests | N/A | SCT_NEMESIS_SEQUENCE_SLEEP_BETWEEN_OPS
 | **<a href="#user-content-nemesis_during_prepare" name="nemesis_during_prepare">nemesis_during_prepare</a>**  | Run nemesis during prepare stage of the test | True | SCT_NEMESIS_DURING_PREPARE
 | **<a href="#user-content-nemesis_seed" name="nemesis_seed">nemesis_seed</a>**  | A seed number in order to repeat nemesis sequence as part of SisyphusMonkey | N/A | SCT_NEMESIS_SEED
+| **<a href="#user-content-cql_schema_seed" name="cql_schema_seed">cql_schema_seed</a>**  | A seed number in order to repeat CQL schema configuration | N/A | SCT_CQL_SCHEMA_SEED
 | **<a href="#user-content-nemesis_add_node_cnt" name="nemesis_add_node_cnt">nemesis_add_node_cnt</a>**  | Add/remove nodes during GrowShrinkCluster nemesis | 1 | SCT_NEMESIS_ADD_NODE_CNT
 | **<a href="#user-content-cluster_target_size" name="cluster_target_size">cluster_target_size</a>**  | Used for scale test: max size of the cluster | N/A | SCT_CLUSTER_TARGET_SIZE
 | **<a href="#user-content-space_node_threshold" name="space_node_threshold">space_node_threshold</a>**  | Space node threshold before starting nemesis (bytes)<br>The default value is 6GB (6x1024^3 bytes)<br>This value is supposed to reproduce<br>https://github.com/scylladb/scylla/issues/1140 | N/A | SCT_SPACE_NODE_THRESHOLD

--- a/longevity_large_partition_test.py
+++ b/longevity_large_partition_test.py
@@ -12,7 +12,9 @@ class LargePartitionLongevityTest(LongevityTest):
 
     def pre_create_large_partitions_schema(self, compaction_strategy=CompactionStrategy.SIZE_TIERED.value):
         node = self.db_cluster.nodes[0]
-        create_table_query = create_scylla_bench_table_query(compaction_strategy=compaction_strategy)
+        table_setup_seed = self.params.get('cql_schema_seed')
+        create_table_query = create_scylla_bench_table_query(compaction_strategy=compaction_strategy,
+                                                             seed=table_setup_seed)
         with self.db_cluster.cql_connection_patient(node) as session:
             # pylint: disable=no-member
             session.execute("""

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -50,7 +50,7 @@ from sdcm.utils.ldap import SASLAUTHD_AUTHENTICATOR
 from sdcm.utils.common import (get_db_tables, generate_random_string,
                                update_certificates, reach_enospc_on_node, clean_enospc_on_node,
                                parse_nodetool_listsnapshots,
-                               update_authenticator, ParallelObject)
+                               update_authenticator, ParallelObject, get_table_clustering_order)
 from sdcm.utils import cdc
 from sdcm.utils.decorators import retrying, latency_calculator_decorator
 from sdcm.utils.decorators import timeout as timeout_decor
@@ -1547,9 +1547,12 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 if exclude_partitions and partition_key in exclude_partitions:
                     continue
 
-                # The scylla_bench.test table is created WITH CLUSTERING ORDER BY (ck DESC).
-                # So first returned value is max cl value in the partition
-                cmd = f"select ck from {ks_cf} where pk={partition_key} limit 1"
+                # Get the max cl value in the partition according to the table's clustering order.
+                table_clustering_order = get_table_clustering_order(ks_cf=ks_cf, ck_name='ck', session=session)
+                # Build the query 'from the right side' so it finds the highest cl value using 'limit 1'.
+                # So it has to check the table's clustering order and set a reversed order if needed.
+                reversed_order = 'desc' if table_clustering_order.lower() == 'asc' else 'asc'
+                cmd = f"select ck from {ks_cf} where pk={partition_key} order by ck {reversed_order} limit 1"
                 try:
                     result = session.execute(cmd, timeout=300)
                 except Exception as exc:  # pylint: disable=broad-except

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -489,6 +489,9 @@ class SCTConfiguration(dict):
         dict(name="nemesis_seed", env="SCT_NEMESIS_SEED", type=int,
              help="""A seed number in order to repeat nemesis sequence as part of SisyphusMonkey"""),
 
+        dict(name="cql_schema_seed", env="SCT_CQL_SCHEMA_SEED", type=int,
+             help="""A seed number in order to repeat CQL schema configuration"""),
+
         dict(name="nemesis_add_node_cnt",
              env="SCT_NEMESIS_ADD_NODE_CNT",
              type=int,

--- a/test_lib/scylla_bench_tools.py
+++ b/test_lib/scylla_bench_tools.py
@@ -1,27 +1,29 @@
 import logging
+import random
 
 LOGGER = logging.getLogger(__name__)
 
 
-def create_scylla_bench_table_query(compaction_strategy=None):
+def create_scylla_bench_table_query(compaction_strategy=None, seed: int = None):
     """
 
     :return: cql create table query for scylla-bench
     """
-
-    compaction_strategy_option = "AND compaction = {{'class': '{}'}};".format(
+    seed = seed or random.randint(0, 1000)
+    clustering_order = random.Random(seed).choice(['ASC', 'DESC'])
+    compaction_strategy_option = "AND compaction = {{'class': '{}'}}".format(
         compaction_strategy) if compaction_strategy else ""
-    scylla_bench_table_query = """
+    scylla_bench_table_query = f"""
                     CREATE TABLE IF NOT EXISTS scylla_bench.test (
                     pk bigint,
                     ck bigint,
                     v blob,
                     PRIMARY KEY (pk, ck)
-                ) WITH CLUSTERING ORDER BY (ck ASC)
+                ) WITH CLUSTERING ORDER BY (ck {clustering_order})
                     AND bloom_filter_fp_chance = 0.01
-                    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
+                    AND caching = {{'keys': 'ALL', 'rows_per_partition': 'ALL'}}
                     AND comment = ''
-                    AND compression = {}
+                    AND compression = {{}}
 
                     AND crc_check_chance = 1.0
                     AND dclocal_read_repair_chance = 0.0
@@ -32,5 +34,7 @@ def create_scylla_bench_table_query(compaction_strategy=None):
                     AND min_index_interval = 128
                     AND read_repair_chance = 0.0
                     AND speculative_retry = 'NONE'
-                    """ + compaction_strategy_option
+                    {compaction_strategy_option};
+                    """
+    LOGGER.debug("Generated a create-table query with a seed of [%s]: %s", seed, scylla_bench_table_query)
     return scylla_bench_table_query


### PR DESCRIPTION
	In order to cover testing of both options of table configuration.

** READY FOR MERGE **

This PR is dependant in merging the reversed-queries PR from task:
https://trello.com/c/TWqm0bE5

https://github.com/scylladb/scylla-cluster-tests/pull/4147

 Refs #1413 - The internal layer for managing queries now supports reversed queries natively. This lays the groundwork for reversed reads in memtables, cache, and sstables, so that reversed queries will perform efficiently.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
