### PR TITLE
fix(longevity_twcs_test): Apply post_prepare_cql_commands

### DIFF
--- a/longevity_test.py
+++ b/longevity_test.py
@@ -159,9 +159,7 @@ class LongevityTest(ClusterTester):
             for stress in verify_queue:
                 self.verify_stress_thread(cs_thread_pool=stress)
 
-        post_prepare_cql_cmds = self.params.get('post_prepare_cql_cmds')
-        if post_prepare_cql_cmds:
-            self._run_cql_commands(post_prepare_cql_cmds)
+        self.run_post_prepare_cql_cmds()
 
         prepare_wait_no_compactions_timeout = self.params.get('prepare_wait_no_compactions_timeout')
         if prepare_wait_no_compactions_timeout:
@@ -169,6 +167,11 @@ class LongevityTest(ClusterTester):
                 node.run_nodetool("compact")
             self.wait_no_compactions_running(n=prepare_wait_no_compactions_timeout)
         self.log.info('Prepare finished')
+
+    def run_post_prepare_cql_cmds(self):
+        if post_prepare_cql_cmds := self.params.get('post_prepare_cql_cmds'):
+            self.log.debug("Execute post prepare queries: %s", post_prepare_cql_cmds)
+            self._run_cql_commands(post_prepare_cql_cmds)
 
     def test_custom_time(self):
         """

--- a/longevity_twcs_test.py
+++ b/longevity_twcs_test.py
@@ -21,13 +21,17 @@ class TWCSLongevityTest(LongevityTest):
                 ) WITH CLUSTERING ORDER BY (ck ASC)
                     AND default_time_to_live = {ttl}
                     AND compaction = {{'class': 'TimeWindowCompactionStrategy', 'compaction_window_size': '{window_size}',
-                    'compaction_window_unit': 'MINUTES'}}"""
-                            )
+                    'compaction_window_unit': 'MINUTES'}}""")
 
     def run_prepare_write_cmd(self):
         self.create_tables_for_scylla_bench()
-        with ignore_mutation_write_errors():
-            super().run_prepare_write_cmd()
+        if self.params.get("prepare_write_cmd"):
+            # run_prepare_write_cmd executes run_post_prepare_cql_cmds
+            # it doesn't need to call run_post_prepare_cql_cmds twice.
+            with ignore_mutation_write_errors():
+                super().run_prepare_write_cmd()
+        else:
+            self.run_post_prepare_cql_cmds()
 
         # Run nemesis during stress as it was stopped before copy expected data
         if self.params.get('nemesis_during_prepare'):

--- a/test-cases/longevity/longevity-twcs-48h.yaml
+++ b/test-cases/longevity/longevity-twcs-48h.yaml
@@ -25,7 +25,7 @@ space_node_threshold: 64424
 
 user_prefix: 'longevity-twcs-48h'
 
-post_prepare_cql_cmds: "ALTER TABLE scylla_bench.test with gc_grace_seconds = 300 and default_time_to_live = 21600 and compaction = {'class':'TimeWindowCompactionStrategy', 'compaction_window_size': 60, 'compaction_window_unit': 'MINUTES'};"
+post_prepare_cql_cmds: "ALTER TABLE scylla_bench.test with gc_grace_seconds = 15000 and default_time_to_live = 21600 and compaction = {'class':'TimeWindowCompactionStrategy', 'compaction_window_size': 60, 'compaction_window_unit': 'MINUTES'};"
 
 # Temporarily downgrade scylla_bench to a stable version
 scylla_bench_version: v0.1.3


### PR DESCRIPTION
Method write_prepare_write_cmd execute the post_prepare_cql_cmds
from config yaml. But twcs yaml doesn't use the 'prepare_write_cmd".
And it is a reason, why post_cql_cmd are not applied. This
cql commands are important to change gc and ttl for twcs tests.

these 2 parameters should decrease number of sstables and
should avoid sb read errors.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
