### PR TITLE
sct show-monitor: restore stack with effectively infinite retention

### DIFF
--- a/sdcm/monitorstack/__init__.py
+++ b/sdcm/monitorstack/__init__.py
@@ -360,7 +360,8 @@ def start_dockers(monitoring_dockers_dir, monitoring_stack_data_dir, scylla_vers
             -g {graf_port} -m {alert_port} -p {prom_port} \
             -s {monitoring_dockers_dir}/config/scylla_servers.yml \
             -n {monitoring_dockers_dir}/config/node_exporter_servers.yml \
-            -d {monitoring_stack_data_dir} -v {scylla_version}""".format(**locals()))
+            -d {monitoring_stack_data_dir} -v {scylla_version} \
+            -b '-storage.tsdb.retention.time=100y'""".format(**locals()))
     res = lr.run(cmd)
     if res.ok:
         LOGGER.info("Docker containers for monitoring stack are started")


### PR DESCRIPTION
When a monitoring data older than 15 days in investigated using:
'sct investigate show-monitor' , prometheus will compact the data
away. This will appear to the user as if the data disappeared after
some that prometheus was running. The reason is that the default
retention configuration is 15 days.
Here we add a parameter that will increase the monitoring data retention
time to 100 years which is effectively infinite in our time resolution.

Note: This change also exploits a "bug" in the newer monitoring system where,
flags added using the '-b' option and starts with one '-' sign will be
prefixed with a '-' sign two (making it a '--' option). This is
convenient because on older monitoring version the parameters were
prefixed with '-' unconditionally.
This means that in both versions adding a parameter which is prefixed
with one '-' (e.g -storage.tsdb.retention.time) will result in actually
adding a parameter with '--' (--storage.tsdb.retention.time).

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
