### PR TITLE
fix(docker_backend): pre-install syslog-ng

### DIFF
--- a/docker/scylla-sct/centos/Dockerfile
+++ b/docker/scylla-sct/centos/Dockerfile
@@ -16,6 +16,7 @@ RUN yum -y install \
         iproute \
         sudo \
         collectd \
+        syslog-ng \
         rsync && \
     yum clean all && \
     echo $'[program:collectd]\n\

--- a/docker/scylla-sct/ubuntu/Dockerfile
+++ b/docker/scylla-sct/ubuntu/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && \
     apt install -y \
         iproute2 \
         collectd \
+        syslog-ng \
         rsync && \
     rm -rf /var/lib/apt/lists/* && \
     echo $'[program:collectd]\n\


### PR DESCRIPTION
since we are now defaulting to syslog-ng, it's quicker and
less error prune to install it at the Dockerfile we have
for docker backend

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
