### PR TITLE
fix(sdcm.monitorstack): tolerate absence of some dashboard

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -566,7 +566,8 @@ class GrafanaSnapshot(GrafanaEntity):
 
                     snapshots.append(dashboard.get_snapshot(self.remote_browser.browser))
                 except Exception as details:  # pylint: disable=broad-except
-                    LOGGER.error("Error get snapshot %s: %s", dashboard.name, details)
+                    LOGGER.error("Error get snapshot %s: %s, traceback: %s",
+                                 dashboard.name, details, traceback.format_exc())
 
             LOGGER.info(snapshots)
             return snapshots

--- a/sdcm/monitorstack/__init__.py
+++ b/sdcm/monitorstack/__init__.py
@@ -414,7 +414,12 @@ def verify_grafana_is_available():
             LOGGER.error("Dashboard %s is not available. Error: %s", dashboard.title, details)
             grafana_statuses.append(False)
 
-    return all(grafana_statuses)
+    result = any(grafana_statuses)
+
+    if not result:
+        LOGGER.error("None of the expected dashboards are available.")
+
+    return result
 
 
 def verify_prometheus_is_available():


### PR DESCRIPTION
- Fail if only all expected dashboards are not loaded
- Add traceback for failed snapshot message

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
