### PR TITLE
fix(housekeeping): workaround for the issue w/ Azure builder

### DIFF
--- a/sdcm/utils/housekeeping.py
+++ b/sdcm/utils/housekeeping.py
@@ -54,6 +54,7 @@ class HousekeepingDB:
 
     def execute(self, query: str, args: Optional[Sequence[Any]] = None) -> Sequence[Row]:
         LOGGER.debug("Query: `%s', Args: %s", query, args)
+        self._connection.reconnect()
         self._cursor.execute(query, args)
         result = self._cursor.fetchall()
         self._connection.commit()


### PR DESCRIPTION
Trello: https://trello.com/c/81NEOYcp/4890-artifacts-docker-test-failed-to-query-housekeeping-db-while-running-on-azure-builder

The root cause is a problem with a link, but it requires more investigations.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
