### PR TITLE
fix(artifact timesync check): skip the test for docker runs

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -239,27 +239,30 @@ class ArtifactsTest(ClusterTester):
         with self.subTest("check Scylla server after installation"):
             self.check_scylla()
 
-        with self.subTest("check if scylla unnecessarily installed a time synchronization service"):
-            # Checks https://github.com/scylladb/scylla/issues/8339
-            # If the instance already has systemd-timesyncd
-            is_timesyncd_service_installed = self.check_service_existence(service_name="systemd-timesyncd")
-            # Do note: On Redhat based distributions the services are named ntpd and chronyd, while on debian based
-            # distributions they're named ntp and chrony.
-            if self.node.is_rhel_like():
-                is_ntp_service_installed = self.check_service_existence(service_name="ntpd")
-                is_chrony_service_installed = self.check_service_existence(service_name="chronyd")
-            else:
-                is_ntp_service_installed = self.check_service_existence(service_name="ntp")
-                is_chrony_service_installed = self.check_service_existence(service_name="chrony")
-            if is_timesyncd_service_installed:
-                assert not is_ntp_service_installed, \
-                    "systemd-timesyncd is already installed, yet scylla installed ntp service on top of it"
-                assert not is_chrony_service_installed, \
-                    "systemd-timesyncd is already installed, yet scylla installed chrony service on top of it"
-            else:
-                assert is_ntp_service_installed or is_chrony_service_installed, \
-                    "systemd-timesyncd is not installed on the instance, yet Scylla did not install ntp or chrony " \
-                    "services as a replacement"
+        # We don't install any time sync service in docker, so the test is unnecessary:
+        # https://github.com/scylladb/scylla/tree/master/dist/docker/etc/supervisord.conf.d
+        if backend != "docker":
+            with self.subTest("check if scylla unnecessarily installed a time synchronization service"):
+                # Checks https://github.com/scylladb/scylla/issues/8339
+                # If the instance already has systemd-timesyncd
+                is_timesyncd_service_installed = self.check_service_existence(service_name="systemd-timesyncd")
+                # Do note: On Redhat based distributions the services are named ntpd and chronyd, while on debian based
+                # distributions they're named ntp and chrony.
+                if self.node.is_rhel_like():
+                    is_ntp_service_installed = self.check_service_existence(service_name="ntpd")
+                    is_chrony_service_installed = self.check_service_existence(service_name="chronyd")
+                else:
+                    is_ntp_service_installed = self.check_service_existence(service_name="ntp")
+                    is_chrony_service_installed = self.check_service_existence(service_name="chrony")
+                if is_timesyncd_service_installed:
+                    assert not is_ntp_service_installed, \
+                        "systemd-timesyncd is already installed, yet scylla installed ntp service on top of it"
+                    assert not is_chrony_service_installed, \
+                        "systemd-timesyncd is already installed, yet scylla installed chrony service on top of it"
+                else:
+                    assert is_ntp_service_installed or is_chrony_service_installed, \
+                        "systemd-timesyncd is not installed on the instance, yet Scylla did not install ntp or " \
+                        "chrony services as a replacement"
 
             # TODO: implement after the new provision will be added
             # Task: https://trello.com/c/BIdIUwyT/4096-housekeeping-implemented-a-test-that-checks-i-value-when-scylla-


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
