### PR TITLE
fix(scan_operation_thread.py): Wait for table to be created before running a scan thread

### DIFF
--- a/test-cases/longevity/longevity-100GB-48h-cloud-CloudLimitedChaosMonkey-tls.yaml
+++ b/test-cases/longevity/longevity-100GB-48h-cloud-CloudLimitedChaosMonkey-tls.yaml
@@ -3,7 +3,7 @@ prepare_write_cmd: "cassandra-stress write cl=ALL n=100100150  -schema 'replicat
 
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=2860m  -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=250  -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=400200300..500200300 -log interval=15"]
 stress_read_cmd: ["cassandra-stress read cl=ONE duration=2860m -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=250  -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..100100150 -log interval=5"]
-run_fullscan: 'keyspace1.standard1, 5' # 'ks.cf|random, interval(min)''
+run_fullscan: '{"ks_cf": "keyspace1.standard1", "interval": 5}' # 'ks.cf|random, interval(min)'
 
 n_db_nodes: 4
 n_loaders: 1

--- a/test-cases/longevity/longevity-10gb-3h.yaml
+++ b/test-cases/longevity/longevity-10gb-3h.yaml
@@ -9,8 +9,7 @@ n_monitor_nodes: 1
 instance_type_db: 'i3.4xlarge'
 gce_instance_type_db: 'n1-highmem-16'
 gce_instance_type_loader: 'e2-standard-4'
-run_fullscan: 'keyspace1.standard1, 5' # 'ks.cf|random, interval(min)''
-
+run_fullscan: '{"ks_cf": "keyspace1.standard1", "interval": 5}' # 'ks.cf|random, interval(min)'
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '111'
 nemesis_interval: 2

--- a/test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml
@@ -12,8 +12,7 @@ stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=6800m -schema 'replicati
 stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=6800m -port jmx=6868 -mode cql3 native  -rate threads=10 -pop seq=1..1100200300  -log interval=5 -col 'size=FIXED(200) n=FIXED(5)'" ]
 
 
-run_fullscan: 'random, 120'  # 'ks.cf|random, interval(min)''
-
+run_fullscan: '{"ks_cf": "random", "interval": 120}' # 'ks.cf|random, interval(min)'
 round_robin: true
 
 n_db_nodes: 4

--- a/test-cases/longevity/longevity-200GB-48h-network-monkey.yaml
+++ b/test-cases/longevity/longevity-200GB-48h-network-monkey.yaml
@@ -3,8 +3,7 @@ prepare_write_cmd: "cassandra-stress write cl=ALL n=200200300  -schema 'replicat
 
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=2780m  -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=250  -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=400200300..600200300 -log interval=15"]
 stress_read_cmd: ["cassandra-stress read cl=ONE duration=2780m -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=250  -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..200200300 -log interval=5"]
-run_fullscan: 'keyspace1.standard1, 5' # 'ks.cf|random, interval(min)''
-
+run_fullscan: '{"ks_cf": "keyspace1.standard1", "interval": 5}' # 'ks.cf|random, interval(min)'
 n_db_nodes: 6
 n_loaders: 1
 n_monitor_nodes: 1

--- a/test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
+++ b/test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
@@ -4,8 +4,7 @@ prepare_write_cmd: "cassandra-stress write cl=ALL n=200200300  -schema 'replicat
 
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=2860m  -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=250  -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=400200300..600200300 -log interval=15"]
 stress_read_cmd: ["cassandra-stress read cl=ONE duration=2860m -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=250  -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..200200300 -log interval=5"]
-run_fullscan: 'keyspace1.standard1, 5' # 'ks.cf|random, interval(min)''
-
+run_fullscan: '{"ks_cf": "keyspace1.standard1", "interval": 5}' # 'ks.cf|random, interval(min)'
 n_db_nodes: 4
 n_loaders: 1
 n_monitor_nodes: 1

--- a/test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
+++ b/test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
@@ -9,8 +9,7 @@ stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=2460m -schema 'replicati
 
 stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=2460m -port jmx=6868 -mode cql3 native  -rate threads=10 -pop seq=1..2147483648  -log interval=5 -col 'size=FIXED(64) n=FIXED(16)'"]
 
-run_fullscan: 'random, 240'  # 'ks.cf|random, interval(min)''
-
+run_fullscan: '{"ks_cf": "random", "interval": 240}' # 'ks.cf|random, interval(min)'
 round_robin: true
 
 n_db_nodes: 5

--- a/test-cases/longevity/longevity-50GB-12h-verifier-LimitedMonkey-tls.yaml
+++ b/test-cases/longevity/longevity-50GB-12h-verifier-LimitedMonkey-tls.yaml
@@ -3,8 +3,7 @@ prepare_write_cmd: "cassandra-stress write cl=ALL n=50050075  -schema 'replicati
 
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=360m  -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=250  -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=400200300..600200300 -log interval=15"]
 stress_read_cmd: ["cassandra-stress read cl=ONE duration=360m -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=250  -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..50050075 -log interval=5"]
