### PR TITLE
fix(get test duration): separate it from `checkout scm`

### DIFF
--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -98,6 +98,19 @@ def call(Map pipelineParams) {
                                         AWS_ACCESS_KEY_ID     = credentials('qa-aws-secret-key-id')
                                         AWS_SECRET_ACCESS_KEY = credentials('qa-aws-secret-access-key')
                                     }
+                                    stage('Checkout') {
+                                        catchError(stageResult: 'FAILURE') {
+                                            timeout(time: 5, unit: 'MINUTES') {
+                                                script {
+                                                    wrap([$class: 'BuildUser']) {
+                                                        dir('scylla-cluster-tests') {
+                                                            checkout scm
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
                                     stage('Get test duration') {
                                         catchError(stageResult: 'FAILURE') {
                                             timeout(time: 2, unit: 'MINUTES') {
@@ -105,7 +118,6 @@ def call(Map pipelineParams) {
                                                     env.SCT_TEST_ID = UUID.randomUUID().toString()
                                                     wrap([$class: 'BuildUser']) {
                                                         dir('scylla-cluster-tests') {
-                                                            checkout scm
                                                             (testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCleanupTimeout) = getJobTimeouts(params, builder.region)
                                                         }
                                                     }


### PR DESCRIPTION
in almost all upgrade jobs in last master, this
stage called "get test duration" was timing out,
failing the whole test.

it could be a problem with Jenkins load (as
all the jobs are running in parallel), an issue
with GitHub or either some networking issue.
now, the `checkout scm` will be done in a
different stage, letting enough time to get
the test's duration.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
