### PR TITLE
feature(longevity-large-partition): clone cases with i4i.2xlarge

### DIFF
--- a/configurations/aws/i4i_2xlarge.yaml
+++ b/configurations/aws/i4i_2xlarge.yaml
@@ -1,0 +1,1 @@
+instance_type_db: 'i4i.2xlarge'

--- a/configurations/aws/i4i_4xlarge.yaml
+++ b/configurations/aws/i4i_4xlarge.yaml
@@ -1,0 +1,1 @@
+instance_type_db: 'i4i.4xlarge'

--- a/jenkins-pipelines/longevity-50gb-3days-aws-i4i.jenkinsfile
+++ b/jenkins-pipelines/longevity-50gb-3days-aws-i4i.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "configurations/aws/i4i_4xlarge.yaml"]',
+
+    timeout: [time: 5000, unit: 'MINUTES']
+)

--- a/jenkins-pipelines/longevity-large-partition-200k-pks-4days-aws-i4i.jenkinsfile
+++ b/jenkins-pipelines/longevity-large-partition-200k-pks-4days-aws-i4i.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
+    test_config: '["test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml", "configurations/aws/i4i_4xlarge.yaml"]',
+
+    timeout: [time: 6540, unit: 'MINUTES']
+)

--- a/jenkins-pipelines/longevity-large-partition-8h-aws-i4i.jenkinsfile
+++ b/jenkins-pipelines/longevity-large-partition-8h-aws-i4i.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
+    test_config: '''["test-cases/longevity/longevity-large-partition-8h.yaml", "configurations/aws/i4i_2xlarge.yaml"]''',
+
+    timeout: [time: 610, unit: 'MINUTES']
+)

--- a/jenkins-pipelines/longevity-large-partition-asymmetric-cluster-3h-aws-i4i.jenkinsfile
+++ b/jenkins-pipelines/longevity-large-partition-asymmetric-cluster-3h-aws-i4i.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
+    test_config: '''["test-cases/longevity/longevity-large-partition-3h.yaml", "configurations/db-nodes-shards-random.yaml", "configurations/aws/i4i_2xlarge.yaml"]''',
+
+    timeout: [time: 240, unit: 'MINUTES']
+)


### PR DESCRIPTION
the new i4i family seems to have twice as performance in the
same price, testing out  some of the performance sensitive use
cases with it.

Testing those out with 5.0.rc8:
- [x] [longevity-large-partition-asymmetric-cluster-3h-aws-i4i-test](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-large-partition-asymmetric-cluster-3h-test/2/) 
 similar timeout as the master runs, also the CPU usage seems similar to the i3 based runs, I don't think we need to touch the load.

- [x] [longevity-large-partition-8h-aws-i4i-test](https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-large-partition-8h-test/2/)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
