### PR TITLE
fix(k8s): make "reuse_cluster" work again

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2088,6 +2088,10 @@ class PodCluster(cluster.BaseCluster):
         )
 
     def generate_namespace(self, namespace_template: str) -> str:
+        # TODO: make it work correctly for case with reusage of multi-tenant cluster
+        if self.k8s_cluster.tenants_number < 2:
+            return namespace_template
+
         # Pick up not used namespace knowing that we may have more than 1 Scylla cluster
         with NAMESPACE_CREATION_LOCK:
             namespaces = self.k8s_cluster.kubectl(


### PR DESCRIPTION
Addition of the multi-tenant support broke the possibility to reuse
existing K8S cluster.
It was broken the way that it tried to create new namespace `scylla-2`
instead of reusing existing `scylla` one as expected.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
