### PR TITLE
fix(ldap-init): do not run ldap code if ldap is disabled

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -662,17 +662,23 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             else:
                 self.init_nodes(db_cluster=db_cluster)
 
-            with temp_authenticator(db_cluster.nodes[0], "org.apache.cassandra.auth.PasswordAuthenticator"):
-                # running `set_system_auth_rf()` before changing authorization/authentication protocols
-                self.set_system_auth_rf(db_cluster=db_cluster)
-                if self.params.get('use_ldap'):
+            if self.params.get('use_ldap'):
+                with temp_authenticator(db_cluster.nodes[0], "org.apache.cassandra.auth.PasswordAuthenticator"):
+                    # running `set_system_auth_rf()` before changing authorization/authentication protocols
+                    self.set_system_auth_rf(db_cluster=db_cluster)
+
                     self._setup_ldap_roles(db_cluster=db_cluster)
-                if self.params.get('ldap_server_type') == LdapServerType.MS_AD:
-                    change_default_password(node=db_cluster.nodes[0],
-                                            user=self.params.get('authenticator_user'),
-                                            password=self.params.get('authenticator_password'))
-                    self.loaders.added_password_suffix = True
-                    self.monitors.added_password_suffix = True  # FIXME: Replace with strong password generation.
+                    if self.params.get('ldap_server_type') == LdapServerType.MS_AD:
+                        change_default_password(node=db_cluster.nodes[0],
+                                                user=self.params.get('authenticator_user'),
+                                                password=self.params.get('authenticator_password'))
+                        # TODO: update proper loader and monitor in multi-tenant case.
+                        #       Now it updates only the first ones all the time.
+                        self.loaders.added_password_suffix = True
+                        # TODO: Replace with strong password generation
+                        self.monitors.added_password_suffix = True
+            else:
+                self.set_system_auth_rf(db_cluster=db_cluster)
 
             db_node_address = db_cluster.nodes[0].ip_address
             if self.loaders and not self.loaders_multitenant:


### PR DESCRIPTION
Recently merged refactor of the LDAP init (https://github.com/scylladb/scylla-cluster-tests/pull/4705) broke the K8S deployment.
Following error gets raised:

    AttributeError: 'dict' object has no attribute 'authenticator'

The reason for it is that new context manager called `temp_authenticator` gets run always.
This context manager does 2 restarts of the first node.
At first, it is redundant in most of the cases.
At second, it is not compatible with the K8S deployment.

So, make the new context manager be called only if it is needed.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
