### PR TITLE
fix(ycsb): remove usage of cql_ip_address from YcsbStatsPublisher

### DIFF
--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -55,7 +55,7 @@ class YcsbStatsPublisher(FileFollowerThread):
 
     def set_metric(self, operation, name, value):
         metric = self.METRICS[self.gauge_name(operation)]
-        metric.labels(self.loader_node.cql_ip_address, self.loader_idx, self.uuid, name).set(value)
+        metric.labels(self.loader_node.ip_address, self.loader_idx, self.uuid, name).set(value)
 
     def handle_verify_metric(self, line):
         verify_status_regex = re.compile(r"Return\((?P<status>.*?)\)=(?P<value>\d*)")


### PR DESCRIPTION
cause of this usage on each line of stats being used, we copy
back and forth the scylla.yaml of the loader, for no good reason
blowing up the logs, and taking lots of cpu from the test runner
(which is shared in perf test anyhow)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
