### PR TITLE
feature(eks-multi-tenant): New performance tests for multi-tenant

### DIFF
--- a/configurations/performance/perf-eks-multi-tenant.yaml
+++ b/configurations/performance/perf-eks-multi-tenant.yaml
@@ -1,0 +1,1 @@
+k8s_tenants_num: 2

--- a/defaults/k8s_eks_config.yaml
+++ b/defaults/k8s_eks_config.yaml
@@ -49,3 +49,5 @@ mgmt_docker_image: 'scylladb/scylla-manager:2.6.0'
 
 backup_bucket_backend: 's3'
 backup_bucket_location: 'minio-bucket'
+
+k8s_tenants_num: 1

--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -58,3 +58,5 @@ append_scylla_args: ''
 docker_image: ''
 backup_bucket_backend: 's3'
 backup_bucket_location: 'minio-bucket'
+
+k8s_tenants_num: 1

--- a/defaults/k8s_local_kind_config.yaml
+++ b/defaults/k8s_local_kind_config.yaml
@@ -31,3 +31,5 @@ backtrace_decoding: false
 append_scylla_args: ''
 docker_image: ''
 backup_bucket_location: 'minio-bucket'
+
+k8s_tenants_num: 1

--- a/functional_tests/scylla_operator/libs/helpers.py
+++ b/functional_tests/scylla_operator/libs/helpers.py
@@ -79,7 +79,7 @@ def get_pods_without_probe(db_cluster: ScyllaPodCluster,
 
 def scylla_pod_names(db_cluster: ScyllaPodCluster) -> list:
     pods = db_cluster.k8s_cluster.kubectl(
-        f"get pods -n {SCYLLA_NAMESPACE} --no-headers "
+        f"get pods -n {db_cluster.namespace} --no-headers "
         f"-l scylla/cluster={db_cluster.params.get('k8s_scylla_cluster_name')} "
         f"-o=custom-columns='NAME:.metadata.name'")
     return pods.stdout.split()
@@ -88,7 +88,7 @@ def scylla_pod_names(db_cluster: ScyllaPodCluster) -> list:
 def scylla_services_names(db_cluster: ScyllaPodCluster) -> list:
     scylla_cluster_name = db_cluster.params.get('k8s_scylla_cluster_name')
     services = db_cluster.k8s_cluster.kubectl(
-        f"get svc -n {SCYLLA_NAMESPACE} --no-headers "
+        f"get svc -n {db_cluster.namespace} --no-headers "
         f"-l scylla/cluster={scylla_cluster_name} "
         f"-o=custom-columns='NAME:.metadata.name'")
     return [name for name in services.stdout.split()

--- a/jenkins-pipelines/operator/performance/perf-regression-latency-eks-multi-tenant.jenkinsfile
+++ b/jenkins-pipelines/operator/performance/perf-regression-latency-eks-multi-tenant.jenkinsfile
@@ -1,0 +1,20 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "k8s-eks",
+    region: 'us-east-1',
+    test_name: "performance_regression_operator_multi_tenant_test.PerformanceRegressionMultiTenantTest",
+    test_config: '''["test-cases/performance/perf-regression-latency-500gb-30min.yaml", "configurations/performance/perf-eks-multi-tenant.yaml"]''',
+    sub_tests: ["test_latency"],
+    email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    k8s_enable_performance_tuning: true,
+    availability_zone: 'a,b',
+    k8s_deploy_monitoring: false,
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy',
+    post_behavior_k8s_cluster: 'destroy'
+)

--- a/performance_regression_operator_multi_tenant_test.py
+++ b/performance_regression_operator_multi_tenant_test.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2022 ScyllaDB
+
+import logging
+
+from performance_regression_test import PerformanceRegressionTest
+from sdcm.db_stats import TestStatsMixin
+from sdcm.cluster_k8s import eks, LOADER_CLUSTER_CONFIG, LoaderPodCluster
+
+
+class TenantStats(TestStatsMixin):
+
+    def __init__(self, db_cluster, loaders, monitors, params, _id):
+        self.db_cluster = db_cluster
+        self.loaders = loaders
+        self.monitors = monitors
+        self.params = params
+        self.log = logging.getLogger(self.__class__.__name__)
+        self.create_stats = True
+        self._id = _id
+        super().__init__()
+
+    def id(self):  # pylint: disable=invalid-name
+        return self._id
+
+
+class PerformanceRegressionMultiTenantTest(PerformanceRegressionTest):  # pylint: disable=too-many-public-methods
+
+    """
+    Test Scylla performance regression with cassandra-stress.
+    """
+
+    def __init__(self, *args):
+        self.tenants_stats: list[TenantStats] = []
+        super().__init__(*args)
+
+    def init_resources(self, *args, **kwargs):
+        super().init_resources(*args, **kwargs)
+        # add the first created Pods
+        self.tenants_stats += [TenantStats(self.db_cluster, self.loaders, self.monitors, self.params, _id=self.id())]
+
+        # create extra pods for dbs and loaders, on the same pools
+
+        scylla_pool = self.k8s_cluster.pools[self.k8s_cluster.SCYLLA_POOL_NAME]
+        loader_pool = self.k8s_cluster.pools[self.k8s_cluster.LOADER_POOL_NAME]
+
+        for i in range(1, self.params.get('k8s_tenants_num')):
+            db_cluster = eks.EksScyllaPodCluster(
+                k8s_cluster=self.k8s_cluster,
+                scylla_cluster_name=self.params.get("k8s_scylla_cluster_name"),
+                user_prefix=self.params.get("user_prefix"),
+                n_nodes=self.params.get("n_db_nodes"),
+                params=self.params,
+                node_pool=scylla_pool,
+                namespace=f'scylla-{i}',
+                skip_node_prepare=True,
+            )
+            loaders = LoaderPodCluster(k8s_cluster=self.k8s_cluster,
+                                       loader_cluster_config=LOADER_CLUSTER_CONFIG,
+                                       loader_cluster_name=self.params.get("k8s_loader_cluster_name"),
+                                       user_prefix=self.params.get("user_prefix"),
+                                       n_nodes=self.params.get("n_loaders"),
+                                       params=self.params,
+                                       node_pool=loader_pool,
+                                       namespace=f"sct-loader-{i}")
+
+            self.init_nodes(db_cluster=db_cluster)
+            loaders.wait_for_init()
+            self.tenants_stats += [TenantStats(db_cluster=db_cluster, loaders=loaders,
+                                               monitors=self.monitors, params=self.params,
+                                               _id=self.id())]
+
+    # Override the stress related method so we can run the stress commands on each tenant
+    # on it's own, (and not mix the stats between them, TODO: check if we don't need a separate monitor for each)
+
+    def create_test_stats(self, *args, **kwargs):
+        for tenant in self.tenants_stats:
+            tenant.create_test_stats(*args, **kwargs)
+
+    def check_regression(self, es_index=None, es_doc_type=None):
+        for tenant in self.tenants_stats:
+            super().check_regression(tenant._test_index, tenant._es_doc_type)  # pylint: disable=protected-access
+
+    def get_stress_results(self, queue, store_results=True):
+        for stress_queue, tenant in zip(queue, self.tenants_stats):
+            results = stress_queue.get_results()
+            tenant.update_stress_results(results)
+
+    def update_stress_results(self, *args, **kwargs):
+        pass
+
+    def display_results(self, results, test_name=''):
+        pass
+
+    def update_test_details(self, *args, **kwargs):
+        for tenant in self.tenants_stats:
+            tenant.update_test_details(*args, **kwargs)
+
+    def run_stress_thread(self, *args, **kwargs):
+        queues = []
+        for tenant in self.tenants_stats:
+            queues += super().run_stress_thread(*args, loader_set=tenant.loaders, node_list=tenant.db_cluster.nodes, **kwargs)
+
+        return queues

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -796,7 +796,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
             },
             'developerMode': False,
             'cpuset': True,
