### PR TITLE
improvement(ssh-transport): enabling libssh2 by default

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -22,7 +22,7 @@ db_nodes_shards_selection: 'default'
 # for for version selection
 scylla_linux_distro: 'ubuntu-focal'
 scylla_linux_distro_loader: 'centos'
-ssh_transport: 'fabric'
+ssh_transport: 'libssh2'
 system_auth_rf: 3
 
 monitor_branch: 'branch-3.10'


### PR DESCRIPTION
following -1 exit code issues
https://github.com/scylladb/scylla-cluster-tests/issues/4301

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
