### PR TITLE
test(range tombstones): Add a new nemesis: DeleteOverlappingRowRangesMonkey

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1803,6 +1803,26 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         self.run_deletions(queries=queries, ks_cf=ks_cf)
 
+    def disrupt_delete_overlapping_row_ranges(self):
+        """
+        Delete several overlapping row ranges in the table with large partitions.
+        """
+        self.verify_initial_inputs_for_delete_nemesis()
+        ks_cf = 'scylla_bench.test'
+        partitions_for_delete = self.choose_partitions_for_delete(10, ks_cf, with_clustering_key_data=True)
+        if not partitions_for_delete:
+            self.log.error('No partitions for delete found!')
+            raise UnsupportedNemesis("DeleteOverlappingRowRangesMonkey: No partitions for delete found!")
+
+        self.log.debug('Delete random row ranges in few partitions')
+        queries = []
+        for pkey, ckey in partitions_for_delete.items():
+            for _ in range(random.randint(3, 20)):  # Get a random number of ranges to delete.
+                min_ck = random.randint(0, ckey[1])  # Generate a random range of rows to delete in a single partition.
+                max_ck = random.randint(min_ck, ckey[1])
+                queries.append(f"delete from {ks_cf} where pk = {pkey} and ck > {min_ck} and ck < {max_ck}")
+        self.run_deletions(queries=queries, ks_cf=ks_cf)
+
     def disrupt_delete_by_rows_range(self):
         """
         Delete few partitions in the table with large partitions
@@ -3617,6 +3637,14 @@ class DeleteByRowsRangeMonkey(Nemesis):
 
     def disrupt(self):
         self.disrupt_delete_by_rows_range()
+
+
+class DeleteOverlappingRowRangesMonkey(Nemesis):
+    disruptive = False
+    kubernetes = True
+
+    def disrupt(self):
+        self.disrupt_delete_overlapping_row_ranges()
 
 
 class ChaosMonkey(Nemesis):


### PR DESCRIPTION


	In order to test multiple overlapping range-tombstones.
	Tests the fix of: https://github.com/scylladb/scylla/commit/c3f17ea0a34346223d90e4955f21b1047442a375

Trello: https://trello.com/c/jN5WRPkL
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
