### PR TITLE
fix(managerPipeline): fetched the value of manager_version

### DIFF
--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -104,7 +104,7 @@ def call(Map pipelineParams) {
                    description: 'If empty - the default manager version will be taken',
                    name: 'scylla_mgmt_address')
 
-            string(defaultValue: "master_latest",
+            string(defaultValue: "${pipelineParams.get('manager_version', 'master_latest')",
                    description: 'master_latest|2.6|2.5|2.4|2.3',
                    name: 'manager_version')
 


### PR DESCRIPTION
The manager_version was hardcoded as master_latest. Now the pipeline
will fetch the value from the jenkinsfile.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
