### PR TITLE
fix(sct_config): make sure siren is handled correctly

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1833,7 +1833,8 @@ class SCTConfiguration(dict):
 
         if not self.get('use_preinstalled_scylla'):
             one_of_options_must_exist += ['scylla_repo']
-        elif self.get('db_type') == 'cloud_scylla':
+
+        if self.get('db_type') == 'cloud_scylla':
             one_of_options_must_exist += ['cloud_cluster_id']
         elif backend == 'aws':
             one_of_options_must_exist += ['ami_id_db_scylla']


### PR DESCRIPTION
seem like the change in #4847 was breaking gce backend
for siren, since the default is `use_preinstalled_scylla: false`
and it didn't fallback into using also `cloud_cluster_id`

Ref: #4847

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
