### PR TITLE
feature(azure): reuse provision logic in test

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -201,7 +201,7 @@ def provision_resources(backend, test_name: str, config: str):
     params = create_sct_configuration(test_name=test_name)
     test_config = get_test_config()
     test_id = test_config.test_id()
-    if test_id is None or test_id == "None":
+    if not test_id or test_id == "None":
         raise ValueError("No test_id was provided. Aborting provisioning.")
     localhost = LocalHost(user_prefix=params.get("user_prefix"), test_id=test_config.test_id())
 

--- a/sdcm/cluster_azure.py
+++ b/sdcm/cluster_azure.py
@@ -16,9 +16,10 @@ from functools import cached_property
 from typing import Dict, List
 
 from sdcm import cluster
-from sdcm.keystore import KeyStore
 from sdcm.provision.azure.provisioner import AzureProvisioner
-from sdcm.provision.provisioner import InstanceDefinition, PricingModel, VmInstance
+from sdcm.provision.provisioner import PricingModel, VmInstance
+from sdcm.sct_provision.azure.azure_instance_request_definition_builder import generate_instance_definition
+from sdcm.sct_provision.instances_provider import provision_instances_with_fallback
 from sdcm.utils.decorators import retrying
 
 LOGGER = logging.getLogger(__name__)
@@ -38,14 +39,14 @@ class AzureNode(cluster.BaseNode):
 
     def __init__(self, azure_instance: VmInstance,  # pylint: disable=too-many-arguments
                  credentials, parent_cluster,
-                 node_prefix='node', node_index=1, user_name='root',
+                 node_prefix='node', node_index=1,
                  base_logdir=None, dc_idx=0):
         region = parent_cluster.params.get('azure_region_name')[dc_idx]
         name = f"{node_prefix}-{region}-{node_index}".lower()
         self.node_index = node_index
-        self._instance: VmInstance = azure_instance
+        self._instance = azure_instance
         ssh_login_info = {'hostname': None,
-                          'user': user_name,
+                          'user': azure_instance.user_name,
                           'key_file': credentials.key_file,
                           'extra_ssh_options': '-tt'}
         super().__init__(name=name,
@@ -171,7 +172,6 @@ class AzureCluster(cluster.BaseCluster):   # pylint: disable=too-many-instance-a
             node = AzureNode(azure_instance=instance,
                              credentials=self._credentials[0],
                              parent_cluster=self,
-                             user_name=self._user_name,
                              node_prefix=self.node_prefix,
                              node_index=node_index,
                              base_logdir=self.logdir,
@@ -181,28 +181,17 @@ class AzureCluster(cluster.BaseCluster):   # pylint: disable=too-many-instance-a
         except Exception as ex:
             raise CreateAzureNodeError('Failed to create node: %s' % ex) from ex
 
-    def _create_instances(self, count, dc_idx=0):
+    def _create_instances(self, count, dc_idx=0) -> List[VmInstance]:
         region = self.params.get('azure_region_name')[dc_idx]
         assert region, "no region provided, please add `azure_region_name` param"
         pricing_model = PricingModel.SPOT if 'spot' in self.instance_provision else PricingModel.ON_DEMAND
-        instances = []
+        definitions = []
         for node_index in range(self._node_index + 1, self._node_index + count + 1):
-            instance_definition = InstanceDefinition(
-                name=f"{self._node_prefix}-{region}-{node_index}".lower(),
-                image_id=self._image_id,
-                type=self._instance_type,
-                user_name=self._user_name,
-                tags=self.tags,
-                ssh_public_key=KeyStore().get_gce_ssh_key_pair().public_key.decode()
+            definitions.append(
+                generate_instance_definition(self.params, node_type=self.node_type, region=region, index=node_index)
             )
-            instances.append(self._provision_instance(instance_definition=instance_definition,
-                                                      pricing_model=pricing_model, dc_idx=dc_idx))
-        return instances
-
-    @retrying(n=3, sleep_time=1)
-    def _provision_instance(self, instance_definition: InstanceDefinition, pricing_model: PricingModel, dc_idx: int):
-        return self.provisioners[dc_idx].get_or_create_instance(definition=instance_definition,
-                                                                pricing_model=pricing_model)
+        return provision_instances_with_fallback(self.provisioners[dc_idx], definitions=definitions, pricing_model=pricing_model,
+                                                 fallback_on_demand=self.params.get("instance_provision_fallback_on_demand"))
 
     def get_node_ips_param(self, public_ip=True):
         # todo lukasz: why gce cluster didn't have to implement this?

--- a/sdcm/provision/azure/virtual_machine_provider.py
+++ b/sdcm/provision/azure/virtual_machine_provider.py
@@ -58,7 +58,7 @@ class VirtualMachineProvider:
             LOGGER.info("Instance params: %s", definition)
             params = {
                 "location": self._region,
-                "tags": definition.tags,
+                "tags": definition.tags | {"ssh_user": definition.user_name, "ssh_key": definition.ssh_key.name},
                 "hardware_profile": {
                     "vm_size": definition.type,
                 },
@@ -69,14 +69,14 @@ class VirtualMachineProvider:
                     }],
                 },
             }
