### PR TITLE
fix(Jenkinsfile): add 10s sleep after start of a mock server

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -156,6 +156,7 @@ pipeline {
                 script {
                     try {
                         sh ''' ./docker/env/hydra.sh run-aws-mock -r us-east-1 '''
+                        sleep 10  // seconds
                         sh ''' ./docker/env/hydra.sh --aws-mock run-pytest functional_tests/mocked '''
                         pullRequestSetResult('success', 'jenkins/mocked_tests', 'All mocked tests are passed')
                     } catch(Exception ex) {


### PR DESCRIPTION
Fixes #4357 

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
