### PR TITLE
fix(logging): reduce the usage of info level logging

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -471,7 +471,7 @@ class AWSNode(cluster.BaseNode):
 
     @retrying(n=3, sleep_time=5, allowed_exceptions=NETWORK_EXCEPTIONS, message="Retrying set_hostname")
     def set_hostname(self):
-        self.log.info('Changing hostname to %s', self.name)
+        self.log.debug('Changing hostname to %s', self.name)
         # Using https://aws.amazon.com/premiumsupport/knowledge-center/linux-static-hostname-rhel7-centos7/
         # FIXME: workaround to avoid host rename generating errors on other commands
         if self.is_debian():

--- a/sdcm/db_log_reader.py
+++ b/sdcm/db_log_reader.py
@@ -187,9 +187,9 @@ class DbLogReader(Process):
         """
         Keep reporting new events from db log, every 30 seconds.
         """
-        LOGGER.info('Logging for node %s is started with following configuration:\nsystem_log=%s'
-                    '\nlog_lines=%s\ndecoding_queue=%s',
-                    self._node_name, self._system_log, self._log_lines, self._decoding_queue is not None)
+        LOGGER.debug('Logging for node %s is started with following configuration:\nsystem_log=%s'
+                     '\nlog_lines=%s\ndecoding_queue=%s',
+                     self._node_name, self._system_log, self._log_lines, self._decoding_queue is not None)
         make_threads_be_daemonic_by_default()
         while not self._terminate_event.wait(0.1):
             try:

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -609,7 +609,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         ]
 
         num_of_reboots = random.randint(2, 10)
-        InfoEvent(message=f'MultipleHardRebootNode {self.target_node}')
+        InfoEvent(message=f'MultipleHardRebootNode {self.target_node}').publish()
         for i in range(num_of_reboots):
             self.log.debug("Rebooting %s out of %s times", i + 1, num_of_reboots)
             cdc_expected_error = self.target_node.follow_system_log(patterns=cdc_expected_error_patterns)

--- a/sdcm/sct_events/base.py
+++ b/sdcm/sct_events/base.py
@@ -67,6 +67,16 @@ class EventPeriod(Enum):
     NOT_DEFINED = "not-set"
 
 
+LOG_LEVEL_MAPPING = {
+    Severity.WARNING: logging.DEBUG,
+    Severity.CRITICAL: logging.CRITICAL,
+    Severity.ERROR: logging.ERROR,
+    Severity.DEBUG: logging.DEBUG,
+    Severity.NORMAL: logging.INFO,
+    Severity.UNKNOWN: logging.WARNING,
+}
+
+
 class SctEvent:
     _sct_event_types_registry: SctEventTypesRegistry = SctEventTypesRegistry()
     _events_processes_registry: Optional[EventsProcessesRegistry] = None
@@ -109,7 +119,7 @@ class SctEvent:
         self.severity = severity
         self._ready_to_publish = True
         self.event_id = str(uuid.uuid4())
-        self.log_level = logging.INFO
+        self.log_level = LOG_LEVEL_MAPPING.get(severity, logging.ERROR)
 
     @classmethod
     def is_abstract(cls) -> bool:

--- a/sdcm/sct_events/events_device.py
+++ b/sdcm/sct_events/events_device.py
@@ -92,7 +92,7 @@ class EventsDevice(multiprocessing.Process):
                 self._sub_port.value = pub.bind_to_random_port("tcp://*")
                 self._running.set()
 
-                LOGGER.info("EventsDevice listen on %s", self.subscribe_address)
+                LOGGER.debug("EventsDevice listen on %s", self.subscribe_address)
 
                 # Delivery verification subscriber.
                 sub.connect(self.subscribe_address)
@@ -128,7 +128,7 @@ class EventsDevice(multiprocessing.Process):
             self._events_counter.value += 1
 
     def _sub_socket(self, ctx: zmq.Context) -> zmq.Socket:
-        LOGGER.info("Subscribe to %s", self.subscribe_address)
+        LOGGER.debug("Subscribe to %s", self.subscribe_address)
         sub = ctx.socket(zmq.SUB)
         sub.connect(self.subscribe_address)
         sub.subscribe(b"")

