### PR TITLE
fix(gce availability zones): Remove zone 'b' from us-east1 list

### DIFF
--- a/sdcm/utils/gce_utils.py
+++ b/sdcm/utils/gce_utils.py
@@ -32,8 +32,8 @@ GceDriver = get_driver(Provider.GCE)  # pylint: disable=invalid-name
 # The keys are the region name, the value is the available zones, which will be used for random.choice()
 SUPPORTED_REGIONS = {
     # us-east1 zones: b, c, and d. Details: https://cloud.google.com/compute/docs/regions-zones#locations
-    # choose zones c and d twice as often as zone b
-    'us-east1': 'bccdd',
+    # Currently choose only zones c and d as zone b frequently fails allocating resources.
+    'us-east1': 'cd',
     'us-west1': 'abc'}
 
 


### PR DESCRIPTION
	Since zone 'b' frequently fails allocating resources.

Example failure of zone `b`:
2022-05-10 09:15:14.905: (TestFrameworkEvent Severity.ERROR) period_type=one-time event_id=1f8ebacd-aed1-4a17-a8cf-6af3622c1723, source=ArtifactsTest.SetUp()
exception="The zone 'projects/skilled-adapter-452/zones/us-east1-b' does not have enough resources available to fulfill the request.  '(resource type:compute)'."

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
