### PR TITLE
fix(sasl setup): only prepare sasl when `is_enterprise`

### DIFF
--- a/sdcm/provision/scylla_yaml/cluster_builder.py
+++ b/sdcm/provision/scylla_yaml/cluster_builder.py
@@ -55,7 +55,7 @@ class ScyllaYamlClusterAttrBuilder(ScyllaYamlAttrBuilderBase):
 
     @property
     def saslauthd_socket_path(self) -> Optional[str]:
-        if self._is_authenticator_valid:
+        if self._is_authenticator_valid and self.params.get('prepare_saslauthd'):
             return '/run/saslauthd/mux'
         return None
 

--- a/unit_tests/test_scylla_yaml_builders.py
+++ b/unit_tests/test_scylla_yaml_builders.py
@@ -115,6 +115,7 @@ class ScyllaYamlClusterAttrBuilderTest(ScyllaYamlClusterAttrBuilderBase):
                     'internode_encryption': False,
                     'client_encrypt': False,
                     'hinted_handoff': None,
+                    'prepare_saslauthd': True,
                 }
             },
             expected_as_dict={
@@ -149,6 +150,7 @@ class ScyllaYamlClusterAttrBuilderTest(ScyllaYamlClusterAttrBuilderBase):
                     'internode_encryption': False,
                     'client_encrypt': False,
                     'hinted_handoff': None,
+                    'prepare_saslauthd': True,
                 }
             },
             expected_as_dict={
@@ -189,6 +191,7 @@ class ScyllaYamlClusterAttrBuilderTest(ScyllaYamlClusterAttrBuilderBase):
                     'internode_encryption': True,
                     'client_encrypt': True,
                     'hinted_handoff': True,
+                    'prepare_saslauthd': True,
                 }
             },
             expected_as_dict={
@@ -552,6 +555,7 @@ class IntegrationTests(unittest.TestCase):
                 os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
                 os.environ['SCT_REGION_NAME'] = '["eu-west-1", "us-east-1"]'
                 os.environ['SCT_CONFIG_FILES'] = config_path
+                os.environ['SCT_PREPARE_SASLAUTHD'] = "true"
 
                 conf = SCTConfiguration()
                 test_config = TestConfig()


### PR DESCRIPTION
we are seeing many warning/error messages in
SCT, because it tried in some cases to
run `prepare_and_start_saslauthd_service` when
running on OSS, but it is not supported by it.

Fixes: #4502

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
