### PR TITLE
fix(random-region): define supported_regions in right context

### DIFF
--- a/vars/getJenkinsLabels.groovy
+++ b/vars/getJenkinsLabels.groovy
@@ -22,21 +22,21 @@ def call(String backend, String region=null, String datacenter=null, String loca
 
     def cloud_provider = getCloudProviderFromBackend(backend)
 
-    if ((cloud_provider == 'aws' && region) || (cloud_provider == 'gce' && datacenter) || (cloud_provider == 'azure' && location))
-    {
-        if (cloud_provider == 'aws')
-        {
-            def supported_regions = ["eu-west-2", "eu-north-1", "eu-central-1"]
+    if ((cloud_provider == 'aws' && region) || (cloud_provider == 'gce' && datacenter) || (cloud_provider == 'azure' && location)) {
+        def supported_regions = []
+
+        if (cloud_provider == 'aws') {
+            supported_regions = ["eu-west-2", "eu-north-1", "eu-central-1"]
         } else if (cloud_provider == 'gce') {
-            def supported_regions = ["us-east1", "us-west1"]
+            supported_regions = ["us-east1", "us-west1"]
             region = datacenter
         } else {
-            def supported_regions = ["eastus"]
+            supported_regions = ["eastus"]
             region = location
         }
 
         println("Finding builder for region: " + region)
-        if (region == "random" || datacenter == "random"){
+        if (region == "random" || datacenter == "random") {
             Collections.shuffle(supported_regions)
             region = supported_regions[0]
         }
@@ -45,15 +45,13 @@ def call(String backend, String region=null, String datacenter=null, String loca
         println("Checking if we have a label for " + cp_region)
 
         def label = jenkins_labels.get(cp_region, null)
-        if (label != null){
+        if (label != null) {
             println("Found builder with label: " + label)
             return [ "label": label, "region": region ]
         } else {
             throw new Exception("=================== ${cloud_provider} region ${region} not supported ! ===================")
         }
-    }
-    else
-    {
+    } else {
         return [ "label": jenkins_labels[cloud_provider], "region": region ]
     }
 }


### PR DESCRIPTION
Since `supported_regions` was define inside the context of
an if statment, later when it was needed it wasn't available.

Fixes: #4712

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
