### PR TITLE
fix(gce-reboot): fix hard_reboot method for gce

### DIFF
--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -163,7 +163,7 @@ class GCENode(cluster.BaseNode):
         self._instance_wait_safe(self._instance.reboot)
 
     def hard_reboot(self):
-        self._instance_wait_safe(self._instance.reboot_instance)
+        self._instance_wait_safe(self._instance.reboot)
 
     def _safe_destroy(self):
         try:


### PR DESCRIPTION
When fixing topology changes nemesis for Azure, some unintended change
got leaked to GCE.

Fix is about reverting this change.

https://trello.com/c/5kL3Dipd
Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/4547

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
