### PR TITLE
fix(syslog-ng): wait for APT locks in more reliable way

### DIFF
--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -20,21 +20,28 @@ from textwrap import dedent
 def configure_rsyslog_rate_limits_script(interval: int, burst: int) -> str:
     # Configure rsyslog.  Use obsolete legacy format here because it's easier to redefine imjournal parameters.
     return dedent(fr"""
-    if ! grep imjournalRatelimitInterval /etc/rsyslog.conf; then
+        if ! grep imjournalRatelimitInterval /etc/rsyslog.conf; then
         cat <<EOF >> /etc/rsyslog.conf
+
         #
         # The following configuration was added by SCT.
         #
         \$ModLoad imjournal
         \$imjournalRatelimitInterval {interval}
         \$imjournalRatelimitBurst {burst}
-    EOF
-    fi
+
+        EOF
+        fi
     """)
 
 
 def configure_rsyslog_target_script(host: str, port: int) -> str:
-    return f'echo "action(type=\\"omfwd\\" Target=\\"{host}\\" Port=\\"{port}\\" Protocol=\\"tcp\\")" >> /etc/rsyslog.conf\n'
+    fwd_action = fr'action(type=\"omfwd\" Target=\"{host}\" Port=\"{port}\" Protocol=\"tcp\")'
+    return dedent(f"""
+        if ! grep "{fwd_action}" /etc/rsyslog.conf ; then
+            echo "{fwd_action}" >> /etc/rsyslog.conf
+        fi
+    """)
 
 
 def configure_syslogng_target_script(host: str, port: int, throttle_per_second: int, hostname: str = "") -> str:
@@ -166,10 +173,9 @@ def install_syslogng_service():
                 done
 
                 for n in 1 2 3; do # cloud-init is running it with set +o braceexpand
-                    while ! find /proc/*/fd -lname /var/lib/dpkg/lock-frontend -exec false {} + -quit ; do
-                        sleep 1
+                    while grep "Could not get lock" <(apt-get install -y syslog-ng 2>&1) ; do
+                        sleep 5
                     done
-                    apt-get install -y syslog-ng || true
                     if dpkg-query --show syslog-ng ; then
                         SYSLOG_NG_INSTALLED=1
                         break


### PR DESCRIPTION
Trello: https://trello.com/c/kXD88YtP/4947-db-node-log-lines-are-printed-twice-in-the-sctlog

Found that sometimes syslog-ng setup failed to install the package because of APT locks.  In result, rsyslog used and we can see log message duplicates in SCT log.

Also, add rsyslog forward action conditionally.

Fixes #4606 

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
