### PR TITLE
fix(operator): do proper image path check for the Scylla upgrades

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2288,7 +2288,9 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
             sleep_time=self.PodContainerClass.pod_readiness_delay)
         def wait_till_any_node_get_new_image(nodes_with_old_image: list):
             for node in nodes_with_old_image.copy():
-                if node.image == new_image:
+                # NOTE: 'node.image' may be 'docker.io/scylladb/scylla:4.5.3'
+                #       as well as 'scylladb/scylla:4.5.3'
+                if node.image.endswith(new_image):
                     nodes_with_old_image.remove(node)
                     return True
             raise RuntimeError('No node was upgraded')


### PR DESCRIPTION
Upgrading a Scylla cluster on K8S we check Scylla pod info update.
It's 'status.image' field must start containing new value.
And right now we check equality of expected and actual values.
But there may be 2 variants of it like following:

- scylladb/scylla:4.5.3
- docker.io/scylladb/scylla:4.5.3

So, to avoid false negative errors make it perform checks considering
both cases.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
