### PR TITLE
fix(k8s-local): exclude calico pods from not-allowed list

### DIFF
--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -365,6 +365,7 @@ class LocalKindCluster(LocalMinimalClusterBase):
         return [
             ('k8s-app', 'kindnet'),
             ('k8s-app', 'kube-proxy'),
+            ('k8s-app', 'calico-node'),
             ('scylla/cluster', self.k8s_scylla_cluster_name),
         ]
 


### PR DESCRIPTION
It is follow-up for this PR: https://github.com/scylladb/scylla-cluster-tests/pull/4762

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
