### PR TITLE
fix(fill_db_data.py): change session consistency level in paged_query

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -3372,6 +3372,7 @@ class FillDatabaseData(ClusterTester):
                 session.execute(f'INSERT INTO paged_query_test (k, v1, v2) VALUES ({i}, {random_int}, {random_int+i})')
         node = self.db_cluster.nodes[-1]
         with self.db_cluster.cql_connection_patient(node, keyspace=keyspace) as session:
+            session.default_consistency_level = ConsistencyLevel.QUORUM
             create_table()
             self.db_cluster.wait_for_schema_agreement()  # WORKAROUND TO SCHEMA PROPAGATION TAKING TOO LONG
             fill_table()


### PR DESCRIPTION
Changed the default CL for the CQL session in paged_query test.
Now data are being inserted into table and both select queries are running with the same CL - QUORUM
This change is supposed to prevent issues like https://github.com/scylladb/scylla/issues/10049

[Trello task](https://trello.com/c/ONhKubC4/4650-reproduce-pagedquery-failure-scylla-issue-10049)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] ~~I added the relevant `backport` labels~~
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
