### PR TITLE
Warning events backport

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -12,6 +12,7 @@ DataValidatorEvent.DeletedRowsValidator: ERROR
 ScyllaHelpErrorEvent.duplicate: ERROR
 ScyllaHelpErrorEvent.filtered: ERROR
 FullScanEvent: ERROR
+DatabaseLogEvent.WARNING: WARNING
 DatabaseLogEvent.NO_SPACE_ERROR: ERROR
 DatabaseLogEvent.UNKNOWN_VERB: WARNING
 DatabaseLogEvent.CLIENT_DISCONNECT: WARNING

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -72,7 +72,7 @@ class ReactorStalledMixin(Generic[T_log_event]):
 
 
 DatabaseLogEvent.add_subevent_type("WARNING", severity=Severity.WARNING,
-                                   regex="!WARNING ")
+                                   regex=r"!\s*?WARNING ")
 DatabaseLogEvent.add_subevent_type("NO_SPACE_ERROR", severity=Severity.ERROR,
                                    regex="No space left on device")
 DatabaseLogEvent.add_subevent_type("UNKNOWN_VERB", severity=Severity.WARNING,

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -28,6 +28,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 class DatabaseLogEvent(LogEvent, abstract=True):
+    WARNING: Type[LogEventProtocol]
     NO_SPACE_ERROR: Type[LogEventProtocol]
     UNKNOWN_VERB: Type[LogEventProtocol]
     CLIENT_DISCONNECT: Type[LogEventProtocol]
@@ -70,6 +71,8 @@ class ReactorStalledMixin(Generic[T_log_event]):
         return super().add_info(node=node, line=line, line_number=line_number)
 
 
+DatabaseLogEvent.add_subevent_type("WARNING", severity=Severity.WARNING,
+                                   regex="!WARNING ")
 DatabaseLogEvent.add_subevent_type("NO_SPACE_ERROR", severity=Severity.ERROR,
                                    regex="No space left on device")
 DatabaseLogEvent.add_subevent_type("UNKNOWN_VERB", severity=Severity.WARNING,
@@ -123,6 +126,7 @@ DatabaseLogEvent.add_subevent_type("stream_exception", severity=Severity.ERROR,
 
 
 SYSTEM_ERROR_EVENTS = (
+    DatabaseLogEvent.WARNING(),
     DatabaseLogEvent.NO_SPACE_ERROR(),
     DatabaseLogEvent.UNKNOWN_VERB(),
     DatabaseLogEvent.CLIENT_DISCONNECT(),


### PR DESCRIPTION
this PR is a back port of fac5ac21a6944fb4639777cfe9fef672434dcbbf and eb6e05ae007a97045e4d8abda948bb97aafdfd0f

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
