### PR TITLE
test(rbno): Add longevities for repair based node operations

### DIFF
--- a/jenkins-pipelines/repair-based-operation/longevity-100gb-4h-Decommission.jenkinsfile
+++ b/jenkins-pipelines/repair-based-operation/longevity-100gb-4h-Decommission.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "test-cases/features/repair-based-operations/longevity-100gb-4h-Decommission.yaml"]''',
+
+    timeout: [time: 360, unit: 'MINUTES']
+)

--- a/jenkins-pipelines/repair-based-operation/longevity-100gb-4h-RemoveNode.jenkinsfile
+++ b/jenkins-pipelines/repair-based-operation/longevity-100gb-4h-RemoveNode.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "test-cases/features/repair-based-operations/longevity-100gb-4h-RemoveNode.yaml"]''',
+
+    timeout: [time: 360, unit: 'MINUTES']
+)

--- a/jenkins-pipelines/repair-based-operation/longevity-100gb-4h-ReplaceNode.jenkinsfile
+++ b/jenkins-pipelines/repair-based-operation/longevity-100gb-4h-ReplaceNode.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "test-cases/features/repair-based-operations/longevity-100gb-4h-ReplaceNode.yaml"]''',
+
+    timeout: [time: 360, unit: 'MINUTES']
+)

--- a/jenkins-pipelines/repair-based-operation/longevity-1tb-12h-GrowShrink.jenkinsfile
+++ b/jenkins-pipelines/repair-based-operation/longevity-1tb-12h-GrowShrink.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "test-cases/features/repair-based-operations/longevity-1TB-12h-GrowShrink.yaml"]''',
+
+    timeout: [time: 800, unit: 'MINUTES']
+)

--- a/jenkins-pipelines/repair-based-operation/longevity-200gb-48h-Decommission.jenkinsfile
+++ b/jenkins-pipelines/repair-based-operation/longevity-200gb-48h-Decommission.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml", "test-cases/features/repair-based-operations/longevity-200GB-48h-Decommission.yaml"]''',
+
+    timeout: [time: 3060, unit: 'MINUTES']
+)

--- a/jenkins-pipelines/repair-based-operation/longevity-50gb-12h-RemoveNode.jenkinsfile
+++ b/jenkins-pipelines/repair-based-operation/longevity-50gb-12h-RemoveNode.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "test-cases/features/repair-based-operations/longevity-50GB-12h-RemoveNode.yaml"]''',
+
+    timeout: [time: 800, unit: 'MINUTES']
+)

--- a/jenkins-pipelines/repair-based-operation/longevity-50gb-12h-ReplaceNode.jenkinsfile
+++ b/jenkins-pipelines/repair-based-operation/longevity-50gb-12h-ReplaceNode.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "test-cases/features/repair-based-operations/longevity-50GB-12h-ReplaceNode.yaml"]''',
+
+    timeout: [time: 800, unit: 'MINUTES']
+)

--- a/jenkins-pipelines/repair-based-operation/longevity-cdc-4h-Decommission.jenkinsfile
+++ b/jenkins-pipelines/repair-based-operation/longevity-cdc-4h-Decommission.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-cdc-100gb-4h.yaml", "test-cases/features/repair-based-operations/longevity-cdc-100gb-4h-Decommission.yaml"]''',
+
+    timeout: [time: 360, unit: 'MINUTES']
+)

--- a/jenkins-pipelines/repair-based-operation/longevity-cdc-4h-RemoveNode.jenkinsfile
+++ b/jenkins-pipelines/repair-based-operation/longevity-cdc-4h-RemoveNode.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-cdc-100gb-4h.yaml", "test-cases/features/repair-based-operations/longevity-cdc-100gb-4h-RemoveNode.yaml"]''',
+
+    timeout: [time: 360, unit: 'MINUTES']
+)

--- a/jenkins-pipelines/repair-based-operation/longevity-cdc-4h-ReplaceNode.jenkinsfile
+++ b/jenkins-pipelines/repair-based-operation/longevity-cdc-4h-ReplaceNode.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    aws_region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-cdc-100gb-4h.yaml", "test-cases/features/repair-based-operations/longevity-cdc-100gb-4h-ReplaceNode.yaml"]''',
+
+    timeout: [time: 360, unit: 'MINUTES']
+)

--- a/test-cases/features/repair-based-operations/longevity-100gb-4h-Decommission.yaml
+++ b/test-cases/features/repair-based-operations/longevity-100gb-4h-Decommission.yaml
@@ -1,0 +1,5 @@
+nemesis_class_name: 'DecommissionMonkey'
+nemesis_interval: 2
+nemesis_filter_seeds: false
+
+user_prefix: 'longevity-rbno-4h-decommission'

--- a/test-cases/features/repair-based-operations/longevity-100gb-4h-RemoveNode.yaml
+++ b/test-cases/features/repair-based-operations/longevity-100gb-4h-RemoveNode.yaml
@@ -1,0 +1,5 @@
+nemesis_class_name: 'TerminateAndRemoveNodeMonkey'
+nemesis_interval: 2
+nemesis_filter_seeds: false
+
+user_prefix: 'longevity-rbno-4h-remove-node'

--- a/test-cases/features/repair-based-operations/longevity-100gb-4h-ReplaceNode.yaml
+++ b/test-cases/features/repair-based-operations/longevity-100gb-4h-ReplaceNode.yaml
@@ -1,0 +1,6 @@
+nemesis_class_name: 'NodeTerminateAndReplace'
+nemesis_interval: 2
+nemesis_filter_seeds: false
+seeds_num: 3
+
+user_prefix: 'longevity-rbno-4h-replace-node'

