### PR TITLE
Sla workload type tests

### DIFF
--- a/jenkins-pipelines/features-sla-workload-types.jenkinsfile
+++ b/jenkins-pipelines/features-sla-workload-types.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'sla_per_user_system_test.SlaPerUserTest.test_workload_types',
+    test_config: 'test-cases/features/sl-workloads-test.yaml',
+
+    timeout: [time: 480, unit: 'MINUTES']
+)

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -378,6 +378,22 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         raise AssertionError(f"Could not find the requested node {self.ip_address} in nodetool status")
 
     @property
+    def db_node_instance_type(self) -> Optional[str]:
+        backend = self.parent_cluster.cluster_backend()
+        if backend in ("aws", "aws-siren"):
+            return self.parent_cluster.params.get("instance_type_db")
+        elif backend == "azure":
+            return self.parent_cluster.params.get('azure_instance_type_db')
+        elif backend in ("gce", "gce-siren"):
+            return self.parent_cluster.params.get("gce_instance_type_db")
+        elif backend == "docker":
+            return "docker"
+        else:
+            self.log.warning("Unrecognized backend type, defaulting to 'Unknown' for"
+                             "db instance type.")
+            return None
+
+    @property
     def _proposed_scylla_yaml_properties(self) -> dict:
         node_params_builder = ScyllaYamlNodeAttrBuilder(params=self.parent_cluster.params, node=self)
         certificate_params_builder = ScyllaYamlCertificateAttrBuilder(params=self.parent_cluster.params, node=self)

--- a/sdcm/report_templates/results_sl_workloads.html
+++ b/sdcm/report_templates/results_sl_workloads.html
@@ -1,0 +1,48 @@
+{% extends 'results_base.html' %}
+{% block body %}
+    <h3>
+        <span>System under test </span>
+    </h3>
+    <div>
+        <ul>
+            <li>Scylla version: {{ scylla_version }}</li>
+            <li>Scylla ami id: {{ scylla_ami_id }}</li>
+            <li>Region: {{region}}</li>
+            <li>Instance type: {{ scylla_instance_type }}</li>
+            <li>Number of scylladb nodes: {{ number_of_db_nodes }}</li>
+        </ul>
+    </div>
+    <h3>
+        <span>SL cassandra-stress comparison results</span>
+    </h3>
+    {% if workload_comparison %}
+    <div>
+        <table class='nodes_info_table'>
+            <tr>
+                <th>
+                    <span>Metric</span>
+                </th>
+                {% for column in workload_comparison["op rate"].keys() %}
+                    <th>{{ column }}</th>
+                {% endfor %}
+            </tr>
+            {% for metric in workload_comparison.keys() %}
+            <tr>
+                <td>{{ metric }}</td>
+                {% for item in workload_comparison[metric].values() %}
+                    {% if item is boolean %}
+                        {% if item is true %}
+                            <td style="color: green">{{ item }}</td>
+                        {% else %}
+                            <td style="color: red">{{ item }}</td>
+                        {% endif %}
+                    {% else %}
+                        <td>{{ "%.2f"|format(item) }}</td>
+                    {% endif %}
+                {% endfor %}
+            </tr>
+            {% endfor %}
+        </table>
+    </div>
+    {% endif %}
+{% endblock %}

--- a/sdcm/send_email.py
+++ b/sdcm/send_email.py
@@ -535,7 +535,7 @@ class JepsenEmailReporter(BaseEmailReporter):
 def build_reporter(name: str,
                    email_recipients: Sequence[str] = (),
                    logdir: Optional[str] = None) -> Optional[BaseEmailReporter]:
-    #  pylint: disable=too-many-return-statements
+    # pylint: disable=too-many-return-statements
     if "Gemini" in name:
         return GeminiEmailReporter(email_recipients=email_recipients, logdir=logdir)
     elif "Longevity" in name or 'SlaPerUser' in name:

--- a/sdcm/send_email.py
+++ b/sdcm/send_email.py
@@ -532,14 +532,27 @@ class JepsenEmailReporter(BaseEmailReporter):
         return (attachments_data["jepsen_report"], )
 
 
+class SlaPerUserEmailReporter(LongevityEmailReporter):
+    _fields = (
+        "grafana_screenshots",
+        "grafana_snapshots",
+        "scylla_ami_id",
+        "parallel_timelines_report",
+        "workload_comparison"
+    )
+    email_template_file = "results_sl_workloads.html"
+
+
 def build_reporter(name: str,
                    email_recipients: Sequence[str] = (),
                    logdir: Optional[str] = None) -> Optional[BaseEmailReporter]:
     # pylint: disable=too-many-return-statements
     if "Gemini" in name:
         return GeminiEmailReporter(email_recipients=email_recipients, logdir=logdir)
-    elif "Longevity" in name or 'SlaPerUser' in name:
+    elif "Longevity" in name:
         return LongevityEmailReporter(email_recipients=email_recipients, logdir=logdir)
+    elif "SlaPerUser" in name:
+        return SlaPerUserEmailReporter(email_recipients=email_recipients, logdir=logdir)
     elif "ManagerUpgrade" in name:
         return ManagerUpgradeEmailReporter(email_recipients=email_recipients, logdir=logdir)
     elif "Upgrade" in name:

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -241,7 +241,7 @@ class CassandraStressThread:  # pylint: disable=too-many-instance-attributes
                                timeout=self.timeout,
                                ignore_status=True)
 
-    def get_results(self):
+    def get_results(self) -> list[dict | None]:
         ret = []
         results = []
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1685,7 +1685,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         if errors:
             self.log.warning("cassandra-stress errors on nodes:\n%s", "\n".join(errors))
 
-    def get_stress_results(self, queue, store_results=True):
+    def get_stress_results(self, queue, store_results=True) -> list[dict | None]:
         results = queue.get_results()
         if store_results and self.create_stats:
             self.update_stress_results(results)

--- a/sla_per_user_system_test.py
+++ b/sla_per_user_system_test.py
@@ -320,7 +320,7 @@ class SlaPerUserTest(LongevityTest):
             read_users.append({'user': User(session=session, name='user%d' % share, password='user%d' % share),
                                'role': Role(session=session, name='role%d' % share),
                                'service_level': ServiceLevel(session=session, name='sla%d' % share,
-                                                             service_shares=share)})
+                                                             shares=share)})
 
         expected_shares_ratio = self.calculate_metrics_ratio_per_user(two_users_list=read_users)
 
@@ -386,7 +386,7 @@ class SlaPerUserTest(LongevityTest):
             read_users.append({'user': User(session=session, name='user%d' % share, password='user%d' % share),
                                'role': Role(session=session, name='role%d' % share),
                                'service_level': ServiceLevel(session=session, name='sla%d' % share,
-                                                             service_shares=share)})
+                                                             shares=share)})
 
         # Create Service Levels/Roles/Users
         self.create_auths(entities_list_of_dict=read_users)
@@ -439,7 +439,7 @@ class SlaPerUserTest(LongevityTest):
             read_users.append({'user': User(session=session, name='user%d' % share, password='user%d' % share),
                                'role': Role(session=session, name='role%d' % share),
                                'service_level': ServiceLevel(session=session, name='sla%d' % share,
-                                                             service_shares=share)})
+                                                             shares=share)})
 
         # Create Service Levels/Roles/Users
         self.create_auths(entities_list_of_dict=read_users)
@@ -498,7 +498,7 @@ class SlaPerUserTest(LongevityTest):
             read_users.append({'user': User(session=session, name='user%d' % share, password='user%d' % share),
                                'role': Role(session=session, name='role%d' % share),
                                'service_level': ServiceLevel(session=session, name='sla%d' % share,
-                                                             service_shares=share)})
+                                                             shares=share)})
 
         # Create Service Levels/Roles/Users
         self.create_auths(entities_list_of_dict=read_users)
