### PR TITLE
fix(operator): skip networking nemesis for K8S backends

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2430,6 +2430,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         """
         Generates random firewall rule to drop/reject packets for node exporter connections, port 9100
         """
+        if self._is_it_on_kubernetes():
+            raise UnsupportedNemesis("Not implemented for the K8S backend.")
         name = 'RejectNodeExporterNetwork'
         textual_matching_rule, matching_rule = self._iptables_randomly_get_random_matching_rule()
         textual_pkt_action, pkt_action = self._iptables_randomly_get_disrupting_target()
@@ -2448,6 +2450,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         """
         Generates random firewall rule to drop/reject packets for thrift connections, port 9100
         """
+        if self._is_it_on_kubernetes():
+            raise UnsupportedNemesis("Not implemented for the K8S backend.")
         name = 'RejectThriftNetwork'
         textual_matching_rule, matching_rule = self._iptables_randomly_get_random_matching_rule()
         textual_pkt_action, pkt_action = self._iptables_randomly_get_disrupting_target()


### PR DESCRIPTION
Port blocking logic of couple of nemesis is not compatible as is
with the K8S approach.
So, skip it while it's support is not implemented for K8S.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
