### PR TITLE
feature(events): Add a new WARNING event

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -14,6 +14,7 @@ ScyllaHelpErrorEvent.filtered: ERROR
 FullScanEvent: ERROR
 FullPartitionScanReversedOrderEvent: ERROR
 FullPartitionScanEvent: ERROR
+DatabaseLogEvent.WARNING: WARNING
 DatabaseLogEvent.NO_SPACE_ERROR: ERROR
 DatabaseLogEvent.UNKNOWN_VERB: WARNING
 DatabaseLogEvent.CLIENT_DISCONNECT: WARNING

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -29,6 +29,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 class DatabaseLogEvent(LogEvent, abstract=True):
+    WARNING: Type[LogEventProtocol]
     NO_SPACE_ERROR: Type[LogEventProtocol]
     UNKNOWN_VERB: Type[LogEventProtocol]
     CLIENT_DISCONNECT: Type[LogEventProtocol]
@@ -73,6 +74,8 @@ class ReactorStalledMixin(Generic[T_log_event]):
         return super().add_info(node=node, line=line, line_number=line_number)
 
 
+DatabaseLogEvent.add_subevent_type("WARNING", severity=Severity.WARNING,
+                                   regex="!WARNING ")
 DatabaseLogEvent.add_subevent_type("NO_SPACE_ERROR", severity=Severity.ERROR,
                                    regex="No space left on device")
 DatabaseLogEvent.add_subevent_type("UNKNOWN_VERB", severity=Severity.WARNING,
@@ -130,6 +133,7 @@ DatabaseLogEvent.add_subevent_type("stream_exception", severity=Severity.ERROR,
 
 
 SYSTEM_ERROR_EVENTS = (
+    DatabaseLogEvent.WARNING(),
     DatabaseLogEvent.NO_SPACE_ERROR(),
     DatabaseLogEvent.UNKNOWN_VERB(),
     DatabaseLogEvent.CLIENT_DISCONNECT(),


### PR DESCRIPTION
There are lines which are warning level, and we treat them as error
only cause the word `exception` is part of the print
we have those a lot in 2021.1, and we should put them into warning
events as they should.

```
2022-01-04T06:36:22+00:00  ip-10-0-1-54 !WARNING | scylla:  [shard 0]
workload prioritization - update_from_distributed_data: failed to
update configuration for more than  90 seconds :
exceptions::read_timeout_exception (Operation timed out for
system_distributed.service_levels - received only 0 responses
from 1 CL=ONE.)
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
