### PR TITLE
fix(longevity-twcs-48h): Set round robin for loaders

### DIFF
--- a/test-cases/longevity/longevity-twcs-48h.yaml
+++ b/test-cases/longevity/longevity-twcs-48h.yaml
@@ -29,3 +29,5 @@ post_prepare_cql_cmds: "ALTER TABLE scylla_bench.test with gc_grace_seconds = 30
 
 # Temporarily downgrade scylla_bench to a stable version
 scylla_bench_version: v0.1.3
+
+round_robin: true


### PR DESCRIPTION
Job longevity-twcs-48h terminated by timeout because too
many s-b threads are running. Instead of each loader
runs only one s-b command, each loader run 3 commands
(write and 2 reads)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
