### PR TITLE
fix(log-collector): raise expected exception for unsupported backend

### DIFF
--- a/sdcm/provision/provisioner.py
+++ b/sdcm/provision/provisioner.py
@@ -174,6 +174,8 @@ class ProvisionerFactory:
         """Discovers regions where resources for given test_id are created.
         Returning provisioner class instance for each region."""
         provisioner = self._classes.get(backend)
+        if not provisioner:
+            raise ProvisionerError("Provisioner class was not registered for the '%s' backend" % backend)
         return provisioner.discover_regions(test_id, **config)
 
 

--- a/unit_tests/provisioner/test_provisioner.py
+++ b/unit_tests/provisioner/test_provisioner.py
@@ -16,7 +16,11 @@ import uuid
 import pytest
 
 from sdcm.keystore import KeyStore
-from sdcm.provision.provisioner import InstanceDefinition, provisioner_factory
+from sdcm.provision.provisioner import (
+    InstanceDefinition,
+    provisioner_factory,
+    ProvisionerError,
+)
 from sdcm.provision.user_data import UserDataObject
 
 
@@ -107,6 +111,13 @@ def test_can_discover_regions(test_id, region, backend, provisioner_params):
     provisioner = provisioner_factory.discover_provisioners(backend=backend, **provisioner_params)[0]
     assert provisioner.region == region
     assert provisioner.test_id == test_id
+
+
+def test_discover_provisioners_wrong_backend(provisioner_params):
+    wrong_backend = "absent-name-in-backend-mapping"
+    match_err_msg = "Provisioner class was not registered for the '%s' backend" % wrong_backend
+    with pytest.raises(ProvisionerError, match=match_err_msg):
+        provisioner_factory.discover_provisioners(backend=wrong_backend, **provisioner_params)
 
 
 def test_can_add_tags(provisioner, definition, backend, provisioner_params):


### PR DESCRIPTION
For the moment, if we run any test with local K8S backend then we get
following error on the 'collect logs' stage:

```
  File "sdcm/provision/provisioner.py", line 177, in discover_provisioners
    return provisioner.discover_regions(test_id, **config)
  AttributeError: 'NoneType' object has no attribute 'discover_regions'
```

It happens for any backend that doesn't register provisioner.
So, fix this unsafe coding and add unit test to cover this case.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
