### PR TITLE
fix(k8s-functional): make sure test report correct when setup fails

### DIFF
--- a/functional_tests/scylla_operator/libs/auxiliary.py
+++ b/functional_tests/scylla_operator/libs/auxiliary.py
@@ -45,7 +45,7 @@ class ScyllaOperatorFunctionalClusterTester(ClusterTester):
         for _, test_data in self.test_data.items():
             if not test_data[0] in ('SUCCESS', 'SKIPPED'):
                 return 'FAILED'
-        return 'SUCCESS'
+        return 'SUCCESS' if self.test_data else 'FAILED'
 
 
 def sct_abs_path(relative_filename=""):


### PR DESCRIPTION
moved the tearDown calls into a finalizer, so they would be called
regardless if setUp worked or not.

Trello: https://trello.com/c/zELDTUFH, https://trello.com/c/cMxs57CC

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
