### PR TITLE
fix(version_util): get scylla version

### DIFF
--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -415,7 +415,7 @@ class scylla_versions:  # pylint: disable=invalid-name,too-few-public-methods
             try:
                 cluster_object = getattr(cls_self, 'cluster', cls_self)
                 scylla_version = cluster_object.params.get("scylla_version")
-                if scylla_version.endswith(":latest"):
+                if not scylla_version or scylla_version.endswith(":latest"):
                     # NOTE: in case we run Scylla cluster with "latest" version then we need
                     #       to pick up a more precise version from one of it's nodes, i.e. '4.7.dev'
                     scylla_version = cluster_object.nodes[0].scylla_version

--- a/unit_tests/test_version_utils.py
+++ b/unit_tests/test_version_utils.py
@@ -159,10 +159,9 @@ def test_07_get_git_tag_from_helm_chart_version__wrong_input(chart_version):
 class ClassWithVersiondMethods:  # pylint: disable=too-few-public-methods
     def __init__(self, scylla_version, nemesis_like_class):
         params = {"scylla_version": scylla_version}
-        node_scylla_version = ""
         if scylla_version.startswith('enterprise:'):
             node_scylla_version = "2023.dev"
-        elif scylla_version.startswith('master:'):
+        elif scylla_version.startswith('master:') or scylla_version == "":
             node_scylla_version = "4.7.dev"
         else:
             node_scylla_version = "{}.dev".format(scylla_version.split(":")[0])
@@ -227,7 +226,7 @@ class ClassWithVersiondMethods:  # pylint: disable=too-few-public-methods
 
 
 @pytest.mark.parametrize("scylla_version,method", [(scylla_version, method) for scylla_version in (
-    "4.2.rc1", "4.2", "4.2.0", "4.2.1",
+    "", "4.2.rc1", "4.2", "4.2.0", "4.2.1",
     "4.3.rc1", "4.3", "4.3.0", "4.3.1",
     "4.4.rc1", "4.4.rc4", "4.4", "4.4.0", "4.4.4",
     "4.5.rc1", "4.5", "4.5.0", "4.5.1",


### PR DESCRIPTION
If scylla_version is empty in the cluster params (test uses scylla_ami for example),
the nemesis will be skipped with 'version is not supported' reason because cluster
version won't be recognized

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
