### PR TITLE
improvement(sdcm.argus_test_run): Parse JOB_NAME instead of branch names

### DIFF
--- a/sdcm/argus_test_run.py
+++ b/sdcm/argus_test_run.py
@@ -11,7 +11,6 @@
 #
 # Copyright (c) 2021 ScyllaDB
 import time
-import os
 import logging
 import unittest.mock
 from uuid import UUID
@@ -27,8 +26,8 @@ from sdcm.keystore import KeyStore
 from sdcm.sct_config import SCTConfiguration
 from sdcm.utils.net import get_my_ip, get_sct_runner_ip
 from sdcm.utils.get_username import get_username
-from sdcm.utils.git import get_git_current_branch, get_git_commit_id
-from sdcm.utils.ci_tools import get_job_url, get_job_name, get_test_name
+from sdcm.utils.git import get_git_commit_id
+from sdcm.utils.ci_tools import get_job_url, get_job_name
 
 LOGGER = logging.getLogger(__name__)
 
@@ -170,6 +169,45 @@ def _prepare_docker_resource_setup(sct_config: SCTConfiguration):
     return cloud_setup
 
 
+def parse_run_details(details: list) -> tuple:
+    """
+    Parse a jenkins job url into a three element tuple containing
+    release, group, test names. Most runs should fit into this pattern easily
+    and some will need some additional parsing / adjustments
+    Examples:
+    scylla-master/artifacts/artifacts-amazon2-test
+    -> [scylla-master, artifacts, artifacts-amazon2-test]
+    manager-master/ubuntu20-sanity-test
+    -> [manager-master, manager-tests, ubuntu20-sanity-test]
+    """
+    release = ""
+    group = ""
+    name = ""
+    if "manager" in details[0]:
+        release, *name = details
+        name = "-".join(name)
+        group = "manager-tests"
+    elif "scylla-operator" in details[0]:
+        _, release, group, *name = details
+        name = "-".join(name)
+    elif "scylla-staging" in details[0]:
+        release, group, *name_split = details
+        name = "-".join(name_split)
+    elif len(details) == 3:
+        release, group, name = details
+    elif len(details) < 3:
+        LOGGER.warning("Non-parseable build name detected, this run won't be stored in argus: %s", details)
+    else:
+        # try to make up a test name from arbitrary nesting
+        release, *group, name = details
+        group = "-".join(group)
+
+    # FIXUP: some groups have a trailing dash
+    group = group.strip("-")
+
+    return release, group, name
+
+
 class ArgusTestRun:
     WARNINGS_SENT = set()
     TESTRUN_INSTANCE: TestRunWithHeartbeat | None = None
@@ -185,13 +223,6 @@ class ArgusTestRun:
         "docker": _prepare_docker_resource_setup,
         "unknown": _prepare_unknown_resource_setup,
     }
-    AVAILABLE_RELEASES = [
-        "master",
-        "branch-2022.1",
-        "branch-4.6",
-        "manager-2.7",
-        "operator-1.6",
-    ]
     _config: ArgusConfig = None
 
     def __init__(self):
@@ -211,26 +242,29 @@ class ArgusTestRun:
         LOGGER.warning(message, *args)
 
     @classmethod
-    def from_sct_config(cls, test_id: UUID, test_module_path: str,
-                        sct_config: SCTConfiguration) -> TestRunWithHeartbeat:
+    def from_sct_config(cls, test_id: UUID, sct_config: SCTConfiguration) -> TestRunWithHeartbeat:
         # pylint: disable=too-many-locals
         if cls.TESTRUN_INSTANCE:
             raise ArgusTestRunError("Instance already initialized")
 
-        release_name = os.getenv("GIT_BRANCH", get_git_current_branch()).split("/")[-1]
-        if release_name not in cls.AVAILABLE_RELEASES:
-            raise ArgusTestRunError("Refusing to track a non-whitelisted branch", release_name, cls.AVAILABLE_RELEASES)
         LOGGER.info("Preparing Test Details...")
-        test_group, *_ = test_module_path.split(".")
-        config_files = sct_config.get("config_files")
         job_name = get_job_name()
+        if job_name == "local_run":
+            raise ArgusTestRunError("Will not track a locally run job")
+
         job_url = get_job_url()
+        release_name, group_name, test_name = parse_run_details(job_name.split("/"))
+        if not release_name:
+            raise ArgusTestRunError(f"Unable to track a job: {job_name}", job_name)
+
+        config_files = sct_config.get("config_files")
         started_by = get_username()
 
-        details = TestDetails(name=get_test_name(), scm_revision_id=get_git_commit_id(), started_by=started_by,
+        details = TestDetails(name=test_name, scm_revision_id=get_git_commit_id(), started_by=started_by,
                               build_job_name=job_name, build_job_url=job_url,
                               yaml_test_duration=sct_config.get("test_duration"), start_time=int(time.time()),
                               config_files=config_files, packages=[])
+
         LOGGER.info("Preparing Resource Setup...")
         backend = sct_config.get("cluster_backend")
         raw_regions = sct_config.get("region_name") or sct_config.get("gce_datacenter") or "undefined_region"
@@ -251,7 +285,7 @@ class ArgusTestRun:
 
         run_info = TestRunInfo(details=details, setup=setup_details, resources=resources, logs=logs, results=results)
         LOGGER.info("Initializing TestRun...")
-        cls.TESTRUN_INSTANCE = TestRunWithHeartbeat(test_id=test_id, group=test_group, release_name=release_name,
+        cls.TESTRUN_INSTANCE = TestRunWithHeartbeat(test_id=test_id, group=group_name, release_name=release_name,
                                                     assignee="",
                                                     run_info=run_info,
                                                     config=cls.config())

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -372,12 +372,12 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     def argus_test_run(self):
         try:
             argus_test_run = ArgusTestRun.from_sct_config(test_id=UUID(self.test_id),
-                                                          test_module_path=self.test_config.test_name(),
                                                           sct_config=self.params)
             argus_test_run.save()
             return argus_test_run
-        except Exception:  # pylint: disable=broad-except
-            self.log.error("ERROR SETTING UP ARGUS CONNECTION", exc_info=True)
+        except Exception as exc:  # pylint: disable=broad-except
+            self.log.warning("Unable to set up Argus connection: %s", exc.args[0])
+            self.log.debug("Error details: ", exc_info=True)
             return unittest.mock.MagicMock()
 
     def argus_update_status(self, status: TestStatus):


### PR DESCRIPTION
This commit changes the way argus will track SCT runs. Previously, it
would use a list of whitelisted SCM branches and organize it this way:
branch, module name, test name (from JOB_NAME url). Now, it will refuse
to run locally (any time get_job_name returns "local_run"), but for any
build system run it will submit the runs into the database - by first
parsing the JOB_NAME environment provided by Jenkins into three
components. This function will also handle certain corner cases (like
releng-testing folder for example), and arbitrary nesting.

[Trello](https://trello.com/c/aDyI6n3Y/4257-add-group-and-test-name-to-all-test-yamls)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [x] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [x] All new and existing unit tests passed (CI)
- [x] ~I have updated the Readme/doc folder accordingly (if needed)~
