### PR TITLE
improvement(k8s-local): retag non-semver scylla versions as semver-like

### DIFF
--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -414,6 +414,18 @@ def resolve_latest_repo_symlink(url: str) -> str:
     return resolved_url
 
 
+def transform_non_semver_scylla_version_to_semver(scylla_version: str):
+    # NOTE: as of May 2022 all the non-GA versions of Scylla are not semver-like and it is problem
+    #       for the scylla-operator.
+    if SEMVER_REGEX.match(scylla_version):
+        return scylla_version
+    version_parts = scylla_version.split(".")
+    new_scylla_version = f"{version_parts[0]}.{version_parts[1]}.0-{'.'.join(version_parts[2:])}"
+    if SEMVER_REGEX.match(new_scylla_version):
+        return new_scylla_version
+    raise ValueError("Cannot transform '%s' to semver-like string" % scylla_version)
+
+
 def get_git_tag_from_helm_chart_version(chart_version: str) -> str:
     """Utility function used to parse out the git tag from a Helm chart version
 


### PR DESCRIPTION
Do it as a workaround for the following bug:

    https://github.com/scylladb/scylla/issues/9543

To unblock bunch of K8S functional tests.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
