### PR TITLE
fix(scylla-bench large-partitions): Downgrade scylla-bench to a stable version

### DIFF
--- a/test-cases/longevity/longevity-counters-multidc.yaml
+++ b/test-cases/longevity/longevity-counters-multidc.yaml
@@ -24,3 +24,6 @@ internode_encryption: 'dc'
 ip_ssh_connections: 'public'
 
 use_legacy_cluster_init: false
+
+# Temporarily downgrade scylla_bench to a stable version
+scylla_bench_version: v0.1.3

--- a/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
@@ -71,3 +71,6 @@ space_node_threshold: 644245094
 stop_test_on_stress_failure: false
 
 run_full_partition_scan: '{"ks_cf": "scylla_bench.test", "interval": 90, "pk_name":"pk", "rows_count": 100000}' # 'ks.cf, interval(sec), partition-key name, number-of-rows-per-partition'
+
+# Temporarily downgrade scylla_bench to a stable version
+scylla_bench_version: v0.1.3

--- a/test-cases/longevity/longevity-large-partition-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-4days.yaml
@@ -41,3 +41,6 @@ table_name: "scylla_bench.test"
 primary_key_column: "pk"
 
 run_full_partition_scan: '{"ks_cf": "scylla_bench.test", "interval": 180, "pk_name":"pk", "rows_count": 10000000}' # 'ks.cf, interval(sec), partition-key name, number-of-rows-per-partition'
+
+# Temporarily downgrade scylla_bench to a stable version
+scylla_bench_version: v0.1.3

--- a/test-cases/longevity/longevity-twcs-48h.yaml
+++ b/test-cases/longevity/longevity-twcs-48h.yaml
@@ -26,3 +26,6 @@ space_node_threshold: 64424
 user_prefix: 'longevity-twcs-48h'
 
 post_prepare_cql_cmds: "ALTER TABLE scylla_bench.test with gc_grace_seconds = 300 and default_time_to_live = 21600 and compaction = {'class':'TimeWindowCompactionStrategy', 'compaction_window_size': 60, 'compaction_window_unit': 'MINUTES'};"
+
+# Temporarily downgrade scylla_bench to a stable version
+scylla_bench_version: v0.1.3


### PR DESCRIPTION
	scylla-bench latest version of 0.1.8 is not stable.
	Therefore downgrading it on large-partitions relevant longevities.

Trello: https://trello.com/c/8U4dGEEI
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
