### PR TITLE
fix(test_default): Add default value for gce_pd_standard_disk_size_db

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -178,6 +178,8 @@ data_volume_disk_num: 0
 data_volume_disk_type: ''
 data_volume_disk_size: 0
 data_volume_disk_iops: 0 # depend on type iops could be 100-16000 for io2|io3 and 3000-16000 for gp3
+gce_pd_standard_disk_size_db: 0
+
 install_mode: 'repo'  # install from scylla_repo
 nosqlbench_image: 'scylladb/hydra-loaders:nosqlbench-4.15.49'
 run_db_node_benchmarks: false


### PR DESCRIPTION
job: scylla-master/longevity/longevity-100gb-4h-test#462,
failed:
Traceback (most recent call last):
File "/home/ubuntu/scylla-cluster-tests/sdcm/cluster.py", line 3511, in node_setup
cl_inst.node_setup(_node, **setup_kwargs)
File "/home/ubuntu/scylla-cluster-tests/sdcm/cluster.py", line 4210, in node_setup
if self.is_additional_data_volume_used():
File "/home/ubuntu/scylla-cluster-tests/sdcm/cluster.py", line 4470, in is_additional_data_volume_used
return self.params.get("data_volume_disk_num") > 0 or self.params.get('gce_pd_standard_disk_size_db') > 0
TypeError: '>' not supported between instances of 'NoneType' and 'int'

it happened because gce_pd_standard_disk_size_db is not defined for aws job.

Related to this PR: fix(gce-image-persistent-disk): make sure we run `scylla_io_setup`


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
