### PR TITLE
fix(manager): enlarged data size in gce feature and ipv6 sanity tests

### DIFF
--- a/test-cases/manager/manager-regression-gce.yaml
+++ b/test-cases/manager/manager-regression-gce.yaml
@@ -1,6 +1,6 @@
 test_duration: 360
 
-stress_cmd: "cassandra-stress write cl=QUORUM n=1200300 -schema 'replication(factor=3)' -mode cql3 native -rate threads=200 -pop seq=400200300..600200300"
+stress_cmd: "cassandra-stress write cl=QUORUM n=4000000 -schema 'replication(factor=3)' -mode cql3 native -rate threads=200 -pop seq=400000000..600000000"
 
 n_db_nodes: 3
 n_loaders: 1

--- a/test-cases/manager/manager-regression-ipv6.yaml
+++ b/test-cases/manager/manager-regression-ipv6.yaml
@@ -1,6 +1,6 @@
 test_duration: 120
 
-stress_cmd: "cassandra-stress write cl=QUORUM n=1200300 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=200 -pop seq=400200300..600200300"
+stress_cmd: "cassandra-stress write cl=QUORUM n=4000000 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=200 -pop seq=400000000..600000000"
 
 instance_type_db: 'i3.large'
 instance_type_loader: 'c5.large'


### PR DESCRIPTION
The number of rows written in most manager test cases was boosted to 4000000, but
some test cases, namely the ipv6 sanity test and the gce backup feature test, were left
out of this change, because they use different config files. This commit amends that for them.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
