### PR TITLE
fix(artifacts_test): do fstrim.timer check only for scylla preinstalled

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -248,8 +248,10 @@ class ArtifactsTest(ClusterTester):
         mount_options = run("findmnt -no options -t xfs -T /var/lib/scylla").stdout.strip().split(",")
         self.assertIn("discard", mount_options)
 
-        self.log.info("Ensure that we don't run fstrim")
-        self.assertEqual(run("systemctl is-enabled fstrim.timer", ignore_status=True).stdout.strip(), "disabled")
+        # we only test this in images created by scylla-machine-image
+        if self.params.get("use_preinstalled_scylla"):
+            self.log.info("Ensure that we don't run fstrim")
+            self.assertEqual(run("systemctl is-enabled fstrim.timer", ignore_status=True).stdout.strip(), "disabled")
 
     def check_service_existence(self, service_name):
         res = self.node.remoter.run(f'systemctl list-units --full | grep -Fq "{service_name}"',


### PR DESCRIPTION
Since we don't care about it on distro we didn't supply as images
we should only check this on our own images

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
