### PR TITLE
test(azure): enabled fast azure provision tests

### DIFF
--- a/sdcm/provision/provisioner.py
+++ b/sdcm/provision/provisioner.py
@@ -85,15 +85,17 @@ class VmInstance:  # pylint: disable=too-many-instance-attributes
 class Provisioner(ABC):
     """Abstract class for instance (virtual machines) provisioner, cloud-provider and sct agnostic.
     Limits only to machines related to provided test_id. """
-    _test_id: str
-    _region: str
+
+    def __init__(self, test_id, region):
+        self._test_id = test_id
+        self._region = region
 
     @property
-    def test_id(self):
+    def test_id(self) -> str:
         return self._test_id
 
     @property
-    def region(self):
+    def region(self) -> str:
         return self._region
 
     @classmethod
@@ -132,24 +134,24 @@ class Provisioner(ABC):
 
 class ProvisionerFactory:
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._classes = {}
 
     def register_provisioner(self, backend: str, provisioner_class: Provisioner) -> None:
         self._classes[backend] = provisioner_class
 
-    def create_provisioner(self, backend: str, test_id: str, region: str) -> Provisioner:
+    def create_provisioner(self, backend: str, test_id: str, region: str, **config) -> Provisioner:
         """Creates provisioner for given backend, test_id and region and returns it."""
         provisioner = self._classes.get(backend)
         if not provisioner:
             raise ValueError(backend)
-        return provisioner(test_id, region)
+        return provisioner(test_id, region, **config)
 
-    def discover_provisioners(self, backend: str, test_id: str) -> List[Provisioner]:
+    def discover_provisioners(self, backend: str, test_id: str, **config) -> List[Provisioner]:
         """Discovers regions where resources for given test_id are created.
         Returning provisioner class instance for each region."""
         provisioner = self._classes.get(backend)
-        return provisioner.discover_regions(test_id)
+        return provisioner.discover_regions(test_id, **config)
 
 
 provisioner_factory = ProvisionerFactory()

