### PR TITLE
fix(artifactPipeline): put the timeout on the test stage

### DIFF
--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -111,19 +111,21 @@ def call(Map pipelineParams) {
                             def instance_type = it
                             tasks["${instance_type}"] = {
                                 node(builder.label) {
-                                    // Timeout for the test itself
-                                    timeout(time: pipelineParams.timeout.time, unit: 'MINUTES') {
-                                        withEnv(["AWS_ACCESS_KEY_ID=${env.AWS_ACCESS_KEY_ID}",
-                                                 "AWS_SECRET_ACCESS_KEY=${env.AWS_SECRET_ACCESS_KEY}",
-                                                 "SCT_TEST_ID=${UUID.randomUUID().toString()}",]) {
+                                    withEnv(["AWS_ACCESS_KEY_ID=${env.AWS_ACCESS_KEY_ID}",
+                                             "AWS_SECRET_ACCESS_KEY=${env.AWS_SECRET_ACCESS_KEY}",
+                                             "SCT_TEST_ID=${UUID.randomUUID().toString()}",]) {
 
-                                            def test_config = groovy.json.JsonOutput.toJson(params.test_config)
-                                            stage("Checkout (${instance_type})") {
-                                                dir('scylla-cluster-tests') {
+                                        def test_config = groovy.json.JsonOutput.toJson(params.test_config)
+                                        stage("Checkout (${instance_type})") {
+                                            dir('scylla-cluster-tests') {
+                                                timeout(time: 10, unit: 'MINUTES') {
                                                     checkout scm
                                                 }
                                             }
-                                            stage("Run SCT Test (${instance_type})") {
+                                        }
+                                        stage("Run SCT Test (${instance_type})") {
+                                            // Timeout for the test itself
+                                            timeout(time: pipelineParams.timeout.time, unit: 'MINUTES') {
                                                 def cloud_provider = getCloudProviderFromBackend(params.backend)
                                                 sctScript """
                                                     rm -fv ./latest
@@ -208,36 +210,36 @@ def call(Map pipelineParams) {
                                                     echo "end test ....."
                                                 """
                                             }
-                                            stage("Collect log data (${instance_type})") {
-                                                catchError(stageResult: 'FAILURE') {
-                                                    wrap([$class: 'BuildUser']) {
-                                                        dir('scylla-cluster-tests') {
-                                                            timeout(time: 30, unit: 'MINUTES') {
-                                                                runCollectLogs(params, builder.region)
-                                                            }
+                                        }
+                                        stage("Collect log data (${instance_type})") {
+                                            catchError(stageResult: 'FAILURE') {
+                                                wrap([$class: 'BuildUser']) {
+                                                    dir('scylla-cluster-tests') {
+                                                        timeout(time: 30, unit: 'MINUTES') {
+                                                            runCollectLogs(params, builder.region)
                                                         }
                                                     }
                                                 }
                                             }
-                                            stage("Clean resources (${instance_type})") {
-                                                catchError(stageResult: 'FAILURE') {
-                                                    wrap([$class: 'BuildUser']) {
-                                                        dir('scylla-cluster-tests') {
-                                                            timeout(time: 10, unit: 'MINUTES') {
-                                                                runCleanupResource(params, builder.region)
-                                                            }
+                                        }
+                                        stage("Clean resources (${instance_type})") {
+                                            catchError(stageResult: 'FAILURE') {
+                                                wrap([$class: 'BuildUser']) {
+                                                    dir('scylla-cluster-tests') {
+                                                        timeout(time: 10, unit: 'MINUTES') {
+                                                            runCleanupResource(params, builder.region)
                                                         }
                                                     }
                                                 }
                                             }
-                                            stage("Send email with result ${instance_type}") {
-                                                def email_recipients = groovy.json.JsonOutput.toJson(params.email_recipients)
-                                                catchError(stageResult: 'FAILURE') {
-                                                    wrap([$class: 'BuildUser']) {
-                                                        dir('scylla-cluster-tests') {
-                                                            timeout(time: 10, unit: 'MINUTES') {
-                                                                runSendEmail(params, currentBuild)
-                                                            }
+                                        }
+                                        stage("Send email with result ${instance_type}") {
+                                            def email_recipients = groovy.json.JsonOutput.toJson(params.email_recipients)
+                                            catchError(stageResult: 'FAILURE') {
+                                                wrap([$class: 'BuildUser']) {
+                                                    dir('scylla-cluster-tests') {
+                                                        timeout(time: 10, unit: 'MINUTES') {
+                                                            runSendEmail(params, currentBuild)
                                                         }
                                                     }
                                                 }


### PR DESCRIPTION
Seem like in #4730, by mistake the timeout was put on all
of the parallel task, which include log collection phase.
this started failing on master, cause 30min wasn't enough
for the whole sequence (including log/email phases)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
