### PR TITLE
improvement(sct_config): add bare_loaders option 

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -189,3 +189,5 @@ scylla_apt_keys:
   - 'D0A112E067426AB2'  # ScyllaDB Package Signing Key 2022 <security@scylladb.com>
 
 raid_level: 0
+
+bare_loaders: false

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -289,3 +289,4 @@
 | **<a href="#user-content-scylla_bench_version" name="scylla_bench_version">scylla_bench_version</a>**  | A valid tag under the scylla bench repo: https://github.com/scylladb/scylla-bench | N/A | SCT_SCYLLA_BENCH_VERSION
 | **<a href="#user-content-nosqlbench_image" name="nosqlbench_image">nosqlbench_image</a>**  | A docker image of NoSQLBench | N/A | SCT_NOSQLBENCH_IMAGE
 | **<a href="#user-content-raid_level" name="raid_level">raid_level</a>**  | Configure RAID0 or RAID5 on instance | N/A | SCT_RAID_LEVEL
+| **<a href="#user-content-bare_loaders" name="bare_loaders">bare_loaders</a>**  | Don't install anything but collectd to the loaders during cluster setup | False | SCT_BARE_LOADERS

--- a/jepsen_test.py
+++ b/jepsen_test.py
@@ -34,7 +34,7 @@ class JepsenTest(ClusterTester):
     @log_run_info
     def setup_jepsen(self):
         remoter = self.jepsen_node.remoter
-        remoter.sudo("apt-get install -y libjna-java gnuplot graphviz git")
+        remoter.sudo("apt-get install -y openjdk-11-jre openjdk-11-jre-headless libjna-java gnuplot graphviz git")
         remoter.run(shell_script_cmd(f"""\
             curl -O https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
             chmod +x lein

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4516,6 +4516,11 @@ class BaseLoaderSet():
 
         collectd_setup = ScyllaCollectdSetup()
         collectd_setup.install(node)
+
+        if self.params.get("bare_loaders"):
+            self.log.info("Don't install anything because bare loaders requested")
+            return
+
         self.install_gemini(node=node)
         if self.params.get('client_encrypt'):
             node.config_client_encrypt()

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1238,6 +1238,9 @@ class SCTConfiguration(dict):
         dict(name="raid_level", env="SCT_RAID_LEVEL",
              type=int,
              help="Number of of raid level: 0 - RAID0, 5 - RAID5"),
+
+        dict(name="bare_loaders", env="SCT_BARE_LOADERS", type=boolean,
+             help="Don't install anything but collectd to the loaders during cluster setup")
     ]
 
     required_params = ['cluster_backend', 'test_duration', 'n_db_nodes', 'n_loaders', 'use_preinstalled_scylla',
@@ -1445,7 +1448,12 @@ class SCTConfiguration(dict):
                 raise ValueError("'scylla_version' can't used together with 'ami_id_db_scylla', 'gce_image_db' "
                                  "or with 'scylla_repo'")
 
-            if self.get("n_loaders") and not self.get("scylla_repo_loader") and self.get("cluster_backend") != "aws":
+            if (
+                self.get("n_loaders") and
+                not self.get("bare_loaders") and
+                not self.get("scylla_repo_loader") and
+                self.get("cluster_backend") != "aws"
+            ):
                 scylla_linux_distro_loader = self.get('scylla_linux_distro_loader')
                 dist_type_loader = scylla_linux_distro_loader.split('-')[0]
                 dist_version_loader = scylla_linux_distro_loader.split('-')[-1]

--- a/test-cases/jepsen/jepsen.yaml
+++ b/test-cases/jepsen/jepsen.yaml
@@ -19,3 +19,4 @@ scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/debian/
 jepsen_scylla_repo: 'https://github.com/scylladb/jepsen.git'
 jepsen_test_count: 5
 jepsen_test_run_policy: any
+bare_loaders: true


### PR DESCRIPTION
Trello: https://trello.com/c/7dJvsZ56/4586-allow-setup-of-bare-loader-node

For some tests (e.g., Jepsen) we don't need anything to be installed by default on loaders nodes.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
