### PR TITLE
fix(cluster_docker.py): Implement region property

### DIFF
--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -171,6 +171,10 @@ class DockerNode(cluster.BaseNode, NodeContainerMixin):  # pylint: disable=abstr
         """systemd is not used in Docker"""
         return "docker"
 
+    @property
+    def region(self):
+        return "docker"
+
 
 class DockerCluster(cluster.BaseCluster):  # pylint: disable=abstract-method
     node_container_user = "scylla-test"


### PR DESCRIPTION
This fixes an issue with argus where a docker node would fail to
instantiate argus resource because of BaseNode.region not being
implemented

[Trello](https://trello.com/c/4OFrS2q9/4951-init-argus-not-implemented-exception)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
