### PR TITLE
fix(k8s-local): use proper IP addresses for network connectivity

### DIFF
--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -472,6 +472,16 @@ class LocalMinimalScyllaPodContainer(BaseScyllaPodContainer):
     def terminate_k8s_host(self):
         raise NotImplementedError("Not supported on local K8S backends")
 
+    def _refresh_instance_state(self):
+        # NOTE: Local K8S must use service IP address for connections, not pod's
+        public_ips, private_ips = [], []
+        if cluster_ip_service := self._cluster_ip_service:
+            private_ips.append(cluster_ip_service.spec.cluster_ip)
+        if pod_status := self._pod_status:
+            public_ips.append(pod_status.host_ip)
+            private_ips.append(pod_status.pod_ip)
+        return (public_ips or [None, ], private_ips or [None, ])
+
 
 # pylint: disable=too-many-ancestors
 class LocalMinimalScyllaPodCluster(ScyllaPodCluster):


### PR DESCRIPTION
One of the recent changes [1] where we stop depending on the host networking in K8S deployments changed the default IP addresses taken as "private".
So, change it for the local K8S case which must use "service IP" for connection as it was before.
Reason for it is that "KinD" tool has docker-wide network connectivity using exactly service IPs.

[1] https://github.com/scylladb/scylla-cluster-tests/pull/4635

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
