### PR TITLE
hydra.sh: fix check for already-available docker image

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -5,7 +5,8 @@ set -eo pipefail
 CMD=$@
 DOCKER_ENV_DIR=$(readlink -f "$0")
 DOCKER_ENV_DIR=$(dirname "${DOCKER_ENV_DIR}")
-DOCKER_REPO=docker.io/scylladb/hydra
+DOCKER_REPO=scylladb/hydra
+DOCKER_REGISTRY=docker.io
 SCT_DIR=$(dirname "${DOCKER_ENV_DIR}")
 SCT_DIR=$(dirname "${SCT_DIR}")
 VERSION=v$(cat "${DOCKER_ENV_DIR}/version")
@@ -160,9 +161,9 @@ fi
 
 if [[ ${USER} == "jenkins" || -z "`$tool images ${DOCKER_REPO}:${VERSION} -q`" ]]; then
     echo "Pull version $VERSION from Docker Hub..."
-    $tool pull ${DOCKER_REPO}:${VERSION}
+    $tool pull ${DOCKER_REGISTRY}/${DOCKER_REPO}:${VERSION}
 else
-    echo "There is ${DOCKER_REPO}:${VERSION} in local cache, use it."
+    echo "There is ${DOCKER_REPO}:${VERSION} in local cache, using it."
 fi
 
 # Check for SSH keys


### PR DESCRIPTION
Hydra has code to avoid even trying to pull the docker image if it
knows that the desired version is already available locally.
However, this check simply doesn't work -

It turns out that the syntax docker.io/scylladb/hydra works with
"docker pull" but not with "docker images". The syntax scylladb/hydra
works with both, so in this patch we switch to use it.

On my machine, this reduces "hydra" run time by about 2.5 seconds.

Fixes #4783

Signed-off-by: Nadav Har'El <nyh@scylladb.com>