### PR TITLE
fix(cluster.py): fix is_apt_lock_free method

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1784,7 +1784,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         self.remoter.sudo(f'{pkg_cmd} install -y {package_name}')
 
     def is_apt_lock_free(self) -> bool:
-        return self.remoter.sudo("lsof /var/lib/dpkg/lock", ignore_status=True).ok
+        result = self.remoter.sudo("lsof /var/lib/dpkg/lock", ignore_status=True)
+        return result.exit_status == 1
 
     def install_manager_agent(self, package_path: Optional[str] = None) -> None:
         package_name = "scylla-manager-agent"


### PR DESCRIPTION
'lsof /var/lib/dpkg/lock' command return code is 1 when no process is
reffering to tested file (in our case no apt is running). Current logic is
inverted. That's why we can see in most of our runs log message:
'Wait for: Checking if package manager is free: timeout - 60 seconds -
expired'

Fix ensures rc==1 - it happens when apt lock is free

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
