### PR TITLE
fix(cdc-8h-multi-dc): set correct config yaml file

### DIFF
--- a/jenkins-pipelines/longevity-cdc-8h-multi-dc-large-cluster.jenkinsfile
+++ b/jenkins-pipelines/longevity-cdc-8h-multi-dc-large-cluster.jenkinsfile
@@ -7,7 +7,7 @@ longevityPipeline(
     backend: 'aws',
     region: '''["eu-west-1", "us-east-1", "eu-west-2"]''',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-cdc-100gb-3h-multi-dc-large-cluster.yaml',
+    test_config: 'test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-large-cluster.yaml',
 
     timeout: [time: 800, unit: 'MINUTES']
 )


### PR DESCRIPTION
Jenkins file for jenkins-pipelines/longevity-cdc-8h-multi-dc-large-cluster.jenkinsfile
has wrong yaml file.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
