### PR TITLE
fix(sct_config): take care of unsupported aws regions

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1432,7 +1432,10 @@ class SCTConfiguration(dict):
 
         if cluster_backend in ['aws', 'aws-siren', 'k8s-eks']:
             for region in region_names:
-                for key, value in regions_data[region].items():
+                if region not in regions_data:
+                    raise ValueError(f"{region} isn't supported, use: {list(regions_data.keys())}")
+
+                for key, value in regions_data.get(region, {}).items():
                     if key not in self.keys():
                         self[key] = value
                     elif len(self[key].split()) < len(region_names):

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -551,6 +551,14 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
 
             self.clear_sct_env_variables()
 
+    def test_19_aws_region_with_no_region_data(self):
+        os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
+        os.environ['SCT_REGION_NAME'] = 'not-exists-2'
+
+        with self.assertRaisesRegex(ValueError, expected_regex="not-exists-2 isn't supported"):
+            conf = sct_config.SCTConfiguration()
+            conf.verify_configuration()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Make sure we don't fail when trying to get paramters from
`regions_data` structure,
saying this isn't a supported region:

```
...
raise ValueError(f"{region} isn't supported, use: {list(regions_data.keys())}")

ValueError: us-east-2 isn't supported, use: ['us-east-1', 'us-west-2',
'eu-west-1', 'eu-west-2', 'eu-north-1', 'eu-central-1']

```
fix: #4864

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
