### PR TITLE
fix(syslog-ng): fix bind mount on hosts with selinux

### DIFF
--- a/sdcm/utils/syslogng.py
+++ b/sdcm/utils/syslogng.py
@@ -53,8 +53,8 @@ class SyslogNGContainerMixin:  # pylint: disable=too-few-public-methods
         os.makedirs(logdir, exist_ok=True)
         LOGGER.debug("syslog-ng will store logs at %s", logdir)
         volumes = {
-            self.syslogng_confpath: {"bind": "/config/syslog-ng.conf", "mode": "ro"},
-            logdir: {"bind": "/var/log"},
+            self.syslogng_confpath: {"bind": "/config/syslog-ng.conf", "mode": "ro,z"},
+            logdir: {"bind": "/var/log", "mode": "z"},
         }
         username = getpass.getuser()
         return {


### PR DESCRIPTION
Hydra runs "syslog-ng" in separate docker instances, and the way it passes
the config file to this image and extracts log files from it is by bind-
mounting the outside host's files.

Unfortunately, on hosts which use SELinux, files cannot be mounted
into docker without "relabeling" the mounted file to be usable from
docker. Without relabeling, the syslog-ng silently doesn't do what it's
supposed to do, and hydra mysteriously doesn't work (the autossh dockers
can't connect to it).

So in this patch we add the "z" option to the mount, which relabels the file
as required when selinux is in enforcing mode.

Fixes #4843

Signed-off-by: Nadav Har'El <nyh@scylladb.com>

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
