### PR TITLE
fix(nemesis): not start nodetool rebuild if another rebuild runs

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2839,8 +2839,14 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             wait_db_up_timeout = 1800
         node_to_rebuild = new_node if new_node else self.target_node
         node_to_rebuild.wait_db_up(verbose=True, timeout=wait_db_up_timeout)
+        rebuild_in_log = node_to_rebuild.follow_system_log(patterns=["range_streamer - Rebuild.*"],
+                                                           start_from_beginning=False)
         node_to_rebuild.wait_jmx_up(timeout=wait_db_up_timeout)
-        node_to_rebuild.run_nodetool('rebuild')
+        rebuild_found = list(rebuild_in_log)
+        if not rebuild_found:
+            node_to_rebuild.run_nodetool('rebuild')
+        else:
+            self.log.debug("Another operation rebuild is in progress. Rebuild process will not start")
 
     def disrupt_decommission_streaming_err(self):
         """


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylla-cluster-tests/issues/4602

Check if rebuild process runs already, do not start nodetool('rebuild')
on the new node during disrupt_rebuild_streaming_err.

Task:
https://trello.com/c/GbLuxgrV/4948-operation-rebuild-is-in-progress-try-again

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
