### PR TITLE
fix(database_error): stop using `exception` and use log level

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -24,13 +24,11 @@ DatabaseLogEvent.SERVICE_LEVEL_CONTROLLER: WARNING
 DatabaseLogEvent.GATE_CLOSED: WARNING
 DatabaseLogEvent.RESTARTED_DUE_TO_TIME_OUT: WARNING
 DatabaseLogEvent.EMPTY_NESTED_EXCEPTION: WARNING
-DatabaseLogEvent.DATABASE_ERROR: ERROR
 DatabaseLogEvent.BAD_ALLOC: ERROR
 DatabaseLogEvent.SCHEMA_FAILURE: ERROR
 DatabaseLogEvent.RUNTIME_ERROR: ERROR
 DatabaseLogEvent.FILESYSTEM_ERROR: ERROR
 DatabaseLogEvent.DISK_ERROR: ERROR
-DatabaseLogEvent.STACKTRACE: ERROR
 DatabaseLogEvent.BACKTRACE: ERROR
 DatabaseLogEvent.ABORTING_ON_SHARD: ERROR
 DatabaseLogEvent.SEGMENTATION: ERROR
@@ -42,6 +40,9 @@ DatabaseLogEvent.STOP: NORMAL
 DatabaseLogEvent.SUPPRESSED_MESSAGES: WARNING
 DatabaseLogEvent.stream_exception: ERROR
 DatabaseLogEvent.COMPACTION_STOPPED: NORMAL
+DatabaseLogEvent.RPC_CONNECTION: WARNING
+DatabaseLogEvent.DATABASE_ERROR: ERROR
+DatabaseLogEvent.STACKTRACE: ERROR
 IndexSpecialColumnErrorEvent: ERROR
 CassandraHarryEvent.failure: CRITICAL
 CassandraHarryEvent.error: ERROR

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -173,7 +173,12 @@ SYSTEM_ERROR_EVENTS = (
 )
 SYSTEM_ERROR_EVENTS_PATTERNS: List[Tuple[re.Pattern, LogEventProtocol]] = \
     [(re.compile(event.regex, re.IGNORECASE), event) for event in SYSTEM_ERROR_EVENTS]
-BACKTRACE_RE = re.compile(r'(?P<other_bt>/lib.*?\+0x[0-f]*$)|(?P<scylla_bt>0x[0-f]*$)', re.IGNORECASE)
+
+# BACKTRACE_RE should match those:
+# 2022-03-05T08:33:48+00:00 rolling-*-0-1 !    INFO |   /opt/scylladb/libreloc/libc.so.6+0x35a15
+# 2022-03-05T08:33:48+00:00 rolling-*-0-1 !    INFO |   0x2e8653d
+BACKTRACE_RE = re.compile(r'(?P<other_bt>/lib.*?\+0x[0-9a-f]*$)|'
+                          r'(?P<scylla_bt>0x[0-9a-f]*$)', re.IGNORECASE)
 
 
 class ScyllaHelpErrorEvent(SctEvent, abstract=True):

--- a/sdcm/sct_events/setup.py
+++ b/sdcm/sct_events/setup.py
@@ -65,7 +65,7 @@ def start_events_device(log_dir: Optional[Union[str, Path]] = None,
                                 regex='cdc - Could not update CDC description table with generation').publish()
     DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line='Rate-limit: supressed').publish()
     DbEventsFilter(db_event=DatabaseLogEvent.BACKTRACE, line='Rate-limit: suppressed').publish()
-
+    DbEventsFilter(db_event=DatabaseLogEvent.WARNING, line='abort_requested_exception').publish()
     atexit.register(stop_events_device, _registry=_registry)
 
 

