### PR TITLE
fix(centos8): Centos8 is EOL, need to change mirrors

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1883,6 +1883,12 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
     def update_repo_cache(self):
         try:
+            if self.distro.is_centos8:
+                # since centos8 is EOL, we need to switch to vault.centos.org
+                self.remoter.sudo(shell_script_cmd("""
+                    sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*
+                    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+                """))
             if self.is_rhel_like():
                 # try to avoid ERROR 404 of yum, reference https://wiki.centos.org/yum-errors
                 self.remoter.sudo('yum clean all')


### PR DESCRIPTION
Since recently centos8 is EOL, and moved to a diffent mirror site,
we can't yum install on it, until patching the repo files.

Fix: #4393

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
