### PR TITLE
fix(cql_ip_address): change to be @cached_property

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -420,6 +420,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
     def refresh_ip_address(self):
         # Invalidate ip address cache
         self._private_ip_address_cached = self._public_ip_address_cached = self._ipv6_ip_address_cached = None
+        self.__dict__.pop('cql_ip_address', None)
 
         if self.ssh_login_info["hostname"] == self.external_address:
             return
@@ -879,7 +880,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
     def _refresh_instance_state(self):
         raise NotImplementedError()
 
-    @property
+    @cached_property
     def cql_ip_address(self):
         if self.is_kubernetes():
             return self.ip_address


### PR DESCRIPTION
cql_ip_address is looking into scylla.yaml to get broadcast_rpc_address.
To prevent unessesary downloading and uploading of scylla.yaml every time that we need to get
cql_ip_address, change it to be 'cached_property' instead of 'property'

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