--- a/test-cases/features/repair-based-operations/longevity-1TB-12h-GrowShrink.yaml
+++ b/test-cases/features/repair-based-operations/longevity-1TB-12h-GrowShrink.yaml
@@ -1,0 +1,16 @@
+test_duration: 750
+
+stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=11h -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=1..550100150  -log interval=5 -col 'size=FIXED(200) n=FIXED(5)'",
+             "cassandra-stress mixed cl=QUORUM duration=11h -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=550100151..1100200300  -log interval=5 -col 'size=FIXED(200) n=FIXED(5)'",
+             "cassandra-stress user profile=/tmp/cs_mv_profile.yaml ops'(insert=3,read1=1,read2=1,read3=1)' cl=QUORUM duration=11h -port jmx=6868 -mode cql3 native -rate threads=10"]
+
+
+stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=11h -port jmx=6868 -mode cql3 native  -rate threads=10 -pop seq=1..1100200300  -log interval=5 -col 'size=FIXED(200) n=FIXED(5)'" ]
+
+nemesis_class_name: 'GrowShrinkClusterNemesis'
+nemesis_add_node_cnt: 3
+nemesis_interval: 5
+nemesis_filter_seeds: false
+seeds_num: 2
+
+user_prefix: 'longevity-rbno-1tb-12h-grow-shrink'

--- a/test-cases/features/repair-based-operations/longevity-200GB-48h-Decommission.yaml
+++ b/test-cases/features/repair-based-operations/longevity-200GB-48h-Decommission.yaml
@@ -1,0 +1,5 @@
+nemesis_class_name: 'DecommissionMonkey'
+nemesis_interval: 5
+nemesis_during_prepare: false
+
+user_prefix: 'longevity-rbno-200gb-48h-Decommission'

--- a/test-cases/features/repair-based-operations/longevity-50GB-12h-RemoveNode.yaml
+++ b/test-cases/features/repair-based-operations/longevity-50GB-12h-RemoveNode.yaml
@@ -1,0 +1,12 @@
+test_duration: 760
+
+stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=11h -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native  -rate threads=100 -pop seq=1..100000000 -log interval=5",
+             "cassandra-stress user profile=/tmp/cs_mv_profile.yaml ops'(insert=3,read1=1,read2=1,read3=1)' cl=QUORUM duration=11h -port jmx=6868 -mode cql3 native -rate threads=20"]
+
+stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=11h -port jmx=6868 -mode cql3 native  -rate threads=50 -pop seq=1..100000000 -log interval=5"]
+
+nemesis_class_name: 'TerminateAndRemoveNodeMonkey'
+nemesis_interval: 5
+nemesis_during_prepare: false
+
+user_prefix: 'longevity-rbno-12h-remove-node'

--- a/test-cases/features/repair-based-operations/longevity-50GB-12h-ReplaceNode.yaml
+++ b/test-cases/features/repair-based-operations/longevity-50GB-12h-ReplaceNode.yaml
@@ -1,0 +1,12 @@
+test_duration: 760
+
+stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=11h -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native  -rate threads=100 -pop seq=1..100000000 -log interval=5",
+             "cassandra-stress user profile=/tmp/cs_mv_profile.yaml ops'(insert=3,read1=1,read2=1,read3=1)' cl=QUORUM duration=11h -port jmx=6868 -mode cql3 native -rate threads=20"]
+
+stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=11h -port jmx=6868 -mode cql3 native  -rate threads=50 -pop seq=1..100000000 -log interval=5"]
+
+nemesis_class_name: 'NodeTerminateAndReplace'
+nemesis_interval: 5
+nemesis_during_prepare: false
+
+user_prefix: 'longevity-rbno-12h-replace-node'

--- a/test-cases/features/repair-based-operations/longevity-cdc-100gb-4h-Decommission.yaml
+++ b/test-cases/features/repair-based-operations/longevity-cdc-100gb-4h-Decommission.yaml
@@ -1,0 +1,5 @@
+nemesis_class_name: 'DecommissionMonkey'
+nemesis_interval: 5
+nemesis_during_prepare: false
+
+user_prefix: 'longevity-rbno-cdc-100gb-4h-decommission'

--- a/test-cases/features/repair-based-operations/longevity-cdc-100gb-4h-RemoveNode.yaml
+++ b/test-cases/features/repair-based-operations/longevity-cdc-100gb-4h-RemoveNode.yaml
@@ -1,0 +1,5 @@
+nemesis_class_name: 'TerminateAndRemoveNodeMonkey'
+nemesis_interval: 5
+nemesis_during_prepare: false
+
+user_prefix: 'longevity-rbno-cdc-100gb-4h-remove-node'

--- a/test-cases/features/repair-based-operations/longevity-cdc-100gb-4h-ReplaceNode.yaml
+++ b/test-cases/features/repair-based-operations/longevity-cdc-100gb-4h-ReplaceNode.yaml
@@ -1,0 +1,6 @@
+nemesis_class_name: 'NodeTerminateAndReplace'
+nemesis_interval: 5
+nemesis_during_prepare: false
+seeds_num: 3
+
+user_prefix: 'longevity-rbno-cdc-100gb-4h-replace-node'


### PR DESCRIPTION
Adding several longevities to test RBNO feature.
Four types of nemesis are being used to test it:
1. Remove Node and bootstrap new node instead.
2. Replace a dead node.
3. Decommission and add new node.
4. Grow cluster by adding nodes then shrink it back with decommission

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
