### PR TITLE
fix(collect-logs): fix wrong way of nodes collection

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1247,12 +1247,14 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
                                                instance=instance,
                                                global_ip=instance.public_ip_address,
                                                tags=instance.tags) for instance in instances]
-            self.db_cluster = [c_node for c_node in collecting_nodes if c_node.tags.get(
-                "NodeType") in ("scylla-db", "oracle-db")]
-            self.monitor_set = [c_node for c_node in collecting_nodes if c_node.tags.get("NodeType") == "monitor"]
-            self.loader_set = [c_node for c_node in collecting_nodes if c_node.tags.get("NodeType") == "loader"]
-            self.kubernetes_set = [c_node for c_node in collecting_nodes
-                                   if c_node.tags.get("NodeType") == "k8s"]  # why aws and gce uses 'loader'? Bug?
+            for c_node in collecting_nodes:
+                match c_node.tags.get("NodeType"):
+                    case "scylla-db" | "oracle-db":
+                        self.db_cluster.append(c_node)
+                    case "monitor":
+                        self.monitor_set.append(c_node)
+                    case "loader":
+                        self.loader_set.append(c_node)
             if self.params["use_cloud_manager"]:
                 self.find_and_append_cloud_manager_instance_to_collecting_nodes()
         except ProvisionerError:


### PR DESCRIPTION
It was not working properly due to overwriting collection instead
of appending.

I removed `k8s` nodes as this tag is not used anyway.
When we get with unified provisioning to k8s, we'll add proper stuff.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
