### PR TITLE
fix(k8s-func): make stacktraces have proper indentation in email reports

### DIFF
--- a/sdcm/report_templates/results_functional.html
+++ b/sdcm/report_templates/results_functional.html
@@ -43,11 +43,9 @@
             <li>
                 <h4> {{ test_name }} </h4>
                 <ul>
-                    <h5>
-                        {% for line in test_error.split('\n') %}
-                            {{ line }} <br/>
-                        {% endfor %}
-                    </h5>
+                    <h4><pre>
+{% for line in test_error.split('\n') %}{{ line }} <br/>{% endfor %}
+                    </pre></h4>
                 </ul>
             </li>
             {% endfor %}


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
