### PR TITLE
fix(k8s): make sure we have an event for the test outcome

### DIFF
--- a/functional_tests/scylla_operator/conftest.py
+++ b/functional_tests/scylla_operator/conftest.py
@@ -70,9 +70,9 @@ def fixture_tester() -> ScyllaOperatorFunctionalClusterTester:
     global TESTER  # pylint: disable=global-statement
     os.chdir(sct_abs_path())
     tester_inst = ScyllaOperatorFunctionalClusterTester()
+    TESTER = tester_inst  # putting tester global, so we can report skipped test (one with mark.skip)
     tester_inst.setUpClass()
     tester_inst.setUp()
-    TESTER = tester_inst  # putting tester global, so we can report skipped test (one with mark.skip)
     yield tester_inst
     with contextlib.suppress(Exception):
         tester_inst.tearDown()


### PR DESCRIPTION
in k8s functional tests, we don't have any event with the result
of the test. in longevity test we almost always have error or
critical event.

it should be helping investigation of k8s-functional in argus

Trello: https://trello.com/c/CIfZmTDL

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
