### PR TITLE
fix(ycsb filter): added to EventsFilter

### DIFF
--- a/sdcm/sct_events/filters.py
+++ b/sdcm/sct_events/filters.py
@@ -53,7 +53,7 @@ class DbEventsFilter(BaseFilter):
 
 class EventsFilter(BaseFilter):
     def __init__(self,
-                 event_class: Optional[Type[SctEventProtocol]] = None,
+                 event_class: Optional[Union[Type[SctEventProtocol], Type[SctEvent]]] = None,
                  regex: Optional[Union[str, re.Pattern]] = None,
                  extra_time_to_expiration: Optional[int] = None):
 

--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -148,7 +148,7 @@ def ignore_mutation_write_errors():
 
 @contextmanager
 def ignore_ycsb_connection_refused():
-    with EventsFilter(event_class=YcsbStressEvent, regex='Unable to execute HTTP request: .*Connection refused'):
+    with EventsFilter(event_class=YcsbStressEvent, regex='.*Unable to execute HTTP request: .*Connection refused'):
         yield
 
 


### PR DESCRIPTION
following commit in #4195 the failure
described in there kept happening,
and it seemed that there was a mismatch
between the event filter being called
and the supported types.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