-            if definition.user_name is None:
+            if definition.user_name == "specialized":
                 # in case we use specialized image, we don't change things like computer_name, usernames, ssh_keys
                 os_profile = {}
             else:
                 os_profile = self._get_os_profile(computer_name=definition.name,
                                                   admin_username=definition.user_name,
                                                   admin_password=binascii.hexlify(os.urandom(20)).decode(),
-                                                  ssh_public_key=definition.ssh_public_key)
+                                                  ssh_public_key=definition.ssh_key.public_key.decode())
             storage_profile = self._get_scylla_storage_profile(image_id=definition.image_id, name=definition.name,
                                                                disk_size=definition.root_disk_size)
             params.update(os_profile)

--- a/sdcm/provision/provisioner.py
+++ b/sdcm/provision/provisioner.py
@@ -14,7 +14,9 @@
 from abc import ABC
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List, Dict, Optional
+from typing import List, Dict
+
+from sdcm.keystore import SSHKey
 
 
 class VmArch(Enum):
@@ -34,12 +36,12 @@ class InstanceDefinition:  # pylint: disable=too-many-instance-attributes
     name: str
     image_id: str
     type: str   # instance_type from yaml
-    user_name: Optional[str] = None
-    ssh_public_key: Optional[str] = field(default=None, repr=False)
+    user_name: str
+    ssh_key: SSHKey = field(repr=False)
     tags: Dict[str, str] = field(default_factory=dict)
     arch: VmArch = VmArch.X86
-    root_disk_size: Optional[int] = None
-    data_disks: Optional[List[DataDisk]] = None
+    root_disk_size: int | None = None
+    data_disks: List[DataDisk] | None = None
 
 
 class ProvisionError(Exception):
@@ -62,6 +64,7 @@ class VmInstance:  # pylint: disable=too-many-instance-attributes
     name: str
     region: str
     user_name: str
+    ssh_key_name: str
     public_ip_address: str
     private_ip_address: str
     tags: Dict[str, str]

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1500,7 +1500,13 @@ class SCTConfiguration(dict):
                 self.log.debug("Found GCE image %s for scylla_version='%s'", gce_image.name, scylla_version)
                 self["gce_image_db"] = gce_image.extra["selfLink"]
             elif not self.get("azure_image_db") and self.get("cluster_backend") == "azure":
-                self["azure_image_db"] = get_scylla_images(scylla_version, self.get('azure_region_name'))[0].id
+                scylla_azure_images = []
+                for region in self.get('azure_region_name'):
+                    azure_image = get_scylla_images(scylla_version, region)[0]
+                    self.log.debug("Found AMI %s for scylla_version='%s' in %s",
+                                   azure_image.name, scylla_version, region)
+                    scylla_azure_images.append(azure_image)
+                self["azure_image_db"] = " ".join(image.id for image in scylla_azure_images)
             elif not self.get('scylla_repo'):
                 self['scylla_repo'] = find_scylla_repo(scylla_version, dist_type, dist_version)
             else:

--- a/sdcm/sct_provision/azure/azure_instance_request_definition_builder.py
+++ b/sdcm/sct_provision/azure/azure_instance_request_definition_builder.py
@@ -11,13 +11,13 @@
 #
 # Copyright (c) 2022 ScyllaDB
 from dataclasses import dataclass
-from typing import List, Literal, Dict
+from typing import List, Dict
 
 from sdcm.cluster import DEFAULT_USER_PREFIX
 from sdcm.keystore import KeyStore
 from sdcm.provision.provisioner import InstanceDefinition
 from sdcm.sct_config import SCTConfiguration
