### PR TITLE
fix(add-remove-dc-nemesis): fix switch replication strategy

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2972,8 +2972,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                     f"-mode cql3 native compression=lz4 -rate threads=5 -pop seq=1..10000 -log interval=5"
         write_thread = self.tester.run_stress_thread(stress_cmd=write_cmd, use_single_loader=True)
         self.tester.verify_stress_thread(cs_thread_pool=write_thread)
-        read_cmd = f"cassandra-stress read no-warmup cl=ALL n=10000 -schema 'keyspace=keyspace_new_dc " \
-                   f"replication(strategy=NetworkTopologyStrategy,{datacenters[0]}=3,{datacenters[1]}=1) " \
+        self._verify_multi_dc_keyspace_data(consistency_level="ALL")
+
+    def _verify_multi_dc_keyspace_data(self, consistency_level: str = "ALL"):
+        read_cmd = f"cassandra-stress read no-warmup cl={consistency_level} n=10000 -schema 'keyspace=keyspace_new_dc " \
                    f"compression=LZ4Compressor' -port jmx=6868 -mode cql3 native compression=lz4 -rate threads=5 " \
                    f"-pop seq=1..10000 -log interval=5"
         read_thread = self.tester.run_stress_thread(stress_cmd=read_cmd, use_single_loader=True)
@@ -3029,6 +3031,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.monitoring_set.reconfigure_scylla_monitoring()
         datacenters = list(self.tester.db_cluster.get_nodetool_status().keys())
         assert not [dc for dc in datacenters if dc.endswith("_nemesis_dc")], "new datacenter was not unregistered"
+        self._verify_multi_dc_keyspace_data(consistency_level="QUORUM")
 
 
 def disrupt_method_wrapper(method):  # pylint: disable=too-many-statements

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2994,20 +2994,23 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 # no need to switch as already is NetworkTopology
                 continue
             self.log.info(f"Switching replication strategy to Network for '{keyspace}' keyspace")
-            if keyspace == "system_auth":
-                # system_auth keyspace must have full replication
-                replication_strategy.replication_factor = len(nodes_by_region[region])
+            if keyspace == "system_auth" and replication_strategy.replication_factor != len(nodes_by_region[region]):
+                self.log.warning(f"system_auth keyspace is not replicated on all nodes "
+                                 f"({replication_strategy.replication_factor}/{len(nodes_by_region[region])}).")
             network_replication = NetworkTopologyReplicationStrategy(
                 **{dc_name: replication_strategy.replication_factor})
             network_replication.apply(node, keyspace)
-            for node in nodes_by_region[0]:
-                node.run_nodetool(sub_cmd=f"repair {keyspace}", publish_event=True)
+
+    def _get_user_keyspaces(self):
+        node = self.cluster.nodes[0]
+        keyspaces = node.run_cqlsh("describe keyspaces").stdout.split()
+        return [ks for ks in keyspaces if not ks.startswith("system")]
 
     def disrupt_add_remove_dc(self) -> None:
         InfoEvent(message='Starting New DC Nemesis').publish()
         node = self.cluster.nodes[0]
         system_keyspaces = ["system_auth", "system_distributed", "system_traces"]
-        self._switch_to_network_replication_strategy(system_keyspaces)
+        self._switch_to_network_replication_strategy(self._get_user_keyspaces() + system_keyspaces)
         with temporary_replication_strategy_setter(node) as replication_strategy_setter:
             new_node = self._add_new_node_in_new_dc()
             datacenters = list(self.tester.db_cluster.get_nodetool_status().keys())

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -68,8 +68,8 @@ from sdcm.sct_events.decorators import raise_event_on_failure
 from sdcm.sct_events.group_common_events import (ignore_alternator_client_errors, ignore_no_space_errors,
                                                  ignore_scrub_invalid_errors)
 from sdcm.db_stats import PrometheusDBStats
-from sdcm.utils.replication_strategy_utils import temporary_replication_strategy_setter,\
-    NetworkTopologyReplicationStrategy
+from sdcm.utils.replication_strategy_utils import temporary_replication_strategy_setter, \
+    NetworkTopologyReplicationStrategy, ReplicationStrategy, SimpleReplicationStrategy
 from sdcm.utils.sstable.load_utils import SstableLoadUtils
 from sdcm.utils.toppartition_util import NewApiTopPartitionCmd, OldApiTopPartitionCmd
 from sdcm.utils.version_utils import MethodVersionNotFound, scylla_versions
