### PR TITLE
fix(sct_config): user get readable messge if versio/repo missing

### DIFF
--- a/internal_test_data/complex_test_case_with_version.yaml
+++ b/internal_test_data/complex_test_case_with_version.yaml
@@ -43,7 +43,7 @@ gce_n_local_ssd_disk_monitor: 0
 
 db_type: scylla
 instance_type_db: 'i3.4xlarge'
-scylla_version: '3.0.3'
+scylla_version: '4.5.3'
 
 ami_id_loader: 'ami-07bcb57f57a485721'
 ami_id_monitor: 'ami-07bcb57f57a485721'

--- a/internal_test_data/minimal_test_case.yaml
+++ b/internal_test_data/minimal_test_case.yaml
@@ -15,4 +15,3 @@ stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_profile_4mv_5queries.y
 
 db_type: scylla
 instance_type_db: 'i3.large'
-ami_id_db_scylla: 'ami-06f919eb'

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1738,6 +1738,7 @@ class SCTConfiguration(dict):
         self._validate_sct_variable_values()
         backend = self.get('cluster_backend')
         db_type = self.get('db_type')
+        self._check_version_supplied(backend)
         self._check_per_backend_required_values(backend)
         if backend in ['aws'] and db_type != 'cloud_scylla':
             self._check_aws_multi_region_params()
@@ -1823,6 +1824,33 @@ class SCTConfiguration(dict):
         opts = [o for o in self.config_options if o['name'] in required_params]
         for _opt in opts:
             assert _opt['name'] in self, "{} missing from config for {}".format(_opt['name'], backend)
+
+    def _check_version_supplied(self, backend: str):
+        one_of_options_must_exist = []
+
+        if not self.get('use_preinstalled_scylla'):
+            one_of_options_must_exist += ['scylla_repo']
+        elif self.get('db_type') == 'cloud_scylla':
+            one_of_options_must_exist += ['cloud_cluster_id']
+        elif backend == 'aws':
+            one_of_options_must_exist += ['ami_id_db_scylla']
+        elif backend == 'gce':
+            one_of_options_must_exist += ['gce_image_db']
+        elif backend == 'azure':
+            one_of_options_must_exist += ['azure_image_db']
+        elif backend == 'docker':
+            one_of_options_must_exist += ['docker_image']
+        elif backend == 'baremetal':
+            one_of_options_must_exist += ['db_nodes_public_ip']
+        elif 'k8s' in backend:
+            one_of_options_must_exist += ['scylla_version']
+
+        if not one_of_options_must_exist:
+            return
+        assert any(self.get(o) for o in one_of_options_must_exist), \
+            "scylla version/repos wasn't configured correctly\n" \
+            f"configure one of the following: {one_of_options_must_exist}\n" \
+            f"or one of those environment variables: {['SCT_' + o.upper() for o in one_of_options_must_exist]}"
 
     def _check_partition_range_with_data_validation_correctness(self):
         partition_range_with_data_validation = self.get('partition_range_with_data_validation')

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -32,29 +32,38 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         logging.getLogger('boto3').setLevel(logging.CRITICAL)
         logging.getLogger('anyconfig').setLevel(logging.ERROR)
 
-        os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
-        os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/minimal_test_case.yaml'
+        cls.setup_default_env()
 
+        os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
+        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-06f919eb'
         cls.conf = sct_config.SCTConfiguration()
 
-        for k in os.environ:
-            if k.startswith('SCT_'):
-                del os.environ[k]
+        cls.clear_sct_env_variables()
 
         # some of the tests assume this basic case is define, to avoid putting this again and again in each test
-        # and so we can run those tests specificly
-        os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/minimal_test_case.yaml'
+        # and so we can run those tests specifically
+        cls.setup_default_env()
 
     def tearDown(self):
+        self.clear_sct_env_variables()
+        self.setup_default_env()
+
+    @classmethod
+    def setup_default_env(cls):
+        os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/minimal_test_case.yaml'
+
+    @classmethod
+    def clear_sct_env_variables(cls):
         for k in os.environ:
             if k.startswith('SCT_'):
                 del os.environ[k]
