### PR TITLE
Scylla node benchmarks

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -180,6 +180,7 @@ data_volume_disk_size: 0
 data_volume_disk_iops: 0 # depend on type iops could be 100-16000 for io2|io3 and 3000-16000 for gp3
 install_mode: 'repo'  # install from scylla_repo
 nosqlbench_image: 'scylladb/hydra-loaders:nosqlbench-4.15.49'
+run_db_node_benchmarks: false
 
 nemesis_multiply_factor: 6
 

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -290,3 +290,4 @@
 | **<a href="#user-content-nosqlbench_image" name="nosqlbench_image">nosqlbench_image</a>**  | A docker image of NoSQLBench | N/A | SCT_NOSQLBENCH_IMAGE
 | **<a href="#user-content-raid_level" name="raid_level">raid_level</a>**  | Configure RAID0 or RAID5 on instance | N/A | SCT_RAID_LEVEL
 | **<a href="#user-content-bare_loaders" name="bare_loaders">bare_loaders</a>**  | Don't install anything but collectd to the loaders during cluster setup | False | SCT_BARE_LOADERS
+| **<a href="#user-content-run-db-node-benchmarks" name="run_db_node_benchmarks">run_db_node_benchmarks</a>**  | Run benchmarks on db nodes before the test | false | SCT_RUN_DB_NODE_BENCHMARKS

--- a/docs/node_benchmarks.md
+++ b/docs/node_benchmarks.md
@@ -27,7 +27,7 @@ ElasticSearch index `node_benchmarks`.
 
 ### How are the benchmark results structured?
 
-Since the benchmarks are meant to compare relative performance of db node
+Since the benchmarks are meant to compare relative performance of db node 
 instances, each ES doc represents benchmark results for one node.
 
 Each ElasticSearch doc has the following top-level fields (apart from the regular metadata fields like `_id`):

