### PR TITLE
feature(longevity tests): integrate parallel timelines report

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1028,6 +1028,22 @@ class JepsenLogCollector(LogCollector):
         return s3_link
 
 
+class ParallelTimelinesReportCollector(SCTLogCollector):
+    """
+    Collect HTML file with parallel timelines report and upload it to S3
+    """
+    log_entities = [
+        FileLog(name='parallel-timelines-report.html',
+                search_locally=True)
+    ]
+    cluster_log_type = "parallel-timelines-report"
+    cluster_dir_prefix = "parallel-timelines-report"
+
+    @property
+    def is_collect_to_a_single_archive(self) -> bool:
+        return True
+
+
 class Collector:  # pylint: disable=too-many-instance-attributes,
     """Collector instance
 
@@ -1060,6 +1076,7 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
         self.loader_set = []
         self.kubernetes_set = []
         self.sct_set = []
+        self.pt_report_set = []
         self.cluster_log_collectors = {
             ScyllaLogCollector: self.db_cluster,
             MonitorLogCollector: self.monitor_set,
@@ -1067,6 +1084,7 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
             LoaderLogCollector: self.loader_set,
             SCTLogCollector: self.sct_set,
             JepsenLogCollector: self.loader_set,
+            ParallelTimelinesReportCollector: self.pt_report_set,
         }
         if self.backend.startswith("k8s"):
             self.cluster_log_collectors[KubernetesLogCollector] = self.kubernetes_set

--- a/sdcm/report_templates/results_base.html
+++ b/sdcm/report_templates/results_base.html
@@ -307,7 +307,7 @@
 {% endblock %}
 
 {% block links %}
-    {% if kibana_url or job_url or grafana_screenshots or grafana_snapshots %}
+    {% if kibana_url or job_url or grafana_screenshots or grafana_snapshots or parallel_timelines_report %}
     <h3>Links:</h3>
     <ul>
         {% if kibana_url %}
@@ -337,6 +337,9 @@
             {% if grafana_snapshots[2] %}
                 <li><a href={{  grafana_snapshots[2] }}>Shared "Alternator metrics" Grafana Snapshot</a></li>
             {% endif %}
+        {% endif %}
+        {% if parallel_timelines_report %}
+            <li><a href={{ parallel_timelines_report }}>Download Parallel Timelines report</a></li>
         {% endif %}
     </ul>
         {% if grafana_screenshots %}

--- a/sdcm/send_email.py
+++ b/sdcm/send_email.py
@@ -358,6 +358,7 @@ class LongevityEmailReporter(BaseEmailReporter):
         "nemesis_details",
         "nemesis_name",
         "scylla_ami_id",
+        "parallel_timelines_report",
     )
     email_template_file = "results_longevity.html"
     last_events_body_limit_per_severity_in_attachment = 3000000

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -297,6 +297,18 @@ def list_logs_by_test_id(test_id):
     return results
 
 
+def list_parallel_timelines_report_urls(test_id: str) -> list[str | None]:
+    name_to_search = 'parallel-timelines-report'
+    available_logs_paths = S3Storage().search_by_path(path=test_id)
+    report_path_list = [log_file_path for log_file_path in available_logs_paths if name_to_search in log_file_path]
+    LOGGER.debug("Found saved report files:\n%s", ", ".join(report_path_list))
+    # log_file_path looks like
+    # 88605a0b-aa5a-4da9-bb58-5dd2a94c5350/20220109_092346/parallel-timelines-report-88605a0b.tar.gz
+    # Perform reverse order sorting by date inside this path
+    report_path_list.sort(key=lambda x: x.split('/')[1], reverse=True)
+    return [f"https://{S3Storage.bucket_name}.s3.amazonaws.com/{report_path}" for report_path in report_path_list]
+
+
 def all_aws_regions(cached=False):
     if cached:
         return [

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -224,6 +224,22 @@ def call(Map pipelineParams) {
                     }
                 }
             }
+            stage("Parallel timelines report") {
+                steps {
+                    catchError(stageResult: 'FAILURE') {
+                        script {
+                            wrap([$class: 'BuildUser']) {
+                                dir('scylla-cluster-tests') {
+                                    timeout(time: 5, unit: 'MINUTES') {
+                                        runGeneratePTReport(testDuration)
+                                        completed_stages['generate_parallel_timelines_report'] = true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
             stage("Collect log data") {
                 steps {
                     catchError(stageResult: 'FAILURE') {

--- a/vars/runGeneratePTReport.groovy
+++ b/vars/runGeneratePTReport.groovy
@@ -1,0 +1,22 @@
+#! groovy
+
+def call(Integer test_duration){
+    if (test_duration <= 480) {
+        sh '''#!/bin/bash
+
+            set -xe
+            env
+
+            echo "Starting generating parallel timelines report ..."
+            RUNNER_IP=$(cat sct_runner_ip||echo "")
+            if [[ -n "${RUNNER_IP}" ]] ; then
+                ./docker/env/hydra.sh --execute-on-runner ${RUNNER_IP} generate-pt-report
+            else
+                ./docker/env/hydra.sh generate-pt-report --logdir "`pwd`"
+            fi
+            echo "Parallel timelines report has been generated"
+        '''
+    } else {
+        echo 'Skipping this stage for tests that are longer than 4 hours'
+    }
+}


### PR DESCRIPTION
Integration of the parallel timelines generator with SCT. The generator creates HTML-reports for the graphical representation of the SCT events. Currently, it works only for Longevities (4 hours and shorter).

Trello tasks:
- [3962-integrate-parallel-timelines-with-sct](https://trello.com/c/oC3GruWg/3962-integrate-parallel-timelines-with-sct)
- [4124-add-compaction-events-to-the-parallel-timeline-chart](https://trello.com/c/6S3ga9KY/4124-add-compaction-events-to-the-parallel-timeline-chart)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
