### PR TITLE
fix(cluster.py): fix nodetool status for ipv6

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3895,7 +3895,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         # see TestNodetoolStatus test in test_cluster.py
         pattern = re.compile(
             r"(?P<state>\w{2})\s+"
-            r"(?P<ip>[\d.]+)\s+"
+            r"(?P<ip>[\w:.]+)\s+"
             r"(?P<load>[\d.]+ [\w]+|\?)\s+"
             r"(?P<tokens>[\d]+)\s+"
             r"(?P<owns>[\w?]+)\s+"

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -429,6 +429,28 @@ class TestNodetoolStatus(unittest.TestCase):
                            '10.0.198.153': {'state': 'UN', 'load': '?', 'tokens': '256', 'owns': '?',
                                             'host_id': 'fba174cd-917a-40f6-ab62-cc58efaaf301', 'rack': '1a'}}}
 
+    def test_can_get_nodetool_status_ipv6(self):  # pylint: disable=no-self-use
+        resp = "\n".join(["Datacenter: eu-north",
+                          "====================",
+                          "Status=Up/Down",
+                          "|/ State=Normal/Leaving/Joining/Moving",
+                          "--  Address                                 Load       Tokens       Owns    Host ID                Rack",
+                          "UN  2a05:d016:cf8:de00:e07d:5832:c5c0:36a0  774 KB     256          ?       e2ed6943  1a",
+                          "UN  2a05:d016:cf8:de00:339e:d0d:9446:1980   1.04 MB    256          ?       d67e8502  1a",
+                          ]
+                         )
+        node = NodetoolDummyNode(resp=resp)
+        db_cluster = DummyScyllaCluster([node])
+
+        status = db_cluster.get_nodetool_status()
+
+        assert status == {'eu-north':
+                          {'2a05:d016:cf8:de00:e07d:5832:c5c0:36a0':
+                           {'state': 'UN', 'load': '774KB', 'tokens': '256', 'owns': '?',
+                            'host_id': 'e2ed6943', 'rack': '1a'},
+                           '2a05:d016:cf8:de00:339e:d0d:9446:1980': {'state': 'UN', 'load': '1.04MB', 'tokens': '256', 'owns': '?',
+                                                                     'host_id': 'd67e8502', 'rack': '1a'}}}
+
     def test_can_get_nodetool_status_azure(self):  # pylint: disable=no-self-use
         resp = "\n".join(["Datacenter: eastus",
                          "==================",


### PR DESCRIPTION
Current nodetool status regexp didn't work properly for ipv6.
Fix is about correcting this regex to work with ipv6.

fixes https://github.com/scylladb/scylla-cluster-tests/issues/4780

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
