### PR TITLE
fix(centos8-arm): using official CentOS Stream 8

### DIFF
--- a/configurations/arm/centos8.yaml
+++ b/configurations/arm/centos8.yaml
@@ -1,5 +1,5 @@
 ami_db_scylla_user: 'centos'
-ami_id_db_scylla: 'ami-0528bc21ac93f3461'
+ami_id_db_scylla: 'ami-07d54ca4e98347364'
 region_name: 'eu-west-1'
 instance_type_db: 'r6gd.large'
 use_preinstalled_scylla: false


### PR DESCRIPTION
CentOS 8 is EOL hence we need to change the AMI.
Using official from https://wiki.centos.org/Cloud/AWS

tested: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/bentsi-staging/job/bentsi-artifacts-centos8-arm-test/2/console

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