-from sdcm.sct_provision.instances_request_definition_builder import InstancesRequest
+from sdcm.sct_provision.instances_request_definition_builder import InstancesRequest, NodeTypeType
 from sdcm.test_config import TestConfig
 
 
@@ -45,7 +45,7 @@ monitor_map = ConfigParamsMap(image_id="azure_image_monitor",
                               user_name="ami_monitor_user",
                               root_disk_size="azure_root_disk_size_monitor")
 
-mappers: Dict[str, ConfigParamsMap] = {"db": db_map,
+mappers: Dict[str, ConfigParamsMap] = {"scylla-db": db_map,
                                        "loader": loader_map,
                                        "monitor": monitor_map}
 
@@ -60,25 +60,27 @@ def get_node_count_for_each_region(sct_config: SCTConfiguration, n_str: str) -> 
     return ([int(v) for v in str(n_str).split()] + [0] * region_count)[:region_count]
 
 
-def generate_instance_definition_params(sct_config: SCTConfiguration, node_type: Literal["db", "loader", "monitor"], region: str,
-                                        index: int) -> Dict[str, str]:
+def generate_instance_definition(sct_config: SCTConfiguration,
+                                 node_type: NodeTypeType, region: str,
+                                 index: int) -> InstanceDefinition:
     """Generates parameters for InstanceDefinition based on node_type and SCT Configuration."""
     user_prefix = sct_config.get('user_prefix') or DEFAULT_USER_PREFIX
     common_tags = TestConfig.common_tags()
-    name = f"{user_prefix}-{node_type}-node-{region}-{index}".lower()
-    action = sct_config.get(f"post_behavior_{node_type}_nodes")
+    node_type_short = "db" if "db" in node_type else node_type
+    name = f"{user_prefix}-{node_type_short}-node-{region}-{index}".lower()
+    action = sct_config.get(f"post_behavior_{node_type_short}_nodes")
     tags = common_tags | {"NodeType": node_type,
-                          "keep_action": "terminate" if action == "destroy" else ""}
-    ssh_public_key = KeyStore().get_gce_ssh_key_pair().public_key.decode()
+                          "keep_action": "terminate" if action == "destroy" else "",
+                          "NodeIndex": str(index)}
+    ssh_key = KeyStore().get_gce_ssh_key_pair()
     mapper = mappers[node_type]
-    params = {"name": name,
-              "image_id": sct_config.get(mapper.image_id),
-              "type": sct_config.get(mapper.type),
-              "user_name": sct_config.get(mapper.user_name),
-              "root_disk_size": sct_config.get(mapper.root_disk_size),
-              "tags": tags,
-              "ssh_public_key": ssh_public_key}
-    return params
+    return InstanceDefinition(name=name,
+                              image_id=sct_config.get(mapper.image_id),
+                              type=sct_config.get(mapper.type),
+                              user_name=sct_config.get(mapper.user_name),
+                              root_disk_size=sct_config.get(mapper.root_disk_size),
+                              tags=tags,
+                              ssh_key=ssh_key)
 
 
 def azure_instance_request_builder(sct_config: SCTConfiguration) -> List[InstancesRequest]:
