### PR TITLE
fix(perf report): unhashable slice

### DIFF
--- a/sdcm/results_analyze/__init__.py
+++ b/sdcm/results_analyze/__init__.py
@@ -292,8 +292,9 @@ class LatencyDuringOperationsPerformanceAnalyzer(BaseResultsAnalyzer):
 
         last_error_events, error_events_summary = self.get_events(event_severity=[Severity.ERROR.name])
         last_critical_events, critical_events_summary = self.get_events(event_severity=[Severity.CRITICAL.name])
-        last_events = {Severity.ERROR.name: last_error_events[:100], Severity.CRITICAL.name: last_critical_events[:100]}
-        events_summary = error_events_summary + critical_events_summary
+        last_events = {Severity.ERROR.name: last_error_events[Severity.ERROR.name][:100],
+                       Severity.CRITICAL.name: last_critical_events[Severity.CRITICAL.name][:100]}
+        events_summary = error_events_summary[Severity.ERROR.name] + critical_events_summary[Severity.CRITICAL.name]
         reactor_stall_events = self.get_reactor_stall_events()
         reactor_stall_events_summary = {Severity.DEBUG.name: len(reactor_stall_events)}
         kernel_callstack_events = self.get_kernel_callstack_events()


### PR DESCRIPTION
somewhere it got mixed up, and we were
trying to slice a dictionary rather than
a list, making the code to fail.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
