### PR TITLE
fix(artifacts): change instance_type_db to im4gn.xlarge

### DIFF
--- a/configurations/arm/centos8.yaml
+++ b/configurations/arm/centos8.yaml
@@ -1,7 +1,7 @@
 ami_db_scylla_user: 'centos'
 ami_id_db_scylla: 'ami-07d54ca4e98347364'
 region_name: 'eu-west-1'
-instance_type_db: 'r6gd.large'
+instance_type_db: 'im4gn.xlarge'
 use_preinstalled_scylla: false
 # enhanced network isn't supported
 append_scylla_setup_args: ' --no-ec2-check '

--- a/configurations/arm/debian10.yaml
+++ b/configurations/arm/debian10.yaml
@@ -1,7 +1,7 @@
 ami_db_scylla_user: 'admin'
 ami_id_db_scylla: 'ami-03505f4be3ad4f07b'
 region_name: 'eu-west-1'
-instance_type_db: 'r6gd.large'
+instance_type_db: 'im4gn.xlarge'
 # enhanced network isn't supported
 append_scylla_setup_args: ' --no-ec2-check '
 use_preinstalled_scylla: false

--- a/configurations/arm/ubuntu2004.yaml
+++ b/configurations/arm/ubuntu2004.yaml
@@ -1,7 +1,7 @@
 ami_db_scylla_user: 'ubuntu'
 ami_id_db_scylla: 'ami-0127b718f588563a0'
 region_name: 'eu-west-1'
-instance_type_db: 'r6gd.large'
+instance_type_db: 'im4gn.xlarge'
 use_preinstalled_scylla: false
 # enhanced network isn't supported
 append_scylla_setup_args: ' --no-ec2-check '


### PR DESCRIPTION
Moving the default instance type for arm artifacts tests
from r6gd.large to im4gn.xlarge

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
