### PR TITLE
fix(rolling-upgrade): Set a fixed gemini_seed for rolling-upgrades

### DIFF
--- a/test-cases/upgrades/rolling-upgrade.yaml
+++ b/test-cases/upgrades/rolling-upgrade.yaml
@@ -47,5 +47,6 @@ gemini_cmd: "gemini -d --duration 2h \
 --async-objects-stabilization-attempts 5 --async-objects-stabilization-backoff 500ms \
 --replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '3'}\" \
 --table-options \"cdc={'enabled': true}\" --test-username cassandra --test-password cassandra"
+gemini_seed: 66
 gemini_version: 'latest'
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used


### PR DESCRIPTION
The randomness of gemini cause the rolling-upgrades to be very flaky
since some workloads are heavier than others and the tests fail due
to timeouts.
This commit sets the gemini_seed to be "66" (a seed we know that
should pass according to previous runs).

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
