### PR TITLE
fix(rollingOperatorUpgradePipeline): better handle platform upgrade

### DIFF
--- a/vars/rollingOperatorUpgradePipeline.groovy
+++ b/vars/rollingOperatorUpgradePipeline.groovy
@@ -128,9 +128,14 @@ def call(Map pipelineParams) {
                         for (base_version in base_versions_list) {
                             run_params =  readJSON text: groovy.json.JsonOutput.toJson(params)
                             run_params.scylla_version = base_version
-                            tasks["Scylla Operator upgrade from ${base_version} to ${new_version}"] = {
 
-                                stage("${base_version} -> ${new_version} - Running test") {
+                            def phase = "${base_version} -> ${new_version}"
+                            if (run_params.test_name.contains('platform_upgrade')) {
+                                phase = "platform-upgrade"
+                            }
+                            tasks["Scylla Operator upgrade - ${phase}"] = {
+
+                                stage("${phase} - Running test") {
                                     catchError(stageResult: 'FAILURE') {
                                         script {
                                             wrap([$class: 'BuildUser']) {
@@ -144,7 +149,7 @@ def call(Map pipelineParams) {
                                         }
                                     }
                                 }
-                                stage("${base_version} -> ${new_version} - Collect logs") {
+                                stage("${phase} - Collect logs") {
                                     catchError(stageResult: 'FAILURE') {
                                         script {
                                             wrap([$class: 'BuildUser']) {
@@ -157,7 +162,7 @@ def call(Map pipelineParams) {
                                         }
                                     }
                                 }
-                                stage("${base_version} -> ${new_version} - Clean resources") {
+                                stage("${phase} - Clean resources") {
                                     catchError(stageResult: 'FAILURE') {
                                         script {
                                             wrap([$class: 'BuildUser']) {
@@ -170,7 +175,7 @@ def call(Map pipelineParams) {
                                         }
                                     }
                                 }
-                                stage("${base_version} -> ${new_version} - Send email with result") {
+                                stage("${phase} - Send email with result") {
                                     catchError(stageResult: 'FAILURE') {
                                         script {
                                             wrap([$class: 'BuildUser']) {


### PR DESCRIPTION
since in platorm upgrade test we are not upgrade between two
version of scylla, we should title is a bit more clear to
avoid confusion

Trello: https://trello.com/c/1aypWH9P

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
