### PR TITLE
fix(cassandra-harry): clone repo as non-root user

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -488,7 +488,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         # destination_dir_name=str(cassandra_harry_path))
         self.remoter.run(shell_script_cmd(f"""rm -rf {cassandra_harry_path}"""))
         clone_repo(remoter=self.remoter, repo_url="https://github.com/apache/cassandra-harry.git",
-                   destination_dir_name=str(cassandra_harry_path))
+                   destination_dir_name=str(cassandra_harry_path), clone_as_root=False)
         self.remoter.run(shell_script_cmd(f"""\
             cd {cassandra_harry_path}
             git checkout standalone


### PR DESCRIPTION
Commit
https://github.com/scylladb/scylla-cluster-tests/commit/8a7c665f041b0f4315ee313a4d4fc8ed07e3faa3

changed clone cassandra-harry repo from non-root to root user. Fix it

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
