### PR TITLE
fix(manager): enable manager log collection for siren cluster

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1112,16 +1112,15 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
                                                    instance=instance,
                                                    global_ip=instance['PublicIpAddress'],
                                                    tags={**self.tags, "NodeType": "monitor", }))
-        # Temporarily disabling cloud-manager logs collection
-        # due to: https://github.com/scylladb/scylla-cluster-tests/issues/3816
-        if self.params["use_cloud_manager"] and False:  # pylint: disable=condition-evals-to-constant
+        if self.params["use_cloud_manager"]:
             try:
                 from cluster_cloud import get_manager_instance_by_cluster_id  # pylint: disable=import-outside-toplevel
             except ImportError:
                 LOGGER.error("Couldn't collect Siren manager logs, cluster_cloud module isn't installed")
             else:
                 instance = get_manager_instance_by_cluster_id(cluster_id=self.params["cloud_cluster_id"],
-                                                              region_name=self.params["region_name"][0])
+                                                              region_name=self.params["region_name"][0],
+                                                              cloud_manager_id=self.params["cloud_manager_id"])
                 name = [tag["Value"]
                         for tag in instance["Tags"] if tag["Key"] == "Name"]
                 self.siren_manager_set.append(CollectingNode(name=name[0],


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
