### PR TITLE
fix(enospc nemesis): ignore 'filesystem error'

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -116,6 +116,11 @@ def ignore_no_space_errors(node):
         ))
         stack.enter_context(DbEventsFilter(
             db_event=DatabaseLogEvent.FILESYSTEM_ERROR,
+            line="filesystem error",
+            node=node,
+        ))
+        stack.enter_context(DbEventsFilter(
+            db_event=DatabaseLogEvent.FILESYSTEM_ERROR,
             line="No space left on device",
             node=node,
         ))


### PR DESCRIPTION
Ignore 'filesystem error' during EnospcMonkey nemesis.

Error example (see `FAILED: scylla-master/longevity/longevity-200gb-48h#166: 2022-02-18 04:36:14`):
```
commitlog - Could not delete segment /var/lib/scylla/hints/8/10.0.1.21/HintsLog-2-144115188076546803.log: std::filesystem::__cxx11::filesystem_error (error system:2, filesystem error: stat failed: No such file or directory [/var/lib/scylla/hints/8/10.0.1.21/HintsLog-2-144115188076546803.log])
```

Received in longevity-200gb-48h (mater)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
