### PR TITLE
feature(raft_config): Add config file for raft experimental

### DIFF
--- a/configurations/raft/enable_raft_experimental.yaml
+++ b/configurations/raft/enable_raft_experimental.yaml
@@ -1,0 +1,3 @@
+append_scylla_yaml: |
+  experimental_features:
+    - raft


### PR DESCRIPTION
Added new config file which enable the raft feature in experimental mode.

New jenkins file doesn't need. longevity pipeline supports several config files configuration parameter. 
So only several jenkins job will be copied and run with additional config file to test with raft experimental

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
