### PR TITLE
fix(destroy_data_and_restart_scylla): two small fixes

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3438,17 +3438,15 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
 
         return list(regular_table_names - materialized_view_table_names)
 
-    def is_table_has_data(self, db_node: BaseNode, table_name: str) -> bool:
+    def is_table_has_data(self, session, table_name: str) -> bool:
         """
         Return True if `table_name` has data in it
         """
-
         current_rows = 0
-        with self.cql_connection_patient(db_node) as session:
-            try:
-                current_rows = session.execute(f"SELECT * FROM {table_name} LIMIT 1").current_rows
-            except Exception as exc:  # pylint: disable=broad-except
-                self.log.warning(f'Failed to get rows from {table_name} table. Error: {exc}')
+        try:
+            current_rows = session.execute(f"SELECT * FROM {table_name} LIMIT 1").current_rows
+        except Exception as exc:  # pylint: disable=broad-except
+            self.log.warning(f'Failed to get rows from {table_name} table. Error: {exc}')
         return bool(current_rows)
 
     def get_all_tables_with_cdc(self, db_node: BaseNode) -> List[str]:


### PR DESCRIPTION
1. Do not create cql connection every time that select from table
2. Stop Scylla after checking is the table has data

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
