### PR TITLE
fix(sct.py): Always use log filename instead of cluster_type value

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1015,9 +1015,10 @@ def store_logs_in_argus(test_id: UUID, logs: dict[str, list[list[str] | str]]):
     try:
         from sdcm.argus_test_run import ArgusTestRun  # pylint: disable=import-outside-toplevel
         test_run = ArgusTestRun.get(test_id=test_id)
-        for cluster_type, s3_links in logs.items():
+        for _, s3_links in logs.items():
             for link in s3_links:
-                test_run.run_info.logs.add_log(cluster_type, link)
+                file_name = link.split("/")[-1]
+                test_run.run_info.logs.add_log(file_name, link)
         test_run.save()
         ArgusTestRun.destroy()
     except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
This makes store_logs_in_argus always use log filename in the url
instead of using cluster_type value as provided by log collector, as it
can provide duplicate values in case when sct-runner logs are split into
multiple parts due to size. Type can be further inferred from said
filename by splitting by the dash symbol down the line.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [x] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [x] All new and existing unit tests passed (CI)
- [x] ~I have updated the Readme/doc folder accordingly (if needed)~

[Trello](https://trello.com/c/XviyVMoq/4510-argus-use-file-name-instead-of-log-type-in-logs-tab)