### PR TITLE
fix(node_benchmarks): make it tolerate when some data is absent

### DIFF
--- a/sdcm/utils/benchmarks.py
+++ b/sdcm/utils/benchmarks.py
@@ -190,11 +190,16 @@ class ScyllaClusterBenchmarkManager(metaclass=Singleton):
             return Averages()
 
         for item in docs:
-            results.append(ComparableResult(
-                sysbench_eps=item["sysbench_events_per_second"],
-                cassandra_fio_read_bw=item["cassandra_fio_lcs_64k_read"]["read"]["bw"],
-                cassandra_fio_write_bw=item["cassandra_fio_lcs_64k_write"]["write"]["bw"]
-            ))
+            try:
+                results.append(ComparableResult(
+                    sysbench_eps=item["sysbench_events_per_second"],
+                    cassandra_fio_read_bw=item["cassandra_fio_lcs_64k_read"]["read"]["bw"],
+                    cassandra_fio_write_bw=item["cassandra_fio_lcs_64k_write"]["write"]["bw"]
+                ))
+            except Exception as exc:  # pylint: disable=broad-except
+                LOGGER.warning(
+                    "Failed to generate comparable result for the following item:\n%s"
+                    "\nException:%s", item, exc)
         eps = [item.sysbench_eps for item in results]
         read_bw = [item.cassandra_fio_read_bw for item in results]
         write_bw = [item.cassandra_fio_write_bw for item in results]


### PR DESCRIPTION
For now, we get following error:

    KeyError: 'cassandra_fio_lcs_64k_read'

getting all the previous data in ElasticSearch.
And the problem with it is that in some cases SCT may fail to find
data for some fields. And it leads to the incomplete set of data.
So, tolerate it instead of failing with 'KeyError' exception.

fixes https://github.com/scylladb/scylla-cluster-tests/issues/4586

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
