### PR TITLE
fix(azure): fix user-data error when creating runner

### DIFF
--- a/sdcm/provision/azure/virtual_machine_provider.py
+++ b/sdcm/provision/azure/virtual_machine_provider.py
@@ -71,22 +71,22 @@ class VirtualMachineProvider:
                     }],
                 },
             }
-            builder = UserDataBuilder(user_data_objects=definition.user_data)
             if definition.user_data is None:
                 # in case we use specialized image, we don't change things like computer_name, usernames, ssh_keys
                 os_profile = {}
             else:
+                builder = UserDataBuilder(user_data_objects=definition.user_data)
                 custom_data = builder.build_user_data_yaml()
                 os_profile = self._get_os_profile(computer_name=definition.name,
                                                   admin_username=definition.user_name,
                                                   admin_password=binascii.hexlify(os.urandom(20)).decode(),
                                                   ssh_public_key=definition.ssh_key.public_key.decode(),
                                                   custom_data=custom_data)
+                params.update({"user_data": base64.b64encode(
+                    builder.get_scylla_machine_image_json().encode('utf-8')).decode('latin-1')})
             storage_profile = self._get_scylla_storage_profile(image_id=definition.image_id, name=definition.name,
                                                                disk_size=definition.root_disk_size)
             params.update(os_profile)
-            params.update({"user_data": base64.b64encode(
-                builder.get_scylla_machine_image_json().encode('utf-8')).decode('latin-1')})
             params.update(storage_profile)
             params.update(self._get_pricing_params(pricing_model))
             try:


### PR DESCRIPTION
When creating sct-runner on Azure there's iterating over None error.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
