### PR TITLE
fix(rolling_upgrade): use pro images for ubuntu 1604

### DIFF
--- a/jenkins-pipelines/rolling-upgrade-ubuntu16.04.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-ubuntu16.04.jenkinsfile
@@ -7,7 +7,7 @@ rollingUpgradePipeline(
     backend: 'gce',
     base_versions: [],  // auto mode
     linux_distro: 'ubuntu-xenial',
-    gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts',
+    gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-pro-cloud/global/images/family/ubuntu-pro-1604-lts',
 
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
     test_config: 'test-cases/upgrades/rolling-upgrade.yaml',

--- a/test-cases/artifacts/ubuntu1604.yaml
+++ b/test-cases/artifacts/ubuntu1604.yaml
@@ -1,6 +1,6 @@
 backtrace_decoding: false
 cluster_backend: 'gce'
-gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts'
+gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-pro-cloud/global/images/family/ubuntu-pro-1604-lts'
 gce_instance_type_db: 'n1-standard-2'
 gce_root_disk_type_db: 'pd-ssd'
 gce_root_disk_size_db: 50


### PR DESCRIPTION
Since ubuntu 1604 LTS is finished, moving to use ubuntu pro images.
which should be available until April 2026

Ref: https://cloud.google.com/compute/docs/images/os-details#ubuntu_pro

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
