### PR TITLE
feature(run-test): make sure we don't select multiple test methods

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -24,6 +24,7 @@ import time
 import subprocess
 import traceback
 import uuid
+import pprint
 from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 from functools import partial
@@ -166,6 +167,15 @@ class CloudRegion(click.ParamType):
         if value not in regions:
             self.fail(f"invalid region: {value}. (choose from {', '.join(regions)})")
         return value
+
+
+class SctLoader(unittest.TestLoader):
+    def getTestCaseNames(self, testCaseClass):
+        test_cases = super().getTestCaseNames(testCaseClass)
+        num_of_cases = len(test_cases)
+        assert num_of_cases < 2, f"SCT expect only one test case to be selected, found {num_of_cases}:" \
+                                 f"\n{pprint.pformat(test_cases)}"
+        return test_cases
 
 
 @click.group()
@@ -954,7 +964,7 @@ def run_test(argv, backend, config, logdir):
     sys.stderr = OutputLogger(logfile, sys.stderr)
 
     unittest.main(module=None, argv=['python -m unittest', argv],
-                  failfast=False, buffer=False, catchbreak=True)
+                  failfast=False, buffer=False, catchbreak=True, testLoader=SctLoader())
 
 
 @cli.command('run-pytest', help="Run tests using pytest")


### PR DESCRIPTION
Since SCT is built on running only one test method, we should
be more clear about and fail early on, if user by mistake selected
more then one test method

now we he does that, this is the error that would be presented:
```
AssertionError: SCT expect only one test case to be selected, found 3:
['test_batch_custom_time', 'test_custom_time', 'test_user_batch_custom_time']
```

Fixes: #4840

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
