### PR TITLE
test(artifact): scylla doesn't use ntp/chrony with systemd-timesyncd

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -200,6 +200,11 @@ class ArtifactsTest(ClusterTester):
             write_cache = run(f"cat /sys/block/{nvme_device.removeprefix('/dev/')}/queue/write_cache").stdout.strip()
             self.assertEqual(write_cache, expected_write_cache_value)
 
+    def check_service_existence(self, service_name):
+        res = self.node.remoter.run(f'systemctl list-units --full | grep -Fq "{service_name}"',
+                                    ignore_status=True)
+        return not res.exit_status
+
     def test_scylla_service(self):
         backend = self.params["cluster_backend"]
 
@@ -231,6 +236,24 @@ class ArtifactsTest(ClusterTester):
 
         with self.subTest("check Scylla server after installation"):
             self.check_scylla()
+
+        with self.subTest("check if scylla unnecessarily installed a time synchronization service"):
+            # Checks https://github.com/scylladb/scylla/issues/8339
+            # If the instance already has systemd-timesyncd
+            is_timesyncd_service_installed = self.check_service_existence(service_name="systemd-timesyncd")
+            is_ntp_service_installed = self.check_service_existence(service_name="ntp")
+            is_chrony_service_installed = self.check_service_existence(service_name="chrony")
+            # Do note: On Redhat based distributions the services are named ntpd and chronyd, while on debian based
+            # distributions they're named ntp and chrony. As such, I looked for the shorter name of the two.
+            if is_timesyncd_service_installed:
+                assert not is_ntp_service_installed, \
+                    "systemd-timesyncd is already installed, yet scylla installed ntp service on top of it"
+                assert not is_chrony_service_installed, \
+                    "systemd-timesyncd is already installed, yet scylla installed chrony service on top of it"
+            else:
+                assert is_ntp_service_installed or is_chrony_service_installed, \
+                    "systemd-timesyncd is not installed on the instance, yet Scylla did not install ntp or chrony " \
+                    "services as a replacement"
 
             # TODO: implement after the new provision will be added
             # Task: https://trello.com/c/BIdIUwyT/4096-housekeeping-implemented-a-test-that-checks-i-value-when-scylla-


### PR DESCRIPTION
As described in https://github.com/scylladb/scylla/issues/8339, if the systemd-timesyncd
service is already installed in the machine, Scylla should not install a different time
synchronization service (ntpd or chronyd) as well. The subtest I added in the artifact
test will make sure of that.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
