### PR TITLE
fix(scylla-bench): use newer version with fixed memory consumption

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -172,7 +172,7 @@ backup_bucket_region: ''  # use the same region as a cluster
 
 events_limit_in_email: 10
 
-scylla_bench_version: v0.1.6
+scylla_bench_version: v0.1.8
 
 data_volume_disk_num: 0
 data_volume_disk_type: ''


### PR DESCRIPTION
Currently we use v0.1.6 version of the "scylla-bench" tool.
And it uses to much memory starting with v0.1.4 version.
Bug: https://github.com/scylladb/scylla-bench/issues/84
    
It was fixed in the v0.1.7
So, switch to that new version to make "scylla-bench" use normal amount of memory avoiding OOMKills.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
