### PR TITLE
fix(sct.py): list-resources for docker failed for no `SSH_AGENT_PID`

### DIFF
--- a/sdcm/utils/ssh_agent.py
+++ b/sdcm/utils/ssh_agent.py
@@ -28,7 +28,7 @@ class SSHAgent:
     def start(cls, verbose: bool = True) -> None:
         if cls.is_running():
             LOGGER.warning("ssh-agent started already:\n\t\tSSH_AUTH_SOCK=%s\n\t\tSSH_AGENT_PID=%s",
-                           os.environ["SSH_AUTH_SOCK"], os.environ["SSH_AGENT_PID"])
+                           os.getenv("SSH_AUTH_SOCK", "N/A"), os.getenv("SSH_AGENT_PID", "N/A"))
             return
 
         res = LOCALRUNNER.run(r"""eval $(ssh-agent -s) && """


### PR DESCRIPTION
Running sct.py list/clean-resources from commandline (not inside hydra),
yielded the following error, only for a warning print.
```
  File "/home/fruch/Projects/scylla-cluster-tests/sdcm/utils/common.py"
    SSHAgent.start(verbose=verbose)
  File "/home/fruch/Projects/scylla-cluster-tests/sdcm/utils/ssh_agent.py"
    os.environ["SSH_AUTH_SOCK"], os.environ["SSH_AGENT_PID"])
  File "/home/fruch/.pyenv/versions/3.10.0/lib/python3.10/os.py"
    raise KeyError(key) from None
KeyError: 'SSH_AGENT_PID'
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
