### PR TITLE
fix(jepsen test): change owner of jepsen-scylla folder

### DIFF
--- a/jepsen_test.py
+++ b/jepsen_test.py
@@ -42,7 +42,8 @@ class JepsenTest(ClusterTester):
         """))
         clone_repo(remoter=remoter,
                    repo_url=self.params.get('jepsen_scylla_repo'),
-                   destination_dir_name="jepsen-scylla")
+                   destination_dir_name="jepsen-scylla",
+                   clone_as_root=False)
         for db_node in self.db_cluster.nodes:
             remoter.run(f"ssh-keyscan -t rsa {db_node.ip_address} >> ~/.ssh/known_hosts")
         remoter.send_files(os.path.expanduser(self.db_cluster.nodes[0].ssh_login_info["key_file"]), DB_SSH_KEY)

--- a/sdcm/utils/git.py
+++ b/sdcm/utils/git.py
@@ -25,14 +25,18 @@ def get_git_current_branch() -> str:
     return proc.stdout.decode(encoding="utf-8").strip()
 
 
-def clone_repo(remoter, repo_url: str, destination_dir_name: str = ""):
+def clone_repo(remoter, repo_url: str, destination_dir_name: str = "", clone_as_root=True):
     # pylint: disable=broad-except
     try:
         LOGGER.debug("Cloning from %s...", repo_url)
         rm_cmd = f"rm -rf ./{repo_url.split('/')[-1].split('.')[0]}"
         remoter.sudo(rm_cmd, ignore_status=False)
         clone_cmd = f"git clone {repo_url} {destination_dir_name}"
-        remoter.sudo(clone_cmd)
+        if clone_as_root:
+            remoter.sudo(clone_cmd)
+        else:
+            remoter.run(clone_cmd)
+
         LOGGER.debug("Finished cloning from %s.", repo_url)
     except Exception as exc:
         LOGGER.warning("Failed to clone from %s. Failed with: %s", repo_url, exc)


### PR DESCRIPTION
Jepsen test failed due a change presented in the commit
https://github.com/scylladb/scylla-cluster-tests/commit/8a7c665f041b0f4315ee313a4d4fc8ed07e3faa3

Tests failed to start because jepsen-scylla repo folder was cloned with root.
This fix allow to clone repository with non-root user

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
