### PR TITLE
refactor(get-user-keyspaces): remove duplication

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4026,19 +4026,9 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         self.check_nodes_up_and_normal(nodes=nodes, verification_node=verification_node)
 
     def get_test_keyspaces(self):
-        out = self.nodes[0].run_cqlsh('select keyspace_name from system_schema.keyspaces',
-                                      split=True)
-        # Possible output:
-        # Warning: Cannot create directory at `/home/scyllaadm/.cassandra`. Command history will not be saved.
-        #
-        #
-        #  keyspace_name
-        # --------------------
-        #         system_auth
-        #
-        # (1 rows)
-        ks_names_index = [i for i, ks in enumerate(out) if '--------' in ks][0]
-        return [ks.strip() for ks in out[ks_names_index + 1:-3] if 'system' not in ks]
+        """Function returning a list of non-system keyspaces (created by test)"""
+        keyspaces = self.nodes[0].run_cqlsh("describe keyspaces").stdout.split()
+        return [ks for ks in keyspaces if not ks.startswith("system")]
 
     def cfstat_reached_threshold(self, key, threshold, keyspaces=None):
         """


### PR DESCRIPTION
get_user_keyspaces method got duplicated.
Replaced implementation of this method to easier one.
It also shall remove issue when user calls keyspace as
'test_system' which would be not returned by old implementation.

https://trello.com/c/CS9YUrSM

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
