### PR TITLE
fix(k8s): skip functional tests which use mgmt 2.6.3

### DIFF
--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -172,6 +172,7 @@ def test_drain_terminate_decommission_add_node_kubernetes(db_cluster):
 
 
 # NOTE: Scylla manager versions notes:
+#       - '2.6.3' is broken: https://github.com/scylladb/scylla-manager/issues/3156
 #       - '2.5.4' is broken: https://github.com/scylladb/scylla-manager/issues/3147
 #       - '2.5.3' is broken: https://github.com/scylladb/scylla-manager/issues/3150
 #       - '2.5.2' is broken: https://github.com/scylladb/scylla-manager/issues/3150
@@ -184,6 +185,8 @@ def test_drain_terminate_decommission_add_node_kubernetes(db_cluster):
     "3.0-dev-0.20220508.3847b8ff7f0",
 ))
 def test_mgmt_repair(db_cluster, manager_version):
+    if manager_version == "2.6.3":
+        raise pytest.skip("Disabled due to the https://github.com/scylladb/scylla-manager/issues/3156")
     reinstall_scylla_manager(db_cluster, manager_version)
 
     # Run manager repair operation
@@ -196,6 +199,7 @@ def test_mgmt_repair(db_cluster, manager_version):
 
 
 # NOTE: Scylla manager versions notes:
+#       - '2.6.3' is broken: https://github.com/scylladb/scylla-manager/issues/3156
 #       - '2.5.4' is broken: https://github.com/scylladb/scylla-manager/issues/3147
 #       - '2.5.3' is broken: https://github.com/scylladb/scylla-manager/issues/3150
 #       - '2.5.2' is broken: https://github.com/scylladb/scylla-manager/issues/3150
@@ -208,6 +212,8 @@ def test_mgmt_repair(db_cluster, manager_version):
     "2.6.3",
 ))
 def test_mgmt_backup(db_cluster, manager_version):
+    if manager_version == "2.6.3":
+        raise pytest.skip("Disabled due to the https://github.com/scylladb/scylla-manager/issues/3156")
     reinstall_scylla_manager(db_cluster, manager_version)
 
     # Run manager backup operation


### PR DESCRIPTION
The reason for skip is the following bug:

https://github.com/scylladb/scylla-manager/issues/3156

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