--- a/docs/node_benchmarks.md
+++ b/docs/node_benchmarks.md
@@ -1,0 +1,416 @@
+# Node Benchmarks for Scylla
+
+Whether you're running performance jobs or investigating an issue, you might
+want to now if the hardware Scylla is running on meets your baseline performance
+expectations. That's what node benchmarks are for.
+
+### Which benchmarks do we run?
+
+We run:
+* sysbench - for CPU benchmarking. Github: https://github.com/akopytov/sysbench
+* cassandra-fio - for disk IO benchmarking. Github: https://github.com/KnifeyMoloko/cassandra-fio
+
+### How to run the benchmarks?
+
+Simply add the line `run_db_node_benchmarks: true` in your test case yaml.
+
+### At which point in time of a test run are these benchmarks performed?
+
+Both benchmarks are performed at the end of the "adding nodes" step.
+Nodes added after the cluster initialization are not included.
+
+### How are the benchmark results collected and stored?
+
+Benchmarks are performed locally on each node and collected at the end by a
+manager class. They are collected in JSON format and uploaded to an
+ElasticSearch index `node_benchmarks`.
+
+### How are the benchmark results structured?
+
+Since the benchmarks are meant to compare relative performance of db node
+instances, each ES doc represents benchmark results for one node.
+
+Each ElasticSearch doc has the following top-level fields (apart from the regular metadata fields like `_id`):
+* node_instance_type - e.g. 'i3.4xlarge'
+* test_id - same as SCT `test_id`, e.g. '4e96c762-e16a-49fe-916e-b566ebb9ec3f'
+* sysbench_* - fields with sysbench metrics
+* cassandra_fio_<name_of_fio_job>_* - metrics for `fio` jobs, e.g. `lcs_64k_write`
+* cassandra_fio_global options - global options for the `cassandra-fio`, e.g. `fio-version` or `filesize`
+* cassandra_fio_* - other `cassandra-fio` data, e.g. `time` or `timestamp`
+
+
+#### Sysbench results
+Example:
+
+```json
+{
+  "sysbench_events_per_second": 7317.29,
+  "sysbench_latency_min": 1.09,
+  "sysbench_latency_max": 1.61,
+  "sysbench_latency_avg": 1.09,
+  "sysbench_latency_p95": 1.1,
+  "sysbench_thread_fairness_avg": 109760.375,
+  "sysbench_thread_fairness_stdev": 100.32,
+  "sysbench_thread_fairness_time_avg": 119.9706,
+  "sysbench_thread_fairness_time_stdev": 0
+}
+```
+
+#### Cassandra-fio results
+
+Cassandra-fio results have the following keys:
+
+* `cassandra_fio_fio version` - example: 'fio-.3.16'
+* `cassandra_fio_timestamp_ms` - example: 1640785143919
+* `cassandra_fio_timestamp` - example: 1640785143
+* `cassandra_fio_time` - example: 'Wed Dec 29 13:39:03 2021'
+* `cassandra_fio_global options` - example:
+```json
+{
+  'fadvise_hint': '0',
+  'rw': 'readwrite',
+  'direct': '1',
+  'invalidate': '1',
+  'thread': '1',
+  'filesize': '160m',
+  'filename_format': 'cassandra.$filenum',
+  'directory': './data',
+  'fallocate': 'none',
+  'file_service_type': 'sequential',
+  'ioengine': 'libaio',
+  'bs': '64k',
+  'iodepth': '8',
+  'nrfiles': '10',
+  'time_based': '1',
+  'randrepeat': '1'
+}
+```
+* `cassandra_fio_disk_util` - example:
+```json
+[
+  {
+    'write_merges': 29,
+    'in_queue': 626036,
+    'write_ticks': 487533,
+    'util': 99.864867,
+    'name': 'xvda',
+    'read_ticks': 477113,
+    'read_ios': 64390,
+    'read_merges': 0,
+    'write_ios': 60874
+  }
+]
+```
+###### Fio jobs:
+* `cassandra_fio_lcs_64k_write` - the lcs64k job includes the following jobs: 'lcs_setup', 'lcs_64k_write',
+'lcs_64k_read'. We do not upload the `lcs_setup` job metrics, we only use write and read metrics. Each job is
+described with the same set of metrics. For example, the 'lcs_64_write' job metrics look like this:
+```json
+{
+  'error': 0,
+  'latency_ns': {
+    '100': 0.0,
+    '2': 0.0,
+    '750': 0.0,
+    '4': 0.0,
+    '500': 0.0,
+    '1000': 0.0,
+    '50': 0.0,
+    '250': 0.0,
+    '20': 0.0,
+    '10': 0.0
+  },
+  'latency_depth': 8,
+  'latency_window': 0,
+  'elapsed': 61,
+  'eta': 0,
+  'job options': {
+    'write_bw_log': 'lcs.64k.write',
+    'write_iops_log': 'lcs.64k.write',
+    'rw': 'write',
+    'openfiles': '1',
+    'name': 'lcs_64k_write',
+    'runtime': '60s',
+    'write_lat_log': 'lcs.64k.write'
+  },
+  'trim': {
+    'io_kbytes': 0,
+    'drop_ios': 0,
+    'iops_max': 0,
+    'iops_mean': 0.0,
+    'bw_agg': 0.0,
+    'runtime': 0,
+    'short_ios': 0,
+    'clat_ns': {
+      'min': 0,
+      'percentile': {
+        '90.000000': 0,
+        '99.500000': 0,
+        '80.000000': 0,
+        '1.000000': 0,
+        '20.000000': 0,
+        '99.950000': 0,
+        '30.000000': 0,
+        '95.000000': 0,
+        '99.000000': 0,
+        '99.990000': 0,
+        '40.000000': 0,
+        '50.000000': 0,
+        '99.900000': 0,
+        '5.000000': 0,
+        '70.000000': 0,
+        '10.000000': 0,
+        '60.000000': 0
+      },
+      'max': 0,
+      'mean': 0.0,
+      'stddev': 0.0
+    },
+    'total_ios': 0,
+    'bw_max': 0,
+    'bw_mean': 0.0,
+    'iops_samples': 0,
+    'bw_bytes': 0,
+    'iops_min': 0,
+    'iops_stddev': 0.0,
+    'bw': 0,
+    'iops': 0.0,
+    'io_bytes': 0,
+    'bw_min': 0,
+    'bw_samples': 0,
+    'slat_ns': {
+      'min': 0,
+      'max': 0,
+      'mean': 0.0,
+      'stddev': 0.0
+    },
+    'lat_ns': {
+      'min': 0,
+      'max': 0,
+      'mean': 0.0,
+      'stddev': 0.0
+    },
+    'bw_dev': 0.0
+  },
+  'usr_cpu': 0.0,
+  'latency_us': {
+    '100': 0.0,
+    '2': 0.0,
+    '750': 0.0,
+    '4': 0.0,
+    '500': 0.0,
+    '1000': 0.0,
+    '50': 0.0,
+    '250': 0.0,
+    '20': 0.0,
+    '10': 0.0
+  },
+  'write': {
+    'io_kbytes': 3838208,
+    'drop_ios': 0,
+    'iops_max': 1,
+    'iops_mean': 1.0,
+    'bw_agg': 12.954007,
+    'runtime': 60008,
+    'short_ios': 0,
+    'clat_ns': {
+      'min': 1085021,
+      'percentile': {
+        '90.000000': 8290304,
+        '99.500000': 11862016,
+        '80.000000': 8159232,
+        '1.000000': 7110656,
+        '20.000000': 7634944,
+        '99.950000': 12910592,
+        '30.000000': 7700480,
+        '95.000000': 8585216,
+        '99.000000': 11337728,
+        '99.990000': 13434880,
+        '40.000000': 7831552,
+        '50.000000': 7962624,
+        '99.900000': 12386304,
+        '5.000000': 7438336,
+        '70.000000': 8093696,
+        '10.000000': 7569408,
+        '60.000000': 8028160
+      },
+      'max': 14403867,
+      'mean': 7970888.317231,
+      'stddev': 607156.487881
+    },
+    'total_ios': 59972,
+    'bw_max': 60400,
+    'bw_mean': 8285.512256,
+    'iops_samples': 59972,
+    'bw_bytes': 65496683,
+    'iops_min': 1,
+    'iops_stddev': 0.0,
+    'bw': 63961,
+    'iops': 999.40008,
+    'io_bytes': 3930324992,
+    'bw_min': 4549,
+    'bw_samples': 59972,
+    'slat_ns': {
+      'min': 8695,
+      'max': 5810551,
+      'mean': 28954.745781,
+      'stddev': 28415.189436
+    },
+    'lat_ns': {
+      'min': 1121824,
+      'max': 14429349,
+      'mean': 8000209.100514,
+      'stddev': 606476.899328
+    },
+    'bw_dev': 1190.721429
+  },
+  'jobname': 'lcs_64k_write',
+  'sys_cpu': 5.4277,
+  'latency_target': 0,
+  'read': {
+    'io_kbytes': 0,
+    'drop_ios': 0,
+    'iops_max': 0,
+    'iops_mean': 0.0,
+    'bw_agg': 0.0,
+    'runtime': 0,
+    'short_ios': 0,
+    'clat_ns': {
+      'min': 0,
+      'percentile': {
+        '90.000000': 0,
+        '99.500000': 0,
+        '80.000000': 0,
+        '1.000000': 0,
+        '20.000000': 0,
+        '99.950000': 0,
+        '30.000000': 0,
+        '95.000000': 0,
+        '99.000000': 0,
+        '99.990000': 0,
+        '40.000000': 0,
+        '50.000000': 0,
+        '99.900000': 0,
+        '5.000000': 0,
+        '70.000000': 0,
+        '10.000000': 0,
+        '60.000000': 0
+      },
+      'max': 0,
+      'mean': 0.0,
+      'stddev': 0.0
+    },
+    'total_ios': 0,
+    'bw_max': 0,
+    'bw_mean': 0.0,
+    'iops_samples': 0,
+    'bw_bytes': 0,
+    'iops_min': 0,
+    'iops_stddev': 0.0,
+    'bw': 0,
+    'iops': 0.0,
+    'io_bytes': 0,
+    'bw_min': 0,
+    'bw_samples': 0,
+    'slat_ns': {
+      'min': 0,
+      'max': 0,
+      'mean': 0.0,
+      'stddev': 0.0
+    },
+    'lat_ns': {
+      'min': 0,
+      'max': 0,
+      'mean': 0.0,
+      'stddev': 0.0
+    },
+    'bw_dev': 0.0
+  },
+  'majf': 0,
+  'ctx': 55725,
+  'groupid': 1,
+  'minf': 2346,
+  'job_runtime': 60007,
+  'iodepth_submit': {
+    '0': 0.0,
+    '>=64': 0.0,
+    '4': 100.0,
+    '16': 0.0,
+    '8': 0.0,
+    '64': 0.0,
+    '32': 0.0
+  },
+  'sync': {
+    'lat_ns': {
+      'min': 0,
+      'percentile': {
+        '90.000000': 0,
+        '99.500000': 0,
+        '80.000000': 0,
+        '1.000000': 0,
+        '20.000000': 0,
+        '99.950000': 0,
+        '30.000000': 0,
+        '95.000000': 0,
+        '99.000000': 0,
+        '99.990000': 0,
+        '40.000000': 0,
+        '50.000000': 0,
+        '99.900000': 0,
+        '5.000000': 0,
+        '70.000000': 0,
+        '10.000000': 0,
+        '60.000000': 0
+      },
+      'max': 0,
+      'mean': 0.0,
+      'stddev': 0.0
+    },
+    'total_ios': 0
+  },
+  'latency_ms': {
+    '100': 0.0,
+    '2': 0.100047,
+    '750': 0.0,
+    '>=2000': 0.0,
+    '4': 0.038351,
+    '500': 0.0,
+    '1000': 0.0,
+    '2000': 0.0,
+    '50': 0.0,
+    '250': 0.0,
+    '20': 1.403989,
+    '10': 98.457614
+  },
+  'iodepth_level': {
+    '>=64': 0.0,
+    '1': 0.1,
+    '2': 0.1,
+    '4': 0.1,
+    '16': 0.0,
+    '8': 99.929967,
+    '32': 0.0
+  },
+  'latency_percentile': 100.0,
+  'iodepth_complete': {
+    '0': 0.0,
+    '>=64': 0.0,
+    '4': 99.998332,
+    '16': 0.0,
+    '8': 0.1,
+    '64': 0.0,
+    '32': 0.0
+  }
+}
+```
+
+Usually we are most interested with the bandwidth and iops metrics for a given
+job, so for the 'lcs_64_write' job, we're interested with the contents of it's
+'write' key. (Details about specific fields and how to read them can be found
+in the fio documentation below.)
+
+
+Resources:
+* fio docs: https://fio.readthedocs.io/en/latest/
+* cassandra-fio repo: https://github.com/KnifeyMoloko/cassandra-fio
+* sysbench repo: https://github.com/akopytov/sysbench

