### PR TITLE
fix(check_regression_with_subtest_baseline): use use_wide_query=True

### DIFF
--- a/sdcm/results_analyze/__init__.py
+++ b/sdcm/results_analyze/__init__.py
@@ -661,7 +661,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
             return False
 
         # filter tests
-        query = self._query_filter(doc, is_gce)
+        query = self._query_filter(doc, is_gce, use_wide_query=True)
         self.log.debug(query)
         if not query:
             return False


### PR DESCRIPTION
alternator perf jobs was failing to generate the report with the
following error
```
elasticsearch.exceptions.RequestError: RequestError(400,
'search_phase_execution_exception', 'failed to create query: field
expansion for [*] matches too many fields, limit: 1024, got: 2748')
```

removing the multiple matches to the `job_name` using `use_wide_query`
flag fixed the issue.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
