### PR TITLE
fix(print on console): change log level for repair and compaction events

### DIFF
--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -264,8 +264,8 @@ class RepairEvent(ScyllaDatabaseContinuousEvent):
     continuous_hash_fields = ('node', 'shard', 'uuid')
 
     def __init__(self, node: str, shard: int, severity=Severity.NORMAL, **__):
-        self.log_level = logging.DEBUG
         super().__init__(node=node, shard=shard, severity=severity)
+        self.log_level = logging.DEBUG
 
 
 class CompactionEvent(ScyllaDatabaseContinuousEvent):
@@ -281,8 +281,8 @@ class CompactionEvent(ScyllaDatabaseContinuousEvent):
                  severity=Severity.NORMAL, **__):
         self.table = table
         self.compaction_process_id = compaction_process_id
-        self.log_level = logging.DEBUG
         super().__init__(node=node, shard=shard, severity=severity)
+        self.log_level = logging.DEBUG
 
     @property
     def msgfmt(self):


### PR DESCRIPTION
As result of https://github.com/scylladb/scylla-cluster-tests/pull/4245 log level for
Repair and Compaction events is back to INFO instead of DEBUG and those events are
printed out on the job console. It's a lot of events and we don't want to see them
on the console

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