--- a/docs/node_benchmarks.md
+++ b/docs/node_benchmarks.md
@@ -27,8 +27,7 @@ ElasticSearch index `node_benchmarks`.
 
 ### How are the benchmark results structured?
 
-Since the benchmarks are meant to compare relative performance of db node 
-instances, each ES doc represents benchmark results for one node.
+Since the benchmarks are meant to compare relative performance of db node instances, each ES doc represents benchmark results for one node.
 
 Each ElasticSearch doc has the following top-level fields (apart from the regular metadata fields like `_id`):
 * node_instance_type - e.g. 'i3.4xlarge'

--- a/jepsen_test.py
+++ b/jepsen_test.py
@@ -19,7 +19,7 @@ import requests
 from sdcm.remote import shell_script_cmd
 from sdcm.tester import ClusterTester, teardown_on_exception
 from sdcm.utils.decorators import log_run_info
-
+from sdcm.utils.git import clone_repo
 
 JEPSEN_WEB_SERVER_START_DELAY = 15  # seconds
 DB_SSH_KEY = "db_node_ssh_key"
@@ -35,12 +35,14 @@ class JepsenTest(ClusterTester):
     def setup_jepsen(self):
         remoter = self.jepsen_node.remoter
         remoter.sudo("apt-get install -y openjdk-11-jre openjdk-11-jre-headless libjna-java gnuplot graphviz git")
