### PR TITLE
feature(sct-runner): increase root disk size for SCT runners

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1324,14 +1324,15 @@ def create_runner_image(cloud_provider, region, availability_zone):
 @click.option("-r", "--region", required=True, type=CloudRegion(), help="Cloud region")
 @click.option("-z", "--availability-zone", default="", type=str, help="Name of availability zone, ex. 'a'")
 @click.option("-i", "--instance-type", required=False, type=str, default="", help="Instance type")
+@click.option("-i", "--root-disk-size-gb", required=False, type=int, default=0, help="Root disk size in Gb")
 @click.option("-t", "--test-id", required=True, type=str, help="Test ID")
 @click.option("-d", "--duration", required=True, type=int, help="Test duration in MINUTES")
 @click.option("-rm", "--restore-monitor", required=False, type=bool,
               help="Is the runner for restore monitor purpose or not")
 @click.option("-rt", "--restored-test-id", required=False, type=str,
               help="Test ID of the test that the runner is created for restore monitor")
-def create_runner_instance(cloud_provider, region, availability_zone, instance_type, test_id, duration,
-                           restore_monitor=False, restored_test_id=""):
+def create_runner_instance(cloud_provider, region, availability_zone, instance_type, root_disk_size_gb,
+                           test_id, duration, restore_monitor=False, restored_test_id=""):
     if cloud_provider == "aws":
         assert len(availability_zone) == 1, f"Invalid AZ: {availability_zone}, availability-zone is one-letter a-z."
     add_file_logger()
@@ -1340,6 +1341,7 @@ def create_runner_instance(cloud_provider, region, availability_zone, instance_t
     sct_runner = get_sct_runner(cloud_provider=cloud_provider, region_name=region, availability_zone=availability_zone)
     instance = sct_runner.create_instance(
         instance_type=instance_type,
+        root_disk_size_gb=root_disk_size_gb,
         test_id=test_id,
         test_duration=duration,
         restore_monitor=restore_monitor,

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -251,6 +251,7 @@ class SctRunner(ABC):
                          base_image: Any,
                          tags: dict[str, str],
                          instance_name: str,
+                         root_disk_size_gb: int = 0,
                          region_az: str = "",
                          test_duration: Optional[int] = None) -> Any:
         ...
@@ -339,7 +340,8 @@ class SctRunner(ABC):
     def _get_base_image(self, image: Optional[Any] = None) -> Any:
         ...
 
-    def create_instance(self, test_id: str, test_duration: int, instance_type: str = "",  # pylint: disable=too-many-arguments
+    def create_instance(self, test_id: str, test_duration: int,  # pylint: disable=too-many-arguments
+                        instance_type: str = "",  root_disk_size_gb: int = 0,
                         restore_monitor: bool = False, restored_test_id: str = "") -> Any:
         LOGGER.info("Creating SCT Runner instance...")
         image = self.image
@@ -362,6 +364,7 @@ class SctRunner(ABC):
         return self._create_instance(
             instance_type=instance_type or self.instance_type(test_duration=test_duration),
             base_image=self._get_base_image(self.image),
+            root_disk_size_gb=root_disk_size_gb,
             tags=tags,
             instance_name=f"{self.image_name}-{'restored-monitor-' if restore_monitor else ''}instance-{test_id[:8]}",
             region_az=self.region_az(
@@ -441,6 +444,7 @@ class AwsSctRunner(SctRunner):
                          base_image: Any,
                          tags: dict[str, str],
                          instance_name: str,
+                         root_disk_size_gb: int = 0,
                          region_az: str = "",
                          test_duration: Optional[int] = None) -> Any:
         if region_az.startswith(self.SOURCE_IMAGE_REGION):
@@ -474,7 +478,7 @@ class AwsSctRunner(SctRunner):
             BlockDeviceMappings=[{
                 "DeviceName": ec2_ami_get_root_device_name(image_id=base_image, region=aws_region.region_name),
                 "Ebs": {
-                    "VolumeSize": self.instance_root_disk_size(test_duration),
+                    "VolumeSize": root_disk_size_gb or self.instance_root_disk_size(test_duration),
                     "VolumeType": "gp2"
                 }
             }]
@@ -630,6 +634,7 @@ class GceSctRunner(SctRunner):
                          base_image: Any,
                          tags: dict[str, str],
                          instance_name: str,
+                         root_disk_size_gb: int = 0,
                          region_az: str = "",
                          test_duration: Optional[int] = None) -> Any:
         LOGGER.info("Creating instance...")
@@ -649,7 +654,7 @@ class GceSctRunner(SctRunner):
                 "initializeParams": {
                     "diskName": f"{instance_name}-root-pd-ssd",
                     "diskType": f"projects/{self.project_name}/zones/{gce_service.zone.name}/diskTypes/pd-ssd",
-                    "diskSizeGb": self.instance_root_disk_size(test_duration),
+                    "diskSizeGb": root_disk_size_gb or self.instance_root_disk_size(test_duration),
                     "sourceImage": base_image,
                 },
                 "boot": True,
@@ -794,6 +799,7 @@ class AzureSctRunner(SctRunner):
                          base_image: Any,
                          tags: dict[str, str],
                          instance_name: str,
+                         root_disk_size_gb: int = 0,
                          region_az: str = "",
                          test_duration: Optional[int] = None) -> Any:
         if base_image is self.BASE_IMAGE:
@@ -808,7 +814,7 @@ class AzureSctRunner(SctRunner):
                 vm_name=instance_name,
                 vm_size=instance_type,
                 image=base_image,
-                disk_size=self.instance_root_disk_size(test_duration=test_duration),
+                disk_size=root_disk_size_gb or self.instance_root_disk_size(test_duration=test_duration),
                 tags=tags | {"launch_time": get_current_datetime_formatted()},
                 **additional_kwargs,
             )
