### PR TITLE
fix(cassandra-stress): disable debug output

### DIFF
--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -185,6 +185,9 @@ class CassandraStressThread:  # pylint: disable=too-many-instance-attributes
 
         result = None
 
+        # disable logging for cassandra stress
+        node.remoter.run("cp /etc/scylla/cassandra/logback-tools.xml .", ignore_status=True)
+
         with CassandraStressExporter(instance_name=node.cql_ip_address,
                                      metrics=nemesis_metrics_obj(),
                                      stress_operation=stress_cmd_opt,


### PR DESCRIPTION
since we built on our own the cassandra-stress it's running
with debug enabled by default, for some test cases which use lot of
cassandra stress this is a killer.

this is moving the configuration file into the direcotry the stress
is running from, which case c-s to respect that configuration.
(and only show WARN level and up)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
