### PR TITLE
test(arm support): Created new arm longevities

### DIFF
--- a/configurations/arm_instance_types/Is4gen_4xlarge.yaml
+++ b/configurations/arm_instance_types/Is4gen_4xlarge.yaml
@@ -1,0 +1,4 @@
+instance_type_db: 'is4gen.4xlarge'  # The equivalent of i3.4xlarge
+# enhanced network isn't supported
+append_scylla_setup_args: ' --no-ec2-check '
+use_mgmt: false

--- a/jenkins-pipelines/longevity-100gb-4h-arm.jenkinsfile
+++ b/jenkins-pipelines/longevity-100gb-4h-arm.jenkinsfile
@@ -1,0 +1,14 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/arm_instance_types/Is4gen_4xlarge.yaml"]''',
+    availability_zone: 'c',
+
+    timeout: [time: 360, unit: 'MINUTES']
+)

--- a/jenkins-pipelines/longevity-200gb-48h-arm.jenkinsfile
+++ b/jenkins-pipelines/longevity-200gb-48h-arm.jenkinsfile
@@ -1,0 +1,14 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml", "configurations/arm_instance_types/Is4gen_4xlarge.yaml"]''',
+    availability_zone: 'c',
+
+    timeout: [time: 3060, unit: 'MINUTES']
+)

--- a/jenkins-pipelines/longevity-50gb-3days-arm.jenkinsfile
+++ b/jenkins-pipelines/longevity-50gb-3days-arm.jenkinsfile
@@ -1,0 +1,14 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "configurations/arm_instance_types/Is4gen_4xlarge.yaml"]''',
+    availability_zone: 'c',
+
+    timeout: [time: 5000, unit: 'MINUTES']
+)

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -30,7 +30,7 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('gce_datacenter', 'us-east1')}",
                    description: 'GCE datacenter',
                    name: 'gce_datacenter')
-            string(defaultValue: "a",
+            string(defaultValue: "${pipelineParams.get('availability_zone', 'a')}",
                description: 'Availability zone',
                name: 'availability_zone')
 

--- a/vars/provisionResources.groovy
+++ b/vars/provisionResources.groovy
@@ -18,6 +18,11 @@ def call(Map params, String region){
     if [[ -n "${params.region ? params.region : ''}" ]] ; then
         export SCT_REGION_NAME=${current_region}
     fi
+
+    if [[ -n "${params.availability_zone ? params.availability_zone : ''}" ]] ; then
+        export SCT_AVAILABILITY_ZONE="${params.availability_zone}"
+    fi
+
     if [[ -n "${params.gce_datacenter ? params.gce_datacenter : ''}" ]] ; then
         export SCT_GCE_DATACENTER=${params.gce_datacenter}
     fi

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -27,6 +27,11 @@ def call(Map params, String region, functional_test = false){
     if [[ -n "${params.region ? params.region : ''}" ]] ; then
         export SCT_REGION_NAME=${current_region}
     fi
+
+    if [[ -n "${params.availability_zone ? params.availability_zone : ''}" ]] ; then
+        export SCT_AVAILABILITY_ZONE="${params.availability_zone}"
+    fi
+
     if [[ -n "${params.gce_datacenter ? params.gce_datacenter : ''}" ]] ; then
         export SCT_GCE_DATACENTER=${params.gce_datacenter}
     fi


### PR DESCRIPTION
Since arm is only supported in specific availability zones across different
aws regions, I set the availability_zone of all arm jobs to 'c' by default,
since it is supported both in us-east-1 and eu-west-1.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
