### PR TITLE
Fix sisyphus checking for empty list of disruptions

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1266,7 +1266,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def call_next_nemesis(self):
         self.log.info(f'Selecting the next nemesis out of stack {self.disruptions_list}')
-        if self.disruptions_list is not None:
+        if self.disruptions_list:
             self.execute_disrupt_method(disrupt_method=self.disruptions_list.pop())
             self.log.info(f'Remaining nemesis to execute {self.disruptions_list}')
         else:

--- a/test-cases/longevity/longevity-200GB-48h-network-monkey.yaml
+++ b/test-cases/longevity/longevity-200GB-48h-network-monkey.yaml
@@ -14,6 +14,7 @@ nemesis_class_name: 'SisyphusMonkey'
 nemesis_include_filter: ['networking']
 nemesis_seed: '002'
 nemesis_interval: 10
+nemesis_multiply_factor: 15
 
 extra_network_interface: true
 # when using multiple network interfaces in the same subnet, we run into the the possibility


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
