### PR TITLE
fix(jepsen.yaml): set scylla_repo_loader

### DIFF
--- a/test-cases/jepsen/jepsen.yaml
+++ b/test-cases/jepsen/jepsen.yaml
@@ -15,6 +15,7 @@ nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'debian-buster'
 user_prefix: 'jepsen'
 use_legacy_cluster_init: true
+scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/debian/scylla-4.6-buster.list'
 jepsen_scylla_repo: 'https://github.com/scylladb/jepsen.git'
 jepsen_test_count: 5
 jepsen_test_run_policy: any


### PR DESCRIPTION
Trello: https://trello.com/c/1ypTcfNo/4568-jepsen-run-on-master-ends-up-with-repository-content-has-invalid-line-4362

The issue was introduced by #4299.

Fixes #4362 

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
