### PR TITLE
fix(cluster.py): add architecture to package call

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2066,7 +2066,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             self.remoter.run(f'sudo apt-get install -y openjdk-11-jre-headless {additional_pkgs}')
         else:
             self.remoter.run(f'sudo apt-get install -y openjdk-8-jre-headless {additional_pkgs}')
-            self.remoter.run('sudo update-java-alternatives --jre-headless -s java-1.8.0-openjdk-amd64')
+            self.remoter.run('sudo update-java-alternatives --jre-headless '
+                             '-s java-1.8.0-openjdk-${dpkg-architecture -q DEB_BUILD_ARCH}')
 
         if nonroot:
             # Make sure env variable (XDG_RUNTIME_DIR) is set, which is necessary for systemd user


### PR DESCRIPTION
package is being called with wrong architecture name,
and it is consistently failing Ubuntu20 ARM artifacts
jobs.
with this fix, we will be able to run both ARM and
regular artifacts without any issue.
Fixes: #4769

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
