### PR TITLE
improvement(monitoring): support K8S multi-tenant case

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -17,6 +17,7 @@ import queue
 import getpass
 import logging
 import os
+import shutil
 import sys
 import random
 import re
@@ -4879,7 +4880,15 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
             if not os.path.exists(sct_dashboard_json_path):
                 sct_dashboard_json_filename = "scylla-dash-per-server-nemesis.master.json"
                 sct_dashboard_json_path = get_data_dir_path(sct_dashboard_json_filename)
-            self._sct_dashboard_json_file = sct_dashboard_json_path
+
+            # NOTE: use separate path per monitoring to support multi-tenant setups in K8S
+            original_path_parts = sct_dashboard_json_path.split("/")
+            current_sct_dashboard_json_path = "/".join(
+                original_path_parts[:-1]
+                + [f"sct-monitor-{generate_random_string(5)}-{original_path_parts[-1]}"])
+            shutil.copyfile(sct_dashboard_json_path, current_sct_dashboard_json_path)
+
+            self._sct_dashboard_json_file = current_sct_dashboard_json_path
             self.sct_dashboard_json_file_content_update(update_params=self.json_file_params_for_replace,
                                                         json_file=self._sct_dashboard_json_file)
         return self._sct_dashboard_json_file

--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -28,6 +28,7 @@ from mypy_boto3_ec2.type_defs import LaunchTemplateBlockDeviceMappingRequestType
 from sdcm import sct_abs_path, cluster
 from sdcm.cluster_aws import MonitorSetAWS
 from sdcm.utils.aws_utils import tags_as_ec2_tags, EksClusterCleanupMixin
+from sdcm.utils.ci_tools import get_test_name
 from sdcm.utils.k8s import TokenUpdateThread
 from sdcm.wait import wait_for, exponential_retry
 from sdcm.cluster_k8s import (
@@ -585,6 +586,12 @@ class EksScyllaPodCluster(ScyllaPodCluster, IptablesClusterOpsMixin):
 class MonitorSetEKS(MonitorSetAWS):
     # On EKS nodes you can't communicate to cluster nodes outside of it, so we have to enforce using public ip
     DB_NODES_IP_ADDRESS = 'public_ip_address'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.json_file_params_for_replace = {
+            "$test_name": f"{get_test_name()}--{self.targets['db_cluster'].scylla_cluster_name}",
+        }
 
     def install_scylla_manager(self, node):
         pass

--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -24,6 +24,7 @@ from sdcm import sct_abs_path, cluster
 from sdcm.wait import exponential_retry
 from sdcm.utils.k8s import ApiCallRateLimiter, TokenUpdateThread
 from sdcm.utils.gce_utils import GcloudContextManager
+from sdcm.utils.ci_tools import get_test_name
 from sdcm.cluster_k8s import KubernetesCluster, ScyllaPodCluster, BaseScyllaPodContainer, CloudK8sNodePool
 from sdcm.cluster_k8s.iptables import IptablesPodIpRedirectMixin, IptablesClusterOpsMixin
 from sdcm.cluster_gce import MonitorSetGCE
@@ -444,6 +445,12 @@ class GkeScyllaPodCluster(ScyllaPodCluster, IptablesClusterOpsMixin):
 
 class MonitorSetGKE(MonitorSetGCE):
     DB_NODES_IP_ADDRESS = 'public_ip_address'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.json_file_params_for_replace = {
+            "$test_name": f"{get_test_name()}--{self.targets['db_cluster'].scylla_cluster_name}",
+        }
 
     def install_scylla_manager(self, node):
         pass


### PR DESCRIPTION
Provisioning SCT monitoring we add there our custom dashboard.
And this dashboard updates the json file stored in the source code
and then uploads it to a monitoring node.
So, if we want to substitute it with different values for different
monitoring nodes then it is not possible as of now.

So, update this logic by copying source file first and only then update
it and upload.

Also, add DB cluster names to the dashboard name, so we could
distinguish monitorings in case of multi-tenant setup just its by title.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
