### PR TITLE
fix(runner): name of SCT runners that are use to restore monitoring

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -114,12 +114,22 @@ if [[ -n "${CREATE_RUNNER_INSTANCE}" ]]; then
     else
         HYDRA="echo $0"
     fi
+
+    if [[ -n "${RESTORED_TEST_ID}" ]]; then
+        RESTORED_TEST_ID="--restored-test-id ${RESTORED_TEST_ID}"
+    else
+        RESTORED_TEST_ID=""
+    fi
+
     ${HYDRA} create-runner-instance \
       --cloud-provider aws \
       --region "${RUNNER_REGION:-us-east-1}" \
       --availability-zone "${RUNNER_AZ:-a}" \
       --test-id "${SCT_TEST_ID}" \
-      --duration "${RUNNER_DURATION:-1440}"
+      --duration "${RUNNER_DURATION:-1440}" \
+      --restore-monitor "${RESTORE_MONITOR_RUNNER:-False}" \
+      ${RESTORED_TEST_ID}
+
     if [[ -z "${HYDRA_DRY_RUN}" ]]; then
         RUNNER_IP=$(<"${RUNNER_IP_FILE}")
     else

--- a/jenkins-pipelines/hydra-show-monitor.jenkinsfile
+++ b/jenkins-pipelines/hydra-show-monitor.jenkinsfile
@@ -66,6 +66,8 @@ pipeline {
                     export RUNNER_DURATION="${params.duration}"
                     export RUNNER_REGION="${params.region}"
                     export RUNNER_AZ="${params.availability_zone}"
+                    export RESTORE_MONITOR_RUNNER="True"
+                    export RESTORED_TEST_ID="${params.test_id}"
 
                     ./docker/env/hydra.sh --execute-on-new-runner investigate show-monitor "${params.test_id}"
                 """

--- a/sct.py
+++ b/sct.py
@@ -1301,7 +1301,12 @@ def create_runner_image(cloud_provider, region, availability_zone):
 @click.option("-i", "--instance-type", required=False, type=str, default="", help="Instance type")
 @click.option("-t", "--test-id", required=True, type=str, help="Test ID")
 @click.option("-d", "--duration", required=True, type=int, help="Test duration in MINUTES")
-def create_runner_instance(cloud_provider, region, availability_zone, instance_type, test_id, duration):
+@click.option("-rm", "--restore-monitor", required=False, type=bool,
+              help="Is the runner for restore monitor purpose or not")
+@click.option("-rt", "--restored-test-id", required=False, type=str,
+              help="Test ID of the test that the runner is created for restore monitor")
+def create_runner_instance(cloud_provider, region, availability_zone, instance_type, test_id, duration,
+                           restore_monitor=False, restored_test_id=""):
     if cloud_provider == "aws":
         assert len(availability_zone) == 1, f"Invalid AZ: {availability_zone}, availability-zone is one-letter a-z."
     add_file_logger()
@@ -1312,6 +1317,8 @@ def create_runner_instance(cloud_provider, region, availability_zone, instance_t
         instance_type=instance_type,
         test_id=test_id,
         test_duration=duration,
+        restore_monitor=restore_monitor,
+        restored_test_id=restored_test_id,
     )
     if not instance:
         sys.exit(1)


### PR DESCRIPTION
The idea is to distinguish SCT runners with restored monitoring from others.

Task:
https://trello.com/c/V8nikgXa/4744-name-sct-runners-that-are-use-to-restore-monitoring

![Screenshot from 2022-04-20 15-37-27](https://user-images.githubusercontent.com/34435448/164233862-2ada74d6-e0a9-4b20-bd17-ea643adb2a43.png)


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
