### PR TITLE
improvement(reversed queries): Added reversed queries data validation

### DIFF
--- a/sdcm/scan_operation_thread.py
+++ b/sdcm/scan_operation_thread.py
@@ -1,20 +1,25 @@
 import json
 import logging
 import random
+import tempfile
 import threading
 import time
 from abc import abstractmethod
 from typing import Optional
+
 from cassandra import ConsistencyLevel
+from cassandra.cluster import ResponseFuture  # pylint: disable=no-name-in-module
 from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
 
 from sdcm import wait
 from sdcm.cluster import BaseNode, BaseScyllaCluster, BaseCluster
+from sdcm.remote import LocalCmdRunner
 from sdcm.utils.common import get_partition_keys, get_table_clustering_order
 from sdcm.sct_events import Severity
-from sdcm.sct_events.database import FullScanEvent, FullPartitionScanReversedOrderEvent
+from sdcm.sct_events.database import FullScanEvent, FullPartitionScanReversedOrderEvent, FullPartitionScanEvent
 
 ERROR_SUBSTRINGS = ("timed out", "unpack requires", "timeout")
+LOCAL_CMD_RUNNER = LocalCmdRunner()
 
 
 # pylint: disable=too-many-instance-attributes
@@ -24,7 +29,8 @@ class ScanOperationThread:
 
     # pylint: disable=too-many-arguments,unused-argument
     def __init__(self, db_cluster: [BaseScyllaCluster, BaseCluster], duration: int, interval: int,
-                 termination_event: threading.Event, ks_cf: str, page_size: int = 10000, **kwargs):
+                 termination_event: threading.Event, ks_cf: str,
+                 scan_event: [FullScanEvent, FullPartitionScanReversedOrderEvent], page_size: int = 10000, **kwargs):
         self.ks_cf = ks_cf
         self.db_cluster = db_cluster
         self.page_size = page_size
@@ -36,6 +42,7 @@ class ScanOperationThread:
         self.scans_counter = 0
         self.time_elapsed = 0
         self.total_scan_time = 0
+        self.scan_event = scan_event
         self.termination_event = termination_event
         self.log = logging.getLogger(self.__class__.__name__)
         self._thread = threading.Thread(daemon=True, name=self.__class__.__name__, target=self.run)
@@ -86,12 +93,18 @@ class ScanOperationThread:
             if read_pages > 0:
                 pages += 1
 
-    def run_scan_operation(self, scan_operation_event, cmd: str = None):  # pylint: disable=too-many-locals
+    def update_stats(self):
+        self.scans_counter += 1
+        self.total_scan_time += self.time_elapsed
+        self.log.info('Average scan duration of %s scans is: %s', self.scans_counter,
+                      (self.total_scan_time / self.scans_counter))
+
+    def run_scan_operation(self, cmd: str = None, update_stats: bool = True):  # pylint: disable=too-many-locals
         db_node = self.db_node
         self.wait_until_user_table_exists(db_node=db_node, table_name=self.ks_cf)
         if self.ks_cf.lower() == 'random':
             self.ks_cf = random.choice(self.db_cluster.get_non_system_ks_cf_list(db_node))
-        with scan_operation_event(node=db_node.name, ks_cf=self.ks_cf, message="") as operation_event:
+        with self.scan_event(node=db_node.name, ks_cf=self.ks_cf, message="") as operation_event:
             cmd = cmd or self.randomly_form_cql_statement()
             if not cmd:
                 return
@@ -105,11 +118,9 @@ class ScanOperationThread:
                     result = self.execute_query(session=session, cmd=cmd)
                     self.fetch_result_pages(result=result, read_pages=self.read_pages)
                     self.time_elapsed = time.time() - start_time
-                    self.total_scan_time += self.time_elapsed
+                    self.update_stats()
                     self.log.info('[%s] last scan duration of %s rows is: %s', {type(self).__name__},
                                   self.number_of_rows_read, self.time_elapsed)
-                    self.log.info('Average scan duration of %s scans is: %s', self.scans_counter,
-                                  (self.total_scan_time / self.scans_counter))
                     operation_event.message = f"{type(self).__name__} operation ended successfully"
                 except Exception as exc:  # pylint: disable=broad-except
                     msg = str(exc)
@@ -121,19 +132,14 @@ class ScanOperationThread:
                     else:
                         operation_event.severity = Severity.ERROR
 
