### PR TITLE
fix(Tombstone GC-mode): The CQL statement filtering is fixed

### DIFF
--- a/test_lib/compaction.py
+++ b/test_lib/compaction.py
@@ -42,7 +42,7 @@ def get_gc_mode(node: BaseNode, keyspace: str, table: str) -> str | GcMode:
         table
     """
     table_gc_mode_result = node.run_cqlsh(
-        f'SELECT extensions FROM system_schema.tables where keyspace_name = {keyspace} and table_name = {table}',
+        f"SELECT extensions FROM system_schema.tables where keyspace_name = '{keyspace}' and table_name = '{table}'",
         split=True)
     LOGGER.debug("Query result for %s.%s GC mode is: %s", keyspace, table, table_gc_mode_result)
     gc_mode = 'N/A'


### PR DESCRIPTION
	Had missing quotation marks for the keyspace and table names.
	Fixes: #4747

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
