### PR TITLE
fix(perf-test): stop after one nemesis cycle

### DIFF
--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -19,6 +19,9 @@ import time
 import yaml
 
 from sdcm.tester import ClusterTester
+from sdcm.sct_events import Severity
+from sdcm.sct_events.filters import EventsSeverityChangerFilter
+from sdcm.sct_events.loaders import CassandraStressEvent
 
 KB = 1024
 
@@ -155,6 +158,14 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
         with open(email_data_path, 'w', encoding="utf-8"):
             pass
 
+    def _stop_load_after_one_nemesis_cycle(self):
+        time.sleep(300)  # wait 5 minutes to be sure nemesis has started
+        self.db_cluster.stop_nemesis(timeout=None)  # wait for Nemesis to end and don't start another cycle
+        with EventsSeverityChangerFilter(new_severity=Severity.NORMAL,  # killing stress creates Critical error
+                                         event_class=CassandraStressEvent,
+                                         extra_time_to_expiration=60):
+            self.loaders.kill_cassandra_stress_thread()
+
     def preload_data(self):
         # if test require a pre-population of data
         prepare_write_cmd = self.params.get('prepare_write_cmd')
@@ -248,6 +259,7 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
             time.sleep(interval * 60)  # Sleeping one interval (in minutes) before starting the nemesis
             self.db_cluster.add_nemesis(nemesis=self.get_nemesis_class(), tester_obj=self)
             self.db_cluster.start_nemesis(interval=interval)
+            self._stop_load_after_one_nemesis_cycle()
         results = self.get_stress_results(queue=stress_queue)
         self.update_test_details(scrap_metrics_step=60)
         self.display_results(results, test_name='test_latency' if not nemesis else 'test_latency_with_nemesis')

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4667,8 +4667,9 @@ class BaseLoaderSet():
     def kill_cassandra_stress_thread(self):
         for loader in self.nodes:
             try:
-                loader.remoter.run(cmd='pgrep -f cassandra-stress | xargs -I{}  kill -TERM -{}',
+                loader.remoter.run(cmd='pgrep -f cassandra.stress | xargs -I{}  kill -TERM {}',
                                    verbose=False, ignore_status=True)
+                self.log.info("Killed cassandra stress on node: %s", loader.name)
             except Exception as ex:  # pylint: disable=broad-except
                 self.log.warning("failed to kill stress-command on [%s]: [%s]",
                                  str(loader), str(ex))
@@ -4677,6 +4678,7 @@ class BaseLoaderSet():
         for loader in self.nodes:
             try:
                 loader.remoter.run(cmd='docker ps -a -q | docker rm -f', verbose=False, ignore_status=True)
+                self.log.info("Killed docker loader on node: %s", loader.name)
             except Exception as ex:  # pylint: disable=broad-except
                 self.log.warning("failed to kill docker stress command on [%s]: [%s]",
                                  str(loader), str(ex))

--- a/test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml
+++ b/test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml
@@ -4,9 +4,9 @@ prepare_write_cmd: ["cassandra-stress write no-warmup cl=ALL n=62500000 -schema 
                     "cassandra-stress write no-warmup cl=ALL n=62500000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=125000001..187500000",
                     "cassandra-stress write no-warmup cl=ALL n=62500000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=187500001..250000000"]
 
-stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=350m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=50 throttle=5000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..250000000,125000000,12500000)' "
-stress_cmd_r: "cassandra-stress read no-warmup  cl=QUORUM duration=350m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=50 throttle=4000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..250000000,125000000,12500000)' "
-stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=350m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=50 throttle=3500/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..250000000,125000000,12500000)' "
+stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=600m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=50 throttle=5000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..250000000,125000000,12500000)' "
+stress_cmd_r: "cassandra-stress read no-warmup  cl=QUORUM duration=600m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=50 throttle=4000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..250000000,125000000,12500000)' "
+stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=600m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=50 throttle=3500/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..250000000,125000000,12500000)' "
 
 n_db_nodes: 3
 nemesis_add_node_cnt: 3


### PR DESCRIPTION
During performance test with running nemesis, when nemesis ends
we want to prevent from starting another Nemesis cycle to not spoil
the results.
Also there's no need for running the load anymore.
This fix is about stopping nemesis in perf test after one cycle
and aborting load to finish the test quicker.

https://trello.com/c/SD5IN13F
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
