### PR TITLE
fix(WarningEvent): make warning event regex work as expected

### DIFF
--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -75,7 +75,7 @@ class ReactorStalledMixin(Generic[T_log_event]):
 
 
 DatabaseLogEvent.add_subevent_type("WARNING", severity=Severity.WARNING,
-                                   regex="!WARNING ")
+                                   regex=r"!\s*?WARNING ")
 DatabaseLogEvent.add_subevent_type("NO_SPACE_ERROR", severity=Severity.ERROR,
                                    regex="No space left on device")
 DatabaseLogEvent.add_subevent_type("UNKNOWN_VERB", severity=Severity.WARNING,


### PR DESCRIPTION
seem like fac5ac21a6944fb4639777cfe9fef672434dcbbf wasn't enough
of a fix, and log line level have changed a bit since then.
changing the regex of the event to catch both cases

Fixes: #4478

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
