### PR TITLE
fix(config): do not enable auth on client side correctly

### DIFF
--- a/configurations/operator/200GB-no-tls.yaml
+++ b/configurations/operator/200GB-no-tls.yaml
@@ -4,3 +4,7 @@ k8s_minio_storage_size: '4096Gi'
 # NOTE: operator doesn't support encryption as of January 2022
 server_encrypt: false
 client_encrypt: false
+authenticator: 'AllowAllAuthenticator'
+authenticator_user: ''
+authenticator_password: ''
+authorizer: 'AllowAllAuthenticator'


### PR DESCRIPTION
Disable auth on the loader side correctly for the "200Gb-48h" CI job
that runs for operator to avoid following errors:

    An authentication challenge was not sent, this is suspicious
        because the driver expects authentication
        (configured authenticator = PlainTextAuthenticator)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
