### PR TITLE
fix(filter_rc_only_version): don't filter on master branch

### DIFF
--- a/unit_tests/test_base_version.py
+++ b/unit_tests/test_base_version.py
@@ -33,7 +33,7 @@ class TestBaseVersion(unittest.TestCase):
         scylla_repo = self.url_base + 'unstable/scylla/master/rpm/centos/2021-08-29T00:58:58Z/scylla.repo'
         linux_distro = 'centos'
         version_list = general_test(scylla_repo, linux_distro)
-        self.assertEqual(version_list, ['4.5'])
+        self.assertEqual(version_list, ['4.6'])
 
     def test_4_5_with_centos8(self):
         scylla_repo = self.url_base + 'unstable/scylla/branch-4.5/rpm/centos/2021-08-29T00:58:58Z/scylla.repo'

--- a/unit_tests/test_base_version.py
+++ b/unit_tests/test_base_version.py
@@ -33,7 +33,7 @@ class TestBaseVersion(unittest.TestCase):
         scylla_repo = self.url_base + 'unstable/scylla/master/rpm/centos/2021-08-29T00:58:58Z/scylla.repo'
         linux_distro = 'centos'
         version_list = general_test(scylla_repo, linux_distro)
-        self.assertEqual(version_list, ['4.6'])
+        self.assertEqual(version_list, ['5.0'])
 
     def test_4_5_with_centos8(self):
         scylla_repo = self.url_base + 'unstable/scylla/branch-4.5/rpm/centos/2021-08-29T00:58:58Z/scylla.repo'

--- a/utils/get_supported_scylla_base_versions.py
+++ b/utils/get_supported_scylla_base_versions.py
@@ -123,15 +123,11 @@ class UpgradeBaseVersion:  # pylint: disable=too-many-instance-attributes
     def filter_rc_only_version(self, base_version_list, release_list):
         if base_version_list:
             # if there's only release candidates in this repo, skip this version
-            current_version = base_version_list[-1]
-            filter_rc = {v for v in get_all_versions(self.repo_maps[current_version]) if 'rc' not in v}
+            filter_rc = {v for v in get_all_versions(self.repo_maps[base_version_list[-1]]) if 'rc' not in v}
             if not filter_rc:
                 base_version_list = base_version_list[:-1]
                 if not base_version_list:
-                    release_list.remove(current_version)
-                    base_version_list.append(release_list[-1])
-                    # check the next version in line
-                    base_version_list = self.filter_rc_only_version(base_version_list, release_list)
+                    base_version_list.append(release_list[-2])
         return base_version_list
 
     def get_version_list(self):

--- a/utils/get_supported_scylla_base_versions.py
+++ b/utils/get_supported_scylla_base_versions.py
@@ -88,7 +88,7 @@ class UpgradeBaseVersion:  # pylint: disable=too-many-instance-attributes
                     # Choose the last two releases as upgrade base
                     ent_base_version += ent_release_list[idx-1:][:2]
             elif version == 'enterprise' or parse_version(version) > parse_version(ent_release_list[0]):
-                oss_base_version.append(ent_release_list[-1])
+                ent_base_version.append(ent_release_list[-1])
             elif re.match(r'\d+.\d+', version) and parse_version(version) >= parse_version(ent_release_list[0]):
                 oss_base_version.append(oss_release_list[-1])
                 ent_base_version += ent_release_list[-2:]
@@ -115,19 +115,17 @@ class UpgradeBaseVersion:  # pylint: disable=too-many-instance-attributes
         ent_base_version = [v for v in ent_base_version if v in supported_versions]
 
         # if there's only release candidates in those repos, skip this version
-        oss_base_version = self.filter_rc_only_version(oss_base_version, oss_release_list)
-        ent_base_version = self.filter_rc_only_version(ent_base_version, ent_release_list)
+        oss_base_version = self.filter_rc_only_version(oss_base_version)
+        ent_base_version = self.filter_rc_only_version(ent_base_version)
 
         return oss_base_version + ent_base_version
 
-    def filter_rc_only_version(self, base_version_list, release_list):
-        if base_version_list:
+    def filter_rc_only_version(self, base_version_list):
+        if base_version_list and len(base_version_list) > 1:
             # if there's only release candidates in this repo, skip this version
             filter_rc = {v for v in get_all_versions(self.repo_maps[base_version_list[-1]]) if 'rc' not in v}
             if not filter_rc:
                 base_version_list = base_version_list[:-1]
-                if not base_version_list:
-                    base_version_list.append(release_list[-2])
         return base_version_list
 
     def get_version_list(self):


### PR DESCRIPTION
stop filtering rc only base version when running on master
or enterprise branches

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
