### PR TITLE
fix(5000-tables): added duration too big

### DIFF
--- a/longevity_test.py
+++ b/longevity_test.py
@@ -341,7 +341,7 @@ class LongevityTest(ClusterTester):
 
         if customer_profiles:
             cs_duration = self.params.get('cs_duration')
-            duration = int(cs_duration.translate(str.maketrans('', '', string.ascii_letters))) * 60 + 60
+            duration = int(cs_duration.translate(str.maketrans('', '', string.ascii_letters)))
 
             for cs_profile in customer_profiles:
                 assert os.path.exists(cs_profile), 'File not found: {}'.format(cs_profile)


### PR DESCRIPTION
56857ba522b9c7de9406d38c296ecc61994a09a2 add a duration, but the
calculation of it was wrong, and multipled twice by 60

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
