### PR TITLE
Revert "fix(cassandra-harry): disable nemesis"

### DIFF
--- a/test-cases/longevity/longevity-harry-2h.yaml
+++ b/test-cases/longevity/longevity-harry-2h.yaml
@@ -9,7 +9,7 @@ instance_type_db: 'i3.large'
 
 aws_root_disk_size_loader: 80 # enlarge loader disk, cause of cassandra-harry operation.log that can't be disabled
 
-nemesis_class_name: 'NoOpMonkey'
+nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '001'
 nemesis_interval: 2
 ssh_transport: 'libssh2'


### PR DESCRIPTION
now we proven the the nemesis mostly works,
beside scylladb/scylla#10598 that still under
investigation

This reverts commit 820d561986ea70de573b5bc41793f3a24e1694ad.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
