### PR TITLE
fix(arm ami test): set availability_zone to c

### DIFF
--- a/jenkins-pipelines/artifacts-ami-arm.jenkinsfile
+++ b/jenkins-pipelines/artifacts-ami-arm.jenkinsfile
@@ -1,0 +1,15 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/ami.yaml',
+    backend: 'aws',
+    provision_type: 'spot_low_price',
+    availability_zone: 'c',  // Since ARM processors aren't available in zone 'a' (the default) at the moment.
+
+    timeout: [time: 45, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy',
+    builds_to_keep: '100'
+)

--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -71,6 +71,10 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('email_recipients', 'qa@scylladb.com')}",
                    description: 'email recipients of email report',
                    name: 'email_recipients')
+            string(defaultValue: "${pipelineParams.get('availability_zone', 'a')}",
+               description: 'Availability zone',
+               name: 'availability_zone')
+
         }
         options {
             timestamps()
@@ -185,6 +189,7 @@ def call(Map pipelineParams) {
                                                     export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
                                                     export SCT_IP_SSH_CONNECTIONS="${params.ip_ssh_connections}"
                                                     export SCT_INSTANCE_PROVISION="${params.provision_type}"
+                                                    export SCT_AVAILABILITY_ZONE="${params.availability_zone}"
 
                                                     echo "start test ......."
                                                     ./docker/env/hydra.sh run-test artifacts_test --backend ${params.backend} --logdir "`pwd`"


### PR DESCRIPTION
Since arm instances cannot be currently created in our default availability zone (a)
I created a seperate jenkinsfile for the artifact ami of arm processors
which uses the proper availability zone.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
