### PR TITLE
fix(nemesis.py): Ignoring "got error in row level repair" error during repair

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2614,6 +2614,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                            node=self.target_node), \
             DbEventsFilter(db_event=DatabaseLogEvent.DATABASE_ERROR,
                            line="streaming::stream_exception",
+                           node=self.target_node), \
+            DbEventsFilter(db_event=DatabaseLogEvent.RUNTIME_ERROR,
+                           line="got error in row level repair",
                            node=self.target_node):
             self.target_node.reboot(hard=True, verify_ssh=True)
             streaming_thread.join(60)


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- ~[] New configuration option are added and documented (in `sdcm/sct_config.py`)~
- ~[ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [x] All new and existing unit tests passed (CI)
- ~[ ] I have updated the Readme/doc folder accordingly (if needed)~