--- a/sdcm/sct_events/file_logger.py
+++ b/sdcm/sct_events/file_logger.py
@@ -75,7 +75,7 @@ class EventsFileLogger(BaseEventsProcess[Tuple[str, Any], None], multiprocessing
         super().__init__(_registry=_registry)
 
     def run(self) -> None:
-        LOGGER.info("Writing to %s", self.events_log)
+        LOGGER.debug("Writing to %s", self.events_log)
 
         for log_file in chain((self.events_log, self.events_summary_log, ), self.events_logs_by_severity.values(), ):
             log_file.touch()
@@ -136,7 +136,7 @@ class EventsFileLogger(BaseEventsProcess[Tuple[str, Any], None], multiprocessing
                     events_bucket.append("\n".join(event))
             except Exception as exc:  # pylint: disable=broad-except
                 error_msg = f"{self}: failed to read {log_file}: {exc}"
-                LOGGER.info(error_msg)
+                LOGGER.error(error_msg)
                 if not events_bucket:
                     events_bucket.append(error_msg)
             output[severity.name] = list(events_bucket)

--- a/sdcm/test_config.py
+++ b/sdcm/test_config.py
@@ -198,10 +198,10 @@ class TestConfig(metaclass=Singleton):  # pylint: disable=too-many-public-method
         if not syslog_logdir:
             raise RuntimeError("Can't fund syslog docker log directory")
         if syslog_logdir == current_logdir:
-            LOGGER.info("Syslog docker is running on the same directory where SCT is running")
+            LOGGER.debug("Syslog docker is running on the same directory where SCT is running")
             return
-        LOGGER.info("Syslog docker is running on the another directory. Linking it's directory %s to %s",
-                    syslog_logdir, current_logdir)
+        LOGGER.debug("Syslog docker is running on the another directory. Linking it's directory %s to %s",
+                     syslog_logdir, current_logdir)
         current_logdir = Path(current_logdir) / "hosts"
         docker_logdir = Path(syslog_logdir) / "hosts"
         if current_logdir.exists():

--- a/sdcm/utils/distro.py
+++ b/sdcm/utils/distro.py
@@ -89,7 +89,7 @@ class Distro(enum.Enum):
         if distro == cls.UNKNOWN:
             LOGGER.error("Unable to detect Linux distribution name")
         else:
-            LOGGER.info("Detected Linux distribution: %s", distro.name)
+            LOGGER.debug("Detected Linux distribution: %s", distro.name)
 
         return distro
 

--- a/sdcm/utils/health_checker.py
+++ b/sdcm/utils/health_checker.py
@@ -38,10 +38,10 @@ def check_nodes_status(nodes_status: dict, current_node, removed_nodes_list=()) 
     if not nodes_status:
         LOGGER.warning("Node status info is not available. Search for the warning above")
         return
-    LOGGER.info("Status for %s node %s", node_type, current_node.name)
+    LOGGER.debug("Status for %s node %s", node_type, current_node.name)
     for node, node_properties in nodes_status.items():
         if node_properties['status'] != "UN":
-            LOGGER.info("All nodes that have been removed up until this point: %s", str(removed_nodes_list))
+            LOGGER.debug("All nodes that have been removed up until this point: %s", str(removed_nodes_list))
             is_target = current_node.print_node_running_nemesis(node.ip_address)
             yield ClusterHealthValidatorEvent.NodeStatus(
                 severity=Severity.CRITICAL,
@@ -251,5 +251,5 @@ def check_schema_agreement_in_gossip_and_peers(node, retries: int = CHECK_NODE_H
     else:
         return False  # Something was wrong even on the last cycle.
 
-    LOGGER.info('Schema agreement has been completed on all nodes')
+    LOGGER.debug('Schema agreement has been completed on all nodes')
     return True

--- a/sdcm/utils/log.py
+++ b/sdcm/utils/log.py
@@ -172,6 +172,12 @@ def configure_logging(exception_handler=None,  # pylint: disable=too-many-argume
             'anyconfig': {
                 'level': 'ERROR'
             },
+            'urllib3.connectionpool': {
+                'level': 'INFO'
+            },
+            'selenium.webdriver.remote.remote_connection': {
+                'level': 'INFO'
+            },
             'argus': {
                 'handlers': ['argus'],
                 'level': 'DEBUG',

--- a/sdcm/utils/syslogng.py
+++ b/sdcm/utils/syslogng.py
@@ -51,7 +51,7 @@ class SyslogNGContainerMixin:  # pylint: disable=too-few-public-methods
         basedir, logdir = os.path.split(logdir)
         logdir = os.path.abspath(os.path.join(os.environ.get("_SCT_LOGDIR", basedir), logdir))
         os.makedirs(logdir, exist_ok=True)
-        LOGGER.info("syslog-ng will store logs at %s", logdir)
+        LOGGER.debug("syslog-ng will store logs at %s", logdir)
         volumes = {
             self.syslogng_confpath: {"bind": "/config/syslog-ng.conf", "mode": "ro"},
             logdir: {"bind": "/var/log"},

--- a/unit_tests/test_sct_events_base.py
+++ b/unit_tests/test_sct_events_base.py
@@ -155,7 +155,7 @@ class TestSctEvent(SctEventTestCase):
         self.assertEqual(
             y.to_json(),
             f'{{"base": "Y", "type": null, "subtype": null, "event_timestamp": {y.event_timestamp}, "source_timestamp": null, '
-            f'"severity": "UNKNOWN", "event_id": "fa4a84a2-968b-474c-b188-b3bac4be8527", "log_level": 20}}'
+            f'"severity": "UNKNOWN", "event_id": "fa4a84a2-968b-474c-b188-b3bac4be8527", "log_level": 30}}'
         )
 
     def test_publish(self):


### PR DESCRIPTION
The output to jenkins is becoming incressincly big, it's hard to
track what's an ongoing job is doing, and there an history
of too much output slows down jenkins, and even fills the
jenkins master drive.

lot of those info messages was added for development of new
features, but never remove or reduced to debug level

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
