### PR TITLE
fix(rsyslog_daemon): strip rsyslog listen_port

### DIFF
--- a/sdcm/rsyslog_daemon.py
+++ b/sdcm/rsyslog_daemon.py
@@ -112,7 +112,7 @@ def start_rsyslog(docker_name, log_dir, port="514"):
     res = local_runner.run('docker port {0} 514'.format(RSYSLOG_DOCKER_ID))
     listening_port = res.stdout.strip().split(':')[1]
 
-    return listening_port
+    return listening_port.strip()
 
 
 def stop_rsyslog():


### PR DESCRIPTION
docker port return
```
 0.0.0.0:49159
 :::49159
```

after code stripped and splitted by ':',
listen_port become: 49159\n

in this case the rsyslog.conf has wrong config line:
```
$IncludeConfig /etc/rsyslog.d/*.conf
action(type="omfwd" Target="172.30.0.119" Port="49159
" Protocol="tcp")
```

add additional strip()

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
