### PR TITLE
fix(gemini): use proper user for the oracle nodes in ICS jobs

### DIFF
--- a/test-cases/gemini/gemini-3h-ics-with-nondisruptive-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-ics-with-nondisruptive-nemesis.yaml
@@ -6,6 +6,7 @@ n_monitor_nodes: 1
 instance_type_db: 'i3.large'
 
 user_prefix: 'ics-gemini-nemesis-3h'
+ami_db_scylla_user: 'centos'
 
 nemesis_class_name: 'GeminiNonDisruptiveChaosMonkey'
 nemesis_interval: 5

--- a/test-cases/gemini/gemini-basic-3h-ics.yaml
+++ b/test-cases/gemini/gemini-basic-3h-ics.yaml
@@ -6,6 +6,7 @@ n_monitor_nodes: 1
 instance_type_db: 'i3.large'
 
 user_prefix: 'ics-gemini-basic-3h'
+ami_db_scylla_user: 'centos'
 
 # gemini
 # cmd: gemini -d -n [NUM_OF_TEST_ITERATIONS] -c [NUM_OF_THREADS] -m mixed -f


### PR DESCRIPTION
Recently was changed [1] Scylla type for oracle nodes in ICS jobs.
And such a switch needed also switch of a username.
So, do it here the same way as it was done for other ICS jobs [2].

[1] https://github.com/scylladb/scylla-cluster-tests/pull/4788
[2] https://github.com/scylladb/scylla-cluster-tests/pull/4658

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