--- a/unit_tests/provisioner/fake_azure_service.py
+++ b/unit_tests/provisioner/fake_azure_service.py
@@ -1,0 +1,596 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2022 ScyllaDB
+
+import json
+import os
+import shutil
+
+from pathlib import Path
+from typing import List, Any, Dict
+
+from azure.core.exceptions import ResourceNotFoundError
+from azure.mgmt.network.models import (NetworkSecurityGroup, Subnet, PublicIPAddress, NetworkInterface, VirtualNetwork)
+from azure.mgmt.resource.resources.models import ResourceGroup
+from azure.mgmt.compute.models import VirtualMachine
+
+from sdcm.utils.azure_utils import AzureService    # pylint: disable=import-error
+
+
+def snake_case_to_camel_case(string):
+    temp = string.split('_')
+    return temp[0] + ''.join(ele.title() for ele in temp[1:])
+
+
+def dict_keys_to_camel_case(dct):
+    if isinstance(dct, list):
+        return [dict_keys_to_camel_case(i) if isinstance(i, (dict, list)) else i for i in dct]
+    return {snake_case_to_camel_case(a): dict_keys_to_camel_case(b) if isinstance(b, (dict, list))
+            else b for a, b in dct.items()}
+
+
+class WaitableObject:  # pylint: disable=too-few-public-methods
+
+    def wait(self):
+        pass
+
+
+class FakeResourceGroups:
+
+    def __init__(self, path: Path):
+        self.path = path
+
+    def create_or_update(self, resource_group_name: str, parameters: Dict[str, Any]) -> ResourceGroup:
+        res_group = {
+            "id": f"/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/{resource_group_name}",
+            "name": resource_group_name,
+            "type": "Microsoft.Resources/resourceGroups",
+            "properties": {
+                "provisioningState": "Succeeded"
+            },
+        }
+        res_group.update(**parameters)
+        (self.path / resource_group_name).mkdir(exist_ok=True)
+        with open(self.path / resource_group_name / "resource_group.json", "w", encoding="utf-8") as file:
+            json.dump(res_group, fp=file, indent=2)
+        return ResourceGroup.deserialize(res_group)
+
+    def get(self, name) -> ResourceGroup:
+        try:
+            with open(self.path / name / "resource_group.json", "r", encoding="utf-8") as file:
+                return ResourceGroup.deserialize(json.load(file))
+        except FileNotFoundError:
+            raise ResourceNotFoundError("Resource group not found") from None
+
+    def begin_delete(self, name: str) -> WaitableObject:
+        shutil.rmtree(self.path / name)
+        return WaitableObject()
+
+
+class FakeNetworkSecurityGroup:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def list(self, resource_group_name: str) -> List[NetworkSecurityGroup]:
+        try:
+            files = [file for file in os.listdir(self.path / resource_group_name) if file.startswith("nsg-")]
+        except FileNotFoundError:
+            raise ResourceNotFoundError("No resource group") from None
+        elements = []
+        for file in files:
+            with open(self.path / resource_group_name / file, "r", encoding="utf-8") as file:
+                elements.append(NetworkSecurityGroup.deserialize(json.load(file)))
+        return elements
+
+    def begin_create_or_update(self, resource_group_name: str, network_security_group_name: str,
+                               parameters: Dict[str, Any]) -> WaitableObject:
+        base = {
+            "id": f"/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/{resource_group_name}/providers"
+                  f"/Microsoft.Network/networkSecurityGroups/default",
+            "name": network_security_group_name,
+            "type": "Microsoft.Network/networkSecurityGroups",
+            "location": parameters["location"],
+            "etag": "W/\"90369d69-7507-4e77-8b90-66e1f971f290\"",
+            "properties": {
+                "subnets": [
+                ],
+                "resourceGuid": "2100b376-ad42-449d-a9c2-62cdade9db83",
+                "provisioningState": "Succeeded"
+            }
+        }
+        rules = []
+        for rule in parameters["security_rules"]:
+            rules.append({
+                "id": f"/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/{resource_group_name}"
+                      f"/providers/Microsoft.Network/networkSecurityGroups/default/securityRules/{rule['name']}",
+                "name": rule["name"],
+                "etag": "W/\"90369d69-7507-4e77-8b90-66e1f971f290\"",
+                "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+                "properties": {
+                    "protocol": rule["protocol"],
+                    "sourcePortRange": rule["source_port_range"],
+                    "destinationPortRange": rule["destination_port_range"],
+                    "sourceAddressPrefix": rule["source_address_prefix"],
+                    "sourceAddressPrefixes": [],
+                    "destinationAddressPrefix": rule["destination_address_prefix"],
+                    "destinationAddressPrefixes": [],
+                    "sourcePortRanges": [],
+                    "destinationPortRanges": [],
+                    "access": rule["access"],
+                    "priority": rule["priority"],
+                    "direction": rule["direction"],
+                    "provisioningState": "Succeeded"
+                }
+            })
+        base.update({"securityRules": rules})
+        with open(self.path / resource_group_name / f"nsg-{network_security_group_name}.json", "w",
+                  encoding="utf-8") as file:
+            json.dump(base, fp=file, indent=2)
+        return WaitableObject()
+
+    def get(self, resource_group_name: str, network_security_group_name: str) -> NetworkSecurityGroup:
+        try:
+            with open(self.path / resource_group_name / f"nsg-{network_security_group_name}.json", "r",
+                      encoding="utf-8") as file:
+                return NetworkSecurityGroup.deserialize(json.load(file))
+        except FileNotFoundError:
+            raise ResourceNotFoundError("Network security group not found") from None
+
+
+class FakeVirtualNetwork:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def list(self, resource_group_name: str) -> List[VirtualNetwork]:
+        try:
+            files = [file for file in os.listdir(self.path / resource_group_name) if file.startswith("vnet-")]
+        except FileNotFoundError:
+            raise ResourceNotFoundError("No resource group") from None
+        elements = []
+        for file in files:
+            with open(self.path / resource_group_name / file, "r", encoding="utf-8") as file:
+                elements.append(VirtualNetwork.deserialize(json.load(file)))
+        return elements
+
+    def begin_create_or_update(self, resource_group_name: str, virtual_network_name: str, parameters: Dict[str, Any]
+                               ) -> WaitableObject:
+        base = {
+            "id": f"/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/{resource_group_name}/providers"
+                  f"/Microsoft.Network/virtualNetworks/{virtual_network_name}",
+            "name": virtual_network_name,
+            "type": "Microsoft.Network/virtualNetworks",
+            "location": parameters["location"],
+            "etag": "W/\"821c1ea3-6313-4798-859b-63ba15e882cc\"",
+            "properties": {
+                "addressSpace": {
+                    "addressPrefixes": [
+                        parameters['address_space']['address_prefixes']
+                    ]
+                },
+                "subnets": [
+                ],
+                "virtualNetworkPeerings": [],
+                "resourceGuid": "e9660f35-9f2b-4134-8b0e-309bd9b3792c",
+                "provisioningState": "Succeeded",
+                "enableDdosProtection": False
+            }
+        }
+        with open(self.path / resource_group_name / f"vnet-{virtual_network_name}.json", "w", encoding="utf-8") as file:
+            json.dump(base, fp=file, indent=2)
+        return WaitableObject()
+
+    def get(self, resource_group_name: str, virtual_network_name: str) -> NetworkSecurityGroup:
+        try:
+            with open(self.path / resource_group_name / f"vnet-{virtual_network_name}.json", "r", encoding="utf-8") as file:
+                return VirtualNetwork.deserialize(json.load(file))
+        except FileNotFoundError:
+            raise ResourceNotFoundError("Network security group not found") from None
+
+
+class FakeSubnet:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def list(self, resource_group_name: str, virtual_network_name: str) -> List[Subnet]:
+        try:
+            files = [file for file in os.listdir(self.path / resource_group_name) if
+                     file.startswith(f"subnet-{virtual_network_name}")]
+        except FileNotFoundError:
+            raise ResourceNotFoundError("No resource group") from None
+        elements = []
+        for file in files:
+            with open(self.path / resource_group_name / file, "r", encoding="utf-8") as file:
+                elements.append(Subnet.deserialize(json.load(file)))
+        return elements
+
+    def begin_create_or_update(self, resource_group_name: str, virtual_network_name: str, subnet_name: str,
+                               subnet_parameters: Dict[str, Any]) -> WaitableObject:
+        base = {
+            "id": f"/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/{resource_group_name}/providers"
+                  f"/Microsoft.Network/virtualNetworks/{virtual_network_name}/subnets/{subnet_name}",
+            "name": subnet_name,
+            "etag": "W/\"821c1ea3-6313-4798-859b-63ba15e882cc\"",
+            "type": "Microsoft.Network/virtualNetworks/subnets",
+            "properties": {
+                "addressPrefix": subnet_parameters["address_prefix"],
+                "networkSecurityGroup": {
+                    "id": subnet_parameters["network_security_group"]["id"]
+                },
+                "ipConfigurations": [
+                ],
+                "delegations": [],
+                "provisioningState": "Succeeded",
+                "privateEndpointNetworkPolicies": "Enabled",
+                "privateLinkServiceNetworkPolicies": "Enabled"
+            }
+        }
+        with open(self.path / resource_group_name / f"subnet-{virtual_network_name}-{subnet_name}.json", "w",
+                  encoding="utf-8") as file:
+            json.dump(base, fp=file, indent=2)
+        return WaitableObject()
+
+    def get(self, resource_group_name: str, virtual_network_name: str, subnet_name: str) -> NetworkSecurityGroup:
+        try:
+            with open(self.path / resource_group_name / f"subnet-{virtual_network_name}-{subnet_name}.json", "r",
+                      encoding="utf-8") as file:
+                return Subnet.deserialize(json.load(file))
+        except FileNotFoundError:
+            raise ResourceNotFoundError("Subnet group not found") from None
+
+
+class FakeIpAddress:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def list(self, resource_group_name: str) -> List[PublicIPAddress]:
+        try:
+            files = [file for file in os.listdir(self.path / resource_group_name) if file.startswith("ip-")]
+        except FileNotFoundError:
+            raise ResourceNotFoundError("No resource group") from None
+        elements = []
+        for file in files:
+            with open(self.path / resource_group_name / file, "r", encoding="utf-8") as file:
+                elements.append(PublicIPAddress.deserialize(json.load(file)))
+        return elements
+
+    def begin_create_or_update(self, resource_group_name: str, public_ip_address_name: str, parameters: Dict[str, Any]
+                               ) -> WaitableObject:
+        base = {
+            "id": f"/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/{resource_group_name}/providers"
+                  f"/Microsoft.Network/publicIPAddresses/{public_ip_address_name}",
+            "name": public_ip_address_name,
+            "type": "Microsoft.Network/publicIPAddresses",
+            "location": parameters["location"],
+            "sku": {
+                "name": parameters["sku"]["name"],
+                "tier": "Regional"
+            },
+            "etag": "W/\"c6bd8f78-66eb-4fc6-90d0-98d790c5467e\"",
+            "properties": {
+                "publicIPAllocationMethod": parameters["public_ip_allocation_method"],
+                "publicIPAddressVersion": parameters["public_ip_address_version"],
+                "ipConfiguration": {
+                },
+                "ipTags": [],
+                "ipAddress": "52.240.59.45",
+                "idleTimeoutInMinutes": 4,
+                "resourceGuid": "63d8cd05-8056-488f-a252-2c5e6b38360e",
+                "provisioningState": "Succeeded"
+            }
+        }
+        with open(self.path / resource_group_name / f"ip-{public_ip_address_name}.json", "w", encoding="utf-8") as file:
+            json.dump(base, fp=file, indent=2)
+        return WaitableObject()
+
+    def get(self, resource_group_name: str, public_ip_address_name: str) -> PublicIPAddress:
+        try:
+            with open(self.path / resource_group_name / f"ip-{public_ip_address_name}.json", "r",
+                      encoding="utf-8") as file:
+                return PublicIPAddress.deserialize(json.load(file))
+        except FileNotFoundError:
+            raise ResourceNotFoundError("Public IP address not found") from None
+
+    def begin_delete(self, resource_group_name: str, public_ip_address_name: str) -> WaitableObject:
+        os.remove(self.path / resource_group_name / f"ip-{public_ip_address_name}.json")
+        return WaitableObject()
+
+
+class FakeNetworkInterface:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def list(self, resource_group_name: str) -> List[NetworkInterface]:
+        try:
+            files = [file for file in os.listdir(self.path / resource_group_name) if file.startswith("nic-")]
+        except FileNotFoundError:
+            raise ResourceNotFoundError("No resource group") from None
+        elements = []
+        for file in files:
+            with open(self.path / resource_group_name / file, "r", encoding="utf-8") as file:
+                elements.append(NetworkInterface.deserialize(json.load(file)))
+        return elements
+
+    def begin_create_or_update(self, resource_group_name: str, network_interface_name: str, parameters: Dict[str, Any]
+                               ) -> WaitableObject:
+        base = {
+            "id": f"/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/{resource_group_name}/providers"
+                  f"/Microsoft.Network/networkInterfaces/{network_interface_name}",
+            "name": network_interface_name,
+            "type": "Microsoft.Network/networkInterfaces",
+            "location": parameters["location"],
+            "etag": "W/\"a1a80a74-a244-4e0b-9883-41eb47fa633e\"",
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "id": f"/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups"
+                              f"/{resource_group_name}/providers/Microsoft.Network/networkInterfaces/"
+                              f"{network_interface_name}/ipConfigurations/{parameters['ip_configurations'][0]['name']}",
+                        "name": parameters['ip_configurations'][0]['name'],
+                        "etag": "W/\"a1a80a74-a244-4e0b-9883-41eb47fa633e\"",
+                        "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
+                        "properties": {
+                            "privateIPAddress": "10.0.0.4",
+                            "privateIPAllocationMethod": "Dynamic",
+                            "privateIPAddressVersion": "IPv4",
+                            "subnet": {
+                                "id": parameters["ip_configurations"][0]["subnet"]["id"]
+                            },
+                            "primary": True,
+                            "publicIPAddress": {
+                                "id": parameters['ip_configurations'][0]['public_ip_address']["id"],
+                                "name": parameters['ip_configurations'][0]['public_ip_address']["id"].split("/", -1)[
+                                    -1],
+                                "type": "Microsoft.Network/publicIPAddresses",
+                                "sku": {
+                                    "name": "Basic",
+                                    "tier": "Regional"
+                                },
+                                "properties": {
+                                    "publicIPAllocationMethod": "Dynamic",
+                                    "publicIPAddressVersion": "IPv4",
+                                    "ipConfiguration": {
+                                        "id": f"/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups"
+                                              f"/{resource_group_name}/providers/Microsoft.Network/networkInterfaces"
+                                              f"/{network_interface_name}/ipConfigurations"
+                                              f"/{parameters['ip_configurations'][0]['name']}"
+                                    },
+                                    "ipTags": [],
+                                    "idleTimeoutInMinutes": 4,
+                                    "resourceGuid": "cbf93df3-72ac-4c54-8bc1-71c9ebfb1907",
+                                    "provisioningState": "Succeeded",
+                                    "deleteOption": "Delete"
+                                }
+                            },
+                            "provisioningState": "Succeeded"
+                        }
+                    }
+                ],
+                "tapConfigurations": [],
+                "dnsSettings": {
+                    "dnsServers": [],
+                    "appliedDnsServers": [],
+                    "internalDomainNameSuffix": "guhwn0jlt20edcyogcn3tm1zfe.bx.internal.cloudapp.net"
+                },
+                "macAddress": "00-0D-3A-14-3F-92",
+                "primary": True,
+                "enableAcceleratedNetworking": parameters["enable_accelerated_networking"],
+                "enableIPForwarding": False,
+                "hostedWorkloads": [],
+                "resourceGuid": "3232a287-da4c-40eb-b5c8-cadb487d6dce",
+                "provisioningState": "Succeeded",
+                "nicType": "Standard"
+            }
+        }
+        with open(self.path / resource_group_name / f"nic-{network_interface_name}.json", "w", encoding="utf-8") as file:
+            json.dump(base, fp=file, indent=2)
+        return WaitableObject()
+
+    def get(self, resource_group_name: str, network_interface_name: str) -> NetworkInterface:
+        try:
+            with open(self.path / resource_group_name / f"nic-{network_interface_name}.json", "r",
+                      encoding="utf-8") as file:
+                return NetworkInterface.deserialize(json.load(file))
+        except FileNotFoundError:
+            raise ResourceNotFoundError("NIC not found") from None
+
+    def begin_delete(self, resource_group_name: str, network_interface_name: str) -> WaitableObject:
+        os.remove(self.path / resource_group_name / f"nic-{network_interface_name}.json")
+        return WaitableObject()
+
+
+class FakeNetwork:  # pylint: disable=too-few-public-methods
+
+    def __init__(self, path) -> None:
+        self.path: Path = path
+        self.network_security_groups = FakeNetworkSecurityGroup(self.path)
+        self.virtual_networks = FakeVirtualNetwork(self.path)
+        self.subnets = FakeSubnet(self.path)
+        self.public_ip_addresses = FakeIpAddress(self.path)
+        self.network_interfaces = FakeNetworkInterface(self.path)
+
+
+class FakeVirtualMachines:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def list(self, resource_group_name: str) -> List[VirtualMachine]:
+        try:
+            files = [file for file in os.listdir(self.path / resource_group_name) if file.startswith("vm-")]
+        except FileNotFoundError:
+            raise ResourceNotFoundError("No resource group") from None
+        elements = []
+        for fle in files:
+            with open(self.path / resource_group_name / fle, "r", encoding="utf-8") as file:
+                elements.append(VirtualMachine.deserialize(json.load(file)))
+        return elements
+
+    def begin_create_or_update(self, resource_group_name: str, vm_name: str, parameters: Dict[str, Any]
+                               ) -> WaitableObject:
+        parameters = dict_keys_to_camel_case(parameters)
+        location = parameters.pop("location")
+        tags = parameters.pop("tags")
+
+        base = {
+            "id": f"/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/{resource_group_name}"
+                  f"/providers/Microsoft.Compute/virtualMachines/{vm_name}",
+            "name": vm_name,
+            "type": "Microsoft.Compute/virtualMachines",
+            "location": location,
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "Standard_D2_v5"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "publisher": "OpenLogic",
+                        "offer": "CentOS",
+                        "sku": "7.5",
+                        "version": "latest",
+                        "exactVersion": "7.5.201808150"
+                    },
+                    "osDisk": {
+                        "osType": "Linux",
+                        "name": "lukasz-3_OsDisk_1_7fcdd979aec64c40b5b153bfe9daed35",
+                        "caching": "ReadWrite",
+                        "createOption": "FromImage",
+                        "diskSizeGB": 30,
+                        "managedDisk": {
+                            "id": f"/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups"
+                                  f"/{resource_group_name}/providers/Microsoft.Compute/disks"
+                                  f"/{vm_name}_OsDisk_1_7fcdd979aec64c40b5b153bfe9daed35",
+                            "storageAccountType": "Standard_LRS"
+                        },
+                        "deleteOption": "Detach"
+                    },
+                    "dataDisks": []
+                },
+                "osProfile": {
+                    "computerName": "lukasz-3",
+                    "adminUsername": "lukasz",
+                    "linuxConfiguration": {
+                        "disablePasswordAuthentication": True,
+                        "ssh": {
+                            "publicKeys": [
+                                {
+                                    "path": "/home/lukasz/.ssh/authorized_keys",
+                                    "keyData": "ssh-rsa fake_key_data== scylla-qa-ec2\n"
+                                }
+                            ]
+                        },
+                        "provisionVMAgent": True,
+                        "patchSettings": {
+                            "patchMode": "ImageDefault",
+                            "assessmentMode": "ImageDefault"
+                        }
+                    },
+                    "secrets": [],
+                    "allowExtensionOperations": True,
+                    "requireGuestProvisionSignal": True
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": f"/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups"
+                                  f"/{resource_group_name}/providers/Microsoft.Network/networkInterfaces/lukasz-3-nic",
+                            "properties": {
+                                "deleteOption": "Delete"
+                            }
+                        }
+                    ]
+                },
+                "priority": "Spot",
+                "evictionPolicy": "Delete",
+                "billingProfile": {
+                    "maxPrice": -1.0
+                },
+                "provisioningState": "Succeeded",
+                "vmId": "ce7b8d6c-4204-4262-9504-862189431e5d"
+            }
+        }
+        base["properties"].update(**parameters)
+        base["tags"] = tags
+        with open(self.path / resource_group_name / f"vm-{vm_name}.json", "w", encoding="utf-8") as file:
+            json.dump(base, fp=file, indent=2)
+        return WaitableObject()
+
+    def begin_update(self, resource_group_name: str, vm_name: str, parameters: Dict[str, Any]) -> WaitableObject:
+        try:
+            with open(self.path / resource_group_name / f"vm-{vm_name}.json", "r", encoding="utf-8") as file:
+                v_m = json.loads(file.read())
+        except FileNotFoundError:
+            raise ResourceNotFoundError("Virtual Machine not found") from None
+
+        tags = parameters.pop("tags") if "tags" in parameters else {}
+        v_m["properties"].update(**dict_keys_to_camel_case(parameters))
+        v_m["tags"].update(**tags)
+        VirtualMachine.deserialize(v_m)
+        with open(self.path / resource_group_name / f"vm-{vm_name}.json", "w", encoding="utf-8") as file:
+            json.dump(v_m, fp=file, indent=2)
+        return WaitableObject()
+
+    def begin_delete(self, resource_group_name: str, vm_name: str) -> WaitableObject:
+        network_svc = FakeNetwork(self.path)
+        v_m = self.get(resource_group_name, vm_name)
+        os.remove(self.path / resource_group_name / f"vm-{vm_name}.json")
+        nic_name = v_m.network_profile.network_interfaces[0].id.split("/", -1)[-1]
+        nic = network_svc.network_interfaces.get(resource_group_name, nic_name)
+        network_svc.network_interfaces.begin_delete(resource_group_name, nic_name)
+        network_svc.public_ip_addresses.begin_delete(
+            resource_group_name, nic.ip_configurations[0].public_ip_address.name)
+        return WaitableObject()
+
+    def get(self, resource_group_name: str, vm_name: str) -> VirtualMachine:
+        try:
+            with open(self.path / resource_group_name / f"vm-{vm_name}.json", "r", encoding="utf-8") as file:
+                return VirtualMachine.deserialize(json.load(file))
+        except FileNotFoundError:
+            raise ResourceNotFoundError("Virtual Machine not found") from None
+
+    def begin_restart(self, resource_group_name, vm_name  # pylint: disable=unused-argument, no-self-use
+                      ) -> WaitableObject:
+        return WaitableObject()
+
+
+class Compute:  # pylint: disable=too-few-public-methods
+
+    def __init__(self, path) -> None:
+        self.path: Path = path
+        self.virtual_machines = FakeVirtualMachines(self.path)
+
+
+class FakeResourceManagementClient:  # pylint: disable=too-few-public-methods
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    @property
+    def resource_groups(self) -> FakeResourceGroups:
+        return FakeResourceGroups(self.path)
+
+
+class FakeAzureService(AzureService):
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.mkdir(exist_ok=True)
+
+    @property
+    def resource(self) -> FakeResourceManagementClient:
+        return FakeResourceManagementClient(self.path)
+
+    @property
+    def network(self) -> FakeNetwork:
+        return FakeNetwork(self.path)
+
+    @property
+    def compute(self) -> Compute:
+        return Compute(self.path)

