### PR TITLE
fix(alternator-pref): move to us-east-1

### DIFF
--- a/jenkins-pipelines/perf-regression-alternator-latency-30min.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-alternator-latency-30min.jenkinsfile
@@ -5,6 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
+    region: "us-east-1",
     test_name: "performance_regression_alternator_test.PerformanceRegressionAlternatorTest",
     test_config: "test-cases/performance/perf-regression-alternator-latency-500gb-30min.yaml",
     sub_tests: ["test_latency"],

--- a/jenkins-pipelines/perf-regression-alternator-throughput-30min.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-alternator-throughput-30min.jenkinsfile
@@ -5,6 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
+    region: "us-east-1",
     test_name: "performance_regression_alternator_test.PerformanceRegressionAlternatorTest",
     test_config: "test-cases/performance/perf-regression-alternator.100threads.30M-keys.yaml",
     sub_tests: ["test_write", "test_read", "test_mixed"],

--- a/test-cases/performance/perf-regression-alternator-latency-500gb-30min.yaml
+++ b/test-cases/performance/perf-regression-alternator-latency-500gb-30min.yaml
@@ -34,7 +34,7 @@ n_db_nodes: 3
 n_loaders: 3
 n_monitor_nodes: 1
 
-instance_type_loader: 'c4.2xlarge'
+instance_type_loader: 'c5.2xlarge'
 instance_type_monitor: 't3.small'
 instance_type_db: 'i3.4xlarge'
 

--- a/test-cases/performance/perf-regression-alternator.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression-alternator.100threads.30M-keys.yaml
@@ -43,7 +43,7 @@ n_loaders: 3
 n_monitor_nodes: 1
 
 instance_type_db: 'i3.2xlarge'
-instance_type_loader: 'c4.2xlarge'
+instance_type_loader: 'c5.2xlarge'
 instance_type_monitor: 't3.small'
 
 alternator_port: 8080


### PR DESCRIPTION
Also moving to c5.2xlarge instance types for loaders

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
