### PR TITLE
fix(managerPipeline): rearanged param order

### DIFF
--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -104,17 +104,13 @@ def call(Map pipelineParams) {
                    description: 'If empty - the default manager version will be taken',
                    name: 'scylla_mgmt_address')
 
-            string(defaultValue: "master_latest",
-                   description: 'master_latest|2.6|2.5|2.4|2.3',
-                   name: 'manager_version')
-
-            string(defaultValue: "${pipelineParams.get('target_manager_version', '')}",
-                   description: 'master_latest|2.6|2.5|2.4|2.3',
-                   name: 'target_manager_version')
-
             string(defaultValue: "${pipelineParams.get('scylla_mgmt_agent_address', '')}",
                    description: 'manager agent repo',
                    name: 'scylla_mgmt_agent_address')
+
+            string(defaultValue: "master_latest",
+                   description: 'master_latest|2.6|2.5|2.4|2.3',
+                   name: 'manager_version')
 
             string(defaultValue: "${pipelineParams.get('target_scylla_mgmt_server_address', '')}",
                    description: 'Link to the repository of the manager that will be used as a target of the manager server in the manager upgrade test',
@@ -123,6 +119,10 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('target_scylla_mgmt_agent_address', '')}",
                    description: 'Link to the repository of the manager that will be used as a target of the manager agents in the manager upgrade test',
                    name: 'target_scylla_mgmt_agent_address')
+
+            string(defaultValue: "${pipelineParams.get('target_manager_version', '')}",
+                   description: 'master_latest|2.6|2.5|2.4|2.3',
+                   name: 'target_manager_version')
 
             string(defaultValue: "'qa@scylladb.com','mgmt@scylladb.com'",
                    description: 'email recipients of email report',


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
