### PR TITLE
fix(rollingUpgradePipeline.groovy): base_versions to Jenkins

### DIFF
--- a/jenkins-pipelines/rolling-upgrade-debian10.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-debian10.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: '4.3','2021.1',
+    base_versions: '4.3,2021.1',
     linux_distro: 'debian-buster',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-10',
 

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -64,7 +64,7 @@ def call(Map pipelineParams) {
                 steps {
                     script {
                         def tasks = [:]
-                        def base_versions_list = params.base_versions.contains('.') ? params.base_versions.split('\\,') : []
+                        ArrayList base_versions_list = params.base_versions.contains('.') ? params.base_versions.split('\\,') : []
 
                         for (version in supportedUpgradeFromVersions(base_versions_list, params.new_scylla_repo)) {
                             def base_version = version


### PR DESCRIPTION
previous commit had a typo in one of the jobs, that created
a list of 2 strings, instead of a single string.
this PR is only a fix for that typo.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
