### PR TITLE
fix(ipv6_workaround_script): find the network device

### DIFF
--- a/sdcm/provision/aws/utils.py
+++ b/sdcm/provision/aws/utils.py
@@ -251,7 +251,7 @@ def sort_by_index(item: dict) -> str:
 
 
 def network_config_ipv6_workaround_script():
-    return dedent("""
+    return dedent(r"""
         if grep -qi "ubuntu" /etc/os-release; then
             echo "On Ubuntu we don't need this workaround, so done"
         else
@@ -259,24 +259,25 @@ def network_config_ipv6_workaround_script():
             MAC=`curl -s ${BASE_EC2_NETWORK_URL}`
             IPv6_CIDR=`curl -s ${BASE_EC2_NETWORK_URL}${MAC}/subnet-ipv6-cidr-blocks`
 
-            while ! ls /etc/sysconfig/network-scripts/ifcfg-eth0; do sleep 1; done
+            NETWORK_DEVICE=`ip -4 route ls | grep default | grep -Po '(?<=dev )(\S+)'`
+
+            while ! ls /etc/sysconfig/network-scripts/ifcfg-$NETWORK_DEVICE; do sleep 1; done
 
             if ! grep -qi "amazon linux" /etc/os-release; then
-                ip route add $IPv6_CIDR dev eth0
-                echo "ip route add $IPv6_CIDR dev eth0" >> /etc/sysconfig/network-scripts/init.ipv6-global
+                ip route add $IPv6_CIDR dev $NETWORK_DEVICE
+                echo "ip route add $IPv6_CIDR dev $NETWORK_DEVICE" >> /etc/sysconfig/network-scripts/init.ipv6-global
             fi
 
-            if grep -q IPV6_AUTOCONF /etc/sysconfig/network-scripts/ifcfg-eth0; then
-                sed -i 's/^IPV6_AUTOCONF=[^ ]*/IPV6_AUTOCONF=yes/' /etc/sysconfig/network-scripts/ifcfg-eth0
+            if grep -q IPV6_AUTOCONF /etc/sysconfig/network-scripts/ifcfg-$NETWORK_DEVICE; then
+                sed -i 's/^IPV6_AUTOCONF=[^ ]*/IPV6_AUTOCONF=yes/' /etc/sysconfig/network-scripts/ifcfg-$NETWORK_DEVICE
             else
-                echo "IPV6_AUTOCONF=yes" >> /etc/sysconfig/network-scripts/ifcfg-eth0
-                echo "echo \"IPV6_AUTOCONF=yes\" >> /etc/sysconfig/network-scripts/ifcfg-eth0" >>/CMDS
+                echo "IPV6_AUTOCONF=yes" >> /etc/sysconfig/network-scripts/ifcfg-$NETWORK_DEVICE
             fi
 
-            if grep -q IPV6_DEFROUTE /etc/sysconfig/network-scripts/ifcfg-eth0; then
-                sed -i 's/^IPV6_DEFROUTE=[^ ]*/IPV6_DEFROUTE=yes/' /etc/sysconfig/network-scripts/ifcfg-eth0
+            if grep -q IPV6_DEFROUTE /etc/sysconfig/network-scripts/ifcfg-$NETWORK_DEVICE; then
+                sed -i 's/^IPV6_DEFROUTE=[^ ]*/IPV6_DEFROUTE=yes/' /etc/sysconfig/network-scripts/ifcfg-$NETWORK_DEVICE
             else
-                echo "IPV6_DEFROUTE=yes" >> /etc/sysconfig/network-scripts/ifcfg-eth0
+                echo "IPV6_DEFROUTE=yes" >> /etc/sysconfig/network-scripts/ifcfg-$NETWORK_DEVICE
             fi
 
             systemctl restart network


### PR DESCRIPTION
since the name of the network device isn't always eth0
the workaround wasn't working in some cases

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
