### PR TITLE
fix(rolling-upgrades): Remove total pipeline timeout

### DIFF
--- a/jenkins-pipelines/rolling-upgrade-alternator.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-alternator.jenkinsfile
@@ -10,7 +10,5 @@ rollingUpgradePipeline(
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7',
 
     test_name: 'upgrade_test.UpgradeTest.test_generic_cluster_upgrade',
-    test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-alternator.yaml"]''',
-
-    timeout: [time: 360, unit: 'MINUTES']
+    test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-alternator.yaml"]'''
 )

--- a/jenkins-pipelines/rolling-upgrade-ami.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-ami.jenkinsfile
@@ -11,7 +11,5 @@ rollingUpgradePipeline(
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
     test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
     workaround_kernel_bug_for_iotune: false,
-    internode_compression: 'all',
-
-    timeout: [time: 360, unit: 'MINUTES']
+    internode_compression: 'all'
 )

--- a/jenkins-pipelines/rolling-upgrade-centos7-ldap-authorization.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-centos7-ldap-authorization.jenkinsfile
@@ -11,7 +11,5 @@ rollingUpgradePipeline(
 
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
     test_config: '''["test-cases/upgrades/rolling-upgrade.yaml", "configurations/ldap-authorization.yaml"]''',
-    workaround_kernel_bug_for_iotune: false,
-
-    timeout: [time: 360, unit: 'MINUTES']
+    workaround_kernel_bug_for_iotune: false
 )

--- a/jenkins-pipelines/rolling-upgrade-centos7.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-centos7.jenkinsfile
@@ -12,7 +12,5 @@ rollingUpgradePipeline(
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
     test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
     workaround_kernel_bug_for_iotune: false,
-    internode_compression: 'all',
-
-    timeout: [time: 360, unit: 'MINUTES']
+    internode_compression: 'all'
 )

--- a/jenkins-pipelines/rolling-upgrade-centos8.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-centos8.jenkinsfile
@@ -12,7 +12,5 @@ rollingUpgradePipeline(
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
     test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
     workaround_kernel_bug_for_iotune: false,
-    internode_compression: 'all',
-
-    timeout: [time: 360, unit: 'MINUTES']
+    internode_compression: 'all'
 )

--- a/jenkins-pipelines/rolling-upgrade-debian10.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-debian10.jenkinsfile
@@ -11,7 +11,5 @@ rollingUpgradePipeline(
 
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
     test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
-    workaround_kernel_bug_for_iotune: false,
-
-    timeout: [time: 360, unit: 'MINUTES']
+    workaround_kernel_bug_for_iotune: false
 )

--- a/jenkins-pipelines/rolling-upgrade-debian11.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-debian11.jenkinsfile
@@ -11,7 +11,5 @@ rollingUpgradePipeline(
 
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
     test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
-    workaround_kernel_bug_for_iotune: false,
-
-    timeout: [time: 360, unit: 'MINUTES']
+    workaround_kernel_bug_for_iotune: false
 )

--- a/jenkins-pipelines/rolling-upgrade-debian9.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-debian9.jenkinsfile
@@ -11,7 +11,5 @@ rollingUpgradePipeline(
 
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
     test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
-    workaround_kernel_bug_for_iotune: false,
-
-    timeout: [time: 360, unit: 'MINUTES']
+    workaround_kernel_bug_for_iotune: false
 )

--- a/jenkins-pipelines/rolling-upgrade-multidc.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-multidc.jenkinsfile
@@ -12,7 +12,5 @@ rollingUpgradePipeline(
     test_name: 'upgrade_test.UpgradeTest.test_generic_cluster_upgrade',
     test_config: 'test-cases/upgrades/multi-dc-rolling-upgrade.yaml',
     workaround_kernel_bug_for_iotune: false,
-    internode_compression: 'all',
-
-    timeout: [time: 360, unit: 'MINUTES']
+    internode_compression: 'all'
 )

