### PR TITLE
fix(log_collector): stop compressing files remotely

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -166,13 +166,11 @@ class CommandLog(BaseLogEntity):  # pylint: disable=too-few-public-methods
         remote_logfile = LogCollector.collect_log_remotely(node=node,
                                                            cmd=self.cmd,
                                                            log_filename=os.path.join(remote_dst, self.name))
-        if archive_logfile := LogCollector.archive_log_remotely(node=node, log_filename=remote_logfile):
-            LogCollector.receive_log(node=node,
-                                     remote_log_path=archive_logfile,
-                                     local_dir=local_dst,
-                                     timeout=self.collect_timeout)
-            return os.path.join(local_dst, os.path.basename(archive_logfile))
-        return None
+        LogCollector.receive_log(node=node,
+                                 remote_log_path=remote_logfile,
+                                 local_dir=local_dst,
+                                 timeout=self.collect_timeout)
+        return os.path.join(local_dst, os.path.basename(remote_logfile))
 
 
 class FileLog(CommandLog):
@@ -231,8 +229,7 @@ class FileLog(CommandLog):
 
     def collect_from_builder(self, builder, local_dst, search_in_dir) -> None:
         if file_path := self.find_on_builder(builder, self.name, search_in_dir):
-            if archive_logfile := LogCollector.archive_log_remotely(builder, file_path):
-                builder.remoter.receive_files(archive_logfile, local_dst, timeout=self.collect_timeout)
+            builder.remoter.receive_files(file_path, local_dst, timeout=self.collect_timeout)
 
 
 class DirLog(FileLog):


### PR DESCRIPTION
Since after we collect those files, we compress it yet again
into a tar.gz for the whole cluster/set, like db-cluster-**.tar.gz

Closes: #4793, #1820

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
