### PR TITLE
Rolling upgrade base version discovery - add logging and faster pipeline exit

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -587,7 +587,7 @@ def get_scylla_base_versions(scylla_version, scylla_repo, linux_distro, only_pri
 
     # We can't detect the support versions for this distro, which shares the repo with others, eg: centos8
     # so we need to assign the start support versions for it.
-    version_detector.get_start_support_version()
+    version_detector.set_start_support_version()
 
     supported_versions, version_list = version_detector.get_version_list()
     click.echo(f'Supported Versions: {supported_versions}')

--- a/unit_tests/test_base_version.py
+++ b/unit_tests/test_base_version.py
@@ -21,7 +21,7 @@ def general_test(scylla_repo='', linux_distro=''):
     scylla_version = None
 
     version_detector = UpgradeBaseVersion(scylla_repo, linux_distro, scylla_version)
-    version_detector.get_start_support_version()
+    version_detector.set_start_support_version()
     _, version_list = version_detector.get_version_list()
     return version_list
 

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -93,24 +93,22 @@ def call(Map pipelineParams) {
                     }
                 }
                 steps {
-                    catchError(stageResult: 'FAILURE') {
-                        timeout(time: 10, unit: 'MINUTES') {
-                            script {
-                                wrap([$class: 'BuildUser']) {
-                                    dir('scylla-cluster-tests') {
-                                        checkout scm
-                                        ArrayList base_versions_list = params.base_versions.contains('.') ? params.base_versions.split('\\,') : []
-                                        supportedVersions = supportedUpgradeFromVersions(
-                                            base_versions_list,
-                                            pipelineParams.linux_distro,
-                                            params.new_scylla_repo
-                                        )
-                                        (testDuration,
-                                         testRunTimeout,
-                                         runnerTimeout,
-                                         collectLogsTimeout,
-                                         resourceCleanupTimeout) = getJobTimeouts(params, builder.region)
-                                    }
+                    timeout(time: 10, unit: 'MINUTES') {
+                        script {
+                            wrap([$class: 'BuildUser']) {
+                                dir('scylla-cluster-tests') {
+                                    checkout scm
+                                    ArrayList base_versions_list = params.base_versions.contains('.') ? params.base_versions.split('\\,') : []
+                                    supportedVersions = supportedUpgradeFromVersions(
+                                        base_versions_list,
+                                        pipelineParams.linux_distro,
+                                        params.new_scylla_repo
+                                    )
+                                    (testDuration,
+                                     testRunTimeout,
+                                     runnerTimeout,
+                                     collectLogsTimeout,
+                                     resourceCleanupTimeout) = getJobTimeouts(params, builder.region)
                                 }
                             }
                         }

--- a/vars/supportedUpgradeFromVersions.groovy
+++ b/vars/supportedUpgradeFromVersions.groovy
@@ -5,11 +5,12 @@ def call(List base_versions_list, String linux_distro, String new_scylla_repo) {
         def result = sh (returnStdout: true,
                          script: """ ./docker/env/hydra.sh get-scylla-base-versions --only-print-versions true \
                                      --linux-distro ${linux_distro} --scylla-repo ${new_scylla_repo} """)
-        println(result)
+        printf('Docker get-scylla-base-versions output:\n%s', result)
         def last_line = result.split('\n')[-1]
-        if (last_line.contains('Base Versions: ')) {
+        if (last_line.matches("Base\\sVersions:\\s*[\\d\\w\\W]*")) {
             return last_line.replaceAll('Base Versions: ', '').split(' ')
         } else {
+        println("Did not find a valid base versions string!")
             throw new Exception("Didn't get valid base versions automatically!")
         }
 


### PR DESCRIPTION
A recent failure of the rolling upgrades tests was caused by with the path creation for enterprise releases in scylla-pkg. It was unclear to releng folks looking at the output of the job if the issue is with their code or in SCT. This PR:

- adds logging to the methods used when querying, filtering and listing valid versions for the rolling upgrade
- adds a try / catch in the rollingUpgradePipeline to allow for the pipeline to abort upon failing to retrieve an upgrade versions list

The downside is that we'll see ~10 new log lines in the output per upgrade run, but it should be worth it for the additional troubleshooting context.

Trello task: https://trello.com/c/76FOtld4
Original (closed) issue: https://github.com/scylladb/scylla-cluster-tests/issues/4581 
Example Jenkins run: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/maciej/job/mc-rolling-upgrade-centos-07-base-version-fix/16

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
