### PR TITLE
improvement(logcollector): collect systemd status for DB nodes

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -793,7 +793,9 @@ class ScyllaLogCollector(LogCollector):
                     CommandLog(name='dmesg.log',
                                command='dmesg -P'),
                     CommandLog(name='kallsyms',
-                               command='sudo cat /proc/kallsyms')
+                               command='sudo cat /proc/kallsyms'),
+                    CommandLog(name='systemctl.status',
+                               command='sudo systemctl status --all --full --no-pager'),
                     ]
     cluster_log_type = "db-cluster"
     cluster_dir_prefix = "db-cluster"


### PR DESCRIPTION
Trello: https://trello.com/c/61PP5n8O/4569-collect-systemd-unit-files-status-at-the-end-of-the-test

Don't think we need to collect it for loader and monitoring nodes.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
