### PR TITLE
fix(Jenkinsfile): put timeout for each stage on it's own

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,11 +110,13 @@ pipeline {
     }
     options {
         timestamps()
-        timeout(time: 90, unit: 'MINUTES')
         buildDiscarder(logRotator(numToKeepStr: '10'))
     }
     stages {
         stage("precommit") {
+            options {
+                timeout(time: 15, unit: 'MINUTES')
+            }
             steps {
                 script {
                     try {
@@ -128,6 +130,9 @@ pipeline {
             }
         }
         stage("unittest") {
+            options {
+                timeout(time: 20, unit: 'MINUTES')
+            }
             steps {
                 script {
                     try {
@@ -140,6 +145,9 @@ pipeline {
             }
         }
         stage("lint test-cases") {
+            options {
+                timeout(time: 10, unit: 'MINUTES')
+            }
             steps {
                 script {
                     try {
@@ -152,6 +160,9 @@ pipeline {
             }
         }
         stage("run mocked tests") {
+            options {
+                timeout(time: 10, unit: 'MINUTES')
+            }
             steps {
                 script {
                     try {
@@ -171,6 +182,9 @@ pipeline {
                 expression {
                     return pullRequestContainsLabels("test-provision,test-provision-aws,test-provision-gce,test-provision-docker") && currentBuild.result == null
                 }
+            }
+            options {
+                timeout(time: 120, unit: 'MINUTES')
             }
             steps {
                 script {


### PR DESCRIPTION
since some of the stages (i.e. provision tests) can be more
then 90min long (gce provision take more then an hour)

also we don't want to count the waiting time for a builder

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
