### PR TITLE
fix(disrupt_no_corrupt_repair): remove timeout from thread result

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1218,7 +1218,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                     with self.cluster.cql_connection_patient(self.target_node) as session:
                         session.execute(f'DROP TABLE drop_table_during_repair_ks_{i}.standard1')
             finally:
-                thread.result(timeout=120)
+                thread.result()
 
     def disrupt_major_compaction(self):
         self.target_node.run_nodetool("compact")


### PR DESCRIPTION
Since we can't actully stop the thread while it's working, the timeout
was only used to error once the thread finished, regardless 120s
wasn't enough for the repair on long longevity.
if ever this would be getting stuck, we'll need to
timeout the command inside the thread and maybe use coredump_on_timeout
param.

Fixes: #4540

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
