### PR TITLE
fix(file_logger): limit CRITICAL events to first N instead of last

### DIFF
--- a/sdcm/sct_events/file_logger.py
+++ b/sdcm/sct_events/file_logger.py
@@ -20,7 +20,7 @@ from typing import Tuple, Optional, Callable, Any, Dict, List, cast
 from pathlib import Path
 from functools import partial
 from itertools import chain
-from collections import deque
+from collections import deque as tail
 
 from sdcm.sct_events import Severity
 from sdcm.sct_events.base import SctEvent
@@ -42,6 +42,18 @@ DEBUG_LOG: str = "debug.log"
 LINE_START_RE = re.compile(r"^\d{4}-\d{2}-\d{2} ")  # date in YYYY-MM-DD format
 
 LOGGER = logging.getLogger(__name__)
+
+
+class head(list):  # pylint: disable=invalid-name
+    def __init__(self, maxlen: Optional[int] = None):
+        super().__init__()
+        if maxlen is None:
+            self.append = super().append
+        self.maxlen = maxlen
+
+    def append(self, item: Any) -> None:
+        if len(self) < self.maxlen:
+            super().append(item)
 
 
 class EventsFileLogger(BaseEventsProcess[Tuple[str, Any], None], multiprocessing.Process):
@@ -108,7 +120,8 @@ class EventsFileLogger(BaseEventsProcess[Tuple[str, Any], None], multiprocessing
     def get_events_by_category(self, limit: Optional[int] = None) -> Dict[str, List[str]]:
         output = {}
         for severity, log_file in self.events_logs_by_severity.items():
-            events_bucket = deque(maxlen=limit)
+            # Get first `limit' events with CRITICAL severity and last `limit' for other severities.
+            events_bucket = (head if severity is Severity.CRITICAL else tail)(maxlen=limit)
             event = []
             try:
                 with log_file.open() as fobj:

--- a/unit_tests/test_sct_events_file_logger.py
+++ b/unit_tests/test_sct_events_file_logger.py
@@ -24,60 +24,83 @@ from unit_tests.lib.events_utils import EventsUtilsMixin
 
 
 class TestFileLogger(unittest.TestCase, EventsUtilsMixin):
-    @classmethod
-    def setUpClass(cls) -> None:
-        cls.setup_events_processes(events_device=False, events_main_device=True, registry_patcher=False)
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        cls.teardown_events_processes()
-
     # pylint: disable=protected-access
-    def test_file_logger(self):
+    def setUp(self) -> None:
+        self.setup_events_processes(events_device=False, events_main_device=True, registry_patcher=False)
         start_events_logger(_registry=self.events_processes_registry)
-        file_logger = get_events_logger(_registry=self.events_processes_registry)
+        self.file_logger = get_events_logger(_registry=self.events_processes_registry)
 
         time.sleep(EVENTS_SUBSCRIBERS_START_DELAY)
 
-        try:
-            self.assertIsInstance(file_logger, EventsFileLogger)
-            self.assertTrue(file_logger.is_alive())
-            self.assertEqual(file_logger._registry, self.events_main_device._registry)
-            self.assertEqual(file_logger._registry, self.events_processes_registry)
+        self.assertIsInstance(self.file_logger, EventsFileLogger)
+        self.assertTrue(self.file_logger.is_alive())
+        self.assertEqual(self.file_logger._registry, self.events_main_device._registry)
+        self.assertEqual(self.file_logger._registry, self.events_processes_registry)
 
-            event_normal = SpotTerminationEvent(node="n1", message="m1")
-            event_normal.severity = Severity.NORMAL
-            event_warning = SpotTerminationEvent(node="n2", message="m2")
-            event_warning.severity = Severity.WARNING
-            event_error = SpotTerminationEvent(node="n3", message="m3")
-            event_error.severity = Severity.ERROR
-            event_critical = SpotTerminationEvent(node="n4", message="m4")
-            event_critical.severity = Severity.CRITICAL
+    def tearDown(self) -> None:
+        self.file_logger.stop(timeout=1)
+        self.teardown_events_processes()
 
-            with self.wait_for_n_events(file_logger, count=10, timeout=3):
-                self.events_main_device.publish_event(event_normal)
-                self.events_main_device.publish_event(event_warning)
-                self.events_main_device.publish_event(event_warning)
-                self.events_main_device.publish_event(event_error)
-                self.events_main_device.publish_event(event_error)
-                self.events_main_device.publish_event(event_error)
-                self.events_main_device.publish_event(event_critical)
-                self.events_main_device.publish_event(event_critical)
-                self.events_main_device.publish_event(event_critical)
-                self.events_main_device.publish_event(event_critical)
+    def test_file_logger(self) -> None:
+        event_normal = SpotTerminationEvent(node="n1", message="m1")
+        event_normal.severity = Severity.NORMAL
+        event_warning = SpotTerminationEvent(node="n2", message="m2")
+        event_warning.severity = Severity.WARNING
+        event_error = SpotTerminationEvent(node="n3", message="m3")
+        event_error.severity = Severity.ERROR
+        event_critical = SpotTerminationEvent(node="n4", message="m4")
+        event_critical.severity = Severity.CRITICAL
+        event_debug = SpotTerminationEvent(node="n5", message="m5")
+        event_debug.severity = Severity.DEBUG
 
-            self.assertEqual(self.events_main_device.events_counter, file_logger.events_counter)
+        with self.wait_for_n_events(self.file_logger, count=15, timeout=3):
+            self.events_main_device.publish_event(event_normal)
+            self.events_main_device.publish_event(event_warning)
+            self.events_main_device.publish_event(event_warning)
+            self.events_main_device.publish_event(event_error)
+            self.events_main_device.publish_event(event_error)
+            self.events_main_device.publish_event(event_error)
+            self.events_main_device.publish_event(event_critical)
+            self.events_main_device.publish_event(event_critical)
+            self.events_main_device.publish_event(event_critical)
+            self.events_main_device.publish_event(event_critical)
+            self.events_main_device.publish_event(event_debug)
+            self.events_main_device.publish_event(event_debug)
+            self.events_main_device.publish_event(event_debug)
+            self.events_main_device.publish_event(event_debug)
+            self.events_main_device.publish_event(event_debug)
 
-            summary = get_logger_event_summary(_registry=self.events_processes_registry)
-            self.assertDictEqual(summary, {Severity.NORMAL.name: 1,
-                                           Severity.WARNING.name: 2,
-                                           Severity.ERROR.name: 3,
-                                           Severity.CRITICAL.name: 4, })
+        self.assertEqual(self.events_main_device.events_counter, self.file_logger.events_counter)
 
-            grouped = get_events_grouped_by_category(_registry=self.events_processes_registry)
-            self.assertEqual(len(grouped[Severity.NORMAL.name]), 1)
-            self.assertEqual(len(grouped[Severity.WARNING.name]), 2)
-            self.assertEqual(len(grouped[Severity.ERROR.name]), 3)
-            self.assertEqual(len(grouped[Severity.CRITICAL.name]), 4)
-        finally:
-            file_logger.stop(timeout=1)
+        summary = get_logger_event_summary(_registry=self.events_processes_registry)
+        self.assertDictEqual(summary, {Severity.NORMAL.name: 1,
+                                       Severity.WARNING.name: 2,
+                                       Severity.ERROR.name: 3,
+                                       Severity.CRITICAL.name: 4,
+                                       Severity.DEBUG.name: 5, })
+
+        grouped = get_events_grouped_by_category(_registry=self.events_processes_registry)
+        self.assertEqual(len(grouped[Severity.NORMAL.name]), 1)
+        self.assertEqual(len(grouped[Severity.WARNING.name]), 2)
+        self.assertEqual(len(grouped[Severity.ERROR.name]), 3)
+        self.assertEqual(len(grouped[Severity.CRITICAL.name]), 4)
+        self.assertEqual(len(grouped[Severity.DEBUG.name]), 5)
+
+    def test_get_events_grouped_by_category_limit(self) -> None:
+        with self.wait_for_n_events(self.file_logger, count=len(Severity) * 10, timeout=3):
+            for severity in Severity:
+                for num in range(10):
+                    event = SpotTerminationEvent(node="node", message=f"m-{num}-{severity.name}")
+                    event.severity = severity
+                    self.events_main_device.publish_event(event)
+
+        self.assertEqual(self.events_main_device.events_counter, self.file_logger.events_counter)
+
+        summary = get_logger_event_summary(_registry=self.events_processes_registry)
+        self.assertEqual(set(summary.values()), {10})
+
+        grouped = get_events_grouped_by_category(_registry=self.events_processes_registry, limit=5)
+        for severity, group in grouped.items():
+            self.assertEqual(len(group), 5)
+            for num, event in enumerate(group, start=0 if severity == Severity.CRITICAL.name else 5):
+                self.assertIn(f"m-{num}-{severity}", event)


### PR DESCRIPTION
Trello: https://trello.com/c/Xl7JvNlP/4670-too-many-critical-events

In usual case it should be no more than 1 event with CRITICAL severity, but in case such events raise during teardown they push out the initial one from the report. Limiting them to the first 100 instead of last 100 like for other severities will solve this problem.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
