### PR TITLE
fix(gce-sct-runner): keep instance alive

### DIFF
--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -635,6 +635,7 @@ class GceSctRunner(SctRunner):
             size=instance_type,
             image=base_image,
             ex_network=self.SCT_NETWORK,
+            ex_tags="keep-alive",
             ex_disks_gce_struct=[{
                 "type": "PERSISTENT",
                 "deviceName": f"{instance_name}-root-pd-ssd",


### PR DESCRIPTION
Since Cloud instance stopper supports only tags/labels
we need to set the instance keep tag to alive.
This is needed to prevent Cloud instance stopper script
to kill the SCT Runner

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
