### PR TITLE
fix(argus): do not save logs in argus when no test id

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1021,7 +1021,9 @@ def collect_logs(test_id=None, logdir=None, backend=None, config_file=None):
             table.add_row([current_cluster_type, link])
 
     click.echo(table.get_string(title="Collected logs by test-id: {}".format(collector.test_id)))
-    store_logs_in_argus(test_id=UUID(collector.test_id), logs=collected_logs)
+
+    if test_id:
+        store_logs_in_argus(test_id=UUID(collector.test_id), logs=collected_logs)
 
 
 def store_logs_in_argus(test_id: UUID, logs: dict[str, list[list[str] | str]]):


### PR DESCRIPTION
If test_id is missed, does not try to save logs in argus (no logs in this case)
because of collection logs step fails and cause to failure of next steps

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
