### PR TITLE
improvement(artifacts_test.py): Verify docker image locale settings

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -211,6 +211,22 @@ class ArtifactsTest(ClusterTester):
             expected_write_back_cache_param = None
         self.assertEqual(self.write_back_cache, expected_write_back_cache_param)
 
+    def verify_docker_locale_settings(self) -> None:
+        run = self.node.remoter.run
+        expected_locale_settings = {
+            "LC_ALL": "en_US.UTF-8",
+            "LANG": "en_US.UTF-8",
+            "LANGUAGE": "en_US:en",
+        }
+
+        locale_settings_raw = run("locale").stdout.split(sep="\n")
+        locale_settings = [setting.split(sep="=") for setting in locale_settings_raw if setting]
+        locale_settings = {setting[0]: setting[1].strip("\"") for setting in locale_settings if len(setting) == 2}
+
+        for setting_key, expected_value in expected_locale_settings.items():
+            configured_value = locale_settings.get(setting_key)
+            self.assertEqual(configured_value, expected_value)
+
     def verify_nvme_write_cache(self) -> None:
         if self.write_back_cache is None:
             return
@@ -264,6 +280,10 @@ class ArtifactsTest(ClusterTester):
 
         with self.subTest("check Scylla server after installation"):
             self.check_scylla()
+
+        if backend == "docker":
+            with self.subTest("check locale settings in the docker image"):
+                self.verify_docker_locale_settings()
 
         # We don't install any time sync service in docker, so the test is unnecessary:
         # https://github.com/scylladb/scylla/tree/master/dist/docker/etc/supervisord.conf.d


### PR DESCRIPTION
This commit addresses changes
in scylladb/scylla@546e4adf9e1d560cbb99932925b13e30200c0d3a,
adding a sub test to artifacts test that verifies said settings are
applied to the resulting docker image.

[Trello](https://trello.com/c/nCCilfJY/4778-9570-the-locale-is-now-set-to-use-utf-8-encoding-in-the-container-image-so-cqlsh-works-correctly-when-displaying-non-ascii-data)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~New configuration option are added and documented (in `sdcm/sct_config.py`)~
- [x] ~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~
- [x] All new and existing unit tests passed (CI)
- [x] ~I have updated the Readme/doc folder accordingly (if needed)~
