### PR TITLE
fix(gemini.yamls): Switch to use sisyphus monkey nemesis

### DIFF
--- a/test-cases/gemini/gemini-1tb-10h.yaml
+++ b/test-cases/gemini/gemini-1tb-10h.yaml
@@ -8,8 +8,10 @@ instance_type_loader: 'm5.xlarge'
 
 user_prefix: 'gemini-1tb-10h'
 
-nemesis_class_name: 'GeminiChaosMonkey'
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_include_filter: ['run_with_gemini']
 nemesis_interval: 5
+nemesis_seed: '041'
 
 gemini_cmd: "gemini -d --duration 8h --warmup 2h -c 50 \
 -m mixed -f --non-interactive --cql-features normal \

--- a/test-cases/gemini/gemini-3h-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nemesis.yaml
@@ -7,8 +7,10 @@ instance_type_db: 'i3.large'
 
 user_prefix: 'gemini-with-nemesis-3h-normal'
 
-nemesis_class_name: 'GeminiChaosMonkey'
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_include_filter: ['run_with_gemini']
 nemesis_interval: 5
+nemesis_seed: '032'
 
 # gemini
 # cmd: gemini -d -n [NUM_OF_TEST_ITERATIONS] -c [NUM_OF_THREADS] -p [NUM_OF_PARTITION_KEYS_PER_THREAD] -m mixed -f

--- a/test-cases/gemini/gemini-8h-large-num-columns.yaml
+++ b/test-cases/gemini/gemini-8h-large-num-columns.yaml
@@ -8,8 +8,10 @@ instance_type_loader: 'c5.4xlarge'
 
 user_prefix: 'gemini-8h-large-num-columns'
 
-nemesis_class_name: 'GeminiChaosMonkey'
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_include_filter: ['run_with_gemini']
 nemesis_interval: 5
+nemesis_seed: '023'
 
 # gemini
 # cmd: gemini -d -n [NUM_OF_TEST_ITERATIONS] -c [NUM_OF_THREADS] -p [NUM_OF_PARTITION_KEYS_PER_THREAD] -m mixed -f


### PR DESCRIPTION
Gemini uses GeminiChaosMonkey: specific set of nemesis
which should be run with gemini tool. But order of nemesis
is always random.
Switch gemini job to use sisyphus nemesis with filter
it is allow to have reproducable set and order of nemesis

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
