### PR TITLE
improvement(grafana): support K8S multi-tenant case

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -74,6 +74,7 @@ from sdcm.sct_events.setup import start_events_device, stop_events_device
 from sdcm.sct_events.system import InfoEvent, TestFrameworkEvent, TestResultEvent, TestTimeoutEvent
 from sdcm.sct_events.file_logger import get_events_grouped_by_category, get_logger_event_summary
 from sdcm.sct_events.events_analyzer import stop_events_analyzer
+from sdcm.sct_events.grafana import start_posting_grafana_annotations
 from sdcm.stress_thread import CassandraStressThread
 from sdcm.gemini_thread import GeminiStressThread
 from sdcm.utils.log_time_consistency import DbLogTimeConsistencyAnalyzer
@@ -1417,6 +1418,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         elif cluster_backend == 'azure':
             self.get_cluster_azure(loader_info=loader_info, db_info=db_info,
                                    monitor_info=monitor_info)
+
+        # NOTE: following starts processing of the monitoring inbound events which will be posted
+        #       for each of the Grafana instances (may be more than 1 in case of K8S multi-tenant setup)
+        start_posting_grafana_annotations()
 
     def _cs_add_node_flag(self, stress_cmd):
         if '-node' not in stress_cmd:


### PR DESCRIPTION
For the moment we support only one grafana endpoint for publishing of
annotations. It leads to the situation that in case of multi-tenant
setup with multiple monitorings we post events only to one of them.
So, add support for multiple grafana endpoints.

Known side-effect: all monitorings will store all the info, even
not related to them. It is considered ok for now.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
