### PR TITLE
feature(azure): make Azure provision in parallel

### DIFF
--- a/sdcm/provision/azure/ip_provider.py
+++ b/sdcm/provision/azure/ip_provider.py
@@ -14,7 +14,7 @@
 import logging
 from dataclasses import dataclass, field
 
-from typing import Dict
+from typing import Dict, List
 
 from azure.core.exceptions import ResourceNotFoundError
 from azure.mgmt.network.models import PublicIPAddress
@@ -41,29 +41,37 @@ class IpAddressProvider:
         except ResourceNotFoundError:
             pass
 
-    def get_or_create(self, name: str = "default", version: str = "IPV4") -> PublicIPAddress:
-        ip_name = self._get_ip_name(name, version)
-        if ip_name in self._cache:
-            return self._cache[ip_name]
-        LOGGER.info("Creating public_ip in resource group %s...", self._resource_group_name)
-        self._azure_service.network.public_ip_addresses.begin_create_or_update(
-            resource_group_name=self._resource_group_name,
-            public_ip_address_name=ip_name,
-            parameters={
-                "location": self._region,
-                "sku": {
-                    "name": "Standard",
+    def get_or_create(self, names: List[str] = "default", version: str = "IPV4") -> List[PublicIPAddress]:
+        addresses = []
+        pollers = []
+        for name in names:
+            ip_name = self._get_ip_name(name, version)
+            if ip_name in self._cache:
+                addresses.append(self._cache[ip_name])
+                continue
+            LOGGER.info("Creating public_ip %s in resource group %s...",  ip_name, self._resource_group_name)
+            poller = self._azure_service.network.public_ip_addresses.begin_create_or_update(
+                resource_group_name=self._resource_group_name,
+                public_ip_address_name=ip_name,
+                parameters={
+                    "location": self._region,
+                    "sku": {
+                        "name": "Standard",
+                    },
+                    "public_ip_allocation_method": "Static",
+                    "public_ip_address_version": version.upper(),
                 },
-                "public_ip_allocation_method": "Static",
-                "public_ip_address_version": version.upper(),
-            },
-        ).wait()
-        # need to get it separately as seems not always it gets created even if result() returns proper ip_address.
-        public_ip_address = self._azure_service.network.public_ip_addresses.get(self._resource_group_name, ip_name)
-        LOGGER.info("Provisioned public ip %s (%s) in the %s resource group", public_ip_address.name,
-                    self._resource_group_name, public_ip_address.ip_address)
-        self._cache[ip_name] = public_ip_address
-        return public_ip_address
+            )
+            pollers.append((ip_name, poller))
+        for ip_name, poller in pollers:
+            poller.wait()
+            # need to get it separately as seems not always it gets created even if result() returns proper ip_address.
+            address = self._azure_service.network.public_ip_addresses.get(self._resource_group_name, ip_name)
+            LOGGER.info("Provisioned public ip %s (%s) in the %s resource group", address.name,
+                        address.ip_address, self._resource_group_name)
+            self._cache[ip_name] = address
+            addresses.append(address)
+        return addresses
 
     def get(self, name: str = "default", version: str = "IPV4"):
         ip_name = self._get_ip_name(name, version)


### PR DESCRIPTION
Makes provisioning for Azure in parallel by triggering all resources creation,
and then waiting for creation one by one. No threading used.

No API change, nor unit-tests had to be adapted. 
This change saves quite a lot of time, lowers test cost and improves dev experience.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
