### PR TITLE
fix(cluster_docker): wrong path to build context

### DIFF
--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -201,7 +201,9 @@ class DockerCluster(cluster.BaseCluster):  # pylint: disable=abstract-method
 
     @property
     def node_container_context_path(self):
-        return os.path.join(os.path.dirname(__file__), '../docker/scylla-sct', self.params.get("scylla_linux_distro"))
+        # scylla_linux_distro can be: centos or ubuntu-focal, hence we need to split it
+        return os.path.join(os.path.dirname(__file__), '../docker/scylla-sct',
+                            self.params.get("scylla_linux_distro").split('-')[0])
 
     def _create_node(self, node_index, container=None):
         node = DockerNode(parent_cluster=self,

--- a/sdcm/utils/distro.py
+++ b/sdcm/utils/distro.py
@@ -43,6 +43,7 @@ class Distro(enum.Enum):
     UBUNTU18 = ("ubuntu", "18.04")
     UBUNTU20 = ("ubuntu", "20.04")
     UBUNTU21 = ("ubuntu", "21.04")
+    UBUNTU21_10 = ("ubuntu", "21.10")
     SLES15 = ("sles", "15")
 
     @classmethod
@@ -148,6 +149,10 @@ class Distro(enum.Enum):
     @property
     def is_ubuntu20(self):
         return self == self.UBUNTU20
+
+    @property
+    def is_ubuntu21(self):
+        return self in (self.UBUNTU21, self.UBUNTU21_10)
 
     @property
     def is_ubuntu(self):


### PR DESCRIPTION
since build context path was base on `scylla_linux_distro`
which can be: `centos` or `ubuntu-focal`, hence we need to split it.

default `scylla_linux_distro` was changed `ubuntu-focal`
and since then the docker backend was failing like this:

```
TypeError: You must specify a directory to build in path
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