--- a/jenkins-pipelines/rolling-upgrade-ubuntu-ami.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-ubuntu-ami.jenkinsfile
@@ -12,6 +12,4 @@ rollingUpgradePipeline(
     test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
     workaround_kernel_bug_for_iotune: false,
     internode_compression: 'all',
-
-    timeout: [time: 360, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/rolling-upgrade-ubuntu16.04.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-ubuntu16.04.jenkinsfile
@@ -11,7 +11,5 @@ rollingUpgradePipeline(
 
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
     test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
-    workaround_kernel_bug_for_iotune: false,
-
-    timeout: [time: 360, unit: 'MINUTES']
+    workaround_kernel_bug_for_iotune: false
 )

--- a/jenkins-pipelines/rolling-upgrade-ubuntu18.04-ldap-authorization.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-ubuntu18.04-ldap-authorization.jenkinsfile
@@ -12,7 +12,5 @@ rollingUpgradePipeline(
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
     test_config: '''["test-cases/upgrades/rolling-upgrade.yaml", "configurations/ldap-authorization.yaml"]''',
     workaround_kernel_bug_for_iotune: false,
-    internode_compression: 'all',
-
-    timeout: [time: 360, unit: 'MINUTES']
+    internode_compression: 'all'
 )

--- a/jenkins-pipelines/rolling-upgrade-ubuntu18.04.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-ubuntu18.04.jenkinsfile
@@ -12,7 +12,5 @@ rollingUpgradePipeline(
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
     test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
     workaround_kernel_bug_for_iotune: false,
-    internode_compression: 'all',
-
-    timeout: [time: 360, unit: 'MINUTES']
+    internode_compression: 'all'
 )

--- a/jenkins-pipelines/rolling-upgrade-ubuntu20.04.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-ubuntu20.04.jenkinsfile
@@ -13,6 +13,4 @@ rollingUpgradePipeline(
     test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
     workaround_kernel_bug_for_iotune: false,
     internode_compression: 'all',
-
-    timeout: [time: 360, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/rolling-upgrade-with-null-inserts.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-with-null-inserts.jenkinsfile
@@ -10,7 +10,5 @@ rollingUpgradePipeline(
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-8',
 
     test_name: 'upgrade_test.UpgradeTest.test_generic_cluster_upgrade',
-    test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-with-null-inserts.yaml"]''',
-
-    timeout: [time: 360, unit: 'MINUTES']
+    test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-with-null-inserts.yaml"]'''
 )

--- a/test-cases/upgrades/generic-rolling-upgrade.yaml
+++ b/test-cases/upgrades/generic-rolling-upgrade.yaml
@@ -2,6 +2,7 @@
 # stress_before_upgrade:           # To be configured in additional yaml
 # stress_during_entire_upgrade:       # To be configured in additional yaml
 # stress_after_cluster_upgrade:    # To be configured in additional yaml
+test_duration: 360
 
 n_db_nodes: 3
 n_loaders: 1

--- a/test-cases/upgrades/multi-dc-rolling-upgrade.yaml
+++ b/test-cases/upgrades/multi-dc-rolling-upgrade.yaml
@@ -1,4 +1,4 @@
-test_duration: 240
+test_duration: 360
 # Workloads
 stress_before_upgrade: cassandra-stress write no-warmup cl=ALL n=10100200 -schema 'replication(strategy=NetworkTopologyStrategy,eu-westscylla_node_west=3,eu-west-2scylla_node_west=3) compression=LZ4Compressor compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=lz4 -rate threads=1000 -pop seq=1..10100200 -log interval=5
 stress_during_entire_upgrade: cassandra-stress write no-warmup cl=QUORUM n=20100200 -schema 'replication(strategy=NetworkTopologyStrategy,eu-westscylla_node_west=3,eu-west-2scylla_node_west=3) compression=LZ4Compressor compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=lz4 -rate threads=60 -pop seq=10100201..30200400 -log interval=5

--- a/test-cases/upgrades/rolling-upgrade.yaml
+++ b/test-cases/upgrades/rolling-upgrade.yaml
@@ -1,6 +1,6 @@
 # TODO: need to qualify on GCE and AWS
 
-test_duration: 300
+test_duration: 360
 
 # workloads
 write_stress_during_entire_test: cassandra-stress write no-warmup cl=QUORUM n=20100200 -schema 'keyspace=keyspace_entire_test replication(factor=3) compression=LZ4Compressor compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native compression=lz4 -rate threads=100 -pop seq=1..20100200 -log interval=5


### PR DESCRIPTION
Rolling upgrade jobs keep timeing out during log collection or
sending mails out, this change aligns the pipeline timeout are handled
to the same method as longevity pipelines are doing that

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
