### PR TITLE
fix(test_sct_events_operator): remove hard-coded dates for test

### DIFF
--- a/unit_tests/test_sct_events_operator.py
+++ b/unit_tests/test_sct_events_operator.py
@@ -14,6 +14,7 @@
 import pickle
 import re
 import unittest
+import datetime
 
 from sdcm.sct_events.base import LogEvent
 from sdcm.sct_events.operator import ScyllaOperatorLogEvent
@@ -34,7 +35,10 @@ class TestOperatorEvents(unittest.TestCase):
 
         self.assertEqual(event, pickle.loads(pickle.dumps(event)))
         event.event_id = "9bb2980a-5940-49a7-8b08-d5c323b46aa9"
-        assert event.timestamp == 1624895582.269804
+        expected_timestamp = datetime.datetime(
+            year=datetime.datetime.now().year, month=6, day=28, hour=15, minute=53, second=2,
+            microsecond=269804, tzinfo=datetime.timezone.utc).timestamp()
+        assert event.timestamp == expected_timestamp
         self.assertEqual(
             '(ScyllaOperatorLogEvent Severity.WARNING) period_type=one-time '
             'event_id=9bb2980a-5940-49a7-8b08-d5c323b46aa9: type=TLS_HANDSHAKE_ERROR regex=TLS handshake error '
@@ -57,7 +61,10 @@ class TestOperatorEvents(unittest.TestCase):
 
         self.assertEqual(event, pickle.loads(pickle.dumps(event)))
         event.event_id = "9bb2980a-5940-49a7-8b08-d5c323b46aa9"
-        assert event.timestamp == 1624896463.572294
+        expected_timestamp = datetime.datetime(
+            year=datetime.datetime.now().year, month=6, day=28, hour=16, minute=7, second=43,
+            microsecond=572294, tzinfo=datetime.timezone.utc).timestamp()
+        assert event.timestamp == expected_timestamp
         self.assertEqual(
             '(ScyllaOperatorLogEvent Severity.NORMAL) period_type=one-time '
             'event_id=9bb2980a-5940-49a7-8b08-d5c323b46aa9: type=OPERATOR_STARTED_INFO regex="Starting controller" '


### PR DESCRIPTION
Since year is getting from `.now()` and not from the log print itself
the hardcoded numbers in the test are not valid anymore, now that
we are at 2022.

test was failing like this in PRs CI:
```
12:14:06  >       assert event.timestamp == 1624896463.572294
12:14:06  E       AssertionError: assert 1656432463.572294 == 1624896463.572294
12:14:06  E         +1656432463.572294
12:14:06  E         -1624896463.572294
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
