### PR TITLE
fix(functional_tests): Verify that all tests have passed at the end

### DIFF
--- a/functional_tests/scylla_operator/libs/auxiliary.py
+++ b/functional_tests/scylla_operator/libs/auxiliary.py
@@ -12,6 +12,7 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2021 ScyllaDB
+import logging
 import os
 
 from sdcm.cluster_k8s import ScyllaPodCluster
@@ -19,6 +20,7 @@ from sdcm.tester import ClusterTester
 
 
 SCT_ROOT = os.path.realpath(os.path.join(__file__, '..', '..', '..', '..'))
+LOGGER = logging.getLogger(__name__)
 
 
 class ScyllaOperatorFunctionalClusterTester(ClusterTester):
@@ -36,16 +38,17 @@ class ScyllaOperatorFunctionalClusterTester(ClusterTester):
         return email_data
 
     def update_test_status(self, test_name, status, error=None):
+        LOGGER.debug("Updating test status: %s - %s", test_name, status)
         self.test_data[test_name] = (status, error)
 
     def get_test_failures(self):
         pass
 
-    def get_test_status(self):
-        for _, test_data in self.test_data.items():
-            if test_data[0] != 'SUCCESS':
-                return 'FAILED'
-        return 'SUCCESS'
+    def get_test_status(self) -> str:
+        cumulative_status = all(v[0] == 'SUCCESS' for v in self.test_data.values())
+        status = 'SUCCESS' if cumulative_status else 'FAILED'
+        LOGGER.debug("Setting overall status for this run: %s", status)
+        return status
 
 
 def sct_abs_path(relative_filename=""):


### PR DESCRIPTION
This commit fixes an issue with functional tests, where first test in
the series of tests decides the final overarching test status, ignoring
any subsequent failed test in the test data.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
