### PR TITLE
improvement(results_performance.html): add build-id to report

### DIFF
--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -371,6 +371,10 @@ class TestStatsMixin(Stats):
                         versions[package.replace('-enterprise', '')] = {'version': match.group(2),
                                                                         'date': match.group(4),
                                                                         'commit_id': match.group(5)}
+            build_id_output = node.remoter.run('scylla --build-id').stdout.strip()
+            if 'scylla-server' not in versions.keys():
+                versions['scylla-server'] = dict()
+            versions['scylla-server']['build_id'] = build_id_output if build_id_output else 'Not Found'
         except Exception as ex:  # pylint: disable=broad-except
             LOGGER.error('Failed getting scylla versions: %s', ex)
 

--- a/sdcm/results_performance.html
+++ b/sdcm/results_performance.html
@@ -19,6 +19,10 @@
             <span> commit id: </span>
             <span class="blue"> {{ test_version.commit_id }} </span>
         </li>
+        <li>
+            <span> build-id: </span>
+            <span class="blue"> {{ test_version.build_id }} </span>
+        </li>
     </div>
     <div>
         <span> Setup Details: </span>


### PR DESCRIPTION
as running from this old branch (`branch-perf-v8`)
the report is missing the `build-id`, although it
is being collected, but not added to the report.
This commit is meant to specific branch only, and
if still not fixed in master (or newer branches),
another PR will be sent to fix it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
