### PR TITLE
fix(database.py): lower event severity

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -41,6 +41,7 @@ DatabaseLogEvent.BOOT: NORMAL
 DatabaseLogEvent.STOP: NORMAL
 DatabaseLogEvent.SUPPRESSED_MESSAGES: WARNING
 DatabaseLogEvent.stream_exception: ERROR
+DatabaseLogEvent.COMPACTION_STOPPED: NORMAL
 IndexSpecialColumnErrorEvent: ERROR
 CassandraHarryEvent.failure: CRITICAL
 CassandraHarryEvent.error: ERROR

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -46,6 +46,7 @@ class DatabaseLogEvent(LogEvent, abstract=True):
     FILESYSTEM_ERROR: Type[LogEventProtocol]
     STACKTRACE: Type[LogEventProtocol]
     DISK_ERROR: Type[LogEventProtocol]
+    COMPACTION_STOPPED: Type[LogEventProtocol]
 
     # REACTOR_STALLED must be above BACKTRACE as it has "Backtrace" in its message
     REACTOR_STALLED: Type[LogEventProtocol]
@@ -101,6 +102,8 @@ DatabaseLogEvent.add_subevent_type("RESTARTED_DUE_TO_TIME_OUT", severity=Severit
 DatabaseLogEvent.add_subevent_type("EMPTY_NESTED_EXCEPTION", severity=Severity.WARNING,
                                    regex=r"cql_server - exception while processing connection: "
                                          r"seastar::nested_exception \(seastar::nested_exception\)$")
+DatabaseLogEvent.add_subevent_type("COMPACTION_STOPPED", severity=Severity.NORMAL,
+                                   regex="compaction_stopped_exception")
 DatabaseLogEvent.add_subevent_type("DATABASE_ERROR", severity=Severity.ERROR,
                                    regex="Exception ")
 DatabaseLogEvent.add_subevent_type("BAD_ALLOC", severity=Severity.ERROR,
@@ -153,6 +156,7 @@ SYSTEM_ERROR_EVENTS = (
     DatabaseLogEvent.FILESYSTEM_ERROR(),
     DatabaseLogEvent.DISK_ERROR(),
     DatabaseLogEvent.STACKTRACE(),
+    DatabaseLogEvent.COMPACTION_STOPPED(),
 
     # REACTOR_STALLED must be above BACKTRACE as it has "Backtrace" in its message
     DatabaseLogEvent.REACTOR_STALLED(),


### PR DESCRIPTION
compaction of sstables can now be stopped,
and we are raising error events for these messages
(when in fact, they are just a message to the user and cause no harm):

```
Compacting of 2 sstables interrupted due to: sstables::compaction_stopped_exception
 (Compaction for keyspace1/standard1 was stopped due to: user-triggered operation)
```

there is a long term fix proposed, but not yet merged.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
