### PR TITLE
fix(sdcm/cluster.py): Fixing install_cassandra_harry method

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -27,6 +27,7 @@ import uuid
 import itertools
 import json
 import ipaddress
+from pathlib import Path
 from typing import List, Optional, Dict, Union, Set, Iterable, ContextManager
 from datetime import datetime
 from textwrap import dedent
@@ -453,6 +454,10 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
     @retrying(n=3)
     def install_cassandra_harry(self):
+        # The SCT code runs from another machine, and the current code runs from the loader machine.
+        # Therefore, one needs to execute the "pwd" command to get the user path.
+        cassandra_harry_folder_path = Path(self.remoter.sudo("pwd", ignore_status=True).stdout.strip())
+        cassandra_harry_path = cassandra_harry_folder_path / "cassandra-harry"
         if self.distro.is_rhel_like:
             self.remoter.sudo("yum install -y git make maven")
         else:
@@ -460,15 +465,24 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 apt-get update
                 apt-get install -y git make maven
             """))
-        self.remoter.run(shell_script_cmd("""\
-            rm -rf cassandra-harry
-            git clone https://github.com/apache/cassandra-harry
-            cd cassandra-harry
-            git checkout 26bb6696ba1b18ff5c062d780a9360e750691052
-            make mvn
+        # TODO: Needs to uncomment the following lines after https://github.com/apache/cassandra-harry/pull/12 will
+        # self.remoter.run(shell_script_cmd(f"""\
+        #     rm -rf {cassandra_harry_path}
+        #     git clone https://github.com/apache/cassandra-harry.git {cassandra_harry_path}
+        # """))
+        self.remoter.run(shell_script_cmd(f"""\
+            rm -rf {cassandra_harry_path}
+            git clone https://github.com/fruch/cassandra-harry {cassandra_harry_path}
         """))
-        result = self.remoter.run('realpath ~/cassandra-harry/scripts/cassandra-harry')
-        self.remoter.sudo(f"ln -s {result.stdout.strip()} /usr/bin/cassandra-harry", ignore_status=True)
+        self.remoter.run(shell_script_cmd(f"""\
+            cd {cassandra_harry_path}
+            git checkout standalone
+            make standalone
+        """))
+        cassandra_harry_tool_path = cassandra_harry_path / "scripts" / "cassandra-harry"
+        # Edit the "cassandra-harry' file and set the correct HARRY_HOME value (the value should be repo's path)
+        self.remoter.run(rf"sed -i '2s;^;HARRY_HOME={cassandra_harry_path}\n;' {cassandra_harry_tool_path}")
+        self.remoter.sudo(f"ln -svf {cassandra_harry_tool_path} /usr/bin/cassandra-harry", ignore_status=True)
         self.is_cassandra_harry_installed = True
 
     @property

--- a/test-cases/longevity/longevity-harry-2h.yaml
+++ b/test-cases/longevity/longevity-harry-2h.yaml
@@ -1,5 +1,5 @@
 test_duration: 240
-stress_cmd: ["/usr/bin/cassandra-harry -run-time 2 -run-time-unit HOURS"]
+stress_cmd: ["cassandra-harry -run-time 2 -run-time-unit HOURS"]
 
 n_db_nodes: 6
 n_loaders: 2

--- a/test-cases/longevity/longevity-harry-2h.yaml
+++ b/test-cases/longevity/longevity-harry-2h.yaml
@@ -2,7 +2,7 @@ test_duration: 240
 stress_cmd: ["cassandra-harry -run-time 2 -run-time-unit HOURS"]
 
 n_db_nodes: 6
-n_loaders: 2
+n_loaders: 1
 n_monitor_nodes: 1
 
 instance_type_db: 'i3.large'


### PR DESCRIPTION
The command contained the full path of the command and not just
 the "tool" name. Thus, the "cassandra-harry" is not installed
 because the following "if" returned a False value.
```
if 'cassandra-harry' in self.params.list_of_stress_tools:
    if not node.is_cassandra_harry_installed:
        node.install_cassandra_harry(node)
```

The second problem was that the POM file contained
 a failed dependency.
Thus, this dependency to remove as Amos did in his branch.
Add a new test to verify the installation of
 `cassandra-harry` is working.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
