### PR TITLE
improvement(pipelines): propagate pipelineParams to runSctTest

### DIFF
--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -215,7 +215,7 @@ def call(Map pipelineParams) {
                             wrap([$class: 'BuildUser']) {
                                 dir('scylla-cluster-tests') {
                                     timeout(time: testRunTimeout, unit: 'MINUTES') {
-                                        runSctTest(params, builder.region, functional_test)
+                                        runSctTest(params, builder.region, functional_test, pipelineParams)
                                         completed_stages['run_tests'] = true
                                     }
                                 }

--- a/vars/rollingOperatorUpgradePipeline.groovy
+++ b/vars/rollingOperatorUpgradePipeline.groovy
@@ -137,7 +137,7 @@ def call(Map pipelineParams) {
                                                 dir('scylla-cluster-tests') {
                                                     timeout(time: testRunTimeout, unit: 'MINUTES') {
                                                         checkout scm
-                                                        runSctTest(run_params, builder.region)
+                                                        runSctTest(run_params, builder.region, functional_test=false, pipelineParams)
                                                     }
                                                 }
                                             }

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -1,6 +1,6 @@
 #!groovy
 
-def call(Map params, String region, functional_test = false){
+def call(Map params, String region, functional_test = false, Map pipelineParams = [:]){
     // handle params which can be a json list
     def current_region = initAwsRegionParam(params.region, region)
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)
@@ -57,6 +57,9 @@ def call(Map params, String region, functional_test = false){
     fi
     if [[ -n "${params.k8s_scylla_operator_upgrade_chart_version ? params.k8s_scylla_operator_upgrade_chart_version : ''}" ]] ; then
         export SCT_K8S_SCYLLA_OPERATOR_UPGRADE_CHART_VERSION=${params.k8s_scylla_operator_upgrade_chart_version}
+    fi
+    if [[ -n "${pipelineParams.k8s_enable_performance_tuning ? pipelineParams.k8s_enable_performance_tuning : ''}" ]] ; then
+        export SCT_K8S_ENABLE_PERFORMANCE_TUNING=${pipelineParams.k8s_enable_performance_tuning}
     fi
 
     if [[ -n "${params.scylla_mgmt_agent_version ? params.scylla_mgmt_agent_version : ''}" ]] ; then


### PR DESCRIPTION
Longevity pipelines call bunch of other groovy functions and
in some cases it is needed to get option from the pipelineParams
which must not be exposed in user-facing 'params' dictionary.
So, update runSctTest groovy func to accept one more argument.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
