### PR TITLE
improvement(tester.py): support multitenancy for K8S

### DIFF
--- a/defaults/k8s_eks_config.yaml
+++ b/defaults/k8s_eks_config.yaml
@@ -41,6 +41,7 @@ k8s_minio_storage_size: '60Gi'
 
 n_monitor_nodes: 1
 n_loaders: 1
+k8s_n_loader_pods_per_cluster: 1
 n_db_nodes: 3
 
 append_scylla_args: ''

--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -41,6 +41,7 @@ k8s_loader_cluster_name: 'sct-loaders'
 gce_instance_type_loader: 'e2-standard-4'
 
 n_loaders: 1
+k8s_n_loader_pods_per_cluster: 1
 
 gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
 gce_instance_type_monitor: 'e2-medium'

--- a/defaults/k8s_local_kind_config.yaml
+++ b/defaults/k8s_local_kind_config.yaml
@@ -22,6 +22,7 @@ k8s_scylla_disk_class: ''
 k8s_minio_storage_size: '20Gi'
 
 n_loaders: 1
+k8s_n_loader_pods_per_cluster: 1
 n_monitor_nodes: 1
 
 user_credentials_path: '~/.ssh/scylla-test'

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -172,6 +172,7 @@
 | **<a href="#user-content-k8s_scylla_cluster_name" name="k8s_scylla_cluster_name">k8s_scylla_cluster_name</a>**  |  | N/A | SCT_K8S_SCYLLA_CLUSTER_NAME
 | **<a href="#user-content-k8s_scylla_disk_gi" name="k8s_scylla_disk_gi">k8s_scylla_disk_gi</a>**  |  | N/A | SCT_K8S_SCYLLA_DISK_GI
 | **<a href="#user-content-k8s_loader_cluster_name" name="k8s_loader_cluster_name">k8s_loader_cluster_name</a>**  |  | N/A | SCT_K8S_LOADER_CLUSTER_NAME
+| **<a href="#user-content-k8s_n_loader_pods_per_cluster" name="k8s_n_loader_pods_per_cluster">k8s_n_loader_pods_per_cluster</a>**  |  | N/A | SCT_K8S_N_LOADER_PODS_PER_CLUSTER
 | **<a href="#user-content-mini_k8s_version" name="mini_k8s_version">mini_k8s_version</a>**  |  | N/A | SCT_MINI_K8S_VERSION
 | **<a href="#user-content-k8s_cert_manager_version" name="k8s_cert_manager_version">k8s_cert_manager_version</a>**  |  | N/A | SCT_K8S_CERT_MANAGER_VERSION
 | **<a href="#user-content-k8s_minio_storage_size" name="k8s_minio_storage_size">k8s_minio_storage_size</a>**  |  | N/A | SCT_K8S_MINIO_STORAGE_SIZE

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3056,7 +3056,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
 
     # pylint: disable=too-many-arguments
     def __init__(self, cluster_uuid=None, cluster_prefix='cluster', node_prefix='node', n_nodes=3, params=None,
-                 region_names=None, node_type=None, extra_network_interface=False):
+                 region_names=None, node_type=None, extra_network_interface=False, add_nodes=True):
         self.extra_network_interface = extra_network_interface
         if params is None:
             params = {}
@@ -3092,14 +3092,17 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
             self._node_private_ips = self.params.get(self.get_node_ips_param(public_ip=False)) or []
             self.log.debug('Node public IPs: {}, private IPs: {}'.format(self._node_public_ips, self._node_private_ips))
 
-        if isinstance(n_nodes, list):
-            for dc_idx, num in enumerate(n_nodes):
-                self.add_nodes(num, dc_idx=dc_idx, enable_auto_bootstrap=self.auto_bootstrap)
-        elif isinstance(n_nodes, int):  # legacy type
-            self.add_nodes(n_nodes, enable_auto_bootstrap=self.auto_bootstrap)
-        else:
-            raise ValueError('Unsupported type: {}'.format(type(n_nodes)))
-        self.run_node_benchmarks()
+        # NOTE: following is needed in case of K8S where we init multiple DB clusters first
+        #       and only then we add nodes to it calling code in parallel.
+        if add_nodes:
+            if isinstance(n_nodes, list):
+                for dc_idx, num in enumerate(n_nodes):
+                    self.add_nodes(num, dc_idx=dc_idx, enable_auto_bootstrap=self.auto_bootstrap)
+            elif isinstance(n_nodes, int):  # legacy type
+                self.add_nodes(n_nodes, enable_auto_bootstrap=self.auto_bootstrap)
+            else:
+                raise ValueError('Unsupported type: {}'.format(type(n_nodes)))
+            self.run_node_benchmarks()
         self.coredumps = {}
         super().__init__()
 
