### PR TITLE
fix(nemesis): skip message for cloud in TerminateAndRemoveNodeMonkey

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2478,7 +2478,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         5. Run nodetool cleanup (on each node) for each keyspace
         """
         if self.cluster.params.get("db_type") == 'cloud_scylla':
-            raise UnsupportedNemesis("Skipping this nemesis due this job run from Siren cloud with 2019 version!")
+            raise UnsupportedNemesis("Skipping this nemesis due the replace node option that supported by Cloud "
+                                     "is tested by CloudReplaceNonResponsiveNode nemesis")
         if self._is_it_on_kubernetes():
             raise UnsupportedNemesis("On K8S nodes get removed differently. Skipping.")
 


### PR DESCRIPTION
Task:
https://trello.com/c/mH3w1kNZ/4504-enable-disruptremovenodethenaddnode-for-cloud-longevities

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
