### PR TITLE
fix(web installation): if `is_enterprise` code is missing param

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -99,7 +99,7 @@ from sdcm.utils.health_checker import check_nodes_status, check_node_status_in_g
 from sdcm.utils.decorators import NoValue, retrying, log_run_info, optional_cached_property
 from sdcm.utils.remotewebbrowser import WebDriverContainerMixin
 from sdcm.test_config import TestConfig
-from sdcm.utils.version_utils import SCYLLA_VERSION_RE, get_gemini_version, get_systemd_version
+from sdcm.utils.version_utils import SCYLLA_VERSION_RE, get_gemini_version, get_systemd_version, assume_version
 from sdcm.sct_events import Severity
 from sdcm.sct_events.base import LogEvent
 from sdcm.sct_events.health import ClusterHealthValidatorEvent
@@ -2104,20 +2104,10 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
         https://github.com/scylladb/scylla-web-install
         """
-
-        # Try to get the major version from the branch name, it will only be used when scylla_version isn't assigned.
-        # It can be switched to RELEASE_BRANCH from upstream job
-        git_branch = os.environ.get('GIT_BRANCH')  # origin/branch-4.5
-        self.log.debug("scylla_version: %s, git_branch: %s", scylla_version, git_branch)
-
-        if match := re.match(r'\D*(\d+\.\d+)', scylla_version or git_branch):
-            version = f"nightly-{match.group(1)}"
-        elif git_branch and 'master' in git_branch:
-            version = "nightly-master"
-        else:
-            raise Exception("Scylla version for web install isn't identified")
-
-        self.remoter.run(f"curl -sSf get.scylladb.com/server | sudo bash -s -- --scylla-version {version}")
+        is_enterprise, version = assume_version(self.parent_cluster.params, scylla_version)
+        product_type = '--scylla-product scylla-enterprise' if is_enterprise else ''
+        self.remoter.run(
+            f"curl -sSf get.scylladb.com/server | sudo bash -s -- --scylla-version {version} {product_type}")
 
     def install_scylla_debuginfo(self) -> None:
         if self.distro.is_rhel_like:


### PR DESCRIPTION
seems like we must pass an extra param to the
web-installation jobs, when it is enterprise.
Fixes: https://github.com/scylladb/scylla-web-install/issues/32

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
