### PR TITLE
Tombstone gc mode

### DIFF
--- a/jenkins-pipelines/longevity-large-partition-200k-pks-4days-tombstone-gc.jenkinsfile
+++ b/jenkins-pipelines/longevity-large-partition-200k-pks-4days-tombstone-gc.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
+    test_config: 'test-cases/longevity/longevity-large-partition-200k_pks-4days-tombstone-gc.yaml',
+
+)

--- a/jenkins-pipelines/longevity-twcs-48h-tombstone-gc.jenkinsfile
+++ b/jenkins-pipelines/longevity-twcs-48h-tombstone-gc.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_twcs_test.TWCSLongevityTest.test_custom_time',
+    test_config: 'test-cases/longevity/longevity-twcs-48h-tombstone-gc.yaml',
+
+)

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1290,7 +1290,7 @@ class SCTConfiguration(dict):
              type=boolean,
              help="""nemesis_exclude_disabled determines whether 'disabled' nemeses are filtered out from list
              or are allowed to be used. This allows to easily disable too 'risky' or 'extreme' nemeses by default,
-             for all longevities. For example: it is unwanted to run the ToggleGcModeMonkey in standard longevities
+             for all longevities. For example: it is unwanted to run the ModifyGcModeMonkey in standard longevities
              that runs a stress with data validation."""),
 
         dict(name="nemesis_multiply_factor", env="SCT_NEMESIS_MULTIPLY_FACTOR",

--- a/test-cases/longevity/longevity-large-partition-200k_pks-4days-tombstone-gc.yaml
+++ b/test-cases/longevity/longevity-large-partition-200k_pks-4days-tombstone-gc.yaml
@@ -1,0 +1,76 @@
+test_duration: 6480
+
+bench_run: true
+max_partitions_in_test_table: 1000
+partition_range_with_data_validation: 0-250
+prepare_write_cmd:  ["scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=250 -clustering-row-count=100000 -clustering-row-size=uniform:3072..5120 -concurrency=10 -connection-count=10 -rows-per-request=10 -consistency-level=quorum -timeout=90s -validate-data" ,
+                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=250 -clustering-row-count=100000 -partition-offset=251 -clustering-row-size=uniform:3072..5120 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=90s",
+                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=250 -clustering-row-count=100000 -partition-offset=501 -clustering-row-size=uniform:3072..5120 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=90s",
+                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=250 -clustering-row-count=100000 -partition-offset=751 -clustering-row-size=uniform:3072..5120 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=90s"
+                    ]
+prepare_verify_cmd: ["scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -rows-per-request=10 -consistency-level=quorum -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=15 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=31 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=46 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=61 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=76 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=91 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=106 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=121 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=136 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=151 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=166 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=181 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=196 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=211 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data",
+                     "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=25 -clustering-row-count=100000 -partition-offset=226 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 1 -validate-data"
+                    ]
+
+stress_cmd: [
+"scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=300 -clustering-row-count=200000 -clustering-row-size=uniform:10..10240 -partition-offset=1001 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=90s",
+             "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=300 -clustering-row-count=200000 -clustering-row-size=uniform:10..10240 -partition-offset=1301 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=90s",
+             "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=400 -clustering-row-count=200000 -clustering-row-size=uniform:10..10240 -partition-offset=1601 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -timeout=90s",
+             "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -rows-per-request=10 -consistency-level=quorum -timeout=90s -iterations 10 -validate-data",
+             "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=15 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 10 -validate-data",
+             "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=31 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 10 -validate-data",
+             "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=46 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 10 -validate-data",
+             "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=61 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 10 -validate-data",
+             "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=76 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 10 -validate-data",
+             "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=91 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 10 -validate-data",
+             "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=106 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 10 -validate-data",
+             "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=121 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 10 -validate-data",
+             "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=136 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 10 -validate-data",
+             "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=15 -clustering-row-count=100000 -partition-offset=151 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 10 -validate-data",
+             "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=42 -clustering-row-count=100000 -partition-offset=166 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 10 -validate-data",
+             "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=43 -clustering-row-count=100000 -partition-offset=208 -clustering-row-size=uniform:3072..5120 -concurrency=100 -connection-count=100 -consistency-level=quorum -rows-per-request=10 -timeout=90s -iterations 10 -validate-data"
+            ]
+
+stress_read_cmd: [
+                  "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=1000 -clustering-row-count=200000 -clustering-row-size=uniform:10..10240 -partition-offset=1001 -concurrency=10 -connection-count=10 -consistency-level=quorum -rows-per-request=10 -iterations=20 -timeout=90s",
+                  "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=250 -clustering-row-count=100000 -clustering-row-size=uniform:3072..5120 -concurrency=10 -connection-count=10 -rows-per-request=10 -consistency-level=quorum -iterations=26 -timeout=300s -validate-data",
+                  "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=1000 -clustering-row-count=100000 -clustering-row-size=uniform:3072..5120 -rows-per-request=10 -consistency-level=quorum -timeout=90s -concurrency=100 -connection-count=100 -iterations=0 -duration=6420m",
+                  "scylla-bench -workload=sequential -mode=read -replication-factor=3 -partition-count=1000 -clustering-row-count=200000 -clustering-row-size=uniform:10..10240 -rows-per-request=10 -consistency-level=quorum -timeout=90s -partition-offset=1001 -concurrency=100 -connection-count=100 -iterations=0 -duration=6420m"
+                 ]
+
+n_db_nodes: 5
+n_loaders: 4
+n_monitor_nodes: 1
+
+round_robin: true
+
+instance_type_db: 'i3en.3xlarge'
+
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_selector: ['tombstone_gc_standard_mode']
+nemesis_seed: '016'
+nemesis_interval: 30
+
+user_prefix: 'longevity-large-partitions-200k-pks-4d-tombstone-gc'
+
+space_node_threshold: 644245094
+
+stop_test_on_stress_failure: false
+
+# Temporarily downgrade scylla_bench to a stable version
+scylla_bench_version: v0.1.3
+run_full_partition_scan: '{"ks_cf": "scylla_bench.test", "interval": 90, "pk_name":"pk", "rows_count": 100000, "validate_data": "true"}' # 'ks.cf, interval(sec), partition-key name, number-of-rows-per-partition, validate reversed query output, include data-column or only validate pk + ck'

--- a/test-cases/longevity/longevity-twcs-48h-tombstone-gc.yaml
+++ b/test-cases/longevity/longevity-twcs-48h-tombstone-gc.yaml
@@ -1,0 +1,36 @@
+test_duration: 3000
+bench_run: true
+max_partitions_in_test_table: 20000
+partition_range_with_data_validation: 0-1  # Not validating any data.
+
+stress_cmd: ["scylla-bench -workload=timeseries -mode=write -replication-factor=3 -partition-count=400 -clustering-row-count=10000000 -clustering-row-size=200 -concurrency=100 -rows-per-request=100 -start-timestamp=SET_WRITE_TIMESTAMP -connection-count 100 -max-rate 50000 --timeout 120s -duration=2880m"]
+# write-rate with timeseries workload for read mode
+# calculated from timeseries workload for write mode by formula:
+# write-rate = -max-rate / -partition-count = 50000 / 400 = 125
+stress_read_cmd: [
+    "scylla-bench -workload=timeseries -mode=read -partition-count=20000 -concurrency=100 -replication-factor=3 -clustering-row-count=10000000 -clustering-row-size=200  -rows-per-request=100 -start-timestamp=GET_WRITE_TIMESTAMP -write-rate 125 -distribution hnormal --connection-count 100 -duration=2880m",
+    "scylla-bench -workload=timeseries -mode=read -partition-count=20000 -concurrency=100 -replication-factor=3 -clustering-row-count=10000000 -clustering-row-size=200  -rows-per-request=100 -start-timestamp=GET_WRITE_TIMESTAMP -write-rate 125 -distribution uniform --connection-count 100 -duration=2880m"
+    ]
+
+
+n_db_nodes: 4
+n_loaders: 3
+n_monitor_nodes: 1
+
+instance_type_db: 'i3en.2xlarge'
+
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_selector: ['tombstone_gc_advanced_mode']
+nemesis_exclude_disabled: false
+nemesis_seed: '025'
+nemesis_interval: 15
+nemesis_during_prepare: false
+space_node_threshold: 64424
+user_prefix: 'longevity-twcs-tombstone-gc-48h'
+
+post_prepare_cql_cmds: "ALTER TABLE scylla_bench.test with gc_grace_seconds = 300 and default_time_to_live = 21600 and compaction = {'class':'TimeWindowCompactionStrategy', 'compaction_window_size': 60, 'compaction_window_unit': 'MINUTES'};"
+
+# Temporarily downgrade scylla_bench to a stable version
+scylla_bench_version: v0.1.3
+
+round_robin: true

--- a/unit_tests/test_nemesis.py
+++ b/unit_tests/test_nemesis.py
@@ -2,7 +2,7 @@ import inspect
 from collections import namedtuple
 
 import sdcm.utils.cloud_monitor  # pylint: disable=unused-import # import only to avoid cyclic dependency
-from sdcm.nemesis import Nemesis, CategoricalMonkey, SisyphusMonkey, ToggleGcModeMonkey
+from sdcm.nemesis import Nemesis, CategoricalMonkey, SisyphusMonkey, ModifyGcModeMonkey
 from sdcm.cluster_k8s.mini_k8s import LocalMinimalScyllaPodCluster
 from sdcm.cluster_k8s.gke import GkeScyllaPodCluster
 from sdcm.cluster_k8s.eks import EksScyllaPodCluster
@@ -164,7 +164,7 @@ def test_list_topology_changes_monkey():
 
 def test_disabled_monkey():
 
-    ToggleGcModeMonkey.disabled = True
+    ModifyGcModeMonkey.disabled = True
 
     tester = FakeTester()
 
@@ -176,12 +176,12 @@ def test_disabled_monkey():
 
     collected_disrupt_methods_names = {disrupt.__name__ for disrupt in sisyphus.disruptions_list}
     # Note: this test will fail and have to be adjusted once additional 'disabled' nemeses added.
-    assert collected_disrupt_methods_names == all_disrupt_methods - {'disrupt_toggle_table_gc_mode'}
+    assert collected_disrupt_methods_names == all_disrupt_methods - {'disrupt_modify_table_gc_mode'}
 
 
 def test_use_disabled_monkey():
 
-    ToggleGcModeMonkey.disabled = True
+    ModifyGcModeMonkey.disabled = True
 
     tester = FakeTester()
 
@@ -190,4 +190,4 @@ def test_use_disabled_monkey():
 
     collected_disrupt_methods_names = {disrupt.__name__ for disrupt in sisyphus.disruptions_list}
 
-    assert 'disrupt_toggle_table_gc_mode' in collected_disrupt_methods_names
+    assert 'disrupt_modify_table_gc_mode' in collected_disrupt_methods_names


### PR DESCRIPTION
There is now optional automatic management of tombstone garbage collection, replacing gc_grace_seconds. Tombstones that are older than the most recent repair will be purged, and newer ones will be kept. This drops tombstones more frequently if repairs are made in a timely manner, and prevents data resurrection if repairs are delayed beyond gc_grace_seconds. The feature is disabled by default and needs to be enabled via ALTER TABLE.

https://github.com/scylladb/scylla/commit/a8ad385ecd3e2b372db3c354492dbe57d9d91760

In order to focus on testing Tombstones GC operations,
	Added 2 labels for Nemesis and 2 pipelines.
        tombstone_gc_standard_mode: toggles between 'repair' and 'timeout' modes.
        tombstone_gc_advanced_mode: modifies any gc-mode value (including
	'disabled' and 'immediate').
Trello: https://trello.com/c/ifxQKAtH

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
