### PR TITLE
test(manager 3.0): Added test for on-resume-start-tasks flag

### DIFF
--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -813,8 +813,12 @@ class ManagerCluster(ScyllaManagerBase):
             return value_list[0]
         return default_value
 
-    def suspend(self):
+    def suspend(self, on_resume_start_tasks=False, duration=None):
         cmd = f"suspend -c {self.id}"
+        if on_resume_start_tasks:
+            cmd += " --on-resume-start-tasks"
+        if duration is not None:
+            cmd += f" --duration {duration}"
         self.sctool.run(cmd=cmd)
 
     def resume(self, start_tasks=True):
@@ -824,8 +828,8 @@ class ManagerCluster(ScyllaManagerBase):
         self.sctool.run(cmd=cmd)
 
     @contextmanager
-    def suspend_manager_then_resume(self, start_tasks=True):
-        self.suspend()
+    def suspend_manager_then_resume(self, start_tasks=True, start_tasks_in_advance=False, duration=None):
+        self.suspend(on_resume_start_tasks=start_tasks_in_advance, duration=duration)
         try:
             yield
         finally:

--- a/sdcm/mgmt/common.py
+++ b/sdcm/mgmt/common.py
@@ -157,3 +157,7 @@ class TaskStatus:  # pylint: disable=too-few-public-methods
             return getattr(cls, output_str)
         except AttributeError as err:
             raise ScyllaManagerError("Could not recognize returned task status: {}".format(output_str)) from err
+
+    @classmethod
+    def all_statuses(cls):
+        return set(getattr(cls, name) for name in dir(cls) if name.isupper())


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