-            'hostNetworking': True,
+            'hostNetworking': not self.params.get('k8s_tenants_num') > 1,
             'automaticOrphanedNodeCleanup': True,
             # NOTE: '5578536' value is defined in the scylla repo here:
             #       dist/common/sysctl.d/99-scylla-aio.conf
@@ -999,7 +999,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
         # split cpu/memory available for each tenant
         cpu_limit = cpu_limit / self.params.get('k8s_tenants_num')
         memory_limit = memory_limit / self.params.get('k8s_tenants_num')
-        
+
         cpu_limit = convert_cpu_units_to_k8s_value(cpu_limit)
         memory_limit = convert_memory_units_to_k8s_value(memory_limit)
 

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2054,7 +2054,7 @@ class PodCluster(cluster.BaseCluster):
 
 
 class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disable=too-many-public-methods
-    NODE_PREPARE_FILE = None
+    node_prepare_file = None
     node_setup_requires_scylla_restart = False
     node_terminate_methods: List[str] = None
 
@@ -2068,7 +2068,7 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
                  namespace: str = SCYLLA_NAMESPACE) -> None:
         k8s_cluster.deploy_scylla_cluster(
             node_pool=node_pool,
-            node_prepare_config=self.NODE_PREPARE_FILE,
+            node_prepare_config=self.node_prepare_file,
             namespace=namespace
         )
         self.scylla_cluster_name = scylla_cluster_name

