### PR TITLE
fix(loader): fix missing ICS in c-s

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -6,24 +6,25 @@ region_name:
 user_credentials_path: '~/.ssh/scylla-qa-ec2'
 instance_type_loader: 'c5.xlarge'
 instance_type_monitor: 't3.large'
+# manual on creating loader AMI's: see docs/new_loader_ami.md
 regions_data:
   us-east-1: # US East (N. Virginia)
-    ami_id_loader: 'ami-04d4eb45311c3d153' # Loader dedicated AMI v17
+    ami_id_loader: 'ami-04ba971b593b243c5' # Loader dedicated AMI v18
     ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
   us-west-2: # US West (Oregon)
-    ami_id_loader: 'ami-010d3b9ac4fb647b0' # Loader dedicated AMI v17
+    ami_id_loader: 'ami-034e122f3d6577a73' # Loader dedicated AMI v18
     ami_id_monitor: 'ami-01ed306a12b7d1c96' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
   eu-west-1: # Europe (Ireland)
-    ami_id_loader: 'ami-0e8fcdd01f9f0389a' # Loader dedicated AMI v17
+    ami_id_loader: 'ami-0f2aac9a9d7a29979' # Loader dedicated AMI v18
     ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
   eu-west-2: # Europe (London)
-    ami_id_loader: 'ami-08d92dab04a81ad5c' # Loader dedicated AMI v17
+    ami_id_loader: 'ami-099a7a92db81b3500' # Loader dedicated AMI v18
     ami_id_monitor: 'ami-0eab3a90fc693af19' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
   eu-north-1: # Europe (Stockholm)
-    ami_id_loader: 'ami-0dec498596f7c2cdd' # Loader dedicated AMI v17
+    ami_id_loader: 'ami-0f1099eae729b80f1' # Loader dedicated AMI v18
     ami_id_monitor: 'ami-5ee66f20' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
   eu-central-1: # Europe (Frankfurt)
-    ami_id_loader: 'ami-0a1c1394c5d28f435' # Loader dedicated AMI v17
+    ami_id_loader: 'ami-0cc124517d1f5710e' # Loader dedicated AMI v18
     ami_id_monitor: 'ami-04cf43aca3e6f3de3' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
 
 availability_zone: 'a'

--- a/docs/new_loader_ami.md
+++ b/docs/new_loader_ami.md
@@ -1,0 +1,26 @@
+# Introduction
+This docs show how to create new loader AMI on AWS
+
+# Steps
+1. Create loader instance using SCT in e.g. us-east-1 region
+1. Login to loader and install required packages:
+    1. c-s (enterprise, master branch)
+        ```bash
+        curl http://downloads.scylladb.com/unstable/scylla-enterprise/enterprise/rpm/centos/latest/scylla.repo -o scylla.repo
+        sudo mv scylla.repo /etc/yum.repos.d/scylla.repo
+        sudo yum install scylla-enterprise-tools scylla-enterprise-tools-core -y
+        # verify it works:
+        cassandra-stress version
+        cassandra-stress write cl=QUORUM n=1 -schema 'replication(factor=1) compaction(strategy=IncrementalCompactionStrategy)' -port jmx=6868 -mode cql3 native -rate threads=1 -pop seq=1..1
+        # it should fail with NoHostAvailableException (unless you provide valid node)
+        ```
+2. create image in AWS console
+    1. write c-s version in description
+    2. wait until process completes (status turns from Pending to Active)
+3. Copy image to other regions
+
+```
+# repeat for destination_regions: ["us-west-2", "eu-west-1", "eu-west-2", "eu-north-1", "eu-central-1"]
+# assuming source-region is us-east-1, otherwise adapt destination regions accordingly.
+aws ec2 copy-image --region <destination_region> --name scylla-qa-loader-ami-<version> --source-region us-east-1 --source-image-id <ami_id>
+```


### PR DESCRIPTION
latest loader AMI's don't support ICS in c-s.
New AMI's with c-s from enterprise package was created.
This PR updates AMI's.
Also created basic manual for updating loader AMI's
New AMI's were created according to this manual.

trello: https://trello.com/c/lkxKuWgM

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
