### PR TITLE
improvement(sct_events): no traceback in publish_or_dump

### DIFF
--- a/sdcm/sct_events/base.py
+++ b/sdcm/sct_events/base.py
@@ -201,8 +201,8 @@ class SctEvent:
             return
         try:
             proc = get_events_main_device(_registry=self._events_processes_registry)
-        except RuntimeError:
-            LOGGER.exception("Unable to get events main device")
+        except RuntimeError as exc:
+            LOGGER.warning("Unable to get events main device: %s", exc)
             proc = None
         if proc:
             if proc.is_alive():


### PR DESCRIPTION
Trello: https://trello.com/c/0ntvupKX/4637-runtimeerror-you-should-create-default-eventsprocessregistry-first

Stop printing traceback of RuntimeError in case of not started
EventsDevice.  It confuses people when there is something wrong
with the latest repo URL.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
