### PR TITLE
fix(aws_user_data): make sure logs_transport is being passed

### DIFF
--- a/sdcm/sct_provision/aws/user_data.py
+++ b/sdcm/sct_provision/aws/user_data.py
@@ -53,6 +53,7 @@ class ScyllaUserDataBuilder(ScyllaUserDataBuilderBase):
             aws_additional_interface=self.params.get('extra_network_interface') or False,
             aws_ipv6_workaround=self.params.get('ip_ssh_connections') == 'ipv6',
             syslog_host_port=self.syslog_host_port,
+            logs_transport=self.params.get('logs_transport'),
             disable_ssh_while_running=True,
         ).to_string()
         return base64.b64encode(post_boot_script.encode('utf-8')).decode('ascii')
@@ -81,6 +82,7 @@ class AWSInstanceUserDataBuilder(UserDataBuilderBase):
             # Monitoring and loader nodes does not use additional interface
             aws_additional_interface=False,
             aws_ipv6_workaround=self.params.get('ip_ssh_connections') == 'ipv6',
+            logs_transport=self.params.get('logs_transport'),
             syslog_host_port=self.syslog_host_port,
             disable_ssh_while_running=True,
         ).to_string()


### PR DESCRIPTION
Fixes: #4563

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