-    def run_for_a_duration(self, scan_operation_event):
+    def run(self):
         end_time = time.time() + self.duration
         while time.time() < end_time and not self.termination_event.is_set():
             self.db_node = random.choice(self.db_cluster.nodes)
             self.read_pages = random.choice([100, 1000, 0])
-            self.scans_counter += 1
-            self.run_scan_operation(scan_operation_event=scan_operation_event)
-            self.log.info('Executed %s number: %s', scan_operation_event, self.scans_counter)
+            self.run_scan_operation()
+            self.log.info('Executed %s number: %s', self.scan_event.__name__, self.scans_counter)
             time.sleep(self.interval)
-
-    @abstractmethod
-    def run(self):
-        ...
 
     def start(self):
         self._thread.start()
@@ -145,14 +151,11 @@ class ScanOperationThread:
 class FullScanThread(ScanOperationThread):
 
     def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+        super().__init__(scan_event=FullScanEvent, **kwargs)
 
     def randomly_form_cql_statement(self) -> Optional[str]:
         cmd = self.randomly_bypass_cache(cmd=self.basic_query).format(self.ks_cf)
         return self.randomly_add_timeout(cmd)
-
-    def run(self):
-        self.run_for_a_duration(scan_operation_event=FullScanEvent)
 
 
 class FullPartitionScanThread(ScanOperationThread):
@@ -173,12 +176,13 @@ class FullPartitionScanThread(ScanOperationThread):
                                    'no_filter': ''}
 
     def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+        super().__init__(scan_event=FullPartitionScanReversedOrderEvent, **kwargs)
         self.full_partition_scan_params = kwargs
         self.full_partition_scan_params['validate_data'] = json.loads(
             self.full_partition_scan_params.get('validate_data', 'false'))
         self.pk_name = self.full_partition_scan_params.get('pk_name', 'pk')
         self.ck_name = self.full_partition_scan_params.get('ck_name', 'ck')
+        self.data_column_name = self.full_partition_scan_params.get('data_column_name', 'v')
         self.rows_count = self.full_partition_scan_params.get('rows_count', 5000)
         self.table_clustering_order = self.get_table_clustering_order()
         self.reversed_order = 'desc' if self.table_clustering_order.lower() == 'asc' else 'asc'
@@ -187,6 +191,11 @@ class FullPartitionScanThread(ScanOperationThread):
                                                'lt_and_gt': {'count': 0, 'total_scan_duration': 0},
                                                'no_filter': {'count': 0, 'total_scan_duration': 0}}
         self.ck_filter = ''
+        self.limit = ''
+        self.reversed_query_output = tempfile.NamedTemporaryFile(mode='w+', delete=False,  # pylint: disable=consider-using-with
+                                                                 encoding='utf-8')
+        self.normal_query_output = tempfile.NamedTemporaryFile(mode='w+', delete=False,  # pylint: disable=consider-using-with
+                                                               encoding='utf-8')
 
     def get_table_clustering_order(self) -> str:
         for node in self.db_cluster.nodes:
@@ -221,14 +230,12 @@ class FullPartitionScanThread(ScanOperationThread):
                 # Form a random query out of all options, like:
                 # select * from scylla_bench.test where pk = 1234 and ck < 4721 and ck > 2549 order by ck desc
                 # limit 3467 bypass cache
-                normal_query = reversed_query = self.basic_query.format(
-                    self.ks_cf) + f' where {pk_name} = {partition_key}'
-                query_suffix = limit = ''
-
-                if random.choice([False] + [True]):  # Randomly add a LIMIT
-                    limit = random.randint(a=1, b=rows_count)
-                    query_suffix += f' limit {limit}'
-                query_suffix = self.randomly_bypass_cache(cmd=query_suffix)
+                selected_columns = [pk_name, ck_name]
+                if self.full_partition_scan_params.get('include_data_column'):
+                    selected_columns.append(self.data_column_name)
+                reversed_query = f'select {",".join(selected_columns)} from {self.ks_cf}' + \
+                    f' where {pk_name} = {partition_key}'
+                query_suffix = self.limit = ''
 
                 # Randomly add CK filtering ( less-than / greater-than / both / non-filter )
 
@@ -244,15 +251,6 @@ class FullPartitionScanThread(ScanOperationThread):
                                                                                              ck_random_max_value,
                                                                                              ck_name,
                                                                                              ck_random_min_value)
