### PR TITLE
fix(manager versions): bump version of manager

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -7,8 +7,8 @@ ip_ssh_connections: 'private'
 mgmt_port: 10090
 scylla_repo: ''
 scylla_repo_m: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylla-2020.1.repo'
-scylla_mgmt_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-2.3.repo'
-scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/focal/branch-2.3/latest/scylladb-manager-2.3/scylla-manager.list'
+scylla_mgmt_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.6.repo'
+scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.6-focal.list'
 scylla_repo_loader: ''
 
 experimental: true

--- a/test-cases/artifacts/centos7.yaml
+++ b/test-cases/artifacts/centos7.yaml
@@ -17,4 +17,4 @@ scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-
 test_duration: 60
 user_prefix: 'artifacts-centos7'
 system_auth_rf: 1
-scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.3.repo'
+scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.6.repo'

--- a/test-cases/artifacts/centos8.yaml
+++ b/test-cases/artifacts/centos8.yaml
@@ -17,4 +17,4 @@ scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-
 test_duration: 60
 user_prefix: 'artifacts-centos8'
 system_auth_rf: 1
-scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.3.repo'
+scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.6.repo'

--- a/test-cases/artifacts/debian10.yaml
+++ b/test-cases/artifacts/debian10.yaml
@@ -17,4 +17,4 @@ scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/debian/scylla-
 test_duration: 60
 user_prefix: 'artifacts-debian10'
 system_auth_rf: 1
-scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/buster/branch-2.3/latest/scylladb-manager-2.3/scylla-manager.list'
+scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/deb/debian/scylladb-manager-2.6-buster.list'

--- a/test-cases/artifacts/debian9.yaml
+++ b/test-cases/artifacts/debian9.yaml
@@ -17,4 +17,4 @@ scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/debian/scylla-
 test_duration: 60
 user_prefix: 'artifacts-debian9'
 system_auth_rf: 1
-scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/deb/debian/scylladb-manager-2.3-stretch.list'
+scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/deb/debian/scylladb-manager-2.6-stretch.list'

--- a/test-cases/artifacts/gce-image.yaml
+++ b/test-cases/artifacts/gce-image.yaml
@@ -17,4 +17,4 @@ scylla_linux_distro: 'centos'
 test_duration: 60
 user_prefix: 'artifacts-gce-image'
 system_auth_rf: 1
-scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.3.repo'
+scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.6.repo'

--- a/test-cases/artifacts/oel76.yaml
+++ b/test-cases/artifacts/oel76.yaml
@@ -18,4 +18,4 @@ test_duration: 60
 use_preinstalled_scylla: false
 user_prefix: 'artifacts-oel76'
 system_auth_rf: 1
-scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.3.repo'
+scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.6.repo'

--- a/test-cases/artifacts/oel81.yaml
+++ b/test-cases/artifacts/oel81.yaml
@@ -18,4 +18,4 @@ test_duration: 60
 use_preinstalled_scylla: false
 user_prefix: 'artifacts-oel76'
 system_auth_rf: 1
-scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.3.repo'
+scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.6.repo'

--- a/test-cases/artifacts/ubuntu1604.yaml
+++ b/test-cases/artifacts/ubuntu1604.yaml
@@ -17,4 +17,4 @@ scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-
 test_duration: 60
 user_prefix: 'artifacts-ubuntu1604'
 system_auth_rf: 1
-scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-2.3-xenial.list'
+scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.6-xenial.list'

--- a/test-cases/artifacts/ubuntu1804.yaml
+++ b/test-cases/artifacts/ubuntu1804.yaml
@@ -17,4 +17,4 @@ scylla_repo: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-
 test_duration: 60
 user_prefix: 'artifacts-ubuntu1804'
 system_auth_rf: 1
-scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.3-bionic.list'
+scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.6-bionic.list'

--- a/test-cases/artifacts/ubuntu2004.yaml
+++ b/test-cases/artifacts/ubuntu2004.yaml
@@ -17,4 +17,4 @@ scylla_repo: 'http://downloads.scylladb.com/deb/unstable/unified/master/latest/s
 test_duration: 60
 user_prefix: 'artifacts-ubuntu2004'
 system_auth_rf: 1
-scylla_mgmt_agent_repo: 'http://downloads.scylladb.com.s3.amazonaws.com/manager/deb/unstable/focal/branch-2.3/2/scylla-manager-2.3/scylla-manager.list'
+scylla_mgmt_agent_repo: 'http://downloads.scylladb.com/deb/ubuntu/scylladb-manager-2.6-focal.list'

--- a/test-cases/upgrades/manager-upgrade.yaml
+++ b/test-cases/upgrades/manager-upgrade.yaml
@@ -21,6 +21,6 @@ ip_ssh_connections: 'private'
 use_mgmt: true
 mgmt_port: 12345
 manager_prometheus_port: 10091
-scylla_mgmt_agent_repo: "http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.1.repo"
+scylla_mgmt_agent_repo: "http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.6.repo"
 
 aws_instance_profile_name: 'qa-scylla-manager-backup-instance-profile'


### PR DESCRIPTION
as ARM support was added to branch-2021.1 and
the manager 2.6 is the first one that supports
it, bumping the version to be able to run tests
in this branch uniformly.

Fixes #4288.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
