### PR TITLE
improvement(results_performance.html): add build-id to report

### DIFF
--- a/sdcm/report_templates/results_performance.html
+++ b/sdcm/report_templates/results_performance.html
@@ -21,6 +21,10 @@
             <span> commit id: </span>
             <span class="blue"> {{ test_version.commit_id }} </span>
         </li>
+        <li>
+            <span> build-id: </span>
+            <span class="blue"> {{ test_version.build_id }} </span>
+        </li>
     </div>
     <div>
         <span> Setup Details: </span>


### PR DESCRIPTION
adding `build-id` to the report, as this value will
help to decode back traces, without the need to
open logs, as this value is being collected and
saved into ES anyway.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
