### PR TITLE
fix(build_n_push): requirement.in relative when calling pip-compile

### DIFF
--- a/docker/env/build_n_push.sh
+++ b/docker/env/build_n_push.sh
@@ -24,7 +24,8 @@ if [[ -n "$(docker images scylladb/hydra:${VERSION} -q)" ]]; then
 else
     echo "Hydra image with version $VERSION not found locally. Building..."
     cd "${DOCKER_ENV_DIR}"
-    pip-compile ${SCT_DIR}/requirements.in --allow-unsafe --generate-hashes > ${SCT_DIR}/${PY_PREREQS_FILE}
+    REQUIREMENTS_IN=$(realpath --relative-to=${DOCKER_ENV_DIR} ${SCT_DIR}/requirements.in)
+    pip-compile $REQUIREMENTS_IN --allow-unsafe --generate-hashes > ${SCT_DIR}/${PY_PREREQS_FILE}
     cp -f ${SCT_DIR}/${PY_PREREQS_FILE} .
     docker build --network=host -t scylladb/hydra:${VERSION} .
     rm -f ${PY_PREREQS_FILE}


### PR DESCRIPTION
Since the path of the input file appear in the output requriements.txt
multiple times, it shouldn't be a full path, since it's generating
lots of diffs every time new image created

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