@@ -548,7 +548,7 @@ class SlaPerUserTest(LongevityTest):
             read_users.append({'user': User(session=session, name='user%d' % share, password='user%d' % share),
                                'role': Role(session=session, name='role%d' % share),
                                'service_level': ServiceLevel(session=session, name='sla%d' % share,
-                                                             service_shares=share)})
+                                                             shares=share)})
 
         # Create Service Levels/Roles/Users
         self.create_auths(entities_list_of_dict=read_users)

--- a/sla_per_user_system_test.py
+++ b/sla_per_user_system_test.py
@@ -587,7 +587,6 @@ class SlaPerUserTest(LongevityTest):
         """
         session = self.prepare_schema()
         self.create_test_data(rows_amount=100_000)
-
         stress_duration_min = 180
 
         # Define Service Levels/Roles/Users
@@ -628,7 +627,8 @@ class SlaPerUserTest(LongevityTest):
                 read_cmds["throughput_batch"]
             ],
                 'round_robin': True})
-            self._compare_workloads_c_s_metrics(workloads_queue)
+            self._comparison_results = self._compare_workloads_c_s_metrics(workloads_queue)
+            logger.info("C-S comparison results:\n%s", self._comparison_results)
         finally:
             pass
 
@@ -686,7 +686,6 @@ class SlaPerUserTest(LongevityTest):
             self.clean_auth(entities_list_of_dict=read_users)
 
     def _compare_workloads_c_s_metrics(self, workloads_queue: list) -> dict:
-        # define what difference margin is expected for interactive vs. batch workload metrics
         comparison_axis = {"latency 95th percentile": 1.5,
                            "latency 99th percentile": 1.5,
                            "op rate": 0.3}
@@ -741,6 +740,7 @@ class SlaPerUserTest(LongevityTest):
         email_data.update({"grafana_screenshots": grafana_dataset.get("screenshots", []),
                            "grafana_snapshots": grafana_dataset.get("snapshots", []),
                            "scylla_ami_id": self.params.get("ami_id_db_scylla") or "-",
+                           "region": self.params.get("region_name") or "-",
                            "workload_comparison": self._comparison_results if self._comparison_results else {}
                            })
 

--- a/sla_per_user_system_test.py
+++ b/sla_per_user_system_test.py
@@ -12,14 +12,17 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2016 ScyllaDB
-
+import logging
 import time
 
 from longevity_test import LongevityTest
 from sdcm.db_stats import PrometheusDBStats
 from test_lib.sla import ServiceLevel, Role, User
 
+logger = logging.getLogger(__name__)
 
+
+# pylint: disable=too-many-public-methods
 class SlaPerUserTest(LongevityTest):
     """
     Test SLA per user feature using cassandra-stress.
@@ -54,6 +57,7 @@ class SlaPerUserTest(LongevityTest):
         self.backgroud_task = None
         self.class_users = {}
         self.connection_cql = None
+        self._comparison_results = None
 
     def prepare_schema(self):
         self.prometheus_stats = PrometheusDBStats(host=self.monitors.nodes[0].public_ip_address)
@@ -248,13 +252,17 @@ class SlaPerUserTest(LongevityTest):
         self.run_stress_and_verify_threads(params={'stress_cmd': read_cmds})
 
     # pylint: disable=too-many-arguments, too-many-locals
-    def define_read_cassandra_stress_command(self, user, load_type, workload_type, threads, stress_duration_min,
-                                             max_rows_for_read=None, stress_command=STRESS_READ_CMD,
-                                             throttle=20000, **kwargs):
+    def define_read_cassandra_stress_command(self,
+                                             role: Role, load_type: str,
+                                             c_s_workload_type: str,
+                                             threads: int, stress_duration_min: int,
+                                             max_rows_for_read: int = None,
+                                             stress_command: str = STRESS_READ_CMD,
+                                             throttle: int = 20000, **kwargs):
         """
-        :param user: dict with User/Role/ServiceLevel objects
+        :param role: Role object
         :param load_type: cache_only/disk_only/mixed
-        :param workload_type: latency: with ops restriction - using throttle
+        :param c_s_workload_type: latency: with ops restriction - using throttle
                                 or
                               throughput: no restriction
         """
@@ -282,16 +290,15 @@ class SlaPerUserTest(LongevityTest):
                 max_rows_for_read = int(self.num_of_partitions * 0.3)
             return 'seq=%d..%d' % (max_rows_for_read, max_rows_for_read+int(self.num_of_partitions*0.25))
 
-        user_name = user['user'].name
-
-        rate = locals()[workload_type]()  # define -rate for c-s command depend on workload type
+        rate = locals()[c_s_workload_type]()  # define -rate for c-s command depend on workload type
         pop = locals()[load_type](max_rows_for_read)  # define -pop for c-s command depend on load type
 
