### PR TITLE
Fix critical error handling

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -278,7 +278,7 @@ class ArtifactsTest(ClusterTester):
         email_data = self._get_common_email_data()
         try:
             node = self.node
-        except:  # pylint: disable=bare-except
+        except Exception:  # pylint: disable=broad-except
             node = None
         if node:
             scylla_packages = node.scylla_packages_installed

--- a/docker/alternator-dns/dns_server.py
+++ b/docker/alternator-dns/dns_server.py
@@ -34,7 +34,7 @@ def livenodes_update():
             # If we're successful, replace livenodes by the new list
             livenodes = a
             print(livenodes)
-        except:
+        except Exception:  # pylint: disable=broad-except
             # TODO: contacting this ip was unsuccessful, maybe we should
             # remove it from the list of live nodes.
             pass

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1372,7 +1372,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
                 config_map = self.k8s_core_v1_api.read_namespaced_config_map(
                     name=SCYLLA_CONFIG_NAME, namespace=SCYLLA_NAMESPACE).data or {}
                 exists = True
-            except:  # pylint: disable=bare-except
+            except Exception:  # pylint: disable=broad-except
                 config_map = {}
                 exists = False
             original_config_map = deepcopy(config_map)

--- a/sdcm/coredump.py
+++ b/sdcm/coredump.py
@@ -170,7 +170,7 @@ class CoredumpThreadBase(Thread):  # pylint: disable=too-many-instance-attribute
                 if result:
                     uploaded.append(core_info)
                     self.publish_event(core_info)
-            except:  # pylint: disable=bare-except
+            except Exception:  # pylint: disable=broad-except
                 pass
 
     @abstractmethod

--- a/sdcm/db_log_reader.py
+++ b/sdcm/db_log_reader.py
@@ -151,7 +151,7 @@ class DbLogReader(Process):
 
                     if one_line_backtrace and backtraces:
                         backtraces[-1]['backtrace'] = one_line_backtrace
-                except (BaseException, Exception):  # pylint: disable=broad-except
+                except Exception:  # pylint: disable=broad-except
                     LOGGER.exception('Processing of %s line of %s failed, line content:\n%s',
                                      index, self._system_log, line)
 
@@ -196,7 +196,7 @@ class DbLogReader(Process):
                 self._read_and_publish_events()
             except (SystemExit, KeyboardInterrupt) as ex:
                 LOGGER.debug("db_log_reader_thread() stopped by %s", ex.__class__.__name__)
-            except BaseException:  # pylint: disable=broad-except
+            except Exception:  # pylint: disable=broad-except
                 LOGGER.exception("failed to read db log")
 
     def filter_backtraces(self, backtrace):

--- a/sdcm/remote/libssh2_client/__init__.py
+++ b/sdcm/remote/libssh2_client/__init__.py
@@ -150,7 +150,7 @@ class KeepAliveThread(Thread):
             try:
                 time_to_wait = self._session.eagain(
                     self._session.keepalive_send, timeout=self._keepalive_timeout)
-            except:  # pylint: disable=bare-except
+            except Exception:  # pylint: disable=broad-except
                 time_to_wait = self._keepalive_timeout
             sleep(time_to_wait)
 
@@ -356,7 +356,7 @@ class Client:  # pylint: disable=too-many-instance-attributes
                 with self.session.lock:
                     self.session.agent_auth(self.user)
                 return
-            except:  # pylint: disable=bare-except
+            except Exception:  # pylint: disable=broad-except
                 pass
         self._password_auth()
 
@@ -403,7 +403,7 @@ class Client:  # pylint: disable=too-many-instance-attributes
         if self.sock:
             try:
                 self.sock.close()
-            except:  # pylint: disable=bare-except
+            except Exception:  # pylint: disable=broad-except
                 pass
         family = self._get_socket_family(host)
         if family is None:
@@ -447,7 +447,7 @@ class Client:  # pylint: disable=too-many-instance-attributes
                     stdout_stream.write(data)
                     for watcher in watchers:
                         watcher.submit_line(data)
-                except:  # pylint: disable=bare-except
+                except Exception:  # pylint: disable=broad-except
                     pass
             if stderr_stream is not None:
                 if reader.stderr.qsize():
@@ -457,7 +457,7 @@ class Client:  # pylint: disable=too-many-instance-attributes
                         stderr_stream.write(data)
                         for watcher in watchers:
                             watcher.submit_line(data)
-                    except:  # pylint: disable=bare-except
+                    except Exception:  # pylint: disable=broad-except
                         pass
         return True
 
@@ -540,14 +540,14 @@ class Client:  # pylint: disable=too-many-instance-attributes
         if self.session is not None:
             try:
                 self.session.eagain(self.session.disconnect)
-            except:  # pylint: disable=bare-except
+            except Exception:  # pylint: disable=broad-except
                 pass
             del self.session
             self.session = None
         if self.sock is not None:
             try:
                 self.sock.close()
-            except:  # pylint: disable=bare-except
+            except Exception:  # pylint: disable=broad-except
                 pass
             self.sock = None
 
@@ -678,7 +678,7 @@ class Client:  # pylint: disable=too-many-instance-attributes
                 chan = self.session.eagain(self.session.open_session)
                 if chan != LIBSSH2_ERROR_EAGAIN:
                     break
