### PR TITLE
fix(email data): do not collect data if cluster was not created

### DIFF
--- a/longevity_test.py
+++ b/longevity_test.py
@@ -576,10 +576,14 @@ class LongevityTest(ClusterTester):
         except Exception as error:  # pylint: disable=broad-except
             self.log.error("Error in gathering Grafana screenshots and snapshots. Error:\n%s", error)
 
+        benchmarks_results = self.db_cluster.get_node_benchmarks_results() if self.db_cluster else {}
+        # If cluster was not created, not need to collect nemesis stats - they do not exist
+        nemeses_stats = self.get_nemesises_stats() if self.db_cluster else {}
+
         email_data.update({"grafana_screenshots": grafana_dataset.get("screenshots", []),
                            "grafana_snapshots": grafana_dataset.get("snapshots", []),
-                           "node_benchmarks": self.db_cluster.get_node_benchmarks_results(),
-                           "nemesis_details": self.get_nemesises_stats(),
+                           "node_benchmarks": benchmarks_results,
+                           "nemesis_details": nemeses_stats,
                            "nemesis_name": self.params.get("nemesis_class_name"),
                            "scylla_ami_id": self.params.get("ami_id_db_scylla") or "-", })
         return email_data


### PR DESCRIPTION
If cluster creation failed (for example, I got it in the siren-test), got error while saving email data:
`Error: 'NoneType' object has no attribute 'get_node_benchmarks_results'`

If cluster was not created, we do not need to collect benchmarks results and nemesis stats

Task:
https://trello.com/c/cgvXHxPs/4910-cloud-error-while-saving-email-data-error-nonetype-object-has-no-attribute-getnodebenchmarksresults

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
