### PR TITLE
fix(backtrace_decoding): decoding wasn't done

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1472,24 +1472,29 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             if self.termination_event.is_set() and self.test_config.DECODING_QUEUE.empty():
                 break
 
-    def copy_scylla_debug_info(self, node, debug_file):
+    def copy_scylla_debug_info(self, node_name: str, debug_file: str):
         """Copy scylla debug file from db-node to monitor-node
 
         Copy via builder
-        :param node: db node
-        :type node: BaseNode
+        :param node_name: db node name
+        :type node_name: str
         :param scylla_debug_file: path to scylla_debug_file on db-node
         :type scylla_debug_file: str
         :returns: path on monitor node
         :rtype: {str}
         """
+
+        db_nodes = self.parent_cluster.targets['db_cluster'].nodes
+        db_node = next(iter([n for n in db_nodes if n.name == node_name]), None)
+        assert db_node, f"Node named: {node_name} wasn't found"
+
         base_scylla_debug_file = os.path.basename(debug_file)
-        transit_scylla_debug_file = os.path.join(node.parent_cluster.logdir,
+        transit_scylla_debug_file = os.path.join(db_node.parent_cluster.logdir,
                                                  base_scylla_debug_file)
         final_scylla_debug_file = os.path.join("/tmp", base_scylla_debug_file)
 
         if not os.path.exists(transit_scylla_debug_file):
-            node.remoter.receive_files(debug_file, transit_scylla_debug_file)
+            db_node.remoter.receive_files(debug_file, transit_scylla_debug_file)
         res = self.remoter.run(
             "test -f {}".format(final_scylla_debug_file), ignore_status=True, verbose=False)
         if res.exited != 0:

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -166,7 +166,7 @@ SYSTEM_ERROR_EVENTS = (
 )
 SYSTEM_ERROR_EVENTS_PATTERNS: List[Tuple[re.Pattern, LogEventProtocol]] = \
     [(re.compile(event.regex, re.IGNORECASE), event) for event in SYSTEM_ERROR_EVENTS]
-BACKTRACE_RE = re.compile(r'(?P<other_bt>/lib.*?\+0x[0-f]*\n)|(?P<scylla_bt>0x[0-f]*\n)', re.IGNORECASE)
+BACKTRACE_RE = re.compile(r'(?P<other_bt>/lib.*?\+0x[0-f]*$)|(?P<scylla_bt>0x[0-f]*$)', re.IGNORECASE)
 
 
 class ScyllaHelpErrorEvent(SctEvent, abstract=True):

--- a/unit_tests/test_decode_backtrace.py
+++ b/unit_tests/test_decode_backtrace.py
@@ -28,7 +28,7 @@ from unit_tests.lib.events_utils import EventsUtilsMixin
 
 class DecodeDummyNode(DummyNode):  # pylint: disable=abstract-method
 
-    def copy_scylla_debug_info(self, node, debug_file):
+    def copy_scylla_debug_info(self, node_name, debug_file):
         return "scylla_debug_info_file"
 
 
@@ -117,6 +117,7 @@ class TestDecodeBactraces(unittest.TestCase, EventsUtilsMixin):
             for line in events_file.readlines():
                 events.append(json.loads(line))
 
+        assert any(event.get('raw_backtrace') for event in events), "should have at least one backtrace"
         for event in events:
             if event.get('raw_backtrace'):
                 self.assertIsNone(event['backtrace'])
@@ -137,6 +138,7 @@ class TestDecodeBactraces(unittest.TestCase, EventsUtilsMixin):
             for line in events_file.readlines():
                 events.append(json.loads(line))
 
+        assert any(event.get('raw_backtrace') for event in events), "should have at least one backtrace"
         for event in events:
             if event.get('backtrace') and event.get('raw_backtrace'):
                 self.assertEqual(event['backtrace'].strip(),
@@ -161,6 +163,7 @@ class TestDecodeBactraces(unittest.TestCase, EventsUtilsMixin):
             for line in events_file.readlines():
                 events.append(json.loads(line))
 
+        assert any(event.get('raw_backtrace') for event in events), "should have at least one backtrace"
         for event in events:
             if event.get('backtrace') and event.get('raw_backtrace'):
                 self.assertEqual(event['backtrace'].strip(),
@@ -185,6 +188,7 @@ class TestDecodeBactraces(unittest.TestCase, EventsUtilsMixin):
             for line in events_file.readlines():
                 events.append(json.loads(line))
 
+        assert any(event.get('raw_backtrace') for event in events), "should have at least one backtrace"
         for event in events:
             if event.get('backtrace') and event.get('raw_backtrace'):
                 self.assertEqual(event['backtrace'].strip(),


### PR DESCRIPTION
* since lines are are now `.strip()` the regex for backtraces expected `\n`

* `copy_scylla_debug_info` was expecting a node object, but since the
  dbreader is moved to be a process, it's sending only the node name

failure was like the following:

```
Node perf-ycsb-latency-nemesis-ycsb-per-monitor-node-1bbc1102-1
[100.26.248.120 | 10.0.0.70] (seed: False):
failed to decode backtrace 'str' object has no attribute 'parent_cluster'
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