-                        ck_range = ck_random_max_value - ck_random_min_value - 1  # e.g. 15 - 10 - 1 = 4
-                        if limit and limit < ck_range:
-                            # Example: select * from scylla_bench.test where pk = 1 and ck > 10 and ck < 15
-                            # order by ck desc limit 3
-                            # output of ck should be: [12,13,14]
-                            normal_query += \
-                                f' and {ck_name} < {ck_random_max_value} and {ck_name} >= {ck_random_max_value - limit}'
-                        else:
-                            normal_query = reversed_query
 
                     case 'gt':
                         # example: rows-count = 20, ck > 10, limit = 5 ==> ck_range = 20 - 10 = 10 ==> limit < ck_range
@@ -261,12 +259,6 @@ class FullPartitionScanThread(ScanOperationThread):
                         # normal query should be: select * from scylla_bench.test where pk = 1 and ck > 15 limit 5
                         reversed_query += self.reversed_query_filter_ck_by[ck_filter].format(ck_name,
                                                                                              ck_random_min_value)
-                        ck_range = rows_count - ck_random_min_value
-                        if limit and limit < ck_range:
-                            normal_query += self.reversed_query_filter_ck_by[ck_filter].format(ck_name,
-                                                                                               rows_count - limit)
-                        else:
-                            normal_query = reversed_query
 
                     case 'lt':
                         # example: rows-count = 20, ck < 10, limit = 5 ==> limit < ck_random_min_value (ck_range)
@@ -275,14 +267,12 @@ class FullPartitionScanThread(ScanOperationThread):
                         # normal query should be: select * from scylla_bench.test where pk = 1 and ck >= 5 limit 5
                         reversed_query += self.reversed_query_filter_ck_by[ck_filter].format(ck_name,
                                                                                              ck_random_min_value)
-                        if limit and limit < ck_random_min_value:
-                            normal_query += f' and {ck_name} >= {ck_random_min_value - limit}'
-                        else:
-                            normal_query = reversed_query
-                reversed_query += f' order by {ck_name} {self.reversed_order}'
-
-                normal_query += query_suffix
-                reversed_query += query_suffix
+                query_suffix = self.randomly_bypass_cache(cmd=query_suffix)
+                normal_query = reversed_query + query_suffix
+                if random.choice([False] + [True]):  # Randomly add a LIMIT
+                    self.limit = random.randint(a=1, b=rows_count)
+                    query_suffix = f' limit {self.limit}' + query_suffix
+                reversed_query += f' order by {ck_name} {self.reversed_order}' + query_suffix
                 self.log.info('Randomly formed normal query is: %s', normal_query)
                 self.log.info('[scan: %s, type: %s] Randomly formed reversed query is: %s', self.scans_counter,
                               ck_filter, reversed_query)
@@ -291,7 +281,7 @@ class FullPartitionScanThread(ScanOperationThread):
                 return None
         return normal_query, reversed_query
 
-    def fetch_result_pages(self, result, read_pages):
+    def fetch_result_pages(self, result: ResponseFuture, read_pages):
         self.log.info('Will fetch up to %s result pages.."', read_pages)
         self.number_of_rows_read = 0
         handler = PagedResultHandler(future=result, scan_operation_thread=self)
@@ -307,28 +297,73 @@ class FullPartitionScanThread(ScanOperationThread):
         session.default_consistency_level = ConsistencyLevel.ONE
         return session.execute_async(cmd)
 
