### PR TITLE
fix(nemesis): remove wait for no compactions running

### DIFF
--- a/jenkins-pipelines/features-nodetool-stop-compaction.jenkinsfile
+++ b/jenkins-pipelines/features-nodetool-stop-compaction.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'aws',
-    aws_region: 'eu-west-1',
+    region: 'eu-west-1',
     test_name: 'stop_compaction_test.StopCompactionTest.test_stop_compaction',
     test_config: '''["test-cases/features/stop-compaction.yaml"]'''
 )

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -498,7 +498,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                              watch_for="User initiated compaction started on behalf of",
                              timeout=timeout,
                              stop_func=compaction_ops.stop_major_compaction)
-        self.tester.wait_no_compactions_running()
         ParallelObject(objects=[trigger_func, watch_func], timeout=timeout).call_objects()
 
     def disrupt_start_stop_scrub_compaction(self):
@@ -512,7 +511,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                              watch_for="Scrubbing",
                              timeout=timeout,
                              stop_func=compaction_ops.stop_scrub_compaction)
-        self.tester.wait_no_compactions_running()
         ParallelObject(objects=[trigger_func, watch_func], timeout=timeout).call_objects()
 
     def disrupt_start_stop_cleanup_compaction(self):
@@ -527,7 +525,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                              timeout=timeout,
                              watch_for="Cleaning",
                              stop_func=compaction_ops.stop_cleanup_compaction)
-        # self.tester.wait_no_compactions_running()
         ParallelObject(objects=[trigger_func, watch_func], timeout=timeout).call_objects()
 
     def disrupt_start_stop_validation_compaction(self):
@@ -542,7 +539,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                              watch_for="Scrubbing ",
                              timeout=timeout,
                              stop_func=compaction_ops.stop_validation_compaction)
-        # self.tester.wait_no_compactions_running()
         ParallelObject(objects=[trigger_func, watch_func], timeout=timeout).call_objects()
 
     # This nemesis should be run with "private" ip_ssh_connections till the issue #665 is not fixed

--- a/stop_compaction_test.py
+++ b/stop_compaction_test.py
@@ -230,6 +230,7 @@ class StopCompactionTest(ClusterTester):
     def _stop_compaction_base_test_scenario(self,
                                             compaction_nemesis):
         try:
+            self.wait_no_compactions_running()
             compaction_nemesis.disrupt()
             node = compaction_nemesis.target_node
             self._grep_log_and_assert(node)


### PR DESCRIPTION
Fix for: https://github.com/scylladb/scylla-cluster-tests/issues/4248
Trello task: https://trello.com/c/WAMaLJBv

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] ~~I added the relevant `backport` labels~~
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
