### PR TITLE
fix(monitoring_download): revert to master dashboard if not available

### DIFF
--- a/sdcm/monitorstack/__init__.py
+++ b/sdcm/monitorstack/__init__.py
@@ -250,6 +250,10 @@ def get_monitoring_stack_scylla_version(monitoring_stack_dir):
         with open(os.path.join(monitoring_stack_dir, 'monitor_version'), encoding="utf-8") as f:  # pylint: disable=invalid-name
             versions = f.read().strip()
         monitoring_version, scylla_version = versions.split(':')
+        if not requests.head(f'https://github.com/scylladb/scylla-monitoring/tree/{monitoring_version}'
+                             f'/grafana/build/ver_{scylla_version}').ok:
+            scylla_version = 'master'
+
         return monitoring_version, scylla_version
     except Exception:  # pylint: disable=broad-except
         return 'branch-3.0', 'master'


### PR DESCRIPTION
when monitoring doesn't have dashboards for the scylla version we
are using, revert to use the master dashboard

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
