### PR TITLE
fix(logcollector): not need cloud manager id for log collection on GCE

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1229,27 +1229,24 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
             except ImportError:
                 LOGGER.error("Couldn't collect Siren manager logs, cluster_cloud module isn't installed")
             else:
-                cloud_manager_id = self.params.get["cloud_manager_id"]
-                LOGGER.info("GCE manager instance id: %s", cloud_manager_id)
-                if cloud_manager_id:
-                    cloud_cluster_id = self.params["cloud_cluster_id"]
-                    try:
-                        instance = get_gce_manager_instance_by_cluster_id(cluster_id=cloud_cluster_id)
-                        if not instance:
-                            raise ValueError(f"Cloud manager for the cluster {cloud_cluster_id} not found")
-                    except Exception as exc:  # pylint: disable=broad-except
-                        LOGGER.error("Failed to get cloud manager instance. Error: %s", exc)
-                        return
+                cloud_cluster_id = self.params["cloud_cluster_id"]
+                try:
+                    instance = get_gce_manager_instance_by_cluster_id(cluster_id=cloud_cluster_id)
+                    if not instance:
+                        raise ValueError(f"Cloud manager for the cluster {cloud_cluster_id} not found")
+                except Exception as exc:  # pylint: disable=broad-except
+                    LOGGER.error("Failed to get cloud manager instance. Error: %s", exc)
+                    return
 
-                    LOGGER.info("GCE manager instance: %s", instance)
-                    ssh_login_info = {"hostname": instance["publicip"],
-                                      "user": "support",
-                                      "key_file": self.params["cloud_credentials_path"]}
-                    LOGGER.info("GCE manager instance ssh_login_info: %s", ssh_login_info)
-                    self.siren_manager_set.append(CollectingNode(name=instance["externalid"],
-                                                                 ssh_login_info=ssh_login_info,
-                                                                 instance=instance,
-                                                                 global_ip=instance["publicip"]))
+                LOGGER.info("GCE manager instance: %s", instance)
+                ssh_login_info = {"hostname": instance["publicip"],
+                                  "user": "support",
+                                  "key_file": self.params["cloud_credentials_path"]}
+                LOGGER.info("GCE manager instance ssh_login_info: %s", ssh_login_info)
+                self.siren_manager_set.append(CollectingNode(name=instance["externalid"],
+                                                             ssh_login_info=ssh_login_info,
+                                                             instance=instance,
+                                                             global_ip=instance["publicip"]))
 
     def get_docker_instances_by_testid(self):
         instances = list_instances_gce({"TestId": self.test_id}, running=True)


### PR DESCRIPTION
When cloud longevity test runs on GCE we do not need manager id for getting
manager instance. Remove redundant code

Test passed: https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/siren-tests/job/yulia-scylla-cloud-longevity-small-data-set-1h-gcp/55/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
