### PR TITLE
feature(hydra): Support running with podman

### DIFF
--- a/docker/docker_mocked_as_podman
+++ b/docker/docker_mocked_as_podman
@@ -1,0 +1,12 @@
+if [[ "$*" == "--help" ]]; then
+   echo "podman"
+   exit 0
+fi
+args=("$@")
+for ((i=0; i<"${#args[@]}"; ++i)); do
+    case ${args[i]} in
+        --userns) unset args[i]; unset args[i+1]; break;;
+        --userns=*) unset args[i]; break;;
+    esac
+done
+/usr/bin/docker "${args[@]}"

--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -9,7 +9,6 @@ DOCKER_REPO=docker.io/scylladb/hydra
 SCT_DIR=$(dirname "${DOCKER_ENV_DIR}")
 SCT_DIR=$(dirname "${SCT_DIR}")
 VERSION=v$(cat "${DOCKER_ENV_DIR}/version")
-WORK_DIR=/sct
 HOST_NAME=SCT-CONTAINER
 RUN_BY_USER=$(python3 "${SCT_DIR}/sdcm/utils/get_username.py")
 USER_ID=$(id -u "${USER}")
@@ -175,15 +174,9 @@ if [[ -z "$HYDRA_HELP" ]]; then
     fi
 fi
 
-# change ownership of results directories
-echo "Making sure the ownerships of results directories are of the user"
 if [ -z "$HYDRA_DRY_RUN" ]; then
-    sudo chown -R `whoami`:`whoami` ~/sct-results &> /dev/null || true
-    sudo chown -R `whoami`:`whoami` "${SCT_DIR}/sct-results" &> /dev/null || true
     DOCKER_GROUP_ARGS=()
 else
-    echo "sudo chown -R `whoami`:`whoami` ~/sct-results &> /dev/null || true"
-    echo "sudo chown -R `whoami`:`whoami` \"${SCT_DIR}/sct-results\" &> /dev/null || true"
     # Setting it for testing purpose
     DOCKER_GROUP_ARGS='--group-add 1 --group-add 2 --group-add 3'
 fi
@@ -371,7 +364,7 @@ if [ -z "${DOCKER_GROUP_ARGS[@]}" ]; then
     done
 fi
 
-PREPARE_CMD="sudo ln -s '${SCT_DIR}' '${WORK_DIR}'"
+PREPARE_CMD="test"
 
 if [[ -n "${AWS_MOCK}" ]]; then
     if [[ -z "${HYDRA_DRY_RUN}" ]]; then
@@ -391,7 +384,7 @@ if [[ -n "${AWS_MOCK}" ]]; then
 fi
 
 if [[ -z "${HYDRA_HELP}" ]]; then
-    PREPARE_CMD+="; ${WORK_DIR}/get-qa-ssh-keys.sh"
+    PREPARE_CMD+="; ${SCT_DIR}/get-qa-ssh-keys.sh"
 fi
 
 COMMAND=${HYDRA_COMMAND[0]}

--- a/sdcm/monitorstack/__init__.py
+++ b/sdcm/monitorstack/__init__.py
@@ -359,6 +359,8 @@ def start_dockers(monitoring_dockers_dir, monitoring_stack_data_dir, scylla_vers
     cmd = dedent("""cd {monitoring_dockers_dir};
             echo "" > UA.sh
             ./start-all.sh \
+            $(grep -q -- --no-renderer ./start-all.sh && echo "--no-renderer")  \
+            $(grep -q -- --no-loki ./start-all.sh && echo "--no-loki")  \
             -g {graf_port} -m {alert_port} -p {prom_port} \
             -s {monitoring_dockers_dir}/config/scylla_servers.yml \
             -n {monitoring_dockers_dir}/config/node_exporter_servers.yml \

--- a/sdcm/utils/docker_utils.py
+++ b/sdcm/utils/docker_utils.py
@@ -459,6 +459,9 @@ def docker_hub_login(remoter: CommandRunner) -> None:
     if match := re.search(r"^\s+Username: (.+)$", docker_info.stdout, re.MULTILINE):
         remoter.log.debug("Docker daemon is already logged in as `%s'.", match.group(1))
         return
+    if "Podman Engine" in remoter.run("docker version", ignore_status=True).stdout:
+        remoter.log.info("When Podman daemon is used we don't login")
+        return
     docker_hub_creds = get_docker_hub_credentials()
     password_file = remoter.run("mktemp").stdout.strip()
     with remote_file(remoter=remoter, remote_path=password_file) as fobj:

--- a/unit_tests/test_hydra_sh.py
+++ b/unit_tests/test_hydra_sh.py
@@ -121,7 +121,7 @@ class LongevityPipelineTest:
             re.compile('sudo chown -R [^: ]+:[^ ]+ ~/sct-results &> /dev/null [|][|] true'),
             re.compile(f"sudo chown -R [^: ]+:[^ ]+ \"{self.sct_base_path}/sct-results\" &> /dev/null [|][|] true"),
             re.compile(f"{docker_run_prefix} -l TestId=11111111-1111-1111-1111-111111111111"),
-            re.compile(f"{docker_run_prefix} -v /var/run:/run -v {sct_dir}:{sct_dir}"),
+            re.compile(f"{docker_run_prefix} -v {sct_dir}:{sct_dir} .* -v /var/run:/run"),
             re.compile(f"{docker_run_prefix} --group-add 1 --group-add 2 --group-add 3"),
         )
         if not runner:

--- a/unit_tests/test_hydra_sh.py
+++ b/unit_tests/test_hydra_sh.py
@@ -118,8 +118,6 @@ class LongevityPipelineTest:
         sct_dir = self.sct_path(runner)
         expected = (
             f'{self.sct_base_path}/get-qa-ssh-keys.sh',
-            re.compile('sudo chown -R [^: ]+:[^ ]+ ~/sct-results &> /dev/null [|][|] true'),
-            re.compile(f"sudo chown -R [^: ]+:[^ ]+ \"{self.sct_base_path}/sct-results\" &> /dev/null [|][|] true"),
             re.compile(f"{docker_run_prefix} -l TestId=11111111-1111-1111-1111-111111111111"),
             re.compile(f"{docker_run_prefix} -v {sct_dir}:{sct_dir} .* -v /var/run:/run"),
             re.compile(f"{docker_run_prefix} --group-add 1 --group-add 2 --group-add 3"),


### PR DESCRIPTION
this now is working with podman
```bash
HYDRA_TOOL=podman bash -x ./docker/env/hydra.sh list-ami-versions

HYDRA_TOOL=podman ./docker/env/hydra.sh investigate show-monitor c9c0400f-637d-445e-a47f-e047783fcf11
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
