### PR TITLE
feature(nemesis): verify liveness probe doesn't fail during resharding

### DIFF
--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-nodetool-flush-and-reshard.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-nodetool-flush-and-reshard.jenkinsfile
@@ -1,0 +1,16 @@
+#!groovy
+
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'k8s-eks',
+    region: 'eu-north-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-nodetool-flush-and-reshard.yaml',
+    email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    availability_zone: 'a,b',
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy',
+    post_behavior_k8s_cluster: 'destroy'
+)

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-nodetool-flush-and-reshard.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-nodetool-flush-and-reshard.jenkinsfile
@@ -1,0 +1,14 @@
+#!groovy
+
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'k8s-gke',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-nodetool-flush-and-reshard.yaml',
+    email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy',
+    post_behavior_k8s_cluster: 'destroy',
+)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -133,6 +133,9 @@ SCYLLA_DIR = "/var/lib/scylla"
 TEST_USER = 'scylla-test'
 INSTALL_DIR = f"/home/{TEST_USER}/scylladb"
 
+DB_LOG_PATTERN_RESHARDING_START = "(?i)database - Resharding"
+DB_LOG_PATTERN_RESHARDING_FINISH = "(?i)storage_service - Restarting a node in NORMAL"
+
 SPOT_TERMINATION_CHECK_DELAY = 5
 
 LOGGER = logging.getLogger(__name__)
@@ -2539,6 +2542,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         return search_reshard
 
     def restart_node_with_resharding(self, murmur3_partitioner_ignore_msb_bits: int = 12) -> None:
+        # TODO: reuse 'DB_LOG_PATTERN_RESHARDING_START' and 'DB_LOG_PATTERN_RESHARDING_FINISH' vars here.
         search_reshard = self._restart_node_with_resharding(murmur3_partitioner_ignore_msb_bits)
 
         resharding_started = wait.wait_for(func=self._resharding_status, step=5, timeout=180,

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -274,6 +274,8 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
         self.k8s_scylla_cluster_name = self.params.get('k8s_scylla_cluster_name')
         self.scylla_config_lock = RLock()
         self.scylla_restart_required = False
+        self.calculated_cpu_limit = None
+        self.calculated_memory_limit = None
         self.perf_pods_labels = [
             ('app.kubernetes.io/name', 'scylla-node-config'),
             ('app.kubernetes.io/name', 'node-config'),
@@ -903,8 +905,8 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
             - COMMON_CONTAINERS_RESOURCES['memory']
             - SCYLLA_MANAGER_AGENT_RESOURCES['memory']
         )
-        cpu_limit = convert_cpu_units_to_k8s_value(cpu_limit)
-        memory_limit = convert_memory_units_to_k8s_value(memory_limit)
+        self.calculated_cpu_limit = convert_cpu_units_to_k8s_value(cpu_limit)
+        self.calculated_memory_limit = convert_memory_units_to_k8s_value(memory_limit)
 
         # Init 'scylla-config' configMap before installation of Scylla to avoid redundant restart
         self.init_scylla_config_map()
@@ -937,8 +939,8 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
             version=self._scylla_operator_chart_version,
             use_devel=True,
             values=self.get_scylla_cluster_helm_values(
-                cpu_limit=cpu_limit,
-                memory_limit=memory_limit,
+                cpu_limit=self.calculated_cpu_limit,
+                memory_limit=self.calculated_memory_limit,
                 pool_name=node_pool.name if node_pool else None),
             namespace=SCYLLA_NAMESPACE,
         ))

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-nodetool-flush-and-reshard.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-nodetool-flush-and-reshard.yaml
@@ -1,12 +1,11 @@
 test_duration: 300
-k8s_minio_storage_size: '900Gi'
 
 # We should wait for the end of write-prepare stage to avoid unneeded overloads
 nemesis_during_prepare: false
 
-# NOTE: Following is needed to make OperatorNodetoolFlushAndReshard work correctly
-#       It is sub-part of the 'ScyllaOperatorBasicOperationsMonkey' one
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=35123456 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=80 -pop seq=1..35123456 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
+# NOTE: We should have big enough data in DB to make resharding long more than 2 minutes
+#       to exceed the liveness probe timeout making sure it doesn't panic
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=35123456 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=60 -pop seq=1..35123456 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
 
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=100 throttle=5000/s -pop seq=1..10000000 -log interval=5"
              ]
@@ -17,9 +16,8 @@ n_monitor_nodes: 1
 instance_type_db: 'i3.4xlarge'
 gce_instance_type_db: 'n1-highmem-16'
 
-nemesis_class_name: 'ScyllaOperatorBasicOperationsMonkey'
+nemesis_class_name: 'OperatorNodetoolFlushAndReshard'
 nemesis_interval: 5
 
 space_node_threshold: 100246000000
-
-user_prefix: 'longevity-scylla-operator-basic-3h'
+user_prefix: 'longevity-operator-3h-nodetool-flush-and-reshard'


### PR DESCRIPTION
Operator got #894 issue fixed.
In this issue scylla pods were considered down
by operator's liveness probe when Scylla members were running
resharding.

So cover it with nemesis where we populate enough data to make
resharding long more than 2 minutes.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
