### PR TITLE
fix(nemesis): skip decommission_streaming_err on K8S

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1946,6 +1946,10 @@ class PodCluster(cluster.BaseCluster):
                   rack: int = 0,
                   enable_auto_bootstrap: bool = False) -> List[BasePodContainer]:
 
+        # TODO: make it work when we have decommissioned (by nodetool) nodes.
+        #       Now it will fail because pod which hosts decommissioned Scylla member is reported
+        #       as 'NotReady' and will fail the pod waiter function below.
+
         # Wait while whole cluster (on all racks) including new nodes are up and running
         self.wait_for_pods_readiness(pods_to_wait=count, total_pods=len(self.nodes) + count)
 
@@ -2205,6 +2209,10 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
                   rack: int = 0,
                   enable_auto_bootstrap: bool = False) -> List[BasePodContainer]:
         self._create_k8s_rack_if_not_exists(rack)
+        # TODO: 'self.get_rack_nodes(rack)' returns correct number only
+        #       when there are no decommissioned, by nodetool, nodes.
+        #       Having 1 decommissioned node we do not change node count.
+        #       Having 2 decommissioned nodes we will reduce node count.
         current_members = len(self.get_rack_nodes(rack))
         self.replace_scylla_cluster_value(f"/spec/datacenter/racks/{rack}/members", current_members + count)
 


### PR DESCRIPTION
We should not run 'decommission_streaming_err' nemesis on K8S due to
the following reasons:
- 'decommission_streaming_err' nemesis uses 'nodetool decommision'
  command which will make K8S Scylla pod be in 'NotReady' state
  but exist all the time. Instead we should decomission it by reducing
  number of Scylla cluster members via the ScyllaCluster CR update.
- The approach for the node number increase checks the workability of
  all the pods and will fail on that 'NotReady' pod.
- Increate of pod number will exclude decommissioned pod from the
  list of nodes increase it by 1 and the resulting value will be
  equal to the pod count. So, nothing will change.

So, skip this nemesis as it is not expected to work.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
