### PR TITLE
fix(sct.py): Use collector.test_id instead of test_id

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1022,7 +1022,7 @@ def collect_logs(test_id=None, logdir=None, backend=None, config_file=None):
 
     click.echo(table.get_string(title="Collected logs by test-id: {}".format(collector.test_id)))
 
-    if test_id:
+    if collector.test_id:
         store_logs_in_argus(test_id=UUID(collector.test_id), logs=collected_logs)
 
 


### PR DESCRIPTION
The test_id is not updated in case it wasn't supplied, but if a test_id
was located via other means, this caused argus to never submit logs due
to it using a null value

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
