### PR TITLE
test(artifact): validate housekeeping service

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -109,3 +109,4 @@ InstanceStatusEvent.STARTUP: WARNING
 InstanceStatusEvent.REBOOT: WARNING
 InstanceStatusEvent.POWER_OFF: WARNING
 CompactionEvent: NORMAL
+ScyllaHousekeepingServiceEvent: ERROR

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2396,7 +2396,10 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             cmd = f'sudo service {service_name} {cmd}'
         else:
             cmd = f'{self.systemctl} {cmd} {service_name}.service'
-        self.remoter.run(cmd, timeout=timeout, ignore_status=ignore_status)
+        return self.remoter.run(cmd, timeout=timeout, ignore_status=ignore_status)
+
+    def get_service_status(self, service_name: str, timeout: int = 500, ignore_status=False):
+        return self._service_cmd(service_name=service_name, cmd='status', timeout=timeout, ignore_status=ignore_status)
 
     def start_service(self, service_name: str, timeout: int = 500, ignore_status=False):
         self._service_cmd(service_name=service_name, cmd='start', timeout=timeout, ignore_status=ignore_status)

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -102,6 +102,10 @@ class DockerNode(cluster.BaseNode, NodeContainerMixin):  # pylint: disable=abstr
     def restart(self):
         ContainerManager.get_container(self, "node").restart()
 
+    def get_service_status(self, service_name: str, timeout: int = 500, ignore_status=False):
+        return self.remoter.sudo('sh -c "{0} || {0}.service"'.format(f"supervisorctl status {service_name}"),
+                                 timeout=timeout, ignore_status=ignore_status)
+
     def start_scylla_server(self, verify_up=True, verify_down=False, timeout=300, verify_up_timeout=300):
         if verify_down:
             self.wait_db_down(timeout=timeout)

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -189,6 +189,17 @@ ScyllaHelpErrorEvent.add_subevent_type("duplicate")
 ScyllaHelpErrorEvent.add_subevent_type("filtered")
 
 
+class ScyllaHousekeepingServiceEvent(InformationalEvent):
+    def __init__(self, message: str, severity: Severity = Severity.NORMAL):
+        super().__init__(severity=severity)
+
+        self.message = message
+
+    @property
+    def msgfmt(self) -> str:
+        return super().msgfmt + ": message={0.message}"
+
+
 class IndexSpecialColumnErrorEvent(InformationalEvent):
     def __init__(self, message: str, severity: Severity = Severity.ERROR):
         super().__init__(severity=severity)


### PR DESCRIPTION
This commit introduce two changes:
1. Add HousekeepingServiceEvent
2. Check that housekeeping service is running and validate its status

Task: https://trello.com/c/EkPg2rht/4381-gether-scylla-houskeeping-log-and-check-for-errors-of-the-houskeeping-service

Tested with:
- ubuntu 20.04
- oel81
- docker
- amazon2
- gce-image
- debian10
- oel76
- ubuntu2004-arm

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
