### PR TITLE
fix(artifacts): disable fstrim for ubuntu20

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -248,6 +248,9 @@ class ArtifactsTest(ClusterTester):
         mount_options = run("findmnt -no options -t xfs -T /var/lib/scylla").stdout.strip().split(",")
         self.assertIn("discard", mount_options)
 
+        if self.node.distro.is_ubuntu20:
+            run('systemctl is-active -q fstrim.timer && systemctl disable fstrim.timer')
+
         self.log.info("Ensure that we don't run fstrim")
         self.assertEqual(run("systemctl is-enabled fstrim.timer", ignore_status=True).stdout.strip(), "disabled")
 


### PR DESCRIPTION
in ubuntu20 fstrim is enabled by default, and
with the new verification added on 55e885a650fdf490047bf19bcb62679498e65976
the artifacts tests on Ubuntu20 fails in it,
as it is enabled by default in the clean image we
use for this test.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