-        params = {'n': self.num_of_partitions, 'user': user_name, 'password': user_name, 'pop': pop,
+        params = {'n': self.num_of_partitions, 'user': role.name, 'password': role.password, 'pop': pop,
                   'duration': '%dm' % stress_duration_min, 'threads': rate}
         if kwargs:
             params.update(kwargs['kwargs'])
         c_s_cmd = stress_command.format(**params)
+        logger.info("Created cassandra-stress command: %s", c_s_cmd)
 
         return c_s_cmd
 
@@ -328,11 +335,11 @@ class SlaPerUserTest(LongevityTest):
         self.create_auths(entities_list_of_dict=read_users)
 
         stress_duration = 10  # minutes
-        read_cmds = [self.define_read_cassandra_stress_command(user=read_users[0], load_type=load,
-                                                               workload_type=self.WORKLOAD_THROUGHPUT, threads=250,
+        read_cmds = [self.define_read_cassandra_stress_command(role=read_users[0]["role"], load_type=load,
+                                                               c_s_workload_type=self.WORKLOAD_THROUGHPUT, threads=250,
                                                                stress_duration_min=stress_duration),
-                     self.define_read_cassandra_stress_command(user=read_users[1], load_type=load,
-                                                               workload_type=self.WORKLOAD_THROUGHPUT, threads=250,
+                     self.define_read_cassandra_stress_command(role=read_users[1]["role"], load_type=load,
+                                                               c_s_workload_type=self.WORKLOAD_THROUGHPUT, threads=250,
                                                                stress_duration_min=stress_duration)
                      ]
 
@@ -392,14 +399,14 @@ class SlaPerUserTest(LongevityTest):
         self.create_auths(entities_list_of_dict=read_users)
 
         # Define stress commands
-        read_cmds = {'troughput': self.define_read_cassandra_stress_command(user=read_users[0],
+        read_cmds = {'troughput': self.define_read_cassandra_stress_command(role=read_users[0]["role"],
                                                                             load_type=self.MIXED_LOAD,
-                                                                            workload_type=self.WORKLOAD_THROUGHPUT,
+                                                                            c_s_workload_type=self.WORKLOAD_THROUGHPUT,
                                                                             threads=200,
                                                                             stress_duration_min=stress_duration),
-                     'latency': self.define_read_cassandra_stress_command(user=read_users[1],
+                     'latency': self.define_read_cassandra_stress_command(role=read_users[1]["role"],
                                                                           load_type=self.MIXED_LOAD,
-                                                                          workload_type=self.WORKLOAD_LATENCY,
+                                                                          c_s_workload_type=self.WORKLOAD_LATENCY,
                                                                           threads=250,
                                                                           stress_duration_min=stress_duration)
                      }
@@ -444,15 +451,15 @@ class SlaPerUserTest(LongevityTest):
         # Create Service Levels/Roles/Users
         self.create_auths(entities_list_of_dict=read_users)
 
-        read_cmds = {'troughput': self.define_read_cassandra_stress_command(user=read_users[0],
+        read_cmds = {'troughput': self.define_read_cassandra_stress_command(role=read_users[0]["role"],
                                                                             load_type=self.CACHE_ONLY_LOAD,
-                                                                            workload_type=self.WORKLOAD_THROUGHPUT,
+                                                                            c_s_workload_type=self.WORKLOAD_THROUGHPUT,
                                                                             threads=200,
                                                                             stress_duration_min=stress_duration,
                                                                             max_rows_for_read=max_key_for_read),
-                     'latency': self.define_read_cassandra_stress_command(user=read_users[1],
+                     'latency': self.define_read_cassandra_stress_command(role=read_users[1]["role"],
                                                                           load_type=self.CACHE_ONLY_LOAD,
-                                                                          workload_type=self.WORKLOAD_LATENCY,
+                                                                          c_s_workload_type=self.WORKLOAD_LATENCY,
                                                                           threads=250,
                                                                           stress_duration_min=stress_duration,
                                                                           max_rows_for_read=max_key_for_read)
@@ -503,21 +510,21 @@ class SlaPerUserTest(LongevityTest):
         # Create Service Levels/Roles/Users
         self.create_auths(entities_list_of_dict=read_users)
 
-        read_cmds = {'troughput': self.define_read_cassandra_stress_command(user=read_users[0],
+        read_cmds = {'troughput': self.define_read_cassandra_stress_command(role=read_users[0]["role"],
                                                                             load_type=self.DISK_ONLY_LOAD,
-                                                                            workload_type=self.WORKLOAD_THROUGHPUT,
+                                                                            c_s_workload_type=self.WORKLOAD_THROUGHPUT,
                                                                             threads=200,
                                                                             stress_duration_min=stress_duration,
                                                                             max_rows_for_read=max_key_for_cache*2),
-                     'latency': self.define_read_cassandra_stress_command(user=read_users[1],
+                     'latency': self.define_read_cassandra_stress_command(role=read_users[1]["role"],
                                                                           load_type=self.DISK_ONLY_LOAD,
-                                                                          workload_type=self.WORKLOAD_LATENCY,
+                                                                          c_s_workload_type=self.WORKLOAD_LATENCY,
                                                                           threads=250,
                                                                           stress_duration_min=stress_duration,
                                                                           max_rows_for_read=max_key_for_cache*3),
-                     'latency_only': self.define_read_cassandra_stress_command(user=read_users[1],
+                     'latency_only': self.define_read_cassandra_stress_command(role=read_users[1]["role"],
                                                                                load_type=self.DISK_ONLY_LOAD,
-                                                                               workload_type=self.WORKLOAD_LATENCY,
+                                                                               c_s_workload_type=self.WORKLOAD_LATENCY,
                                                                                threads=250,
                                                                                stress_duration_min=stress_duration,
                                                                                max_rows_for_read=max_key_for_cache)
@@ -553,15 +560,16 @@ class SlaPerUserTest(LongevityTest):
         # Create Service Levels/Roles/Users
         self.create_auths(entities_list_of_dict=read_users)
 
-        read_cmds = {'troughput': self.define_read_cassandra_stress_command(user=read_users[0], load_type=self.MIXED_LOAD,
-                                                                            workload_type=self.WORKLOAD_THROUGHPUT,
+        read_cmds = {'troughput': self.define_read_cassandra_stress_command(role=read_users[0]["role"],
+                                                                            load_type=self.MIXED_LOAD,
+                                                                            c_s_workload_type=self.WORKLOAD_THROUGHPUT,
                                                                             threads=120,
                                                                             stress_duration_min=stress_duration_min,
                                                                             stress_command=self.STRESS_MIXED_CMD,
                                                                             kwargs={'write_ratio': 1, 'read_ratio': 1}),
-                     'latency': self.define_read_cassandra_stress_command(user=read_users[1],
+                     'latency': self.define_read_cassandra_stress_command(role=read_users[1]["role"],
                                                                           load_type=self.MIXED_LOAD,
-                                                                          workload_type=self.WORKLOAD_LATENCY,
+                                                                          c_s_workload_type=self.WORKLOAD_LATENCY,
                                                                           threads=120,
                                                                           stress_duration_min=stress_duration_min,
                                                                           stress_command=self.STRESS_MIXED_CMD,
@@ -569,6 +577,60 @@ class SlaPerUserTest(LongevityTest):
                      }
 
         self._throughput_latency_tests_run(read_users=read_users, read_cmds=read_cmds, latency_user=read_users[1])
+
+    def test_workload_types(self):
+        """
+        Test scenario: run 2 workload types (batch, interactive) using
+        Roles with relevant ServiceLevel objects attached to them.
+        Validate that the metrics differ and that the difference is
+        within the expected margins.
+        """
+        session = self.prepare_schema()
+        self.create_test_data(rows_amount=100_000)
+
+        stress_duration_min = 180
+
+        # Define Service Levels/Roles/Users
+        interactive_role = Role(session=session, name="interactive",
+                                password="interactive", login=True, verbose=True).create()
+        batch_role = Role(session=session, name="batch", password="batch", login=True, verbose=True).create()
+        interactive_sla = ServiceLevel(session=session, name="interactive", shares=None,
+                                       workload_type="interactive").create()
+        batch_sla = ServiceLevel(session=session, name="batch", shares=None,
+                                 workload_type="batch").create()
+        interactive_role.attach_service_level(interactive_sla)
+        batch_role.attach_service_level(batch_sla)
+
+        read_cmds = {
+            'throughput_interactive': self.define_read_cassandra_stress_command(
+                role=interactive_role,
+                load_type=self.MIXED_LOAD,
+                c_s_workload_type=self.WORKLOAD_THROUGHPUT,
+                threads=120,
+                stress_duration_min=stress_duration_min,
+                stress_command=self.STRESS_MIXED_CMD,
+                kwargs={'write_ratio': 1, 'read_ratio': 1}
+            ),
+            'throughput_batch': self.define_read_cassandra_stress_command(
+                role=batch_role,
+                load_type=self.MIXED_LOAD,
+                c_s_workload_type=self.WORKLOAD_THROUGHPUT,
+                threads=120,
+                stress_duration_min=stress_duration_min,
+                stress_command=self.STRESS_MIXED_CMD,
+                kwargs={'write_ratio': 1, 'read_ratio': 1}
+            )}
+
+        try:
+            self.log.debug('Running interactive and batch workloads in sequence...')
+            workloads_queue = self.run_stress_and_verify_threads(params={'stress_cmd': [
+                read_cmds['throughput_interactive'],
+                read_cmds["throughput_batch"]
+            ],
+                'round_robin': True})
+            self._compare_workloads_c_s_metrics(workloads_queue)
+        finally:
+            pass
 
     def _throughput_latency_tests_run(self, read_cmds, read_users, latency_user):
         # pylint: disable=too-many-locals
@@ -622,3 +684,76 @@ class SlaPerUserTest(LongevityTest):
             self.log.info(result_print_str)
         finally:
             self.clean_auth(entities_list_of_dict=read_users)
+
+    def _compare_workloads_c_s_metrics(self, workloads_queue: list) -> dict:
+        # define what difference margin is expected for interactive vs. batch workload metrics
+        comparison_axis = {"latency 95th percentile": 1.5,
+                           "latency 99th percentile": 1.5,
+                           "op rate": 0.3}
+        workloads_results = {}
+        for workload in workloads_queue:
+            result = self.get_stress_results(queue=workload, store_results=False)
+
+            workloads_results.update({result[0].get("username"): result[0]})
+
+        assert len(workloads_results) == 2, \
+            "Expected workload_results length to be 2, got: %s. workload_results: %s" % (
+                len(workloads_results), workloads_results)
+        comparison_results = {}
+        try:
+            for item, target_margin in comparison_axis.items():
+                interactive = float(workloads_results["interactive"][item])
+                batch = float(workloads_results["batch"][item])
+                ratio = batch / interactive
+
+                comparison_results.update(
+                    {
+                        item: {
+                            "interactive": interactive,
+                            "batch": batch,
+                            "diff": batch - interactive,
+                            "within_margin": ratio <= target_margin if item == "op rate" else ratio >= target_margin
+                        }
+                    }
+                )
+            return comparison_results
+        except Exception:
+            logger.info("Failed to compare c-s results for batch and interactive"
+                        "workloads.")
+            raise
+
+    def get_email_data(self):
+        self.log.info("Prepare data for email")
+        email_data = {}
+        grafana_dataset = {}
+
+        try:
+            email_data = self._get_common_email_data()
+        except Exception as error:  # pylint: disable=broad-except
+            self.log.error("Error in gathering common email data: Error:\n%s", error)
+
+        try:
+            grafana_dataset = self.monitors.get_grafana_screenshot_and_snapshot(
+                self.start_time) if self.monitors else {}
+        except Exception as error:  # pylint: disable=broad-except
+            self.log.error("Error in gathering Grafana screenshots and snapshots. Error:\n%s", error)
+
+        email_data.update({"grafana_screenshots": grafana_dataset.get("screenshots", []),
+                           "grafana_snapshots": grafana_dataset.get("snapshots", []),
+                           "scylla_ami_id": self.params.get("ami_id_db_scylla") or "-",
+                           "workload_comparison": self._comparison_results if self._comparison_results else {}
+                           })
+
+        return email_data
+
+    # pylint: disable=inconsistent-return-statements
+    def get_test_status(self) -> str:
+        if self._comparison_results:
+            try:
+                if all((item["within_margin"] for item in self._comparison_results.values())):
+                    return "SUCCESS"
+                else:
+                    return "FAILED"
+            except KeyError as exc:
+                logger.error("Exception on attempting to check workload comparison results:\n%s", exc)
+                return super().get_test_status()

--- a/sla_per_user_system_test.py
+++ b/sla_per_user_system_test.py
@@ -12,14 +12,12 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2016 ScyllaDB
-import logging
 import time
 
 from longevity_test import LongevityTest
 from sdcm.db_stats import PrometheusDBStats
+from sdcm.es import ES
 from test_lib.sla import ServiceLevel, Role, User
-
-logger = logging.getLogger(__name__)
 
 
 # pylint: disable=too-many-public-methods
@@ -49,6 +47,7 @@ class SlaPerUserTest(LongevityTest):
     CACHE_ONLY_LOAD = 'cache_only'
     DISK_ONLY_LOAD = 'disk_only'
     MIXED_LOAD = 'mixed'
+    WORKLOAD_TYPES_INDEX = "workload_tests"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -57,7 +56,8 @@ class SlaPerUserTest(LongevityTest):
         self.backgroud_task = None
         self.class_users = {}
         self.connection_cql = None
-        self._comparison_results = None
+        self._comparison_results = {}
+        self._es = ES()
 
     def prepare_schema(self):
         self.prometheus_stats = PrometheusDBStats(host=self.monitors.nodes[0].public_ip_address)
@@ -298,7 +298,7 @@ class SlaPerUserTest(LongevityTest):
         if kwargs:
             params.update(kwargs['kwargs'])
         c_s_cmd = stress_command.format(**params)
-        logger.info("Created cassandra-stress command: %s", c_s_cmd)
+        self.log.info("Created cassandra-stress command: %s", c_s_cmd)
 
         return c_s_cmd
 
@@ -618,17 +618,19 @@ class SlaPerUserTest(LongevityTest):
                 stress_duration_min=stress_duration_min,
                 stress_command=self.STRESS_MIXED_CMD,
                 kwargs={'write_ratio': 1, 'read_ratio': 1}
-            )}
+            ),
+        }
 
         try:
             self.log.debug('Running interactive and batch workloads in sequence...')
             workloads_queue = self.run_stress_and_verify_threads(params={'stress_cmd': [
                 read_cmds['throughput_interactive'],
-                read_cmds["throughput_batch"]
+                read_cmds["throughput_batch"],
             ],
                 'round_robin': True})
             self._comparison_results = self._compare_workloads_c_s_metrics(workloads_queue)
-            logger.info("C-S comparison results:\n%s", self._comparison_results)
+            self.log.info("C-S comparison results:\n%s", self._comparison_results)
+            self.upload_c_s_comparison_to_es()
         finally:
             pass
 
@@ -686,9 +688,9 @@ class SlaPerUserTest(LongevityTest):
             self.clean_auth(entities_list_of_dict=read_users)
 
     def _compare_workloads_c_s_metrics(self, workloads_queue: list) -> dict:
-        comparison_axis = {"latency 95th percentile": 1.5,
-                           "latency 99th percentile": 1.5,
-                           "op rate": 0.3}
+        comparison_axis = {"latency 95th percentile": 2.0,
+                           "latency 99th percentile": 2.0,
+                           "op rate": 2.0}
         workloads_results = {}
         for workload in workloads_queue:
             result = self.get_stress_results(queue=workload, store_results=False)
@@ -703,7 +705,7 @@ class SlaPerUserTest(LongevityTest):
             for item, target_margin in comparison_axis.items():
                 interactive = float(workloads_results["interactive"][item])
                 batch = float(workloads_results["batch"][item])
-                ratio = batch / interactive
+                ratio = interactive / batch if item == "op rate" else batch / interactive
 
                 comparison_results.update(
                     {
@@ -711,15 +713,30 @@ class SlaPerUserTest(LongevityTest):
                             "interactive": interactive,
                             "batch": batch,
                             "diff": batch - interactive,
-                            "within_margin": ratio <= target_margin if item == "op rate" else ratio >= target_margin
+                            "ratio": ratio,
+                            "within_margin": ratio >= target_margin
                         }
                     }
                 )
             return comparison_results
         except Exception:
-            logger.info("Failed to compare c-s results for batch and interactive"
-                        "workloads.")
+            self.log.info("Failed to compare c-s results for batch and interactive"
+                          "workloads.")
             raise
+
+    def upload_c_s_comparison_to_es(self) -> None:
+        self.log.info("Uploading c-s comparison to ES...")
+        es_body = {
+            self.db_cluster.get_node().db_node_instance_type: {
+                "test_id": self.test_id,
+                "backend": self.db_cluster.params.get("cluster_backend"),
+                "scylla_version": self.get_scylla_versions(),
+                **self._comparison_results
+            }
+        }
+        self._es.create_doc(index="workload_types", doc_type="test_stats",
+                            doc_id=self.test_id, body=es_body)
+        self.log.info("C-s comparison uploaded to ES.")
 
     def get_email_data(self):
         self.log.info("Prepare data for email")
@@ -755,5 +772,5 @@ class SlaPerUserTest(LongevityTest):
                 else:
                     return "FAILED"
             except KeyError as exc:
-                logger.error("Exception on attempting to check workload comparison results:\n%s", exc)
+                self.log.error("Exception on attempting to check workload comparison results:\n%s", exc)
                 return super().get_test_status()

--- a/test-cases/features/sl-workloads-test.yaml
+++ b/test-cases/features/sl-workloads-test.yaml
@@ -1,0 +1,18 @@
+test_duration: 300
+
+n_db_nodes: 3
+n_loaders: 2
+n_monitor_nodes: 1
+
+instance_type_db: 'i3.xlarge'
+instance_type_loader: 'c5.2xlarge'
+
+user_prefix: 'sl-workloads'
+
+space_node_threshold: 64424
+round_robin: true
+
+authenticator: 'PasswordAuthenticator'
+authenticator_user: cassandra
+authenticator_password: cassandra
+authorizer: 'ScyllaAuthorizer'

--- a/test_lib/sla.py
+++ b/test_lib/sla.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
+from __future__ import annotations
 
 import logging
-import time
+from dataclasses import dataclass, field, fields
 
-from cassandra import InvalidRequest
+
+LOGGER = logging.getLogger(__name__)
 
 
 def sla_result_to_dict(sla_result):
@@ -20,18 +22,67 @@ def sla_result_to_dict(sla_result):
 DEFAULT_SERVICE_LEVEL_SHARES = 1000
 
 
-class ServiceLevel():  # pylint: disable=too-many-instance-attributes
+@dataclass
+class ServiceLevelAttributes:
+    shares: int = None
+    timeout: str = None
+    workload_type: str = None
+    query_string: str = field(init=False, repr=False)
+
+    def __setattr__(self, key, value):
+        super().__setattr__(key, value)
+        if key != "query_string":
+            self._generate_query_string()
+
+    def __post_init__(self):
+        self._generate_query_string()
+
+    def _generate_query_string(self):
+        attr_strings = []
+
+        for item in fields(self):
+            value = getattr(self, item.name) if item.repr else None
+            if value is not None:
+                # pylint: disable=literal-comparison
+                if item.type is str:
+                    attr_strings.append(f" AND {item.name} = '{value}'")
+                else:
+                    attr_strings.append(f" AND {item.name} = {value}")
+        if attr_strings:
+            attr_strings[0] = attr_strings[0].replace(" AND", " WITH")
+        else:
+            self.query_string = ""
+            return
+
+        self.query_string = "".join(attr_strings)
+
+
+class ServiceLevel:
     # The class provide interface to manage SERVICE LEVEL
-    def __init__(self, session, name, service_shares=None, verbose=True):
+    # pylint: disable=too-many-arguments
+    def __init__(self, session,
+                 name: str,
+                 shares: int = 1000,
+                 timeout: str = None,
+                 workload_type: str = None):
         self.session = session
-        self._name = name
-        self._service_shares = service_shares
-        self.verbose = verbose
-        self._is_created = False
-        self.log = logging.getLogger("test")
+        self._name = f'"{name}"'
+        self.verbose = True
+        self._created = False
+        self._sl_attributes = ServiceLevelAttributes(
+            shares=shares,
+            timeout=timeout,
+            workload_type=workload_type
+        )
+
+    @classmethod
+    def from_row(cls, session, row):
+        row_dict = row._asdict()
+        row_dict["name"] = row_dict.pop("service_level")
+        return ServiceLevel(session=session, **row_dict)
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._name
 
     @name.setter
@@ -39,82 +90,120 @@ class ServiceLevel():  # pylint: disable=too-many-instance-attributes
         self._name = name
 
     @property
-    def service_shares(self):
-        return self._service_shares
+    def shares(self) -> int:
+        return self._sl_attributes.shares
 
-    @service_shares.setter
-    def service_shares(self, service_level_shares):
-        self._service_shares = service_level_shares
+    @shares.setter
+    def shares(self, service_level_shares):
+        self._sl_attributes.shares = service_level_shares
 
     @property
-    def is_created(self):
-        return self._is_created
+    def created(self) -> bool:
+        return self.created
 
-    @is_created.setter
-    def is_created(self, is_created):
-        self._is_created = is_created
+    @created.setter
+    def created(self, created: bool):
+        self._created = created
 
-    def create(self, if_not_exists=True):
-        query = 'CREATE SERVICE_LEVEL{if_not_exists} {service_level_name}{shares}' \
-            .format(if_not_exists=' IF NOT EXISTS' if if_not_exists else '',
-                    service_level_name=self.name,
-                    shares=' WITH SHARES = %d' % self.service_shares if self.service_shares is not None else '')
+    @property
+    def timeout(self) -> str:
+        return self._sl_attributes.timeout
+
+    @timeout.setter
+    def timeout(self, timeout: int):
+        self._sl_attributes.timeout = timeout
+
+    @property
+    def workload_type(self) -> str:
+        return self._sl_attributes.workload_type
+
+    @workload_type.setter
+    def workload_type(self, workload_type: str):
+        self._sl_attributes.workload_type = workload_type
+
+    def __eq__(self, other):
+        return (self.name == other.name) and self._sl_attributes == other._sl_attributes
+
+    def __repr__(self):
+        return "%s: name: %s, attributes: %s" % (self.__class__.__name__, self.name, self._sl_attributes)
+
+    def create(self, if_not_exists=True) -> ServiceLevel:
+        query = 'CREATE SERVICE_LEVEL{if_not_exists} {service_level_name}{query_attributes}'\
+                .format(if_not_exists=' IF NOT EXISTS' if if_not_exists else '',
+                        service_level_name=self.name,
+                        query_attributes=self._sl_attributes.query_string)
         if self.verbose:
-            self.log.debug('Create service level query: {}'.format(query))
+            LOGGER.debug('Create service level query: {}'.format(query))
         self.session.execute(query)
-        # It's take the about 10 sec to create service level. Waiting for the finish
-        time.sleep(12)
-        self.log.debug('Service level "{}" has been created'.format(self.name))
-        self.is_created = True
+        LOGGER.debug('Service level "{}" has been created'.format(self.name))
+        self.created = True
+        return self
 
-    def alter(self, new_shares):
-        query = 'ALTER SERVICE_LEVEL {service_level_name} WITH SHARES = {shares}' \
-            .format(service_level_name=self.name,
-                    shares=new_shares)
+    def alter(self, new_shares: int = None, new_timeout: str = None, new_workload_type: str = None):
+        sla = ServiceLevelAttributes(shares=new_shares, timeout=new_timeout, workload_type=new_workload_type)
+        query = 'ALTER SERVICE_LEVEL {service_level_name} {query_string}'\
+                .format(service_level_name=self.name,
+                        query_string=sla.query_string)
         if self.verbose:
-            self.log.debug('Change service level query: {}'.format(query))
+            LOGGER.debug('Change service level query: {}'.format(query))
         self.session.execute(query)
-        self.log.debug('Service level "{}" has been altered'.format(self.name))
-        self.service_shares = new_shares
+        LOGGER.debug('Service level "{}" has been altered'.format(self.name))
+        self.shares = new_shares
 
     def drop(self, if_exists=True):
-        query = 'DROP SERVICE_LEVEL{if_exists} {service_level_name}' \
-            .format(service_level_name=self.name,
-                    if_exists=' IF EXISTS' if if_exists else '')
+        query = 'DROP SERVICE_LEVEL{if_exists} {service_level_name}'\
+                .format(service_level_name=self.name,
+                        if_exists=' IF EXISTS' if if_exists else '')
         if self.verbose:
-            self.log.debug('Drop service level query: {}'.format(query))
+            LOGGER.debug('Drop service level query: {}'.format(query))
         self.session.execute(query)
-        self.log.debug('Service level "{}" has been dropped'.format(self.name))
-        self.is_created = False
+        LOGGER.debug('Service level "{}" has been dropped'.format(self.name))
+        self.created = False
 
-    def list_service_level(self):
+    def list_service_level(self) -> ServiceLevel | None:
         query = 'LIST SERVICE_LEVEL {}'.format(self.name)
         if self.verbose:
-            self.log.debug('List service level query: {}'.format(query))
-        res = list(self.session.execute(query))
-        return sla_result_to_dict(res)
+            LOGGER.debug('List service level query: {}'.format(query))
+        res = self.session.execute(query).all()
+        assert len(res) <= 1, "Received %s service levels when expecting to receive only 1" % len(res)
 
-    def list_all_service_levels(self):
+        if len(res) == 0:
+            return None
+
+        result_dict = res[0]._asdict()
+        result_dict["name"] = result_dict.pop("service_level")
+
+        return ServiceLevel(session=self.session, **result_dict)
+
+    def list_all_service_levels(self) -> list[ServiceLevel]:
         query = 'LIST ALL SERVICE_LEVELS'
         if self.verbose:
-            self.log.debug('List all service levels query: {}'.format(query))
-        res = list(self.session.execute(query))
-        return sla_result_to_dict(res)
+            LOGGER.debug('List all service levels query: {}'.format(query))
+        res_list = self.session.execute(query).all()
+        output = []
+
+        for res in res_list:
+            result_dict = res._asdict()
+            result_dict["name"] = result_dict.pop("service_level")
+            output.append(ServiceLevel(session=self.session, **result_dict))
+        return output
+
+# pylint: disable=too-many-arguments, too-many-instance-attributes, unused-argument
 
 
-class UserRoleBase():  # pylint: disable=too-many-instance-attributes
+class UserRoleBase:
     # Base class for ROLES and USERS
     AUTHENTICATION_ENTITY = ''
 
-    def __init__(self, session, name, password=None, superuser=None, verbose=True):  # pylint: disable=too-many-arguments
+    def __init__(self, session, name, password=None, superuser=None, verbose=False, **kwargs):
         self._name = name
         self.password = password
         self.session = session
         self.superuser = superuser
         self.verbose = verbose
+        self._attached_service_level = None
         self._attached_service_level_name = ''
         self._attached_service_level_shares = None
-        self.log = logging.getLogger("test")
 
     @property
     def name(self):
@@ -125,119 +214,95 @@ class UserRoleBase():  # pylint: disable=too-many-instance-attributes
         self._name = name
 
     @property
-    def attached_service_level_name(self):
-        return self._attached_service_level_name
-
-    @attached_service_level_name.setter
-    def attached_service_level_name(self, service_level_name):
-        self._attached_service_level_name = service_level_name
+    def attached_service_level(self):
+        return self._attached_service_level
 
     @property
-    def attached_service_level_shares(self):
-        return self._attached_service_level_shares
-
-    @attached_service_level_shares.setter
-    def attached_service_level_shares(self, service_level_shares):
-        self._attached_service_level_shares = service_level_shares
+    def attached_service_level_name(self):
+        return self._attached_service_level.name
 
     def attach_service_level(self, service_level):
-        query = 'ATTACH SERVICE_LEVEL {service_level_name} TO {role_name}' \
-            .format(service_level_name=service_level.name,
-                    role_name=self.name)
+        """
+        :param auth_name: it may be role name or user name
+        """
+        query = 'ATTACH SERVICE_LEVEL {service_level_name} TO {role_name}'\
+                .format(service_level_name=service_level.name,
+                        role_name=self.name)
         if self.verbose:
-            self.log.debug('Attach service level query: {}'.format(query))
+            LOGGER.debug('Attach service level query: {}'.format(query))
         self.session.execute(query)
-        self.log.debug('Service level "{}" has been attached to {} role'.format(service_level.name, self.name))
-        self.attached_service_level_name = service_level.name
-        self.attached_service_level_shares = service_level.service_shares \
-            if service_level.service_shares \
-            else DEFAULT_SERVICE_LEVEL_SHARES
+        LOGGER.debug('Service level "{}" has been attached to {} role'.format(service_level.name, self.name))
+        self._attached_service_level = service_level
 
     def detach_service_level(self):
-        query = 'DETACH SERVICE_LEVEL FROM {role_name}' \
-            .format(role_name=self.name)
+        """
+        :param auth_name: it may be role name or user name
+        """
+        query = 'DETACH SERVICE_LEVEL FROM {role_name}'\
+                .format(role_name=self.name)
         if self.verbose:
-            self.log.debug('Detach service level query: {}'.format(query))
+            LOGGER.debug('Detach service level query: {}'.format(query))
         self.session.execute(query)
-        self.log.debug('The service level has been detached from {} role'.format(self.name))
-
-        self.attached_service_level_name = ''
-        self.attached_service_level_shares = None
+        LOGGER.debug('The service level has been detached from {} role'.format(self.name))
+        self._attached_service_level = None
 
     def grant_me_to(self, grant_to):
         role_be_granted = self.name
         grant_to = grant_to.name
-        query = 'GRANT {role_be_granted} to {grant_to}'.format(role_be_granted=role_be_granted, grant_to=grant_to)
+        query = 'GRANT {role_be_granted} to {grant_to}'.format(**locals())
         if self.verbose:
-            self.log.debug('GRANT role query: {}'.format(query))
-        try:
-            self.session.execute(query)
-        except InvalidRequest as ex:
-            assert ex.message.split('message=')[1].replace('"', '') == \
-                '{grant_to} already includes role {role_be_granted}.'.format(role_be_granted=role_be_granted, grant_to=grant_to), \
-                'Unexpected error during grant: {}'.format(ex.message)
-        self.log.debug('Role "{role_be_granted}" has been granted to {grant_to}'.format(
-            role_be_granted=role_be_granted, grant_to=grant_to))
+            LOGGER.debug('GRANT role query: {}'.format(query))
+        self.session.execute(query)
+        LOGGER.debug('Role "{role_be_granted}" has been granted to {grant_to}'.format(**locals()))
 
     def revoke_me_from(self, revoke_from):
         role_be_revoked = self.name
         role_revokes_from = revoke_from.name
-        query = 'REVOKE {role_be_revoked} FROM {role_revokes_from}'.format(role_be_revoked=role_be_revoked,
-                                                                           role_revokes_from=role_revokes_from)
+        query = 'REVOKE ROLE {role_be_revoked} FROM {role_revokes_from}'.format(**locals())
         if self.verbose:
-            self.log.debug('REVOKE role query: {}'.format(query))
-        try:
-            self.session.execute(query)
-        except InvalidRequest as ex:
-            assert ex.message.split('message=')[1].replace('"', '') == \
-                '{role_revokes_from} was not granted role {role_be_revoked}, so it cannot be revoked.' \
-                .format(role_be_revoked=role_be_revoked, role_revokes_from=role_revokes_from), \
-                'Unexpected error during revoke: {}'.format(ex.message)
-        self.log.debug('Role "{role_be_revoked}" has been revocked from {role_revokes_from}'.format(
-            role_be_revoked=role_be_revoked, role_revokes_from=role_revokes_from))
+            LOGGER.debug('REVOKE role query: {}'.format(query))
+        self.session.execute(query)
+        LOGGER.debug('Role "{role_be_revoked}" has been revocked from {role_revokes_from}'.format(**locals()))
 
-    def list_attached_sla_of_user_or_role(self):  # pylint: disable=invalid-name
+    def attach_another_sla_to_role(self, service_level):
+        self.detach_service_level()
+        self.attach_service_level(service_level=service_level)
+
+    def list_user_role_attached_service_levels(self):
         query = 'LIST ATTACHED SERVICE_LEVEL OF {}'.format(self.name)
         if self.verbose:
-            self.log.debug('List attached service level(s) query: {}'.format(query))
-        res = list(self.session.execute(query))
-        return sla_result_to_dict(res)
+            LOGGER.debug('List attached service level(s) query: {}'.format(query))
+        # res = list(self.session.execute(query))
+        return self.session.execute(query).all()
 
-    def list_all_attached_service_levels(self):   # pylint: disable=invalid-name
+    def list_all_attached_service_levels(self):
         query = 'LIST ATTACHED ALL SERVICE_LEVELS'
         if self.verbose:
-            self.log.debug('List attached service level(s) query: {}'.format(query))
+            LOGGER.debug('List attached service level(s) query: {}'.format(query))
         res = list(self.session.execute(query))
-        return sla_result_to_dict(res)
-
-    def list_effective_service_levels(self, auth_obj):
-        query = 'LIST SERVICE_LEVELS OF {}'.format(auth_obj.name)
-        if self.verbose:
-            self.log.debug('List effective service levels query: {}'.format(query))
-        res = list(self.session.execute(query))
-        return sla_result_to_dict(res)
+        return res
 
     def drop(self, if_exists=True):
         query = 'DROP {entity}{if_exists} {name}'.format(entity=self.AUTHENTICATION_ENTITY,
                                                          name=self.name,
                                                          if_exists=' IF EXISTS' if if_exists else '')
         if self.verbose:
-            self.log.debug('Drop {entity} query: {query}'.format(entity=self.AUTHENTICATION_ENTITY, query=query))
+            LOGGER.debug('Drop {entity} query: {query}'.format(entity=self.AUTHENTICATION_ENTITY, query=query))
 
         self.session.execute(query)
-        self.log.debug('{entity} "{name}" has been dropped'.format(entity=self.AUTHENTICATION_ENTITY, name=self.name))
+        LOGGER.debug('{entity} "{name}" has been dropped'.format(entity=self.AUTHENTICATION_ENTITY, name=self.name))
 
 
 class Role(UserRoleBase):
     # The class provide interface to manage ROLES
     AUTHENTICATION_ENTITY = 'ROLE'
 
-    def __init__(self, session, name, password=None, login=False, superuser=False, options_dict=None, verbose=True):  # pylint: disable=too-many-arguments
+    def __init__(self, session, name, password=None, login=False, superuser=False, options_dict=None, verbose=True):
         super().__init__(session, name, password, superuser, verbose)
         self.login = login
         self.options_dict = options_dict
 
-    def create(self):
+    def create(self) -> Role:
         # Example: CREATE ROLE bob WITH PASSWORD = 'password_b'AND LOGIN = true AND SUPERUSER = true;
         # Example: CREATE ROLE carlos WITH OPTIONS = {'custom_option1': 'option1_value', 'custom_option2': 99};
         role_options = {}
@@ -251,22 +316,22 @@ class Role(UserRoleBase):
         if role_options_str:
             role_options_str = ' WITH {}'.format(role_options_str)
 
-        query = 'CREATE ROLE IF NOT EXISTS {name}{role_options_str}'.format(name=self.name,
-                                                                            role_options_str=role_options_str)
+        query = 'CREATE ROLE {name}{role_options_str}'.format(name=self.name, role_options_str=role_options_str)
         if self.verbose:
-            self.log.debug('CREATE role query: {}'.format(query))
+            LOGGER.debug('CREATE role query: {}'.format(query))
         self.session.execute(query)
-
-        # It's take the about 10 sec to create role. Waiting for the finish
-        time.sleep(12)
-        self.log.debug('Role "{}" has been created'.format(self.name))
+        LOGGER.debug('Role "{}" has been created'.format(self.name))
+        return self
 
 
 class User(UserRoleBase):
     # The class provide interface to manage USERS
     AUTHENTICATION_ENTITY = 'USER'
 
-    def create(self):
+    def __init__(self, session, name, password=None, superuser=None, verbose=True):
+        super().__init__(session, name, password, superuser, verbose)
+
+    def create(self) -> User:
         user_options_str = '{password}{superuser}'.format(password=' PASSWORD \'{}\''
                                                           .format(self.password) if self.password else '',
                                                           superuser='' if self.superuser is None else ' SUPERUSER'
@@ -274,13 +339,10 @@ class User(UserRoleBase):
         if user_options_str:
             user_options_str = ' WITH {}'.format(user_options_str)
 
-        query = 'CREATE USER IF NOT EXISTS {name}{user_options_str}'.format(name=self.name,
-                                                                            user_options_str=user_options_str)
+        query = 'CREATE USER {name}{user_options_str}'.format(name=self.name, user_options_str=user_options_str)
         if self.verbose:
-            self.log.debug('Create user query: {}'.format(query))
+            LOGGER.debug('Create user query: {}'.format(query))
 
         self.session.execute(query)
-
-        # It's take the about 10 sec to create user. Waiting for the finish
-        time.sleep(12)
-        self.log.debug('User "{}" has been created'.format(self.name))
+        LOGGER.debug('User "{}" has been created'.format(self.name))
+        return self

--- a/test_lib/sla.py
+++ b/test_lib/sla.py
@@ -49,9 +49,6 @@ class ServiceLevelAttributes:
                     attr_strings.append(f" AND {item.name} = {value}")
         if attr_strings:
             attr_strings[0] = attr_strings[0].replace(" AND", " WITH")
-        else:
-            self.query_string = ""
-            return
 
         self.query_string = "".join(attr_strings)
 
@@ -132,9 +129,9 @@ class ServiceLevel:
                         service_level_name=self.name,
                         query_attributes=self._sl_attributes.query_string)
         if self.verbose:
-            LOGGER.debug('Create service level query: {}'.format(query))
+            LOGGER.debug('Create service level query: %s', query)
         self.session.execute(query)
-        LOGGER.debug('Service level "{}" has been created'.format(self.name))
+        LOGGER.debug('Service level %s has been created', self.name)
         self.created = True
         return self
 
@@ -144,9 +141,9 @@ class ServiceLevel:
                 .format(service_level_name=self.name,
                         query_string=sla.query_string)
         if self.verbose:
-            LOGGER.debug('Change service level query: {}'.format(query))
+            LOGGER.debug('Change service level query: %s', query)
         self.session.execute(query)
-        LOGGER.debug('Service level "{}" has been altered'.format(self.name))
+        LOGGER.debug('Service level %s has been altered', self.name)
         self.shares = new_shares
 
     def drop(self, if_exists=True):
@@ -154,15 +151,15 @@ class ServiceLevel:
                 .format(service_level_name=self.name,
                         if_exists=' IF EXISTS' if if_exists else '')
         if self.verbose:
-            LOGGER.debug('Drop service level query: {}'.format(query))
+            LOGGER.debug('Drop service level query: %s', query)
         self.session.execute(query)
-        LOGGER.debug('Service level "{}" has been dropped'.format(self.name))
+        LOGGER.debug('Service level %s has been dropped', self.name)
         self.created = False
 
     def list_service_level(self) -> ServiceLevel | None:
         query = 'LIST SERVICE_LEVEL {}'.format(self.name)
         if self.verbose:
-            LOGGER.debug('List service level query: {}'.format(query))
+            LOGGER.debug('List service level query: %s', query)
         res = self.session.execute(query).all()
         assert len(res) <= 1, "Received %s service levels when expecting to receive only 1" % len(res)
 
@@ -177,7 +174,7 @@ class ServiceLevel:
     def list_all_service_levels(self) -> list[ServiceLevel]:
         query = 'LIST ALL SERVICE_LEVELS'
         if self.verbose:
-            LOGGER.debug('List all service levels query: {}'.format(query))
+            LOGGER.debug('List all service levels query: %s', query)
         res_list = self.session.execute(query).all()
         output = []
 
@@ -224,72 +221,66 @@ class UserRoleBase:
         """
         :param auth_name: it may be role name or user name
         """
-        query = 'ATTACH SERVICE_LEVEL {service_level_name} TO {role_name}'\
-                .format(service_level_name=service_level.name,
-                        role_name=self.name)
+        query = f'ATTACH SERVICE_LEVEL {service_level.name} TO {self.name}'
         if self.verbose:
-            LOGGER.debug('Attach service level query: {}'.format(query))
+            LOGGER.debug('Attach service level query: %s', query)
         self.session.execute(query)
-        LOGGER.debug('Service level "{}" has been attached to {} role'.format(service_level.name, self.name))
+        LOGGER.debug('Service level %s has been attached to %s role', service_level.name, self.name)
         self._attached_service_level = service_level
 
     def detach_service_level(self):
         """
         :param auth_name: it may be role name or user name
         """
-        query = 'DETACH SERVICE_LEVEL FROM {role_name}'\
-                .format(role_name=self.name)
+        query = f'DETACH SERVICE_LEVEL FROM {self.name}'
         if self.verbose:
-            LOGGER.debug('Detach service level query: {}'.format(query))
+            LOGGER.debug('Detach service level query: %s', query)
         self.session.execute(query)
-        LOGGER.debug('The service level has been detached from {} role'.format(self.name))
+        LOGGER.debug('The service level has been detached from %s role', self.name)
         self._attached_service_level = None
 
     def grant_me_to(self, grant_to):
         role_be_granted = self.name
         grant_to = grant_to.name
-        query = 'GRANT {role_be_granted} to {grant_to}'.format(**locals())
+        query = f'GRANT {role_be_granted} to {grant_to}'
         if self.verbose:
-            LOGGER.debug('GRANT role query: {}'.format(query))
+            LOGGER.debug('GRANT role query: %s', query)
         self.session.execute(query)
-        LOGGER.debug('Role "{role_be_granted}" has been granted to {grant_to}'.format(**locals()))
+        LOGGER.debug('Role %s has been granted to %s', role_be_granted, grant_to)
 
     def revoke_me_from(self, revoke_from):
         role_be_revoked = self.name
         role_revokes_from = revoke_from.name
-        query = 'REVOKE ROLE {role_be_revoked} FROM {role_revokes_from}'.format(**locals())
+        query = f'REVOKE ROLE {role_be_revoked} FROM {role_revokes_from}'
         if self.verbose:
-            LOGGER.debug('REVOKE role query: {}'.format(query))
+            LOGGER.debug('REVOKE role query: %s', query)
         self.session.execute(query)
-        LOGGER.debug('Role "{role_be_revoked}" has been revocked from {role_revokes_from}'.format(**locals()))
+        LOGGER.debug('Role %s has been revoked from %s', role_be_revoked, role_revokes_from)
 
     def attach_another_sla_to_role(self, service_level):
         self.detach_service_level()
         self.attach_service_level(service_level=service_level)
 
     def list_user_role_attached_service_levels(self):
-        query = 'LIST ATTACHED SERVICE_LEVEL OF {}'.format(self.name)
+        query = f'LIST ATTACHED SERVICE_LEVEL OF {self.name}'
         if self.verbose:
-            LOGGER.debug('List attached service level(s) query: {}'.format(query))
-        # res = list(self.session.execute(query))
+            LOGGER.debug('List attached service level(s) query: %s', query)
         return self.session.execute(query).all()
 
     def list_all_attached_service_levels(self):
         query = 'LIST ATTACHED ALL SERVICE_LEVELS'
         if self.verbose:
-            LOGGER.debug('List attached service level(s) query: {}'.format(query))
+            LOGGER.debug('List attached service level(s) query: %s', query)
         res = list(self.session.execute(query))
         return res
 
     def drop(self, if_exists=True):
-        query = 'DROP {entity}{if_exists} {name}'.format(entity=self.AUTHENTICATION_ENTITY,
-                                                         name=self.name,
-                                                         if_exists=' IF EXISTS' if if_exists else '')
+        query = f"""DROP {self.AUTHENTICATION_ENTITY}{' IF EXISTS' if if_exists else ''} {self.name}"""
         if self.verbose:
-            LOGGER.debug('Drop {entity} query: {query}'.format(entity=self.AUTHENTICATION_ENTITY, query=query))
+            LOGGER.debug('Drop %s query: %s', self.AUTHENTICATION_ENTITY, query)
 
         self.session.execute(query)
-        LOGGER.debug('{entity} "{name}" has been dropped'.format(entity=self.AUTHENTICATION_ENTITY, name=self.name))
+        LOGGER.debug('%s %s has been dropped', self.AUTHENTICATION_ENTITY, self.name)
 
 
 class Role(UserRoleBase):
@@ -315,11 +306,11 @@ class Role(UserRoleBase):
         if role_options_str:
             role_options_str = ' WITH {}'.format(role_options_str)
 
-        query = "CREATE ROLE {name}{role_options_str}".format(name=self.name, role_options_str=role_options_str)
+        query = f"CREATE ROLE {self.name}{role_options_str}"
         if self.verbose:
-            LOGGER.debug('CREATE role query: {}'.format(query))
+            LOGGER.debug('CREATE role query: %s', query)
         self.session.execute(query)
-        LOGGER.debug('Role "{}" has been created'.format(self.name))
+        LOGGER.debug('Role %s has been created', self.name)
         return self
 
 
@@ -338,10 +329,10 @@ class User(UserRoleBase):
         if user_options_str:
             user_options_str = ' WITH {}'.format(user_options_str)
 
-        query = 'CREATE USER {name}{user_options_str}'.format(name=self.name, user_options_str=user_options_str)
+        query = f'CREATE USER {self.name}{user_options_str}'
         if self.verbose:
-            LOGGER.debug('Create user query: {}'.format(query))
+            LOGGER.debug('Create user query: %s', query)
 
         self.session.execute(query)
-        LOGGER.debug('User "{}" has been created'.format(self.name))
+        LOGGER.debug('User %s has been created', self.name)
         return self

--- a/test_lib/sla.py
+++ b/test_lib/sla.py
@@ -43,8 +43,7 @@ class ServiceLevelAttributes:
         for item in fields(self):
             value = getattr(self, item.name) if item.repr else None
             if value is not None:
-                # pylint: disable=literal-comparison
-                if item.type is str:
+                if item.type == "str":
                     attr_strings.append(f" AND {item.name} = '{value}'")
                 else:
                     attr_strings.append(f" AND {item.name} = {value}")
@@ -66,7 +65,7 @@ class ServiceLevel:
                  timeout: str = None,
                  workload_type: str = None):
         self.session = session
-        self._name = f'"{name}"'
+        self._name = f"'{name}'"
         self.verbose = True
         self._created = False
         self._sl_attributes = ServiceLevelAttributes(
@@ -128,7 +127,7 @@ class ServiceLevel:
         return "%s: name: %s, attributes: %s" % (self.__class__.__name__, self.name, self._sl_attributes)
 
     def create(self, if_not_exists=True) -> ServiceLevel:
-        query = 'CREATE SERVICE_LEVEL{if_not_exists} {service_level_name}{query_attributes}'\
+        query = "CREATE SERVICE_LEVEL{if_not_exists} {service_level_name}{query_attributes}"\
                 .format(if_not_exists=' IF NOT EXISTS' if if_not_exists else '',
                         service_level_name=self.name,
                         query_attributes=self._sl_attributes.query_string)
@@ -196,7 +195,7 @@ class UserRoleBase:
     AUTHENTICATION_ENTITY = ''
 
     def __init__(self, session, name, password=None, superuser=None, verbose=False, **kwargs):
-        self._name = name
+        self._name = f'"{name}"'
         self.password = password
         self.session = session
         self.superuser = superuser
@@ -316,7 +315,7 @@ class Role(UserRoleBase):
         if role_options_str:
             role_options_str = ' WITH {}'.format(role_options_str)
 
-        query = 'CREATE ROLE {name}{role_options_str}'.format(name=self.name, role_options_str=role_options_str)
+        query = "CREATE ROLE {name}{role_options_str}".format(name=self.name, role_options_str=role_options_str)
         if self.verbose:
             LOGGER.debug('CREATE role query: {}'.format(query))
         self.session.execute(query)


### PR DESCRIPTION
This PR introduces a number of changes that allow testing the new Service Level attributes in SCT, as well as a new test using the Service Level infrastructure. The new test's goal is to allow us to see how "interactive" and "batch" workload types perform when running in parallel. In addition to adding the test itself I've also added a custom e-mail report and ES upload (to allow comparing results across multiple runs, db instance types).

Scylla commit: https://github.com/scylladb/scylla/commit/e8e4456ec73c16ad223b173119829277bb3e2fee
Trello task: https://trello.com/c/gFygxKqG

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
