### PR TITLE
improvement(k8s-local): use static local volume provisioner

### DIFF
--- a/defaults/k8s_local_kind_config.yaml
+++ b/defaults/k8s_local_kind_config.yaml
@@ -18,7 +18,7 @@ k8s_scylla_datacenter: 'dc-1'
 k8s_scylla_rack: 'kind'
 k8s_scylla_cluster_name: 'sct-cluster'
 k8s_scylla_disk_gi: 5
-k8s_scylla_disk_class: ''
+k8s_scylla_disk_class: 'local-raid-disks'
 k8s_minio_storage_size: '20Gi'
 
 n_loaders: 1

--- a/sdcm/k8s_configs/provisioner/values.yaml
+++ b/sdcm/k8s_configs/provisioner/values.yaml
@@ -71,9 +71,8 @@ classes:
   #  - "/scripts/blkdiscard.sh"
   # Uncomment to create storage class object with default configuration.
   storageClass: true
-  # Uncomment to create storage class object and configure it.
-  # storageClass:
-  #   reclaimPolicy: Delete # Avaiable reclaim policies: Delete/Retain, defaults: Delete.
+  # Uncomment to set reclaimPolicy for the storageClass when storageClass=true
+  reclaimPolicy: Delete # Avaiable reclaim policies: Delete/Retain, defaults: Delete.
 #
 # Configure DaemonSet for provisioner.
 #

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1179,6 +1179,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             image_type="fake-image-type",
             instance_type="fake-instance-type")
         self.k8s_cluster.deploy_node_pool(scylla_pool, wait_till_ready=False)
+        self.k8s_cluster.install_static_local_volume_provisioner(node_pool=scylla_pool)
 
         self.k8s_cluster.deploy_cert_manager(pool_name=self.k8s_cluster.AUXILIARY_POOL_NAME)
         self.k8s_cluster.deploy_scylla_operator(pool_name=self.k8s_cluster.AUXILIARY_POOL_NAME)


### PR DESCRIPTION
We should use static local volume provisioner to avoid possible
strange failures of operator and scylla interactions when we
remove/replace/decommission a Scylla pod.
Having static local volume provisioner we do not lose data removing
pod, but using dynamic provisioner we do lose data removing a Scylla pod.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
