### PR TITLE
fix(manager upgrade): no longer only backup up system keyspaces

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -179,16 +179,18 @@ class BackupFunctionsMixIn:
         self.restore_backup_from_backup_task(mgr_cluster=mgr_cluster, backup_task=backup_task,
                                              keyspace_and_table_list=per_keyspace_tables_dict)
 
-    def _generate_load(self):
+    def _generate_load(self, keyspace_name_to_replace=None):
         self.log.info('Starting c-s write workload')
         stress_cmd = self.params.get('stress_cmd')
+        if keyspace_name_to_replace:
+            stress_cmd = stress_cmd.replace("keyspace1", keyspace_name_to_replace)
         stress_thread = self.run_stress_thread(stress_cmd=stress_cmd)
         self.log.info('Sleeping for 15s to let cassandra-stress run...')
         time.sleep(15)
         return stress_thread
 
-    def generate_load_and_wait_for_results(self):
-        load_thread = self._generate_load()
+    def generate_load_and_wait_for_results(self, keyspace_name_to_replace=None):
+        load_thread = self._generate_load(keyspace_name_to_replace=keyspace_name_to_replace)
         load_results = load_thread.get_results()
         self.log.info(f'load={load_results}')
 

--- a/mgmt_upgrade_test.py
+++ b/mgmt_upgrade_test.py
@@ -106,11 +106,12 @@ class ManagerUpgradeTest(BackupFunctionsMixIn, ClusterTester):
                 f"Unknown failure in task {rerunning_backup_task.id}"
 
         with self.subTest("Creating a backup task and stopping it"):
+            self.generate_load_and_wait_for_results(keyspace_name_to_replace="keyspace2")
             legacy_args = "--force" if manager_tool.sctool.client_version.startswith("2.1") else None
             pausable_backup_task = mgr_cluster.create_backup_task(
                 interval="1d",
                 location_list=self.locations,
-                keyspace_list=["system_*"],
+                keyspace_list=["keyspace2"],
                 legacy_args=legacy_args,
             )
             pausable_backup_task.wait_for_status(list_status=[TaskStatus.RUNNING], timeout=180, step=2)

--- a/test-cases/upgrades/manager-upgrade.yaml
+++ b/test-cases/upgrades/manager-upgrade.yaml
@@ -1,6 +1,6 @@
 test_duration: 360
 
-stress_cmd: "cassandra-stress write cl=QUORUM n=1200300 -schema 'replication(factor=3)' -mode cql3 native -rate threads=200 -pop seq=400200300..600200300"
+stress_cmd: "cassandra-stress write cl=QUORUM n=1200300 -schema 'replication(factor=3) keyspace=keyspace1' -mode cql3 native -rate threads=200 -pop seq=400200300..600200300"
 
 instance_type_db: 'i3.large'
 instance_type_loader: 'c5.large'


### PR DESCRIPTION
As part of the upgrade test, we create a backup (of the system keyspaces) and
stop it mid-run, with the intention of continuing it in a later stage of the test.
The problem is that backup only the system keyspaces is causing the task to end
way too fast, so we don't have a chance to stop it.
As such, I added the ability in the _generate_load function to create a new, larger
keyspace and changed the task to backup only it so it will last longer.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
