### PR TITLE
feature(cloud-init): add cloud-init user-data for gce

### DIFF
--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -24,6 +24,7 @@ import tenacity
 from libcloud.common.google import GoogleBaseError, ResourceNotFoundError, InvalidRequestError
 
 from sdcm import cluster
+from sdcm.provision.helpers.cloud_init import get_cloud_init_config
 from sdcm.wait import exponential_retry
 from sdcm.keystore import pub_key_from_private_key_file
 from sdcm.sct_events.system import SpotTerminationEvent
@@ -290,6 +291,14 @@ class GCECluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
         self.log.debug(gce_disk_struct)
         return gce_disk_struct
 
+    def _prepare_user_data(self):
+        if not self.params.get("use_preinstalled_scylla"):
+            return get_cloud_init_config()
+        else:
+            return json.dumps(dict(scylla_yaml=dict(cluster_name=self.name),
+                                   start_scylla_on_first_boot=False,
+                                   raid_level=self.params.get("raid_level")))
+
     def _create_instance(self, node_index, dc_idx, spot=False):
         def set_tags_as_labels(_instance):
             self.log.debug(f"Expected tags are {self.tags}")
@@ -321,7 +330,6 @@ class GCECluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
             """)
         username = self.params.get("gce_image_username")
         public_key = pub_key_from_private_key_file(self.params.get("user_credentials_path"))
-        raid_level = self.params.get("raid_level")
         create_node_params = dict(name=name,
                                   size=self._gce_instance_type,
                                   image=self._gce_image,
@@ -331,9 +339,7 @@ class GCECluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
                                                "Name": name,
                                                "NodeIndex": node_index,
                                                "startup-script": startup_script,
-                                               "user-data": json.dumps(dict(scylla_yaml=dict(cluster_name=self.name),
-                                                                            start_scylla_on_first_boot=False,
-                                                                            raid_level=raid_level)),
+                                               "user-data": self._prepare_user_data(),
                                                "block-project-ssh-keys": "true",
                                                "ssh-keys": f"{username}:ssh-rsa {public_key}", },
                                   ex_service_accounts=self._service_accounts,


### PR DESCRIPTION
PR complimentary of https://github.com/scylladb/scylla-cluster-tests/pull/4844 The basic idea is: if we run with `use_preinstalled_scylla`, we'll use the usual, legacy-style `UserData`; if not, we can use `cloud-init`-compatible `UserData`.

Sanity jobs:
https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/maciej/job/artifacts-2004/13/  [ PASSED]
https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/maciej/job/artfiacts-centos-8/6/ [PASSED]

Trello task:
https://trello.com/c/ChdoRZBV

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
