### PR TITLE
fix(install_scylla): adding workaround to JDK

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2044,6 +2044,21 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 'sudo apt-get install -y '
                 ' {} '.format(self.scylla_pkg()))
 
+        # THIS IS A WORKAROUND FOR ISSUE https://github.com/scylladb/scylla/issues/10442
+        # the issue is related to JDK version, and the fix was added to later patches of multiple base versions,
+        # hence this is a temporary workaround to make the rolling upgrade tests to pass, until the latest
+        # patch of the supported releases will include the fix.
+        package_manager = 'yum' if self.is_rhel_like() else 'apt'
+        self.remoter.sudo(f'{package_manager} install zip unzip -y')
+        self.remoter.run('curl -s "https://get.sdkman.io" | bash')
+        self.remoter.run(shell_script_cmd("""
+            source "/home/$USER/.sdkman/bin/sdkman-init.sh"
+            sed -i s/sdkman_auto_answer=false/sdkman_auto_answer=true/  ~/.sdkman/etc/config
+            sed -i s/sdkman_auto_env=false/sdkman_auto_env=true/  ~/.sdkman/etc/config
+            sdk install java 8.0.302-open
+            sdk default java 8.0.302-open
+        """))
+
     def offline_install_scylla(self, unified_package, nonroot):
         """
         Offline install scylla by unified package.

--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -1114,7 +1114,7 @@ class FillDatabaseData(ClusterTester):
                         "SELECT v1, v2 FROM range_tombstones_test WHERE k = %d" % 2,
                         "SELECT v1, v2 FROM range_tombstones_test WHERE k = %d" % 3,
                         "SELECT v1, v2 FROM range_tombstones_test WHERE k = %d" % 4,
-                        "#REMOTER_SUDO nodetool flush",
+                        "#REMOTER_RUN nodetool flush",
                         "SELECT v1, v2 FROM range_tombstones_test WHERE k = %d" % 0,
                         "SELECT v1, v2 FROM range_tombstones_test WHERE k = %d" % 1,
                         "SELECT v1, v2 FROM range_tombstones_test WHERE k = %d" % 2,
@@ -1157,10 +1157,10 @@ class FillDatabaseData(ClusterTester):
             'truncates': [],
             'inserts': ["INSERT INTO range_tombstones_compaction_test (k, c1, c2, v1) VALUES (0, %d, %d, '%s')" % (
                 c1, c2, '%i%i' % (c1, c2)) for c1 in range(0, 4) for c2 in range(0, 2)],
-            'queries': ["#REMOTER_SUDO nodetool flush",
+            'queries': ["#REMOTER_RUN nodetool flush",
                         "DELETE FROM range_tombstones_compaction_test WHERE k = 0 AND c1 = 1",
-                        "#REMOTER_SUDO nodetool flush",
-                        "#REMOTER_SUDO nodetool compact",
+                        "#REMOTER_RUN nodetool flush",
+                        "#REMOTER_RUN nodetool compact",
                         "SELECT v1 FROM range_tombstones_compaction_test WHERE k = 0"],
             'results': [None,
                         [],
@@ -2559,9 +2559,9 @@ class FillDatabaseData(ClusterTester):
                 "CREATE TABLE collection_flush_test (k int PRIMARY KEY, s set<int>)"],
             'truncates': ["TRUNCATE collection_flush_test"],
             'inserts': ["INSERT INTO collection_flush_test(k, s) VALUES (1, {1})",
-                        "#REMOTER_SUDO nodetool flush",
+                        "#REMOTER_RUN nodetool flush",
                         "INSERT INTO collection_flush_test(k, s) VALUES (1, {2})",
-                        "#REMOTER_SUDO nodetool flush"],
+                        "#REMOTER_RUN nodetool flush"],
             'queries': ["SELECT * FROM collection_flush_test"],
             'results': [[[1, set([2])]]],
             'min_version': '',
@@ -3216,9 +3216,9 @@ class FillDatabaseData(ClusterTester):
                 for insert in item['inserts']:
                     with self._execute_and_log(f'Populated data for test "{test_name}" in {{}} seconds'):
                         try:
-                            if insert.startswith("#REMOTER_SUDO"):
+                            if insert.startswith("#REMOTER_RUN"):
                                 for node in self.db_cluster.nodes:
-                                    node.remoter.sudo(insert.replace('#REMOTER_SUDO', ''))
+                                    node.remoter.run(insert.replace('#REMOTER_RUN', ''))
                             else:
                                 session.execute(insert)
                         except Exception as ex:
@@ -3239,9 +3239,9 @@ class FillDatabaseData(ClusterTester):
                 if item['queries'][i].startswith("#SORTED"):
                     res = session.execute(item['queries'][i].replace('#SORTED', ''))
                     self.assertEqual(sorted([list(row) for row in res]), item['results'][i])
-                elif item['queries'][i].startswith("#REMOTER_SUDO"):
+                elif item['queries'][i].startswith("#REMOTER_RUN"):
                     for node in self.db_cluster.nodes:
-                        node.remoter.sudo(item['queries'][i].replace('#REMOTER_SUDO', ''))
+                        node.remoter.run(item['queries'][i].replace('#REMOTER_RUN', ''))
                 elif item['queries'][i].startswith("#LENGTH"):
                     res = session.execute(item['queries'][i].replace('#LENGTH', ''))
                     self.assertEqual(len([list(row) for row in res]), item['results'][i])


### PR DESCRIPTION
because of issue https://github.com/scylladb/scylla/issues/10442
we need to add here this workaround, as the
base versions patches don't include the fix
for this issue.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
