### PR TITLE
fix(perf with nemesis): reduce email size

### DIFF
--- a/sdcm/report_templates/results_latency_during_ops.html
+++ b/sdcm/report_templates/results_latency_during_ops.html
@@ -28,14 +28,14 @@
         </ul>
     </div>
     <div>
-        {% for severity, events in debug_events.items() %}
-            {% if debug_events_summary.get(severity, 0) > 0 %}
-                <h3>
-                    <span>Amount of reactor stalls:</span>
-                    <span class="blue">{{ debug_events_summary.get(severity) }}</span>
-                </h3>
-            {% endif %}
-        {% endfor %}
+        <h3>
+            <span>Amount of reactor stalls:</span>
+            <span class="blue">{{ reactor_stall_events_summary.get('DEBUG', 0) }}</span>
+        </h3>
+        <h3>
+            <span>Amount of kernel callstacks:</span>
+            <span class="blue">{{ kernel_callstack_events_summary.get('DEBUG', 0) }}</span>
+        </h3>
     </div>
         <div>
             {% for operation, results in stats.items() %}

--- a/sdcm/report_templates/results_latency_during_ops_short.html
+++ b/sdcm/report_templates/results_latency_during_ops_short.html
@@ -28,14 +28,14 @@
         </ul>
     </div>
     <div>
-        {% for severity, events in debug_events.items() %}
-            {% if debug_events_summary.get(severity, 0) > 0 %}
-                <h3>
-                    <span>Amount of reactor stalls:</span>
-                    <span class="blue">{{ debug_events_summary.get(severity) }}</span>
-                </h3>
-            {% endif %}
-        {% endfor %}
+        <h3>
+            <span>Amount of reactor stalls:</span>
+            <span class="blue">{{ reactor_stall_events_summary.get('DEBUG', 0) }}</span>
+        </h3>
+        <h3>
+            <span>Amount of kernel callstacks:</span>
+            <span class="blue">{{ kernel_callstack_events_summary.get('DEBUG', 0) }}</span>
+        </h3>
     </div>
         <div>
             {% for operation, results in stats.items() %}

--- a/sdcm/report_templates/results_reactor_stall_events_list.html
+++ b/sdcm/report_templates/results_reactor_stall_events_list.html
@@ -7,13 +7,13 @@
 
 {%- block events -%}
     <div>
-        {% if debug_events %}
+        {% if reactor_stall_events %}
             <h3>
                 <span>Last events by severity</span>
             </h3>
-            {% for severity, events in debug_events.items() %}
+            {% for severity, events in reactor_stall_events.items() %}
                 <h4>
-                {{ severity }} - [{{ debug_events_summary.get(severity, 0) }}]
+                {{ severity }} - [{{ reactor_stall_events_summary.get(severity, 0) }}]
                 </h4>
                 {% for event in events %}
                     {% if "Reactor stalled" in event %}


### PR DESCRIPTION
emails lately are not being sent, as they are
oversized for the allowed by the suite.
so about half of the runs are not sending correctly
the emails, because the attachments sizes are above
25MB. with this fix, i'm removing unnecessary
WARNING events, and also limiting the amount of
reactor stall events, and also removing the new
kernel callstack events, as their amount is huge.
Fixes #4376

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