@@ -2979,21 +2979,46 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         read_thread = self.tester.run_stress_thread(stress_cmd=read_cmd, use_single_loader=True)
         self.tester.verify_stress_thread(cs_thread_pool=read_thread)
 
+    def _switch_to_network_replication_strategy(self, keyspaces: List[str]) -> None:
+        """Switches replication strategy to NetworkTopology for given keyspaces.
+        """
+        node = self.cluster.nodes[0]
+        nodes_by_region = self.tester.db_cluster.nodes_by_region()
+        region = list(nodes_by_region.keys())[0]
+        dc_name = self.tester.db_cluster.get_nodetool_info(nodes_by_region[region][0])['Data Center']
+        for keyspace in keyspaces:
+            replication_strategy = ReplicationStrategy.get(node, keyspace)
+            if not isinstance(replication_strategy, SimpleReplicationStrategy):
+                # no need to switch as already is NetworkTopology
+                continue
+            self.log.info(f"Switching replication strategy to Network for '{keyspace}' keyspace")
+            if keyspace == "system_auth":
+                # system_auth keyspace must have full replication
+                replication_strategy.replication_factor = len(nodes_by_region[region])
+            network_replication = NetworkTopologyReplicationStrategy(
+                **{dc_name: replication_strategy.replication_factor})
+            network_replication.apply(node, keyspace)
+            for node in nodes_by_region[0]:
+                node.run_nodetool(sub_cmd=f"repair {keyspace}", publish_event=True)
+
     def disrupt_add_remove_dc(self) -> None:
         InfoEvent(message='Starting New DC Nemesis').publish()
         node = self.cluster.nodes[0]
-        status = self.tester.db_cluster.get_nodetool_status()
-        full_replication = NetworkTopologyReplicationStrategy(**{dc: len(status[dc].keys()) for dc in status})
         system_keyspaces = ["system_auth", "system_distributed", "system_traces"]
+        self._switch_to_network_replication_strategy(system_keyspaces)
         with temporary_replication_strategy_setter(node) as replication_strategy_setter:
-            replication_strategy_setter(system_auth=full_replication)
             new_node = self._add_new_node_in_new_dc()
             datacenters = list(self.tester.db_cluster.get_nodetool_status().keys())
             status = self.tester.db_cluster.get_nodetool_status()
-            assert [dc for dc in list(status.keys()) if dc.endswith("_nemesis_dc")], "new datacenter was not registered"
-            full_replication = NetworkTopologyReplicationStrategy(**{dc: len(status[dc].keys()) for dc in status})
-            replication_strategies = {keyspace: full_replication for keyspace in system_keyspaces}
-            replication_strategy_setter(**replication_strategies)
+            new_dc_list = [dc for dc in list(status.keys()) if dc.endswith("_nemesis_dc")]
+            assert new_dc_list, "new datacenter was not registered"
+            new_dc_name = new_dc_list[0]
+            for keyspace in system_keyspaces:
+                strategy = ReplicationStrategy.get(node, keyspace)
+                assert isinstance(strategy, NetworkTopologyReplicationStrategy), \
+                    "Should have been already switched to NetworkStrategy"
+                strategy.replication_factors.update({new_dc_name: 1})
+                replication_strategy_setter(**{keyspace: strategy})
             InfoEvent(message='execute rebuild on new datacenter').publish()
             new_node.run_nodetool(sub_cmd=f"rebuild -- {datacenters[0]}")
             InfoEvent(message='Running full cluster repair on each node').publish()


### PR DESCRIPTION
fix for https://github.com/scylladb/scylla-cluster-tests/issues/4300

Seems problem was occurring when e.g. system_traces keyspace is using SimpleStrategy and we switch it to NetworkStrategy with changed replication factor.
This fix makes we don't change rf when switching to Network Replication Strategy (unless `system_auth`, it requires to be replicated across all the nodes). Also added repair for each switched keyspace (I'm not sure if required).
This fix should also resolve problem of leaking garbage from `get_nodetool_status` - as we're not relying on it that much

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
