### PR TITLE
feature(provision): use cloud-init for ssh config

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -13,44 +13,44 @@
 
 # pylint: disable=too-many-lines, too-many-public-methods
 
-import os
-import re
+import base64
 import json
+import logging
+import os
+import random
+import re
+import tempfile
 import time
 import uuid
-import base64
-import random
-import logging
-import tempfile
-from math import floor
-from typing import Dict, Optional, ParamSpec, TypeVar
-from datetime import datetime
-from textwrap import dedent
-from functools import cached_property
-from contextlib import ExitStack
 from collections.abc import Callable
+from contextlib import ExitStack
+from datetime import datetime
+from functools import cached_property
+from math import floor
+from textwrap import dedent
+from typing import Dict, Optional, ParamSpec, TypeVar
 
-import yaml
 import boto3
 import tenacity
+import yaml
 from mypy_boto3_ec2 import EC2Client
 from pkg_resources import parse_version
 
 from sdcm import ec2_client, cluster, wait
-from sdcm.wait import exponential_retry
+from sdcm.ec2_client import CreateSpotInstancesError
 from sdcm.provision.aws.utils import configure_eth1_script, network_config_ipv6_workaround_script, \
     configure_set_preserve_hostname_script
 from sdcm.provision.common.utils import configure_hosts_set_hostname_script
+from sdcm.provision.helpers.cloud_init import get_cloud_init_config
 from sdcm.provision.scylla_yaml import SeedProvider
 from sdcm.remote import LocalCmdRunner, shell_script_cmd, NETWORK_EXCEPTIONS
-from sdcm.ec2_client import CreateSpotInstancesError
+from sdcm.sct_events.database import DatabaseLogEvent
+from sdcm.sct_events.filters import DbEventsFilter
+from sdcm.sct_events.system import SpotTerminationEvent
 from sdcm.utils.aws_utils import tags_as_ec2_tags, ec2_instance_wait_public_ip
 from sdcm.utils.common import list_instances_aws, get_ami_tags, MAX_SPOT_DURATION_TIME
 from sdcm.utils.decorators import retrying
-from sdcm.sct_events.system import SpotTerminationEvent
-from sdcm.sct_events.filters import DbEventsFilter
-from sdcm.sct_events.database import DatabaseLogEvent
-
+from sdcm.wait import exponential_retry
 
 LOGGER = logging.getLogger(__name__)
 
@@ -380,6 +380,10 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
                     base64.b64encode(post_boot_script.encode('utf-8')).decode('ascii'))
             else:
                 ec2_user_data = post_boot_script
+
+        #  replace user_data json with cloud-init content if preinstalled scylla is not used
+        if not self.params.get("use_preinstalled_scylla"):
+            ec2_user_data = get_cloud_init_config()
 
         instances = self._create_or_find_instances(count=count, ec2_user_data=ec2_user_data, dc_idx=dc_idx)
         added_nodes = [self._create_node(instance, self._ec2_ami_username,

--- a/sdcm/provision/aws-cloud-init.txt
+++ b/sdcm/provision/aws-cloud-init.txt
@@ -1,0 +1,31 @@
+Content-Type: multipart/mixed; boundary="//"
+MIME-Version: 1.0
+
+--//
+Content-Type: text/cloud-config; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment; filename="cloud-config.txt"
+#cloud-config
+
+cloud_final_modules:
+ - [scripts-user, always]
+
+--//
+Content-Type: text/x-shellscript; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment; filename="custom_user_script.txt"
+
+#!/bin/bash
+echo "Running the legacy ssh keys script" > /tmp/User scripts
+systemctl stop sshd || true
+if (( $(ssh -V 2>&1 | tr -d "[:alpha:][:blank:][:punct:]" | cut -c-2) >= 88 )); then
+    sed -i 's/#PubkeyAuthentication \(.*\)$/PubkeyAuthentication yes/' /etc/ssh/sshd_config || true
+    sed -i -e '$aPubkeyAcceptedAlgorithms +ssh-rsa' /etc/ssh/sshd_config || true
+    sed -i -e '$aHostKeyAlgorithms +ssh-rsa' /etc/ssh/sshd_config || true
+fi
+systemctl restart sshd || true
+echo "Finished running the legacy ssh keys script"
+
+--//--

--- a/sdcm/provision/helpers/cloud_init.py
+++ b/sdcm/provision/helpers/cloud_init.py
@@ -11,7 +11,9 @@
 #
 # Copyright (c) 2022 ScyllaDB
 import logging
+from pathlib import Path
 
+from sdcm import sct_abs_path
 from sdcm.provision.provisioner import VmInstance
 from sdcm.provision.user_data import CLOUD_INIT_SCRIPTS_PATH
 from sdcm.remote import RemoteCmdRunnerBase
@@ -58,3 +60,7 @@ def log_user_data_scripts_errors(remoter: RemoteCmdRunnerBase) -> bool:
         LOGGER.error("User data scripts were not executed at all.")
         errors_found = True
     return errors_found
+
+
+def get_cloud_init_config():
+    return Path(sct_abs_path("sdcm/provision/aws-cloud-init.txt")).read_text(encoding="utf-8")


### PR DESCRIPTION
This PR adds support for running our SCT tests with `cloud-init`-compatible `UserData`. The current implementation makes the usage conditioned on the `use_preinstalled_scylla` param being set to `false` to avoid impacting jobs that use AMIs (interfering with their `UserData`).

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
