### PR TITLE
fix(getJobTimeouts): +20min to collect logs timeout

### DIFF
--- a/vars/getJobTimeouts.groovy
+++ b/vars/getJobTimeouts.groovy
@@ -15,7 +15,7 @@ List<Integer> call(Map params, String region){
     testDuration = testData[0][1].toInteger()
     Integer testStartupTimeout = 20
     Integer testTeardownTimeout = 40
-    Integer collectLogsTimeout = 70
+    Integer collectLogsTimeout = 90
     Integer resourceCleanupTimeout = 30
     Integer sendEmailTimeout = 5
     Integer testRunTimeout = testStartupTimeout + testDuration + testTeardownTimeout


### PR DESCRIPTION
Some of recent jobs failed to collect logs in 70min, and succeeded stages took amount of time pretty close to the limit.  Add  another 20min to try to avoid such aborts.

Example of jobs: 
* https://jenkins.scylladb.com/job/scylla-master/job/longevity/job/longevity-200gb-48h/
* https://jenkins.scylladb.com/job/scylla-master/job/longevity/job/longevity-50gb-3days/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