--- a/unit_tests/provisioner/test_azure_provisioner.py
+++ b/unit_tests/provisioner/test_azure_provisioner.py
@@ -13,15 +13,25 @@
 import uuid
 
 import pytest
+from azure.core.exceptions import ResourceNotFoundError
 
 from sdcm.keystore import KeyStore  # pylint: disable=import-error
-from sdcm.provision.azure.provisioner import AzureProvisioner  # pylint: disable=import-error
 from sdcm.provision.azure.utils import get_scylla_images  # pylint: disable=import-error
 from sdcm.provision.provisioner import InstanceDefinition, provisioner_factory  # pylint: disable=import-error
+from sdcm.utils.azure_utils import AzureService  # pylint: disable=import-error
+from unit_tests.provisioner.fake_azure_service import FakeAzureService  # pylint: disable=import-error
 
 
-class DisabledTestProvisionScyllaInstanceAzureE2E:
+class TestProvisionScyllaInstanceAzureE2E:
     """this is rather e2e test - takes around 8 minutes (2m provisioning, 6 min cleanup with wait=True)"""
+
+    @pytest.fixture(scope="session")
+    def azure_service(self, tmp_path_factory) -> AzureService:  # pylint: disable=no-self-use
+        run_on_real_azure = False   # make it True to test with real Azure
+        if run_on_real_azure:
+            # When true this becomes e2e test - takes around 8 minutes (2m provisioning, 6 min cleanup with wait=True)
+            return AzureService()
+        return FakeAzureService(tmp_path_factory.mktemp("azure-provision"))
 
     @pytest.fixture(scope='session')
     def test_id(self):  # pylint: disable=no-self-use
