### PR TITLE
improvement(rollingUpgradePipeline.groovy): base_versions to Jenkins

### DIFF
--- a/jenkins-pipelines/rolling-upgrade-alternator.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-alternator.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: [],  // auto mode
+    base_versions: '',  // auto mode
     linux_distro: 'centos',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7',
 

--- a/jenkins-pipelines/rolling-upgrade-ami.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-ami.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'aws',
-    base_versions: [],  // auto mode
+    base_versions: '',  // auto mode
     linux_distro: 'centos',
 
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',

--- a/jenkins-pipelines/rolling-upgrade-centos7-ldap-authorization.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-centos7-ldap-authorization.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: [],  // auto mode
+    base_versions: '',  // auto mode
     linux_distro: 'centos',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7',
 

--- a/jenkins-pipelines/rolling-upgrade-centos7.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-centos7.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: [],  // auto mode
+    base_versions: '',  // auto mode
     linux_distro: 'centos',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7',
 

--- a/jenkins-pipelines/rolling-upgrade-centos8.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-centos8.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: [],  // auto mode
+    base_versions: '',  // auto mode
     linux_distro: 'centos-8',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-stream-8',
 

--- a/jenkins-pipelines/rolling-upgrade-debian11.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-debian11.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: [],  // auto mode
+    base_versions: '',  // auto mode
     linux_distro: 'debian-bullseye',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-11',
 

--- a/jenkins-pipelines/rolling-upgrade-debian9.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-debian9.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: [],  // auto mode
+    base_versions: '',  // auto mode
     linux_distro: 'debian-stretch',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-9',
 

--- a/jenkins-pipelines/rolling-upgrade-multidc.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-multidc.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 rollingUpgradePipeline(
     backend: 'aws',
     region: '["eu-west-1", "eu-west-2"]',
-    base_versions: [],  // auto mode
+    base_versions: '',  // auto mode
     linux_distro: 'ubuntu-focal',
 
     test_name: 'upgrade_test.UpgradeTest.test_generic_cluster_upgrade',

--- a/jenkins-pipelines/rolling-upgrade-ubuntu16.04.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-ubuntu16.04.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: [],  // auto mode
+    base_versions: '',  // auto mode
     linux_distro: 'ubuntu-xenial',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-pro-cloud/global/images/family/ubuntu-pro-1604-lts',
 

--- a/jenkins-pipelines/rolling-upgrade-ubuntu18.04-ldap-authorization.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-ubuntu18.04-ldap-authorization.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: [],  // auto mode
+    base_versions: '',  // auto mode
     linux_distro: 'ubuntu-bionic',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-1804-lts',
 

--- a/jenkins-pipelines/rolling-upgrade-ubuntu18.04.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-ubuntu18.04.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: [],  // auto mode
+    base_versions: '',  // auto mode
     linux_distro: 'ubuntu-bionic',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-1804-lts',
 

--- a/jenkins-pipelines/rolling-upgrade-ubuntu20.04.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-ubuntu20.04.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: [],  // auto mode
+    base_versions: '',  // auto mode
     linux_distro: 'ubuntu-focal',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2004-lts',
 

--- a/jenkins-pipelines/rolling-upgrade-with-null-inserts.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-with-null-inserts.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: [],  // auto mode
+    base_versions: '',  // auto mode
     linux_distro: 'centos-8',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-stream-8',
 

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -60,6 +60,9 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('test_config', '')}",
                    description: 'Test configuration file',
                    name: 'test_config')
+            string(defaultValue: "${pipelineParams.get('base_versions', '')}",
+                   description: 'Base version in which the upgrade will start from.\nFormat should be for example -> 4.5,4.6 (or single version, or \'\' to use the auto mode)',
+                   name: 'base_versions')
         }
         options {
             timestamps()
@@ -96,8 +99,9 @@ def call(Map pipelineParams) {
                                 wrap([$class: 'BuildUser']) {
                                     dir('scylla-cluster-tests') {
                                         checkout scm
+                                        ArrayList base_versions_list = params.base_versions.contains('.') ? params.base_versions.split('\\,') : []
                                         supportedVersions = supportedUpgradeFromVersions(
-                                            pipelineParams.base_versions,
+                                            base_versions_list,
                                             pipelineParams.linux_distro,
                                             params.new_scylla_repo
                                         )


### PR DESCRIPTION
allowing the base_versions to be set in the jobs parameter.
for now, it was only in the .pipeline files, and when need
to re-run jobs that failed from a single base version, we
need to either change code to be able to do it, or to re-run
all of the base_versions.
this improvement will allow to change it from the Jenkins'
job's parameters page.

running it in [here](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fabio/job/upgrade_base_version/job/upgrade-debian10-base-version-parameter/) to test it

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
