### PR TITLE
fix(DTCS): remove DTCS as is deprecated

### DIFF
--- a/data_dir/cassandra-stress-custom.yaml
+++ b/data_dir/cassandra-stress-custom.yaml
@@ -43,7 +43,7 @@ table_definition: |
         value blob,
         PRIMARY KEY((name,choice), date, address, dbl, lval, ival, uid)
   ) WITH COMPACT STORAGE
-    AND compaction = {'class': 'DateTieredCompactionStrategy', 'base_time_seconds':'3600', 'max_sstable_age_days':'365'}
+    AND compaction = {'class': 'TimeWindowCompactionStrategy', 'compaction_window_unit': 'DAYS', 'compaction_window_size': 1}
     AND comment='A table of many types to test wide rows'
 
 #

--- a/data_dir/cs_profile_background_reads_overload.yaml
+++ b/data_dir/cs_profile_background_reads_overload.yaml
@@ -15,7 +15,7 @@ table_definition: |
         value blob,
         PRIMARY KEY((name,choice), date, address, dbl, lval, ival, uid)
   ) WITH COMPACT STORAGE
-    AND compaction = {'class': 'DateTieredCompactionStrategy', 'base_time_seconds':'3600', 'max_sstable_age_days':'365'}
+    AND compaction = {'class': 'TimeWindowCompactionStrategy', 'compaction_window_unit': 'MINUTES', 'compaction_window_size': 30}
     AND comment='A table of many types to test wide rows'
 columnspec:
   - name: name

--- a/internal_test_data/complex_test_case_with_version.yaml
+++ b/internal_test_data/complex_test_case_with_version.yaml
@@ -1,7 +1,7 @@
 test_duration: 5760
 prepare_write_cmd: "cassandra-stress write cl=QUORUM n=100000000 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=500 -pop seq=1..100000000"
 stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=5760m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=20 -pop seq=1..100000000 -log interval=5",
-             "cassandra-stress counter_write cl=QUORUM duration=5760m -schema 'replication(factor=3) compaction(strategy=DateTieredCompactionStrategy)' -mode cql3 native -rate threads=1 -pop seq=1..1000000",
+             "cassandra-stress counter_write cl=QUORUM duration=5760m -schema 'replication(factor=3) compaction(strategy=TimeWindowCompactionStrategy)' -mode cql3 native -rate threads=1 -pop seq=1..1000000",
              "cassandra-stress user profile=/tmp/cs_mv_profile.yaml ops'(insert=3,read1=1,read2=1,read3=1)' cl=QUORUM duration=5760m -mode cql3 native -rate threads=10",
              "cassandra-stress write cl=QUORUM duration=5760m -schema 'replication(factor=3) compression=LZ4Compressor compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native compression=lz4 -rate threads=50 -pop seq=1..100000000 -log interval=5",
              "cassandra-stress write cl=QUORUM duration=5760m -schema 'replication(factor=3) compression=SnappyCompressor compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native compression=snappy -rate threads=50 -pop seq=1..100000000 -log interval=5",

--- a/internal_test_data/simple_test_case.yaml
+++ b/internal_test_data/simple_test_case.yaml
@@ -2,7 +2,7 @@ test_duration: 90
 
 stress_cmd:
   - "cassandra-stress write cl=ONE duration=1m -schema 'replication(factor=1) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=10 -pop seq=1..10000000 -log interval=5"
-  - "cassandra-stress counter_write cl=ONE duration=1m -schema 'replication(factor=1) compaction(strategy=DateTieredCompactionStrategy)' -mode cql3 native -rate threads=5 -pop seq=1..10000000"
+  - "cassandra-stress counter_write cl=ONE duration=1m -schema 'replication(factor=1) compaction(strategy=TimeWindowCompactionStrategy)' -mode cql3 native -rate threads=5 -pop seq=1..10000000"
 
 n_db_nodes: 3
 n_loaders: 1

--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -113,7 +113,7 @@ class FillDatabaseData(ClusterTester):
                             firstname text,
                             lastname text,
                             age int
-                        ) WITH compaction = {'class': 'DateTieredCompactionStrategy'}"""],
+                        ) WITH compaction = {'class': 'TimeWindowCompactionStrategy'}"""],
             'truncates': ['TRUNCATE static_cf_test_batch'],
             'inserts': [
                 "INSERT INTO static_cf_test_batch (userid, firstname, lastname, age) VALUES "
@@ -233,7 +233,7 @@ class FillDatabaseData(ClusterTester):
                                       time bigint,
                                       PRIMARY KEY (userid, ip, port)
                                       ) WITH COMPACT STORAGE
