### PR TITLE
feature(aws utils): make them respect arch

### DIFF
--- a/sdcm/utils/aws_utils.py
+++ b/sdcm/utils/aws_utils.py
@@ -14,7 +14,7 @@
 import time
 import logging
 from functools import cached_property
-from typing import List, Dict
+from typing import List, Dict, Literal
 
 import boto3
 from botocore.exceptions import ClientError
@@ -25,6 +25,7 @@ from sdcm.wait import wait_for
 
 
 LOGGER = logging.getLogger(__name__)
+AwsArchType = Literal['x86_64', 'arm64']
 
 
 class EksClusterCleanupMixin:


### PR DESCRIPTION
Fix get_branched_ami and get_scylla_ami_versions to respect architecture

ARM image was released and tagged same way we where doing that for x64.
Since SCT ignores architecture flag, we pick it up and run test on it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
