### PR TITLE
fix(k8s): make kind setup be workable again

### DIFF
--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -491,10 +491,10 @@ class LocalMinimalScyllaPodCluster(ScyllaPodCluster):
         @retrying(n=iterations, sleep_time=sleep_time,
                   allowed_exceptions=(cluster.ClusterNodesNotReady, UnexpectedExit),
                   message="Waiting for nodes to join the cluster", timeout=timeout)
-        def _wait_for_nodes_up_and_normal():
+        def _wait_for_nodes_up_and_normal(self):  # pylint: disable=unused-argument
             super().check_nodes_up_and_normal(nodes=nodes, verification_node=verification_node)
 
-        _wait_for_nodes_up_and_normal()
+        _wait_for_nodes_up_and_normal(self)
 
     @cluster.wait_for_init_wrap
     def wait_for_init(self, *_, node_list=None, verbose=False, timeout=None, **__):  # pylint: disable=unused-argument


### PR DESCRIPTION
Fix bug implemented in https://github.com/scylladb/scylla-cluster-tests/pull/4610 where we call `super()` not having
class instance in var scope. Without this fix following error gets
raised:

    File "sdcm/cluster_k8s/mini_k8s.py", line 495, in _wait_for_nodes_up_and_normal
      super().check_nodes_up_and_normal(nodes=nodes, verification_node=verification_node)
    RuntimeError: super(): no arguments

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
