### PR TITLE
fix(k8s_functional): add support for reporting skipped tests

### DIFF
--- a/functional_tests/scylla_operator/libs/auxiliary.py
+++ b/functional_tests/scylla_operator/libs/auxiliary.py
@@ -43,7 +43,7 @@ class ScyllaOperatorFunctionalClusterTester(ClusterTester):
 
     def get_test_status(self):
         for _, test_data in self.test_data.items():
-            if test_data[0] != 'SUCCESS':
+            if not test_data[0] in ('SUCCESS', 'SKIPPED'):
                 return 'FAILED'
         return 'SUCCESS'
 

--- a/sdcm/report_templates/results_functional.html
+++ b/sdcm/report_templates/results_functional.html
@@ -25,6 +25,8 @@
             <li> {{ test_name }} -
                 {% if test_data[0] == "SUCCESS" %}
                     <span class='green'>{{ test_data[0] }}</span>
+                {% elif test_data[0] == "SKIPPED" %}
+                    <span class='orange'>{{ test_data[0] }}</span> : {{test_data[1]}}
                 {% else %}
                     {{ errors.append((test_name, test_data[1])) or '' }}
                     <span class='red'>{{ test_data[0] }}</span>


### PR DESCRIPTION
skipped test were reported as errors and failed the whole job

* needed to add a global tester object, since when skipping a
  test by `pytest.mark.skip` no fixtures are called to collect
  this test report, and we need to report stright to the test
  object inside the hook, and not as done before inside the a
  fixture

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
