### PR TITLE
test(many-clients test): use sisyphus monkey

### DIFF
--- a/test-cases/scale/longevity-many-clients-4h.yaml
+++ b/test-cases/scale/longevity-many-clients-4h.yaml
@@ -13,7 +13,9 @@ n_monitor_nodes: 1
 instance_type_db: 'i3.metal'
 instance_type_loader: 'c5.large'
 instance_type_monitor: 'm5.2xlarge'
-nemesis_class_name: 'ChaosMonkey'
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_seed: '031'
+nemesis_multiply_factor: 1
 nemesis_interval: 5
 nemesis_filter_seeds: false
 seeds_num: 3


### PR DESCRIPTION
Currently we use ChaosMonkey in many-clients test.
This is bad when we want to reproduce the test flow.
Let's change it to SisyphusMonkey with random seed,
so in case we want to reproduce issue we have option for that.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
