### PR TITLE
fix(cassandra stress): disabling client encryption for cloud runs

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1620,7 +1620,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                           profile=profile,
                                           node_list=self.db_cluster.nodes,
                                           round_robin=round_robin,
-                                          client_encrypt=self.db_cluster.nodes[0].is_client_encrypt,
+                                          client_encrypt=self.params.get('client_encrypt'),
                                           keyspace_name=keyspace_name,
                                           stop_test_on_failure=stop_test_on_failure).run()
         scylla_encryption_options = self.params.get('scylla_encryption_options')


### PR DESCRIPTION
In cloud runs, when setting the encryption mode to 'both', we still use non encrypted communication.
However, the BaseNode.is_client_encrypt function still identifies the cluster as strictly encrypted,
which causes the cassandra stress thread to fail.
As such, I made sure that in those runs the cassandra stress thread will not use encryption.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
