### PR TITLE
fix(k8s): skip some K8S functional tests if scylla is not semver-like

### DIFF
--- a/functional_tests/scylla_operator/pytest.ini
+++ b/functional_tests/scylla_operator/pytest.ini
@@ -3,3 +3,4 @@ markers =
     requires_node_termination_support: test gets skipped if backend doesn't support specified K8S node termination method
     requires_mgmt: test requires scylla manager to exist, set "use_mgmt: true" to enable it
     readonly: test that does not make any changes to cluster, only reads. Useful for running fast subset of tests
+    restart_is_used: used for skipping tests which suffer from https://github.com/scylladb/scylla/issues/9543

--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -72,6 +72,7 @@ def test_single_operator_image_tag_is_everywhere(db_cluster):
         f"Pods: {yaml.safe_dump(pods_with_wrong_image_tags, indent=2)}")
 
 
+@pytest.mark.restart_is_used
 @pytest.mark.skip("Disabled due to the https://github.com/scylladb/scylla-operator/issues/797")
 def test_cassandra_rackdc(db_cluster, cassandra_rackdc_properties):
     """
@@ -120,6 +121,7 @@ def test_cassandra_rackdc(db_cluster, cassandra_rackdc_properties):
         assert config_map_props == props
 
 
+@pytest.mark.restart_is_used
 def test_rolling_restart_cluster(db_cluster):
     old_force_redeployment_reason = db_cluster.get_scylla_cluster_value("/spec/forceRedeploymentReason")
     db_cluster.restart_scylla()
@@ -245,6 +247,7 @@ def test_listen_address(db_cluster):
     assert not all_errors, "Following errors found:\n{'\n'.join(errors)}"
 
 
+@pytest.mark.restart_is_used
 def test_check_operator_operability_when_scylla_crd_is_incorrect(db_cluster):
     """Covers https://github.com/scylladb/scylla-operator/issues/447"""
 
@@ -537,6 +540,7 @@ def test_deploy_helm_with_default_values(db_cluster: ScyllaPodCluster):
         db_cluster.k8s_cluster.kubectl(f"delete namespace {namespace}")
 
 
+@pytest.mark.restart_is_used
 def test_scylla_yaml_override(db_cluster, scylla_yaml):  # pylint: disable=too-many-branches
     """
     Test of applying scylla.yaml via configmap

--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -43,6 +43,29 @@ from sdcm.utils.decorators import retrying
 GEMINI_VERSION_RE = re.compile(r'\s(?P<gemini_version>([\d]+\.[\d]+\.[\d]+)?),')
 REPO_VERSIONS_REGEX = re.compile(r'Version: (.*?)\n', re.DOTALL)
 
+# NOTE: following regex is taken from the 'semver' package as is:
+#       https://python-semver.readthedocs.io/en/2.10.0/readme.html
+SEMVER_REGEX = re.compile(
+    r"""
+        ^
+        (?P<major>0|[1-9]\d*)
+        \.
+        (?P<minor>0|[1-9]\d*)
+        \.
+        (?P<patch>0|[1-9]\d*)
+        (?:-(?P<prerelease>
+            (?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)
+            (?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*
+        ))?
+        (?:\+(?P<build>
+            [0-9a-zA-Z-]+
+            (?:\.[0-9a-zA-Z-]+)*
+        ))?
+        $
+    """,
+    re.VERBOSE,
+)
+
 SCYLLA_VERSION_RE = re.compile(r"\d+(\.\d+)?\.[\d\w]+([.~][\d\w]+)?")
 SSTABLE_FORMAT_VERSION_REGEX = re.compile(r'Feature (.*)_SSTABLE_FORMAT is enabled')
 PRIMARY_XML_GZ_REGEX = re.compile(r'="(.*?primary.xml.gz)"')


### PR DESCRIPTION
There is open bug in Scylla [1] which blocks several actions with
Scylla pods deployed by Scylla-operator. Such actions are 'upgrade'
and 'force-restart'.
So, detect situation that reproduces [1] and skip tests affected by it.

[1] https://github.com/scylladb/scylla/issues/9543

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
