### PR TITLE
fix(oel81): set permissions to scylla-manager.repo

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1719,6 +1719,11 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         else:
             repo_path = '/etc/apt/sources.list.d/scylla-manager.list'
         self.remoter.sudo(f"curl -o {repo_path} -L {scylla_repo}")
+
+        # Prevent issue https://github.com/scylladb/scylla/issues/9683
+        if self.distro.is_oel8:
+            self.remoter.sudo(f"chmod 644 {repo_path}")
+
         if self.distro.is_debian_like:
             for apt_key in self.parent_cluster.params.get("scylla_apt_keys"):
                 self.remoter.sudo(f"apt-key adv --keyserver keyserver.ubuntu.com --recv-keys {apt_key}", retry=3)

--- a/sdcm/utils/housekeeping.py
+++ b/sdcm/utils/housekeeping.py
@@ -71,6 +71,7 @@ class HousekeepingDB:
 
     def get_most_recent_record(self, query: str, args: Optional[Sequence[Any]] = None) -> Optional[Row]:
         result = self.execute(query + " ORDER BY -dt LIMIT 1", args)
+        LOGGER.debug("Housekeeping DB saved info, query '%s': %s", query, result)
         return result[0] if result else None
 
     def get_new_records(self, query: str, args: Optional[Sequence[Any]] = None, last_id: int = 0) -> Sequence[Row]:


### PR DESCRIPTION
Issue: https://github.com/scylladb/scylla/issues/9683

Artifact test on OEL81 fails with error:
`Permission denied: '/etc/yum.repos.d/scylla-manager.repo'`

Read permissions for this file are for 'root' user only:
`rw-------. 1 root root  206 Nov 24 15:12 scylla-manager.repo`

This fix change the permission to allow to read scylla-manager.repo from
scylla user.

Test passed

It also fixed https://github.com/scylladb/scylla-enterprise/issues/2062

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
