### PR TITLE
fix(config): increase minio disk size for the "200gb-48h" on K8S

### DIFF
--- a/configurations/operator/200GB-no-tls.yaml
+++ b/configurations/operator/200GB-no-tls.yaml
@@ -1,5 +1,5 @@
 user_prefix: 'longevity-operator-200gb-48h'
-k8s_minio_storage_size: '4096Gi'
+k8s_minio_storage_size: '4608Gi'
 
 # NOTE: operator doesn't support encryption as of January 2022
 server_encrypt: false


### PR DESCRIPTION
For the moment CI job with the "200gb-48h" config has MinIO disk
size be equal to 4Tb. It is not enough for 3 mgmt backups which happen
there. Each backup takes about 1,3-1,4Tb. So, increase it by 500Gb
to make sure we can place 3 mgmt backups on this disk having such
huge set of data - 200Gb (basis) + ~140Gb ongoing load.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
