### PR TITLE
fix(cloud_longevity): collect cloud manager logs for AWS cluster

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1136,26 +1136,30 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
                                                    instance=instance,
                                                    global_ip=instance['PublicIpAddress'],
                                                    tags={**self.tags, "NodeType": "monitor", }))
-        # Temporarily disabling cloud-manager logs collection
-        # due to: https://github.com/scylladb/scylla-cluster-tests/issues/3816
-        if self.params["use_cloud_manager"] and False:  # pylint: disable=condition-evals-to-constant
+        if self.params["use_cloud_manager"]:
             try:
-                from cluster_cloud import get_manager_instance_by_cluster_id  # pylint: disable=import-outside-toplevel
+                from cluster_cloud import get_aws_manager_instance_by_cluster_id  # pylint: disable=import-outside-toplevel
             except ImportError:
                 LOGGER.error("Couldn't collect Siren manager logs, cluster_cloud module isn't installed")
             else:
-                instance = get_manager_instance_by_cluster_id(cluster_id=self.params["cloud_cluster_id"],
-                                                              region_name=self.params["region_name"][0])
-                name = [tag["Value"]
-                        for tag in instance["Tags"] if tag["Key"] == "Name"]
-                self.siren_manager_set.append(CollectingNode(name=name[0],
-                                                             ssh_login_info={
-                                                                 "hostname": instance["PublicIpAddress"],
-                                                                 "user": "support",
-                                                                 "key_file": self.params["cloud_credentials_path"]},
-                                                             instance=instance,
-                                                             global_ip=instance["PublicIpAddress"],
-                                                             tags={**self.tags, "NodeType": "siren-manager", }))
+                cloud_manager_id = self.params["cloud_manager_id"] if "cloud_manager_id" in self.params else None
+                LOGGER.info("Found cloud manager with id: %s", cloud_manager_id)
+                if cloud_manager_id:
+                    instance = get_aws_manager_instance_by_cluster_id(cluster_id=self.params["cloud_cluster_id"],
+                                                                      region_name=self.params["region_name"][0],
+                                                                      cloud_manager_id=cloud_manager_id)
+                    LOGGER.info("AWS manager instance: %s", instance)
+                    name = [tag["Value"] for tag in instance["Tags"] if tag["Key"] == "Name"]
+
+                    ssh_login_info = {"hostname": instance["PublicIpAddress"],
+                                      "user": "support",
+                                      "key_file": self.params["cloud_credentials_path"]}
+                    LOGGER.info("AWS manager instance ssh_login_info: %s", ssh_login_info)
+                    self.siren_manager_set.append(CollectingNode(name=name[0],
+                                                                 ssh_login_info=ssh_login_info,
+                                                                 instance=instance,
+                                                                 global_ip=instance["PublicIpAddress"],
+                                                                 tags={**self.tags, "NodeType": "siren-manager", }))
         for instance in filtered_instances['loader_nodes']:
             name = [tag['Value']
                     for tag in instance['Tags'] if tag['Key'] == 'Name']

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -82,7 +82,7 @@ from sdcm.kcl_thread import KclStressThread, CompareTablesSizesThread
 from sdcm.localhost import LocalHost
 from sdcm.cdclog_reader_thread import CDCLogReaderThread
 from sdcm.logcollector import SCTLogCollector, ScyllaLogCollector, MonitorLogCollector, LoaderLogCollector, \
-    KubernetesLogCollector
+    KubernetesLogCollector, SirenManagerLogCollector
 from sdcm.send_email import build_reporter, read_email_data_from_file, get_running_instances_for_email_report, \
     save_email_data_to_file
 from sdcm.utils import alternator
@@ -598,6 +598,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         self.cs_db_cluster = None
         self.loaders = None
         self.monitors = None
+        self.siren_manager = None
         self.k8s_cluster = None
         self.connections = []
         make_threads_be_daemonic_by_default()
@@ -2734,7 +2735,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                      "loader_log": "",
                      "monitoring_log": "",
                      "prometheus_data": "",
-                     "monitoring_stack": ""}
+                     "monitoring_stack": "",
+                     "siren_manager": "",
+                     }
         storage_dir = os.path.join(self.logdir, "collected_logs")
         os.makedirs(storage_dir, exist_ok=True)
         self.log.info("Storage dir is %s", storage_dir)
@@ -2750,6 +2753,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                     {"name": "monitors",
                      "nodes": self.monitors and self.monitors.nodes,
                      "collector": MonitorLogCollector,
+                     "logname": "monitoring_log", },
+                    {"name": "siren_manager",
+                     "nodes": self.db_cluster and self.db_cluster.manager_instance,
+                     "collector": SirenManagerLogCollector,
                      "logname": "monitoring_log", },
                     {"name": "k8s_cluster",
                      "nodes": [],


### PR DESCRIPTION
Collect and upload siren manager logs  for AWS cluster

Related Siren PR:
https://github.com/scylladb/siren-tests/pull/941

AWS passed test:
https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/siren-tests/job/scylla-cloud-longevity-small-data-set-1h/208/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
