### PR TITLE
test(nodetool-stop): test nodetool stop for ICS

### DIFF
--- a/jenkins-pipelines/features-nodetool-stop-compaction-ics.jenkinsfile
+++ b/jenkins-pipelines/features-nodetool-stop-compaction-ics.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'stop_compaction_test.StopCompactionTestICS.test_stop_major_compaction',
+    test_config: '''["test-cases/features/stop-compaction-ics.yaml"]'''
+)

--- a/test-cases/features/stop-compaction-ics.yaml
+++ b/test-cases/features/stop-compaction-ics.yaml
@@ -1,0 +1,11 @@
+test_duration: 60
+
+n_db_nodes: 3
+n_loaders: 1
+n_monitor_nodes: 1
+
+instance_type_db: 'i3.large'
+
+backtrace_decoding: true
+
+user_prefix: 'stop-compaction-ics'


### PR DESCRIPTION
Testing nodetool stop when using ICS in Scylla Enterprise.

test job: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/lukasz/job/features-nodetool-stop-compaction-ics-test/
trello: https://trello.com/c/fMrUUoxc
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
