### PR TITLE
fix(email): send email when cloud cluster is not created

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1120,7 +1120,11 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
         except ImportError:
             LOGGER.error("Couldn't collect Siren manager logs, cluster_cloud module isn't installed")
         else:
-            cloud_cluster_id = self.params["cloud_cluster_id"]
+            cloud_cluster_id = self.params["cloud_cluster_id"] if "cloud_cluster_id" in self.params else None
+            if not cloud_cluster_id:
+                LOGGER.error("Cloud cluster id is not found. Probably the cluster has not been created")
+                return
+
             try:
                 instance = get_manager_instance_by_cluster_id(cluster_id=cloud_cluster_id)
                 if not instance:

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1304,13 +1304,13 @@ class SCTConfiguration(dict):
         'baremetal': ['db_nodes_private_ip', 'db_nodes_public_ip', 'user_credentials_path'],
 
         'aws-siren': ["user_prefix", "instance_type_loader", "region_name", "cloud_credentials_path",
-                      "cloud_cluster_id", "nemesis_filter_seeds"],
+                      "nemesis_filter_seeds"],
 
         'gce-siren': ['user_prefix', 'gce_network', 'gce_image_username', 'gce_instance_type_db',
                       'gce_root_disk_type_db', 'gce_root_disk_size_db', 'gce_n_local_ssd_disk_db',
                       'gce_instance_type_loader', 'gce_root_disk_type_loader', 'gce_n_local_ssd_disk_loader',
                       'gce_instance_type_monitor', 'gce_root_disk_type_monitor', 'gce_root_disk_size_monitor',
-                      'gce_n_local_ssd_disk_monitor', 'gce_datacenter', "cloud_cluster_id"],
+                      'gce_n_local_ssd_disk_monitor', 'gce_datacenter'],
 
         'k8s-local-kind': ['user_credentials_path', 'scylla_version', 'scylla_mgmt_agent_version',
                            'k8s_scylla_operator_helm_repo', 'k8s_scylla_datacenter', 'k8s_scylla_rack',


### PR DESCRIPTION
If cloud cluster was not created, empty email is sent (or is not sent at all).
Raising exception when cluster id is not found is added by PR
https://github.com/scylladb/siren-tests/pull/982 and it causes to creation of critical error
on SCT step. So user will receive the email with message that cluster was not created.

Task:
https://trello.com/c/kXcQCS5Z/4264-cloud-longevity-if-cluster-wasnt-found-empty-email-is-sent

![Screenshot from 2022-03-31 14-01-01](https://user-images.githubusercontent.com/34435448/161047401-5e1e1da8-52dd-41cb-b23d-0049a5881ae4.png)


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
