### PR TITLE
fix(filter_rc_only_version): last 2 base version don't have release

### DIFF
--- a/unit_tests/test_base_version.py
+++ b/unit_tests/test_base_version.py
@@ -33,7 +33,7 @@ class TestBaseVersion(unittest.TestCase):
         scylla_repo = self.url_base + 'unstable/scylla/master/rpm/centos/2021-08-29T00:58:58Z/scylla.repo'
         linux_distro = 'centos'
         version_list = general_test(scylla_repo, linux_distro)
-        self.assertEqual(version_list, ['4.6'])
+        self.assertEqual(version_list, ['4.5'])
 
     def test_4_5_with_centos8(self):
         scylla_repo = self.url_base + 'unstable/scylla/branch-4.5/rpm/centos/2021-08-29T00:58:58Z/scylla.repo'

--- a/utils/get_supported_scylla_base_versions.py
+++ b/utils/get_supported_scylla_base_versions.py
@@ -123,11 +123,15 @@ class UpgradeBaseVersion:  # pylint: disable=too-many-instance-attributes
     def filter_rc_only_version(self, base_version_list, release_list):
         if base_version_list:
             # if there's only release candidates in this repo, skip this version
-            filter_rc = {v for v in get_all_versions(self.repo_maps[base_version_list[-1]]) if 'rc' not in v}
+            current_version = base_version_list[-1]
+            filter_rc = {v for v in get_all_versions(self.repo_maps[current_version]) if 'rc' not in v}
             if not filter_rc:
                 base_version_list = base_version_list[:-1]
                 if not base_version_list:
-                    base_version_list.append(release_list[-2])
+                    release_list.remove(current_version)
+                    base_version_list.append(release_list[-1])
+                    # check the next version in line
+                    base_version_list = self.filter_rc_only_version(base_version_list, release_list)
         return base_version_list
 
     def get_version_list(self):


### PR DESCRIPTION
we noticed a case the two last base versions (i.e. 4.6, 5.0) don't
have a release yet, the logic for handling master/enterprise branches
was to pick only one base version, and the check was only the last
one, so it filter 5.0 but didn't check if 4.6 is suitable and return
it stright. leading to upgrade base being 4.6.rc5

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
