### PR TITLE
improvement(k8s): stop spamming logs with non-supported ipv6

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1712,7 +1712,7 @@ class BasePodContainer(cluster.BaseNode):  # pylint: disable=too-many-public-met
         return self._container_status.image
 
     def _get_ipv6_ip_address(self):
-        self.log.warning("We don't support IPv6 for k8s-* backends")
+        # NOTE: We don't support IPv6 for k8s-* backends
         return ""
 
     def restart(self):


### PR DESCRIPTION
In all K8S runs we get lots of following warning messages:

    We don't support IPv6 for k8s-* backends

These make no sense. So, remove such logging to make logs be more cleaner.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