@@ -90,20 +92,23 @@ def azure_instance_request_builder(sct_config: SCTConfiguration) -> List[Instanc
 
     for region, db_nodes, loader_nodes, monitor_nodes in zip(
             sct_config.get("azure_region_name"), n_db_nodes, n_loader_nodes, n_monitor_nodes):
-        params_list = []
+        definitions = []
         for idx in range(db_nodes):
-            params_list.append(generate_instance_definition_params(
-                sct_config=sct_config, node_type="db", region=region, index=idx+1))
+            definitions.append(
+                generate_instance_definition(sct_config=sct_config, node_type="scylla-db", region=region, index=idx+1)
+            )
 
         for idx in range(loader_nodes):
-            params_list.append(generate_instance_definition_params(
-                sct_config=sct_config, node_type="loader", region=region, index=idx+1))
+            definitions.append(
+                generate_instance_definition(sct_config=sct_config, node_type="loader", region=region, index=idx+1)
+            )
 
         for idx in range(monitor_nodes):
-            params_list.append(generate_instance_definition_params(
-                sct_config=sct_config, node_type="monitor", region=region, index=idx+1))
+            definitions.append(
+                generate_instance_definition(sct_config=sct_config, node_type="monitor", region=region, index=idx+1)
+            )
 
-        definitions = [InstanceDefinition(**params) for params in params_list]
-        requests.append(InstancesRequest(backend="azure", test_id=sct_config.get(
-            "test_id"), region=region, definitions=definitions))
+        requests.append(
+            InstancesRequest(backend="azure", test_id=sct_config.get("test_id"), region=region, definitions=definitions)
+        )
     return requests

--- a/sdcm/sct_provision/instances_request_definition_builder.py
+++ b/sdcm/sct_provision/instances_request_definition_builder.py
@@ -12,10 +12,13 @@
 # Copyright (c) 2022 ScyllaDB
 
 from dataclasses import dataclass
-from typing import Callable, List
+from typing import Callable, List, Literal
 
 from sdcm.provision.provisioner import InstanceDefinition
 from sdcm.sct_config import SCTConfiguration
+
+
+NodeTypeType = Literal["scylla-db", "loader", "monitor"]
 
 
 @dataclass

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -819,8 +819,8 @@ class AzureSctRunner(SctRunner):
             vm_params = InstanceDefinition(name=instance_name,
                                            image_id=base_image["id"],
                                            type=instance_type,
-                                           user_name=None,
-                                           ssh_public_key=None,
+                                           user_name="specialized",
+                                           ssh_key=self.key_pair,
                                            tags=tags | {"launch_time": get_current_datetime_formatted()},
                                            root_disk_size=self.instance_root_disk_size(test_duration=test_duration))
             return provisioner.get_or_create_instance(definition=vm_params,

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -23,6 +23,7 @@ from sdcm.cluster import BaseNode
 from sdcm.prometheus import start_metrics_server
 from sdcm.utils.docker_remote import RemoteDocker
 
+
 from unit_tests.dummy_remote import LocalNode, LocalScyllaClusterDummy
 
 from unit_tests.lib.events_utils import EventsUtilsMixin

--- a/unit_tests/provisioner/fake_azure_service.py
+++ b/unit_tests/provisioner/fake_azure_service.py
@@ -435,11 +435,11 @@ class FakeVirtualMachines:
 
     def begin_create_or_update(self, resource_group_name: str, vm_name: str, parameters: Dict[str, Any]
                                ) -> WaitableObject:
+        tags = parameters.pop("tags") if "tags" in parameters else {}
         parameters = dict_keys_to_camel_case(parameters)
         location = parameters.pop("location")
-        tags = parameters.pop("tags")
         priority = parameters.get("priority") or ""
-        if tags.get("JenkinsJobTag") == "FailSpotDB" and priority.lower() == "spot" and tags.get("NodeType") == "db":
+        if tags.get("JenkinsJobTag") == "FailSpotDB" and priority.lower() == "spot" and tags.get("NodeType") == "scylla-db":
             # for testing fallback on demand
             raise AzureError("Failing creating db spot instance because JenkinsJobTag is FailSpotDB")
 

--- a/unit_tests/provisioner/test_azure_instance_request_builder.py
+++ b/unit_tests/provisioner/test_azure_instance_request_builder.py
@@ -43,18 +43,19 @@ def test_can_create_basic_scylla_instance_definition_from_sct_config():
     os.environ.update(env_config._asdict())
     config = SCTConfiguration()
     tags = TestConfig.common_tags()
-    ssh_public_key = KeyStore().get_gce_ssh_key_pair().public_key.decode()
+    ssh_key = KeyStore().get_gce_ssh_key_pair()
     prefix = config.get('user_prefix')
     instance_requests = instances_request_builder.build(sct_config=config)
 
     definition = InstanceDefinition(name=f"{prefix}-db-node-eastus-1", image_id=env_config.SCT_AZURE_IMAGE_DB,
                                     type="Standard_L8s_v2", user_name="scyllaadm", root_disk_size=30,
-                                    tags=tags | {"NodeType": "db", "keep_action": ""},
-                                    ssh_public_key=ssh_public_key)
+                                    tags=tags | {"NodeType": "scylla-db", "keep_action": "", 'NodeIndex': '1'},
+                                    ssh_key=ssh_key)
     assert len(instance_requests) == 2
     actual_request = instance_requests[0]
+
     assert actual_request.test_id == env_config.SCT_TEST_ID
     assert actual_request.backend == "azure"
     assert actual_request.region == "eastus"
-    assert actual_request.definitions[0] == definition  # remember ssh_public_key is not shown
-    # - if actual looks the same as expected possibly ssh_public_key differ
+    # ssh_key is not shown, if actual looks the same as expected possibly ssh_key differ
+    assert definition == actual_request.definitions[0]

--- a/unit_tests/provisioner/test_azure_provisioner.py
+++ b/unit_tests/provisioner/test_azure_provisioner.py
@@ -41,7 +41,7 @@ class TestProvisionScyllaInstanceAzureE2E:
             image_id=image_id,
             type="Standard_D2s_v3",
             user_name="tester",
-            ssh_public_key=KeyStore().get_ec2_ssh_key_pair().public_key.decode(),
+            ssh_key=KeyStore().get_ec2_ssh_key_pair(),
             tags={'test-tag': 'test_value'}
         )
 

