### PR TITLE
fix(stress load): start stress command when all nodes are UP

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2083,7 +2083,8 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
 
     get_scylla_args = cluster_docker.ScyllaDockerCluster.get_scylla_args
 
-    def wait_for_nodes_up_and_normal(self, nodes=None, verification_node=None):
+    def wait_for_nodes_up_and_normal(self, nodes=None, verification_node=None, iterations=None, sleep_time=None,
+                                     timeout=None):  # pylint: disable=too-many-arguments
         self.wait_for_pods_readiness(pods_to_wait=len(nodes), total_pods=len(self.nodes))
         self.check_nodes_up_and_normal(nodes=nodes, verification_node=verification_node)
 

--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -484,10 +484,14 @@ class LocalMinimalScyllaPodCluster(ScyllaPodCluster):
             return ['drain_k8s_node']
         return []
 
-    @retrying(n=20, sleep_time=60, allowed_exceptions=(cluster.ClusterNodesNotReady, UnexpectedExit),
-              message="Waiting for nodes to join the cluster")
-    def wait_for_nodes_up_and_normal(self, nodes=None, verification_node=None):
-        super().wait_for_nodes_up_and_normal(nodes, verification_node)
+    def wait_for_nodes_up_and_normal(self, nodes=None, verification_node=None, iterations=20, sleep_time=60, timeout=0):  # pylint: disable=too-many-arguments
+        @retrying(n=iterations, sleep_time=sleep_time,
+                  allowed_exceptions=(cluster.ClusterNodesNotReady, UnexpectedExit),
+                  message="Waiting for nodes to join the cluster", timeout=timeout)
+        def _wait_for_nodes_up_and_normal():
+            super().check_nodes_up_and_normal(nodes=nodes, verification_node=verification_node)
+
+        _wait_for_nodes_up_and_normal()
 
     @cluster.wait_for_init_wrap
     def wait_for_init(self, *_, node_list=None, verbose=False, timeout=None, **__):  # pylint: disable=unused-argument

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -45,6 +45,7 @@ from sdcm.cluster import (
     ClusterNodesNotReady,
     DB_LOG_PATTERN_RESHARDING_START,
     DB_LOG_PATTERN_RESHARDING_FINISH,
+    MAX_TIME_WAIT_FOR_NEW_NODE_UP,
     NodeSetupFailed,
     NodeSetupTimeout,
     NodeStayInClusterAfterDecommission,
@@ -141,8 +142,6 @@ class CdcStreamsWasNotUpdated(Exception):
 
 class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-methods
 
-    MINUTE_IN_SEC: int = 60
-    HOUR_IN_SEC: int = 60 * MINUTE_IN_SEC
     disruptions_list: list[Callable] = []
     DISRUPT_NAME_PREF: str = "disrupt_"
 
@@ -894,7 +893,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             raise LdapNotRunning("LDAP server was supposed to be running, but it is not")
 
     @retrying(n=3, sleep_time=60, allowed_exceptions=(NodeSetupFailed, NodeSetupTimeout))
-    def _add_and_init_new_cluster_node(self, old_node_ip=None, timeout=HOUR_IN_SEC * 6, rack=0):
+    def _add_and_init_new_cluster_node(self, old_node_ip=None, timeout=MAX_TIME_WAIT_FOR_NEW_NODE_UP, rack=0):
         """When old_node_private_ip is not None replacement node procedure is initiated"""
         # TODO: make it work on K8S when we have decommissioned (by nodetool) nodes.
         #       Now it will fail because pod which hosts decommissioned Scylla member is reported

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -38,7 +38,7 @@ from cassandra import ConsistencyLevel
 from argus.db.db_types import TestStatus, PackageVersion
 from sdcm import nemesis, cluster_docker, cluster_k8s, cluster_baremetal, db_stats, wait
 from sdcm.cluster import NoMonitorSet, SCYLLA_DIR, TestConfig, UserRemoteCredentials, BaseLoaderSet, BaseMonitorSet, \
-    BaseScyllaCluster, BaseNode
+    BaseScyllaCluster, BaseNode, MAX_TIME_WAIT_FOR_ALL_NODES_UP
 from sdcm.argus_test_run import ArgusTestRun
 from sdcm.cluster_azure import ScyllaAzureCluster, LoaderSetAzure, MonitorSetAzure
 from sdcm.cluster_gce import ScyllaGCECluster
@@ -1445,6 +1445,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     def run_stress_thread(self, stress_cmd, duration=None, stress_num=1, keyspace_num=1, profile=None, prefix='',
                           round_robin=False, stats_aggregate_cmds=True, keyspace_name=None, use_single_loader=False,
                           stop_test_on_failure=True):
+        # We want to prevent situation when stress command starts on not ready cluster (no all nodes are UP).
+        # It may cause to stress failure and as result the test will be stopped and failed
+        self.db_cluster.wait_for_nodes_up_and_normal(iterations=0, timeout=MAX_TIME_WAIT_FOR_ALL_NODES_UP)
 
         params = dict(stress_cmd=stress_cmd, duration=duration, stress_num=stress_num, keyspace_num=keyspace_num,
                       keyspace_name=keyspace_name, profile=profile, prefix=prefix, round_robin=round_robin,


### PR DESCRIPTION
Task:
https://trello.com/c/vUpBYtA6/4877-do-not-start-stress-load-thread-if-not-all-nodes-in-the-cluster-are-up

If stress command is starting when one node under disruptive nemesis (DOWN or terminated), stress
command fails and fail the test. To prevent it we will wait when all nodes are UP and then will
start the load

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
