### PR TITLE
test(manager): Added sanity and upgrade tests for debian 11

### DIFF
--- a/configurations/manager/debian11.yaml
+++ b/configurations/manager/debian11.yaml
@@ -1,0 +1,2 @@
+ami_id_monitor: 'ami-09a41e26df464c548'  # Debian Bullseye image - debian-11-amd64-20220503-998
+ami_monitor_user: 'admin'

--- a/defaults/manager_versions.yaml
+++ b/defaults/manager_versions.yaml
@@ -38,5 +38,6 @@ scylla_backend_repo_by_version:
     centos7: 'http://downloads.scylladb.com/rpm/centos/scylla-2021.1.repo'
     centos8: 'http://downloads.scylladb.com/rpm/centos/scylla-2021.1.repo'
     debian10: 'http://downloads.scylladb.com/deb/ubuntu/scylla-2021.1.list'
+    debian11: 'http://downloads.scylladb.com/deb/ubuntu/scylla-2021.1.list'
     ubuntu18: 'http://downloads.scylladb.com/deb/ubuntu/scylla-2021.1.list'
     ubuntu20: 'http://downloads.scylladb.com/deb/ubuntu/scylla-2021.1.list'

--- a/jenkins-pipelines/manager/debian11-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/debian11-manager-sanity.jenkinsfile
@@ -1,0 +1,19 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+managerPipeline(
+    backend: 'aws',
+    ip_ssh_connections: 'public',
+    region: '''["us-east-1", "us-west-2"]''',
+    test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
+    test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/debian11.yaml"]''',
+
+    timeout: [time: 240, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy',
+
+    downstream_jobs_to_run: 'debian11-upgrade-test'
+)

--- a/jenkins-pipelines/manager/debian11-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian11-manager-upgrade.jenkinsfile
@@ -1,0 +1,22 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+managerPipeline(
+    manager: true,
+    backend: 'aws',
+    region: 'us-east-1',
+
+    target_manager_version: 'master_latest',
+
+    manager_version: '3.0',
+
+    test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
+    test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/debian11.yaml"]''',
+
+    timeout: [time: 360, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy'
+)

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -851,7 +851,8 @@ class ScyllaManagerTool(ScyllaManagerBase):
         ScyllaManagerBase.__init__(self, id="MANAGER", manager_node=manager_node)
         self._initial_wait(20)
         LOGGER.info("Initiating Scylla-Manager, version: {}".format(self.sctool.version))
-        list_supported_distros = [Distro.CENTOS7, Distro.DEBIAN8, Distro.DEBIAN9, Distro.DEBIAN10,
+        list_supported_distros = [Distro.CENTOS7,
+                                  Distro.DEBIAN8, Distro.DEBIAN9, Distro.DEBIAN10, Distro.DEBIAN11,
                                   Distro.UBUNTU16, Distro.UBUNTU18, Distro.UBUNTU20]
         self.default_user = "centos"
         if manager_node.distro not in list_supported_distros:


### PR DESCRIPTION
Since now we support debian 11 as well, I added new scenarios for it

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
