### PR TITLE
test(operator): cover only 2 latest manager versions in functional tests

### DIFF
--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -186,10 +186,12 @@ def test_mgmt_repair(db_cluster, manager_version):
 
 
 # NOTE: manager versions 2.3.x will fail with following error:
-#     invalid character '\\x1f' looking for beginning of value
+#       invalid character '\\x1f' looking for beginning of value
+#       Versions '2.4.x' are not covered as old ones.
 @pytest.mark.requires_mgmt
 @pytest.mark.parametrize("manager_version", (
-    "2.6.1", "2.5.0", "2.4.1",
+    "2.6.3",
+    "2.5.4",
 ))
 def test_mgmt_backup(db_cluster, manager_version):
     reinstall_scylla_manager(db_cluster, manager_version)


### PR DESCRIPTION
Trello: https://trello.com/c/uwlkJuDf/4985-create-scylla-operator-compatability-job-for-20221-50

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
