### PR TITLE
fix(create_test_release_jobs): stop waiting for the jobs to finish

### DIFF
--- a/utils/build_system/create_test_release_jobs.py
+++ b/utils/build_system/create_test_release_jobs.py
@@ -71,14 +71,7 @@ class JenkinsPipelines:
         # wait while worker will be found
         def check_job_is_started(job_id):
             return self.jenkins.get_queue_item(job_id).get("executable")
-        wait_for(check_job_is_started, step=5, text="Job is starting", timeout=60, throw_exc=True, job_id=job_id)
-
-        # wait while job will be executed
-        def check_job_is_finished(job_name):
-            return not self.jenkins.get_build_info(job_name, 1).get("building")
-
-        wait_for(check_job_is_finished, step=5, text="Check job is finished",
-                 timeout=120, throw_exc=True, job_name=name)
+        wait_for(check_job_is_started, step=5, text="Job is starting", timeout=120, throw_exc=True, job_id=job_id)
 
         LOGGER.info("First build finished")
 


### PR DESCRIPTION
Since we can't predict the time jenkins would pick the job and
actully finish excectuing 2min wasn't enough, and only slowing
down this job it's enough for us just to trigger the job, see
it's in the quoue and continue to the next job

CI would fall with the following:

```
16:47:09  tenacity.RetryError: RetryError[Wait for: Check
job is finished: timeout - 120 seconds - expired]
```

Ref: https://jenkins.scylladb.com/job/QA-tools/job/create-sct-test-jobs-for-branch/12/console

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
