### PR TITLE
fix(operator): add 'keep' tag for EKS cluster nodes

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1650,15 +1650,18 @@ def filter_aws_instances_by_type(instances):
     }
 
     for instance in instances:
-        name = [tag['Value']
-                for tag in instance['Tags'] if tag['Key'] == 'Name']
-        if 'db-node' in name[0]:
+        name = ""
+        for tag in instance['Tags']:
+            if tag['Key'] == 'Name':
+                name = tag['Value']
+                break
+        if 'db-node' in name:
             filtered_instances["db_nodes"].append(instance)
-        if 'monitor-node' in name[0]:
+        elif 'monitor-node' in name:
             filtered_instances["monitor_nodes"].append(instance)
-        if 'loader-node' in name[0]:
+        elif 'loader-node' in name:
             filtered_instances["loader_nodes"].append(instance)
-        elif '-k8s-' in name[0]:
+        elif '-k8s-' in name:
             filtered_instances["kubernetes_nodes"].append(instance)
 
     return filtered_instances


### PR DESCRIPTION
As of now we set tags only to node groups of an EKS cluster.
The problem with it is that it doesn't propagate it further to
the nodes.
So, set it explicitly ourselves to make logic based on the tags work
for nodes deployed by EKS clusters.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
