### PR TITLE
fix(syslog-ng): raise connection limit

### DIFF
--- a/sdcm/utils/syslogng.py
+++ b/sdcm/utils/syslogng.py
@@ -85,6 +85,7 @@ source s_network_tcp {{
     transport("tcp")
     port({port})
     flags(syslog-protocol)
+    max-connections(1000)
   );
 }};
 


### PR DESCRIPTION
Fixes problem when ssh-tunnel is used for logging.
It eats 2-4 connections per host, as result we reach limit of connections quickly.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
