### PR TITLE
fix(upgrade pipeline): add version to stage

### DIFF
--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -98,7 +98,7 @@ def call(Map pipelineParams) {
                                         AWS_ACCESS_KEY_ID     = credentials('qa-aws-secret-key-id')
                                         AWS_SECRET_ACCESS_KEY = credentials('qa-aws-secret-access-key')
                                     }
-                                    stage('Checkout') {
+                                    stage("Checkout for ${base_version}") {
                                         catchError(stageResult: 'FAILURE') {
                                             timeout(time: 5, unit: 'MINUTES') {
                                                 script {
@@ -111,7 +111,7 @@ def call(Map pipelineParams) {
                                             }
                                         }
                                     }
-                                    stage('Get test duration') {
+                                    stage("Get test duration for ${base_version}") {
                                         catchError(stageResult: 'FAILURE') {
                                             timeout(time: 2, unit: 'MINUTES') {
                                                 script {


### PR DESCRIPTION
because in some cases we have upgrade running
for multiple different base versions, we are
seen stages with the same name (like the latest
splitted "checkout"), so adding the base version
to the stage name (as all other stages) will
make it much clearer.

following #4338 , now we see twice "Checkout" (where is one for each base version), but it is a bit misleading.


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
