### PR TITLE
fix(rollingUpgradePipeline): make backported commit work

### DIFF
--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -1,5 +1,6 @@
 #!groovy
 
+List supportedVersions = []
 (testDuration, testRunTimeout, runnerTimeout, collectLogsTimeout, resourceCleanupTimeout) = [0,0,0,0,0]
 
 def call(Map pipelineParams) {
@@ -122,8 +123,7 @@ def call(Map pipelineParams) {
                     script {
                         def tasks = [:]
 
-                        for (version in supportedUpgradeFromVersions(pipelineParams.base_versions, pipelineParams.linux_distro,
-                                                                     params.new_scylla_repo)) {
+                        for (version in supportedVersions) {
                             def base_version = version
 
                             tasks["${base_version}"] = {


### PR DESCRIPTION
seems like the backport wasn't completely done (or partially
broken).
the main function was being called twice, instead of
using the result of the 1st run of the funtion
`supportedUpgradeFromVersions`.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
