### PR TITLE
fix(manager task arguments): Restricted split with maxsplit

### DIFF
--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -243,7 +243,7 @@ class ManagerTask:
         # ╰───────────────┴──────────┴──────────┴──────────┴──────────────┴────────╯
         for task_property in res:
             if task_property[0].startswith("Arguments"):
-                arguments_string = task_property[0].split(':')[1].strip()
+                arguments_string = task_property[0].split(':', maxsplit=1)[1].strip()
                 break
         return arguments_string
 


### PR DESCRIPTION
Since some of the arguments of a manager task can contain colon
we have to limit the split to the first occurrence only

Solves https://github.com/scylladb/siren-tests/issues/1005

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
