### PR TITLE
fix(event): print scylla-bench event stress_cmd

### DIFF
--- a/sdcm/scylla_bench_thread.py
+++ b/sdcm/scylla_bench_thread.py
@@ -183,7 +183,7 @@ class ScyllaBenchThread:  # pylint: disable=too-many-instance-attributes
                                        stress_log_filename=log_file_name,
                                        loader_idx=loader_idx), \
                 ScyllaBenchStressEventsPublisher(node=node, sb_log_filename=log_file_name) as publisher, \
-                ScyllaBenchEvent(node=node, stress_cmd=self.stress_cmd,
+                ScyllaBenchEvent(node=node, stress_cmd=stress_cmd,
                                  log_file_name=log_file_name) as scylla_bench_event:
             publisher.event_id = scylla_bench_event.event_id
             result = None


### PR DESCRIPTION
It's printed with `-start-timestamp=SET_WRITE_TIMESTAMP`:
```
2022-05-31 11:19:56.217: (ScyllaBenchEvent Severity.NORMAL) period_type=begin event_id=aa0029e8-ba64-4f8c-82c4-e3118c8ffd35: node=Node longevity-twcs-3h-2022-1-loader-node-425600b6-1 [13.53.167.151 | 10.0.2.254] (seed: False)
stress_cmd=scylla-bench -workload=timeseries -mode=write -replication-factor=3 -partition-count=400 -clustering-row-count=10000000 -clustering-row-size=200 -concurrency=100 -rows-per-request=100 -start-timestamp=SET_WRITE_TIMESTAMP -connection-count 100 -max-rate 50000 --timeout 120s -duration=170m -error-at-row-limit 1000
```

Change to real write timestamp, as it's running:
```
< t:2022-05-31 11:19:48,695 f:scylla_bench_thread.py l:160  c:sdcm.scylla_bench_thread p:DEBUG > Replaced stress command: scylla-bench -workload=timeseries -mode=write -replication-factor=3 -partition-count=400 -clustering-row-count=10000000 -clustering-row-size=200 -concurrency=100 -rows-per-request=100 -start-timestamp=1653995988695250258 -connection-count 100 -max-rate 50000 --timeout 120s -duration=170m -error-at-row-limit 1000
```

It's connected to https://github.com/scylladb/scylla-cluster-tests/pull/4266

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
