### PR TITLE
improvement(kuber): support creation of multiple K8S PVs on a local disk

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1916,7 +1916,7 @@ class BaseScyllaPodContainer(BasePodContainer):  # pylint: disable=abstract-meth
             self.log.warning(f"Could not find scylla disks path on '{self.node_name}'")
         podname, path = podname_path_list[0].split()
         self.parent_cluster.k8s_cluster.kubectl(
-            f"exec -ti {podname} -- sh -c 'fstrim -v {path}/*'",
+            f"exec -ti {podname} -- sh -c 'fstrim -v {path}'",
             namespace="default")
 
 

--- a/sdcm/k8s_configs/eks/scylla-node-prepare.yaml
+++ b/sdcm/k8s_configs/eks/scylla-node-prepare.yaml
@@ -30,10 +30,15 @@ rules:
       - pods/eviction
     verbs:
       - create
-
-
+  - apiGroups:
+      - scylla.scylladb.com
+    resources:
+      - scyllaclusters
+    verbs:
+      - get
+      - list
+      - watch
 ---
-
 # ServiceAccount for node-setup daemonset.
 apiVersion: v1
 kind: ServiceAccount
@@ -104,7 +109,7 @@ spec:
                 exit 1
             fi
 
-            TOKEN_PATH=$(find / -name token | grep node-setup-daemonset -m1)
+            TOKEN_PATH=$(find /mnt/hostfs -name token | grep node-setup-daemonset -m1)
             TOKEN=$(cat $TOKEN_PATH)
             CA_CRT=$TOKEN_PATH/../ca.crt
             kubectl config set-cluster scylla --server=https://kubernetes.default --certificate-authority=$CA_CRT
@@ -167,7 +172,6 @@ spec:
     spec:
       hostPID: true
       hostIPC: true
-      hostNetwork: true
       serviceAccountName: node-setup-daemonset
       containers:
       - name: node-setup
@@ -194,6 +198,56 @@ spec:
           - name: hostirqbalanceconfig
             mountPath: /etc/conf.d/irqbalance
             mountPropagation: Bidirectional
+      - name: pv-setup
+        image: bitnami/kubectl:1.21.4
+        imagePullPolicy: Always
+        env:
+          - name: HOSTFS
+            value: /mnt/hostfs
+          - name: KUBELET_CONFIG_PATH
+            value: /etc/kubernetes/kubelet/kubelet-config.json
+        securityContext:
+          privileged: true
+          runAsUser: 0
+        volumeMounts:
+          - name: hostfs
+            mountPath: /mnt/hostfs
+            mountPropagation: Bidirectional
+        command:
+          - "/bin/bash"
+          - "-c"
+          - "--"
+        args:
+          - |
+            set -ex
+            if [ ! -f "$HOSTFS$KUBELET_CONFIG_PATH" ]; then
+                echo "Kublet config not found"
+                exit 1
+            fi
+
+            TOKEN_PATH=$(find /mnt/hostfs -name token | grep node-setup-daemonset -m1)
+            TOKEN=$(cat $TOKEN_PATH)
+            CA_CRT=$TOKEN_PATH/../ca.crt
+            kubectl config set-cluster scylla --server=https://kubernetes.default --certificate-authority=$CA_CRT
+            kubectl config set-credentials qa@scylladb.com --token=$TOKEN
+            kubectl config set-context scylla --cluster=scylla --user=qa@scylladb.com
+            kubectl config use-context scylla
+
+            # Create directories for each Scylla cluster on each K8S node which will host PVs
+            while true; do
+              if [[ -z $(mount | grep  "/dev/md0") ]]; then
+                sleep 5;
+                continue
+              fi
+              for i in $(seq -f "pv-%02g" $( kubectl get scyllaclusters -A --field-selector metadata.name!=scylla-manager --no-headers | grep -c " " ) ); do
+                if [[ ! -d "/mnt/hostfs/mnt/raid-disks/disk0/${i}" ]]; then
+                  mkdir "/mnt/hostfs/mnt/raid-disks/disk0/${i}"
+                fi
+                ( mount | grep "/mnt/hostfs/mnt/raid-disks/disk0/${i} " 2>/dev/null 1>&2 ) || \
+                mount --bind "/mnt/hostfs/mnt/raid-disks/disk0/${i}"{,}
+              done
+              sleep 10
+            done
       volumes:
         - name: hostfs
           hostPath:

--- a/sdcm/k8s_configs/gke/scylla-node-prepare.yaml
+++ b/sdcm/k8s_configs/gke/scylla-node-prepare.yaml
@@ -1,3 +1,39 @@
+# ClusterRole for cpu-policy-daemonset.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pv-setup
+rules:
+  - apiGroups:
+      - scylla.scylladb.com
+    resources:
+      - scyllaclusters
+    verbs:
+      - get
+      - list
+      - watch
+---
+# ServiceAccount for cpu-policy daemonset.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pv-setup
+  namespace: default
+---
+# Bind cpu-policy daemonset ServiceAccount with ClusterRole.
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pv-setup
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pv-setup
+subjects:
+- kind: ServiceAccount
+  name: pv-setup
+  namespace: default
+---
 # Daemonset that converts ephemeral-storage to xfs
 apiVersion: apps/v1
 kind: DaemonSet
