### PR TITLE
fix(boot script): wait cloud-init only on aws

### DIFF
--- a/sdcm/provision/aws/configuration_script.py
+++ b/sdcm/provision/aws/configuration_script.py
@@ -22,6 +22,9 @@ class AWSConfigurationScriptBuilder(ConfigurationScriptBuilder):
     aws_additional_interface: bool = False
     aws_ipv6_workaround: bool = False
 
+    def _wait_before_running_script(self) -> str:
+        return 'while ! systemctl status cloud-init.service | grep "active (exited)"; do sleep 1; done\n'
+
     def _script_body(self) -> str:
         script = super()._script_body()
         if self.aws_additional_interface:

--- a/sdcm/provision/common/configuration_script.py
+++ b/sdcm/provision/common/configuration_script.py
@@ -39,10 +39,14 @@ class ConfigurationScriptBuilder(AttrBuilder, metaclass=abc.ABCMeta):
         script += self._end_script()
         return script
 
+    @staticmethod
+    def _wait_before_running_script() -> str:
+        return ''
+
     def _start_script(self) -> str:
         script = '#!/bin/bash\n'
         script += 'set -x\n'
-        script += 'while ! systemctl status cloud-init.service | grep "active (exited)"; do sleep 1; done\n'
+        script += self._wait_before_running_script()
         if self.disable_ssh_while_running:
             script += 'systemctl stop sshd || true\n'
         return script


### PR DESCRIPTION
Currently we wait for cloud-init on GCE, which should not be the case.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