-        remoter.run(shell_script_cmd(f"""\
+        remoter.run(shell_script_cmd("""\
             curl -O https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
             chmod +x lein
             ./lein
-            git clone {self.params.get('jepsen_scylla_repo')} jepsen-scylla
         """))
+        clone_repo(remoter=remoter,
+                   repo_url=self.params.get('jepsen_scylla_repo'),
+                   destination_dir_name="jepsen-scylla")
         for db_node in self.db_cluster.nodes:
             remoter.run(f"ssh-keyscan -t rsa {db_node.ip_address} >> ~/.ssh/known_hosts")
         remoter.send_files(os.path.expanduser(self.db_cluster.nodes[0].ssh_login_info["key_file"]), DB_SSH_KEY)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3067,6 +3067,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
             self.add_nodes(n_nodes, enable_auto_bootstrap=self.auto_bootstrap)
         else:
             raise ValueError('Unsupported type: {}'.format(type(n_nodes)))
+        self.run_node_benchmarks()
         self.coredumps = {}
         super().__init__()
 
@@ -3429,6 +3430,14 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
 
         return ks_tables_with_cdc
 
+    def run_node_benchmarks(self):
+        if not self.params.get("run_db_node_benchmarks") or not self.nodes:
+            return
+
+        self.node_benchmark_manager.add_nodes(self.nodes)
+        self.node_benchmark_manager.install_benchmark_tools()
+        self.node_benchmark_manager.run_benchmarks()
+
     @property
     def cluster_backend(self):
         return self.params.get("cluster_backend")
@@ -3551,7 +3560,6 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         self.nemesis_threads = []
         self.nemesis_count = 0
         self.test_config = TestConfig()
-        self.node_benchmark_manager = ScyllaClusterBenchmarkManager()
         self._node_cycle = None
         super().__init__(*args, **kwargs)
 

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -89,6 +89,7 @@ from sdcm.utils.common import (
 )
 from sdcm.utils.ci_tools import get_test_name
 from sdcm.utils.distro import Distro
+from sdcm.utils.git import clone_repo
 from sdcm.utils.install import InstallMode
 from sdcm.utils.docker_utils import ContainerManager, NotFound, docker_hub_login
 from sdcm.utils.health_checker import check_nodes_status, check_node_status_in_gossip_and_nodetool_status, \
@@ -482,14 +483,12 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 apt-get install -y git make maven
             """))
         # TODO: Needs to uncomment the following lines after https://github.com/apache/cassandra-harry/pull/12 will
