### PR TITLE
fix(ManagerTask.arguments): switched to using progress_string function

### DIFF
--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -202,8 +202,7 @@ class ManagerTask:
         """
         Gets the task's arguments
         """
-        cmd = f"-c {self.cluster_id} progress {self.id}"
-        res = self.sctool.run(cmd=cmd, is_verify_errorless_result=True, parse_table_res=False)
+        res = self.progress_string()
 
         arguments_string = ""  # If arguments parameter doesn't exist, there were no arguments in this task
         # Output example:


### PR DESCRIPTION
Previously, the arguments property executed the task progress command directly,
without considering the manager version beforehand. I changed it so it will
use the progress_string command instead, which does consider the manager version
before executing the progress command

Fixes https://github.com/scylladb/scylla-cluster-tests/issues/4527

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
