### PR TITLE
fix(artifacts): ubuntu20 is failing with timeout

### DIFF
--- a/jenkins-pipelines/artifacts-ubuntu2004.jenkinsfile
+++ b/jenkins-pipelines/artifacts-ubuntu2004.jenkinsfile
@@ -8,6 +8,6 @@ artifactsPipeline(
     backend: 'gce',
     provision_type: 'spot',
 
-    timeout: [time: 30, unit: 'MINUTES'],
+    timeout: [time: 35, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'
 )


### PR DESCRIPTION
lately (last 2 builds) of Ubuntu20 artifacts
on master are timing out, and while investigating
the issue, it seems not too easy to find culprit.

@roydahan requested to increase the timeout,
so we can allow the next promotion to pass, while
we continue to investigate the issue.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