-            except:  # pylint: disable=bare-except
+            except Exception:  # pylint: disable=broad-except
                 pass
             delay = next(delay_iter, delay)
             sleep(delay)

--- a/sdcm/remote/libssh2_client/session.py
+++ b/sdcm/remote/libssh2_client/session.py
@@ -74,11 +74,11 @@ class Session(LibSSH2Session):  # pylint: disable=too-few-public-methods
             self.channels.remove(channel)
         try:
             channel.close()
-        except:  # pylint: disable=bare-except
+        except Exception:  # pylint: disable=broad-except
             pass
         try:
             channel.wait_closed()
-        except:  # pylint: disable=bare-except
+        except Exception:  # pylint: disable=broad-except
             pass
         del channel
 

--- a/sdcm/remote/remote_libssh_cmd_runner.py
+++ b/sdcm/remote/remote_libssh_cmd_runner.py
@@ -54,11 +54,11 @@ class RemoteLibSSH2CmdRunner(RemoteCmdRunnerBase, ssh_transport='libssh2'):  # p
             try:
                 if self.connection.check_if_alive(timeout):
                     return True
-            except:  # pylint: disable=bare-except
+            except Exception:  # pylint: disable=broad-except
                 try:
                     self.connection.close()
                     self.connection.open(timeout)
-                except:  # pylint: disable=bare-except
+                except Exception:  # pylint: disable=broad-except
                     pass
         return False
 
@@ -68,11 +68,11 @@ class RemoteLibSSH2CmdRunner(RemoteCmdRunnerBase, ssh_transport='libssh2'):  # p
             self.log.debug('Reestablish the session...')
             try:
                 self.connection.disconnect()
-            except:  # pylint: disable=bare-except
+            except Exception:  # pylint: disable=broad-except
                 pass
             try:
                 self.connection.connect()
-            except:  # pylint: disable=bare-except
+            except Exception:  # pylint: disable=broad-except
                 pass
         if self._is_error_retryable(str(exc)) or isinstance(exc, self.exception_retryable):
             raise RetryableNetworkException(str(exc), original=exc)

--- a/sdcm/sct_events/continuous_event.py
+++ b/sdcm/sct_events/continuous_event.py
@@ -26,7 +26,7 @@ from sdcm.utils.metaclasses import Singleton
 LOGGER = logging.getLogger(__name__)
 
 
-class ContinuousEventRegistryException(BaseException):
+class ContinuousEventRegistryException(Exception):
     pass
 
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -210,6 +210,10 @@ class silence:  # pylint: disable=invalid-name
         ).publish_or_dump(default_logger=parent.log)
 
 
+class CriticalTestFailure(BaseException):
+    pass
+
+
 def critical_failure_handler(signum, frame):  # pylint: disable=unused-argument
     try:
         if TestConfig().tester_obj().teardown_started:
@@ -217,7 +221,7 @@ def critical_failure_handler(signum, frame):  # pylint: disable=unused-argument
             return
     except Exception:  # pylint: disable=broad-except
         pass
-    raise AssertionError("Critical Error has failed the test")  # pylint: disable=raise-missing-from
+    raise CriticalTestFailure("Critical Error has failed the test")  # pylint: disable=raise-missing-from
 
 
 signal.signal(signal.SIGUSR2, critical_failure_handler)

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -528,7 +528,7 @@ def list_clients_docker(builder_name: Optional[str] = None, verbose: bool = Fals
                     base_url=f"ssh://{builder['user']}@{normalize_ipv6_url(builder['public_ip'])}:22")
             client.ping()
             log.info("%(name)s: connected via SSH (%(user)s@%(public_ip)s)", builder)
-        except:
+        except Exception:  # pylint: disable=broad-except
             log.error("%(name)s: failed to connect to Docker via SSH", builder)
             raise
         docker_clients[builder["name"]] = client

--- a/sdcm/utils/k8s.py
+++ b/sdcm/utils/k8s.py
@@ -747,7 +747,7 @@ class HelmValues:
             last = int(last[1:-1])
         try:
             del parent[last]
-        except:  # pylint: disable=bare-except
+        except Exception:  # pylint: disable=broad-except
             pass
 
     def as_dict(self):

--- a/sdcm/utils/remote_logger.py
+++ b/sdcm/utils/remote_logger.py
@@ -198,7 +198,7 @@ class CommandLoggerBase(LoggerBase):
                 if started:
                     # Update last time only if command successfully started
                     self._last_time_completed = time.time()
-            except:  # pylint: disable=bare-except
+            except Exception:  # pylint: disable=broad-except
                 pass
 
     def start(self):


### PR DESCRIPTION
https://trello.com/c/d7RlVP0u/4480-fix-test-failing-procedure-on-critical-event
Fixes https://github.com/scylladb/scylla-cluster-tests/issues/4309

We raise `AssertionError` in the event handler to stop the test.
Python is taking this exception and throw it at the current execution point of the MainThread.

The problem is that if current execution point in the MainThread is running inside 

```
try:
      ...
except Exception:
      ... 
```
this exception will be caught and test won't stop.

Solution is to probably raise something derived not from `Exception`, but from `BaseException`, which will make it through the except filter unless it is bare exception:

```
except:

```

So, in total, solution is to go over code and convert `except:` to `except Exception:`
And fix `critical_failure_handler` to use child of `BaseException` instead of `AssertionError`

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
