### PR TITLE
fix(upgrade test): remove cdc stressor from test

### DIFF
--- a/test-cases/upgrades/rolling-upgrade.yaml
+++ b/test-cases/upgrades/rolling-upgrade.yaml
@@ -41,8 +41,6 @@ append_scylla_args: '--blocked-reactor-notify-ms 500 --abort-on-lsa-bad-alloc 1 
 
 use_mgmt: false
 
-stress_cdclog_reader_cmd: "cdc-stressor -username cassandra -password cassandra -duration 2h -stream-query-round-duration 30s"
-
 gemini_cmd: "gemini -d --duration 2h \
 -c 10 -m write -f --non-interactive --cql-features normal \
 --max-mutation-retries 5 --max-mutation-retries-backoff 500ms \

--- a/unit_tests/test_data/test_scylla_yaml_builders/rolling-upgrade.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/rolling-upgrade.yaml
@@ -41,8 +41,6 @@ append_scylla_args: '--blocked-reactor-notify-ms 500 --abort-on-lsa-bad-alloc 1 
 
 use_mgmt: false
 
-stress_cdclog_reader_cmd: "cdc-stressor -username cassandra -password cassandra -duration 2h -stream-query-round-duration 30s"
-
 gemini_cmd: "gemini -d --duration 2h \
 -c 10 -m write -f --non-interactive --cql-features normal \
 --max-mutation-retries 5 --max-mutation-retries-backoff 500ms \

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -556,16 +556,12 @@ class UpgradeTest(FillDatabaseData):
             metric_query='collectd_cassandra_stress_write_gauge{type="ops", keyspace="keyspace1"}', n=5)
 
         # start gemini write workload
-        # and cdc log reader
         if self.version_cdc_support():
-            InfoEvent(message="Start gemini and cdc stressor during upgrade").publish()
+            InfoEvent(message="Start gemini during upgrade").publish()
             gemini_thread = self.run_gemini(self.params.get("gemini_cmd"))
             # Let to write_stress_during_entire_test complete the schema changes
             self.metric_has_data(
                 metric_query='gemini_cql_requests', n=10)
-
-            cdc_reader_thread = self.run_cdclog_reader_thread(self.params.get("stress_cdclog_reader_cmd"),
-                                                              keyspace_name="ks1", base_table_name="table1")
 
         with ignore_upgrade_schema_errors():
 
@@ -746,10 +742,9 @@ class UpgradeTest(FillDatabaseData):
                                         'entire test, actual: %d' % (
                 error_factor, schema_load_error_num)
 
-        InfoEvent(message='Step10 - Verify that gemini and cdc stressor are not failed during upgrade').publish()
+        InfoEvent(message='Step10 - Verify that gemini did not failed during upgrade').publish()
         if self.version_cdc_support():
             self.verify_gemini_results(queue=gemini_thread)
-            self.verify_cdclog_reader_results(cdc_reader_thread)
 
         InfoEvent(message='all nodes were upgraded, and last workaround is verified.').publish()
 


### PR DESCRIPTION
back port of 8268fabbe94b9d566a1c081bec387fb7e932217d

seen that the performance was affected since it was
added to the upgrade tests (reported on issue
https://github.com/scylladb/scylla/issues/9744), there was
a decision to remove the CDC Stressor from this test,
as we seen that, tests started timing out when running it
and it can take several hours in addition to the current
test run.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