-    def run_scan_operation(self, scan_operation_event, cmd: str = None):  # pylint: disable=too-many-locals
+    def reset_output_files(self):
+        self.normal_query_output.close()
+        self.reversed_query_output.close()
+        self.reversed_query_output = tempfile.NamedTemporaryFile(mode='w+', delete=False,  # pylint: disable=consider-using-with
+                                                                 encoding='utf-8')
+        self.normal_query_output = tempfile.NamedTemporaryFile(mode='w+', delete=False,  # pylint: disable=consider-using-with
+                                                               encoding='utf-8')
+
+    def _compare_output_files(self):
+        self.normal_query_output.flush()
+        self.reversed_query_output.flush()
+
+        with tempfile.NamedTemporaryFile(mode='w+', delete=True, encoding='utf-8') as reorder_normal_query_output:
+            cmd = f'tac {self.normal_query_output.name}'
+            if self.limit:
+                cmd += f' | head -n {self.limit}'
+            cmd += f' > {reorder_normal_query_output.name}'
+            LOCAL_CMD_RUNNER.run(cmd=cmd, ignore_status=True)
+            reorder_normal_query_output.flush()
+            LOCAL_CMD_RUNNER.run(cmd=f'cp {reorder_normal_query_output.name} {self.normal_query_output.name}',
+                                 ignore_status=True)
+            self.normal_query_output.flush()
+
+        file_names = f' {self.normal_query_output.name} {self.reversed_query_output.name}'
+        diff_cmd = f"diff -y --suppress-common-lines {file_names}"
+        self.log.info("Comparing scan queries output files by: %s", diff_cmd)
+        result = LOCAL_CMD_RUNNER.run(cmd=diff_cmd, ignore_status=True)
+        if not result.stderr:
+            if not result.stdout:
+                self.log.info("Compared output of normal and reversed queries is identical!")
+            else:
+                self.log.warning("Normal and reversed queries output differs: \n%s", result.stdout.strip())
+                ls_cmd = f"ls -alh {file_names}"
+                head_cmd = f"head {file_names}"
+                for cmd in [ls_cmd, head_cmd]:
+                    result = LOCAL_CMD_RUNNER.run(cmd=cmd, ignore_status=True)
+                    if result.stdout:
+                        stdout = result.stdout.strip()
+                        self.log.info("%s command output is: \n%s", cmd, stdout)
+        self.reset_output_files()
+
+    def run_scan_operation(self, cmd: str = None, update_stats: bool = True):  # pylint: disable=too-many-locals
         queries = self.randomly_form_cql_statement()
         if not queries:
             return
         normal_query, reversed_query = queries
-        ScanOperationThread.run_scan_operation(self, scan_operation_event=scan_operation_event, cmd=reversed_query)
+        self.scan_event = FullPartitionScanReversedOrderEvent
+        super().run_scan_operation(cmd=reversed_query)
         self.reversed_query_filter_ck_stats[self.ck_filter]['count'] += 1
         self.reversed_query_filter_ck_stats[self.ck_filter]['total_scan_duration'] += self.time_elapsed
         count = self.reversed_query_filter_ck_stats[self.ck_filter]['count']
         average = self.reversed_query_filter_ck_stats[self.ck_filter]['total_scan_duration'] / count
         self.log.info('Average %s scans duration of %s executions is: %s', self.ck_filter, count, average)
         if self.full_partition_scan_params.get('validate_data'):
-            # TODO: implement when a new hydra docker with deepdiff is available
-            self.log.debug('Temporarily not executing the normal query of: %s', normal_query)
+            self.log.debug('Executing the normal query: %s', normal_query)
+            self.scan_event = FullPartitionScanEvent
+            super().run_scan_operation(cmd=normal_query)
+            self._compare_output_files()
 
-    def run(self):
-        self.run_for_a_duration(scan_operation_event=FullPartitionScanReversedOrderEvent)
+    def update_stats(self):
+        if self.scan_event == FullPartitionScanReversedOrderEvent:
+            super().update_stats()
 
 
 class PagedResultHandler:
 
-    def __init__(self, future, scan_operation_thread: FullPartitionScanThread):
+    def __init__(self, future: ResponseFuture, scan_operation_thread: FullPartitionScanThread):
         self.error = None
         self.finished_event = threading.Event()
         self.future = future
@@ -340,8 +375,26 @@ class PagedResultHandler:
             callback=self.handle_page,
             errback=self.handle_error)
 
+    def _row_to_string(self, row, include_data_column: bool = False) -> str:
+        row_string = str(getattr(row, self.scan_operation_thread.pk_name))
+        row_string += str(getattr(row, self.scan_operation_thread.ck_name))
+        if include_data_column:
+            row_string += str(getattr(row, self.scan_operation_thread.data_column_name))
+        return f'{row_string}\n'
+
     def handle_page(self, rows):