--- a/unit_tests/provisioner/test_provision_sct_resources.py
+++ b/unit_tests/provisioner/test_provision_sct_resources.py
@@ -23,7 +23,7 @@ def test_can_provision_instances_according_to_sct_configuration(sct_config, azur
     provisioner_eastus = provisioner_factory.create_provisioner(
         backend="azure", test_id=sct_config.get("test_id"), region="eastus", azure_service=azure_service)
     eastus_instances = provisioner_eastus.list_instances()
-    db_nodes = [node for node in eastus_instances if node.tags['NodeType'] == "db"]
+    db_nodes = [node for node in eastus_instances if node.tags['NodeType'] == "scylla-db"]
     loader_nodes = [node for node in eastus_instances if node.tags['NodeType'] == "loader"]
     monitor_nodes = [node for node in eastus_instances if node.tags['NodeType'] == "monitor"]
 
@@ -32,13 +32,13 @@ def test_can_provision_instances_according_to_sct_configuration(sct_config, azur
     assert len(monitor_nodes) == 1
     db_node = db_nodes[0]
     assert db_node.region == "eastus"
-    assert list(db_node.tags.keys()) == list(tags.keys()) + ["NodeType", "keepAction"]
+    assert list(db_node.tags.keys()) == list(tags.keys()) + ["NodeType", "keep_action", "NodeIndex"]
     assert db_node.pricing_model == PricingModel.SPOT
 
     provisioner_easteu = provisioner_factory.create_provisioner(backend="azure", test_id=sct_config.get("test_id"),
                                                                 region="easteu", azure_service=azure_service)
     easteu_instances = provisioner_easteu.list_instances()
-    db_nodes = [node for node in easteu_instances if node.tags['NodeType'] == "db"]
+    db_nodes = [node for node in easteu_instances if node.tags['NodeType'] == "scylla-db"]
     loader_nodes = [node for node in easteu_instances if node.tags['NodeType'] == "loader"]
     monitor_nodes = [node for node in easteu_instances if node.tags['NodeType'] == "monitor"]
 
@@ -47,7 +47,7 @@ def test_can_provision_instances_according_to_sct_configuration(sct_config, azur
     assert len(monitor_nodes) == 0
     db_node = db_nodes[0]
     assert db_node.region == "easteu"
-    assert list(db_node.tags.keys()) == list(tags.keys()) + ["NodeType", "keepAction"]
+    assert list(db_node.tags.keys()) == list(tags.keys()) + ["NodeType", "keep_action", "NodeIndex"]
     assert db_node.pricing_model == PricingModel.SPOT
 
 
@@ -57,7 +57,7 @@ def test_fallback_on_demand_when_spot_fails(fallback_on_demand, sct_config, azur
     provisioner_eastus = provisioner_factory.create_provisioner(
         backend="azure", test_id=sct_config.get("test_id"), region="eastus", azure_service=azure_service)
     eastus_instances = provisioner_eastus.list_instances()
-    db_nodes = [node for node in eastus_instances if node.tags['NodeType'] == "db"]
+    db_nodes = [node for node in eastus_instances if node.tags['NodeType'] == "scylla-db"]
     loader_nodes = [node for node in eastus_instances if node.tags['NodeType'] == "loader"]
     monitor_nodes = [node for node in eastus_instances if node.tags['NodeType'] == "monitor"]
 


### PR DESCRIPTION
Currently we had separate logic for provisioning step in jenkins
and for provisioning during sct test execution (e.g. adding new nodes).

This commit reuses logic from provisioning stage so there's no
duplication. It also refactors for better clarity of code.

Most notable changes:
- reuse provision logic during test
- keep ssh credentials info in tags so VmInstance has full ssh info
- prepare for multi-dc scenarios (not tested)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
