### PR TITLE
fix(scan operation thread): fix creating a cql session

### DIFF
--- a/sdcm/scan_operation_thread.py
+++ b/sdcm/scan_operation_thread.py
@@ -12,7 +12,7 @@ from cassandra.cluster import ResponseFuture  # pylint: disable=no-name-in-modul
 from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
 
 from sdcm import wait
-from sdcm.cluster import BaseNode, BaseScyllaCluster, BaseCluster
+from sdcm.cluster import BaseScyllaCluster, BaseCluster
 from sdcm.remote import LocalCmdRunner
 from sdcm.utils.common import get_partition_keys, get_table_clustering_order
 from sdcm.sct_events import Severity
@@ -73,11 +73,6 @@ class ScanOperationThread:
     def randomly_form_cql_statement(self) -> Optional[str]:
         ...
 
-    def create_session(self, db_node: BaseNode):
-        credentials = self.db_cluster.get_db_auth()
-        username, password = credentials if credentials else (None, None)
-        return self.db_cluster.cql_connection_patient(db_node, user=username, password=password)
-
     def execute_query(self, session, cmd: str):
         self.log.info('Will run command "%s"', cmd)
         return session.execute(SimpleStatement(
@@ -108,7 +103,7 @@ class ScanOperationThread:
             cmd = cmd or self.randomly_form_cql_statement()
             if not cmd:
                 return
-            with self.create_session(db_node) as session:
+            with self.db_cluster.cql_connection_patient(node=db_node, connect_timeout=300) as session:
 
                 if self.termination_event.is_set():
                     return
@@ -200,7 +195,9 @@ class FullPartitionScanThread(ScanOperationThread):
     def get_table_clustering_order(self) -> str:
         for node in self.db_cluster.nodes:
             try:
-                with self.create_session(node) as session:
+                with self.db_cluster.cql_connection_patient(node=node, connect_timeout=300) as session:
+                    # Using CL ONE. No need for a quorum since querying a constant fixed attribute of a table.
+                    session.default_consistency_level = ConsistencyLevel.ONE
                     return get_table_clustering_order(ks_cf=self.ks_cf, ck_name=self.ck_name, session=session)
             except Exception as error:  # pylint: disable=broad-except
                 self.log.error('Failed getting table %s clustering order through node %s : %s', self.ks_cf, node.name,
@@ -218,7 +215,7 @@ class FullPartitionScanThread(ScanOperationThread):
         3) Add a random CK filter with random row values.
         :return: a CQL reversed-query
         """
-        with self.create_session(self.db_node) as session:
+        with self.db_cluster.cql_connection_patient(node=self.db_node, connect_timeout=300) as session:
             ck_name = self.ck_name
             rows_count = self.rows_count
             ck_random_min_value = random.randint(a=1, b=rows_count)


### PR DESCRIPTION
	Fix usage and calls of CQL connections for the scan-operation thread.
	This is in order to better cleanup used connections,
	and avoid encountering issues like:
	https://github.com/scylladb/scylla-bench/issues/95
Trello: https://trello.com/c/N7Oya1Ws
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