-        # self.remoter.run(shell_script_cmd(f"""\
-        #     rm -rf {cassandra_harry_path}
-        #     git clone https://github.com/apache/cassandra-harry.git {cassandra_harry_path}
-        # """))
-        self.remoter.run(shell_script_cmd(f"""\
-            rm -rf {cassandra_harry_path}
-            git clone https://github.com/fruch/cassandra-harry {cassandra_harry_path}
-        """))
+        # self.remoter.run(shell_script_cmd(f"""rm -rf {cassandra_harry_path}"""))
+        # clone_repo(remoter=self.remoter, repo_url="https://github.com/apache/cassandra-harry.git",
+        # destination_dir_name=str(cassandra_harry_path))
+        self.remoter.run(shell_script_cmd(f"""rm -rf {cassandra_harry_path}"""))
+        clone_repo(remoter=self.remoter, repo_url="https://github.com/apache/cassandra-harry.git",
+                   destination_dir_name=str(cassandra_harry_path))
         self.remoter.run(shell_script_cmd(f"""\
             cd {cassandra_harry_path}
             git checkout standalone

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1223,7 +1223,9 @@ class SCTConfiguration(dict):
         dict(name="data_volume_disk_iops", env="SCT_DATA_VOLUME_DISK_IOPS",
              type=int,
              help="Number of iops for ebs type io2|io3|gp3"),
-
+        dict(name="run_db_node_benchmarks", env="SCT_RUN_DB_NODE_BENCHMARKS",
+             type=boolean,
+             help="Flag for running db node benchmarks before the tests"),
         dict(name="nemesis_include_filter", env="SCT_NEMESIS_INCLUDE_FILTER",
              type=str_or_list,
              help="""nemesis_include_filter gets a list of "nemesis properties" and filters IN all the nemesis that has

--- a/sdcm/utils/benchmarks.py
+++ b/sdcm/utils/benchmarks.py
@@ -1,0 +1,221 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2021 ScyllaDB
+import json
+import logging
+import re
+from dataclasses import dataclass, field, asdict
+
+from sdcm.es import ES
+from sdcm.remote import RemoteCmdRunnerBase, shell_script_cmd
+from sdcm.test_config import TestConfig
+from sdcm.utils.common import ParallelObject
+from sdcm.utils.git import clone_repo
+from sdcm.utils.metaclasses import Singleton
+
+LOGGER = logging.getLogger(__name__)
+ES_INDEX = "node_benchmarks"
+
+
+@dataclass
+class ScyllaNodeBenchmarkSysbenchResult:
+    # pylint:disable=too-many-instance-attributes
+    cmd_output: str = field(repr=False)
+    sysbench_events_per_second: float = field(init=False)
+    sysbench_latency_min: float = field(init=False)
+    sysbench_latency_max: float = field(init=False)
+    sysbench_latency_avg: float = field(init=False)
+    sysbench_latency_p95: float = field(init=False)
+    sysbench_thread_fairness_avg: float = field(init=False)
+    sysbench_thread_fairness_stdev: float = field(init=False)
+    sysbench_thread_fairness_time_avg: float = field(init=False)
+    sysbench_thread_fairness_time_stdev: float = field(init=False)
+
+    def __post_init__(self):
+        eps_regex = re.compile(
+            r"events per second:\s+(?P<eps>[\d.]+)([\s\w\d.:/()]+)"
+            r"min:\s+(?P<latency_min>[\d.]+)([\s\w\d.:/()]+)"
+            r"avg:\s+(?P<latency_avg>[\d.]+)([\s\w\d.:/()]+)"
+            r"max:\s+(?P<latency_max>[\d.]+)([\s\w\d.:/()]+)"
+            r"95th percentile:\s+(?P<latency_p95>[\d.]+)([\s\w\d.:/()]+)"
+            r"events\s+\(avg/stddev\):\s+(?P<thread_avg>[\d.]+)/(?P<thread_stdev>[\d.]+)([\s\w\d.:/()]+)"
+            r"execution time \(avg/stddev\):\s+(?P<time_avg>[\d.]+)/(?P<time_stdev>[\d.]+)"
+        )
+        search_result = eps_regex.search(self.cmd_output)
+        self.sysbench_events_per_second = float(search_result.groupdict()["eps"])
+        self.sysbench_latency_min = float(search_result.groupdict()["latency_min"])
+        self.sysbench_latency_max = float(search_result.groupdict()["latency_max"])
+        self.sysbench_latency_avg = float(search_result.groupdict()["latency_avg"])
+        self.sysbench_latency_p95 = float(search_result.groupdict()["latency_p95"])
+        self.sysbench_thread_fairness_avg = float(search_result.groupdict()["thread_avg"])
+        self.sysbench_thread_fairness_stdev = float(search_result.groupdict()["thread_stdev"])
+        self.sysbench_thread_fairness_time_avg = float(search_result.groupdict()["time_avg"])
+        self.sysbench_thread_fairness_time_stdev = float(search_result.groupdict()["time_stdev"])
+
+
+class ScyllaClusterBenchmarkManager(metaclass=Singleton):
+    """
+    ScyllaClusterBenchmarkManager gathers the benchmark results
+    of all the relevant db nodes in the cluster and presents
+    them in unified fashion.
+    ElasticSearch is used to store the results.
+    """
+
+    def __init__(self):
+        self._nodes: list["BaseNode"] = []
+        self._benchmark_runners: list[ScyllaNodeBenchmarkRunner] = []
+        self._es = ES()
+
+    def add_node(self, new_node: "BaseNode"):
+        if new_node.distro.is_debian_like:
+            self._benchmark_runners.append(ScyllaNodeBenchmarkRunner(new_node))
+        else:
+            LOGGER.debug("Skipped installing benchmarking tools on a non-debian-like distro.")
+
+    def add_nodes(self, nodes: list["BaseNode"]):
+        for node in nodes:
+            self.add_node(node)
+
+    def install_benchmark_tools(self):
+        try:
+            parallel = ParallelObject(self._benchmark_runners, timeout=300)
+            parallel.run(lambda x: x.install_benchmark_tools(), ignore_exceptions=True)
+        except TimeoutError as exc:
+            LOGGER.warning("Ran into TimeoutError while installing benchmark tools: Exception:\n%s", exc)
+
+    def run_benchmarks(self):
+        try:
+            parallel = ParallelObject(self._benchmark_runners, timeout=300)
+            parallel.run(lambda x: x.run_benchmarks(), ignore_exceptions=True)
+        except TimeoutError as exc:
+            LOGGER.warning("Run into TimeoutError during running benchmarks. Exception:\n%s", exc)
+        self._collect_benchmark_output()
+
+    def _collect_benchmark_output(self):
+        """
+        Collect the results from ScyllaClusterBenchmarkRunner
+        instances and post them to Elasticsearch.
+        """
+        test_id = TestConfig().test_id()
+
+        for runner in self._benchmark_runners:
+            if runner.benchmark_results:
+                results = {
+                    "test_id": test_id,
+                    "node_instance_type": runner.node_instance_type,
+                    "node_name": runner.node_name,
+                    **runner.benchmark_results
+                }
+                doc_id = f"{test_id}-{runner.node_name.split('-')[-1]}"
+                self._es.create_doc(index=ES_INDEX, doc_type=None, doc_id=doc_id, body=results)
+            else:
+                LOGGER.info("No benchmarks results for node: %s", runner.node_name)
+
+
+class ScyllaNodeBenchmarkRunner:
+    # pylint: disable=broad-except
+    """
+    ScyllaNodeBenchmarkRunner installs and runs benchmarking
+    tools on given cluster nodes and collects the output.
+    """
+
+    def __init__(self, node: "BaseNode"):
+        self._node = node
+        self._remoter: RemoteCmdRunnerBase = node.remoter
+        self.node_instance_type = self._get_db_node_instance_type()
+        self._benchmark_results = {}
+
+    @property
+    def node_name(self):
+        return self._node.name
+
+    @property
+    def benchmark_results(self):
+        LOGGER.info("Node benchmarks results for node %s:\n%s", self.node_name, self._benchmark_results)
+        return self._benchmark_results
+
+    def install_benchmark_tools(self):
+        clone_repo(self._remoter, "https://github.com/akopytov/sysbench.git")
+        clone_repo(self._remoter, "https://github.com/KnifeyMoloko/cassandra-fio.git")
+        self._install_ubuntu_prerequisites()
+        self._build_and_install_sysbench()
+
+    def _get_db_node_instance_type(self):
+        backend = self._node.parent_cluster.params.get("cluster_backend")
+        if backend in ("aws", "aws-siren"):
+            return self._node.parent_cluster.params.get("instance_type_db")
+        elif backend in ("gce", "gce-siren"):
+            return self._node.parent_cluster.params.get("gce_instance_type_db")
+        else:
+            LOGGER.warning("Unrecognized backend type, defaulting to 'Unknown' for"
+                           "db instance type.")
+            return None
+
+    def _install_ubuntu_prerequisites(self):
+        package_list = ["make", "automake", "libtool", "pkg-config", "libaio-dev", "fio"]
+        try:
+            LOGGER.info("Installing Ubuntu prerequisites for the node benchmarks...")
+            for pkg in package_list:
+                self._node.install_package(pkg, wait_for_package_manager=False)
+            LOGGER.info("Ubuntu prerequisites for the node benchmarks installed.")
+        except Exception as exc:
+            LOGGER.warning("Failed to install Ubuntu prerequisites for the node benchmarking tools. "
+                           "Exception:\n%s", exc)
+
+    def _build_and_install_sysbench(self):
+        build_and_install_script = """\
+            cd ./sysbench
+            ./autogen.sh
+            ./configure --without-mysql
+            make -j
+            make install
+        """
+        self._remoter.sudo(shell_script_cmd(build_and_install_script), ignore_status=True)
+
+    def run_sysbench(self, thread_num: int = None, test_time: int = 120):
+        thread_num = thread_num or self._node.cpu_cores
+        run_cmd = f"sysbench cpu --threads={thread_num} --time={test_time} run"
+        sysbench_run_result = self._remoter.run(run_cmd, ignore_status=True)
+        results_dict = asdict(ScyllaNodeBenchmarkSysbenchResult(sysbench_run_result.stdout))
+        results_dict.pop("cmd_output")
+        self.benchmark_results.update(results_dict)
+
+    def run_fio(self):
+        run_cmd = """\
+            cd cassandra-fio
+            ./fio_runner.sh lcs
+        """
+        self._remoter.sudo(shell_script_cmd(run_cmd), new_session=True, ignore_status=True)
+        self._get_fio_results()
+
+    def _get_fio_results(self):
+        fio_reports_path = "/home/ubuntu/cassandra-fio/reports/"
+        cat_cmd = f"cat {fio_reports_path}{'lcs.64k.fio.json'}"
+
+        try:
+            cat_out = self._remoter.run(cat_cmd, ignore_status=True)
+            jsoned_output = {f"cassandra_fio_{key}": value for key, value in json.loads(cat_out.stdout).items()}
+
+            if cat_out.stderr:
+                LOGGER.info("Cat error out: %s", cat_out.stderr)
+            cassandra_fio_jobs = jsoned_output.pop("cassandra_fio_jobs")
+            cassandra_fio_jobs = [job for job in cassandra_fio_jobs if "setup" not in job["jobname"]]
+
+            for job in cassandra_fio_jobs:
+                jsoned_output.update({f'cassandra_fio_{job["jobname"]}': job})
+            self.benchmark_results.update(jsoned_output)
+        except Exception as exc:
+            LOGGER.warning("Failed to get cassandra-fio result for node %s with exception:\n%s", self.node_name, exc)
+
+    def run_benchmarks(self):
+        self.run_sysbench()
+        self.run_fio()

--- a/sdcm/utils/benchmarks.py
+++ b/sdcm/utils/benchmarks.py
@@ -207,6 +207,7 @@ class ScyllaNodeBenchmarkRunner:
 
             if cat_out.stderr:
                 LOGGER.info("Cat error out: %s", cat_out.stderr)
+
             cassandra_fio_jobs = jsoned_output.pop("cassandra_fio_jobs")
             cassandra_fio_jobs = [job for job in cassandra_fio_jobs if "setup" not in job["jobname"]]
 

--- a/sdcm/utils/benchmarks.py
+++ b/sdcm/utils/benchmarks.py
@@ -140,11 +140,11 @@ class ScyllaNodeBenchmarkRunner:
 
     @property
     def benchmark_results(self):
-        LOGGER.info("Node benchmarks results for node %s:\n%s", self.node_name, self._benchmark_results)
         return self._benchmark_results
 
     def install_benchmark_tools(self):
         clone_repo(self._remoter, "https://github.com/akopytov/sysbench.git")
+        # upstream repo: https://github.com/ibspoof/cassandra-fio
         clone_repo(self._remoter, "https://github.com/KnifeyMoloko/cassandra-fio.git")
         self._install_ubuntu_prerequisites()
         self._build_and_install_sysbench()
@@ -200,7 +200,6 @@ class ScyllaNodeBenchmarkRunner:
     def _get_fio_results(self):
         fio_reports_path = "/home/ubuntu/cassandra-fio/reports/"
         cat_cmd = f"cat {fio_reports_path}{'lcs.64k.fio.json'}"
-
         try:
             cat_out = self._remoter.run(cat_cmd, ignore_status=True)
             jsoned_output = {f"cassandra_fio_{key}": value for key, value in json.loads(cat_out.stdout).items()}

--- a/sdcm/utils/git.py
+++ b/sdcm/utils/git.py
@@ -23,3 +23,16 @@ def get_git_current_branch() -> str:
         LOGGER.warning("Error running git command", exc_info=True)
         return "#ERROR"
     return proc.stdout.decode(encoding="utf-8").strip()
+
+
+def clone_repo(remoter, repo_url: str):
+    # pylint: disable=broad-except
+    try:
+        LOGGER.debug("Cloning from %s...", repo_url)
+        rm_cmd = f"rm -rf ./{repo_url.split('/')[-1].split('.')[0]}"
+        remoter.sudo(rm_cmd, ignore_status=False)
+        clone_cmd = f"git clone {repo_url}"
+        remoter.sudo(clone_cmd)
+        LOGGER.debug("Finished cloning from %s.", repo_url)
+    except Exception as exc:
+        LOGGER.warning("Failed to clone from %s. Failed with: %s", repo_url, exc)

--- a/sdcm/utils/git.py
+++ b/sdcm/utils/git.py
@@ -25,13 +25,13 @@ def get_git_current_branch() -> str:
     return proc.stdout.decode(encoding="utf-8").strip()
 
 
-def clone_repo(remoter, repo_url: str):
+def clone_repo(remoter, repo_url: str, destination_dir_name: str = ""):
     # pylint: disable=broad-except
     try:
         LOGGER.debug("Cloning from %s...", repo_url)
         rm_cmd = f"rm -rf ./{repo_url.split('/')[-1].split('.')[0]}"
         remoter.sudo(rm_cmd, ignore_status=False)
-        clone_cmd = f"git clone {repo_url}"
+        clone_cmd = f"git clone {repo_url} {destination_dir_name}"
         remoter.sudo(clone_cmd)
         LOGGER.debug("Finished cloning from %s.", repo_url)
     except Exception as exc:


### PR DESCRIPTION
This PR adds the ability to perform node benchmarks on our Ubuntu db nodes. The 2 benchmarks added are `sysbench` for cpu tests and `cassandra-fio` for storage benchmarking. More info can be found in the readme doc added by this PR.


Trello tasl: https://trello.com/c/BmhZ5DN2
Example longevity job: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/maciej/job/mc-longevity/job/mc-byo-new-test/115
Elasticsearch index for collected benchmark stats: `node_benchmarks`

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