@@ -4822,7 +4825,7 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
     DB_NODES_IP_ADDRESS = 'ip_address'
     json_file_params_for_replace = {"$test_name": get_test_name()}
 
-    def __init__(self, targets, params):
+    def __init__(self, targets, params, monitor_id: str = None):
         self.targets = targets
         self.params = params
         self.local_metrics_addr = start_metrics_server()  # start prometheus metrics server locally and return local ip
@@ -4834,6 +4837,7 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
         self.grafana_start_time = 0
         self._sct_dashboard_json_file = None
         self.test_config = TestConfig()
+        self.monitor_id = monitor_id or self.test_config.test_id()
 
     @staticmethod
     @retrying(n=5)
@@ -4917,7 +4921,7 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
                 node.create_swap_file(monitor_swap_size)
         # update repo cache and system after system is up
         node.update_repo_cache()
-        self.mgmt_auth_token = self.test_config.test_id()  # pylint: disable=attribute-defined-outside-init
+        self.mgmt_auth_token = self.monitor_id  # pylint: disable=attribute-defined-outside-init
 
         if self.test_config.REUSE_CLUSTER:
             self.configure_scylla_monitoring(node)
@@ -5326,7 +5330,7 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
                                                      extra_entities=grafana_extra_dashboards)
             screenshot_files = screenshot_collector.collect(node, self.logdir)
             for screenshot in screenshot_files:
-                s3_path = "{test_id}/{date}".format(test_id=self.test_config.test_id(), date=date_time)
+                s3_path = "{monitor_id}/{date}".format(monitor_id=self.monitor_id, date=date_time)
                 screenshot_links.append(S3Storage().upload_file(screenshot, s3_path))
 
             snapshots_collector = GrafanaSnapshot(name="grafana-snapshot",
@@ -5343,7 +5347,7 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
         try:
             annotations = self.get_grafana_annotations(self.nodes[0])
             if annotations:
-                annotations_url = S3Storage().generate_url('annotations.json', self.test_config.test_id())
+                annotations_url = S3Storage().generate_url('annotations.json', self.monitor_id)
                 self.log.info("Uploading 'annotations.json' to {s3_url}".format(
                     s3_url=annotations_url))
                 response = requests.put(annotations_url, data=annotations, headers={
@@ -5361,7 +5365,7 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
         try:
             if snapshot_archive := PrometheusSnapshots(name='prometheus_snapshot').collect(self.nodes[0], self.logdir):
                 self.log.debug("Snapshot local path: %s", snapshot_archive)
-                return upload_archive_to_s3(snapshot_archive, self.test_config.test_id())
+                return upload_archive_to_s3(snapshot_archive, self.monitor_id)
         except Exception as details:  # pylint: disable=broad-except
             self.log.error("Error downloading prometheus data dir: %s", details)
         return ""

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -82,7 +82,8 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
                  ec2_instance_type='c5.xlarge', ec2_ami_username='root',
                  ec2_user_data='', ec2_block_device_mappings=None,
                  cluster_prefix='cluster',
-                 node_prefix='node', n_nodes=10, params=None, node_type=None, extra_network_interface=False):
+                 node_prefix='node', n_nodes=10, params=None, node_type=None,
+                 extra_network_interface=False, add_nodes=True):
         # pylint: disable=too-many-locals
         region_names = params.region_names
         if len(credentials) > 1 or len(region_names) > 1:
@@ -109,7 +110,8 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
                          params=params,
                          region_names=self.region_names,
                          node_type=node_type,
-                         extra_network_interface=extra_network_interface
+                         extra_network_interface=extra_network_interface,
+                         add_nodes=add_nodes,
                          )
 
     def __str__(self):
@@ -980,14 +982,15 @@ class MonitorSetAWS(cluster.BaseMonitorSet, AWSCluster):
                  services, credentials, ec2_instance_type='c5.xlarge',
                  ec2_block_device_mappings=None,
                  ec2_ami_username='centos',
-                 user_prefix=None, n_nodes=10, targets=None, params=None):
+                 user_prefix=None, n_nodes=10, targets=None, params=None,
+                 add_nodes=True, monitor_id=None):
         # pylint: disable=too-many-locals
         node_prefix = cluster.prepend_user_prefix(user_prefix, 'monitor-node')
         node_type = 'monitor'
         cluster_prefix = cluster.prepend_user_prefix(user_prefix, 'monitor-set')
