### PR TITLE
fix(send_email): pick up AWS nodes names properly

### DIFF
--- a/sdcm/send_email.py
+++ b/sdcm/send_email.py
@@ -584,10 +584,15 @@ def get_running_instances_for_email_report(test_id: str, ip_filter: str = None):
     instances = list_instances_aws(tags_dict=tags, group_as_region=True, running=True)
     for region in instances:
         for instance in instances[region]:
-            name = [tag['Value'] for tag in instance['Tags'] if tag['Key'] == 'Name']
+            # NOTE: K8S nodes created by autoscaler never have 'Name' set.
+            name = 'N/A'
+            for tag in instance['Tags']:
+                if tag['Key'] == 'Name':
+                    name = tag['Value']
+                    break
             public_ip_addr = instance.get('PublicIpAddress', 'N/A')
             if public_ip_addr != ip_filter:
-                nodes.append([name[0],
+                nodes.append([name,
                               instance.get('PublicIpAddress', 'N/A'),
                               instance['State']['Name'],
                               "aws",


### PR DESCRIPTION
EKS nodes never have 'Name' tag because it gets created automatically by
the autoscaler which doesn't allow to set names.

So, fix the code that expect the presence of the name making it
set 'N/A' instead.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