@@ -46,12 +56,11 @@ class DisabledTestProvisionScyllaInstanceAzureE2E:
             tags={'test-tag': 'test_value'}
         )
 
-    @pytest.fixture(scope="function")
-    def provisioner(self, test_id, region):  # pylint: disable=no-self-use
-        return provisioner_factory.create_provisioner("azure", test_id, region)
+    @pytest.fixture(scope="session")
+    def provisioner(self, test_id, region, azure_service):  # pylint: disable=no-self-use
+        return provisioner_factory.create_provisioner("azure", test_id, region, azure_service=azure_service)
 
-    def test_can_provision_scylla_vm(self, test_id, region, definition):  # pylint: disable=no-self-use
-        provisioner = provisioner_factory.create_provisioner("azure", test_id, region)
+    def test_can_provision_scylla_vm(self, region, definition, provisioner):  # pylint: disable=no-self-use
         v_m = provisioner.get_or_create_instance(definition)
         assert v_m.name == definition.name
         assert v_m.region == region
@@ -63,8 +72,10 @@ class DisabledTestProvisionScyllaInstanceAzureE2E:
         assert v_m == provisioner.list_instances()[0]
 
     @pytest.mark.timeout(2)
-    def test_can_discover_existing_resources_for_test_id(self, region, provisioner, definition):  # pylint: disable=no-self-use
+    def test_can_discover_existing_resources_for_test_id(self, region, test_id, definition, azure_service):  # pylint: disable=no-self-use
         """should read from cache instead creating anything - so should be fast (after provisioner initialized)"""
