### PR TITLE
fix(cassandra-harry): collect cassandra-harry logs

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -826,6 +826,8 @@ class LoaderLogCollector(LogCollector):
                 search_locally=True),
         FileLog(name='kcl-l*.log',
                 search_locally=True),
+        FileLog(name='*cassandra-harry*.log',
+                search_locally=True),
     ]
 
     def collect_logs(self, local_search_path=None) -> list[str]:

--- a/test-cases/longevity/longevity-harry-2h.yaml
+++ b/test-cases/longevity/longevity-harry-2h.yaml
@@ -7,6 +7,8 @@ n_monitor_nodes: 1
 
 instance_type_db: 'i3.large'
 
+aws_root_disk_size_loader: 80 # enlarge loader disk, cause of cassandra-harry operation.log that can't be disabled
+
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '001'
 nemesis_interval: 2


### PR DESCRIPTION
logs weren't collected so far, and got lost

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
