### PR TITLE
ci(commitlint): decrease scope min length to 3

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -12,7 +12,7 @@ module.exports = {
         'type-empty': [2, 'never'],
         // Scope
         'scope-empty': [2, 'never'],
-        'scope-min-length': [2, 'always', 5],
+        'scope-min-length': [2, 'always', 3],
         // Body
         'body-min-length': [2, 'always', 30],
         'body-max-line-length': [2, 'always', 100],


### PR DESCRIPTION
we can have scope k8s, gcp, aws that are 3 letters length

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
