### PR TITLE
fix(azure): fix missing params attribute in AzureCLuster

### DIFF
--- a/sdcm/cluster_azure.py
+++ b/sdcm/cluster_azure.py
@@ -144,7 +144,7 @@ class AzureCluster(cluster.BaseCluster):   # pylint: disable=too-many-instance-a
         self._user_name = user_name
         self._azure_region_names = region_names
         self._node_prefix = node_prefix
-        self._definition_builder = region_definition_builder.get_builder(self.params, test_config=self.test_config)
+        self._definition_builder = region_definition_builder.get_builder(params, test_config=self.test_config)
         super().__init__(cluster_uuid=cluster_uuid,
                          cluster_prefix=cluster_prefix,
                          node_prefix=node_prefix,


### PR DESCRIPTION
self.params attribute was used before creation causing an error.
`definition_builder` cannot be instantiated in BaseCluster as not all
backends support it yet.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
