### PR TITLE
fix(cluster.py): make run_nodetool not raise TypeError

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2607,7 +2607,10 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             try:
                 # HACK: temporary hack to use libssh2 only for nodetool command
                 remote_class = RemoteCmdRunnerBase.remoter_classes.get('libssh2')
-                remoter = remote_class(**self.ssh_login_info | dict(hostname=self.external_address))
+                if self.ssh_login_info:
+                    remoter = remote_class(**self.ssh_login_info)
+                else:
+                    remoter = remote_class(hostname=self.external_address)
                 result = remoter.run(cmd, timeout=timeout, ignore_status=ignore_status, verbose=verbose)
                 self.log.debug("Command '%s' duration -> %s s" % (result.command, result.duration))
 


### PR DESCRIPTION
If `self.ssh_login_info` is None in the `run_nodetool` method then
we get following error:

    TypeError: unsupported operand type(s) for |: 'NoneType' and 'dict'

It may be empty in case of common VMs deployments and always empty
running on K8S.

So, fix it by using variables more safely.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