-        os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/minimal_test_case.yaml'
 
     def test_01_dump_config(self):
         logging.debug(self.conf.dump_config())
 
     def test_02_verify_config(self):
+        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-06f919eb'
+
         self.conf.verify_configuration()
         self.conf.check_required_files()
 
@@ -114,6 +123,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         os.environ['SCT_CLUSTER_BACKEND'] = 'baremetal'
         os.environ['SCT_DB_NODES_PRIVATE_IP'] = '["1.2.3.4", "1.2.3.5"]'
         os.environ['SCT_DB_NODES_PUBLIC_IP'] = '["1.2.3.4", "1.2.3.5"]'
+        os.environ['SCT_USE_PREINSTALLED_SCYLLA'] = 'true'
         conf = sct_config.SCTConfiguration()
         conf.verify_configuration()
 
@@ -156,6 +166,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         conf.verify_configuration()
 
     def test_12_scylla_version_ami(self):
+        os.environ.pop('SCT_AMI_ID_DB_SCYLLA', None)
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
         os.environ['SCT_SCYLLA_VERSION'] = '3.0.3'
 
@@ -176,6 +187,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         conf.verify_configuration()
 
     def test_12_scylla_version_ami_case2(self):  # pylint: disable=invalid-name
+        os.environ.pop('SCT_AMI_ID_DB_SCYLLA', None)
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
         os.environ['SCT_SCYLLA_VERSION'] = '99.0.3'
         os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/multi_region_dc_test_case.yaml'
@@ -200,6 +212,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         conf.verify_configuration()
 
     def test_12_scylla_version_repo_case2(self):  # pylint: disable=invalid-name
+        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-06f919eb'
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
         os.environ['SCT_SCYLLA_VERSION'] = '99.0.3'
 
@@ -257,6 +270,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
                          'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-4.6.repo')
 
     def test_13_scylla_version_ami_branch(self):  # pylint: disable=invalid-name
+        os.environ.pop('SCT_AMI_ID_DB_SCYLLA', None)
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
         os.environ['SCT_SCYLLA_VERSION'] = 'branch-4.2:100'
         os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/multi_region_dc_test_case.yaml'
@@ -266,6 +280,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         self.assertEqual(conf.get('ami_id_db_scylla'), 'ami-07d3138defbd9a2cf ami-0f703fdc8e06723f0')
 
     def test_13_scylla_version_ami_branch_latest(self):  # pylint: disable=invalid-name
+        os.environ.pop('SCT_AMI_ID_DB_SCYLLA', None)
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
         os.environ['SCT_SCYLLA_VERSION'] = 'branch-4.2:latest'
         os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/multi_region_dc_test_case.yaml'
@@ -277,6 +292,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
 
     def test_conf_check_required_files(self):  # pylint: disable=no-self-use
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
+        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-06f919eb'
         os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/minimal_test_case.yaml'
         os.environ['SCT_STRESS_CMD'] = """cassandra-stress user profile=/tmp/cs_profile_background_reads_overload.yaml \
             ops'(insert=100)' no-warmup cl=ONE duration=10m -mode cql3 native -rate threads=3000 -errors ignore"""
@@ -390,6 +406,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         os.environ['SCT_SCYLLA_VERSION'] = 'master:latest'
         os.environ['SCT_USER_PREFIX'] = 'testing'
         os.environ['SCT_GCE_IMAGE_DB'] = ''
+        os.environ['SCT_USE_PREINSTALLED_SCYLLA'] = 'true'
 
         resolved_image_link = 'https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/' \
                               'scylla-4-7-dev-0-20220113-8bcd23fa0-1-build-359'
@@ -406,6 +423,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
     def test_16_default_oracle_scylla_version_eu_west_1(self):
         ami_4_4_7 = "ami-0cac6b91be579df80"
 
+        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-06f919eb'
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
         os.environ['SCT_REGION_NAME'] = 'eu-west-1'
         os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/minimal_test_case.yaml'
@@ -434,6 +452,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
     def test_16_oracle_scylla_version_eu_west_1(self):
         ami_4_5_2 = "ami-057f1cfd8877782b2"
 
