### PR TITLE
fix(aws-tagging): tag instances with detail as soon as possible

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -138,6 +138,10 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
         if instance_profile:
             params['IamInstanceProfile'] = {'Name': instance_profile}
         instances = self._ec2_services[dc_idx].create_instances(**params)
+
+        ec2 = ec2_client.EC2ClientWrapper(region_name=self.region_names[dc_idx])
+        ec2.add_tags(instances, {'Name': 'on_demand'})
+
         self.log.debug("Created instances: %s." % instances)
         return instances
 


### PR DESCRIPTION
since ec20d478b457cb45b5844c5820b98417f60fcb8b the the tagging
is done in a later stage, and in some cases (test stops in the
provision, or failure to connect to nodes), the resources are
left there, but with out any tags.

We now tried to tag them with the common tags we have.
at a later stage it would be updated with the node specific
tags.

Fixes: #4841

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
