### PR TITLE
fix(upgrade centos8): remove support to upgrade from 4.3

### DIFF
--- a/jenkins-pipelines/rolling-upgrade-centos8.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-centos8.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 rollingUpgradePipeline(
     backend: 'gce',
-    base_versions: '4.3,2021.1',
+    base_versions: '2021.1',
     linux_distro: 'centos',
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-stream-8',
 


### PR DESCRIPTION
following this comment https://github.com/scylladb/scylla/issues/10110#issuecomment-1046825309
we are removing the support in this job to start the
upgrade test from 4.3.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
