### PR TITLE
fix(SCTool.run): Excepting sdcm.remote.libssh2_client.exceptions.Failure

### DIFF
--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -23,7 +23,8 @@ from contextlib import contextmanager
 from distutils.version import LooseVersion
 
 import requests
-from invoke.exceptions import UnexpectedExit, Failure
+from invoke.exceptions import Failure as InvokeFailure
+from sdcm.remote.libssh2_client.exceptions import Failure as Libssh2Failure
 
 from sdcm import wait
 from sdcm.mgmt.common import \
@@ -1056,7 +1057,7 @@ class SCTool:
         try:
             res = self.manager_node.remoter.sudo(f"sctool {cmd}")
             LOGGER.debug("sctool output: %s", res.stdout)
-        except (UnexpectedExit, Failure) as ex:
+        except (InvokeFailure, Libssh2Failure) as ex:
             raise ScyllaManagerError(f"Encountered an error on sctool command: {cmd}: {ex}") from ex
 
         if replace_broken_unicode_values:


### PR DESCRIPTION
Previously, in the SCTool.run method we expected that either invoke.exceptions.UnexpectedExit
and invoke.exceptions.UnexpectedExit would rise as a result of the sctool command's failure,
but it seems that on certain occasions a sdcm.remote.libssh2_client.exceptions.Failure would
rise instead.
Therefore, I added this exception to the except clause

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
