### PR TITLE
Cleanup code in the sdcm/cluster.py module

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3852,36 +3852,6 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                 node_list = self.nodes
             self._update_db_packages(new_scylla_bin, node_list, start_service=start_service)
 
-    def get_node_info_list(self, verification_node):
-        """
-            !!! Deprecated !!!!
-            use self.get_nodetool_status instead
-        """
-        assert verification_node in self.nodes
-        cmd_result = verification_node.run_nodetool('status')
-        node_info_list = []
-        for line in cmd_result.stdout.splitlines():
-            line = line.strip()
-            if line.startswith('UN'):
-                try:
-                    status, ip, load, _, tokens, owns, host_id, rack = line.split()
-                    node_info = {'status': status,
-                                 'ip': ip,
-                                 'load': load,
-                                 'tokens': tokens,
-                                 'owns': owns,
-                                 'host_id': host_id,
-                                 'rack': rack}
-                    # Cassandra banners have nodetool status output as well.
-                    # Need to guarantee unique set of results.
-                    node_ips = [node_info['ip']
-                                for node_info in node_info_list]
-                    if node_info['ip'] not in node_ips:
-                        node_info_list.append(node_info)
-                except ValueError:
-                    pass
-        return node_info_list
-
     @retrying(n=3, sleep_time=5)
     def get_nodetool_status(self, verification_node=None):  # pylint: disable=too-many-locals
         """

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2857,13 +2857,13 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                           sudo /sbin/mkswap /var/sct_configured_swapfile
                           sudo chmod 600 /var/sct_configured_swapfile
                           sudo /sbin/swapon /var/sct_configured_swapfile""".format(size))
-        self.log.info("Add swap file to loader %s", self)
+        self.log.info("Add swap file to %s", self)
         result = self.remoter.run(commands, ignore_status=True)
         if not result.ok:
-            self.log.warning("Swap file was not created on loader node %s.\nError details: %s", self, result.stderr)
+            self.log.warning("Swap file was not created on node %s.\nError details: %s", self, result.stderr)
         result = self.remoter.run("grep /sct_configured_swapfile /proc/swaps", ignore_status=True)
         if "sct_configured_swapfile" not in result.stdout:
-            self.log.warning("Swap file is not used on loader node %s.\nError details: %s", self, result.stderr)
+            self.log.warning("Swap file is not used on node %s.\nError details: %s", self, result.stderr)
 
     def set_hostname(self):
         self.log.warning('Method set_hostname is not implemented for %s' % self.__class__.__name__)


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
