### PR TITLE
fix(5000_tables): use lastest AWS loaders AMIs

### DIFF
--- a/longevity_test.py
+++ b/longevity_test.py
@@ -508,6 +508,9 @@ class LongevityTest(ClusterTester):
             table_template = string.Template(profile_yaml['table_definition'])
 
             with self.db_cluster.cql_connection_patient(node=self.db_cluster.nodes[0]) as session:
+                # since we are using connection while nemesis is running (and we have more then 5000 tables in this
+                # use case), we need a bigger timeout here to keep the following CQL commands from failing
+                session.default_timeout = 60.0 * 5
                 try:
                     session.execute(keyspace_definition)
                 except AlreadyExists:

--- a/test-cases/longevity/longevity-5000-tables.yaml
+++ b/test-cases/longevity/longevity-5000-tables.yaml
@@ -24,19 +24,19 @@ user_prefix: 'longevity-5000-tables'
 #  - fix NoSuchElementException
 #  - enable control over both consistency levels: regular and serial
 #  - bring shard awareness
-regions_data:
-  us-east-1:
-    ami_id_loader: 'ami-0b94f0e897d884b1b'  # A copy of ami-lwt-v5 which is the last supported for this test (java 1.8)
-  eu-west-1:
-    ami_id_loader: 'ami-0bf19545bc7bc9e1f'  # A copy of ami-lwt-v5 which is the last supported for this test (java 1.8)
-  eu-west-2:
-    ami_id_loader: 'ami-043f248f98c105419'  # A copy of ami-lwt-v5 which is the last supported for this test (java 1.8)
-  eu-central-1:
-    ami_id_loader: 'ami-0114531e650c08b74'  # A copy of ami-lwt-v5 which is the last supported for this test (java 1.8)
-  eu-north-1:
-    ami_id_loader: 'ami-036150abbde18c61a'  # A copy of ami-lwt-v5 which is the last supported for this test (java 1.8)
-  us-west-2:
-    ami_id_loader: 'ami-063a97bde47353690'  # A copy of ami-lwt-v5 which is the last supported for this test (java 1.8)
+#regions_data:
+#  us-east-1:
+#    ami_id_loader: 'ami-0b94f0e897d884b1b'  # A copy of ami-lwt-v5 which is the last supported for this test (java 1.8)
+#  eu-west-1:
+#    ami_id_loader: 'ami-0bf19545bc7bc9e1f'  # A copy of ami-lwt-v5 which is the last supported for this test (java 1.8)
+#  eu-west-2:
+#    ami_id_loader: 'ami-043f248f98c105419'  # A copy of ami-lwt-v5 which is the last supported for this test (java 1.8)
+#  eu-central-1:
+#    ami_id_loader: 'ami-0114531e650c08b74'  # A copy of ami-lwt-v5 which is the last supported for this test (java 1.8)
+#  eu-north-1:
+#    ami_id_loader: 'ami-036150abbde18c61a'  # A copy of ami-lwt-v5 which is the last supported for this test (java 1.8)
+#  us-west-2:
+#    ami_id_loader: 'ami-063a97bde47353690'  # A copy of ami-lwt-v5 which is the last supported for this test (java 1.8)
 
 cluster_health_check: false
 


### PR DESCRIPTION
This case is using a very old versions of cassandra stress (loaders),
trying the newest versions

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
