### PR TITLE
fix(add-remove-dc): make verification c-s run on one loader

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3226,7 +3226,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                     f"replication(strategy=NetworkTopologyStrategy,{datacenters[0]}=3,{datacenters[1]}=1) " \
                     f"compression=LZ4Compressor compaction(strategy=SizeTieredCompactionStrategy)' " \
                     f"-mode cql3 native compression=lz4 -rate threads=5 -pop seq=1..10000 -log interval=5"
-        write_thread = self.tester.run_stress_thread(stress_cmd=write_cmd, use_single_loader=True)
+        write_thread = self.tester.run_stress_thread(stress_cmd=write_cmd, round_robin=True, stop_test_on_failure=False)
         self.tester.verify_stress_thread(cs_thread_pool=write_thread)
         self._verify_multi_dc_keyspace_data(consistency_level="ALL")
 
@@ -3234,7 +3234,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         read_cmd = f"cassandra-stress read no-warmup cl={consistency_level} n=10000 -schema 'keyspace=keyspace_new_dc " \
                    f"compression=LZ4Compressor' -mode cql3 native compression=lz4 -rate threads=5 " \
                    f"-pop seq=1..10000 -log interval=5"
-        read_thread = self.tester.run_stress_thread(stress_cmd=read_cmd, use_single_loader=True)
+        read_thread = self.tester.run_stress_thread(stress_cmd=read_cmd, round_robin=True, stop_test_on_failure=False)
         self.tester.verify_stress_thread(cs_thread_pool=read_thread)
 
     def _switch_to_network_replication_strategy(self, keyspaces: List[str]) -> None:


### PR DESCRIPTION
Verification load for add-remove-dc nemesis was intended to be run on
one loader only. With current setup, it was executed on all loaders and
sometimes it happens that 2 loaders start load in almost exact time.

This possibly was causing this nemesis to fail.

Fix makes verification load to happen only on one loader and also
prevents failing whole test due any error with it.

https://trello.com/c/ejIOTBBe

should fix: https://github.com/scylladb/scylla-cluster-tests/issues/4668

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