+        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-06f919eb'
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
         os.environ['SCT_ORACLE_SCYLLA_VERSION'] = "4.5.2"
         os.environ['SCT_REGION_NAME'] = 'eu-west-1'
@@ -475,6 +494,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
 
     def test_17_verify_scylla_bench_required_parameters_in_command(self):
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
+        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-06f919eb'
         os.environ['SCT_STRESS_CMD'] = "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=100"
         os.environ["SCT_STRESS_READ_CMD"] = "scylla-bench -workload=uniform -mode=read -replication-factor=3 -partition-count=100"
 
@@ -486,6 +506,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
 
     def test_17_1_raise_error_if_scylla_bench_command_dont_have_workload(self):
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
+        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-06f919eb'
         os.environ['SCT_STRESS_CMD'] = "scylla-bench -mode=write -replication-factor=3 -partition-count=100"
         os.environ["SCT_STRESS_READ_CMD"] = "scylla-bench -workload=uniform -mode=read -replication-factor=3 -partition-count=100"
 
@@ -499,6 +520,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
 
     def test_17_2_raise_error_if_scylla_bench_command_dont_have_mode(self):
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
+        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-06f919eb'
         os.environ['SCT_STRESS_CMD'] = "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=100"
         os.environ["SCT_STRESS_READ_CMD"] = "scylla-bench -workload=uniform -replication-factor=3 -partition-count=100"
 
@@ -509,6 +531,25 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
             conf.verify_configuration()
 
         self.assertIn(err_msg, str(context.exception))
+
+    def test_18_error_if_no_version_repo_ami_selected(self):
+        os.environ.pop('SCT_AMI_ID_DB_SCYLLA', None)
+
+        for backend in sct_config.SCTConfiguration.available_backends:
+            if 'k8s' in backend:
+                continue
+            if 'siren' in backend:
+                os.environ['SCT_DB_TYPE'] = 'cloud_scylla'
+
+            os.environ['SCT_CLUSTER_BACKEND'] = backend
+            os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/minimal_test_case.yaml'
+
+            conf = sct_config.SCTConfiguration()
+            with self.assertRaises(AssertionError, msg=f"{backend} didn't failed") as context:
+                conf.verify_configuration()
+            self.assertIn("scylla version/repos wasn't configured correctly", str(context.exception), )
+
+            self.clear_sct_env_variables()
 
 
 if __name__ == "__main__":

--- a/utils/lint_test_cases.sh
+++ b/utils/lint_test_cases.sh
@@ -4,7 +4,7 @@ OUT=0
 SCT_SCYLLA_VERSION=4.4.1 ./sct.py lint-yamls -i '.yaml' -e 'multi-dc,multiDC,multidc,multiple-dc,rolling,docker,artifacts,private-repo,ics/long,scylla-operator,gce,jepsen,repair-based-operations'
 OUT=$(($OUT + $?))
 
-SCT_SCYLLA_REPO='http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylla-2021.1.repo' ./sct.py lint-yamls -b gce -i 'multi-dc,multiDC,multidc,multiple-dc,rolling,artifacts,private-repo,gce,jepsen' -e 'docker'
+SCT_GCE_IMAGE_DB=image SCT_SCYLLA_REPO='http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylla-2021.1.repo' ./sct.py lint-yamls -b gce -i 'multi-dc,multiDC,multidc,multiple-dc,rolling,artifacts,private-repo,gce,jepsen' -e 'docker,azure'
 OUT=$(($OUT + $?))
 
 SCT_SCYLLA_VERSION=4.4.1 ./sct.py lint-yamls -b k8s-local-kind -i 'scylla-operator.*\.yaml'


### PR DESCRIPTION
The message would be base on the backend it's using stating
the expected argument to pass to select the scylla version under
test

```
E       AssertionError: scylla version/repos wasn't configured correctly
E       configure one of the following: ['azure_image_db']
E       or one of those environment variables: ['SCT_AZURE_IMAGE_DB']
```

Fixes: #4838

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
