### PR TITLE
fix(UpgradeBaseVersion): filter repos which has only RCs

### DIFF
--- a/unit_tests/test_base_version.py
+++ b/unit_tests/test_base_version.py
@@ -33,7 +33,7 @@ class TestBaseVersion(unittest.TestCase):
         scylla_repo = self.url_base + 'unstable/scylla/master/rpm/centos/2021-08-29T00:58:58Z/scylla.repo'
         linux_distro = 'centos'
         version_list = general_test(scylla_repo, linux_distro)
-        self.assertEqual(version_list, ['5.0'])
+        self.assertEqual(version_list, ['4.6'])
 
     def test_4_5_with_centos8(self):
         scylla_repo = self.url_base + 'unstable/scylla/branch-4.5/rpm/centos/2021-08-29T00:58:58Z/scylla.repo'

--- a/unit_tests/test_version_utils.py
+++ b/unit_tests/test_version_utils.py
@@ -6,6 +6,7 @@ import pytest
 import sdcm
 from sdcm.utils.version_utils import (
     get_branch_version,
+    get_all_versions,
     get_branch_version_for_multiple_repositories,
     get_git_tag_from_helm_chart_version,
     get_scylla_urls_from_repository,
@@ -127,6 +128,10 @@ class TestVersionUtils(unittest.TestCase):
         self.assertEqual(
             set(),
             urls)
+
+    def test_07_get_all_versions(self):
+        self.assertIn('4.5.3', get_all_versions(
+            'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-4.5.repo'))
 
 
 @pytest.mark.parametrize("chart_version,git_tag", [


### PR DESCRIPTION
Version 5.0/4.6 aren't released yet, hence we don't want to set them
as a base version for rolling upgrades. we do this by getting all the versions
from a repo, and filtering out the release canidate to see if we are
left with anything.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
