### PR TITLE
feature(operator): make MinIO storage be configurable

### DIFF
--- a/defaults/k8s_eks_config.yaml
+++ b/defaults/k8s_eks_config.yaml
@@ -37,6 +37,7 @@ k8s_scylla_operator_helm_repo: 'https://storage.googleapis.com/scylla-operator-c
 k8s_scylla_operator_chart_version: 'latest'
 
 k8s_scylla_rack: 'us-east1'
+k8s_minio_storage_size: '60Gi'
 
 n_monitor_nodes: 1
 n_loaders: 1

--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -36,6 +36,7 @@ k8s_scylla_cluster_name: 'sct-cluster'
 k8s_scylla_disk_gi: 500
 k8s_scylla_disk_class: 'local-raid-disks'
 
+k8s_minio_storage_size: '60Gi'
 k8s_loader_cluster_name: 'sct-loaders'
 gce_instance_type_loader: 'e2-standard-4'
 

--- a/defaults/k8s_local_kind_config.yaml
+++ b/defaults/k8s_local_kind_config.yaml
@@ -19,6 +19,7 @@ k8s_scylla_rack: 'kind'
 k8s_scylla_cluster_name: 'sct-cluster'
 k8s_scylla_disk_gi: 5
 k8s_scylla_disk_class: ''
+k8s_minio_storage_size: '20Gi'
 
 n_loaders: 1
 n_monitor_nodes: 1

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -158,6 +158,7 @@ jepsen_test_run_policy: all
 max_events_severities: ""
 mgmt_docker_image: ''
 k8s_deploy_monitoring: false
+k8s_minio_storage_size: '10Gi'
 
 # NOTE: 'k8s_enable_performance_tuning' is alpha feature in operator-1.6 , so it is disabled by default
 k8s_enable_performance_tuning: false

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -173,6 +173,7 @@
 | **<a href="#user-content-k8s_loader_cluster_name" name="k8s_loader_cluster_name">k8s_loader_cluster_name</a>**  |  | N/A | SCT_K8S_LOADER_CLUSTER_NAME
 | **<a href="#user-content-mini_k8s_version" name="mini_k8s_version">mini_k8s_version</a>**  |  | N/A | SCT_MINI_K8S_VERSION
 | **<a href="#user-content-k8s_cert_manager_version" name="k8s_cert_manager_version">k8s_cert_manager_version</a>**  |  | N/A | SCT_K8S_CERT_MANAGER_VERSION
+| **<a href="#user-content-k8s_minio_storage_size" name="k8s_minio_storage_size">k8s_minio_storage_size</a>**  |  | N/A | SCT_K8S_MINIO_STORAGE_SIZE
 | **<a href="#user-content-mgmt_docker_image" name="mgmt_docker_image">mgmt_docker_image</a>**  | Scylla manager docker image, i.e. 'scylladb/scylla-manager:2.2.1' | N/A | SCT_MGMT_DOCKER_IMAGE
 | **<a href="#user-content-docker_image" name="docker_image">docker_image</a>**  | Scylla docker image repo, i.e. 'scylladb/scylla', if omitted is calculated from scylla_version | N/A | SCT_DOCKER_IMAGE
 | **<a href="#user-content-db_nodes_private_ip" name="db_nodes_private_ip">db_nodes_private_ip</a>**  |  | N/A | SCT_DB_NODES_PRIVATE_IP

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -729,10 +729,13 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
         if not self.params.get('reuse_cluster'):
             LOGGER.info('Deploy minio s3-like backend server')
             self.kubectl(f"create namespace {MINIO_NAMESPACE}")
+            values = HelmValues({})
+            values.set('persistence.size', self.params.get("k8s_minio_storage_size"))
             LOGGER.debug(self.helm_install(
                 target_chart_name="minio",
                 source_chart_name=LOCAL_MINIO_DIR,
                 namespace=MINIO_NAMESPACE,
+                values=values,
             ))
 
         wait_for(lambda: self.minio_ip_address, text='Waiting for minio pod to popup',

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -764,6 +764,8 @@ class SCTConfiguration(dict):
 
         dict(name="k8s_cert_manager_version", env="SCT_K8S_CERT_MANAGER_VERSION", type=str,
              help=""),
+        dict(name="k8s_minio_storage_size", env="SCT_K8S_MINIO_STORAGE_SIZE", type=str,
+             help=""),
 
         # docker config options
         dict(name="mgmt_docker_image", env="SCT_MGMT_DOCKER_IMAGE", type=str,


### PR DESCRIPTION
Mostly we do not need big size for the backup storage of Scylla manager
But we have CI jobs which run Scylla with huge data.
So, make MinIO storage be configurable to be able to increase it's size
for some specific CI jobs.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
