### PR TITLE
fix(get_branched_ami): removed removed self-documenting expression in fstring

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1075,7 +1075,7 @@ def get_branched_ami(scylla_version: str, region_name: str, arch: AwsArchType = 
     )
     images = [image for image in images if not image.name.startswith('debug-image')]
 
-    assert images, f"AMIs for {scylla_version=} not found in {region_name}"
+    assert images, f"AMIs for scylla_version={scylla_version!r} not found in {region_name}"
     if build_id == "all":
         return images
     return images[:1]


### PR DESCRIPTION
Since the builders that use the perf-v8 branch have an older python version (3.6.8)
it does not recognize the self-documenting expression in fstring ( {scylla_version=} ) and the job
fails as a result. This fix should amend that.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
