### PR TITLE
fix(k8s-eks): set availability_zone in pipelines

### DIFF
--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-add-remove-rack.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-add-remove-rack.jenkinsfile
@@ -8,6 +8,7 @@ longevityPipeline(
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-add-remove-rack.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    availability_zone: 'a,b',
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-backup.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-backup.jenkinsfile
@@ -8,6 +8,7 @@ longevityPipeline(
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-backup.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    availability_zone: 'a,b',
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-cluster-rolling.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-cluster-rolling.jenkinsfile
@@ -8,6 +8,7 @@ longevityPipeline(
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-cluster-rolling.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    availability_zone: 'a,b',
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-grow-shrink.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-grow-shrink.jenkinsfile
@@ -8,6 +8,7 @@ longevityPipeline(
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-grow-shrink.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    availability_zone: 'a,b',
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-repair.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-repair.jenkinsfile
@@ -8,6 +8,7 @@ longevityPipeline(
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-repair.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    availability_zone: 'a,b',
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-replace.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-replace.jenkinsfile
@@ -8,6 +8,7 @@ longevityPipeline(
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-replace.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    availability_zone: 'a,b',
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-scylla-enterprise.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-scylla-enterprise.jenkinsfile
@@ -8,6 +8,7 @@ longevityPipeline(
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    availability_zone: 'a,b',
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-stop-start.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-stop-start.jenkinsfile
@@ -8,6 +8,7 @@ longevityPipeline(
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-stop-start.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    availability_zone: 'a,b',
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-terminate-decommission-add.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-terminate-decommission-add.jenkinsfile
@@ -8,6 +8,7 @@ longevityPipeline(
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-terminate-decommission-add.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    availability_zone: 'a,b',
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-terminate-replace.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-terminate-replace.jenkinsfile
@@ -8,6 +8,7 @@ longevityPipeline(
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-terminate-replace.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    availability_zone: 'a,b',
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks.jenkinsfile
@@ -8,6 +8,7 @@ longevityPipeline(
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    availability_zone: 'a,b',
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-basic-3h-eks-scylla-enterprise.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-basic-3h-eks-scylla-enterprise.jenkinsfile
@@ -8,6 +8,7 @@ longevityPipeline(
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-basic-3h.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    availability_zone: 'a,b',
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-basic-3h-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-basic-3h-eks.jenkinsfile
@@ -8,6 +8,7 @@ longevityPipeline(
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/scylla-operator/longevity-scylla-operator-basic-3h.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    availability_zone: 'a,b',
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',

--- a/jenkins-pipelines/operator/functional/functional-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/functional/functional-eks.jenkinsfile
@@ -9,6 +9,7 @@ longevityPipeline(
     test_name: 'functional_tests/scylla_operator',
     test_config: 'test-cases/scylla-operator/functional.yaml',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    availability_zone: 'a,b',
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',

--- a/jenkins-pipelines/operator/performance/perf-regression-latency-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/performance/perf-regression-latency-eks.jenkinsfile
@@ -11,6 +11,7 @@ perfRegressionParallelPipeline(
     sub_tests: ["test_latency"],
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
     k8s_enable_performance_tuning: true,
+    availability_zone: 'a,b',
     k8s_deploy_monitoring: false,
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',

--- a/jenkins-pipelines/operator/performance/perf-regression-throughput-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/performance/perf-regression-throughput-eks.jenkinsfile
@@ -11,6 +11,7 @@ perfRegressionParallelPipeline(
     sub_tests: ["test_write", "test_read", "test_mixed"],
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
     k8s_enable_performance_tuning: true,
+    availability_zone: 'a,b',
     k8s_deploy_monitoring: false,
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',

--- a/jenkins-pipelines/operator/upgrade/upgrade-major-scylla-k8s-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-major-scylla-k8s-eks.jenkinsfile
@@ -9,4 +9,5 @@ rollingOperatorUpgradePipeline(
     new_version: '4.4.1',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_scylla_upgrade',
     test_config: 'test-cases/scylla-operator/kubernetes-scylla-upgrade.yaml',
+    availability_zone: 'a,b',
 )

--- a/jenkins-pipelines/operator/upgrade/upgrade-operator-k8s-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-operator-k8s-eks.jenkinsfile
@@ -7,4 +7,5 @@ rollingOperatorUpgradePipeline(
     region: 'eu-north-1',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_operator_upgrade',
     test_config: 'test-cases/scylla-operator/kubernetes-operator-upgrade.yaml',
+    availability_zone: 'a,b',
 )

--- a/jenkins-pipelines/operator/upgrade/upgrade-platform-k8s-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-platform-k8s-eks.jenkinsfile
@@ -7,4 +7,5 @@ rollingOperatorUpgradePipeline(
     region: 'eu-north-1',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_platform_upgrade',
     test_config: 'test-cases/scylla-operator/kubernetes-platform-upgrade.yaml',
+    availability_zone: 'a,b',
 )

--- a/jenkins-pipelines/operator/upgrade/upgrade-scylla-k8s-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-scylla-k8s-eks.jenkinsfile
@@ -9,4 +9,5 @@ rollingOperatorUpgradePipeline(
     new_version: '4.4.1',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_scylla_upgrade',
     test_config: 'test-cases/scylla-operator/kubernetes-scylla-upgrade.yaml',
+    availability_zone: 'a,b',
 )


### PR DESCRIPTION
Recently was added 'availability_zone' parameter to pipelines
which started getting default value from it instead of the default
config files. It leads to the situation where it has wrong value making
EKS test runs fail on the start.
So, set correct value for the EKS jobs explicitely.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