-run_fullscan: 'keyspace1.standard1, 5' # 'ks.cf|random, interval(min)''
-
+run_fullscan: '{"ks_cf": "keyspace1.standard1", "interval": 5}' # 'ks.cf|random, interval(min)'
 n_db_nodes: 4
 n_loaders: 1
 n_monitor_nodes: 1

--- a/test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml
@@ -6,8 +6,7 @@ stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=4320m -schema 'replicati
 
 stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=4320m -port jmx=6868 -mode cql3 native  -rate threads=50 -pop seq=1..100000000 -log interval=5"]
 
-run_fullscan: 'keyspace1.standard1, 60' # 'ks.cf|random, interval(min)''
-
+run_fullscan: '{"ks_cf": "keyspace1.standard1", "interval": 60}' # 'ks.cf|random, interval(min)'
 n_db_nodes: 6
 n_loaders: 3
 n_monitor_nodes: 1

--- a/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
+++ b/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
@@ -3,8 +3,7 @@ prepare_write_cmd: "cassandra-stress write cl=ALL n=200200300  -schema 'replicat
 
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=360m  -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=50  -col 'size=FIXED(200) n=FIXED(5)' -pop seq=400200300..600200300 -log interval=15"]
 stress_read_cmd: ["cassandra-stress read cl=ONE duration=360m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=50  -col 'size=FIXED(200) n=FIXED(5)' -pop seq=1..200200300 -log interval=5"]
-run_fullscan: 'keyspace1.standard1, 5' # 'ks.cf|random, interval(min)''
-
+run_fullscan: '{"ks_cf": "keyspace1.standard1", "interval": 5}' # 'ks.cf|random, interval(min)'
 n_db_nodes: 4
 n_loaders: 2
 n_monitor_nodes: 1

--- a/test-cases/longevity/longevity-in-memory-36GB-1day.yaml
+++ b/test-cases/longevity/longevity-in-memory-36GB-1day.yaml
@@ -4,8 +4,7 @@ prepare_verify_cmd: ["cassandra-stress read                          cl=QUORUM n
 stress_cmd:         ["cassandra-stress mixed 'ratio(write=1,read=8)' cl=QUORUM duration=1400m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -pop seq=1..21000000 -col 'size=FIXED(200) n=FIXED(5)' -log interval=10"]
 stress_read_cmd:    ["cassandra-stress read                          cl=QUORUM duration=1400m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=100 -pop seq=1..21000000 -col 'size=FIXED(200) n=FIXED(5)' -log interval=10"]
 
-run_fullscan: 'random, 30' # 'ks.cf|random, interval(min)''
-
+run_fullscan: '{"ks_cf": "random", "interval": 30}' # 'ks.cf|random, interval(min)'
 n_db_nodes: 5
 n_loaders: 2
 n_monitor_nodes: 1

--- a/test-cases/longevity/longevity-multi-keyspaces.yaml
+++ b/test-cases/longevity/longevity-multi-keyspaces.yaml
@@ -2,7 +2,8 @@
 test_duration: 3600
 prepare_write_cmd: ["cassandra-stress write no-warmup cl=QUORUM n=4000000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=20 -pop seq=1..4000000 -log interval=30"]
 stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=48h -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=10 -pop seq=1..4000000 -log interval=90"]
-run_fullscan: 'random, 30'
+run_fullscan: '{"ks_cf": "random", "interval": 30}' # 'ks.cf|random, interval(min)'
+
 pre_create_schema: true
 
 keyspace_num: 1000

--- a/test-cases/longevity/longevity-mv-si-4days.yaml
+++ b/test-cases/longevity/longevity-mv-si-4days.yaml
@@ -8,7 +8,7 @@ stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_profile_4mv_5queries.y
                   "cassandra-stress user profile=/tmp/c-s_profile_2si_2queries.yaml ops'(insert=10,si_p_read1=1,si_p_read2=1)' cl=QUORUM duration=5760m -port jmx=6868 -mode cql3 native -rate threads=10"
 
                  ]
-run_fullscan: 'random, 15'
+run_fullscan: '{"ks_cf": "random", "interval": 15}' # 'ks.cf|random, interval(min)'
 
 n_db_nodes: 5
 n_loaders: 2


### PR DESCRIPTION
1. 	Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/4304
2. Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/4306


Added a missing commit from reversed-queries PR:

                - fix(full scan): Update new format of run_fullscan params in yaml
                -     
                -             Following the enhancement of reversed-queries new scan thread,
                -             The yaml parameter of run_fullscan has a new format.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
