### PR TITLE
fix(nemesis_enospc): ignore "No such file or directory" log

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -119,6 +119,16 @@ def ignore_no_space_errors(node):
             line="No space left on device",
             node=node,
         ))
+        stack.enter_context(DbEventsFilter(
+            db_event=DatabaseLogEvent.DATABASE_ERROR,
+            line="No such file or directory",
+            node=node,
+        ))
+        stack.enter_context(DbEventsFilter(
+            db_event=DatabaseLogEvent.FILESYSTEM_ERROR,
+            line="No such file or directory",
+            node=node,
+        ))
         yield
 
 


### PR DESCRIPTION
In recent jobs of branch-4.6, we run into those line which was raised
as error events:

```
ERR |  [shard 2] commitlog - Could not delete segment /var/lib/scylla/
hints/2/10.142.0.61/HintsLog-2-36028797022305996.log: std::filesystem::
__cxx11::filesystem_error (error system:2, filesystem error: stat
failed: No such file or directory [/var/lib/scylla/hints/2/
10.142.0.61/HintsLog-2-36028797022305996.log])
```

those are failure on files that were failing to be written cause of
there is no space on the device, hence we can also ignore those errors.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
