### PR TITLE
improvement(Jenkins): use less workers

### DIFF
--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -6,7 +6,7 @@ def call(Map pipelineParams) {
     pipeline {
         agent {
             label {
-                label builder.label
+                label 'built-in'
             }
         }
         environment {

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -4,13 +4,12 @@ import groovy.json.JsonSlurper
 def (testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCleanupTimeout) = [0,0,0,0,0]
 
 def call(Map pipelineParams) {
-
     def builder = getJenkinsLabels(params.backend, params.region, params.gce_datacenter)
 
     pipeline {
         agent {
             label {
-                label builder.label
+                label 'built-in'
             }
         }
         environment {
@@ -98,6 +97,11 @@ def call(Map pipelineParams) {
                 }
             }
             stage('Get test duration') {
+                agent {
+                    label {
+                        label builder.label
+                    }
+                }
                 steps {
                     catchError(stageResult: 'FAILURE') {
                         timeout(time: 1, unit: 'MINUTES') {


### PR DESCRIPTION
Trello: https://trello.com/c/7gIDHl3Q/3978-jobs-shouldnt-use-two-builders

For jobs which run stages in parallel we can avoid using an additional worker for the main pipeline.  There are 3 such pipelines:

  1. artifactsPipeline
  2. rollingUpgradePipeline
  3. perfRegressionParallelPipeline

Based on work done in https://github.com/scylladb/scylla-pkg/issues/1175

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
