### PR TITLE
fix(health checker): fix case when node was removed from cluster

### DIFF
--- a/sdcm/utils/health_checker.py
+++ b/sdcm/utils/health_checker.py
@@ -106,6 +106,7 @@ def check_node_status_in_gossip_and_nodetool_status(gossip_info, nodes_status, c
 
         if (node_info['status'] == 'NORMAL' and nodes_status[node]['status'] != 'UN') or \
                 (node_info['status'] != 'NORMAL' and nodes_status[node]['status'] == 'UN'):
+            LOGGER.debug("Gossip info: %s\nnodetool.status info: %s", gossip_info, nodes_status)
             yield ClusterHealthValidatorEvent.NodeStatus(
                 severity=Severity.ERROR,
                 node=current_node.name,


### PR DESCRIPTION
This commit presents fix for a case when there is a node with non-UN status (was removed during
decommission, for example) and this node does not exist in the cluster.

Bug from commit:
https://github.com/scylladb/scylla-cluster-tests/pull/4375/commits/5784ba340fc6770b73df2e63e00185b6aadcf223

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
