### PR TITLE
fix(manager): Remove manager ssh-related code

### DIFF
--- a/sdcm/mgmt/operator.py
+++ b/sdcm/mgmt/operator.py
@@ -164,11 +164,11 @@ class OperatorManagerCluster(ManagerCluster):
     scylla_cluster = None
     _id = None
 
-    def __init__(self, manager_node, cluster_id=None, ssh_identity_file=None, client_encrypt=False,
+    def __init__(self, manager_node, cluster_id=None, client_encrypt=False,
                  cluster_name: str = None, scylla_cluster=None):
         self.cluster_name = cluster_name
         self.scylla_cluster = scylla_cluster
-        super().__init__(manager_node=manager_node, cluster_id=cluster_id, ssh_identity_file=ssh_identity_file,
+        super().__init__(manager_node=manager_node, cluster_id=cluster_id,
                          client_encrypt=client_encrypt)
 
     @staticmethod
@@ -364,7 +364,7 @@ class OperatorManagerCluster(ManagerCluster):
     def operator_backup_tasks(self) -> List[ScyllaOperatorBackupTask]:
         return self._get_list_of_entities_from_operator('/spec/backups', ScyllaOperatorBackupTask)
 
-    def update(self, name=None, host=None, ssh_identity_file=None, ssh_user=None, client_encrypt=None):
+    def update(self, name=None, host=None, client_encrypt=None):
         raise NotImplementedError()
 
     def delete_task(self, task_id):


### PR DESCRIPTION
since manager 1.4 there the whole ssh based connection to nodes
was removed and replace by manage-agents

we don't need this code anymore

Ref: https://trello.com/c/kW8f1Qk3

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
