### PR TITLE
fix(4628): handle connection errors in `get_my_public_ip()`

### DIFF
--- a/sdcm/utils/net.py
+++ b/sdcm/utils/net.py
@@ -21,16 +21,18 @@ def get_my_ip():
 
 
 def get_my_public_ip() -> str:
-    hostnames = ['https://api4.my-ip.io/ip', "https://api.ipify.org", 'https://ip4.seeip.org/ip',
+    hostnames = ['https://api4.my-ip.io/ip', 'https://api.ipify.org', 'https://ip4.seeip.org/ip',
                  'http://ipv4.icanhazip.com']
 
-    for hostname in hostnames:
-        result = requests.get(hostname, timeout=10)
-        if result.ok:
-            try:
-                ip_address = result.text.strip()
-                ipaddress.ip_address(ip_address)  # validating that we got IP address
-                return ip_address
-            except ValueError:
-                continue
-    return ""
+    ip_address = "[Not Found]"
+    for idx, hostname in enumerate(hostnames):
+        try:
+            result = requests.get(hostname, timeout=10)
+            result.raise_for_status()
+
+            ip_address = result.text.strip()
+            ipaddress.ip_address(ip_address)  # validating that we got IP address
+        except (ValueError, requests.exceptions.RequestException):
+            if idx == len(hostnames) - 1:
+                raise
+    return ip_address


### PR DESCRIPTION
Since the actual requests call was outside of a try/except
clause, any connection error would be raised and won't
be moving to try the next service

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
