### PR TITLE
fix(autossh): fix bind mount on hosts with selinux

### DIFF
--- a/sdcm/utils/auto_ssh.py
+++ b/sdcm/utils/auto_ssh.py
@@ -31,7 +31,7 @@ class AutoSshContainerMixin:
         hostname = self.ssh_login_info["hostname"]
         port = self.ssh_login_info.get("port", "22")
         user = self.ssh_login_info["user"]
-        volumes = {os.path.expanduser(self.ssh_login_info["key_file"]): {"bind": "/id_rsa", "mode": "ro"}}
+        volumes = {os.path.expanduser(self.ssh_login_info["key_file"]): {"bind": "/id_rsa", "mode": "ro,z"}}
 
         return dict(image=AUTO_SSH_IMAGE,
                     name=f"{self.name}-{hostname.replace(':', '-')}-autossh",


### PR DESCRIPTION
Hydra runs "autossh" in separate docker instances, and the way it passes
the SSH key to this image is by bind-mounting the outside host's file
$HOME/.ssh/scylla-qa-ec2.

Unfortunately, on hosts which use SELinux, directories cannot be mounted
into docker without "relabeling" the mounted file to be readable from
docker. Without relabeling, autossh complains that it can't find the SSH
key file - even though it does exist. So in this patch we add the "z"
option to the mount, which relabels the file as required.

Signed-off-by: Nadav Har'El <nyh@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
