### PR TITLE
fix(sdcm/argus_test_run.py): Only split regions property if it's str

### DIFF
--- a/sdcm/argus_test_run.py
+++ b/sdcm/argus_test_run.py
@@ -259,7 +259,7 @@ class ArgusTestRun:
         backend = sct_config.get("cluster_backend")
         region_key = cls.REGION_PROPERTY_MAP.get(backend, cls.REGION_PROPERTY_MAP["default"])
         raw_regions = sct_config.get(region_key) or "undefined_region"
-        regions = raw_regions.split()
+        regions = raw_regions.split() if isinstance(raw_regions, str) else raw_regions
         primary_region = regions[0]
 
         sct_runner_info = CloudInstanceDetails(public_ip=get_sct_runner_ip(), provider=backend,


### PR DESCRIPTION
This fixes an issue for azure tests where region_name property can be a list of strings already.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
