### PR TITLE
fix(k8s-mgmt): make backup work using mgmt-3.0

### DIFF
--- a/sdcm/mgmt/operator.py
+++ b/sdcm/mgmt/operator.py
@@ -229,7 +229,7 @@ class OperatorManagerCluster(ManagerCluster):
 
         if name is None:
             name = self._pick_original_name(
-                'Default backup task name', [so_task.name for so_task in self.operator_backup_tasks])
+                'default-backup-task-name', [so_task.name for so_task in self.operator_backup_tasks])
 
         so_backup_task = ScyllaOperatorBackupTask(
             name=name,


### PR DESCRIPTION
We should not have spaces in the name of backup to avoid following
errors:

    $ sctool -c %uuid% progress backup/Default backup task name
    Error: accepts 1 arg(s), received 4

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
