### PR TITLE
fix(nemesis.py): disrupt_remove_node_then_add_node description

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2300,10 +2300,11 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         """
         https://docs.scylladb.com/operating-scylla/procedures/cluster-management/remove_node/
 
-        1.Terminate node
-        2.Run full repair
-        3.Nodetool removenode
-        4.Add new node
+        1. Terminate node
+        2. Run full repair
+        3. Nodetool removenode
+        4. Add new node
+        5. Run nodetool cleanup (on each node) for each keyspace
         """
         if self.cluster.params.get("db_type") == 'cloud_scylla':
             raise UnsupportedNemesis("Skipping this nemesis due this job run from Siren cloud with 2019 version!")


### PR DESCRIPTION
MINOR FIX:

the nemesis description is missing an important
step, that was misleading when quickly reading it
(instead of the code).

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
