### PR TITLE
improvement(k8s-loaders): allow to use multiple namespaces

### DIFF
--- a/sdcm/k8s_configs/loaders.yaml
+++ b/sdcm/k8s_configs/loaders.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: sct-loaders
+  name: ${SCT_K8S_LOADER_NAMESPACE}
 
 ---
 
@@ -9,7 +9,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: ${SCT_K8S_LOADER_CLUSTER_NAME}
-  namespace: sct-loaders
+  namespace: ${SCT_K8S_LOADER_NAMESPACE}
 spec:
   selector:
     matchLabels:
@@ -50,4 +50,4 @@ spec:
           hostPath:
             path: /var/run/docker.sock
             type: Socket
-      hostNetwork: true
+      hostNetwork: false


### PR DESCRIPTION
Update K8S code and configs for loaders making it support
multi-tenant setup.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
