### PR TITLE
fix(gemini): use proper user for the oracle node

### DIFF
--- a/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-cdc-with-nemesis.yaml
@@ -6,6 +6,7 @@ n_monitor_nodes: 1
 instance_type_db: 'i3.large'
 
 user_prefix: 'ics-cdc-gemini-basic-3h'
+ami_db_scylla_user: 'centos'
 
 nemesis_class_name: 'GeminiChaosMonkey'
 nemesis_interval: 5


### PR DESCRIPTION
CI job called 'gemini-3h-ics-cdc-with-nemesis-test' uses
enterprise Scylla for oracle node which doesn't have 'scyllaadm'
user. So, switch this particular configuration to usage of the 'centos'
user.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
