### PR TITLE
fix(scylla_yaml): add missed EaR options

### DIFF
--- a/sdcm/provision/scylla_yaml/scylla_yaml.py
+++ b/sdcm/provision/scylla_yaml/scylla_yaml.py
@@ -310,6 +310,10 @@ class ScyllaYaml(BaseModel):  # pylint: disable=too-few-public-methods
     ldap_url_template: str = None
     saslauthd_socket_path: str = None
 
+    system_key_directory: str = None
+    system_info_encryption: dict = None
+    kmip_hosts: dict = None
+
     def dict(  # pylint: disable=arguments-differ
         self,
         *,

--- a/unit_tests/test_scylla_yaml.py
+++ b/unit_tests/test_scylla_yaml.py
@@ -388,7 +388,10 @@ class ScyllaYamlTest(unittest.TestCase):
                 'ldap_bind_dn': None,
                 'ldap_bind_passwd': None,
                 'ldap_url_template': None,
-                'saslauthd_socket_path': None
+                'saslauthd_socket_path': None,
+                'system_key_directory': None,
+                'system_info_encryption': None,
+                'kmip_hosts': None,
             }
         )
 


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
