### PR TITLE
fix(cluster.py): Fix web install parsing for master/enterprise version

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2084,6 +2084,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
         if match := re.match(r'\D*(\d+\.\d+)', scylla_version or git_branch):
             version = f"nightly-{match.group(1)}"
+        elif git_branch and 'master' in git_branch:
+            version = "nightly-master"
         else:
             raise Exception("Scylla version for web install isn't identified")
 


### PR DESCRIPTION
	master/enterprise version types were previously ignored by the parsing for scylla_version

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/4389
Trello: https://trello.com/c/32Bk1HGx
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
