### PR TITLE
fix(DeletedRowsValidator): actual_result can be an empty list

### DIFF
--- a/sdcm/utils/data_validator.py
+++ b/sdcm/utils/data_validator.py
@@ -604,7 +604,7 @@ class LongevityDataValidator:
         actual_result = self.longevity_self_object.fetch_all_rows(session=session, default_fetch_size=self.DEFAULT_FETCH_SIZE,
                                                                   statement=f"SELECT {pk_name} FROM {self.view_name_for_deletion_data}",
                                                                   verbose=not during_nemesis)
-        if not actual_result:
+        if actual_result is None:
             DataValidatorEvent.DeletedRowsValidator(
                 severity=Severity.ERROR,
                 error=f"Can't validate deleted rows. Fetch all rows from {self.view_name_for_deletion_data} failed. "


### PR DESCRIPTION
Since the stress command on long runs, can delete all the
keys in range the `_deletion` view can end empty and that
should be acceptable.

Fixes: #4421

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
