### PR TITLE
ci(operator): add long longevities CI jobs

### DIFF
--- a/configurations/operator/200GB-no-tls.yaml
+++ b/configurations/operator/200GB-no-tls.yaml
@@ -1,0 +1,6 @@
+user_prefix: 'longevity-operator-200gb-48h'
+k8s_minio_storage_size: '4096Gi'
+
+# NOTE: operator doesn't support encryption as of January 2022
+server_encrypt: false
+client_encrypt: false

--- a/configurations/operator/large-collections-12h.yaml
+++ b/configurations/operator/large-collections-12h.yaml
@@ -1,0 +1,1 @@
+user_prefix: 'longevity-operator-large-collections-12h'

--- a/configurations/operator/lwt-basic-24h.yaml
+++ b/configurations/operator/lwt-basic-24h.yaml
@@ -1,0 +1,1 @@
+user_prefix: 'longevity-operator-lwt-24h'

--- a/configurations/operator/twcs-basic-48h.yaml
+++ b/configurations/operator/twcs-basic-48h.yaml
@@ -1,0 +1,1 @@
+user_prefix: 'longevity-operator-twcs-48h'

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-200gb-48h.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-200gb-48h.jenkinsfile
@@ -1,0 +1,18 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'k8s-eks',
+    region: 'eu-north-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml", "configurations/operator/200GB-no-tls.yaml"]''',
+    email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    k8s_enable_performance_tuning: true,
+    availability_zone: 'a,b',
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy',
+    post_behavior_k8s_cluster: 'destroy'
+)

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-large-collections-12h.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-large-collections-12h.jenkinsfile
@@ -1,0 +1,18 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'k8s-eks',
+    region: 'eu-north-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-large-collections-12h.yaml", "configurations/operator/large-collections-12h.yaml"]''',
+    email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    k8s_enable_performance_tuning: true,
+    availability_zone: 'a,b',
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy',
+    post_behavior_k8s_cluster: 'destroy'
+)

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-lwt-24h.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-lwt-24h.jenkinsfile
@@ -1,0 +1,18 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'k8s-eks',
+    region: 'eu-north-1',
+    test_name: 'longevity_lwt_test.LWTLongevityTest.test_lwt_longevity',
+    test_config: '''["test-cases/longevity/longevity-lwt-basic-24h.yaml", "configurations/operator/lwt-basic-24h.yaml"]''',
+    email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    k8s_enable_performance_tuning: true,
+    availability_zone: 'a,b',
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy',
+    post_behavior_k8s_cluster: 'destroy'
+)

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-twcs-48h.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-twcs-48h.jenkinsfile
@@ -1,0 +1,18 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'k8s-eks',
+    region: 'eu-north-1',
+    test_name: 'longevity_twcs_test.TWCSLongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-twcs-48h.yaml", "configurations/operator/twcs-basic-48h.yaml"]''',
+    email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    k8s_enable_performance_tuning: true,
+    availability_zone: 'a,b',
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy',
+    post_behavior_k8s_cluster: 'destroy'
+)


### PR DESCRIPTION
List of new jobs:
- 200gb-48h
- large-collections-12h
- lwt-24h
- twcs-48h

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
