### PR TITLE
fix(cluster.py): modify PATH for monitoring start

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5223,7 +5223,7 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
             cd -P {self.monitor_install_path}
             mkdir -p {self.monitoring_data_dir}
             echo "" > UA.sh
-            ./start-all.sh \
+            PATH=$PATH:/usr/sbin ./start-all.sh \
             -D "{labels}" \
             -s `realpath "{self.monitoring_conf_dir}/scylla_servers.yml"` \
             -n `realpath "{self.monitoring_conf_dir}/node_exporter_servers.yml"` \


### PR DESCRIPTION
Trello: https://trello.com/c/Vurz5AYd/4870-start-grafana-ip-command-not-found

Full path to `ip` command on CentOS 7 is `/usr/sbin/ip` which is a problem for our code.  Modify PATH variable to include required directory.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
