### PR TITLE
fix(monitoring): bump monitoring version to 3.11

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -25,7 +25,7 @@ scylla_linux_distro_loader: 'centos'
 ssh_transport: 'libssh2'
 system_auth_rf: 3
 
-monitor_branch: 'branch-3.10'
+monitor_branch: 'branch-3.11'
 
 space_node_threshold: 0
 


### PR DESCRIPTION
Need to update monitoring version because 3.10 doesn't support 2022.1

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
