### PR TITLE
fix(azure-image-test): use public ssh connection

### DIFF
--- a/jenkins-pipelines/artifacts-azure-image.jenkinsfile
+++ b/jenkins-pipelines/artifacts-azure-image.jenkinsfile
@@ -10,7 +10,8 @@ artifactsPipeline(
     backend: 'azure',
     instance_provision: 'spot',
 
-    timeout: [time: 45, unit: 'MINUTES'],
+    timeout: [time: 145, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
-    builds_to_keep: '30'
+    builds_to_keep: '30',
+    ip_ssh_connections: 'public'
 )


### PR DESCRIPTION
Artifact tests don't use sct-runner. Because jenkins builder belongs to
different virtual network, ssh connection over internal ip is not
possible - that's why it required to use public ip for ssh.

There's some instability in tests - sometimes test hangs after
restarting scylla-server. Logs don't show any reason of that and timeout
stops forcefully the test. When that happens there's no way to get
reasoning what is causing this. Increasing timeout of run might help -
maybe we'll see python traceback that possibly will lead us to the
cause.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
