### PR TITLE
fix(cassandra-harry): install from upstream master branch

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -499,21 +499,17 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 apt-get update
                 apt-get install -y git make maven
             """))
-        # TODO: Needs to uncomment the following lines after https://github.com/apache/cassandra-harry/pull/12 will
-        # self.remoter.run(shell_script_cmd(f"""rm -rf {cassandra_harry_path}"""))
-        # clone_repo(remoter=self.remoter, repo_url="https://github.com/apache/cassandra-harry.git",
-        # destination_dir_name=str(cassandra_harry_path))
         self.remoter.run(shell_script_cmd(f"""rm -rf {cassandra_harry_path}"""))
         clone_repo(remoter=self.remoter, repo_url="https://github.com/apache/cassandra-harry.git",
                    destination_dir_name=str(cassandra_harry_path), clone_as_root=False)
         self.remoter.run(shell_script_cmd(f"""\
             cd {cassandra_harry_path}
-            git checkout standalone
             make standalone
         """))
         cassandra_harry_tool_path = cassandra_harry_path / "scripts" / "cassandra-harry"
         # Edit the "cassandra-harry' file and set the correct HARRY_HOME value (the value should be repo's path)
         self.remoter.run(rf"sed -i '2s;^;HARRY_HOME={cassandra_harry_path}\n;' {cassandra_harry_tool_path}")
+        self.remoter.run(f"sed -i 's/external-.*-SNAPSHOT.jar/external-*-SNAPSHOT.jar/' {cassandra_harry_tool_path}")
         self.remoter.sudo(f"ln -svf {cassandra_harry_tool_path} /usr/bin/cassandra-harry", ignore_status=True)
         self.is_cassandra_harry_installed = True
 

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4639,7 +4639,7 @@ class BaseLoaderSet():
                 node.install_scylla_bench()
         if 'cassandra-harry' in self.params.list_of_stress_tools:
             if not node.is_cassandra_harry_installed:
-                node.install_cassandra_harry(node)
+                node.install_cassandra_harry()
 
         # install docker
         docker_install = dedent("""

--- a/test-cases/longevity/longevity-harry-2h.yaml
+++ b/test-cases/longevity/longevity-harry-2h.yaml
@@ -9,7 +9,7 @@ instance_type_db: 'i3.large'
 
 aws_root_disk_size_loader: 80 # enlarge loader disk, cause of cassandra-harry operation.log that can't be disabled
 
-nemesis_class_name: 'SisyphusMonkey'
+nemesis_class_name: 'NoOpMonkey'
 nemesis_seed: '001'
 nemesis_interval: 2
 ssh_transport: 'libssh2'


### PR DESCRIPTION
Now that https://github.com/apache/cassandra-harry/pull/12 is
merged, we can install and run from master branch.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
