### PR TITLE
fix(cloud_monitor): cast str for GCE instance state

### DIFF
--- a/sdcm/utils/cloud_monitor/resources/instances.py
+++ b/sdcm/utils/cloud_monitor/resources/instances.py
@@ -67,7 +67,7 @@ class GCEInstance(CloudInstance):
             name=instance.name,
             instance_id=instance.id,
             region_az=instance.extra["zone"].name,
-            state=instance.state,
+            state=str(instance.state),
             lifecycle=InstanceLifecycle.SPOT if is_preemptible else InstanceLifecycle.ON_DEMAND,
             instance_type=instance.size,
             owner=tags.get("RunByUser", NA) if tags else NA,


### PR DESCRIPTION
Gce instance state was returned as enum from libcloud
jinja 2 for some reason wasn't able to cast enum to str
hence we had missing state for gce instances

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
