### PR TITLE
fix(nodetool status): raise real error when node is not up

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3828,7 +3828,8 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         if not verification_node:
             verification_node = random.choice(self.nodes)
         status = {}
-        res = verification_node.run_nodetool('status', warning_event_on_exception=(Exception,), publish_event=False)
+        res = verification_node.run_nodetool('status', publish_event=False)
+
         data_centers = res.stdout.strip().split("Datacenter: ")
         for dc in data_centers:
             if dc:


### PR DESCRIPTION
Task: https://trello.com/c/TFF1z6sk/4587-nodestatus-nonetype-has-no-attribute-stdout
If node is down, run_nodetool function will return None object in result variable.
When we try to fetch stdout from result it will fail  with not correct message:
'NoneType' object has no attribute 'stdout'
And real error will be hide.

As result of this fix real error will be raised

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
