### PR TITLE
fix(arm support): allow setting availability zone

### DIFF
--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -26,6 +26,10 @@ def call(Map pipelineParams) {
                description: 'us-east-1|eu-west-1',
                name: 'region')
 
+            string(defaultValue: "${pipelineParams.get('availability_zone', 'a')}",
+                description: 'Availability zone',
+                name: 'availability_zone')
+
             string(defaultValue: "${pipelineParams.get('gce_datacenter', 'us-east1')}",
                    description: 'GCE datacenter',
                    name: 'gce_datacenter')
@@ -154,6 +158,8 @@ def call(Map pipelineParams) {
                                                             export SCT_REGION_NAME=${pipelineParams.region}
                                                         fi
                                                         export SCT_CONFIG_FILES=${test_config}
+
+                                                        export SCT_AVAILABILITY_ZONE="${params.availability_zone}"
 
                                                         if [[ -n "${params.gce_datacenter ? params.gce_datacenter : ''}" ]] ; then
                                                             export SCT_GCE_DATACENTER=${params.gce_datacenter}


### PR DESCRIPTION
to performance jobs.
it was partially done to other jobs, but not for
performance jobs.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
