### PR TITLE
fix(argus): workaround arguns installation in an old branch

### DIFF
--- a/install_argus.sh
+++ b/install_argus.sh
@@ -3,8 +3,9 @@ set -eu
 LOGFILE="/tmp/argus-install.log"
 echo "Installing Argus pip package..."
 echo "[TODO] Remove this once Argus stabilizes"
-sudo /usr/local/bin/pip3 install --force -e git+https://github.com/bentsi/argus#egg=argus >"$LOGFILE" 2>&1 && (
+sudo /usr/local/bin/pip3 install --force https://github.com/scylladb/argus/archive/refs/tags/v0.5.0.zip >"$LOGFILE" 2>&1 && (
   echo "Package installed."
+  cat "$LOGFILE"
   if [ -d "./src" ]; then sudo chown "$(whoami):$(whoami)" -R "./src"; fi
   exit 0
 ) || (


### PR DESCRIPTION
installation of argus is failing on old branches,
because changes done in Argus, making the early
stages of the test to fail, so the tests are not
even starting.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