-        cluster.BaseMonitorSet.__init__(self,
-                                        targets=targets,
-                                        params=params)
+        cluster.BaseMonitorSet.__init__(
+            self, targets=targets, params=params, monitor_id=monitor_id,
+        )
 
         AWSCluster.__init__(self,
                             ec2_ami_id=ec2_ami_id,
@@ -1002,4 +1005,5 @@ class MonitorSetAWS(cluster.BaseMonitorSet, AWSCluster):
                             node_prefix=node_prefix,
                             n_nodes=n_nodes,
                             params=params,
-                            node_type=node_type)
+                            node_type=node_type,
+                            add_nodes=add_nodes)

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -195,7 +195,8 @@ class GCECluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
     def __init__(self, gce_image, gce_image_type, gce_image_size, gce_network, services, credentials,  # pylint: disable=too-many-arguments
                  cluster_uuid=None, gce_instance_type='n1-standard-1', gce_region_names=None,
                  gce_n_local_ssd=1, gce_image_username='root', cluster_prefix='cluster',
-                 node_prefix='node', n_nodes=3, add_disks=None, params=None, node_type=None, service_accounts=None):
+                 node_prefix='node', n_nodes=3, add_disks=None, params=None, node_type=None,
+                 service_accounts=None, add_nodes=True):
 
         # pylint: disable=too-many-locals
         self._gce_image = gce_image
@@ -219,7 +220,8 @@ class GCECluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
                          params=params,
                          # services=services,
                          region_names=gce_region_names,
-                         node_type=node_type)
+                         node_type=node_type,
+                         add_nodes=add_nodes)
         self.log.debug("GCECluster constructor")
 
     def __str__(self):
@@ -541,15 +543,16 @@ class MonitorSetGCE(cluster.BaseMonitorSet, GCECluster):
     def __init__(self, gce_image, gce_image_type, gce_image_size, gce_network, service, credentials,  # pylint: disable=too-many-arguments
                  gce_instance_type='n1-standard-1', gce_n_local_ssd=1,
                  gce_image_username='centos', user_prefix=None, n_nodes=1,
-                 targets=None, add_disks=None, params=None, gce_datacenter=None):
+                 targets=None, add_disks=None, params=None, gce_datacenter=None,
+                 add_nodes=True, monitor_id=None):
         # pylint: disable=too-many-locals
         node_prefix = cluster.prepend_user_prefix(user_prefix, 'monitor-node')
         cluster_prefix = cluster.prepend_user_prefix(user_prefix, 'monitor-set')
 
         targets = targets if targets else {}
-        cluster.BaseMonitorSet.__init__(self,
-                                        targets=targets,
-                                        params=params)
+        cluster.BaseMonitorSet.__init__(
+            self, targets=targets, params=params, monitor_id=monitor_id,
+        )
         GCECluster.__init__(self,
                             gce_image=gce_image,
                             gce_image_type=gce_image_type,
@@ -566,5 +569,6 @@ class MonitorSetGCE(cluster.BaseMonitorSet, GCECluster):
                             add_disks=add_disks,
                             params=params,
                             node_type='monitor',
-                            gce_region_names=gce_datacenter
+                            gce_region_names=gce_datacenter,
+                            add_nodes=add_nodes,
                             )

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1007,7 +1007,7 @@ class KubernetesLogCollector(SCTLogCollector):
         FileLog(name='cert_manager.log', search_locally=True),
         FileLog(name='scylla_manager.log', search_locally=True),
         FileLog(name='scylla_operator.log', search_locally=True),
-        FileLog(name='scylla_cluster_events.log', search_locally=True),
+        FileLog(name='*_cluster_events.log', search_locally=True),
         FileLog(name='kubectl.version', search_locally=True),
         DirLog(name='cluster-scoped-resources/*', search_locally=True),
         DirLog(name='namespaces/*', search_locally=True),

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -791,6 +791,9 @@ class SCTConfiguration(dict):
 
         dict(name="k8s_loader_cluster_name", env="SCT_K8S_LOADER_CLUSTER_NAME", type=str,
              help=""),
+        dict(name="k8s_n_loader_pods_per_cluster", env="SCT_K8S_N_LOADER_PODS_PER_CLUSTER",
+             type=int_or_list,
+             help="Number of loader pods per loader cluster."),
 
         dict(name="mini_k8s_version", env="SCT_MINI_K8S_VERSION", type=str,
              help=""),


### PR DESCRIPTION
1. Add new integer option called `k8s_n_loader_pods_per_cluster`.
Make it define the number of loader pods per loader cluster.
It is different than the existing `n_loaders` option which defines
number of nodes dedicated for loader pods.
As an example - for 2 tenants we may create 6 nodes and 2 clusters
with 3 pods in each of them.

2. Add support for the multi-tenancy in EKS and GKE backends.

3. Add 'monitor_id' tag for each monitoring we deploy per Scylla
cluster to distinguish it during provisioning. It is needed because
previously we used 'test_id' for it, which is the same in current case.

4. Run creation of Scylla and Loader clusters in parallel.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
