### PR TITLE
fix(4341): remove scylla_rsyslog_setup for tests yamls

### DIFF
--- a/test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
+++ b/test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
@@ -27,6 +27,3 @@ authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra
 authenticator_password: cassandra
 authorizer: 'CassandraAuthorizer'
-
-logs_transport: "rsyslog"  # can't use syslog-ng because of next option enabled
-scylla_rsyslog_setup: true

--- a/test-cases/longevity/longevity-50GB-12h-verifier-LimitedMonkey-tls.yaml
+++ b/test-cases/longevity/longevity-50GB-12h-verifier-LimitedMonkey-tls.yaml
@@ -26,6 +26,3 @@ authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra
 authenticator_password: cassandra
 authorizer: 'CassandraAuthorizer'
-
-logs_transport: "rsyslog"  # can't use syslog-ng because of next option enabled
-scylla_rsyslog_setup: true


### PR DESCRIPTION
scylla_rsyslog_setup forces us to use rsyslog and not syslog-ng
using rsyslog is slow and break some of our vaildations depend
on logs getting in timly fashion.

since scylla_rsyslog_setup isn't tested, just configured, we
are remove it from the tests.

Fixes: #4341

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
