### PR TITLE
fix(continuous): add event type to hash

### DIFF
--- a/sdcm/sct_events/continuous_event.py
+++ b/sdcm/sct_events/continuous_event.py
@@ -97,11 +97,12 @@ class ContinuousEvent(SctEvent, abstract=True):
     def get_continuous_hash_from_dict(cls, data: dict):
         if "shard" in data:
             data["shard"] = int(data["shard"])
-        return hash(tuple(data.get(attr_name) for attr_name in cls.continuous_hash_fields))
+        return hash((cls.__name__,) + tuple(data.get(attr_name) for attr_name in cls.continuous_hash_fields))
 
     @property
     def continuous_hash_tuple(self) -> tuple[Any | None]:
-        return tuple(getattr(self, attr_name, None) for attr_name in self.continuous_hash_fields)
+        return (self.__class__.__name__,) + \
+            tuple(getattr(self, attr_name, None) for attr_name in self.continuous_hash_fields)
 
     @property
     def continuous_hash_dict(self) -> dict[str, str]:

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -291,7 +291,8 @@ class RepairEvent(ScyllaDatabaseContinuousEvent):
     save_to_files = False
     continuous_hash_fields = ('node', 'shard', 'uuid')
 
-    def __init__(self, node: str, shard: int, severity=Severity.NORMAL, **__):
+    def __init__(self, node: str, shard: int, uuid: str, severity=Severity.NORMAL, **__):
+        self.uuid = uuid
         super().__init__(node=node, shard=shard, severity=severity)
         self.log_level = logging.DEBUG
 


### PR DESCRIPTION
It will prevent events with different classed to have same hash
Also it adds hash to the RepairEvent body

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
