### PR TITLE
fix(sdcm/cluster.py): Only return suffixed password if it was changed

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3243,7 +3243,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
             user = self.params.get('authenticator_user')
             password = self.params.get('authenticator_password')
             # default password of Role cassandra is `cassandra`, the weak password isn't allowed in MS-AD.
-            if self.added_password_suffix or self.use_saslauthd_authenticator:
+            if self.added_password_suffix:
                 password = self.params.get('authenticator_password') + DEFAULT_PWD_SUFFIX
         return (user, password) if user and password else None
 


### PR DESCRIPTION
Fixes an issue where a suffixed password would be returned even if said
password wasn't changed yet - leading to authentication failures

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
