### PR TITLE
fix(gce-config.yaml): increase gce monitor instance type

### DIFF
--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -11,7 +11,7 @@ gce_instance_type_loader: 'e2-standard-2'
 gce_root_disk_type_loader: 'pd-standard'
 gce_n_local_ssd_disk_loader: 0
 
-gce_instance_type_monitor: 'e2-medium'
+gce_instance_type_monitor: 'n2-highmem-8'
 gce_root_disk_type_monitor: 'pd-standard'
 gce_root_disk_size_monitor: 50
 gce_n_local_ssd_disk_monitor: 0


### PR DESCRIPTION
Monitor instance on gce uses slow instance type.
for large/long jobs sometimes it doesn't have
enough performance. Set better instance type

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
