### PR TITLE
fix(nodetool): make nodetool command work with their own libssh2 remoter

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2606,7 +2606,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             try:
                 # HACK: temporary hack to use libssh2 only for nodetool command
                 remote_class = RemoteCmdRunnerBase.remoter_classes.get('libssh2')
-                remoter = remote_class(**self.ssh_login_info)
+                remoter = remote_class(**self.ssh_login_info | dict(hostname=self.external_address))
                 result = remoter.run(cmd, timeout=timeout, ignore_status=ignore_status, verbose=verbose)
                 self.log.debug("Command '%s' duration -> %s s" % (result.command, result.duration))
 


### PR DESCRIPTION
94ca1193d8e9cdc10e281ec220c86b4cc0ec476c seems to be causing cases
the remoter is starting on the wrong node, causing havoc to nemeis
logic, and can cause very unclear failures.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
