### PR TITLE
fix(alternator_perf): extend throughput test test duration

### DIFF
--- a/test-cases/performance/perf-regression-alternator.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression-alternator.100threads.30M-keys.yaml
@@ -1,4 +1,4 @@
-test_duration: 240
+test_duration: 300
 
 round_robin: true
 prepare_write_cmd:


### PR DESCRIPTION
Some of the tests keep timing out before reaching the dynamodb phase

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
