### PR TITLE
refactor(test_default): Set master branch to use manager 2.6

### DIFF
--- a/defaults/manager_versions.yaml
+++ b/defaults/manager_versions.yaml
@@ -7,6 +7,14 @@ manager_repos_by_version:
     ubuntu16: 'http://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
     ubuntu18: 'http://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
     ubuntu20: 'http://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
+  "2.6":
+    centos7: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.6.repo'
+    centos8: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.6.repo'
+    debian9: 'http://downloads.scylladb.com/deb/debian/scylladb-manager-2.6-stretch.list'
+    debian10: 'http://downloads.scylladb.com/deb/debian/scylladb-manager-2.6-buster.list'
+    ubuntu16: 'http://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.6-xenial.list'
+    ubuntu18: 'http://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.6-bionic.list'
+    ubuntu20: 'http://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.6-focal.list'
   "2.5":
     centos7: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.5.repo'
     centos8: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.5.repo'

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -6,7 +6,7 @@ ip_ssh_connections: 'private'
 
 scylla_repo: ''
 
-manager_version: '2.5'
+manager_version: '2.6'
 manager_scylla_backend_version: '2021'  # Notice: that centos, ubuntu 20 and debian 10 monitors use 2021, while debian 9, ubuntu 16 and ubuntu 18 use 2020, since we support both
 
 scylla_repo_loader: ''


### PR DESCRIPTION
Manager 2.6.0 is released and should be used for master and scylla
v4.6.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
