### PR TITLE
fix(add-dc-test): remove unnecesary dc

### DIFF
--- a/jenkins-pipelines/features-add-new-dc.jenkinsfile
+++ b/jenkins-pipelines/features-add-new-dc.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    region: '''["eu-west-1", "eu-west-2", "eu-north-1"]''',
+    region: '''["eu-west-1", "eu-west-2"]''',
     test_name: 'add_new_dc_test.TestAddNewDc.test_add_new_dc',
     test_config: 'test-cases/features/add-new-dc.yaml',
 

--- a/test-cases/features/add-new-dc.yaml
+++ b/test-cases/features/add-new-dc.yaml
@@ -1,16 +1,16 @@
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=209 -schema 'replication(strategy=NetworkTopologyStrategy,eu-westscylla_node_west=3,eu-west-2scylla_node_west=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=8 -pop seq=1..209 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=20900 -schema 'replication(strategy=NetworkTopologyStrategy,eu-westscylla_node_west=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=8 -pop seq=1..20900 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
 
-stress_cmd: ["cassandra-stress read cl=LOCAL_QUORUM duration=20m -port jmx=6868 -mode cql3 native -rate threads=8 -pop seq=1..209 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
-             "cassandra-stress write cl=LOCAL_QUORUM duration=20m -port jmx=6868 -mode cql3 native -rate threads=8 -pop seq=1..209 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
+stress_cmd: ["cassandra-stress read cl=LOCAL_QUORUM duration=20m -port jmx=6868 -mode cql3 native -rate threads=8 -pop seq=1..20900 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+             "cassandra-stress write cl=LOCAL_QUORUM duration=20m -port jmx=6868 -mode cql3 native -rate threads=8 -pop seq=1..20900 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
              ]
-verify_data_after_entire_test: "cassandra-stress read cl=LOCAL_ONE n=209 -port jmx=6868 -mode cql3 native -rate threads=8 -pop seq=1..209 -col 'n=FIXED(10) size=FIXED(512)' -node {new_node.ip_address} -log interval=5"
+verify_data_after_entire_test: "cassandra-stress read cl=LOCAL_ONE n=20900 -port jmx=6868 -mode cql3 native -rate threads=8 -pop seq=1..20900 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
 
-n_db_nodes: 3 3 0  # make n_db_nodes configured as multi-dc with last dc set to 0 (so later easily new node can be added)
-region_name: 'eu-west-1 eu-west-2 eu-north-1'
+n_db_nodes: 3 0  # make n_db_nodes configured as multi-dc with last dc set to 0 (so later easily new node can be added)
+region_name: 'eu-west-1 eu-west-2'
 n_loaders: 1
 n_monitor_nodes: 1
 
 instance_type_db: 'i3.xlarge'
-seeds_num: 4
+seeds_num: 3
 
 user_prefix: 'add-new-dc'


### PR DESCRIPTION
New dc test required some modifications per comments in https://github.com/scylladb/scylla-cluster-tests/pull/4206
Most important: removing dc, so we start off with one.

trello: https://trello.com/c/v0fwzr67

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
