### PR TITLE
fix(logcollector): collect the cassandra-rackdc.properties file

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -28,7 +28,7 @@ from functools import cached_property
 import requests
 
 import sdcm.monitorstack.ui as monitoring_ui
-from sdcm.paths import SCYLLA_YAML_PATH
+from sdcm.paths import SCYLLA_YAML_PATH, SCYLLA_PROPERTIES_PATH
 from sdcm.provision import provisioner_factory
 from sdcm.provision.provisioner import ProvisionerError
 from sdcm.remote import RemoteCmdRunnerBase, LocalCmdRunner
@@ -798,6 +798,8 @@ class ScyllaLogCollector(LogCollector):
                                command='sudo cat /proc/kallsyms'),
                     CommandLog(name='systemctl.status',
                                command='sudo systemctl status --all --full --no-pager'),
+                    CommandLog(name='cassandra-rackdc.properties',
+                               command=f'cat {SCYLLA_PROPERTIES_PATH}')
                     ]
     cluster_log_type = "db-cluster"
     cluster_dir_prefix = "db-cluster"


### PR DESCRIPTION
currently on on k8s we collect this file, this commit
add the collection of `cassandra-rackdc.properties`

Trello: https://trello.com/c/Lh9wUT4j

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