@@ -13,6 +49,7 @@ spec:
         app: xfs-formatter
     spec:
       hostPID: true
+      serviceAccountName: pv-setup
       nodeSelector:
         cloud.google.com/gke-nodepool: "scylla-pool"
       tolerations:
@@ -91,6 +128,55 @@ spec:
                 xfs_info "$( { grep -E '/mnt/raid-disks/disk0($| )' /proc/mounts || test $? = 1; } | sed -E -e 's/([^ ]+) .+/\1/' )"
           initialDelaySeconds: 10
           periodSeconds: 10
+      - name: pv-setup
+        image: bitnami/kubectl:1.21.4
+        imagePullPolicy: Always
+        env:
+          - name: HOSTFS
+            value: /mnt/hostfs
+          - name: KUBELET_CONFIG_PATH
+            value: /home/kubernetes/kubelet-config.yaml
+        securityContext:
+          privileged: true
+          runAsUser: 0
+        volumeMounts:
+          - name: hostfs
+            mountPath: /mnt/hostfs
+            mountPropagation: Bidirectional
+        command:
+          - "/bin/bash"
+          - "-c"
+          - "--"
+        args:
+          - |
+            set -ex
+            if [ ! -f "$HOSTFS$KUBELET_CONFIG_PATH" ]; then
+                echo "Kublet config not found"
+                exit 1
+            fi
+            TOKEN_PATH=$(find /mnt/hostfs -name token | grep pv-setup -m1)
+            TOKEN=$(cat $TOKEN_PATH)
+            CA_CRT=$TOKEN_PATH/../ca.crt
+            kubectl config set-cluster scylla --server=https://kubernetes.default --certificate-authority=$CA_CRT
+            kubectl config set-credentials qa@scylladb.com --token=$TOKEN
+            kubectl config set-context scylla --cluster=scylla --user=qa@scylladb.com
+            kubectl config use-context scylla
+
+            # Create directories for each Scylla cluster on each K8S node which will host PVs
+            while true; do
+              if [[ -z $(mount | grep  "/dev/md127") ]]; then
+                sleep 5;
+                continue
+              fi
+              for i in $(seq -f "pv-%02g" $( kubectl get scyllaclusters -A --field-selector metadata.name!=scylla-manager --no-headers | grep -c " " ) ); do
+                if [[ ! -d "/mnt/hostfs/mnt/raid-disks/disk0/${i}" ]]; then
+                  mkdir "/mnt/hostfs/mnt/raid-disks/disk0/${i}"
+                fi
+                ( mount | grep "/mnt/hostfs/mnt/raid-disks/disk0/${i} " 2>/dev/null 1>&2 ) || \
+                mount --bind "/mnt/hostfs/mnt/raid-disks/disk0/${i}"{,}
+              done
+              sleep 30
+            done
       volumes:
       - name: hostfs
         hostPath:

--- a/sdcm/k8s_configs/provisioner/templates/provisioner.yaml
+++ b/sdcm/k8s_configs/provisioner/templates/provisioner.yaml
@@ -42,6 +42,9 @@ data:
        {{- if $classConfig.fsType }}
        fsType: {{ $classConfig.fsType }}
        {{- end }}
+       {{- if $classConfig.namePattern }}
+       namePattern: {{ $classConfig.namePattern | quote }}
+       {{- end }}
     {{- end }}
 ---
 apiVersion: apps/v1

--- a/sdcm/k8s_configs/provisioner/values.yaml
+++ b/sdcm/k8s_configs/provisioner/values.yaml
@@ -44,7 +44,7 @@ classes:
 - name: local-raid-disks # Defines name of storage classes.
   # Path on the host where local volumes of this storage class are mounted
   # under.
-  hostDir: /mnt/raid-disks
+  hostDir: /mnt/raid-disks/disk0/
   # Optionally specify mount path of local volumes. By default, we use same
   # path as hostDir in container.
   # mountDir: /mnt/fast-disks
@@ -56,6 +56,8 @@ classes:
   # and desire volume mode is Filesystem.
   # Must be a filesystem type supported by the host operating system.
   fsType: xfs
+  # File name pattern to discover. By default, discover all file names.
+  namePattern: "pv-"
   blockCleanerCommand:
   #  Do a quick reset of the block device during its cleanup.
   #  - "/scripts/quick_reset.sh"


### PR DESCRIPTION
To support multi-tenant approach of Scylla clusters on K8S we should be
able to create more than 1 PV on local raid disks.

So, add such possibility to both of the supported managed-K8S
platforms (EKS, GKE).

Signed-off-by: Israel Fruchter <fruch@scylladb.com>
Signed-off-by: Valerii Ponomarov <valerii.ponomarov@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