--- a/sdcm/utils/syslogng.py
+++ b/sdcm/utils/syslogng.py
@@ -100,7 +100,7 @@ source s_network_tcp {{
 }};
 
 template default_template {{
-  template("${{ISODATE}} ${{HOST}} !$(padding $(uppercase ${{LEVEL}}) 8) | ${{MESSAGE}}\n");
+  template("${{R_ISODATE}} ${{HOST}} $(padding $(uppercase !${{LEVEL}}) 9) | ${{MSGHDR}}${{MESSAGE}}\n");
 }};
 
 destination d_local {{

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -184,9 +184,9 @@ class TestBaseNode(unittest.TestCase, EventsUtilsMixin):
             print(event_backtrace1)
             print(event_backtrace2)
 
-            assert event_backtrace1["type"] == "DATABASE_ERROR"
+            assert event_backtrace1["type"] == "BACKTRACE"
             assert event_backtrace1["raw_backtrace"]
-            assert event_backtrace2["type"] == "DATABASE_ERROR"
+            assert event_backtrace2["type"] == "BACKTRACE"
             assert event_backtrace2["raw_backtrace"]
 
     def test_gate_closed_ignored_exception_is_catched(self):
@@ -197,14 +197,14 @@ class TestBaseNode(unittest.TestCase, EventsUtilsMixin):
         with self.get_raw_events_log().open() as events_file:
             events = [json.loads(line) for line in events_file]
 
-            event_backtrace1, event_backtrace2 = events[-3], events[-2]
+            event_backtrace1, event_backtrace2 = events[-2], events[-1]
             print(event_backtrace1)
             print(event_backtrace2)
 
             assert event_backtrace1["type"] == "GATE_CLOSED"
             assert event_backtrace1["line_number"] == 1
-            assert event_backtrace2["type"] == "DATABASE_ERROR"
-            assert event_backtrace2["line_number"] == 2
+            assert event_backtrace2["type"] == "GATE_CLOSED"
+            assert event_backtrace2["line_number"] == 3
 
     def test_compaction_stopped_exception_is_catched(self):
         self.node.system_log = os.path.join(os.path.dirname(__file__), 'test_data', 'compaction_stopped_exception.log')

--- a/unit_tests/test_data/system.log
+++ b/unit_tests/test_data/system.log
@@ -1,608 +1,608 @@
-[10.0.73.70] [stdout] Apr 02 11:23:52 info   | Starting Scylla AMI Setup...
-[10.0.73.70] [stdout] Apr 02 11:24:10 info   | Waiting for cloud-init to finish...
-[10.0.73.70] [stdout] Apr 02 11:24:10 info   | [INFO] Started with user data set to:
-[10.0.73.70] [stdout] Apr 02 11:24:10 info   | [INFO] --clustername longevity-200gb-48h-vfy-tls-2019-1-db-cluster-927e1ec2 --totalnodes 4 --stop-services --bootstrap false
-[10.0.73.70] [stdout] Apr 02 11:24:10 info   | [INFO] Using user data:
-[10.0.73.70] [stdout] Apr 02 11:24:10 info   | [INFO] --clustername longevity-200gb-48h-vfy-tls-2019-1-db-cluster-927e1ec2 --totalnodes 4 --stop-services --bootstrap false
-[10.0.73.70] [stdout] Apr 02 11:24:10 info   | [INFO] Using instance type: i3.4xlarge
-[10.0.73.70] [stdout] Apr 02 11:24:10 info   | [INFO] meta-data:instance-type: i3.4xlarge
-[10.0.73.70] [stdout] Apr 02 11:24:10 info   | [INFO] meta-data:local-ipv4: 10.0.73.70
-[10.0.73.70] [stdout] Apr 02 11:24:10 info   | [INFO] meta-data:public-hostname: ec2-54-246-228-160.eu-west-1.compute.amazonaws.com
-[10.0.73.70] [stdout] Apr 02 11:24:10 info   | [INFO] meta-data:ami-launch-index: 2
-[10.0.73.70] [stdout] Apr 02 11:24:10 info   | [INFO] meta-data:reservation-id: r-0bebec5f01ea19254
-[10.0.73.70] [stdout] Apr 02 11:24:10 info   | [INFO] Using cluster name: longevity-200gb-48h-vfy-tls-2019-1-db-cluster-927e1ec2
-[10.0.73.70] [stdout] Apr 02 11:24:10 info   | [INFO] Using cluster size: 4
-[10.0.73.70] [stdout] Apr 02 11:24:10 info   | [INFO] Using seed indexes: [0, 4, 4]
-[10.0.73.70] [stdout] Apr 02 11:24:10 info   | [INFO] Reflector loop...
-[10.0.73.70] [stdout] Apr 02 11:24:10 info   | [INFO] 04/02/19-11:24:04 Reflector: Received 0 of 1 responses from: []
-[10.0.73.70] [stdout] Apr 02 11:24:10 info   | [INFO] 04/02/19-11:24:06 Reflector: Received 0 of 1 responses from: []
-[10.0.73.70] [stdout] Apr 02 11:24:10 info   | [INFO] 04/02/19-11:24:10 Reflector: Received 1 of 1 responses from: [u'10.0.222.111']
-[10.0.73.70] [stdout] Apr 02 11:24:10 info   | [INFO] scylla.yaml configured.
-[10.0.73.70] [stdout] Apr 02 11:24:13 info   | mdadm: Defaulting to version 1.2 metadata
-[10.0.73.70] [stdout] Apr 02 11:24:13 info   | mdadm: array /dev/md0 started.
-[10.0.73.70] [stdout] Apr 02 11:24:14 info   | meta-data=/dev/md0               isize=512    agcount=32, agsize=28989696 blks
-[10.0.73.70] [stdout] Apr 02 11:24:14 info   | =                       sectsz=512   attr=2, projid32bit=1
-[10.0.73.70] [stdout] Apr 02 11:24:14 info   | =                       crc=1        finobt=0, sparse=0
-[10.0.73.70] [stdout] Apr 02 11:24:14 info   | data     =                       bsize=4096   blocks=927668224, imaxpct=5
-[10.0.73.70] [stdout] Apr 02 11:24:14 info   | =                       sunit=256    swidth=512 blks
-[10.0.73.70] [stdout] Apr 02 11:24:14 info   | naming   =version 2              bsize=4096   ascii-ci=0 ftype=1
-[10.0.73.70] [stdout] Apr 02 11:24:14 info   | log      =internal log           bsize=4096   blocks=452968, version=2
-[10.0.73.70] [stdout] Apr 02 11:24:14 info   | =                       sectsz=512   sunit=8 blks, lazy-count=1
-[10.0.73.70] [stdout] Apr 02 11:24:14 info   | realtime =none                   extsz=4096   blocks=0, rtextents=0
-[10.0.73.70] [stdout] Apr 02 11:24:14 info   | Creating RAID0 for scylla using 2 disk(s): /dev/nvme0n1,/dev/nvme1n1
-[10.0.73.70] [stdout] Apr 02 11:24:14 info   | [INFO] RAID Array containing ['nvme0n1', 'nvme1n1'] not found. Creating...
-[10.0.73.70] [stdout] Apr 02 11:24:16 info   | kernel.core_pattern = |/usr/lib/systemd/systemd-coredump %p %u %g %s %t %e"
-[10.0.73.70] [stdout] Apr 02 11:24:16 info   | Started Scylla AMI Setup.
-[10.0.73.70] [stdout] Apr 02 11:24:16 info   | Starting Scylla Server...
-[10.0.73.70] [stdout] Apr 02 11:24:16 notice | scylla-server.service: control process exited, code=exited status=1
-[10.0.73.70] [stdout] Apr 02 11:24:16 err    | Failed to start Scylla Server.
-[10.0.73.70] [stdout] Apr 02 11:24:16 warning| Dependency failed for Scylla JMX.
-[10.0.73.70] [stdout] Apr 02 11:24:16 notice | Job scylla-jmx.service/start failed with result 'dependency'.
-[10.0.73.70] [stdout] Apr 02 11:24:16 notice | Unit scylla-server.service entered failed state.
-[10.0.73.70] [stdout] Apr 02 11:24:16 warning| scylla-server.service failed.
-[10.0.73.70] [stdout] Apr 02 11:24:28 info   | Starting Scylla Server...
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Saving the original irqbalance configuration is in /etc/sysconfig/irqbalance.scylla.orig
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Restarting irqbalance: going to ban the following IRQ numbers: 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 215, 214, 218, 216, 212, 217, 211, 213 ...
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Restarting irqbalance via systemctl...
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | No non-NVMe disks to tune
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting NVMe disks: nvme0n1, nvme1n1...
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000001 in /proc/irq/147/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000001 in /proc/irq/148/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000100 in /proc/irq/149/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000100 in /proc/irq/150/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000002 in /proc/irq/151/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000002 in /proc/irq/152/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000200 in /proc/irq/153/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000200 in /proc/irq/154/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000004 in /proc/irq/155/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000004 in /proc/irq/156/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000400 in /proc/irq/157/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000400 in /proc/irq/158/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000008 in /proc/irq/159/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000008 in /proc/irq/160/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000800 in /proc/irq/161/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000800 in /proc/irq/162/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000010 in /proc/irq/178/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000010 in /proc/irq/179/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00001000 in /proc/irq/180/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00001000 in /proc/irq/181/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000020 in /proc/irq/182/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000020 in /proc/irq/183/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00002000 in /proc/irq/184/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00002000 in /proc/irq/185/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000040 in /proc/irq/186/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000040 in /proc/irq/187/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00004000 in /proc/irq/188/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00004000 in /proc/irq/189/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000080 in /proc/irq/190/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000080 in /proc/irq/191/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00008000 in /proc/irq/192/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00008000 in /proc/irq/193/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Writing 'none' to /sys/devices/pci0000:00/0000:00:1d.0/nvme/nvme0/nvme0n1/queue/scheduler
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Writing '2' to /sys/devices/pci0000:00/0000:00:1d.0/nvme/nvme0/nvme0n1/queue/nomerges
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Writing 'none' to /sys/devices/pci0000:00/0000:00:1e.0/nvme/nvme1/nvme1n1/queue/scheduler
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Writing '2' to /sys/devices/pci0000:00/0000:00:1e.0/nvme/nvme1/nvme1n1/queue/nomerges
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting a physical interface eth0...
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Distributing all IRQs
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000001 in /proc/irq/215/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000001 in /proc/irq/214/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000001 in /proc/irq/218/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000001 in /proc/irq/216/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000100 in /proc/irq/212/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000100 in /proc/irq/217/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000100 in /proc/irq/211/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000100 in /proc/irq/213/smp_affinity
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 0000fefe in /sys/class/net/eth0/queues/rx-7/rps_cpus
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 0000fefe in /sys/class/net/eth0/queues/rx-5/rps_cpus
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 0000fefe in /sys/class/net/eth0/queues/rx-3/rps_cpus
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 0000fefe in /sys/class/net/eth0/queues/rx-1/rps_cpus
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 0000fefe in /sys/class/net/eth0/queues/rx-6/rps_cpus
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 0000fefe in /sys/class/net/eth0/queues/rx-4/rps_cpus
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 0000fefe in /sys/class/net/eth0/queues/rx-2/rps_cpus
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 0000fefe in /sys/class/net/eth0/queues/rx-0/rps_cpus
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting net.core.rps_sock_flow_entries to 32768
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting limit 4096 in /sys/class/net/eth0/queues/rx-7/rps_flow_cnt
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting limit 4096 in /sys/class/net/eth0/queues/rx-5/rps_flow_cnt
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting limit 4096 in /sys/class/net/eth0/queues/rx-3/rps_flow_cnt
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting limit 4096 in /sys/class/net/eth0/queues/rx-1/rps_flow_cnt
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting limit 4096 in /sys/class/net/eth0/queues/rx-6/rps_flow_cnt
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting limit 4096 in /sys/class/net/eth0/queues/rx-4/rps_flow_cnt
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting limit 4096 in /sys/class/net/eth0/queues/rx-2/rps_flow_cnt
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting limit 4096 in /sys/class/net/eth0/queues/rx-0/rps_flow_cnt
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Trying to enable ntuple filtering HW offload for eth0...not supported
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000101 in /sys/class/net/eth0/queues/tx-6/xps_cpus
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000202 in /sys/class/net/eth0/queues/tx-4/xps_cpus
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000404 in /sys/class/net/eth0/queues/tx-2/xps_cpus
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00000808 in /sys/class/net/eth0/queues/tx-0/xps_cpus
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00001010 in /sys/class/net/eth0/queues/tx-7/xps_cpus
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00002020 in /sys/class/net/eth0/queues/tx-5/xps_cpus
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00004040 in /sys/class/net/eth0/queues/tx-3/xps_cpus
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Setting mask 00008080 in /sys/class/net/eth0/queues/tx-1/xps_cpus
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Writing '4096' to /proc/sys/net/core/somaxconn
-[10.0.73.70] [stdout] Apr 02 11:24:30 info   | Writing '4096' to /proc/sys/net/ipv4/tcp_max_syn_backlog
-[10.0.73.70] [stdout] Apr 02 11:24:31 info   | Scylla version 2019.1.0.rc0-0.20190322.682865806 starting ...
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] snitch_logger - Ec2Snitch using region: eu-west, zone: 1a.
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] init - Scylla API server listening on 127.0.0.1:10000 ...
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Row: max_vector_size: 32, internal_count: 5
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 1] database - Row: max_vector_size: 32, internal_count: 5
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 3] database - Row: max_vector_size: 32, internal_count: 5
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 2] database - Row: max_vector_size: 32, internal_count: 5
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 5] database - Row: max_vector_size: 32, internal_count: 5
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 6] database - Row: max_vector_size: 32, internal_count: 5
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 8] database - Row: max_vector_size: 32, internal_count: 5
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 10] database - Row: max_vector_size: 32, internal_count: 5
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 12] database - Row: max_vector_size: 32, internal_count: 5
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 11] database - Row: max_vector_size: 32, internal_count: 5
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 9] database - Row: max_vector_size: 32, internal_count: 5
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 13] database - Row: max_vector_size: 32, internal_count: 5
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 7] database - Row: max_vector_size: 32, internal_count: 5
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 4] database - Row: max_vector_size: 32, internal_count: 5
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Populating Keyspace system_schema
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system_schema: Reading CF view_virtual_columns id=08843b63-45dc-3be2-9798-a0418295cfaa version=ac302a39-2fb0-3def-bf61-d0f348567f1a
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system_schema: Reading CF aggregates id=924c5587-2e3a-345b-b10c-12f37c1ba895 version=9556aaa6-f8df-381c-997e-fc7aedc43e05
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system_schema: Reading CF functions id=96489b79-80be-3e14-a701-66a0b9159450 version=76a4e4f7-0adf-381b-9da4-1066ada12806
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system_schema: Reading CF tables id=afddfb9d-bc1e-3068-8056-eed6c302ba09 version=c179c1d7-9503-3f66-a5b3-70e72af3392a
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system_schema: Reading CF dropped_columns id=5e7583b5-f3f4-3af1-9a39-b7e1d6f5f11f version=d4e2a352-3e28-3297-b746-461236df0a1e
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system_schema: Reading CF views id=9786ac1c-dd58-3201-a7cd-ad556410c985 version=6e894071-2cfc-3ce6-96a2-c5c1d7a86996
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system_schema: Reading CF triggers id=4df70b66-6b05-3251-95a1-32b54005fd48 version=72ceb49d-cfce-330b-8dbf-613aa8b16cd9
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system_schema: Reading CF types id=5a8b1ca8-6602-3f77-a045-9273d308917a version=4a083362-11d8-3c56-bf3b-071c1996ed2e
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system_schema: Reading CF keyspaces id=abac5682-dea6-31c5-b535-b3d6cffd0fb6 version=546e75bd-58af-3eb4-8017-5f7c54bad49c
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system_schema: Reading CF indexes id=0feb57ac-311f-382f-ba6d-9024d305702f version=a7860a8c-d89c-30b0-98ba-279ae67fae1e
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system_schema: Reading CF scylla_tables id=5d912ff1-f759-3665-b2c8-8042ab5103dd version=d15e4b38-4294-3cf3-b7e2-5485bd5c9367
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system_schema: Reading CF columns id=24101c25-a2ae-3af7-87c1-b40ee1aca33f version=a4fe505b-053c-3486-9d6a-bd283d568c10
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Populating Keyspace system
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system: Reading CF schema_functions id=d1b675fe-2b50-3ca4-8e49-c0f81989dcad version=e460c9b9-f16f-3fdb-b8c7-9726bf8bbd39
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system: Reading CF schema_usertypes id=3aa75225-4f82-350b-8d5c-430fa221fa0a version=e13d0c09-4360-3fdb-82e3-ce15a5d16646
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system: Reading CF schema_triggers id=0359bc71-7123-3ee1-9a4a-b9dfb11fc125 version=599a9774-a0ce-3c13-805c-4c41d6042e8b
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system: Reading CF schema_columns id=296e9c04-9bec-3085-827d-c17d3df2122a version=7841736d-7d32-31e8-9e25-3e9d47b9fc25
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system: Reading CF schema_keyspaces id=b0f22357-4458-3cdb-9631-c43e59ce3676 version=d18195e9-634f-31a6-87f8-5691d87376fc
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system: Reading CF peers id=37f71aca-7dc2-383b-a706-72528af04d4f version=739aff7c-afc5-30e3-bb9a-aa0b340feedb
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system: Reading CF local id=7ad54392-bcdd-35a6-8417-4e047860b377 version=3e8e18ea-3208-3205-8b39-e62193f76ba8
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system: Reading CF built_views id=4b3c50a9-ea87-3d76-9101-6dbc9c38494a version=7cb318b7-eab5-3637-9ad9-b9d99af3ad37
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system: Reading CF paxos id=b7b7f0c2-fd0a-3410-8c05-3ef614bb7c2d version=8174219f-df55-3f99-9185-c4b1cab65807
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system: Reading CF batchlog id=0290003c-977e-397c-ac3e-fdfdc01d626b version=6bcb22aa-5faa-3b0f-bcfe-8b93fec16d40
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system: Reading CF size_estimates id=618f817b-005f-3678-b8a4-53f3930b8e86 version=9d8e68fd-b530-3e22-ad57-8921880ef2f4
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system: Reading CF IndexInfo id=9f5c6374-d485-3229-9a0a-5094af9ad1e3 version=6d26f9cd-5481-3415-bd86-d5fc853eaade
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system: Reading CF large_partitions id=8a7fe624-96b0-34b1-b90e-f71bddcdd2d3 version=bbae8dd5-345f-3da6-83b1-eb9b26df351e
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system: Reading CF schema_columnfamilies id=45f5b360-24bc-3f83-a363-1034ea4fa697 version=b57bc185-37ec-3429-a019-38c2e3fa61cf
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system: Reading CF views_builds_in_progress id=b7f2c108-78cd-3c80-9cd5-d609b2bd149c version=b3f8840c-04f3-3120-ae35-3c74d35052d1
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system: Reading CF range_xfers id=55d76438-4e55-3f8b-9f6e-676d4af3976d version=c28c4e27-fc89-3655-be9b-83549e67e569
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system: Reading CF compactions_in_progress id=55080ab0-5d9c-3886-90a4-acb25fe1f77b version=4f0ae080-a13e-334e-a6b4-ab9ad38db42b
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system: Reading CF schema_aggregates id=a5fc57fc-9d6c-3bfd-a3fc-01ad54686fea version=2b664525-a49c-3c59-bb0a-76508543e624
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system: Reading CF scylla_views_builds_in_progress id=a04c7bfd-1e13-36c9-a44d-f22da352281d version=a763e6ee-f0ac-39f6-8297-f5d9f82c9f4c
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system: Reading CF hints id=2666e205-73ef-38b3-90fe-fecf96e8f0c7 version=22906784-f0f7-39a1-8376-9b21c8112dee
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system: Reading CF compaction_history id=b4dbb7b4-dc49-3fb5-b3bf-ce6e434832ca version=b7ecaf8a-49da-3462-8d54-510a017926b7
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system: Reading CF peer_events id=59dfeaea-8db2-3341-91ef-109974d81484 version=41ae6768-c385-316c-acc9-b5b749b3d85e
-[10.0.73.70] [stdout] Apr 02 11:24:32 info   |  [shard 0] database - Keyspace system: Reading CF sstable_activity id=5a1ff267-ace0-3f12-8563-cfae6103c65e version=d69820df-9d03-3cd0-91b0-c078c030b708
-[10.0.73.70] [stdout] Apr 02 11:24:33 info   | Reactor stalled for 500 ms on shard 0.
-[10.0.73.70] [stdout] Apr 02 11:24:33 info   | Backtrace:
-[10.0.73.70] [stdout] Apr 02 11:24:33 info   | 0x00000000006c5af2
-[10.0.73.70] [stdout] Apr 02 11:24:33 info   | 0x00000000005d41ac
-[10.0.73.70] [stdout] Apr 02 11:24:33 info   | 0x00000000005d4666
-[10.0.73.70] [stdout] Apr 02 11:24:33 info   | /lib64/libpthread.so.0+0x000000000000f5cf
-[10.0.73.70] [stdout] Apr 02 11:24:33 info   | /lib64/libgmp.so.10+0x000000000002e9e1
-[10.0.73.70] [stdout] Apr 02 11:24:33 info   | Reactor stalled for 1000 ms on shard 0.
-[10.0.73.70] [stdout] Apr 02 11:24:33 info   | Backtrace:
-[10.0.73.70] [stdout] Apr 02 11:24:33 info   | 0x00000000006c5af2
-[10.0.73.70] [stdout] Apr 02 11:24:33 info   | 0x00000000005d41ac
-[10.0.73.70] [stdout] Apr 02 11:24:33 info   | 0x00000000005d4666
-[10.0.73.70] [stdout] Apr 02 11:24:33 info   | /lib64/libpthread.so.0+0x000000000000f5cf
-[10.0.73.70] [stdout] Apr 02 11:24:33 info   | /lib64/libgmp.so.10+0x000000000002e1ef
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | Reactor stalled for 500 ms on shard 4.
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | Backtrace:
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000006c5af2
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000005d41ac
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000005d4666
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libpthread.so.0+0x000000000000f5cf
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libgmp.so.10+0x0000000000056104
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | Reactor stalled for 500 ms on shard 2.
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | Backtrace:
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000006c5af2
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000005d41ac
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000005d4666
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libpthread.so.0+0x000000000000f5cf
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libgmp.so.10+0x00000000000560e2
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | Reactor stalled for 500 ms on shard 3.
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | Backtrace:
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000006c5af2
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000005d41ac
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000005d4666
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libpthread.so.0+0x000000000000f5cf
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libgmp.so.10+0x0000000000056155
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | Reactor stalled for 500 ms on shard 6.
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | Backtrace:
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000006c5af2
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000005d41ac
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000005d4666
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libpthread.so.0+0x000000000000f5cf
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libgmp.so.10+0x0000000000056104
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | Reactor stalled for 500 ms on shard 8.
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | Backtrace:
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000006c5af2
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000005d41ac
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000005d4666
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libpthread.so.0+0x000000000000f5cf
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libgmp.so.10+0x000000000005612a
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | Reactor stalled for 500 ms on shard 9.
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | Backtrace:
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000006c5af2
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000005d41ac
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000005d4666
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libpthread.so.0+0x000000000000f5cf
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libgmp.so.10+0x000000000002e207
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | Reactor stalled for 500 ms on shard 11.
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | Backtrace:
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000006c5af2
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000005d41ac
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000005d4666
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libpthread.so.0+0x000000000000f5cf
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libgmp.so.10+0x0000000000056117
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | Reactor stalled for 500 ms on shard 1.
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | Backtrace:
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000006c5af2
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000005d41ac
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000005d4666
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libpthread.so.0+0x000000000000f5cf
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libgmp.so.10+0x00000000000209cf
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libgmp.so.10+0x0000000000020d10
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libhogweed.so.2+0x0000000000008994
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libhogweed.so.2+0x000000000000b9f7
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libgnutls.so.28+0x00000000000eb9cc
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libgnutls.so.28+0x0000000000038500
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x0000000000a56227
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000031cef6f
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x0000000003ab9f42
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x0000000003abb2a9
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000005b1994
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000005d6538
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000006d3e65
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000005b0314
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x000000000068795e
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x000000000068c1fa
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x000000000077535d
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libpthread.so.0+0x0000000000007dd4
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libc.so.6+0x00000000000fdeac
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | Reactor stalled for 500 ms on shard 7.
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | Backtrace:
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000006c5af2
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000005d41ac
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000005d4666
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libpthread.so.0+0x000000000000f5cf
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libnettle.so.4+0x0000000000006a63
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libnettle.so.4+0x000000000001fc4e
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libnettle.so.4+0x000000000002002d
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libgnutls.so.28+0x00000000000f2664
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libgnutls.so.28+0x00000000000eb76c
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libhogweed.so.2+0x0000000000008559
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libhogweed.so.2+0x00000000000085e3
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libhogweed.so.2+0x0000000000008931
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libhogweed.so.2+0x000000000000b9f7
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libgnutls.so.28+0x00000000000eb9cc
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libgnutls.so.28+0x0000000000038500
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x0000000000a56227
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000031cef6f
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x0000000003ab9f42
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x0000000003abb2a9
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000005b1994
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000005d6538
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000006d3e65
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000005b0314
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x000000000068795e
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x000000000068c1fa
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x000000000077535d
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libpthread.so.0+0x0000000000007dd4
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libc.so.6+0x00000000000fdeac
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | Reactor stalled for 500 ms on shard 13.
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | Backtrace:
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000006c5af2
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000005d41ac
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | 0x00000000005d4666
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libpthread.so.0+0x000000000000f5cf
-[10.0.73.70] [stdout] Apr 02 11:24:34 info   | /lib64/libgmp.so.10+0x000000000002e946
-[10.0.73.70] [stdout] Apr 02 11:24:35 info   | Reactor stalled for 1000 ms on shard 3.
-[10.0.73.70] [stdout] Apr 02 11:24:35 info   | Backtrace:
-[10.0.73.70] [stdout] Apr 02 11:24:35 info   | 0x00000000006c5af2
-[10.0.73.70] [stdout] Apr 02 11:24:35 info   | 0x00000000005d41ac
-[10.0.73.70] [stdout] Apr 02 11:24:35 info   | 0x00000000005d4666
-[10.0.73.70] [stdout] Apr 02 11:24:35 info   | /lib64/libpthread.so.0+0x000000000000f5cf
-[10.0.73.70] [stdout] Apr 02 11:24:35 info   | /lib64/libgmp.so.10+0x000000000002e9c5
-[10.0.73.70] [stdout] Apr 02 11:24:35 info   | Reactor stalled for 1000 ms on shard 4.
-[10.0.73.70] [stdout] Apr 02 11:24:35 info   | Backtrace:
-[10.0.73.70] [stdout] Apr 02 11:24:35 info   | 0x00000000006c5af2
-[10.0.73.70] [stdout] Apr 02 11:24:35 info   | 0x00000000005d41ac
-[10.0.73.70] [stdout] Apr 02 11:24:35 info   | 0x00000000005d4666
-[10.0.73.70] [stdout] Apr 02 11:24:35 info   | /lib64/libpthread.so.0+0x000000000000f5cf
-[10.0.73.70] [stdout] Apr 02 11:24:35 info   | /lib64/libgmp.so.10+0x000000000002e8c5
-[10.0.73.70] [stdout] Apr 02 11:24:35 info   |  [shard 0] legacy_schema_migrator - Moving 0 keyspaces from legacy schema tables to the new schema keyspace (system_schema)
-[10.0.73.70] [stdout] Apr 02 11:24:35 info   |  [shard 0] legacy_schema_migrator - Dropping legacy schema tables
-[10.0.73.70] [stdout] Apr 02 11:24:35 info   |  [shard 0] legacy_schema_migrator - Completed migration of legacy schema tables
-[10.0.73.70] [stdout] Apr 02 11:24:35 info   |  [shard 4] compaction - Compacting [/var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/system-local-ka-32-Data.db:level=0, /var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/system-local-ka-18-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:35 info   | Started Scylla Server.
-[10.0.73.70] [stdout] Apr 02 11:24:35 info   |  [shard 0] storage_service - Loading persisted ring state
-[10.0.73.70] [stdout] Apr 02 11:24:35 info   |  [shard 0] storage_service - load_peer_features: peer_features size=0
-[10.0.73.70] [stdout] Apr 02 11:24:35 info   |  [shard 0] storage_service - Checking remote features with gossip
-[10.0.73.70] [stdout] Apr 02 11:24:35 info   |  [shard 0] messaging_service - Starting Encrypted Messaging Service on SSL port 7001
-[10.0.73.70] [stdout] Apr 02 11:24:35 info   |  [shard 0] messaging_service - Starting Messaging Service on port 7000
-[10.0.73.70] [stdout] Apr 02 11:24:35 info   |  [shard 4] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/system-local-ka-46-Data.db:level=0, ]. 10065 bytes to 5360 (~53% of original) in 7ms = 0.73MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:35 info   | Started Scylla JMX.
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   | Using config file: /etc/scylla/scylla.yaml
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 0] gossip - Feature check passed. Local node 10.0.73.70 features = {CORRECT_COUNTER_ORDER, CORRECT_NON_COMPOUND_RANGE_TOMBSTONES, COUNTERS, DIGEST_MULTIPARTITION_READ, INDEXES, LARGE_PARTITIONS, LA_SSTABLE_FORMAT, MATERIALIZED_VIEWS, RANGE_TOMBSTONES, ROLES, SCHEMA_TABLES_V3, STREAM_WITH_RPC_STREAM, WRITE_FAILURE_REPLY, XXHASH}, Remote common_features = {CORRECT_COUNTER_ORDER, CORRECT_NON_COMPOUND_RANGE_TOMBSTONES, COUNTERS, DIGEST_MULTIPARTITION_READ, INDEXES, LARGE_PARTITIONS, LA_SSTABLE_FORMAT, MATERIALIZED_VIEWS, RANGE_TOMBSTONES, ROLES, SCHEMA_TABLES_V3, STREAM_WITH_RPC_STREAM, WRITE_FAILURE_REPLY, XXHASH}
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 4] compaction - Compacting [/var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/system-local-ka-46-Data.db:level=0, /var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/system-local-ka-60-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 0] storage_service - Starting up server gossip
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 4] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/system-local-ka-74-Data.db:level=0, ]. 10917 bytes to 6116 (~56% of original) in 9ms = 0.65MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 4] compaction - Compacting [/var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/system-local-ka-88-Data.db:level=0, /var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/system-local-ka-74-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 4] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/system-local-ka-102-Data.db:level=0, ]. 10956 bytes to 6147 (~56% of original) in 9ms = 0.65MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 0] database - Schema version changed to 59adb24e-f3cd-3e02-97f0-5b395827453f
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 0] gossip - Feature RANGE_TOMBSTONES is enabled
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 0] gossip - Feature LARGE_PARTITIONS is enabled
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 0] gossip - Feature COUNTERS is enabled
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 0] gossip - Feature DIGEST_MULTIPARTITION_READ is enabled
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 0] gossip - Feature CORRECT_COUNTER_ORDER is enabled
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 0] gossip - Feature SCHEMA_TABLES_V3 is enabled
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 0] gossip - Feature CORRECT_NON_COMPOUND_RANGE_TOMBSTONES is enabled
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 0] gossip - Feature WRITE_FAILURE_REPLY is enabled
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 0] gossip - Feature XXHASH is enabled
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 0] gossip - Feature ROLES is enabled
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 0] gossip - Feature LA_SSTABLE_FORMAT is enabled
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 0] gossip - Feature STREAM_WITH_RPC_STREAM is enabled
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 0] gossip - Feature MATERIALIZED_VIEWS is enabled
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 0] gossip - Feature INDEXES is enabled
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 0] migration_manager - Create new Keyspace: KSMetaData{name=system_distributed, strategyClass=org.apache.cassandra.locator.SimpleStrategy, strategyOptions={replication_factor=3}, cfMetaData={}, durable_writes=1, userTypes=org.apache.cassandra.config.UTMetaData@0x6000092430c8}
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 0] schema_tables - Creating keyspace system_distributed
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 0] database - Schema version changed to f399fd51-3145-3257-9810-0fa435c7075f
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 0] migration_manager - Create new ColumnFamily: org.apache.cassandra.config.CFMetaData@0x600000c7f180[cfId=5582b59f-8e4e-35e1-b913-3acada51eb04,ksName=system_distributed,cfName=view_build_status,cfType=Standard,comparator=org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UUIDType,org.apache.cassandra.db.marshal.UTF8Type),comment=,readRepairChance=0,dcLocalReadRepairChance=0.1,gcGraceSeconds=864000,keyValidator=org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UTF8Type, org.apache.cassandra.db.marshal.UTF8Type),minCompactionThreshold=4,maxCompactionThreshold=32,columnMetadata=[ColumnDefinition{name=keyspace_name, type=org.apache.cassandra.db.marshal.UTF8Type, kind=PARTITION_KEY, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=view_name, type=org.apache.cassandra.db.marshal.UTF8Type, kind=PARTITION_KEY, componentIndex=1, droppedAt=-9223372036854775808}, ColumnDefinition{name=host_id, type=org.apache.cassandra.db.marshal.UUIDType, kind=CLUSTERING_COLUMN, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=status, type=org.apache.cassandra.db.marshal.UTF8Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}],compactionStrategyClass=class org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy,compactionStrategyOptions={enabled=true},compressionParameters={sstable_compression=org.apache.cassandra.io.compress.LZ4Compressor},bloomFilterFpChance=0.01,memtableFlushPeriod=0,caching={"keys":"ALL","rows_per_partition":"ALL"},defaultTimeToLive=0,minIndexInterval=128,maxIndexInterval=2048,speculativeRetry=99.0PERCENTILE,triggers=[],isDense=false,in_memory=false,version=01314a30-dc37-368a-b4af-5591330ffc4c,droppedColumns={},collections={},indices={}]
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 11] compaction - Compacting [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-39-big-Data.db:level=0, /var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-25-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 0] schema_tables - Creating system_distributed.view_build_status id=5582b59f-8e4e-35e1-b913-3acada51eb04 version=807957b8-87c8-3b33-a70a-a799ed3bd7c6
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 11] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-53-big-Data.db:level=0, ]. 9986 bytes to 5321 (~53% of original) in 8ms = 0.63MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 0] database - Schema version changed to 40a644cc-c9f3-3fa5-bc5a-8f3f05d339aa
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 0] migration_manager - Create new ColumnFamily: org.apache.cassandra.config.CFMetaData@0x600000c7ee00[cfId=b8c556bd-212d-37ad-9484-690c73a5994b,ksName=system_distributed,cfName=service_levels,cfType=Standard,comparator=org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UTF8Type),comment=,readRepairChance=0,dcLocalReadRepairChance=0.1,gcGraceSeconds=864000,keyValidator=org.apache.cassandra.db.marshal.UTF8Type,minCompactionThreshold=4,maxCompactionThreshold=32,columnMetadata=[ColumnDefinition{name=service_level, type=org.apache.cassandra.db.marshal.UTF8Type, kind=PARTITION_KEY, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=shares, type=org.apache.cassandra.db.marshal.Int32Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}],compactionStrategyClass=class org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy,compactionStrategyOptions={enabled=true},compressionParameters={sstable_compression=org.apache.cassandra.io.compress.LZ4Compressor},bloomFilterFpChance=0.01,memtableFlushPeriod=0,caching={"keys":"ALL","rows_per_partition":"ALL"},defaultTimeToLive=0,minIndexInterval=128,maxIndexInterval=2048,speculativeRetry=99.0PERCENTILE,triggers=[],isDense=false,in_memory=false,version=d51c448b-da4e-3a49-b723-8e47aa751127,droppedColumns={},collections={},indices={}]
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 11] compaction - Compacting [/var/lib/scylla/data/system_schema/indexes-0feb57ac311f382fba6d9024d305702f/la-39-big-Data.db:level=0, /var/lib/scylla/data/system_schema/indexes-0feb57ac311f382fba6d9024d305702f/la-25-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 11] compaction - Compacted 2 sstables to []. 9732 bytes to 0 (~0% of original) in 1ms = 0.00MB/s. ~256 total partitions merged to 0.
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 11] compaction - Compacting [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-39-big-Data.db:level=0, /var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-25-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 11] compaction - Compacting [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-39-big-Data.db:level=0, /var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-25-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 11] compaction - Compacting [/var/lib/scylla/data/system_schema/dropped_columns-5e7583b5f3f43af19a39b7e1d6f5f11f/la-39-big-Data.db:level=0, /var/lib/scylla/data/system_schema/dropped_columns-5e7583b5f3f43af19a39b7e1d6f5f11f/la-25-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 11] compaction - Compacted 2 sstables to []. 9732 bytes to 0 (~0% of original) in 0ms = 0.00MB/s. ~256 total partitions merged to 0.
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 11] compaction - Compacting [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-67-big-Data.db:level=0, /var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-53-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 11] compaction - Compacting [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-39-big-Data.db:level=0, /var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-25-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 0] schema_tables - Creating system_distributed.service_levels id=b8c556bd-212d-37ad-9484-690c73a5994b version=51884e0d-dc57-3119-a9a8-69d36ba653f3
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 11] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-53-big-Data.db:level=0, ]. 10423 bytes to 5747 (~55% of original) in 23ms = 0.24MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 11] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-53-big-Data.db:level=0, ]. 9974 bytes to 5356 (~53% of original) in 22ms = 0.23MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 11] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-81-big-Data.db:level=0, ]. 10314 bytes to 5321 (~51% of original) in 21ms = 0.24MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:36 info   |  [shard 11] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-53-big-Data.db:level=0, ]. 11001 bytes to 6011 (~54% of original) in 18ms = 0.32MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] database - Schema version changed to 3798c40d-12d3-3719-83e5-c9ed6309fb8c
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] storage_service - Generated random tokens. tokens are {-3560647200451113119, 7346892362217386362, 3424040786029357713, 3577356542844624529, 2085349109937340256, 6784588099063851934, 4155968460579151469, 710908380352128559, -6631664840906127839, 919320017947858935, -442301061652096487, -1309150464435941097, 7651083484250468623, 7050026059284859731, 706942788835379851, 2572923548507576610, -5771676787970073305, 7520114486152970266, -7417875618854868303, -8205083285841462668, 1776767981577948379, -3409393591683476266, -4400851521427719583, 8635937141426200912, -3867786308026236902, 4975279073184617789, -6538562898688735762, -653086548396224770, 6386203322893004674, -1551815588964285711, 5024597484103495298, 620219410446387143, -8123133880417308229, 2771972114192661924, -6991924657129948978, 2230732564871356837, -3809657211705769962, -6595424233149210099, 627632899840663949, 5965834208770872659, 4501696491279204729, -6954475764685584923, -109865962119416336, -5932408933305228477, 2213020225948988895, 8723597742700444563, -7086977539084012413, -2222895300622402028, 5196741466174102399, 5568120702586658657, -3033824418676813684, -517547808921986156, -8722525328218890210, 7087445191667946112, -1610994183788720952, -7741279473951933658, 7076281582362389612, 879734534352661672, -451064240048664652, 2320504833406176178, 7492321640516069057, 7599429348758735316, 4295022056995025915, -1564183286741420170, 2018026179774427825, -6766709827076179081, 9049684491588615408, 5926142249955698397, 3361801238549051338, -8580666733283636341, 3769268861443915337, 4248655417661471761, 5476775636932468075, 2262321001594146368, -1409949059014858007, -945002596494227721, 2351089910672263725, 5207012711731370673, -6217700513740443582, 5471743538708180112, 3971961404682890367, 1383479425847432015, -7456825837456027306, 5899053900432439262, -2153873736256057109, -3207395511436043700, -704093014931303289, -1589313027803907090, 3987750571049477853, 4433479204487566882, 7420338445389804254, 6495518075333865712, -3754347742677734669, 5105426527803766954, 5656594304582466272, 8267221159913090653, -4204266718587515639, -8503643953746504417, 4156231114917073346, -6465178824591881439, 964064776891688080, 6650708804057262205, 2511063316179817690, 4211815607885622990, 5289985802704048353, 2009541059736530906, 8626370565930111405, -6244470818446579805, 240014780401622051, -518376864356919942, -1700287997812580093, -3847022136882421717, -1411686373996433125, -7758236549849950606, 6980983170239016522, 5668146686632565239, 2542513791031005142, -4491507675379055512, 7350578643382699725, -6851924758196891499, -4330388440939713025, -2429442216329648090, 7796603522360813263, 7282824016236190263, 1296109052816909955, 3534472511438420312, -7701048181135457099, -8425727324390787597, -1686052122818749249, -4683272235209677656, -1488089249610267098, 1465087183277001425, 5085675779303776511, -5279490929334304870, 5481846942072543265, -6544396373214618794, -3419909139039795079, 3535764490661021396, -8978427261137769231, -6457762753902060127, -1149142943736173968, 8621612207441066899, -5326459053479771594, -5481882644267305495, -6804207364700821298, -3982551195424618207, -8896827503147370440, -2767439483770981065, -4882128331166646039, 1347671185094235836, -5627894917399000430, -2227078912827657461, -3561495460982598084, 8484272930571916847, 1758560027468483508, -966490361473230315, 5231801075384312836, 4159340253188108894, -751736802849330109, -940763364027222782, -9101184945505144975, -4541704630880806192, -7154902475901447493, 8475057228732358457, -3706204160536746188, -2816499595482872187, 2830735137614401711, 8829729804979754803, -8304011862795811778, -2543391719280979407, 7788535925803506769, -1986895622360489406, -6671493591205157295, 2918157306208349678, -1391207249177763248, 7803620703431458025, -1197714370244946798, -5467516398815973927, -3903890802909442596, -1704020729412708652, 3832351096692031142, -8950875472426717272, 8106860789856375647, 6377763689062202748, 6809012474274996509, -2147571692163799036, -7132360754207552976, 7882663737577365982,
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 4] compaction - Compacting [/var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/la-116-big-Data.db:level=0, /var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/system-local-ka-102-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 4] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/la-144-big-Data.db:level=0, ]. 11033 bytes to 6175 (~55% of original) in 10ms = 0.59MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 4] compaction - Compacting [/var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/la-144-big-Data.db:level=0, /var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/la-130-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] storage_service - Node 10.0.73.70 state jump to normal
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 4] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/la-158-big-Data.db:level=0, ]. 16619 bytes to 11914 (~71% of original) in 7ms = 1.62MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] storage_service - NORMAL: node is now in normal status
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] migration_manager - Create new Keyspace: KSMetaData{name=system_auth, strategyClass=org.apache.cassandra.locator.SimpleStrategy, strategyOptions={replication_factor=1}, cfMetaData={}, durable_writes=1, userTypes=org.apache.cassandra.config.UTMetaData@0x600000f953c8}
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] schema_tables - Creating keyspace system_auth
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] database - Schema version changed to a02e3a85-cb2a-38ba-8df1-4756faa2b96f
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] migration_manager - Create new ColumnFamily: org.apache.cassandra.config.CFMetaData@0x600000c7f880[cfId=6b8c7359-a843-33f2-a1d8-5dc6a187436f,ksName=system_auth,cfName=role_attributes,cfType=Standard,comparator=org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type),comment=,readRepairChance=0,dcLocalReadRepairChance=0.1,gcGraceSeconds=864000,keyValidator=org.apache.cassandra.db.marshal.UTF8Type,minCompactionThreshold=4,maxCompactionThreshold=32,columnMetadata=[ColumnDefinition{name=role, type=org.apache.cassandra.db.marshal.UTF8Type, kind=PARTITION_KEY, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=name, type=org.apache.cassandra.db.marshal.UTF8Type, kind=CLUSTERING_COLUMN, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=value, type=org.apache.cassandra.db.marshal.UTF8Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}],compactionStrategyClass=class org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy,compactionStrategyOptions={enabled=true},compressionParameters={sstable_compression=org.apache.cassandra.io.compress.LZ4Compressor},bloomFilterFpChance=0.01,memtableFlushPeriod=0,caching={"keys":"ALL","rows_per_partition":"ALL"},defaultTimeToLive=0,minIndexInterval=128,maxIndexInterval=2048,speculativeRetry=99.0PERCENTILE,triggers=[],isDense=false,in_memory=false,version=e5f33952-5539-11e9-8c0b-000000000002,droppedColumns={},collections={},indices={}]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] migration_manager - Create new ColumnFamily: org.apache.cassandra.config.CFMetaData@0x600000c7f880[cfId=0ecdaa87-f8fb-3e60-88d1-74fb36fe5c0d,ksName=system_auth,cfName=role_members,cfType=Standard,comparator=org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type),comment=,readRepairChance=0,dcLocalReadRepairChance=0.1,gcGraceSeconds=864000,keyValidator=org.apache.cassandra.db.marshal.UTF8Type,minCompactionThreshold=4,maxCompactionThreshold=32,columnMetadata=[ColumnDefinition{name=role, type=org.apache.cassandra.db.marshal.UTF8Type, kind=PARTITION_KEY, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=member, type=org.apache.cassandra.db.marshal.UTF8Type, kind=CLUSTERING_COLUMN, componentIndex=0, droppedAt=-9223372036854775808}],compactionStrategyClass=class org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy,compactionStrategyOptions={enabled=true},compressionParameters={sstable_compression=org.apache.cassandra.io.compress.LZ4Compressor},bloomFilterFpChance=0.01,memtableFlushPeriod=0,caching={"keys":"ALL","rows_per_partition":"ALL"},defaultTimeToLive=0,minIndexInterval=128,maxIndexInterval=2048,speculativeRetry=99.0PERCENTILE,triggers=[],isDense=false,in_memory=false,version=e5f36062-5539-11e9-8c0b-000000000002,droppedColumns={},collections={},indices={}]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] migration_manager - Create new ColumnFamily: org.apache.cassandra.config.CFMetaData@0x600000c7d500[cfId=5bc52802-de25-35ed-aeab-188eecebb090,ksName=system_auth,cfName=roles,cfType=Standard,comparator=org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.ColumnToCollectionType(6d656d6265725f6f66:org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.UTF8Type))),comment=,readRepairChance=0,dcLocalReadRepairChance=0.1,gcGraceSeconds=864000,keyValidator=org.apache.cassandra.db.marshal.UTF8Type,minCompactionThreshold=4,maxCompactionThreshold=32,columnMetadata=[ColumnDefinition{name=role, type=org.apache.cassandra.db.marshal.UTF8Type, kind=PARTITION_KEY, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=can_login, type=org.apache.cassandra.db.marshal.BooleanType, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=is_superuser, type=org.apache.cassandra.db.marshal.BooleanType, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=member_of, type=org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.UTF8Type), kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=salted_hash, type=org.apache.cassandra.db.marshal.UTF8Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}],compactionStrategyClass=class org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy,compactionStrategyOptions={enabled=true},compressionParameters={sstable_compression=org.apache.cassandra.io.compress.LZ4Compressor},bloomFilterFpChance=0.01,memtableFlushPeriod=0,caching={"keys":"ALL","rows_per_partition":"ALL"},defaultTimeToLive=0,minIndexInterval=128,maxIndexInterval=2048,speculativeRetry=99.0PERCENTILE,triggers=[],isDense=false,in_memory=false,version=e5f36065-5539-11e9-8c0b-000000000002,droppedColumns={},collections={6d656d6265725f6f66 : org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.UTF8Type)},indices={}]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-38-big-Data.db:level=0, /var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-24-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] schema_tables - Creating system_auth.role_attributes id=6b8c7359-a843-33f2-a1d8-5dc6a187436f version=3f51f745-b2d7-3e66-a14b-208004117c9d
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 10] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-52-big-Data.db:level=0, ]. 9916 bytes to 5286 (~53% of original) in 6ms = 0.84MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] database - Schema version changed to 41c3606c-39ac-3e18-b994-5260e44f2e5d
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/indexes-0feb57ac311f382fba6d9024d305702f/la-38-big-Data.db:level=0, /var/lib/scylla/data/system_schema/indexes-0feb57ac311f382fba6d9024d305702f/la-24-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-38-big-Data.db:level=0, /var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-24-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 10] compaction - Compacted 2 sstables to []. 9664 bytes to 0 (~0% of original) in 0ms = 0.00MB/s. ~256 total partitions merged to 0.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-38-big-Data.db:level=0, /var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-24-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/dropped_columns-5e7583b5f3f43af19a39b7e1d6f5f11f/la-38-big-Data.db:level=0, /var/lib/scylla/data/system_schema/dropped_columns-5e7583b5f3f43af19a39b7e1d6f5f11f/la-24-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 10] compaction - Compacted 2 sstables to []. 9664 bytes to 0 (~0% of original) in 0ms = 0.00MB/s. ~256 total partitions merged to 0.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-66-big-Data.db:level=0, /var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-52-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-38-big-Data.db:level=0, /var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-24-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] schema_tables - Creating system_auth.role_members id=0ecdaa87-f8fb-3e60-88d1-74fb36fe5c0d version=2e5e813e-a37d-3e6b-b6f6-682bd899df62
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 10] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-52-big-Data.db:level=0, ]. 10251 bytes to 5630 (~54% of original) in 22ms = 0.24MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 10] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-52-big-Data.db:level=0, ]. 9899 bytes to 5319 (~53% of original) in 21ms = 0.24MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 10] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-80-big-Data.db:level=0, ]. 10244 bytes to 5286 (~51% of original) in 18ms = 0.28MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 10] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-52-big-Data.db:level=0, ]. 10938 bytes to 6068 (~55% of original) in 17ms = 0.34MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] database - Schema version changed to 63be0f27-fab2-3b99-8954-d539f0a20862
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-66-big-Data.db:level=0, /var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-52-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-66-big-Data.db:level=0, /var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-52-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-94-big-Data.db:level=0, /var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-80-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-66-big-Data.db:level=0, /var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-52-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] schema_tables - Creating system_auth.roles id=5bc52802-de25-35ed-aeab-188eecebb090 version=ad082e9b-e0ba-379a-91f4-91c26e1bea18
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 10] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-80-big-Data.db:level=0, ]. 10913 bytes to 5963 (~54% of original) in 20ms = 0.28MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 10] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-80-big-Data.db:level=0, ]. 10243 bytes to 5339 (~52% of original) in 19ms = 0.27MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 10] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-108-big-Data.db:level=0, ]. 10244 bytes to 5286 (~51% of original) in 16ms = 0.32MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 10] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-80-big-Data.db:level=0, ]. 11502 bytes to 6302 (~54% of original) in 19ms = 0.32MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] database - Schema version changed to 75706ed0-55c3-315c-aa71-22827ac6c420
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] migration_manager - Create new Keyspace: KSMetaData{name=system_traces, strategyClass=org.apache.cassandra.locator.SimpleStrategy, strategyOptions={replication_factor=2}, cfMetaData={}, durable_writes=1, userTypes=org.apache.cassandra.config.UTMetaData@0x600000f955c8}
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] schema_tables - Creating keyspace system_traces
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] database - Schema version changed to e09efa52-56d1-3bcf-af89-d5e71e1c1ce6
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] migration_manager - Create new ColumnFamily: org.apache.cassandra.config.CFMetaData@0x600000c7d880[cfId=c5e99f16-8677-3914-b17e-960613512345,ksName=system_traces,cfName=sessions,cfType=Standard,comparator=org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.ColumnToCollectionType(706172616d6574657273:org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type))),comment=,readRepairChance=0,dcLocalReadRepairChance=0.1,gcGraceSeconds=864000,keyValidator=org.apache.cassandra.db.marshal.UUIDType,minCompactionThreshold=4,maxCompactionThreshold=32,columnMetadata=[ColumnDefinition{name=session_id, type=org.apache.cassandra.db.marshal.UUIDType, kind=PARTITION_KEY, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=client, type=org.apache.cassandra.db.marshal.InetAddressType, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=command, type=org.apache.cassandra.db.marshal.UTF8Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=coordinator, type=org.apache.cassandra.db.marshal.InetAddressType, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=duration, type=org.apache.cassandra.db.marshal.Int32Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=parameters, type=org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type), kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=request, type=org.apache.cassandra.db.marshal.UTF8Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=request_size, type=org.apache.cassandra.db.marshal.Int32Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=response_size, type=org.apache.cassandra.db.marshal.Int32Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=started_at, type=org.apache.cassandra.db.marshal.TimestampType, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}],compactionStrategyClass=class org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy,compactionStrategyOptions={enabled=true},compressionParameters={sstable_compression=org.apache.cassandra.io.compress.LZ4Compressor},bloomFilterFpChance=0.01,memtableFlushPeriod=0,caching={"keys":"ALL","rows_per_partition":"ALL"},defaultTimeToLive=86400,minIndexInterval=128,maxIndexInterval=2048,speculativeRetry=99.0PERCENTILE,triggers=[],isDense=false,in_memory=false,version=e61f7972-5539-11e9-8c0b-000000000002,droppedColumns={},collections={706172616d6574657273 : org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type)},indices={}]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-36-big-Data.db:level=0, /var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-22-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] schema_tables - Creating system_traces.sessions id=c5e99f16-8677-3914-b17e-960613512345 version=cea87552-239e-3a4c-85f0-c205caf56e64
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-50-big-Data.db:level=0, ]. 9934 bytes to 5295 (~53% of original) in 8ms = 0.63MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] database - Schema version changed to d2342792-25ef-313e-9a93-d7d93d1f07ed
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] migration_manager - Create new ColumnFamily: org.apache.cassandra.config.CFMetaData@0x600000c7e000[cfId=0ebf001c-c1d1-3693-9a63-c3d96ac53318,ksName=system_traces,cfName=sessions_time_idx,cfType=Standard,comparator=org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.TimestampType,org.apache.cassandra.db.marshal.UUIDType,org.apache.cassandra.db.marshal.UTF8Type),comment=,readRepairChance=0,dcLocalReadRepairChance=0.1,gcGraceSeconds=864000,keyValidator=org.apache.cassandra.db.marshal.TimestampType,minCompactionThreshold=4,maxCompactionThreshold=32,columnMetadata=[ColumnDefinition{name=minute, type=org.apache.cassandra.db.marshal.TimestampType, kind=PARTITION_KEY, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=started_at, type=org.apache.cassandra.db.marshal.TimestampType, kind=CLUSTERING_COLUMN, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=session_id, type=org.apache.cassandra.db.marshal.UUIDType, kind=CLUSTERING_COLUMN, componentIndex=1, droppedAt=-9223372036854775808}],compactionStrategyClass=class org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy,compactionStrategyOptions={enabled=true},compressionParameters={sstable_compression=org.apache.cassandra.io.compress.LZ4Compressor},bloomFilterFpChance=0.01,memtableFlushPeriod=0,caching={"keys":"ALL","rows_per_partition":"ALL"},defaultTimeToLive=86400,minIndexInterval=128,maxIndexInterval=2048,speculativeRetry=99.0PERCENTILE,triggers=[],isDense=false,in_memory=false,version=e62a75f2-5539-11e9-8c0b-000000000002,droppedColumns={},collections={},indices={}]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/indexes-0feb57ac311f382fba6d9024d305702f/la-36-big-Data.db:level=0, /var/lib/scylla/data/system_schema/indexes-0feb57ac311f382fba6d9024d305702f/la-22-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacted 2 sstables to []. 9684 bytes to 0 (~0% of original) in 0ms = 0.00MB/s. ~256 total partitions merged to 0.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-36-big-Data.db:level=0, /var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-22-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-22-big-Data.db:level=0, /var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-36-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/dropped_columns-5e7583b5f3f43af19a39b7e1d6f5f11f/la-36-big-Data.db:level=0, /var/lib/scylla/data/system_schema/dropped_columns-5e7583b5f3f43af19a39b7e1d6f5f11f/la-22-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacted 2 sstables to []. 9684 bytes to 0 (~0% of original) in 1ms = 0.00MB/s. ~256 total partitions merged to 0.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-64-big-Data.db:level=0, /var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-50-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-22-big-Data.db:level=0, /var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-36-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] schema_tables - Creating system_traces.sessions_time_idx id=0ebf001c-c1d1-3693-9a63-c3d96ac53318 version=cf8bb10b-1839-348f-8b46-5a2090c6a0ce
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-50-big-Data.db:level=0, ]. 10796 bytes to 6156 (~57% of original) in 22ms = 0.27MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-50-big-Data.db:level=0, ]. 9909 bytes to 5323 (~53% of original) in 23ms = 0.22MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-78-big-Data.db:level=0, ]. 10262 bytes to 5295 (~51% of original) in 20ms = 0.25MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-50-big-Data.db:level=0, ]. 10939 bytes to 6072 (~55% of original) in 17ms = 0.34MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] database - Schema version changed to c69604b3-9c2b-301e-b23c-65f9c56e202e
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] migration_manager - Create new ColumnFamily: org.apache.cassandra.config.CFMetaData@0x600000c7d880[cfId=8826e8e9-e16a-3728-8753-3bc1fc713c25,ksName=system_traces,cfName=events,cfType=Standard,comparator=org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.TimeUUIDType,org.apache.cassandra.db.marshal.UTF8Type),comment=,readRepairChance=0,dcLocalReadRepairChance=0.1,gcGraceSeconds=864000,keyValidator=org.apache.cassandra.db.marshal.UUIDType,minCompactionThreshold=4,maxCompactionThreshold=32,columnMetadata=[ColumnDefinition{name=session_id, type=org.apache.cassandra.db.marshal.UUIDType, kind=PARTITION_KEY, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=event_id, type=org.apache.cassandra.db.marshal.TimeUUIDType, kind=CLUSTERING_COLUMN, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=activity, type=org.apache.cassandra.db.marshal.UTF8Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=scylla_parent_id, type=org.apache.cassandra.db.marshal.LongType, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=scylla_span_id, type=org.apache.cassandra.db.marshal.LongType, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=source, type=org.apache.cassandra.db.marshal.InetAddressType, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=source_elapsed, type=org.apache.cassandra.db.marshal.Int32Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=thread, type=org.apache.cassandra.db.marshal.UTF8Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}],compactionStrategyClass=class org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy,compactionStrategyOptions={enabled=true},compressionParameters={sstable_compression=org.apache.cassandra.io.compress.LZ4Compressor},bloomFilterFpChance=0.01,memtableFlushPeriod=0,caching={"keys":"ALL","rows_per_partition":"ALL"},defaultTimeToLive=86400,minIndexInterval=128,maxIndexInterval=2048,speculativeRetry=99.0PERCENTILE,triggers=[],isDense=false,in_memory=false,version=e637e372-5539-11e9-8c0b-000000000002,droppedColumns={},collections={},indices={}]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-64-big-Data.db:level=0, /var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-50-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-64-big-Data.db:level=0, /var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-50-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-92-big-Data.db:level=0, /var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-78-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-64-big-Data.db:level=0, /var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-50-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] schema_tables - Creating system_traces.events id=8826e8e9-e16a-3728-8753-3bc1fc713c25 version=ea3f87ea-567a-3be3-acdd-4ab84080eb68
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-78-big-Data.db:level=0, ]. 11637 bytes to 6836 (~58% of original) in 19ms = 0.34MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-78-big-Data.db:level=0, ]. 10258 bytes to 5352 (~52% of original) in 17ms = 0.30MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-106-big-Data.db:level=0, ]. 10262 bytes to 5295 (~51% of original) in 19ms = 0.27MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-78-big-Data.db:level=0, ]. 11521 bytes to 6318 (~54% of original) in 17ms = 0.35MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] database - Schema version changed to 224c4382-4a57-339b-b55c-485a17017a34
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] migration_manager - Create new ColumnFamily: org.apache.cassandra.config.CFMetaData@0x600000c7e380[cfId=bfcc4e62-5b63-3aa1-a1c3-6f5e47f3325c,ksName=system_traces,cfName=node_slow_log,cfType=Standard,comparator=org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.InetAddressType,org.apache.cassandra.db.marshal.Int32Type,org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.ColumnToCollectionType(706172616d6574657273:org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type),7461626c655f6e616d6573:org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.UTF8Type))),comment=,readRepairChance=0,dcLocalReadRepairChance=0.1,gcGraceSeconds=864000,keyValidator=org.apache.cassandra.db.marshal.TimeUUIDType,minCompactionThreshold=4,maxCompactionThreshold=32,columnMetadata=[ColumnDefinition{name=start_time, type=org.apache.cassandra.db.marshal.TimeUUIDType, kind=PARTITION_KEY, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=node_ip, type=org.apache.cassandra.db.marshal.InetAddressType, kind=CLUSTERING_COLUMN, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=shard, type=org.apache.cassandra.db.marshal.Int32Type, kind=CLUSTERING_COLUMN, componentIndex=1, droppedAt=-9223372036854775808}, ColumnDefinition{name=command, type=org.apache.cassandra.db.marshal.UTF8Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=date, type=org.apache.cassandra.db.marshal.TimestampType, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=duration, type=org.apache.cassandra.db.marshal.Int32Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=parameters, type=org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type), kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=session_id, type=org.apache.cassandra.db.marshal.UUIDType, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=source_ip, type=org.apache.cassandra.db.marshal.InetAddressType, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=table_names, type=org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.UTF8Type), kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=username, type=org.apache.cassandra.db.marshal.UTF8Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}],compactionStrategyClass=class org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy,compactionStrategyOptions={enabled=true},compressionParameters={sstable_compression=org.apache.cassandra.io.compress.LZ4Compressor},bloomFilterFpChance=0.01,memtableFlushPeriod=0,caching={"keys":"ALL","rows_per_partition":"ALL"},defaultTimeToLive=86400,minIndexInterval=128,maxIndexInterval=2048,speculativeRetry=99.0PERCENTILE,triggers=[],isDense=false,in_memory=false,version=e64502d2-5539-11e9-8c0b-000000000002,droppedColumns={},collections={706172616d6574657273 : org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type), 7461626c655f6e616d6573 : org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.UTF8Type)},indices={}]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/indexes-0feb57ac311f382fba6d9024d305702f/la-64-big-Data.db:level=0, /var/lib/scylla/data/system_schema/indexes-0feb57ac311f382fba6d9024d305702f/la-50-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacted 2 sstables to []. 9684 bytes to 0 (~0% of original) in 1ms = 0.00MB/s. ~256 total partitions merged to 0.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-92-big-Data.db:level=0, /var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-78-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-92-big-Data.db:level=0, /var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-78-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/dropped_columns-5e7583b5f3f43af19a39b7e1d6f5f11f/la-64-big-Data.db:level=0, /var/lib/scylla/data/system_schema/dropped_columns-5e7583b5f3f43af19a39b7e1d6f5f11f/la-50-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacted 2 sstables to []. 9684 bytes to 0 (~0% of original) in 0ms = 0.00MB/s. ~256 total partitions merged to 0.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-120-big-Data.db:level=0, /var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-106-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-92-big-Data.db:level=0, /var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-78-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] schema_tables - Creating system_traces.node_slow_log id=bfcc4e62-5b63-3aa1-a1c3-6f5e47f3325c version=cf80b0df-68ff-3de1-b176-b6811679741a
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-106-big-Data.db:level=0, ]. 12547 bytes to 7721 (~61% of original) in 23ms = 0.32MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-106-big-Data.db:level=0, ]. 10308 bytes to 5391 (~52% of original) in 22ms = 0.23MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-134-big-Data.db:level=0, ]. 10262 bytes to 5295 (~51% of original) in 19ms = 0.27MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-106-big-Data.db:level=0, ]. 11790 bytes to 6686 (~56% of original) in 17ms = 0.38MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] database - Schema version changed to 624dedc0-92c7-303d-a5e7-393a034e0bdb
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] migration_manager - Create new ColumnFamily: org.apache.cassandra.config.CFMetaData@0x600000c7ca80[cfId=f9706768-aa1e-3d87-9e5c-51a3927c2870,ksName=system_traces,cfName=node_slow_log_time_idx,cfType=Standard,comparator=org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.TimestampType,org.apache.cassandra.db.marshal.UUIDType,org.apache.cassandra.db.marshal.UTF8Type),comment=,readRepairChance=0,dcLocalReadRepairChance=0.1,gcGraceSeconds=864000,keyValidator=org.apache.cassandra.db.marshal.TimestampType,minCompactionThreshold=4,maxCompactionThreshold=32,columnMetadata=[ColumnDefinition{name=minute, type=org.apache.cassandra.db.marshal.TimestampType, kind=PARTITION_KEY, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=started_at, type=org.apache.cassandra.db.marshal.TimestampType, kind=CLUSTERING_COLUMN, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=session_id, type=org.apache.cassandra.db.marshal.UUIDType, kind=CLUSTERING_COLUMN, componentIndex=1, droppedAt=-9223372036854775808}, ColumnDefinition{name=node_ip, type=org.apache.cassandra.db.marshal.InetAddressType, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=shard, type=org.apache.cassandra.db.marshal.Int32Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=start_time, type=org.apache.cassandra.db.marshal.TimeUUIDType, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}],compactionStrategyClass=class org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy,compactionStrategyOptions={enabled=true},compressionParameters={sstable_compression=org.apache.cassandra.io.compress.LZ4Compressor},bloomFilterFpChance=0.01,memtableFlushPeriod=0,caching={"keys":"ALL","rows_per_partition":"ALL"},defaultTimeToLive=86400,minIndexInterval=128,maxIndexInterval=2048,speculativeRetry=99.0PERCENTILE,triggers=[],isDense=false,in_memory=false,version=e652e582-5539-11e9-8c0b-000000000002,droppedColumns={},collections={},indices={}]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-120-big-Data.db:level=0, /var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-106-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-120-big-Data.db:level=0, /var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-106-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-148-big-Data.db:level=0, /var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-134-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-120-big-Data.db:level=0, /var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-106-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] schema_tables - Creating system_traces.node_slow_log_time_idx id=f9706768-aa1e-3d87-9e5c-51a3927c2870 version=bf6d4e7c-b70b-31ab-8626-cd3e283b8f6c
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-134-big-Data.db:level=0, ]. 13147 bytes to 8151 (~61% of original) in 19ms = 0.41MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-134-big-Data.db:level=0, ]. 10373 bytes to 5419 (~52% of original) in 19ms = 0.27MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-162-big-Data.db:level=0, ]. 10262 bytes to 5295 (~51% of original) in 19ms = 0.27MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-134-big-Data.db:level=0, ]. 12193 bytes to 7232 (~59% of original) in 18ms = 0.38MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 1] rpc - client 10.0.222.111: server connection dropped: The TLS connection was non-properly terminated.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] database - Schema version changed to 8489e432-105a-371f-a48b-413e6f67013e
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] storage_service - SSTable data integrity checker is disabled.
-[10.0.73.70] [stdout] Apr 02 11:24:37 info   |  [shard 0] gossip - Waiting for gossip to settle before accepting client requests...
-[10.0.73.70] [stdout] Apr 02 11:24:38 info   | Connecting to http://127.0.0.1:10000
-[10.0.73.70] [stdout] Apr 02 11:24:38 info   | Starting the JMX server
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 0] gossip - InetAddress 10.0.222.111 is now UP, status = NORMAL
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 0] migration_manager - Requesting schema pull from 10.0.222.111:0
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 0] Failed to load schema version
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 0] Failed to load schema version
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 0] migration_manager - Pulling schema from 10.0.222.111:0
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 0] migration_manager - Requesting schema pull from 10.0.222.111:0
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 0] migration_manager - Pulling schema from 10.0.222.111:0
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-148-big-Data.db:level=0, /var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-134-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 11] compaction - Compacting [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-67-big-Data.db:level=0, /var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-53-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-148-big-Data.db:level=0, /var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-134-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 11] compaction - Compacting [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-67-big-Data.db:level=0, /var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-53-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-94-big-Data.db:level=0, /var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-80-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-94-big-Data.db:level=0, /var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-80-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-176-big-Data.db:level=0, /var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-162-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 11] compaction - Compacting [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-95-big-Data.db:level=0, /var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-81-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 11] compaction - Compacting [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-67-big-Data.db:level=0, /var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-53-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-94-big-Data.db:level=0, /var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-80-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-148-big-Data.db:level=0, /var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-134-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-122-big-Data.db:level=0, /var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-108-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-162-big-Data.db:level=0, ]. 15975 bytes to 8151 (~51% of original) in 22ms = 0.35MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-162-big-Data.db:level=0, ]. 10491 bytes to 5400 (~51% of original) in 20ms = 0.26MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 11] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-81-big-Data.db:level=0, ]. 11166 bytes to 5747 (~51% of original) in 23ms = 0.24MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 10] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-108-big-Data.db:level=0, ]. 11598 bytes to 5963 (~51% of original) in 20ms = 0.28MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-190-big-Data.db:level=0, ]. 10262 bytes to 5295 (~51% of original) in 19ms = 0.27MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 10] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-108-big-Data.db:level=0, ]. 10342 bytes to 5332 (~51% of original) in 20ms = 0.25MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-162-big-Data.db:level=0, ]. 14134 bytes to 7232 (~51% of original) in 17ms = 0.41MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 11] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-81-big-Data.db:level=0, ]. 10377 bytes to 5349 (~51% of original) in 23ms = 0.22MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 11] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-109-big-Data.db:level=0, ]. 10314 bytes to 5321 (~51% of original) in 21ms = 0.24MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 10] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-136-big-Data.db:level=0, ]. 10244 bytes to 5286 (~51% of original) in 25ms = 0.20MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 10] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-108-big-Data.db:level=0, ]. 12276 bytes to 6302 (~51% of original) in 27ms = 0.22MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 11] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-81-big-Data.db:level=0, ]. 11694 bytes to 6011 (~51% of original) in 29ms = 0.20MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 0] database - Schema version changed to 8489e432-105a-371f-a48b-413e6f67013e
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 0] migration_manager - Schema merge with 10.0.222.111:0 completed
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   | JMX is enabled to receive remote connections on port: 7199
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 0] gossip - Favor newly added node 10.0.222.111
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 6] compaction - Compacting [/var/lib/scylla/data/system/peers-37f71aca7dc2383ba70672528af04d4f/la-34-big-Data.db:level=0, /var/lib/scylla/data/system/peers-37f71aca7dc2383ba70672528af04d4f/la-20-big-Data.db:level=0, ]
-[10.0.73.70] [stdout] Apr 02 11:24:39 warning|  [shard 0] migration_task - Can't send migration request: node 10.0.42.170 is down.
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 0] rpc - client 10.0.42.170: client connection dropped: The TLS connection was non-properly terminated.
-[10.0.73.70] [stdout] Apr 02 11:24:39 warning|  [shard 0] gossip - Fail to send EchoMessage to 10.0.42.170: seastar::rpc::closed_error (connection is closed)
-[10.0.73.70] [stdout] Apr 02 11:24:39 warning|  [shard 0] migration_task - Can't send migration request: node 10.0.42.170 is down.
-[10.0.73.70] [stdout] Apr 02 11:24:39 info   |  [shard 6] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system/peers-37f71aca7dc2383ba70672528af04d4f/la-48-big-Data.db:level=0, ]. 16141 bytes to 11244 (~69% of original) in 7ms = 1.53MB/s. ~256 total partitions merged to 1.
-[10.0.73.70] [stdout] Apr 02 11:24:40 warning|  [shard 0] migration_task - Can't send migration request: node 10.0.42.170 is down.
-[10.0.73.70] [stdout] Apr 02 11:24:40 info   |  [shard 0] gossip - InetAddress 10.0.42.170 is now UP, status = NORMAL
-[10.0.73.70] [stdout] Apr 02 11:24:40 info   |  [shard 0] migration_manager - Requesting schema pull from 10.0.42.170:0
-[10.0.73.70] [stdout] Apr 02 11:24:40 info   |  [shard 0] migration_manager - Pulling schema from 10.0.42.170:0
-[10.0.73.70] [stdout] Apr 02 11:24:40 info   |  [shard 0] database - Schema version changed to 8489e432-105a-371f-a48b-413e6f67013e
-[10.0.73.70] [stdout] Apr 02 11:24:40 info   |  [shard 0] migration_manager - Schema merge with 10.0.42.170:0 completed
-[10.0.73.70] [stdout] Apr 02 11:24:41 info   |  [shard 3] rpc - client 10.0.42.170: server connection dropped: The TLS connection was non-properly terminated.
-[10.0.73.70] [stdout] Apr 02 11:24:41 info   |  [shard 0] gossip - Favor newly added node 10.0.42.170
-[10.0.73.70] [stdout] Apr 02 11:24:41 info   |  [shard 0] migration_manager - Requesting schema pull from 10.0.42.170:0
-[10.0.73.70] [stdout] Apr 02 11:24:41 info   |  [shard 0] migration_manager - Pulling schema from 10.0.42.170:0
-[10.0.73.70] [stdout] Apr 02 17:31:17 info   | Segmentation fault on shard 11.
-[10.0.73.70] [stdout] Apr 02 17:31:17 info   | Backtrace:
-[10.0.73.70] [stdout] Apr 02 17:31:17 info   | 0x00000000006c5af2
-[10.0.73.70] [stdout] Apr 02 17:31:17 info   | 0x00000000005d41ac
-[10.0.73.70] [stdout] Apr 02 17:31:17 info   | 0x00000000005d4455
-[10.0.73.70] [stdout] Apr 02 17:31:17 info   | 0x00000000005d44a3
-[10.0.73.70] [stdout] Apr 02 17:31:17 info   | /lib64/libpthread.so.0+0x000000000000f5cf
-[10.0.73.70] [stdout] Apr 02 17:31:17 info   | 0x0000000001c98946
-[10.0.73.70] [stdout] Apr 02 17:31:17 info   | 0x0000000001cd0761
-[10.0.73.70] [stdout] Apr 02 17:31:17 info   | 0x00000000013d58d2
-[10.0.73.70] [stdout] Apr 02 17:31:17 info   | 0x00000000005d8a2b
-[10.0.73.70] [stdout] Apr 02 17:31:17 info   | 0x00000000005b318b
-[10.0.73.70] [stdout] Apr 02 17:31:17 info   | 0x00000000005b0314
-[10.0.73.70] [stdout] Apr 02 17:31:17 info   | 0x000000000068795e
-[10.0.73.70] [stdout] Apr 02 17:31:17 info   | 0x000000000068c1fa
-[10.0.73.70] [stdout] Apr 02 17:31:17 info   | 0x000000000077535d
-[10.0.73.70] [stdout] Apr 02 17:31:17 info   | /lib64/libpthread.so.0+0x0000000000007dd4
-[10.0.73.70] [stdout] Apr 02 17:31:17 info   | /lib64/libc.so.6+0x00000000000fdeac
-[10.0.73.70] [stdout] Apr 02 17:32:50 notice | scylla-server.service: main process exited, code=killed, status=11/SEGV
-[10.0.73.70] [stdout] Apr 02 18:40:11 info   |  [shard 0] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Executing streaming plan for Bootstrap-keyspace1-index-6 with peers=10.0.106.31, slave
-[10.0.73.70] [stdout] Apr 02 18:40:11 info   |  [shard 9] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=3537067, with new rpc streaming
-[10.0.73.70] [stdout] Apr 02 18:40:11 info   |  [shard 3] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=3628571, with new rpc streaming
-[10.0.73.70] [stdout] Apr 02 18:40:11 info   |  [shard 12] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=3526428, with new rpc streaming
-[10.0.73.70] [stdout] Apr 02 18:40:11 info   |  [shard 13] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=3521601, with new rpc streaming
-[10.0.73.70] [stdout] Apr 02 18:40:11 info   |  [shard 6] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=3649796, with new rpc streaming
-[10.0.73.70] [stdout] Apr 02 18:40:11 info   |  [shard 0] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=3534612, with new rpc streaming
-[10.0.73.70] [stdout] Apr 02 18:40:11 info   |  [shard 7] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=3566892, with new rpc streaming
-[10.0.73.70] [stdout] Apr 02 18:40:11 info   |  [shard 8] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=3539519, with new rpc streaming
-[10.0.73.70] [stdout] Apr 02 18:40:11 info   |  [shard 10] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=3475906, with new rpc streaming
-[10.0.73.70] [stdout] Apr 02 18:40:11 info   |  [shard 4] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=3749560, with new rpc streaming
-[10.0.73.70] [stdout] Apr 02 18:40:11 info   |  [shard 5] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=3705018, with new rpc streaming
-[10.0.73.70] [stdout] Apr 02 18:40:11 info   |  [shard 11] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=3547371, with new rpc streaming
-[10.0.73.70] [stdout] Apr 02 18:40:11 info   |  [shard 2] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=3582785, with new rpc streaming
-[10.0.73.70] [stdout] Apr 02 18:40:11 info   |  [shard 1] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=3626305, with new rpc streaming
-[10.0.73.70] [stdout] Apr 02 18:43:21 info   |  [shard 0] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Streaming plan for Bootstrap-keyspace1-index-6 succeeded, peers={10.0.106.31}, tx=15871500 KiB, 83726.35 KiB/s, rx=0 KiB, 0.00 KiB/s
-[10.0.73.70] [stdout] Apr 02 18:43:21 info   |  [shard 0] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Executing streaming plan for Bootstrap-keyspace1-index-7 with peers=10.0.106.31, slave
-[10.0.73.70] [stdout] Apr 02 18:43:21 info   |  [shard 0] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=2704017, with new rpc streaming
-[10.0.73.70] [stdout] Apr 02 18:43:21 info   |  [shard 9] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=2780837, with new rpc streaming
-[10.0.73.70] [stdout] Apr 02 18:43:21 info   |  [shard 12] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=2828047, with new rpc streaming
-[10.0.73.70] [stdout] Apr 02 18:43:21 info   |  [shard 3] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=2667288, with new rpc streaming
-[10.0.73.70] [stdout] Apr 02 18:43:21 info   |  [shard 6] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=2896392, with new rpc streaming
-[10.0.73.70] [stdout] Apr 02 18:43:21 info   |  [shard 8] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=2790202, with new rpc streaming
-[10.0.73.70] [stdout] Apr 02 18:43:21 info   |  [shard 7] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=2835751, with new rpc streaming
-[10.0.73.70] [stdout] Apr 02 18:43:21 info   |  [shard 5] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=2800956, with new rpc streaming
-[10.0.73.70] [stdout] Apr 02 18:43:21 info   |  [shard 1] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=2795324, with new rpc streaming
-[10.0.73.70] [stdout] Apr 02 18:43:21 info   |  [shard 4] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=2724794, with new rpc streaming
-[10.0.73.70] [stdout] Apr 02 18:43:21 info   |  [shard 2] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=2771897, with new rpc streaming
-[10.0.73.70] [stdout] Apr 02 18:43:21 info   |  [shard 10] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=2829114, with new rpc streaming
-[10.0.73.70] [stdout] Apr 02 18:43:21 info   |  [shard 13] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=2796216, with new rpc streaming
-[10.0.73.70] [stdout] Apr 02 18:43:21 info   |  [shard 11] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=2816990, with new rpc streaming
-[10.0.73.70] [stdout] Apr 02 18:44:40 info   | Reactor stalled for 2252 ms on shard 2.
-[10.0.73.70] [stdout] Apr 02 18:44:40 info   | Backtrace:
-[10.0.73.70] [stdout] Apr 02 18:44:40 info   | 0x00000000006c5af2
-[10.0.73.70] [stdout] Apr 02 18:44:40 info   | 0x00000000005d41ac
-[10.0.73.70] [stdout] Apr 02 18:44:40 info   | 0x00000000005d4666
-[10.0.73.70] [stdout] Apr 02 18:44:40 info   | /lib64/libpthread.so.0+0x000000000000f5cf
-[10.0.73.70] [stdout] Apr 02 18:44:40 info   | 0x00000000005b129f
-[10.0.73.70] [stdout] Apr 02 18:44:40 info   | /lib64/libpthread.so.0+0x000000000000f5cf
-[10.0.73.70] [stdout] Apr 02 18:44:40 info   | 0x000000000162c3d3
-[10.0.73.70] [stdout] Apr 02 18:44:40 info   | 0x00000000014daf0f
-[10.0.73.70] [stdout] Apr 02 18:44:40 info   | 0x00000000015e45b0
-[10.0.73.70] [stdout] Apr 02 18:44:40 info   | 0x00000000015ce1df
-[10.0.73.70] [stdout] Apr 02 18:44:40 info   | 0x00000000015cf52a
-[10.0.73.70] [stdout] Apr 02 18:44:40 info   | 0x00000000015d1483
-[10.0.73.70] [stdout] Apr 02 18:44:40 info   | 0x00000000013ac7f5
-[10.0.73.70] [stdout] Apr 02 18:44:40 info   | 0x000000000123d5cc
-[10.0.73.70] [stdout] Apr 02 18:44:40 info   | 0x000000000123df5a
-[10.0.73.70] [stdout] Apr 02 18:44:40 info   | 0x000000000126ba1d
-[10.0.73.70] [stdout] Apr 02 18:44:40 info   | 0x00000000013ea347
-[10.0.73.70] [stdout] Apr 02 18:44:40 info   | 0x00000000013ea17b
-[10.0.73.70] [stdout] Apr 02 18:44:40 info   | 0x00000000013ea9ee
-[10.0.73.70] [stdout] Apr 02 18:44:40 info   | 0x00000000007374fc
-[10.0.73.70] [stdout] Apr 02 18:44:40 info   | 0x00000000005b4ade
-[10.0.73.70] [stdout] Apr 02 18:44:40 info   | 0x00000000005b4ca1
-[10.0.73.70] [stdout] Apr 02 18:44:40 info   | 0x0000000000687a37
-[10.0.73.70] [stdout] Apr 02 18:44:40 info   | 0x000000000068c1fa
-[10.0.73.70] [stdout] Apr 02 18:44:40 info   | 0x000000000077535d
-[10.0.73.70] [stdout] Apr 02 18:44:40 info   | /lib64/libpthread.so.0+0x0000000000007dd4
-[10.0.73.70] [stdout] Apr 02 18:44:40 info   | /lib64/libc.so.6+0x00000000000fdeac
+[10.0.73.70] [stdout] Apr 02 11:23:52 info   | scylla[124]: Starting Scylla AMI Setup...
+[10.0.73.70] [stdout] Apr 02 11:24:10 info   | scylla[124]: Waiting for cloud-init to finish...
+[10.0.73.70] [stdout] Apr 02 11:24:10 info   | scylla[124]: [INFO] Started with user data set to:
+[10.0.73.70] [stdout] Apr 02 11:24:10 info   | scylla[124]: [INFO] --clustername longevity-200gb-48h-vfy-tls-2019-1-db-cluster-927e1ec2 --totalnodes 4 --stop-services --bootstrap false
+[10.0.73.70] [stdout] Apr 02 11:24:10 info   | scylla[124]: [INFO] Using user data:
+[10.0.73.70] [stdout] Apr 02 11:24:10 info   | scylla[124]: [INFO] --clustername longevity-200gb-48h-vfy-tls-2019-1-db-cluster-927e1ec2 --totalnodes 4 --stop-services --bootstrap false
+[10.0.73.70] [stdout] Apr 02 11:24:10 info   | scylla[124]: [INFO] Using instance type: i3.4xlarge
+[10.0.73.70] [stdout] Apr 02 11:24:10 info   | scylla[124]: [INFO] meta-data:instance-type: i3.4xlarge
+[10.0.73.70] [stdout] Apr 02 11:24:10 info   | scylla[124]: [INFO] meta-data:local-ipv4: 10.0.73.70
+[10.0.73.70] [stdout] Apr 02 11:24:10 info   | scylla[124]: [INFO] meta-data:public-hostname: ec2-54-246-228-160.eu-west-1.compute.amazonaws.com
+[10.0.73.70] [stdout] Apr 02 11:24:10 info   | scylla[124]: [INFO] meta-data:ami-launch-index: 2
+[10.0.73.70] [stdout] Apr 02 11:24:10 info   | scylla[124]: [INFO] meta-data:reservation-id: r-0bebec5f01ea19254
+[10.0.73.70] [stdout] Apr 02 11:24:10 info   | scylla[124]: [INFO] Using cluster name: longevity-200gb-48h-vfy-tls-2019-1-db-cluster-927e1ec2
+[10.0.73.70] [stdout] Apr 02 11:24:10 info   | scylla[124]: [INFO] Using cluster size: 4
+[10.0.73.70] [stdout] Apr 02 11:24:10 info   | scylla[124]: [INFO] Using seed indexes: [0, 4, 4]
+[10.0.73.70] [stdout] Apr 02 11:24:10 info   | scylla[124]: [INFO] Reflector loop...
+[10.0.73.70] [stdout] Apr 02 11:24:10 info   | scylla[124]: [INFO] 04/02/19-11:24:04 Reflector: Received 0 of 1 responses from: []
+[10.0.73.70] [stdout] Apr 02 11:24:10 info   | scylla[124]: [INFO] 04/02/19-11:24:06 Reflector: Received 0 of 1 responses from: []
+[10.0.73.70] [stdout] Apr 02 11:24:10 info   | scylla[124]: [INFO] 04/02/19-11:24:10 Reflector: Received 1 of 1 responses from: [u'10.0.222.111']
+[10.0.73.70] [stdout] Apr 02 11:24:10 info   | scylla[124]: [INFO] scylla.yaml configured.
+[10.0.73.70] [stdout] Apr 02 11:24:13 info   | scylla[124]: mdadm: Defaulting to version 1.2 metadata
+[10.0.73.70] [stdout] Apr 02 11:24:13 info   | scylla[124]: mdadm: array /dev/md0 started.
+[10.0.73.70] [stdout] Apr 02 11:24:14 info   | scylla[124]: meta-data=/dev/md0               isize=512    agcount=32, agsize=28989696 blks
+[10.0.73.70] [stdout] Apr 02 11:24:14 info   | scylla[124]: =                       sectsz=512   attr=2, projid32bit=1
+[10.0.73.70] [stdout] Apr 02 11:24:14 info   | scylla[124]: =                       crc=1        finobt=0, sparse=0
+[10.0.73.70] [stdout] Apr 02 11:24:14 info   | scylla[124]: data     =                       bsize=4096   blocks=927668224, imaxpct=5
+[10.0.73.70] [stdout] Apr 02 11:24:14 info   | scylla[124]: =                       sunit=256    swidth=512 blks
+[10.0.73.70] [stdout] Apr 02 11:24:14 info   | scylla[124]: naming   =version 2              bsize=4096   ascii-ci=0 ftype=1
+[10.0.73.70] [stdout] Apr 02 11:24:14 info   | scylla[124]: log      =internal log           bsize=4096   blocks=452968, version=2
+[10.0.73.70] [stdout] Apr 02 11:24:14 info   | scylla[124]: =                       sectsz=512   sunit=8 blks, lazy-count=1
+[10.0.73.70] [stdout] Apr 02 11:24:14 info   | scylla[124]: realtime =none                   extsz=4096   blocks=0, rtextents=0
+[10.0.73.70] [stdout] Apr 02 11:24:14 info   | scylla[124]: Creating RAID0 for scylla using 2 disk(s): /dev/nvme0n1,/dev/nvme1n1
+[10.0.73.70] [stdout] Apr 02 11:24:14 info   | scylla[124]: [INFO] RAID Array containing ['nvme0n1', 'nvme1n1'] not found. Creating...
+[10.0.73.70] [stdout] Apr 02 11:24:16 info   | scylla[124]: kernel.core_pattern = |/usr/lib/systemd/systemd-coredump %p %u %g %s %t %e"
+[10.0.73.70] [stdout] Apr 02 11:24:16 info   | scylla[124]: Started Scylla AMI Setup.
+[10.0.73.70] [stdout] Apr 02 11:24:16 info   | scylla[124]: Starting Scylla Server...
+[10.0.73.70] [stdout] Apr 02 11:24:16 notice | scylla[124]: scylla-server.service: control process exited, code=exited status=1
+[10.0.73.70] [stdout] Apr 02 11:24:16 err    | scylla[124]: Failed to start Scylla Server.
+[10.0.73.70] [stdout] Apr 02 11:24:16 warning| scylla[124]: Dependency failed for Scylla JMX.
+[10.0.73.70] [stdout] Apr 02 11:24:16 notice | scylla[124]: Job scylla-jmx.service/start failed with result 'dependency'.
+[10.0.73.70] [stdout] Apr 02 11:24:16 notice | scylla[124]: Unit scylla-server.service entered failed state.
+[10.0.73.70] [stdout] Apr 02 11:24:16 warning| scylla[124]: scylla-server.service failed.
+[10.0.73.70] [stdout] Apr 02 11:24:28 info   | scylla[124]: Starting Scylla Server...
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Saving the original irqbalance configuration is in /etc/sysconfig/irqbalance.scylla.orig
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Restarting irqbalance: going to ban the following IRQ numbers: 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 215, 214, 218, 216, 212, 217, 211, 213 ...
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Restarting irqbalance via systemctl...
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: No non-NVMe disks to tune
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting NVMe disks: nvme0n1, nvme1n1...
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000001 in /proc/irq/147/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000001 in /proc/irq/148/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000100 in /proc/irq/149/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000100 in /proc/irq/150/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000002 in /proc/irq/151/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000002 in /proc/irq/152/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000200 in /proc/irq/153/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000200 in /proc/irq/154/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000004 in /proc/irq/155/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000004 in /proc/irq/156/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000400 in /proc/irq/157/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000400 in /proc/irq/158/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000008 in /proc/irq/159/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000008 in /proc/irq/160/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000800 in /proc/irq/161/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000800 in /proc/irq/162/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000010 in /proc/irq/178/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000010 in /proc/irq/179/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00001000 in /proc/irq/180/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00001000 in /proc/irq/181/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000020 in /proc/irq/182/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000020 in /proc/irq/183/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00002000 in /proc/irq/184/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00002000 in /proc/irq/185/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000040 in /proc/irq/186/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000040 in /proc/irq/187/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00004000 in /proc/irq/188/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00004000 in /proc/irq/189/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000080 in /proc/irq/190/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000080 in /proc/irq/191/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00008000 in /proc/irq/192/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00008000 in /proc/irq/193/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Writing 'none' to /sys/devices/pci0000:00/0000:00:1d.0/nvme/nvme0/nvme0n1/queue/scheduler
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Writing '2' to /sys/devices/pci0000:00/0000:00:1d.0/nvme/nvme0/nvme0n1/queue/nomerges
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Writing 'none' to /sys/devices/pci0000:00/0000:00:1e.0/nvme/nvme1/nvme1n1/queue/scheduler
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Writing '2' to /sys/devices/pci0000:00/0000:00:1e.0/nvme/nvme1/nvme1n1/queue/nomerges
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting a physical interface eth0...
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Distributing all IRQs
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000001 in /proc/irq/215/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000001 in /proc/irq/214/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000001 in /proc/irq/218/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000001 in /proc/irq/216/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000100 in /proc/irq/212/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000100 in /proc/irq/217/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000100 in /proc/irq/211/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000100 in /proc/irq/213/smp_affinity
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 0000fefe in /sys/class/net/eth0/queues/rx-7/rps_cpus
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 0000fefe in /sys/class/net/eth0/queues/rx-5/rps_cpus
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 0000fefe in /sys/class/net/eth0/queues/rx-3/rps_cpus
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 0000fefe in /sys/class/net/eth0/queues/rx-1/rps_cpus
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 0000fefe in /sys/class/net/eth0/queues/rx-6/rps_cpus
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 0000fefe in /sys/class/net/eth0/queues/rx-4/rps_cpus
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 0000fefe in /sys/class/net/eth0/queues/rx-2/rps_cpus
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 0000fefe in /sys/class/net/eth0/queues/rx-0/rps_cpus
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting net.core.rps_sock_flow_entries to 32768
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting limit 4096 in /sys/class/net/eth0/queues/rx-7/rps_flow_cnt
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting limit 4096 in /sys/class/net/eth0/queues/rx-5/rps_flow_cnt
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting limit 4096 in /sys/class/net/eth0/queues/rx-3/rps_flow_cnt
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting limit 4096 in /sys/class/net/eth0/queues/rx-1/rps_flow_cnt
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting limit 4096 in /sys/class/net/eth0/queues/rx-6/rps_flow_cnt
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting limit 4096 in /sys/class/net/eth0/queues/rx-4/rps_flow_cnt
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting limit 4096 in /sys/class/net/eth0/queues/rx-2/rps_flow_cnt
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting limit 4096 in /sys/class/net/eth0/queues/rx-0/rps_flow_cnt
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Trying to enable ntuple filtering HW offload for eth0...not supported
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000101 in /sys/class/net/eth0/queues/tx-6/xps_cpus
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000202 in /sys/class/net/eth0/queues/tx-4/xps_cpus
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000404 in /sys/class/net/eth0/queues/tx-2/xps_cpus
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00000808 in /sys/class/net/eth0/queues/tx-0/xps_cpus
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00001010 in /sys/class/net/eth0/queues/tx-7/xps_cpus
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00002020 in /sys/class/net/eth0/queues/tx-5/xps_cpus
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00004040 in /sys/class/net/eth0/queues/tx-3/xps_cpus
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Setting mask 00008080 in /sys/class/net/eth0/queues/tx-1/xps_cpus
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Writing '4096' to /proc/sys/net/core/somaxconn
+[10.0.73.70] [stdout] Apr 02 11:24:30 info   | scylla[124]: Writing '4096' to /proc/sys/net/ipv4/tcp_max_syn_backlog
+[10.0.73.70] [stdout] Apr 02 11:24:31 info   | scylla[124]: Scylla version 2019.1.0.rc0-0.20190322.682865806 starting ...
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] snitch_logger - Ec2Snitch using region: eu-west, zone: 1a.
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] init - Scylla API server listening on 127.0.0.1:10000 ...
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Row: max_vector_size: 32, internal_count: 5
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 1] database - Row: max_vector_size: 32, internal_count: 5
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 3] database - Row: max_vector_size: 32, internal_count: 5
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 2] database - Row: max_vector_size: 32, internal_count: 5
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 5] database - Row: max_vector_size: 32, internal_count: 5
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 6] database - Row: max_vector_size: 32, internal_count: 5
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 8] database - Row: max_vector_size: 32, internal_count: 5
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 10] database - Row: max_vector_size: 32, internal_count: 5
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 12] database - Row: max_vector_size: 32, internal_count: 5
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 11] database - Row: max_vector_size: 32, internal_count: 5
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 9] database - Row: max_vector_size: 32, internal_count: 5
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 13] database - Row: max_vector_size: 32, internal_count: 5
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 7] database - Row: max_vector_size: 32, internal_count: 5
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 4] database - Row: max_vector_size: 32, internal_count: 5
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Populating Keyspace system_schema
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system_schema: Reading CF view_virtual_columns id=08843b63-45dc-3be2-9798-a0418295cfaa version=ac302a39-2fb0-3def-bf61-d0f348567f1a
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system_schema: Reading CF aggregates id=924c5587-2e3a-345b-b10c-12f37c1ba895 version=9556aaa6-f8df-381c-997e-fc7aedc43e05
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system_schema: Reading CF functions id=96489b79-80be-3e14-a701-66a0b9159450 version=76a4e4f7-0adf-381b-9da4-1066ada12806
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system_schema: Reading CF tables id=afddfb9d-bc1e-3068-8056-eed6c302ba09 version=c179c1d7-9503-3f66-a5b3-70e72af3392a
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system_schema: Reading CF dropped_columns id=5e7583b5-f3f4-3af1-9a39-b7e1d6f5f11f version=d4e2a352-3e28-3297-b746-461236df0a1e
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system_schema: Reading CF views id=9786ac1c-dd58-3201-a7cd-ad556410c985 version=6e894071-2cfc-3ce6-96a2-c5c1d7a86996
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system_schema: Reading CF triggers id=4df70b66-6b05-3251-95a1-32b54005fd48 version=72ceb49d-cfce-330b-8dbf-613aa8b16cd9
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system_schema: Reading CF types id=5a8b1ca8-6602-3f77-a045-9273d308917a version=4a083362-11d8-3c56-bf3b-071c1996ed2e
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system_schema: Reading CF keyspaces id=abac5682-dea6-31c5-b535-b3d6cffd0fb6 version=546e75bd-58af-3eb4-8017-5f7c54bad49c
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system_schema: Reading CF indexes id=0feb57ac-311f-382f-ba6d-9024d305702f version=a7860a8c-d89c-30b0-98ba-279ae67fae1e
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system_schema: Reading CF scylla_tables id=5d912ff1-f759-3665-b2c8-8042ab5103dd version=d15e4b38-4294-3cf3-b7e2-5485bd5c9367
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system_schema: Reading CF columns id=24101c25-a2ae-3af7-87c1-b40ee1aca33f version=a4fe505b-053c-3486-9d6a-bd283d568c10
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Populating Keyspace system
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system: Reading CF schema_functions id=d1b675fe-2b50-3ca4-8e49-c0f81989dcad version=e460c9b9-f16f-3fdb-b8c7-9726bf8bbd39
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system: Reading CF schema_usertypes id=3aa75225-4f82-350b-8d5c-430fa221fa0a version=e13d0c09-4360-3fdb-82e3-ce15a5d16646
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system: Reading CF schema_triggers id=0359bc71-7123-3ee1-9a4a-b9dfb11fc125 version=599a9774-a0ce-3c13-805c-4c41d6042e8b
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system: Reading CF schema_columns id=296e9c04-9bec-3085-827d-c17d3df2122a version=7841736d-7d32-31e8-9e25-3e9d47b9fc25
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system: Reading CF schema_keyspaces id=b0f22357-4458-3cdb-9631-c43e59ce3676 version=d18195e9-634f-31a6-87f8-5691d87376fc
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system: Reading CF peers id=37f71aca-7dc2-383b-a706-72528af04d4f version=739aff7c-afc5-30e3-bb9a-aa0b340feedb
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system: Reading CF local id=7ad54392-bcdd-35a6-8417-4e047860b377 version=3e8e18ea-3208-3205-8b39-e62193f76ba8
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system: Reading CF built_views id=4b3c50a9-ea87-3d76-9101-6dbc9c38494a version=7cb318b7-eab5-3637-9ad9-b9d99af3ad37
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system: Reading CF paxos id=b7b7f0c2-fd0a-3410-8c05-3ef614bb7c2d version=8174219f-df55-3f99-9185-c4b1cab65807
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system: Reading CF batchlog id=0290003c-977e-397c-ac3e-fdfdc01d626b version=6bcb22aa-5faa-3b0f-bcfe-8b93fec16d40
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system: Reading CF size_estimates id=618f817b-005f-3678-b8a4-53f3930b8e86 version=9d8e68fd-b530-3e22-ad57-8921880ef2f4
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system: Reading CF IndexInfo id=9f5c6374-d485-3229-9a0a-5094af9ad1e3 version=6d26f9cd-5481-3415-bd86-d5fc853eaade
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system: Reading CF large_partitions id=8a7fe624-96b0-34b1-b90e-f71bddcdd2d3 version=bbae8dd5-345f-3da6-83b1-eb9b26df351e
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system: Reading CF schema_columnfamilies id=45f5b360-24bc-3f83-a363-1034ea4fa697 version=b57bc185-37ec-3429-a019-38c2e3fa61cf
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system: Reading CF views_builds_in_progress id=b7f2c108-78cd-3c80-9cd5-d609b2bd149c version=b3f8840c-04f3-3120-ae35-3c74d35052d1
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system: Reading CF range_xfers id=55d76438-4e55-3f8b-9f6e-676d4af3976d version=c28c4e27-fc89-3655-be9b-83549e67e569
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system: Reading CF compactions_in_progress id=55080ab0-5d9c-3886-90a4-acb25fe1f77b version=4f0ae080-a13e-334e-a6b4-ab9ad38db42b
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system: Reading CF schema_aggregates id=a5fc57fc-9d6c-3bfd-a3fc-01ad54686fea version=2b664525-a49c-3c59-bb0a-76508543e624
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system: Reading CF scylla_views_builds_in_progress id=a04c7bfd-1e13-36c9-a44d-f22da352281d version=a763e6ee-f0ac-39f6-8297-f5d9f82c9f4c
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system: Reading CF hints id=2666e205-73ef-38b3-90fe-fecf96e8f0c7 version=22906784-f0f7-39a1-8376-9b21c8112dee
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system: Reading CF compaction_history id=b4dbb7b4-dc49-3fb5-b3bf-ce6e434832ca version=b7ecaf8a-49da-3462-8d54-510a017926b7
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system: Reading CF peer_events id=59dfeaea-8db2-3341-91ef-109974d81484 version=41ae6768-c385-316c-acc9-b5b749b3d85e
+[10.0.73.70] [stdout] Apr 02 11:24:32 info   | scylla[124]:  [shard 0] database - Keyspace system: Reading CF sstable_activity id=5a1ff267-ace0-3f12-8563-cfae6103c65e version=d69820df-9d03-3cd0-91b0-c078c030b708
+[10.0.73.70] [stdout] Apr 02 11:24:33 info   | scylla[124]: Reactor stalled for 500 ms on shard 0.
+[10.0.73.70] [stdout] Apr 02 11:24:33 info   | scylla[124]: Backtrace:
+[10.0.73.70] [stdout] Apr 02 11:24:33 info   | scylla[124]: 0x00000000006c5af2
+[10.0.73.70] [stdout] Apr 02 11:24:33 info   | scylla[124]: 0x00000000005d41ac
+[10.0.73.70] [stdout] Apr 02 11:24:33 info   | scylla[124]: 0x00000000005d4666
+[10.0.73.70] [stdout] Apr 02 11:24:33 info   | scylla[124]: /lib64/libpthread.so.0+0x000000000000f5cf
+[10.0.73.70] [stdout] Apr 02 11:24:33 info   | scylla[124]: /lib64/libgmp.so.10+0x000000000002e9e1
+[10.0.73.70] [stdout] Apr 02 11:24:33 info   | scylla[124]: Reactor stalled for 1000 ms on shard 0.
+[10.0.73.70] [stdout] Apr 02 11:24:33 info   | scylla[124]: Backtrace:
+[10.0.73.70] [stdout] Apr 02 11:24:33 info   | scylla[124]: 0x00000000006c5af2
+[10.0.73.70] [stdout] Apr 02 11:24:33 info   | scylla[124]: 0x00000000005d41ac
+[10.0.73.70] [stdout] Apr 02 11:24:33 info   | scylla[124]: 0x00000000005d4666
+[10.0.73.70] [stdout] Apr 02 11:24:33 info   | scylla[124]: /lib64/libpthread.so.0+0x000000000000f5cf
+[10.0.73.70] [stdout] Apr 02 11:24:33 info   | scylla[124]: /lib64/libgmp.so.10+0x000000000002e1ef
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: Reactor stalled for 500 ms on shard 4.
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: Backtrace:
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000006c5af2
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000005d41ac
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000005d4666
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libpthread.so.0+0x000000000000f5cf
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libgmp.so.10+0x0000000000056104
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: Reactor stalled for 500 ms on shard 2.
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: Backtrace:
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000006c5af2
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000005d41ac
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000005d4666
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libpthread.so.0+0x000000000000f5cf
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libgmp.so.10+0x00000000000560e2
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: Reactor stalled for 500 ms on shard 3.
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: Backtrace:
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000006c5af2
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000005d41ac
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000005d4666
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libpthread.so.0+0x000000000000f5cf
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libgmp.so.10+0x0000000000056155
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: Reactor stalled for 500 ms on shard 6.
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: Backtrace:
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000006c5af2
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000005d41ac
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000005d4666
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libpthread.so.0+0x000000000000f5cf
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libgmp.so.10+0x0000000000056104
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: Reactor stalled for 500 ms on shard 8.
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: Backtrace:
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000006c5af2
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000005d41ac
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000005d4666
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libpthread.so.0+0x000000000000f5cf
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libgmp.so.10+0x000000000005612a
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: Reactor stalled for 500 ms on shard 9.
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: Backtrace:
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000006c5af2
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000005d41ac
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000005d4666
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libpthread.so.0+0x000000000000f5cf
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libgmp.so.10+0x000000000002e207
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: Reactor stalled for 500 ms on shard 11.
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: Backtrace:
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000006c5af2
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000005d41ac
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000005d4666
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libpthread.so.0+0x000000000000f5cf
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libgmp.so.10+0x0000000000056117
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: Reactor stalled for 500 ms on shard 1.
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: Backtrace:
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000006c5af2
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000005d41ac
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000005d4666
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libpthread.so.0+0x000000000000f5cf
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libgmp.so.10+0x00000000000209cf
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libgmp.so.10+0x0000000000020d10
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libhogweed.so.2+0x0000000000008994
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libhogweed.so.2+0x000000000000b9f7
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libgnutls.so.28+0x00000000000eb9cc
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libgnutls.so.28+0x0000000000038500
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x0000000000a56227
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000031cef6f
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x0000000003ab9f42
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x0000000003abb2a9
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000005b1994
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000005d6538
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000006d3e65
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000005b0314
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x000000000068795e
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x000000000068c1fa
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x000000000077535d
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libpthread.so.0+0x0000000000007dd4
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libc.so.6+0x00000000000fdeac
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: Reactor stalled for 500 ms on shard 7.
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: Backtrace:
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000006c5af2
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000005d41ac
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000005d4666
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libpthread.so.0+0x000000000000f5cf
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libnettle.so.4+0x0000000000006a63
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libnettle.so.4+0x000000000001fc4e
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libnettle.so.4+0x000000000002002d
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libgnutls.so.28+0x00000000000f2664
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libgnutls.so.28+0x00000000000eb76c
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libhogweed.so.2+0x0000000000008559
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libhogweed.so.2+0x00000000000085e3
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libhogweed.so.2+0x0000000000008931
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libhogweed.so.2+0x000000000000b9f7
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libgnutls.so.28+0x00000000000eb9cc
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libgnutls.so.28+0x0000000000038500
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x0000000000a56227
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000031cef6f
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x0000000003ab9f42
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x0000000003abb2a9
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000005b1994
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000005d6538
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000006d3e65
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000005b0314
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x000000000068795e
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x000000000068c1fa
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x000000000077535d
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libpthread.so.0+0x0000000000007dd4
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libc.so.6+0x00000000000fdeac
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: Reactor stalled for 500 ms on shard 13.
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: Backtrace:
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000006c5af2
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000005d41ac
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: 0x00000000005d4666
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libpthread.so.0+0x000000000000f5cf
+[10.0.73.70] [stdout] Apr 02 11:24:34 info   | scylla[124]: /lib64/libgmp.so.10+0x000000000002e946
+[10.0.73.70] [stdout] Apr 02 11:24:35 info   | scylla[124]: Reactor stalled for 1000 ms on shard 3.
+[10.0.73.70] [stdout] Apr 02 11:24:35 info   | scylla[124]: Backtrace:
+[10.0.73.70] [stdout] Apr 02 11:24:35 info   | scylla[124]: 0x00000000006c5af2
+[10.0.73.70] [stdout] Apr 02 11:24:35 info   | scylla[124]: 0x00000000005d41ac
+[10.0.73.70] [stdout] Apr 02 11:24:35 info   | scylla[124]: 0x00000000005d4666
+[10.0.73.70] [stdout] Apr 02 11:24:35 info   | scylla[124]: /lib64/libpthread.so.0+0x000000000000f5cf
+[10.0.73.70] [stdout] Apr 02 11:24:35 info   | scylla[124]: /lib64/libgmp.so.10+0x000000000002e9c5
+[10.0.73.70] [stdout] Apr 02 11:24:35 info   | scylla[124]: Reactor stalled for 1000 ms on shard 4.
+[10.0.73.70] [stdout] Apr 02 11:24:35 info   | scylla[124]: Backtrace:
+[10.0.73.70] [stdout] Apr 02 11:24:35 info   | scylla[124]: 0x00000000006c5af2
+[10.0.73.70] [stdout] Apr 02 11:24:35 info   | scylla[124]: 0x00000000005d41ac
+[10.0.73.70] [stdout] Apr 02 11:24:35 info   | scylla[124]: 0x00000000005d4666
+[10.0.73.70] [stdout] Apr 02 11:24:35 info   | scylla[124]: /lib64/libpthread.so.0+0x000000000000f5cf
+[10.0.73.70] [stdout] Apr 02 11:24:35 info   | scylla[124]: /lib64/libgmp.so.10+0x000000000002e8c5
+[10.0.73.70] [stdout] Apr 02 11:24:35 info   | scylla[124]:  [shard 0] legacy_schema_migrator - Moving 0 keyspaces from legacy schema tables to the new schema keyspace (system_schema)
+[10.0.73.70] [stdout] Apr 02 11:24:35 info   | scylla[124]:  [shard 0] legacy_schema_migrator - Dropping legacy schema tables
+[10.0.73.70] [stdout] Apr 02 11:24:35 info   | scylla[124]:  [shard 0] legacy_schema_migrator - Completed migration of legacy schema tables
+[10.0.73.70] [stdout] Apr 02 11:24:35 info   | scylla[124]:  [shard 4] compaction - Compacting [/var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/system-local-ka-32-Data.db:level=0, /var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/system-local-ka-18-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:35 info   | scylla[124]: Started Scylla Server.
+[10.0.73.70] [stdout] Apr 02 11:24:35 info   | scylla[124]:  [shard 0] storage_service - Loading persisted ring state
+[10.0.73.70] [stdout] Apr 02 11:24:35 info   | scylla[124]:  [shard 0] storage_service - load_peer_features: peer_features size=0
+[10.0.73.70] [stdout] Apr 02 11:24:35 info   | scylla[124]:  [shard 0] storage_service - Checking remote features with gossip
+[10.0.73.70] [stdout] Apr 02 11:24:35 info   | scylla[124]:  [shard 0] messaging_service - Starting Encrypted Messaging Service on SSL port 7001
+[10.0.73.70] [stdout] Apr 02 11:24:35 info   | scylla[124]:  [shard 0] messaging_service - Starting Messaging Service on port 7000
+[10.0.73.70] [stdout] Apr 02 11:24:35 info   | scylla[124]:  [shard 4] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/system-local-ka-46-Data.db:level=0, ]. 10065 bytes to 5360 (~53% of original) in 7ms = 0.73MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:35 info   | scylla[124]: Started Scylla JMX.
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]: Using config file: /etc/scylla/scylla.yaml
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 0] gossip - Feature check passed. Local node 10.0.73.70 features = {CORRECT_COUNTER_ORDER, CORRECT_NON_COMPOUND_RANGE_TOMBSTONES, COUNTERS, DIGEST_MULTIPARTITION_READ, INDEXES, LARGE_PARTITIONS, LA_SSTABLE_FORMAT, MATERIALIZED_VIEWS, RANGE_TOMBSTONES, ROLES, SCHEMA_TABLES_V3, STREAM_WITH_RPC_STREAM, WRITE_FAILURE_REPLY, XXHASH}, Remote common_features = {CORRECT_COUNTER_ORDER, CORRECT_NON_COMPOUND_RANGE_TOMBSTONES, COUNTERS, DIGEST_MULTIPARTITION_READ, INDEXES, LARGE_PARTITIONS, LA_SSTABLE_FORMAT, MATERIALIZED_VIEWS, RANGE_TOMBSTONES, ROLES, SCHEMA_TABLES_V3, STREAM_WITH_RPC_STREAM, WRITE_FAILURE_REPLY, XXHASH}
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 4] compaction - Compacting [/var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/system-local-ka-46-Data.db:level=0, /var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/system-local-ka-60-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 0] storage_service - Starting up server gossip
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 4] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/system-local-ka-74-Data.db:level=0, ]. 10917 bytes to 6116 (~56% of original) in 9ms = 0.65MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 4] compaction - Compacting [/var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/system-local-ka-88-Data.db:level=0, /var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/system-local-ka-74-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 4] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/system-local-ka-102-Data.db:level=0, ]. 10956 bytes to 6147 (~56% of original) in 9ms = 0.65MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 0] database - Schema version changed to 59adb24e-f3cd-3e02-97f0-5b395827453f
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 0] gossip - Feature RANGE_TOMBSTONES is enabled
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 0] gossip - Feature LARGE_PARTITIONS is enabled
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 0] gossip - Feature COUNTERS is enabled
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 0] gossip - Feature DIGEST_MULTIPARTITION_READ is enabled
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 0] gossip - Feature CORRECT_COUNTER_ORDER is enabled
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 0] gossip - Feature SCHEMA_TABLES_V3 is enabled
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 0] gossip - Feature CORRECT_NON_COMPOUND_RANGE_TOMBSTONES is enabled
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 0] gossip - Feature WRITE_FAILURE_REPLY is enabled
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 0] gossip - Feature XXHASH is enabled
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 0] gossip - Feature ROLES is enabled
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 0] gossip - Feature LA_SSTABLE_FORMAT is enabled
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 0] gossip - Feature STREAM_WITH_RPC_STREAM is enabled
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 0] gossip - Feature MATERIALIZED_VIEWS is enabled
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 0] gossip - Feature INDEXES is enabled
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 0] migration_manager - Create new Keyspace: KSMetaData{name=system_distributed, strategyClass=org.apache.cassandra.locator.SimpleStrategy, strategyOptions={replication_factor=3}, cfMetaData={}, durable_writes=1, userTypes=org.apache.cassandra.config.UTMetaData@0x6000092430c8}
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 0] schema_tables - Creating keyspace system_distributed
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 0] database - Schema version changed to f399fd51-3145-3257-9810-0fa435c7075f
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 0] migration_manager - Create new ColumnFamily: org.apache.cassandra.config.CFMetaData@0x600000c7f180[cfId=5582b59f-8e4e-35e1-b913-3acada51eb04,ksName=system_distributed,cfName=view_build_status,cfType=Standard,comparator=org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UUIDType,org.apache.cassandra.db.marshal.UTF8Type),comment=,readRepairChance=0,dcLocalReadRepairChance=0.1,gcGraceSeconds=864000,keyValidator=org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UTF8Type, org.apache.cassandra.db.marshal.UTF8Type),minCompactionThreshold=4,maxCompactionThreshold=32,columnMetadata=[ColumnDefinition{name=keyspace_name, type=org.apache.cassandra.db.marshal.UTF8Type, kind=PARTITION_KEY, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=view_name, type=org.apache.cassandra.db.marshal.UTF8Type, kind=PARTITION_KEY, componentIndex=1, droppedAt=-9223372036854775808}, ColumnDefinition{name=host_id, type=org.apache.cassandra.db.marshal.UUIDType, kind=CLUSTERING_COLUMN, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=status, type=org.apache.cassandra.db.marshal.UTF8Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}],compactionStrategyClass=class org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy,compactionStrategyOptions={enabled=true},compressionParameters={sstable_compression=org.apache.cassandra.io.compress.LZ4Compressor},bloomFilterFpChance=0.01,memtableFlushPeriod=0,caching={"keys":"ALL","rows_per_partition":"ALL"},defaultTimeToLive=0,minIndexInterval=128,maxIndexInterval=2048,speculativeRetry=99.0PERCENTILE,triggers=[],isDense=false,in_memory=false,version=01314a30-dc37-368a-b4af-5591330ffc4c,droppedColumns={},collections={},indices={}]
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 11] compaction - Compacting [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-39-big-Data.db:level=0, /var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-25-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 0] schema_tables - Creating system_distributed.view_build_status id=5582b59f-8e4e-35e1-b913-3acada51eb04 version=807957b8-87c8-3b33-a70a-a799ed3bd7c6
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 11] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-53-big-Data.db:level=0, ]. 9986 bytes to 5321 (~53% of original) in 8ms = 0.63MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 0] database - Schema version changed to 40a644cc-c9f3-3fa5-bc5a-8f3f05d339aa
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 0] migration_manager - Create new ColumnFamily: org.apache.cassandra.config.CFMetaData@0x600000c7ee00[cfId=b8c556bd-212d-37ad-9484-690c73a5994b,ksName=system_distributed,cfName=service_levels,cfType=Standard,comparator=org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UTF8Type),comment=,readRepairChance=0,dcLocalReadRepairChance=0.1,gcGraceSeconds=864000,keyValidator=org.apache.cassandra.db.marshal.UTF8Type,minCompactionThreshold=4,maxCompactionThreshold=32,columnMetadata=[ColumnDefinition{name=service_level, type=org.apache.cassandra.db.marshal.UTF8Type, kind=PARTITION_KEY, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=shares, type=org.apache.cassandra.db.marshal.Int32Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}],compactionStrategyClass=class org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy,compactionStrategyOptions={enabled=true},compressionParameters={sstable_compression=org.apache.cassandra.io.compress.LZ4Compressor},bloomFilterFpChance=0.01,memtableFlushPeriod=0,caching={"keys":"ALL","rows_per_partition":"ALL"},defaultTimeToLive=0,minIndexInterval=128,maxIndexInterval=2048,speculativeRetry=99.0PERCENTILE,triggers=[],isDense=false,in_memory=false,version=d51c448b-da4e-3a49-b723-8e47aa751127,droppedColumns={},collections={},indices={}]
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 11] compaction - Compacting [/var/lib/scylla/data/system_schema/indexes-0feb57ac311f382fba6d9024d305702f/la-39-big-Data.db:level=0, /var/lib/scylla/data/system_schema/indexes-0feb57ac311f382fba6d9024d305702f/la-25-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 11] compaction - Compacted 2 sstables to []. 9732 bytes to 0 (~0% of original) in 1ms = 0.00MB/s. ~256 total partitions merged to 0.
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 11] compaction - Compacting [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-39-big-Data.db:level=0, /var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-25-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 11] compaction - Compacting [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-39-big-Data.db:level=0, /var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-25-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 11] compaction - Compacting [/var/lib/scylla/data/system_schema/dropped_columns-5e7583b5f3f43af19a39b7e1d6f5f11f/la-39-big-Data.db:level=0, /var/lib/scylla/data/system_schema/dropped_columns-5e7583b5f3f43af19a39b7e1d6f5f11f/la-25-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 11] compaction - Compacted 2 sstables to []. 9732 bytes to 0 (~0% of original) in 0ms = 0.00MB/s. ~256 total partitions merged to 0.
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 11] compaction - Compacting [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-67-big-Data.db:level=0, /var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-53-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 11] compaction - Compacting [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-39-big-Data.db:level=0, /var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-25-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 0] schema_tables - Creating system_distributed.service_levels id=b8c556bd-212d-37ad-9484-690c73a5994b version=51884e0d-dc57-3119-a9a8-69d36ba653f3
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 11] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-53-big-Data.db:level=0, ]. 10423 bytes to 5747 (~55% of original) in 23ms = 0.24MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 11] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-53-big-Data.db:level=0, ]. 9974 bytes to 5356 (~53% of original) in 22ms = 0.23MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 11] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-81-big-Data.db:level=0, ]. 10314 bytes to 5321 (~51% of original) in 21ms = 0.24MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:36 info   | scylla[124]:  [shard 11] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-53-big-Data.db:level=0, ]. 11001 bytes to 6011 (~54% of original) in 18ms = 0.32MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] database - Schema version changed to 3798c40d-12d3-3719-83e5-c9ed6309fb8c
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] storage_service - Generated random tokens. tokens are {-3560647200451113119, 7346892362217386362, 3424040786029357713, 3577356542844624529, 2085349109937340256, 6784588099063851934, 4155968460579151469, 710908380352128559, -6631664840906127839, 919320017947858935, -442301061652096487, -1309150464435941097, 7651083484250468623, 7050026059284859731, 706942788835379851, 2572923548507576610, -5771676787970073305, 7520114486152970266, -7417875618854868303, -8205083285841462668, 1776767981577948379, -3409393591683476266, -4400851521427719583, 8635937141426200912, -3867786308026236902, 4975279073184617789, -6538562898688735762, -653086548396224770, 6386203322893004674, -1551815588964285711, 5024597484103495298, 620219410446387143, -8123133880417308229, 2771972114192661924, -6991924657129948978, 2230732564871356837, -3809657211705769962, -6595424233149210099, 627632899840663949, 5965834208770872659, 4501696491279204729, -6954475764685584923, -109865962119416336, -5932408933305228477, 2213020225948988895, 8723597742700444563, -7086977539084012413, -2222895300622402028, 5196741466174102399, 5568120702586658657, -3033824418676813684, -517547808921986156, -8722525328218890210, 7087445191667946112, -1610994183788720952, -7741279473951933658, 7076281582362389612, 879734534352661672, -451064240048664652, 2320504833406176178, 7492321640516069057, 7599429348758735316, 4295022056995025915, -1564183286741420170, 2018026179774427825, -6766709827076179081, 9049684491588615408, 5926142249955698397, 3361801238549051338, -8580666733283636341, 3769268861443915337, 4248655417661471761, 5476775636932468075, 2262321001594146368, -1409949059014858007, -945002596494227721, 2351089910672263725, 5207012711731370673, -6217700513740443582, 5471743538708180112, 3971961404682890367, 1383479425847432015, -7456825837456027306, 5899053900432439262, -2153873736256057109, -3207395511436043700, -704093014931303289, -1589313027803907090, 3987750571049477853, 4433479204487566882, 7420338445389804254, 6495518075333865712, -3754347742677734669, 5105426527803766954, 5656594304582466272, 8267221159913090653, -4204266718587515639, -8503643953746504417, 4156231114917073346, -6465178824591881439, 964064776891688080, 6650708804057262205, 2511063316179817690, 4211815607885622990, 5289985802704048353, 2009541059736530906, 8626370565930111405, -6244470818446579805, 240014780401622051, -518376864356919942, -1700287997812580093, -3847022136882421717, -1411686373996433125, -7758236549849950606, 6980983170239016522, 5668146686632565239, 2542513791031005142, -4491507675379055512, 7350578643382699725, -6851924758196891499, -4330388440939713025, -2429442216329648090, 7796603522360813263, 7282824016236190263, 1296109052816909955, 3534472511438420312, -7701048181135457099, -8425727324390787597, -1686052122818749249, -4683272235209677656, -1488089249610267098, 1465087183277001425, 5085675779303776511, -5279490929334304870, 5481846942072543265, -6544396373214618794, -3419909139039795079, 3535764490661021396, -8978427261137769231, -6457762753902060127, -1149142943736173968, 8621612207441066899, -5326459053479771594, -5481882644267305495, -6804207364700821298, -3982551195424618207, -8896827503147370440, -2767439483770981065, -4882128331166646039, 1347671185094235836, -5627894917399000430, -2227078912827657461, -3561495460982598084, 8484272930571916847, 1758560027468483508, -966490361473230315, 5231801075384312836, 4159340253188108894, -751736802849330109, -940763364027222782, -9101184945505144975, -4541704630880806192, -7154902475901447493, 8475057228732358457, -3706204160536746188, -2816499595482872187, 2830735137614401711, 8829729804979754803, -8304011862795811778, -2543391719280979407, 7788535925803506769, -1986895622360489406, -6671493591205157295, 2918157306208349678, -1391207249177763248, 7803620703431458025, -1197714370244946798, -5467516398815973927, -3903890802909442596, -1704020729412708652, 3832351096692031142, -8950875472426717272, 8106860789856375647, 6377763689062202748, 6809012474274996509, -2147571692163799036, -7132360754207552976, 7882663737577365982,
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 4] compaction - Compacting [/var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/la-116-big-Data.db:level=0, /var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/system-local-ka-102-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 4] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/la-144-big-Data.db:level=0, ]. 11033 bytes to 6175 (~55% of original) in 10ms = 0.59MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 4] compaction - Compacting [/var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/la-144-big-Data.db:level=0, /var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/la-130-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] storage_service - Node 10.0.73.70 state jump to normal
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 4] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system/local-7ad54392bcdd35a684174e047860b377/la-158-big-Data.db:level=0, ]. 16619 bytes to 11914 (~71% of original) in 7ms = 1.62MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] storage_service - NORMAL: node is now in normal status
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] migration_manager - Create new Keyspace: KSMetaData{name=system_auth, strategyClass=org.apache.cassandra.locator.SimpleStrategy, strategyOptions={replication_factor=1}, cfMetaData={}, durable_writes=1, userTypes=org.apache.cassandra.config.UTMetaData@0x600000f953c8}
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] schema_tables - Creating keyspace system_auth
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] database - Schema version changed to a02e3a85-cb2a-38ba-8df1-4756faa2b96f
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] migration_manager - Create new ColumnFamily: org.apache.cassandra.config.CFMetaData@0x600000c7f880[cfId=6b8c7359-a843-33f2-a1d8-5dc6a187436f,ksName=system_auth,cfName=role_attributes,cfType=Standard,comparator=org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type),comment=,readRepairChance=0,dcLocalReadRepairChance=0.1,gcGraceSeconds=864000,keyValidator=org.apache.cassandra.db.marshal.UTF8Type,minCompactionThreshold=4,maxCompactionThreshold=32,columnMetadata=[ColumnDefinition{name=role, type=org.apache.cassandra.db.marshal.UTF8Type, kind=PARTITION_KEY, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=name, type=org.apache.cassandra.db.marshal.UTF8Type, kind=CLUSTERING_COLUMN, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=value, type=org.apache.cassandra.db.marshal.UTF8Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}],compactionStrategyClass=class org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy,compactionStrategyOptions={enabled=true},compressionParameters={sstable_compression=org.apache.cassandra.io.compress.LZ4Compressor},bloomFilterFpChance=0.01,memtableFlushPeriod=0,caching={"keys":"ALL","rows_per_partition":"ALL"},defaultTimeToLive=0,minIndexInterval=128,maxIndexInterval=2048,speculativeRetry=99.0PERCENTILE,triggers=[],isDense=false,in_memory=false,version=e5f33952-5539-11e9-8c0b-000000000002,droppedColumns={},collections={},indices={}]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] migration_manager - Create new ColumnFamily: org.apache.cassandra.config.CFMetaData@0x600000c7f880[cfId=0ecdaa87-f8fb-3e60-88d1-74fb36fe5c0d,ksName=system_auth,cfName=role_members,cfType=Standard,comparator=org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type),comment=,readRepairChance=0,dcLocalReadRepairChance=0.1,gcGraceSeconds=864000,keyValidator=org.apache.cassandra.db.marshal.UTF8Type,minCompactionThreshold=4,maxCompactionThreshold=32,columnMetadata=[ColumnDefinition{name=role, type=org.apache.cassandra.db.marshal.UTF8Type, kind=PARTITION_KEY, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=member, type=org.apache.cassandra.db.marshal.UTF8Type, kind=CLUSTERING_COLUMN, componentIndex=0, droppedAt=-9223372036854775808}],compactionStrategyClass=class org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy,compactionStrategyOptions={enabled=true},compressionParameters={sstable_compression=org.apache.cassandra.io.compress.LZ4Compressor},bloomFilterFpChance=0.01,memtableFlushPeriod=0,caching={"keys":"ALL","rows_per_partition":"ALL"},defaultTimeToLive=0,minIndexInterval=128,maxIndexInterval=2048,speculativeRetry=99.0PERCENTILE,triggers=[],isDense=false,in_memory=false,version=e5f36062-5539-11e9-8c0b-000000000002,droppedColumns={},collections={},indices={}]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] migration_manager - Create new ColumnFamily: org.apache.cassandra.config.CFMetaData@0x600000c7d500[cfId=5bc52802-de25-35ed-aeab-188eecebb090,ksName=system_auth,cfName=roles,cfType=Standard,comparator=org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.ColumnToCollectionType(6d656d6265725f6f66:org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.UTF8Type))),comment=,readRepairChance=0,dcLocalReadRepairChance=0.1,gcGraceSeconds=864000,keyValidator=org.apache.cassandra.db.marshal.UTF8Type,minCompactionThreshold=4,maxCompactionThreshold=32,columnMetadata=[ColumnDefinition{name=role, type=org.apache.cassandra.db.marshal.UTF8Type, kind=PARTITION_KEY, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=can_login, type=org.apache.cassandra.db.marshal.BooleanType, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=is_superuser, type=org.apache.cassandra.db.marshal.BooleanType, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=member_of, type=org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.UTF8Type), kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=salted_hash, type=org.apache.cassandra.db.marshal.UTF8Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}],compactionStrategyClass=class org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy,compactionStrategyOptions={enabled=true},compressionParameters={sstable_compression=org.apache.cassandra.io.compress.LZ4Compressor},bloomFilterFpChance=0.01,memtableFlushPeriod=0,caching={"keys":"ALL","rows_per_partition":"ALL"},defaultTimeToLive=0,minIndexInterval=128,maxIndexInterval=2048,speculativeRetry=99.0PERCENTILE,triggers=[],isDense=false,in_memory=false,version=e5f36065-5539-11e9-8c0b-000000000002,droppedColumns={},collections={6d656d6265725f6f66 : org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.UTF8Type)},indices={}]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-38-big-Data.db:level=0, /var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-24-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] schema_tables - Creating system_auth.role_attributes id=6b8c7359-a843-33f2-a1d8-5dc6a187436f version=3f51f745-b2d7-3e66-a14b-208004117c9d
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 10] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-52-big-Data.db:level=0, ]. 9916 bytes to 5286 (~53% of original) in 6ms = 0.84MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] database - Schema version changed to 41c3606c-39ac-3e18-b994-5260e44f2e5d
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/indexes-0feb57ac311f382fba6d9024d305702f/la-38-big-Data.db:level=0, /var/lib/scylla/data/system_schema/indexes-0feb57ac311f382fba6d9024d305702f/la-24-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-38-big-Data.db:level=0, /var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-24-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 10] compaction - Compacted 2 sstables to []. 9664 bytes to 0 (~0% of original) in 0ms = 0.00MB/s. ~256 total partitions merged to 0.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-38-big-Data.db:level=0, /var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-24-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/dropped_columns-5e7583b5f3f43af19a39b7e1d6f5f11f/la-38-big-Data.db:level=0, /var/lib/scylla/data/system_schema/dropped_columns-5e7583b5f3f43af19a39b7e1d6f5f11f/la-24-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 10] compaction - Compacted 2 sstables to []. 9664 bytes to 0 (~0% of original) in 0ms = 0.00MB/s. ~256 total partitions merged to 0.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-66-big-Data.db:level=0, /var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-52-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-38-big-Data.db:level=0, /var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-24-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] schema_tables - Creating system_auth.role_members id=0ecdaa87-f8fb-3e60-88d1-74fb36fe5c0d version=2e5e813e-a37d-3e6b-b6f6-682bd899df62
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 10] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-52-big-Data.db:level=0, ]. 10251 bytes to 5630 (~54% of original) in 22ms = 0.24MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 10] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-52-big-Data.db:level=0, ]. 9899 bytes to 5319 (~53% of original) in 21ms = 0.24MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 10] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-80-big-Data.db:level=0, ]. 10244 bytes to 5286 (~51% of original) in 18ms = 0.28MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 10] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-52-big-Data.db:level=0, ]. 10938 bytes to 6068 (~55% of original) in 17ms = 0.34MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] database - Schema version changed to 63be0f27-fab2-3b99-8954-d539f0a20862
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-66-big-Data.db:level=0, /var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-52-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-66-big-Data.db:level=0, /var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-52-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-94-big-Data.db:level=0, /var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-80-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-66-big-Data.db:level=0, /var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-52-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] schema_tables - Creating system_auth.roles id=5bc52802-de25-35ed-aeab-188eecebb090 version=ad082e9b-e0ba-379a-91f4-91c26e1bea18
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 10] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-80-big-Data.db:level=0, ]. 10913 bytes to 5963 (~54% of original) in 20ms = 0.28MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 10] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-80-big-Data.db:level=0, ]. 10243 bytes to 5339 (~52% of original) in 19ms = 0.27MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 10] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-108-big-Data.db:level=0, ]. 10244 bytes to 5286 (~51% of original) in 16ms = 0.32MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 10] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-80-big-Data.db:level=0, ]. 11502 bytes to 6302 (~54% of original) in 19ms = 0.32MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] database - Schema version changed to 75706ed0-55c3-315c-aa71-22827ac6c420
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] migration_manager - Create new Keyspace: KSMetaData{name=system_traces, strategyClass=org.apache.cassandra.locator.SimpleStrategy, strategyOptions={replication_factor=2}, cfMetaData={}, durable_writes=1, userTypes=org.apache.cassandra.config.UTMetaData@0x600000f955c8}
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] schema_tables - Creating keyspace system_traces
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] database - Schema version changed to e09efa52-56d1-3bcf-af89-d5e71e1c1ce6
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] migration_manager - Create new ColumnFamily: org.apache.cassandra.config.CFMetaData@0x600000c7d880[cfId=c5e99f16-8677-3914-b17e-960613512345,ksName=system_traces,cfName=sessions,cfType=Standard,comparator=org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.ColumnToCollectionType(706172616d6574657273:org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type))),comment=,readRepairChance=0,dcLocalReadRepairChance=0.1,gcGraceSeconds=864000,keyValidator=org.apache.cassandra.db.marshal.UUIDType,minCompactionThreshold=4,maxCompactionThreshold=32,columnMetadata=[ColumnDefinition{name=session_id, type=org.apache.cassandra.db.marshal.UUIDType, kind=PARTITION_KEY, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=client, type=org.apache.cassandra.db.marshal.InetAddressType, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=command, type=org.apache.cassandra.db.marshal.UTF8Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=coordinator, type=org.apache.cassandra.db.marshal.InetAddressType, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=duration, type=org.apache.cassandra.db.marshal.Int32Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=parameters, type=org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type), kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=request, type=org.apache.cassandra.db.marshal.UTF8Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=request_size, type=org.apache.cassandra.db.marshal.Int32Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=response_size, type=org.apache.cassandra.db.marshal.Int32Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=started_at, type=org.apache.cassandra.db.marshal.TimestampType, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}],compactionStrategyClass=class org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy,compactionStrategyOptions={enabled=true},compressionParameters={sstable_compression=org.apache.cassandra.io.compress.LZ4Compressor},bloomFilterFpChance=0.01,memtableFlushPeriod=0,caching={"keys":"ALL","rows_per_partition":"ALL"},defaultTimeToLive=86400,minIndexInterval=128,maxIndexInterval=2048,speculativeRetry=99.0PERCENTILE,triggers=[],isDense=false,in_memory=false,version=e61f7972-5539-11e9-8c0b-000000000002,droppedColumns={},collections={706172616d6574657273 : org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type)},indices={}]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-36-big-Data.db:level=0, /var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-22-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] schema_tables - Creating system_traces.sessions id=c5e99f16-8677-3914-b17e-960613512345 version=cea87552-239e-3a4c-85f0-c205caf56e64
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-50-big-Data.db:level=0, ]. 9934 bytes to 5295 (~53% of original) in 8ms = 0.63MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] database - Schema version changed to d2342792-25ef-313e-9a93-d7d93d1f07ed
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] migration_manager - Create new ColumnFamily: org.apache.cassandra.config.CFMetaData@0x600000c7e000[cfId=0ebf001c-c1d1-3693-9a63-c3d96ac53318,ksName=system_traces,cfName=sessions_time_idx,cfType=Standard,comparator=org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.TimestampType,org.apache.cassandra.db.marshal.UUIDType,org.apache.cassandra.db.marshal.UTF8Type),comment=,readRepairChance=0,dcLocalReadRepairChance=0.1,gcGraceSeconds=864000,keyValidator=org.apache.cassandra.db.marshal.TimestampType,minCompactionThreshold=4,maxCompactionThreshold=32,columnMetadata=[ColumnDefinition{name=minute, type=org.apache.cassandra.db.marshal.TimestampType, kind=PARTITION_KEY, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=started_at, type=org.apache.cassandra.db.marshal.TimestampType, kind=CLUSTERING_COLUMN, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=session_id, type=org.apache.cassandra.db.marshal.UUIDType, kind=CLUSTERING_COLUMN, componentIndex=1, droppedAt=-9223372036854775808}],compactionStrategyClass=class org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy,compactionStrategyOptions={enabled=true},compressionParameters={sstable_compression=org.apache.cassandra.io.compress.LZ4Compressor},bloomFilterFpChance=0.01,memtableFlushPeriod=0,caching={"keys":"ALL","rows_per_partition":"ALL"},defaultTimeToLive=86400,minIndexInterval=128,maxIndexInterval=2048,speculativeRetry=99.0PERCENTILE,triggers=[],isDense=false,in_memory=false,version=e62a75f2-5539-11e9-8c0b-000000000002,droppedColumns={},collections={},indices={}]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/indexes-0feb57ac311f382fba6d9024d305702f/la-36-big-Data.db:level=0, /var/lib/scylla/data/system_schema/indexes-0feb57ac311f382fba6d9024d305702f/la-22-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacted 2 sstables to []. 9684 bytes to 0 (~0% of original) in 0ms = 0.00MB/s. ~256 total partitions merged to 0.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-36-big-Data.db:level=0, /var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-22-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-22-big-Data.db:level=0, /var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-36-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/dropped_columns-5e7583b5f3f43af19a39b7e1d6f5f11f/la-36-big-Data.db:level=0, /var/lib/scylla/data/system_schema/dropped_columns-5e7583b5f3f43af19a39b7e1d6f5f11f/la-22-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacted 2 sstables to []. 9684 bytes to 0 (~0% of original) in 1ms = 0.00MB/s. ~256 total partitions merged to 0.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-64-big-Data.db:level=0, /var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-50-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-22-big-Data.db:level=0, /var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-36-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] schema_tables - Creating system_traces.sessions_time_idx id=0ebf001c-c1d1-3693-9a63-c3d96ac53318 version=cf8bb10b-1839-348f-8b46-5a2090c6a0ce
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-50-big-Data.db:level=0, ]. 10796 bytes to 6156 (~57% of original) in 22ms = 0.27MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-50-big-Data.db:level=0, ]. 9909 bytes to 5323 (~53% of original) in 23ms = 0.22MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-78-big-Data.db:level=0, ]. 10262 bytes to 5295 (~51% of original) in 20ms = 0.25MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-50-big-Data.db:level=0, ]. 10939 bytes to 6072 (~55% of original) in 17ms = 0.34MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] database - Schema version changed to c69604b3-9c2b-301e-b23c-65f9c56e202e
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] migration_manager - Create new ColumnFamily: org.apache.cassandra.config.CFMetaData@0x600000c7d880[cfId=8826e8e9-e16a-3728-8753-3bc1fc713c25,ksName=system_traces,cfName=events,cfType=Standard,comparator=org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.TimeUUIDType,org.apache.cassandra.db.marshal.UTF8Type),comment=,readRepairChance=0,dcLocalReadRepairChance=0.1,gcGraceSeconds=864000,keyValidator=org.apache.cassandra.db.marshal.UUIDType,minCompactionThreshold=4,maxCompactionThreshold=32,columnMetadata=[ColumnDefinition{name=session_id, type=org.apache.cassandra.db.marshal.UUIDType, kind=PARTITION_KEY, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=event_id, type=org.apache.cassandra.db.marshal.TimeUUIDType, kind=CLUSTERING_COLUMN, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=activity, type=org.apache.cassandra.db.marshal.UTF8Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=scylla_parent_id, type=org.apache.cassandra.db.marshal.LongType, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=scylla_span_id, type=org.apache.cassandra.db.marshal.LongType, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=source, type=org.apache.cassandra.db.marshal.InetAddressType, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=source_elapsed, type=org.apache.cassandra.db.marshal.Int32Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=thread, type=org.apache.cassandra.db.marshal.UTF8Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}],compactionStrategyClass=class org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy,compactionStrategyOptions={enabled=true},compressionParameters={sstable_compression=org.apache.cassandra.io.compress.LZ4Compressor},bloomFilterFpChance=0.01,memtableFlushPeriod=0,caching={"keys":"ALL","rows_per_partition":"ALL"},defaultTimeToLive=86400,minIndexInterval=128,maxIndexInterval=2048,speculativeRetry=99.0PERCENTILE,triggers=[],isDense=false,in_memory=false,version=e637e372-5539-11e9-8c0b-000000000002,droppedColumns={},collections={},indices={}]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-64-big-Data.db:level=0, /var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-50-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-64-big-Data.db:level=0, /var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-50-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-92-big-Data.db:level=0, /var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-78-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-64-big-Data.db:level=0, /var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-50-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] schema_tables - Creating system_traces.events id=8826e8e9-e16a-3728-8753-3bc1fc713c25 version=ea3f87ea-567a-3be3-acdd-4ab84080eb68
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-78-big-Data.db:level=0, ]. 11637 bytes to 6836 (~58% of original) in 19ms = 0.34MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-78-big-Data.db:level=0, ]. 10258 bytes to 5352 (~52% of original) in 17ms = 0.30MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-106-big-Data.db:level=0, ]. 10262 bytes to 5295 (~51% of original) in 19ms = 0.27MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-78-big-Data.db:level=0, ]. 11521 bytes to 6318 (~54% of original) in 17ms = 0.35MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] database - Schema version changed to 224c4382-4a57-339b-b55c-485a17017a34
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] migration_manager - Create new ColumnFamily: org.apache.cassandra.config.CFMetaData@0x600000c7e380[cfId=bfcc4e62-5b63-3aa1-a1c3-6f5e47f3325c,ksName=system_traces,cfName=node_slow_log,cfType=Standard,comparator=org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.InetAddressType,org.apache.cassandra.db.marshal.Int32Type,org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.ColumnToCollectionType(706172616d6574657273:org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type),7461626c655f6e616d6573:org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.UTF8Type))),comment=,readRepairChance=0,dcLocalReadRepairChance=0.1,gcGraceSeconds=864000,keyValidator=org.apache.cassandra.db.marshal.TimeUUIDType,minCompactionThreshold=4,maxCompactionThreshold=32,columnMetadata=[ColumnDefinition{name=start_time, type=org.apache.cassandra.db.marshal.TimeUUIDType, kind=PARTITION_KEY, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=node_ip, type=org.apache.cassandra.db.marshal.InetAddressType, kind=CLUSTERING_COLUMN, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=shard, type=org.apache.cassandra.db.marshal.Int32Type, kind=CLUSTERING_COLUMN, componentIndex=1, droppedAt=-9223372036854775808}, ColumnDefinition{name=command, type=org.apache.cassandra.db.marshal.UTF8Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=date, type=org.apache.cassandra.db.marshal.TimestampType, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=duration, type=org.apache.cassandra.db.marshal.Int32Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=parameters, type=org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type), kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=session_id, type=org.apache.cassandra.db.marshal.UUIDType, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=source_ip, type=org.apache.cassandra.db.marshal.InetAddressType, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=table_names, type=org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.UTF8Type), kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=username, type=org.apache.cassandra.db.marshal.UTF8Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}],compactionStrategyClass=class org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy,compactionStrategyOptions={enabled=true},compressionParameters={sstable_compression=org.apache.cassandra.io.compress.LZ4Compressor},bloomFilterFpChance=0.01,memtableFlushPeriod=0,caching={"keys":"ALL","rows_per_partition":"ALL"},defaultTimeToLive=86400,minIndexInterval=128,maxIndexInterval=2048,speculativeRetry=99.0PERCENTILE,triggers=[],isDense=false,in_memory=false,version=e64502d2-5539-11e9-8c0b-000000000002,droppedColumns={},collections={706172616d6574657273 : org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.UTF8Type), 7461626c655f6e616d6573 : org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.UTF8Type)},indices={}]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/indexes-0feb57ac311f382fba6d9024d305702f/la-64-big-Data.db:level=0, /var/lib/scylla/data/system_schema/indexes-0feb57ac311f382fba6d9024d305702f/la-50-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacted 2 sstables to []. 9684 bytes to 0 (~0% of original) in 1ms = 0.00MB/s. ~256 total partitions merged to 0.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-92-big-Data.db:level=0, /var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-78-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-92-big-Data.db:level=0, /var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-78-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/dropped_columns-5e7583b5f3f43af19a39b7e1d6f5f11f/la-64-big-Data.db:level=0, /var/lib/scylla/data/system_schema/dropped_columns-5e7583b5f3f43af19a39b7e1d6f5f11f/la-50-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacted 2 sstables to []. 9684 bytes to 0 (~0% of original) in 0ms = 0.00MB/s. ~256 total partitions merged to 0.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-120-big-Data.db:level=0, /var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-106-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-92-big-Data.db:level=0, /var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-78-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] schema_tables - Creating system_traces.node_slow_log id=bfcc4e62-5b63-3aa1-a1c3-6f5e47f3325c version=cf80b0df-68ff-3de1-b176-b6811679741a
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-106-big-Data.db:level=0, ]. 12547 bytes to 7721 (~61% of original) in 23ms = 0.32MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-106-big-Data.db:level=0, ]. 10308 bytes to 5391 (~52% of original) in 22ms = 0.23MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-134-big-Data.db:level=0, ]. 10262 bytes to 5295 (~51% of original) in 19ms = 0.27MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-106-big-Data.db:level=0, ]. 11790 bytes to 6686 (~56% of original) in 17ms = 0.38MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] database - Schema version changed to 624dedc0-92c7-303d-a5e7-393a034e0bdb
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] migration_manager - Create new ColumnFamily: org.apache.cassandra.config.CFMetaData@0x600000c7ca80[cfId=f9706768-aa1e-3d87-9e5c-51a3927c2870,ksName=system_traces,cfName=node_slow_log_time_idx,cfType=Standard,comparator=org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.TimestampType,org.apache.cassandra.db.marshal.UUIDType,org.apache.cassandra.db.marshal.UTF8Type),comment=,readRepairChance=0,dcLocalReadRepairChance=0.1,gcGraceSeconds=864000,keyValidator=org.apache.cassandra.db.marshal.TimestampType,minCompactionThreshold=4,maxCompactionThreshold=32,columnMetadata=[ColumnDefinition{name=minute, type=org.apache.cassandra.db.marshal.TimestampType, kind=PARTITION_KEY, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=started_at, type=org.apache.cassandra.db.marshal.TimestampType, kind=CLUSTERING_COLUMN, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=session_id, type=org.apache.cassandra.db.marshal.UUIDType, kind=CLUSTERING_COLUMN, componentIndex=1, droppedAt=-9223372036854775808}, ColumnDefinition{name=node_ip, type=org.apache.cassandra.db.marshal.InetAddressType, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=shard, type=org.apache.cassandra.db.marshal.Int32Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}, ColumnDefinition{name=start_time, type=org.apache.cassandra.db.marshal.TimeUUIDType, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}],compactionStrategyClass=class org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy,compactionStrategyOptions={enabled=true},compressionParameters={sstable_compression=org.apache.cassandra.io.compress.LZ4Compressor},bloomFilterFpChance=0.01,memtableFlushPeriod=0,caching={"keys":"ALL","rows_per_partition":"ALL"},defaultTimeToLive=86400,minIndexInterval=128,maxIndexInterval=2048,speculativeRetry=99.0PERCENTILE,triggers=[],isDense=false,in_memory=false,version=e652e582-5539-11e9-8c0b-000000000002,droppedColumns={},collections={},indices={}]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-120-big-Data.db:level=0, /var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-106-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-120-big-Data.db:level=0, /var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-106-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-148-big-Data.db:level=0, /var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-134-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-120-big-Data.db:level=0, /var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-106-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] schema_tables - Creating system_traces.node_slow_log_time_idx id=f9706768-aa1e-3d87-9e5c-51a3927c2870 version=bf6d4e7c-b70b-31ab-8626-cd3e283b8f6c
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-134-big-Data.db:level=0, ]. 13147 bytes to 8151 (~61% of original) in 19ms = 0.41MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-134-big-Data.db:level=0, ]. 10373 bytes to 5419 (~52% of original) in 19ms = 0.27MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-162-big-Data.db:level=0, ]. 10262 bytes to 5295 (~51% of original) in 19ms = 0.27MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-134-big-Data.db:level=0, ]. 12193 bytes to 7232 (~59% of original) in 18ms = 0.38MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 1] rpc - client 10.0.222.111: server connection dropped: The TLS connection was non-properly terminated.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] database - Schema version changed to 8489e432-105a-371f-a48b-413e6f67013e
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] storage_service - SSTable data integrity checker is disabled.
+[10.0.73.70] [stdout] Apr 02 11:24:37 info   | scylla[124]:  [shard 0] gossip - Waiting for gossip to settle before accepting client requests...
+[10.0.73.70] [stdout] Apr 02 11:24:38 info   | scylla[124]: Connecting to http://127.0.0.1:10000
+[10.0.73.70] [stdout] Apr 02 11:24:38 info   | scylla[124]: Starting the JMX server
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 0] gossip - InetAddress 10.0.222.111 is now UP, status = NORMAL
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 0] migration_manager - Requesting schema pull from 10.0.222.111:0
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 0] Failed to load schema version
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 0] Failed to load schema version
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 0] migration_manager - Pulling schema from 10.0.222.111:0
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 0] migration_manager - Requesting schema pull from 10.0.222.111:0
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 0] migration_manager - Pulling schema from 10.0.222.111:0
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-148-big-Data.db:level=0, /var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-134-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 11] compaction - Compacting [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-67-big-Data.db:level=0, /var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-53-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-148-big-Data.db:level=0, /var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-134-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 11] compaction - Compacting [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-67-big-Data.db:level=0, /var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-53-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-94-big-Data.db:level=0, /var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-80-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-94-big-Data.db:level=0, /var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-80-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-176-big-Data.db:level=0, /var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-162-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 11] compaction - Compacting [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-95-big-Data.db:level=0, /var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-81-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 11] compaction - Compacting [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-67-big-Data.db:level=0, /var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-53-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-94-big-Data.db:level=0, /var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-80-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 8] compaction - Compacting [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-148-big-Data.db:level=0, /var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-134-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 10] compaction - Compacting [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-122-big-Data.db:level=0, /var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-108-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-162-big-Data.db:level=0, ]. 15975 bytes to 8151 (~51% of original) in 22ms = 0.35MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-162-big-Data.db:level=0, ]. 10491 bytes to 5400 (~51% of original) in 20ms = 0.26MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 11] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-81-big-Data.db:level=0, ]. 11166 bytes to 5747 (~51% of original) in 23ms = 0.24MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 10] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/la-108-big-Data.db:level=0, ]. 11598 bytes to 5963 (~51% of original) in 20ms = 0.28MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-190-big-Data.db:level=0, ]. 10262 bytes to 5295 (~51% of original) in 19ms = 0.27MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 10] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-108-big-Data.db:level=0, ]. 10342 bytes to 5332 (~51% of original) in 20ms = 0.25MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 8] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-162-big-Data.db:level=0, ]. 14134 bytes to 7232 (~51% of original) in 17ms = 0.41MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 11] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/scylla_tables-5d912ff1f7593665b2c88042ab5103dd/la-81-big-Data.db:level=0, ]. 10377 bytes to 5349 (~51% of original) in 23ms = 0.22MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 11] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-109-big-Data.db:level=0, ]. 10314 bytes to 5321 (~51% of original) in 21ms = 0.24MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 10] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/keyspaces-abac5682dea631c5b535b3d6cffd0fb6/la-136-big-Data.db:level=0, ]. 10244 bytes to 5286 (~51% of original) in 25ms = 0.20MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 10] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-108-big-Data.db:level=0, ]. 12276 bytes to 6302 (~51% of original) in 27ms = 0.22MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 11] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system_schema/tables-afddfb9dbc1e30688056eed6c302ba09/la-81-big-Data.db:level=0, ]. 11694 bytes to 6011 (~51% of original) in 29ms = 0.20MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 0] database - Schema version changed to 8489e432-105a-371f-a48b-413e6f67013e
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 0] migration_manager - Schema merge with 10.0.222.111:0 completed
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]: JMX is enabled to receive remote connections on port: 7199
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 0] gossip - Favor newly added node 10.0.222.111
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 6] compaction - Compacting [/var/lib/scylla/data/system/peers-37f71aca7dc2383ba70672528af04d4f/la-34-big-Data.db:level=0, /var/lib/scylla/data/system/peers-37f71aca7dc2383ba70672528af04d4f/la-20-big-Data.db:level=0, ]
+[10.0.73.70] [stdout] Apr 02 11:24:39 warning| scylla[124]:  [shard 0] migration_task - Can't send migration request: node 10.0.42.170 is down.
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 0] rpc - client 10.0.42.170: client connection dropped: The TLS connection was non-properly terminated.
+[10.0.73.70] [stdout] Apr 02 11:24:39 warning| scylla[124]:  [shard 0] gossip - Fail to send EchoMessage to 10.0.42.170: seastar::rpc::closed_error (connection is closed)
+[10.0.73.70] [stdout] Apr 02 11:24:39 warning| scylla[124]:  [shard 0] migration_task - Can't send migration request: node 10.0.42.170 is down.
+[10.0.73.70] [stdout] Apr 02 11:24:39 info   | scylla[124]:  [shard 6] compaction - Compacted 2 sstables to [/var/lib/scylla/data/system/peers-37f71aca7dc2383ba70672528af04d4f/la-48-big-Data.db:level=0, ]. 16141 bytes to 11244 (~69% of original) in 7ms = 1.53MB/s. ~256 total partitions merged to 1.
+[10.0.73.70] [stdout] Apr 02 11:24:40 warning| scylla[124]:  [shard 0] migration_task - Can't send migration request: node 10.0.42.170 is down.
+[10.0.73.70] [stdout] Apr 02 11:24:40 info   | scylla[124]:  [shard 0] gossip - InetAddress 10.0.42.170 is now UP, status = NORMAL
+[10.0.73.70] [stdout] Apr 02 11:24:40 info   | scylla[124]:  [shard 0] migration_manager - Requesting schema pull from 10.0.42.170:0
+[10.0.73.70] [stdout] Apr 02 11:24:40 info   | scylla[124]:  [shard 0] migration_manager - Pulling schema from 10.0.42.170:0
+[10.0.73.70] [stdout] Apr 02 11:24:40 info   | scylla[124]:  [shard 0] database - Schema version changed to 8489e432-105a-371f-a48b-413e6f67013e
+[10.0.73.70] [stdout] Apr 02 11:24:40 info   | scylla[124]:  [shard 0] migration_manager - Schema merge with 10.0.42.170:0 completed
+[10.0.73.70] [stdout] Apr 02 11:24:41 info   | scylla[124]:  [shard 3] rpc - client 10.0.42.170: server connection dropped: The TLS connection was non-properly terminated.
+[10.0.73.70] [stdout] Apr 02 11:24:41 info   | scylla[124]:  [shard 0] gossip - Favor newly added node 10.0.42.170
+[10.0.73.70] [stdout] Apr 02 11:24:41 info   | scylla[124]:  [shard 0] migration_manager - Requesting schema pull from 10.0.42.170:0
+[10.0.73.70] [stdout] Apr 02 11:24:41 info   | scylla[124]:  [shard 0] migration_manager - Pulling schema from 10.0.42.170:0
+[10.0.73.70] [stdout] Apr 02 17:31:17 info   | scylla[124]: Segmentation fault on shard 11.
+[10.0.73.70] [stdout] Apr 02 17:31:17 info   | scylla[124]: Backtrace:
+[10.0.73.70] [stdout] Apr 02 17:31:17 info   | scylla[124]: 0x00000000006c5af2
+[10.0.73.70] [stdout] Apr 02 17:31:17 info   | scylla[124]: 0x00000000005d41ac
+[10.0.73.70] [stdout] Apr 02 17:31:17 info   | scylla[124]: 0x00000000005d4455
+[10.0.73.70] [stdout] Apr 02 17:31:17 info   | scylla[124]: 0x00000000005d44a3
+[10.0.73.70] [stdout] Apr 02 17:31:17 info   | scylla[124]: /lib64/libpthread.so.0+0x000000000000f5cf
+[10.0.73.70] [stdout] Apr 02 17:31:17 info   | scylla[124]: 0x0000000001c98946
+[10.0.73.70] [stdout] Apr 02 17:31:17 info   | scylla[124]: 0x0000000001cd0761
+[10.0.73.70] [stdout] Apr 02 17:31:17 info   | scylla[124]: 0x00000000013d58d2
+[10.0.73.70] [stdout] Apr 02 17:31:17 info   | scylla[124]: 0x00000000005d8a2b
+[10.0.73.70] [stdout] Apr 02 17:31:17 info   | scylla[124]: 0x00000000005b318b
+[10.0.73.70] [stdout] Apr 02 17:31:17 info   | scylla[124]: 0x00000000005b0314
+[10.0.73.70] [stdout] Apr 02 17:31:17 info   | scylla[124]: 0x000000000068795e
+[10.0.73.70] [stdout] Apr 02 17:31:17 info   | scylla[124]: 0x000000000068c1fa
+[10.0.73.70] [stdout] Apr 02 17:31:17 info   | scylla[124]: 0x000000000077535d
+[10.0.73.70] [stdout] Apr 02 17:31:17 info   | scylla[124]: /lib64/libpthread.so.0+0x0000000000007dd4
+[10.0.73.70] [stdout] Apr 02 17:31:17 info   | scylla[124]: /lib64/libc.so.6+0x00000000000fdeac
+[10.0.73.70] [stdout] Apr 02 17:32:50 notice | scylla[124]: scylla-server.service: main process exited, code=killed, status=11/SEGV
+[10.0.73.70] [stdout] Apr 02 18:40:11 info   | scylla[124]:  [shard 0] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Executing streaming plan for Bootstrap-keyspace1-index-6 with peers=10.0.106.31, slave
+[10.0.73.70] [stdout] Apr 02 18:40:11 info   | scylla[124]:  [shard 9] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=3537067, with new rpc streaming
+[10.0.73.70] [stdout] Apr 02 18:40:11 info   | scylla[124]:  [shard 3] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=3628571, with new rpc streaming
+[10.0.73.70] [stdout] Apr 02 18:40:11 info   | scylla[124]:  [shard 12] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=3526428, with new rpc streaming
+[10.0.73.70] [stdout] Apr 02 18:40:11 info   | scylla[124]:  [shard 13] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=3521601, with new rpc streaming
+[10.0.73.70] [stdout] Apr 02 18:40:11 info   | scylla[124]:  [shard 6] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=3649796, with new rpc streaming
+[10.0.73.70] [stdout] Apr 02 18:40:11 info   | scylla[124]:  [shard 0] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=3534612, with new rpc streaming
+[10.0.73.70] [stdout] Apr 02 18:40:11 info   | scylla[124]:  [shard 7] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=3566892, with new rpc streaming
+[10.0.73.70] [stdout] Apr 02 18:40:11 info   | scylla[124]:  [shard 8] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=3539519, with new rpc streaming
+[10.0.73.70] [stdout] Apr 02 18:40:11 info   | scylla[124]:  [shard 10] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=3475906, with new rpc streaming
+[10.0.73.70] [stdout] Apr 02 18:40:11 info   | scylla[124]:  [shard 4] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=3749560, with new rpc streaming
+[10.0.73.70] [stdout] Apr 02 18:40:11 info   | scylla[124]:  [shard 5] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=3705018, with new rpc streaming
+[10.0.73.70] [stdout] Apr 02 18:40:11 info   | scylla[124]:  [shard 11] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=3547371, with new rpc streaming
+[10.0.73.70] [stdout] Apr 02 18:40:11 info   | scylla[124]:  [shard 2] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=3582785, with new rpc streaming
+[10.0.73.70] [stdout] Apr 02 18:40:11 info   | scylla[124]:  [shard 1] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=3626305, with new rpc streaming
+[10.0.73.70] [stdout] Apr 02 18:43:21 info   | scylla[124]:  [shard 0] stream_session - [Stream #bf4b5d40-5576-11e9-848d-000000000007] Streaming plan for Bootstrap-keyspace1-index-6 succeeded, peers={10.0.106.31}, tx=15871500 KiB, 83726.35 KiB/s, rx=0 KiB, 0.00 KiB/s
+[10.0.73.70] [stdout] Apr 02 18:43:21 info   | scylla[124]:  [shard 0] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Executing streaming plan for Bootstrap-keyspace1-index-7 with peers=10.0.106.31, slave
+[10.0.73.70] [stdout] Apr 02 18:43:21 info   | scylla[124]:  [shard 0] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=2704017, with new rpc streaming
+[10.0.73.70] [stdout] Apr 02 18:43:21 info   | scylla[124]:  [shard 9] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=2780837, with new rpc streaming
+[10.0.73.70] [stdout] Apr 02 18:43:21 info   | scylla[124]:  [shard 12] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=2828047, with new rpc streaming
+[10.0.73.70] [stdout] Apr 02 18:43:21 info   | scylla[124]:  [shard 3] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=2667288, with new rpc streaming
+[10.0.73.70] [stdout] Apr 02 18:43:21 info   | scylla[124]:  [shard 6] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=2896392, with new rpc streaming
+[10.0.73.70] [stdout] Apr 02 18:43:21 info   | scylla[124]:  [shard 8] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=2790202, with new rpc streaming
+[10.0.73.70] [stdout] Apr 02 18:43:21 info   | scylla[124]:  [shard 7] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=2835751, with new rpc streaming
+[10.0.73.70] [stdout] Apr 02 18:43:21 info   | scylla[124]:  [shard 5] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=2800956, with new rpc streaming
+[10.0.73.70] [stdout] Apr 02 18:43:21 info   | scylla[124]:  [shard 1] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=2795324, with new rpc streaming
+[10.0.73.70] [stdout] Apr 02 18:43:21 info   | scylla[124]:  [shard 4] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=2724794, with new rpc streaming
+[10.0.73.70] [stdout] Apr 02 18:43:21 info   | scylla[124]:  [shard 2] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=2771897, with new rpc streaming
+[10.0.73.70] [stdout] Apr 02 18:43:21 info   | scylla[124]:  [shard 10] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=2829114, with new rpc streaming
+[10.0.73.70] [stdout] Apr 02 18:43:21 info   | scylla[124]:  [shard 13] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=2796216, with new rpc streaming
+[10.0.73.70] [stdout] Apr 02 18:43:21 info   | scylla[124]:  [shard 11] stream_session - [Stream #30488900-5577-11e9-848d-000000000007] Start sending ks=keyspace1, cf=standard1, estimated_partitions=2816990, with new rpc streaming
+[10.0.73.70] [stdout] Apr 02 18:44:40 info   | scylla[124]: Reactor stalled for 2252 ms on shard 2.
+[10.0.73.70] [stdout] Apr 02 18:44:40 info   | scylla[124]: Backtrace:
+[10.0.73.70] [stdout] Apr 02 18:44:40 info   | scylla[124]: 0x00000000006c5af2
+[10.0.73.70] [stdout] Apr 02 18:44:40 info   | scylla[124]: 0x00000000005d41ac
+[10.0.73.70] [stdout] Apr 02 18:44:40 info   | scylla[124]: 0x00000000005d4666
+[10.0.73.70] [stdout] Apr 02 18:44:40 info   | scylla[124]: /lib64/libpthread.so.0+0x000000000000f5cf
+[10.0.73.70] [stdout] Apr 02 18:44:40 info   | scylla[124]: 0x00000000005b129f
+[10.0.73.70] [stdout] Apr 02 18:44:40 info   | scylla[124]: /lib64/libpthread.so.0+0x000000000000f5cf
+[10.0.73.70] [stdout] Apr 02 18:44:40 info   | scylla[124]: 0x000000000162c3d3
+[10.0.73.70] [stdout] Apr 02 18:44:40 info   | scylla[124]: 0x00000000014daf0f
+[10.0.73.70] [stdout] Apr 02 18:44:40 info   | scylla[124]: 0x00000000015e45b0
+[10.0.73.70] [stdout] Apr 02 18:44:40 info   | scylla[124]: 0x00000000015ce1df
+[10.0.73.70] [stdout] Apr 02 18:44:40 info   | scylla[124]: 0x00000000015cf52a
+[10.0.73.70] [stdout] Apr 02 18:44:40 info   | scylla[124]: 0x00000000015d1483
+[10.0.73.70] [stdout] Apr 02 18:44:40 info   | scylla[124]: 0x00000000013ac7f5
+[10.0.73.70] [stdout] Apr 02 18:44:40 info   | scylla[124]: 0x000000000123d5cc
+[10.0.73.70] [stdout] Apr 02 18:44:40 info   | scylla[124]: 0x000000000123df5a
+[10.0.73.70] [stdout] Apr 02 18:44:40 info   | scylla[124]: 0x000000000126ba1d
+[10.0.73.70] [stdout] Apr 02 18:44:40 info   | scylla[124]: 0x00000000013ea347
+[10.0.73.70] [stdout] Apr 02 18:44:40 info   | scylla[124]: 0x00000000013ea17b
+[10.0.73.70] [stdout] Apr 02 18:44:40 info   | scylla[124]: 0x00000000013ea9ee
+[10.0.73.70] [stdout] Apr 02 18:44:40 info   | scylla[124]: 0x00000000007374fc
+[10.0.73.70] [stdout] Apr 02 18:44:40 info   | scylla[124]: 0x00000000005b4ade
+[10.0.73.70] [stdout] Apr 02 18:44:40 info   | scylla[124]: 0x00000000005b4ca1
+[10.0.73.70] [stdout] Apr 02 18:44:40 info   | scylla[124]: 0x0000000000687a37
+[10.0.73.70] [stdout] Apr 02 18:44:40 info   | scylla[124]: 0x000000000068c1fa
+[10.0.73.70] [stdout] Apr 02 18:44:40 info   | scylla[124]: 0x000000000077535d
+[10.0.73.70] [stdout] Apr 02 18:44:40 info   | scylla[124]: /lib64/libpthread.so.0+0x0000000000007dd4
+[10.0.73.70] [stdout] Apr 02 18:44:40 info   | scylla[124]: /lib64/libc.so.6+0x00000000000fdeac


### PR DESCRIPTION
Since we keep on hitting on case exception is in the log text
but it's o.k., we should start looking at the log level insted to
identify error happend.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
