### PR TITLE
fix(sct.py): default for arch values

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -482,7 +482,10 @@ def list_resources(ctx, user, test_id, get_all, get_all_running, verbose):
               type=CloudRegion(cloud_provider="aws"),
               default='eu-west-1',
               help="a region to look for AMIs (default: eu-west-1)")
-@click.option('-a', '--arch', type=click.Choice(['x86_64', 'arm64']))
+@click.option('-a', '--arch',
+              type=click.Choice(AwsArchType.__args__),
+              default='x86_64',
+              help="architecture of the AMI (default: x86_64)")
 def list_ami_versions(region: str, arch: AwsArchType):
     add_file_logger()
 
@@ -498,7 +501,10 @@ def list_ami_versions(region: str, arch: AwsArchType):
               type=CloudRegion(cloud_provider="aws"),
               default='eu-west-1',
               help="a region to look for AMIs (default: eu-west-1)")
-@click.option('-a', '--arch', type=click.Choice(['x86_64', 'arm64']))
+@click.option('-a', '--arch',
+              type=click.Choice(AwsArchType.__args__),
+              default='x86_64',
+              help="architecture of the AMI (default: x86_64)")
 @click.argument('version', type=str, default='branch-3.1:all')
 def list_ami_branch(region: str, arch: AwsArchType, version: str):
     add_file_logger()


### PR DESCRIPTION
since in #4729 no default values defined.
the following error raise when no `arch` was define in
the commandline:
```
Invalid type for parameter Filters[1].Values[0], value:
None, type: <class 'NoneType'>, valid types: <class 'str'>
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
