### PR TITLE
improvement(show-monitor): add sct_branch parameter

### DIFF
--- a/jenkins-pipelines/hydra-show-monitor.jenkinsfile
+++ b/jenkins-pipelines/hydra-show-monitor.jenkinsfile
@@ -14,6 +14,9 @@ pipeline {
         AWS_SECRET_ACCESS_KEY = credentials('qa-aws-secret-access-key')
     }
     parameters {
+        string(defaultValue: 'master',
+               description: 'SCT git branch (usually has same name as Scylla branch, e.g., branch-4.5)',
+               name: 'sct_branch')
         string(defaultValue: '',
                description: 'ID of a SCT test to restore the monitoring stack',
                name: 'test_id')
@@ -49,7 +52,9 @@ pipeline {
         stage('Checkout') {
             steps {
                 dir('scylla-cluster-tests') {
-                    checkout scm
+                    git(url: 'git@github.com:scylladb/scylla-cluster-tests.git',
+                        credentialsId:'b8a774da-0e46-4c91-9f74-09caebaea261',
+                        branch: params.sct_branch)
                 }
             }
         }

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -3018,6 +3018,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         job_name = os.environ.get('JOB_NAME').split("/")[-1] if os.environ.get('JOB_NAME') else config_file_name
         restore_monitor_job_base_link = \
             "https://jenkins.scylladb.com/view/QA/job/QA-tools/job/hydra-show-monitor/parambuild/?"
+        if build_id:
+            sct_branch = os.environ.get("GIT_BRANCH", "master").rsplit("/", maxsplit=1)[-1]
+            restore_monitor_job_base_link += f"sct_branch={sct_branch}&"
 
         return {"backend": backend,
                 "build_id": os.environ.get('BUILD_NUMBER', ''),


### PR DESCRIPTION
Trello: https://trello.com/c/SYxKDlMH/4211-restore-monitoring-stack-job-should-use-relevant-release-branch

Add sct_branch parameter to hydra-show-monitor job.
Also try to auto-detect SCT branch for email report.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
