### PR TITLE
fix(disrupt_delete_by_rows_range): Fix choose_partitions_for_delete

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -58,7 +58,7 @@ from sdcm.utils.ldap import SASLAUTHD_AUTHENTICATOR
 from sdcm.utils.common import (get_db_tables, generate_random_string,
                                update_certificates, reach_enospc_on_node, clean_enospc_on_node,
                                parse_nodetool_listsnapshots,
-                               update_authenticator, ParallelObject, get_table_clustering_order)
+                               update_authenticator, ParallelObject)
 from sdcm.utils import cdc
 from sdcm.utils.decorators import retrying, latency_calculator_decorator
 from sdcm.utils.decorators import timeout as timeout_decor
@@ -1693,12 +1693,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 if exclude_partitions and partition_key in exclude_partitions:
                     continue
 
-                # Get the max cl value in the partition according to the table's clustering order.
-                table_clustering_order = get_table_clustering_order(ks_cf=ks_cf, ck_name='ck', session=session)
-                # Build the query 'from the right side' so it finds the highest cl value using 'limit 1'.
-                # So it has to check the table's clustering order and set a reversed order if needed.
-                reversed_order = 'desc' if table_clustering_order.lower() == 'asc' else 'asc'
-                cmd = f"select ck from {ks_cf} where pk={partition_key} order by ck {reversed_order} limit 1"
+                # Get the max cl value in the partition.
+                cmd = f"select ck from {ks_cf} where pk={partition_key} order by ck desc limit 1"
                 try:
                     result = session.execute(cmd, timeout=300)
                 except Exception as exc:  # pylint: disable=broad-except


### PR DESCRIPTION
	Have to always choose a DESC order to get high clustering-key value

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/4320
Trello: https://trello.com/c/I3UcJeNO
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
