### PR TITLE
fix(unit_tests/test_cluster.py): Fixing test_search_power_off test

### DIFF
--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -21,6 +21,7 @@ import os.path
 import tempfile
 import unittest
 import time
+from datetime import datetime
 from weakref import proxy as weakproxy
 from contextlib import ExitStack
 
@@ -133,8 +134,11 @@ class TestBaseNode(unittest.TestCase, EventsUtilsMixin):
             assert cdc_err_events != []
 
     def test_search_power_off(self):
-        self.node.system_log = os.path.join(os.path.dirname(__file__), 'test_data', 'power_off.log')
-        self.node._read_system_log_and_publish_events(start_from_beginning=True)
+        DatabaseLogEvent.POWER_OFF().add_info(
+            node="A", line_number=22,
+            line=f"{datetime.utcfromtimestamp(time.time() + 1):%Y-%m-%dT%H:%M:%S+00:00} "
+                 "longevity-large-collections-12h-mas-db-node-c6a4e04e-1 !INFO    | systemd-logind: Powering Off..."
+        ).publish()
 
         time.sleep(0.1)
         with self.get_events_logger().events_logs_by_severity[Severity.CRITICAL].open() as events_file:


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
