### PR TITLE
ci(k8s): use more powerful instance types for local K8S SCT runners

### DIFF
--- a/vars/createSctRunner.groovy
+++ b/vars/createSctRunner.groovy
@@ -4,9 +4,9 @@ def call(Map params, Integer test_duration, String region) {
     def cloud_provider = getCloudProviderFromBackend(params.backend)
     def instance_type_arg = ""
     if ( params.backend == "k8s-local-kind-aws" ) {
-        instance_type_arg = "--instance-type c5.xlarge"
+        instance_type_arg = "--instance-type c5.2xlarge"
     } else if ( params.backend == "k8s-local-kind-gce" ) {
-        instance_type_arg = "--instance-type e2-standard-4"
+        instance_type_arg = "--instance-type e2-standard-8"
     }
 
     // NOTE: EKS jobs have 'availability_zone' be defined as 'a,b'


### PR DESCRIPTION
Pretty often running state-changing functional tests SCT runners
get overloaded which may affect stability of testing.
So, increase instance types for AWS and GCE backends.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
