### PR TITLE
fix(spot_failure_fallback): catch all ClientError

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -32,6 +32,7 @@ from collections.abc import Callable
 
 import yaml
 import boto3
+import botocore.exceptions
 import tenacity
 from mypy_boto3_ec2 import EC2Client
 from pkg_resources import parse_version
@@ -251,7 +252,7 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
                 else:
                     instances = self._create_spot_instances(count, interfaces, ec2_user_data, dc_idx)
                 break
-            except CreateSpotInstancesError as cl_ex:
+            except (CreateSpotInstancesError, botocore.exceptions.ClientError) as cl_ex:
                 if instances_provision_type == instances_provision_fallbacks[-1]:
                     raise
                 if not self.check_spot_error(str(cl_ex), instances_provision_type):


### PR DESCRIPTION
the fallback was only catching `CreateSpotInstancesError` which
is raise by SCT code only after the `request_spot_instances` API
call returned, if any exception was raised during the API call
itself, it was rasing it stright away.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
