### PR TITLE
feature(manager-3.0): Switch default to scylla manager-3.0

### DIFF
--- a/defaults/manager_versions.yaml
+++ b/defaults/manager_versions.yaml
@@ -6,6 +6,13 @@ manager_repos_by_version:
     debian11: 'http://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
     ubuntu18: 'http://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
     ubuntu20: 'http://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
+  "3.0":
+    centos7: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-3.0.repo'
+    centos8: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-3.0.repo'
+    debian10: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/debian/scylladb-manager-3.0-buster.list'
+    debian11: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/debian/scylladb-manager-3.0.list'
+    ubuntu18: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.0-bionic.list'
+    ubuntu20: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.0-focal.list'
   "2.6":
     centos7: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.6.repo'
     centos8: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.6.repo'

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -6,7 +6,7 @@ ip_ssh_connections: 'private'
 
 scylla_repo: ''
 
-manager_version: '2.6'
+manager_version: '3.0'
 manager_scylla_backend_version: '2021'  # Notice: that centos, ubuntu 20 and debian 10 monitors use 2021, while debian 9, ubuntu 16 and ubuntu 18 use 2020, since we support both
 
 scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/scylla-4.6.repo'


### PR DESCRIPTION
New release of scylla-manger released 3.0. Switch sct-master and
scylla-master to use relase 3.0

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
