### PR TITLE
fix(k8s-stress): make 'run_stress_thread' work on K8S

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2103,7 +2103,7 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
 
     def wait_for_nodes_up_and_normal(self, nodes=None, verification_node=None, iterations=None, sleep_time=None,
                                      timeout=None):  # pylint: disable=too-many-arguments
-        self.wait_for_pods_readiness(pods_to_wait=len(nodes), total_pods=len(self.nodes))
+        self.wait_for_pods_readiness(pods_to_wait=len(nodes or self.nodes), total_pods=len(self.nodes))
         self.check_nodes_up_and_normal(nodes=nodes, verification_node=verification_node)
 
     @timeout_wrapper(timeout=180, sleep_time=3, allowed_exceptions=NETWORK_EXCEPTIONS + (ClusterNodesNotReady,),


### PR DESCRIPTION
After merge of [1] we get following error running any test which calls
'run_stress_thread' method of the 'tester' class instance:

    >   File "scylla-cluster-tests/sdcm/cluster_k8s/__init__.py", \
    >       line 2130, in wait_for_nodes_up_and_normal
    >     self.wait_for_pods_readiness(\
    >       pods_to_wait=len(nodes), total_pods=len(self.nodes))
    > TypeError: object of type 'NoneType' has no len()

The reason for it is unsafe coding of the K8S' part.
So, make it be safe enough by replacing 'None' with 'empty list' before
calling 'len()' function.

[1] https://github.com/scylladb/scylla-cluster-tests/pull/4610

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