--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -90,6 +90,10 @@ class EksNodePool(CloudK8sNodePool):
         self.user_data = user_data
 
     @property
+    def tags(self):
+        return {**super().tags, **{'Name': self.name}}
+
+    @property
     def launch_template_name(self) -> str:
         return f'sct-{self.k8s_cluster.short_cluster_name}-{self.name}'
 

--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -33,6 +33,7 @@ from sdcm.cluster_k8s import (
     CloudK8sNodePool,
     KubernetesCluster,
     ScyllaPodCluster,
+    SCYLLA_NAMESPACE,
 )
 from sdcm.cluster_k8s.iptables import IptablesPodIpRedirectMixin, IptablesClusterOpsMixin
 from sdcm.remote import LOCALRUNNER
@@ -576,9 +577,10 @@ class EksScyllaPodCluster(ScyllaPodCluster, IptablesClusterOpsMixin):
                  n_nodes: Union[list, int] = 3,
                  params: Optional[dict] = None,
                  node_pool: EksNodePool = None,
+                 namespace: str = SCYLLA_NAMESPACE,
                  ) -> None:
         super().__init__(k8s_cluster=k8s_cluster, scylla_cluster_name=scylla_cluster_name, user_prefix=user_prefix,
-                         n_nodes=n_nodes, params=params, node_pool=node_pool)
+                         n_nodes=n_nodes, params=params, node_pool=node_pool, namespace=namespace)
     # pylint: disable=too-many-arguments
 
     def add_nodes(self,

--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -557,7 +557,7 @@ class EksScyllaPodContainer(BaseScyllaPodContainer, IptablesPodIpRedirectMixin):
 
 
 class EksScyllaPodCluster(ScyllaPodCluster, IptablesClusterOpsMixin):
-    NODE_PREPARE_FILE = sct_abs_path("sdcm/k8s_configs/eks/scylla-node-prepare.yaml")
+    node_prepare_file = sct_abs_path("sdcm/k8s_configs/eks/scylla-node-prepare.yaml")
     node_terminate_methods = [
         'drain_k8s_node',
         # NOTE: uncomment below when following scylla-operator bug is fixed:
@@ -578,7 +578,9 @@ class EksScyllaPodCluster(ScyllaPodCluster, IptablesClusterOpsMixin):
                  params: Optional[dict] = None,
                  node_pool: EksNodePool = None,
                  namespace: str = SCYLLA_NAMESPACE,
+                 skip_node_prepare: bool = False,
                  ) -> None:
+        self.node_prepare_file = None if skip_node_prepare else self.node_prepare_file
         super().__init__(k8s_cluster=k8s_cluster, scylla_cluster_name=scylla_cluster_name, user_prefix=user_prefix,
                          n_nodes=n_nodes, params=params, node_pool=node_pool, namespace=namespace)
     # pylint: disable=too-many-arguments

--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -422,7 +422,7 @@ class GkeScyllaPodContainer(BaseScyllaPodContainer, IptablesPodIpRedirectMixin):
 
 
 class GkeScyllaPodCluster(ScyllaPodCluster, IptablesClusterOpsMixin):
-    NODE_PREPARE_FILE = sct_abs_path("sdcm/k8s_configs/gke/scylla-node-prepare.yaml")
+    node_prepare_file = sct_abs_path("sdcm/k8s_configs/gke/scylla-node-prepare.yaml")
     node_terminate_methods = [
         'drain_k8s_node',
         # NOTE: uncomment below when following scylla-operator bug is fixed:

--- a/sdcm/k8s_configs/eks/scylla-node-prepare.yaml
+++ b/sdcm/k8s_configs/eks/scylla-node-prepare.yaml
@@ -194,6 +194,38 @@ spec:
           - name: hostirqbalanceconfig
             mountPath: /etc/conf.d/irqbalance
             mountPropagation: Bidirectional
+      - name: pv-setup
+        image: registry.access.redhat.com/ubi8/ubi:latest
+        imagePullPolicy: Always
+        command:
+          - "/bin/bash"
+          - "-euExo"
+          - "pipefail"
+          - "-c"
+          - |
+            while true; do
+              if [[ -z $(mount | grep  "/dev/md0") ]]; then
+                sleep 5;
+                continue
+              fi
+              for d in $(seq -f "pv-%05g" 1 $NUM_OF_TENANTS); do
+                if [[ ! -d "/host/mnt/raid-disks/disk0/${d}" ]]; then
+                  mkdir "/host/mnt/raid-disks/disk0/${d}"
+                fi
+                ( mount | grep "/host/mnt/raid-disks/disk0/${d} " 2>/dev/null 1>&2 ) || \
+                mount --bind "/host/mnt/raid-disks/disk0/${d}"{,}
+              done
+              sleep 30
+            done
+        env:
+          - name: NUM_OF_TENANTS
+            value: 1
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - name: hostfs
+            mountPath: /host
+            mountPropagation: Bidirectional
       volumes:
         - name: hostfs
           hostPath:

--- a/sdcm/k8s_configs/loaders.yaml
+++ b/sdcm/k8s_configs/loaders.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: sct-loaders
+  name: ${NAMESPACE}
 
 ---
 
@@ -9,7 +9,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: ${SCT_K8S_LOADER_CLUSTER_NAME}
-  namespace: sct-loaders
+  namespace: ${NAMESPACE}
 spec:
   selector:
     matchLabels:

--- a/sdcm/k8s_configs/provisioner/templates/provisioner.yaml
+++ b/sdcm/k8s_configs/provisioner/templates/provisioner.yaml
@@ -42,6 +42,9 @@ data:
        {{- if $classConfig.fsType }}
        fsType: {{ $classConfig.fsType }}
        {{- end }}
+       {{- if $classConfig.namePattern }}
+       namePattern: {{ $classConfig.namePattern | quote }}
+       {{- end }}
     {{- end }}
 ---
 apiVersion: apps/v1

--- a/sdcm/k8s_configs/provisioner/values.yaml
+++ b/sdcm/k8s_configs/provisioner/values.yaml
@@ -44,7 +44,7 @@ classes:
 - name: local-raid-disks # Defines name of storage classes.
   # Path on the host where local volumes of this storage class are mounted
   # under.
-  hostDir: /mnt/raid-disks
+  hostDir: /mnt/raid-disks/disk0/
   # Optionally specify mount path of local volumes. By default, we use same
   # path as hostDir in container.
   # mountDir: /mnt/fast-disks
@@ -56,6 +56,8 @@ classes:
   # and desire volume mode is Filesystem.
   # Must be a filesystem type supported by the host operating system.
   fsType: xfs
+  # File name pattern to discover. By default, discover all file names.
+  namePattern: "*"
   blockCleanerCommand:
   #  Do a quick reset of the block device during its cleanup.
   #  - "/scripts/quick_reset.sh"

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -800,6 +800,9 @@ class SCTConfiguration(dict):
         dict(name="k8s_minio_storage_size", env="SCT_K8S_MINIO_STORAGE_SIZE", type=str,
              help=""),
 
+        dict(name="k8s_tenants_num", env="SCT_K8S_TENANTS_NUM", type=int,
+             help=""),
+
         # docker config options
         dict(name="mgmt_docker_image", env="SCT_MGMT_DOCKER_IMAGE", type=str,
              help="Scylla manager docker image, i.e. 'scylladb/scylla-manager:2.2.1' "),

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -674,12 +674,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         if system_auth_rf > 1 and not self.test_config.REUSE_CLUSTER:
             self.log.info('change RF of system_auth to %s', system_auth_rf)
             node = self.db_cluster.nodes[0]
-            credentials = self.db_cluster.get_db_auth()
-            username, password = credentials if credentials else (None, None)
-            with self.db_cluster.cql_connection_patient(node, user=username, password=password) as session:
-                session.execute("ALTER KEYSPACE system_auth WITH replication = "
-                                "{'class': 'org.apache.cassandra.locator.SimpleStrategy', "
-                                "'replication_factor': %s};" % system_auth_rf)
+            node.run_cqlsh(cmd="ALTER KEYSPACE system_auth WITH replication = "
+                               "{'class': 'org.apache.cassandra.locator.SimpleStrategy', "
+                               f"'replication_factor': {system_auth_rf}}};")
             self.log.info('repair system_auth keyspace ...')
             node.run_nodetool(sub_cmd="repair", args="-- system_auth")
 

--- a/sdcm/utils/remote_logger.py
+++ b/sdcm/utils/remote_logger.py
@@ -259,10 +259,14 @@ class KubectlGeneralLogger(CommandNodeLoggerBase):
 class KubectlClusterEventsLogger(CommandClusterLoggerBase):
     restart_delay = 30
 
+    def __init__(self, *args, namespace=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.namespace = namespace
+
     @property
     def _logger_cmd(self) -> str:
         cmd = self._cluster.kubectl_cmd("get events -w",
-                                        namespace=self._cluster._scylla_namespace)  # pylint: disable=protected-access
+                                        namespace=self.namespace)
         return f"{cmd} >> {self._target_log_file} 2>&1"
 
 

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -969,7 +969,7 @@ class UpgradeTest(FillDatabaseData):
             f"{self.params.get('k8s_scylla_datacenter')}-{self.params.get('k8s_scylla_rack')}"
             " --watch=true --timeout=20m",
             timeout=1205,
-            namespace=self.k8s_cluster._scylla_namespace)  # pylint: disable=protected-access
+            namespace=self.db_cluster.namespace)
         self.k8s_cluster.check_scylla_cluster_sa_annotations()
 
         InfoEvent(message='Step7 - Add new member to the Scylla cluster').publish()
@@ -1040,7 +1040,7 @@ class UpgradeTest(FillDatabaseData):
         InfoEvent(message='Step7 - Check scylla pods after kubernetes platform upgrade').publish()
         self.k8s_cluster.kubectl_wait(
             "--all --for=condition=Ready pod",
-            namespace=self.k8s_cluster._scylla_namespace,  # pylint: disable=protected-access
+            namespace=self.db_cluster.namespace,
             timeout=600)
         self.k8s_cluster.check_scylla_cluster_sa_annotations()
 


### PR DESCRIPTION
Introducing new test that can setup multi-tenant, and run perf
tests on it.

Currently only supports EKS

Trello: https://trello.com/c/tqWnxLHw

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
