### PR TITLE
improvement(argus): send argus's output to a separate log

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -920,6 +920,8 @@ class SCTLogCollector(LogCollector):
                 search_locally=True),
         FileLog(name='scylla-migrate.log',
                 search_locally=True),
+        FileLog(name='argus.log',
+                search_locally=True),
     ]
     cluster_log_type = 'sct-runner'
     cluster_dir_prefix = 'sct-runner'

--- a/sdcm/utils/log.py
+++ b/sdcm/utils/log.py
@@ -131,6 +131,13 @@ def configure_logging(exception_handler=None,  # pylint: disable=too-many-argume
                 'filename': '{log_dir}/sct.log',
                 'mode': 'a',
                 'formatter': 'default',
+            },
+            'argus': {
+                'level': 'DEBUG',
+                'class': 'logging.FileHandler',
+                'filename': '{log_dir}/argus.log',
+                'mode': 'a',
+                'formatter': 'default',
             }
         }
     if loggers is None:
@@ -164,7 +171,17 @@ def configure_logging(exception_handler=None,  # pylint: disable=too-many-argume
             },
             'anyconfig': {
                 'level': 'ERROR'
-            }
+            },
+            'argus': {
+                'handlers': ['argus'],
+                'level': 'DEBUG',
+                'propagate': False
+            },
+            'sdcm.argus_test_run': {
+                'handlers': ['argus'],
+                'level': 'DEBUG',
+                'propagate': False
+            },
         }
     if config is None:
         config = {


### PR DESCRIPTION
Save all argus messages in the separate argus.log file and collect it within sct-runner.tar.gz

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