-                                      AND compaction = {'class': 'DateTieredCompactionStrategy'}"""],
+                                      AND compaction = {'class': 'TimeWindowCompactionStrategy'}"""],
             'truncates': ['TRUNCATE dense_cf_test'],
             'inserts': [
                 "INSERT INTO dense_cf_test (userid, ip, port, time) VALUES (550e8400-e29b-41d4-a716-446655440000, '192.168.0.1', 80, 42)",

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1973,7 +1973,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             default: compaction = {'class': 'SizeTieredCompactionStrategy'}
         """
         # TODO: Sub-properties for each of compaction strategies should also be tested
-        strategies = ("SizeTieredCompactionStrategy", "DateTieredCompactionStrategy",
+        strategies = ("SizeTieredCompactionStrategy",
                       "TimeWindowCompactionStrategy", "LeveledCompactionStrategy")
         prop_val = {"class": random.choice(strategies)}
         self._modify_table_property(name="compaction", val=str(prop_val))

--- a/test-cases/PR-provision-test-docker.yaml
+++ b/test-cases/PR-provision-test-docker.yaml
@@ -1,6 +1,6 @@
 test_duration: 60
 stress_cmd: ["cassandra-stress write cl=ONE duration=1m -schema 'replication(factor=1) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=10 -pop seq=1..10000000 -log interval=5",
-             "cassandra-stress counter_write cl=ONE duration=1m -schema 'replication(factor=1) compaction(strategy=DateTieredCompactionStrategy)' -mode cql3 native -rate threads=5 -pop seq=1..10000000"
+             "cassandra-stress counter_write cl=ONE duration=1m -schema 'replication(factor=1) compaction(strategy=TimeWindowCompactionStrategy)' -mode cql3 native -rate threads=5 -pop seq=1..10000000"
              ]
 
 n_loaders: 1

--- a/test-cases/PR-provision-test.yaml
+++ b/test-cases/PR-provision-test.yaml
@@ -1,7 +1,7 @@
 test_duration: 60
 max_partitions_in_test_table: 10
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=1m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5",
-             "cassandra-stress counter_write cl=QUORUM duration=1m -schema 'replication(factor=3) compaction(strategy=DateTieredCompactionStrategy)' -mode cql3 native -rate threads=5 -pop seq=1..10000000"
+             "cassandra-stress counter_write cl=QUORUM duration=1m -schema 'replication(factor=3) compaction(strategy=TimeWindowCompactionStrategy)' -mode cql3 native -rate threads=5 -pop seq=1..10000000"
              ]
 
 prepare_write_cmd:  ["scylla-bench -workload=sequential -mode=write -max-rate=300 -replication-factor=3 -partition-count=10 -clustering-row-count=100 -clustering-row-size=5120 -concurrency=7 -rows-per-request=10",

--- a/test_lib/compaction.py
+++ b/test_lib/compaction.py
@@ -22,7 +22,6 @@ class CompactionStrategy(Enum):
     TIME_WINDOW = "TimeWindowCompactionStrategy"
     INCREMENTAL = "IncrementalCompactionStrategy"
     IN_MEMORY = "InMemoryCompactionStrategy"
-    DATE_TIERED = "DateTieredCompactionStrategy"
 
     @classmethod
     def from_str(cls, output_str):

--- a/unit_tests/test_data/test_scylla_yaml_builders/PR-provision-test.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/PR-provision-test.yaml
@@ -1,7 +1,7 @@
 test_duration: 60
 max_partitions_in_test_table: 10
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=1m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=1000 -pop seq=1..10000000 -log interval=5",
-             "cassandra-stress counter_write cl=QUORUM duration=1m -schema 'replication(factor=3) compaction(strategy=DateTieredCompactionStrategy)' -mode cql3 native -rate threads=5 -pop seq=1..10000000"
+             "cassandra-stress counter_write cl=QUORUM duration=1m -schema 'replication(factor=3) compaction(strategy=TimeWindowCompactionStrategy)' -mode cql3 native -rate threads=5 -pop seq=1..10000000"
              ]
 
 prepare_write_cmd:  ["scylla-bench -workload=sequential -mode=write -max-rate=300 -replication-factor=3 -partition-count=10 -clustering-row-count=100 -clustering-row-size=5120 -concurrency=7 -rows-per-request=10",


### PR DESCRIPTION
We still use for some tests DTCS which is deprecated.
Especially it generates many warnings in rolling-upgrade tests,
which obscures other warnings.

Fix is about removing DTCS and replacing it with TWCS wherever possible.

https://trello.com/c/zEPZB5wR
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
