### PR TITLE
test(operator): run multiple mgmt versions in backup and repair tests

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -285,7 +285,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         self._init_port_mapping()
 
         self.set_keep_alive()
-        if self.node_type == "db":
+        if self.node_type == "db" and not self.is_kubernetes():
             try:
                 self.remoter.sudo(shell_script_cmd("""\
                 echo 'kernel.perf_event_paranoid = 0' >> /etc/sysctl.conf

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1303,7 +1303,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
     def dynamic_client(self) -> k8s.dynamic.DynamicClient:
         return KubernetesOps.dynamic_client(self.api_client)
 
-    @cached_property
+    @property
     def scylla_manager_cluster(self) -> 'ManagerPodCluser':
         return ManagerPodCluser(
             k8s_cluster=self,

--- a/sdcm/utils/k8s.py
+++ b/sdcm/utils/k8s.py
@@ -41,7 +41,7 @@ from sdcm.wait import wait_for
 
 
 KUBECTL_BIN = "kubectl"
-HELM_IMAGE = "alpine/helm:3.3.4"
+HELM_IMAGE = "alpine/helm:3.8.0"
 
 KUBECTL_TIMEOUT = 300  # seconds
 


### PR DESCRIPTION
Cover more than 1 supported Scylla manager versions in the operator functional tests.
It will allow to uncover possible compatibility bugs if it appears.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
