### PR TITLE
fix(gce_download): skip first element in bucket

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1591,7 +1591,8 @@ def gce_download_dir(bucket, path, target):
 
     container = driver.get_container(container_name=bucket)
     dir_listing = driver.list_container_objects(container, ex_prefix=path)
-    for obj in dir_listing:
+    # first element is gce dir itself. Skip it.
+    for obj in dir_listing[1:]:
         rel_path = obj.name[len(path):]
         local_file_path = os.path.join(target, rel_path)
 

--- a/unit_tests/test_utils_common.py
+++ b/unit_tests/test_utils_common.py
@@ -75,7 +75,7 @@ class TestDownloadDir(unittest.TestCase):
                 Path(destination_path).touch(exist_ok=overwrite_existing)
 
         self.clear_cloud_downloaded_path(sct_update_db_packages)
-        test_file_names = ["sct_test/bentsi.txt", "sct_test/charybdis.fs"]
+        test_file_names = ["sct_test/", "sct_test/bentsi.txt", "sct_test/charybdis.fs"]
         with unittest.mock.patch("libcloud.storage.drivers.google_storage.GoogleStorageDriver.list_container_objects",
                                  return_value=[FakeObject(name=fname) for fname in test_file_names]):
             update_db_packages = download_dir_from_cloud(sct_update_db_packages)


### PR DESCRIPTION
gce Bucket returned with first element as dir, and this break
downloading files.

Example of failed job:
https://jenkins.scylladb.com/view/scylla-4.6/job/scylla-4.6/job/longevity/job/longevity-1tb-7days-gce-test/10/execution/node/142/log/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
