### PR TITLE
fix(manager sanity): removed unnecessary suspend command

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -1005,13 +1005,11 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
             raise ValueError(f"Not familiar with task type: {task_type}")
         assert suspendable_task.wait_for_status(list_status=[TaskStatus.RUNNING], timeout=300, step=5), \
             f"task {suspendable_task.id} failed to reach status {TaskStatus.RUNNING}"
-        with mgr_cluster.suspend_manager_then_resume(start_tasks=False):
-            mgr_cluster.suspend()
+        with mgr_cluster.suspend_manager_then_resume(start_tasks=True):
             assert suspendable_task.wait_for_status(list_status=[TaskStatus.STOPPED], timeout=300, step=10), \
                 f"task {suspendable_task.id} failed to reach status {TaskStatus.STOPPED}"
-            mgr_cluster.resume(start_tasks=True)
-            assert suspendable_task.wait_for_status(list_status=[TaskStatus.DONE], timeout=1200, step=10), \
-                f"task {suspendable_task.id} failed to reach status {TaskStatus.DONE}"
+        assert suspendable_task.wait_for_status(list_status=[TaskStatus.DONE], timeout=1200, step=10), \
+            f"task {suspendable_task.id} failed to reach status {TaskStatus.DONE}"
         self.log.info('finishing test_suspend_and_resume_{}'.format(task_type))
 
     def test_suspend_and_resume_without_starting_tasks(self):


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