+        # create provisioner from scratch to test resources discovery
+        provisioner = provisioner_factory.create_provisioner("azure", test_id, region, azure_service=azure_service)
         assert provisioner.list_instances()[0]
         v_m = provisioner.get_or_create_instance(definition)
         assert v_m.name == definition.name
@@ -76,8 +87,19 @@ class DisabledTestProvisionScyllaInstanceAzureE2E:
 
         assert v_m == provisioner.list_instances()[0]
 
-    def test_can_terminate_vm_instance(self, test_id, region, provisioner, definition):  # pylint: disable=no-self-use
+    def test_can_add_tags(self, provisioner, definition, azure_service):  # pylint: disable=no-self-use
+        provisioner.add_instance_tags(definition.name, {"tag_key": "tag_value"})
+        assert provisioner.get_or_create_instance(definition).tags.get("tag_key") == "tag_value"
+
+        resource_group = provisioner._rg_provider.get_or_create()  # pylint: disable=protected-access
+        v_m = azure_service.compute.virtual_machines.get(resource_group.name, definition.name)
+        assert v_m.tags.get("tag_key") == "tag_value"
+
+    def test_can_terminate_vm_instance(self, provisioner, definition, azure_service):  # pylint: disable=no-self-use
         """should read from cache instead creating anything - so should be fast (after provisioner initialized)"""
