### PR TITLE
fix(cluster.py): make K8S work again

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -846,6 +846,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
     @property
     def cql_ip_address(self):
+        if self.is_kubernetes():
+            return self.ip_address
         with self.remote_scylla_yaml() as scylla_yaml:
             return scylla_yaml.broadcast_rpc_address if scylla_yaml.broadcast_rpc_address else self.ip_address
 


### PR DESCRIPTION
Recently was added common VMs-specific code into the
'sdcm/cluster.py' module -> 'cql_ip_address' property.
And this property doesn't work for K8S for 2 reasons:
- On K8S we never have 'broadcast_rpc_address' be setup.
- On K8S we do not use ScyllaYaml class, because it's work
  is done by Operator itself.

So, detect that we are on the K8S in this property and return expected
value for it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
