### PR TITLE
fix(sct.py): `list_ami_branch` more resilient

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -504,7 +504,8 @@ def list_ami_branch(region, version):
         test_status = [click.style(k, fg='green') for k, v in test_status if v == 'PASSED'] + \
                       [click.style(k, fg='red') for k, v in test_status if not v == 'PASSED']
         test_status = ", ".join(test_status) if test_status else click.style('Unknown', fg='yellow')
-        tbl.add_row([ami.name, ami.image_id, ami.creation_date, tags['build-id'], test_status])
+        tbl.add_row([ami.name, ami.image_id, ami.creation_date,
+                     tags.get('build-id', tags.get('build_id')), test_status])
     click.echo(tbl.get_string(title="Scylla AMI branch versions"))
 
 


### PR DESCRIPTION
when running few `hydra` commands, seen failures:
```
Traceback (most recent call last):
  File "/home/fabio/git/scylla-cluster-tests/./sct.py", line 1411, in <module>
    cli()
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1062, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1668, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "/home/fabio/git/scylla-cluster-tests/./sct.py", line 509, in list_ami_branch
    tbl.add_row([ami.name, ami.image_id, ami.creation_date, tags['build-id'], test_status])
KeyError: 'build-id'
```

it happens, because old AMIs had different tag than
the newer ones (it will only happen when running
`<branch>:all`.

but the fix is small, and harmless in most cases, hence
submitting it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