-        self.scan_operation_thread.number_of_rows_read += len(rows)
+        include_data_column = self.scan_operation_thread.full_partition_scan_params.get('include_data_column')
+        if self.scan_operation_thread.scan_event == FullPartitionScanEvent:
+            for row in rows:
+                self.scan_operation_thread.normal_query_output.write(
+                    self._row_to_string(row=row, include_data_column=include_data_column))
+        elif self.scan_operation_thread.scan_event == FullPartitionScanReversedOrderEvent:
+            self.scan_operation_thread.number_of_rows_read += len(rows)
+            if self.scan_operation_thread.full_partition_scan_params['validate_data']:
+                for row in rows:
+                    self.scan_operation_thread.reversed_query_output.write(
+                        self._row_to_string(row=row, include_data_column=include_data_column))
+
         if self.future.has_more_pages and self.current_read_pages <= self.max_read_pages:
             self.log.info('Will fetch the next page: %s', self.current_read_pages)
             self.future.start_fetching_next_page()

--- a/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
@@ -70,7 +70,6 @@ space_node_threshold: 644245094
 
 stop_test_on_stress_failure: false
 
-run_full_partition_scan: '{"ks_cf": "scylla_bench.test", "interval": 90, "pk_name":"pk", "rows_count": 100000}' # 'ks.cf, interval(sec), partition-key name, number-of-rows-per-partition'
-
 # Temporarily downgrade scylla_bench to a stable version
 scylla_bench_version: v0.1.3
+run_full_partition_scan: '{"ks_cf": "scylla_bench.test", "interval": 90, "pk_name":"pk", "rows_count": 100000, "validate_data": "true"}' # 'ks.cf, interval(sec), partition-key name, number-of-rows-per-partition, validate reversed query output, include data-column or only validate pk + ck'

--- a/test-cases/longevity/longevity-large-partition-3h.yaml
+++ b/test-cases/longevity/longevity-large-partition-3h.yaml
@@ -44,4 +44,4 @@ space_node_threshold: 644245094
 
 run_fullscan: '{"ks_cf": "scylla_bench.test", "interval": 10}' # 'ks.cf|random, interval(min)'
 
-run_full_partition_scan: '{"ks_cf": "scylla_bench.test", "interval": 2, "pk_name":"pk", "rows_count": 5000, "validate_data": "false"}' # 'ks.cf, interval(sec), partition-key name, number-of-rows-per-partition, validate reversed query output'
+run_full_partition_scan: '{"ks_cf": "scylla_bench.test", "interval": 2, "pk_name":"pk", "rows_count": 5000, "validate_data": "true", "include_data_column": "true"}' # 'ks.cf, interval(sec), partition-key name, number-of-rows-per-partition, validate reversed query output, include data-column or only validate pk + ck'

--- a/test-cases/longevity/longevity-large-partition-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-4days.yaml
@@ -40,7 +40,6 @@ validate_partitions: true
 table_name: "scylla_bench.test"
 primary_key_column: "pk"
 
-run_full_partition_scan: '{"ks_cf": "scylla_bench.test", "interval": 180, "pk_name":"pk", "rows_count": 10000000}' # 'ks.cf, interval(sec), partition-key name, number-of-rows-per-partition'
-
 # Temporarily downgrade scylla_bench to a stable version
 scylla_bench_version: v0.1.3
+run_full_partition_scan: '{"ks_cf": "scylla_bench.test", "interval": 180, "pk_name":"pk", "rows_count": 10000000, "validate_data": "true"}' # 'ks.cf, interval(sec), partition-key name, number-of-rows-per-partition, validate reversed query output, include data-column or only validate pk + ck'

--- a/test-cases/longevity/longevity-large-partition-8h.yaml
+++ b/test-cases/longevity/longevity-large-partition-8h.yaml
@@ -48,4 +48,4 @@ user_prefix: 'longevity-large-partitions-8h'
 
 space_node_threshold: 644245094
 
-run_full_partition_scan: '{"ks_cf": "scylla_bench.test", "interval": 2, "pk_name":"pk", "rows_count": 5555}' # 'ks.cf, interval(sec), partition-key name, number-of-rows-per-partition'
+run_full_partition_scan: '{"ks_cf": "scylla_bench.test", "interval": 2, "pk_name":"pk", "rows_count": 5555, "validate_data": "true"}' # 'ks.cf, interval(sec), partition-key name, number-of-rows-per-partition, validate reversed query output, include data-column or only validate pk + ck'


### PR DESCRIPTION
A followup of: https://trello.com/c/xnqJRs4n - 
In order to compare full-partition-scan data of reversed and normal queries, need to add this enhancement, saving queries output to files and comparing it.

The best practise may be saving each query result page fetch to a file accumulatively, then compare the 2 generated files of reversed and normal queries.

Trello: https://trello.com/c/kZHjbVqC
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
