### PR TITLE
fix(performance_regression_test): Wait no compactions after write

### DIFF
--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -413,6 +413,9 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
         self.get_stress_results(queue=stress_queue, store_results=False)
         self.update_test_details()
 
+        # Wait for compactions to settele before starting read workload
+        self.wait_no_compactions_running()
+
         # create new document in ES with doc_id = test_id + timestamp
         # allow to correctly save results for future compare
         self.create_test_stats(doc_id_with_timestamp=True)
@@ -444,6 +447,9 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
                                               stats_aggregate_cmds=False)
         self.get_stress_results(queue=stress_queue, store_results=False)
         self.update_test_details()
+
+        # Wait for compactions to settele before starting mixed workload
+        self.wait_no_compactions_running()
 
         # run a mixed workload
         # create new document in ES with doc_id = test_id + timestamp


### PR DESCRIPTION
Since there are ongoing changes with compactions, there are cases
where compactions leftovers are still running after the prepare
workload and affecting the results of READ and MIXED workloads.

It was decided to fix it on the original branch and not advancing
to a new branch version despite the fact it may void some of the
previous results.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
