### PR TITLE
fix(nemesis.py): Ignoring "got error in row level repair" error during repair

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2614,6 +2614,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                            node=self.target_node), \
             DbEventsFilter(db_event=DatabaseLogEvent.DATABASE_ERROR,
                            line="streaming::stream_exception",
+                           node=self.target_node), \
+            DbEventsFilter(db_event=DatabaseLogEvent.RUNTIME_ERROR,
+                           line="got error in row level repair",
                            node=self.target_node):
             self.target_node.reboot(hard=True, verify_ssh=True)
             streaming_thread.join(60)


### PR DESCRIPTION
During the stream, a restart is starting, and therefore the following error messages may appear:
```
2022-01-15 00:49:05.632 <2022-01-15 00:47:02.000>: (DatabaseLogEvent Severity.ERROR)
 period_type=one-time event_id=5d8f8270-b1b3-4e6a-bf45-8dbb3eb77f57: type=RUNTIME_ERROR
 regex=std::runtime_error line_number=492793 node=alternator-48h-4-6-db-node-1e00ab80-4
2022-01-15T00:47:02+00:00 alternator-48h-4-6-db-node-1e00ab80-4 ! WARNING |  [shard 11]
 repair - repair id [id=4, uuid=4a70db2c-4a05-45a6-afb1-4c07e5695290] on shard 11,
 keyspace=alternator_usertable, cf=usertable, range=(-8471296100733622237, -8454395072449928136],
 got error in row level repair: std::runtime_error (get_full_row_hashes: Peer failed to process
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