@@ -822,7 +828,8 @@ class AzureSctRunner(SctRunner):
                                            user_name=self.LOGIN_USER,
                                            ssh_key=self.key_pair,
                                            tags=tags | {"launch_time": get_current_datetime_formatted()},
-                                           root_disk_size=self.instance_root_disk_size(test_duration=test_duration),
+                                           root_disk_size=root_disk_size_gb or self.instance_root_disk_size(
+                                               test_duration=test_duration),
                                            user_data=None)
             return provisioner.get_or_create_instance(definition=vm_params,
                                                       pricing_model=PricingModel.ON_DEMAND)

--- a/vars/createSctRunner.groovy
+++ b/vars/createSctRunner.groovy
@@ -3,10 +3,13 @@
 def call(Map params, Integer test_duration, String region) {
     def cloud_provider = getCloudProviderFromBackend(params.backend)
     def instance_type_arg = ""
+    def root_disk_size_gb_arg = ""
     if ( params.backend == "k8s-local-kind-aws" ) {
         instance_type_arg = "--instance-type c5.2xlarge"
+        root_disk_size_gb_arg = "--root-disk-size-gb 120"
     } else if ( params.backend == "k8s-local-kind-gce" ) {
         instance_type_arg = "--instance-type e2-standard-8"
+        root_disk_size_gb_arg = "--root-disk-size-gb 120"
     }
 
     // NOTE: EKS jobs have 'availability_zone' be defined as 'a,b'
@@ -31,6 +34,7 @@ def call(Map params, Integer test_duration, String region) {
             --region ${region} \
             --availability-zone ${availability_zone} \
             $instance_type_arg \
+            $root_disk_size_gb_arg \
             --test-id \${SCT_TEST_ID} \
             --duration ${test_duration}
     else


### PR DESCRIPTION
Add possibility to specify the size of a root disk for an SCT runner.
Also, specify the disk size explicitly for the local K8S deployments
where we need more than default 80Gb for whole set of data.
More space started being required after adding the caching logic
for the docker images on local K8S to avoid the following error:

    ERROR:root:Filesystem at /var/lib/scylla/data has only \
        6025740288 bytes available; that is less than \
        the recommended 10 GB. \
        Please free up space and run scylla_io_setup again.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
