### PR TITLE
fix(longevity-2tb job): `user_prefix` was wrong

### DIFF
--- a/test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
+++ b/test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
@@ -26,7 +26,7 @@ nemesis_during_prepare: false
 nemesis_filter_seeds: false
 seeds_num: 3
 
-user_prefix: 'longevity-tls-2tb-4d-1dis-2nondis'
+user_prefix: 'longevity-tls-2tb-48h-1dis-2nondis'
 space_node_threshold: 644245094
 server_encrypt: true
 client_encrypt: true


### PR DESCRIPTION
it was misleading, so fixed it to reflect
what the job is really doing (it was wrong
most likely due to historical changes, that
didn't reflect in the prefix naming).

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