+        resource_group = provisioner._rg_provider.get_or_create()  # pylint: disable=protected-access
+        nic = provisioner._nic_provider.get(definition.name)  # pylint: disable=protected-access
+        ip = provisioner._ip_provider.get(definition.name)  # pylint: disable=protected-access
         provisioner.terminate_instance(definition.name, wait=True)
 
         # validate cache has been cleaned up
@@ -88,18 +110,19 @@ class DisabledTestProvisionScyllaInstanceAzureE2E:
             assert not provisioner._ip_provider.get(definition.name)  # pylint: disable=protected-access
 
         # verify that truly vm, nic and ip got deleted - not only cache
-        provisioner = AzureProvisioner(test_id, region)
+        with pytest.raises(ResourceNotFoundError):
+            azure_service.compute.virtual_machines.get(resource_group.name, definition.name)
+        with pytest.raises(ResourceNotFoundError):
+            azure_service.network.network_interfaces.get(resource_group.name, nic.name)
+        with pytest.raises(ResourceNotFoundError):
+            azure_service.network.public_ip_addresses.get(resource_group.name, ip.name)
 
-        assert not provisioner.list_instances()
-        with pytest.raises(KeyError):
-            assert not provisioner._nic_provider.get(definition.name)  # pylint: disable=protected-access
-        with pytest.raises(KeyError):
-            assert not provisioner._ip_provider.get(definition.name)  # pylint: disable=protected-access
-
-    def test_can_trigger_cleanup(self, test_id, region):  # pylint: disable=no-self-use
-        provisioner = AzureProvisioner(test_id, region)
+    def test_can_trigger_cleanup(self, test_id, provisioner, azure_service):  # pylint: disable=no-self-use
+        resource_group = provisioner._rg_provider.get_or_create()  # pylint: disable=protected-access
+        provisioner_factory.discover_provisioners("azure", test_id)
         provisioner.cleanup(wait=True)
-        # validating real cleanup - this takes most of the testing time (6mins)
-        provisioner = AzureProvisioner(test_id, region)
+
+        with pytest.raises(ResourceNotFoundError):
+            azure_service.resource.resource_groups.get(resource_group.name)
         assert not provisioner.list_instances(), "failed cleaning up resources"
         assert provisioner._rg_provider._cache is None, "resource group was not deleted"  # pylint: disable=protected-access


### PR DESCRIPTION
Currently Azure provisioning tests are disabled because they involved real Azure service.
This commit makes tests to use fake Azure service that operates on files instead of real resources.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
