### PR TITLE
fix(bump loader repo): there might be old issues with previous version

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -9,7 +9,7 @@ scylla_repo: ''
 manager_version: '2.6'
 manager_scylla_backend_version: '2021'  # Notice: that centos, ubuntu 20 and debian 10 monitors use 2021, while debian 9, ubuntu 16 and ubuntu 18 use 2020, since we support both
 
-scylla_repo_loader: ''
+scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-4.6.repo'
 
 experimental: true
 round_robin: false

--- a/test-cases/longevity/longevity-10gb-3h.yaml
+++ b/test-cases/longevity/longevity-10gb-3h.yaml
@@ -9,7 +9,6 @@ n_monitor_nodes: 1
 instance_type_db: 'i3.4xlarge'
 gce_instance_type_db: 'n1-highmem-16'
 gce_instance_type_loader: 'e2-standard-4'
-scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-4.3.repo'
 run_fullscan: 'keyspace1.standard1, 5' # 'ks.cf|random, interval(min)''
 
 nemesis_class_name: 'SisyphusMonkey'

--- a/test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml
@@ -27,7 +27,6 @@ gce_n_local_ssd_disk_db: 16
 
 instance_type_loader: 'c5.4xlarge'
 gce_instance_type_loader: 'c2-standard-16'
-scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-4.3.repo'
 
 
 nemesis_class_name: 'SisyphusMonkey'

--- a/test-cases/manager/manager-regression-gce.yaml
+++ b/test-cases/manager/manager-regression-gce.yaml
@@ -10,7 +10,6 @@ post_behavior_db_nodes: "destroy"
 post_behavior_loader_nodes: "destroy"
 post_behavior_monitor_nodes: "destroy"
 use_preinstalled_scylla: true
-scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-4.3.repo'
 
 user_prefix: manager-regression
 space_node_threshold: 6442

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -216,7 +216,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         self.assertEqual(conf.get('scylla_repo'),
                          "https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-3.0-xenial.list")
         self.assertEqual(conf.get('scylla_repo_loader'),
-                         "https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-3.0-xenial.list")
+                         "https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-4.6.repo")
 
     def test_12_scylla_version_repo_ubuntu_loader_centos(self):  # pylint: disable=invalid-name
         os.environ['SCT_CLUSTER_BACKEND'] = 'gce'
@@ -230,7 +230,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         self.assertEqual(conf.get('scylla_repo'),
                          "https://s3.amazonaws.com/downloads.scylladb.com/deb/ubuntu/scylla-3.0-xenial.list")
         self.assertEqual(conf.get('scylla_repo_loader'),
-                         "https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-3.0.repo")
+                         "https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-4.6.repo")
 
     def test_12_k8s_scylla_version_ubuntu_loader_centos(self):  # pylint: disable=invalid-name
         os.environ['SCT_CLUSTER_BACKEND'] = 'k8s-local-kind'
@@ -243,7 +243,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         self.assertIn('scylla_repo', conf.dump_config())
         self.assertFalse(conf.get('scylla_repo'))
         self.assertEqual(conf.get('scylla_repo_loader'),
-                         'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-nightly.repo')
+                         'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-4.6.repo')
 
     def test_13_scylla_version_ami_branch(self):  # pylint: disable=invalid-name
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'

--- a/unit_tests/test_data/test_scylla_yaml_builders/longevity-10gb-3h.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/longevity-10gb-3h.yaml
@@ -9,7 +9,6 @@ n_monitor_nodes: 1
 instance_type_db: 'i3.4xlarge'
 gce_instance_type_db: 'n1-highmem-16'
 gce_instance_type_loader: 'e2-standard-4'
-scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-4.3.repo'
 
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '111'


### PR DESCRIPTION
we are seeing in both `branch-4.5` and `branch-4.6` failures
(c-s getting stuck too long after duration is finished)
and is causing failures in GCE tests.
bumping the version might give us the chance to surpass
these failures, as they are most likely to be
already fixed in an later version of it.


have [a job running](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fabio/job/4.6/job/3h-gce-4.6/2/) in my staging folder to confirm it fixes the issue

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
