### PR TITLE
fix(break_streaming_task_and_rebuild): wait for JMX server to be up

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2815,12 +2815,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if self._is_it_on_kubernetes():
             # NOTE: on K8S nodes come up longer.
             wait_db_up_timeout = 1800
-        if new_node:
-            new_node.wait_db_up(verbose=True, timeout=wait_db_up_timeout)
-            new_node.run_nodetool('rebuild')
-        else:
-            self.target_node.wait_db_up(verbose=True, timeout=wait_db_up_timeout)
-            self.target_node.run_nodetool('rebuild')
+        node_to_rebuild = new_node if new_node else self.target_node
+        node_to_rebuild.wait_db_up(verbose=True, timeout=wait_db_up_timeout)
+        node_to_rebuild.wait_jmx_up(timeout=wait_db_up_timeout)
+        node_to_rebuild.run_nodetool('rebuild')
 
     def disrupt_decommission_streaming_err(self):
         """


### PR DESCRIPTION
Added wait_jmx_up() before running the nodetool command.
Sometimes JMX server starts up with some delay after Scylla server
and nodetool command is executed when JMX server is not actually
ready.
Fixes https://github.com/scylladb/scylla-cluster-tests/issues/4539

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
