### PR TITLE
fix(artifact_test): Skip timesync test on offline installation scenarios

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -342,10 +342,17 @@ class ArtifactsTest(ClusterTester):
                             "systemd-timesyncd is already installed, yet scylla installed ntp service on top of it"
                         assert not is_chrony_service_installed, \
                             "systemd-timesyncd is already installed, yet scylla installed chrony service on top of it"
-                    else:
+                    elif not self.params.get("unified_package"):
                         assert is_ntp_service_installed or is_chrony_service_installed, \
                             "systemd-timesyncd is not installed on the instance, yet Scylla did not install ntp or " \
                             "chrony services as a replacement"
+                    else:
+                        # https://github.com/scylladb/scylla/issues/10608#issuecomment-1135770570
+                        # Scylla doesn't install any time sync service when it's an offline installation,
+                        # so if there's no time sync services active after the scylla installation, it's fine.
+                        # However, in such scenario a warning message should be printed during the scylla installation
+                        self.log.warning("No time sync service was installed. "
+                                         "Passable since it's an offline installation.")
                 except AssertionError:
                     full_list = self.node.remoter.run('systemctl list-units --full').stdout.strip()
                     self.log.warning("Seems that there was an issue with ntp check. Here's the full list of services "


### PR DESCRIPTION
According to Avi, the scylla offline installation does not include any timesync service
installation with it. As such, the time synchronization service check should only
run on online installations.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
