### PR TITLE
feature(SisyphusMonkey): negative flag for `nemesis_selector`

### DIFF
--- a/configurations/operator/1tb-7days-no-tls.yaml
+++ b/configurations/operator/1tb-7days-no-tls.yaml
@@ -1,5 +1,5 @@
 user_prefix: 'longevity-operator-1tb-7d'
-nemesis_include_filter: ['kubernetes']
+nemesis_selector: ['kubernetes']
 k8s_minio_storage_size: '2048Gi'
 
 # NOTE: operator doesn't support encryption as of January 2022

--- a/configurations/operator/200GB-no-tls.yaml
+++ b/configurations/operator/200GB-no-tls.yaml
@@ -1,5 +1,5 @@
 user_prefix: 'longevity-operator-200gb-48h'
-nemesis_include_filter: ['kubernetes']
+nemesis_selector: ['kubernetes']
 
 k8s_minio_storage_size: '4608Gi'
 

--- a/configurations/operator/50GB-no-tls.yaml
+++ b/configurations/operator/50GB-no-tls.yaml
@@ -1,5 +1,5 @@
 user_prefix: 'longevity-operator-50gb-3d'
-nemesis_include_filter: ['kubernetes']
+nemesis_selector: ['kubernetes']
 
 k8s_minio_storage_size: '1024Gi'
 

--- a/configurations/operator/cdc-3d-400gb.yaml
+++ b/configurations/operator/cdc-3d-400gb.yaml
@@ -1,4 +1,4 @@
 user_prefix: 'longevity-operator-cdc-3d-400gb'
-nemesis_include_filter: ['kubernetes']
+nemesis_selector: ['kubernetes']
 
 k8s_minio_storage_size: '4608Gi'

--- a/configurations/operator/large-collections-12h.yaml
+++ b/configurations/operator/large-collections-12h.yaml
@@ -1,2 +1,2 @@
 user_prefix: 'longevity-operator-large-collections-12h'
-nemesis_include_filter: ['kubernetes']
+nemesis_selector: ['kubernetes']

--- a/configurations/operator/large-partition-200k-pks-4days.yaml
+++ b/configurations/operator/large-partition-200k-pks-4days.yaml
@@ -1,4 +1,4 @@
 user_prefix: 'long-operator-large-partitions-200k-pks-4d'
-nemesis_include_filter: ['kubernetes']
+nemesis_selector: ['kubernetes']
 
 k8s_minio_storage_size: '7168Gi'

--- a/configurations/operator/lwt-basic-24h.yaml
+++ b/configurations/operator/lwt-basic-24h.yaml
@@ -1,2 +1,2 @@
 user_prefix: 'longevity-operator-lwt-24h'
-nemesis_include_filter: ['kubernetes']
+nemesis_selector: ['kubernetes']

--- a/configurations/operator/twcs-basic-48h.yaml
+++ b/configurations/operator/twcs-basic-48h.yaml
@@ -1,2 +1,2 @@
 user_prefix: 'longevity-operator-twcs-48h'
-nemesis_include_filter: ['kubernetes']
+nemesis_selector: ['kubernetes']

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1559,22 +1559,22 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         finally:
             self.metrics_srv.event_stop(disrupt_method_name)
 
-    def build_list_of_disruptions_to_execute(self, nemesis_include_filter=None, nemesis_multiply_factor=1):
+    def build_list_of_disruptions_to_execute(self, nemesis_selector=None, nemesis_multiply_factor=1):
         """
         Builds the list of disruptions that should be excuted during a test.
 
-        nemesis_include_filter: should be retrived from the test yaml by using the "nemesis_include_filter".
+        nemesis_selector: should be retrived from the test yaml by using the "nemesis_selector".
         Here it kept for future usages and unit testing ability.
-        more about nemesis_include_filter behaviour in sct_config.py
+        more about nemesis_selector behaviour in sct_config.py
 
         nemesis_multiply_factor: should be retrived from the test yaml by using the "nemesis_multiply_factor".
         Here it kept for future usages and unit testing ability.
-        more about nemesis_include_filter behaviour in sct_config.py
+        more about nemesis_selector behaviour in sct_config.py
         """
-        nemesis_include_filter = self.cluster.params.get('nemesis_include_filter')
-        if nemesis_include_filter:
+        nemesis_selector = self.cluster.params.get('nemesis_selector')
+        if nemesis_selector:
             subclasses = self.get_list_of_subclasses_by_property_name(
-                list_of_properties_to_include=nemesis_include_filter)
+                list_of_properties_to_include=nemesis_selector)
             if subclasses:
                 disruptions = self.get_list_of_disrupt_methods(subclasses_list=subclasses)
             else:

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -403,7 +403,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         return disrupt_methods_list
 
     def get_list_of_subclasses_by_property_name(self, list_of_properties_to_include):
-        flags = {flag_name: True for flag_name in list_of_properties_to_include}
+        flags = {flag_name.strip('!'): not flag_name.startswith(
+            '!') for flag_name in list_of_properties_to_include}
         subclasses_list = self._get_subclasses(**flags)
         return subclasses_list
 
@@ -411,7 +412,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         disrupt_methods_list = []
         for subclass in subclasses_list:
             method_name = re.search(
-                r'self\.(?P<method_name>disrupt_[A-Za-z_]+?)\(.*\)', inspect.getsource(subclass), flags=re.MULTILINE)
+                r'self\.(?P<method_name>disrupt_[0-9A-Za-z_]+?)\(.*\)', inspect.getsource(subclass), flags=re.MULTILINE)
             if method_name:
                 disrupt_methods_list.append(method_name.group('method_name'))
         self.log.debug("list of matching disrupions: {}".format(disrupt_methods_list))
@@ -450,12 +451,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             for filter_name, filter_value in flags.items():
                 if filter_value is None:
                     continue
-                try:
-                    attr = getattr(nemesis, filter_name)
-                except AttributeError:
-                    LOGGER.warning("The required nemesis flag {} was not found".format(filter_name))
-                    flags[filter_name] = None
-                    continue
+                attr = getattr(nemesis, filter_name, False)
                 if attr != filter_value:
                     matches = False
                     break

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1277,9 +1277,9 @@ class SCTConfiguration(dict):
         dict(name="run_db_node_benchmarks", env="SCT_RUN_DB_NODE_BENCHMARKS",
              type=boolean,
              help="Flag for running db node benchmarks before the tests"),
-        dict(name="nemesis_include_filter", env="SCT_NEMESIS_INCLUDE_FILTER",
+        dict(name="nemesis_selector", env="SCT_NEMESIS_SELECTOR",
              type=str_or_list,
-             help="""nemesis_include_filter gets a list of "nemesis properties" and filters IN all the nemesis that has
+             help="""nemesis_selector gets a list of "nemesis properties" and filters IN all the nemesis that has
              ALL the properties in that list which are set to true (the intersection of all properties).
              (In other words filters out all nemesis that doesn't ONE of these properties set to true)
              IMPORTANT: If a property doesn't exist, ALL the nemesis will be included."""),

--- a/test-cases/gemini/gemini-1tb-10h.yaml
+++ b/test-cases/gemini/gemini-1tb-10h.yaml
@@ -9,7 +9,7 @@ instance_type_loader: 'm5.xlarge'
 user_prefix: 'gemini-1tb-10h'
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_include_filter: ['run_with_gemini']
+nemesis_selector: ['run_with_gemini']
 nemesis_interval: 5
 nemesis_seed: '041'
 

--- a/test-cases/gemini/gemini-3h-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nemesis.yaml
@@ -8,7 +8,7 @@ instance_type_db: 'i3.large'
 user_prefix: 'gemini-with-nemesis-3h-normal'
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_include_filter: ['run_with_gemini']
+nemesis_selector: ['run_with_gemini']
 nemesis_interval: 5
 nemesis_seed: '032'
 

--- a/test-cases/gemini/gemini-8h-large-num-columns.yaml
+++ b/test-cases/gemini/gemini-8h-large-num-columns.yaml
@@ -9,7 +9,7 @@ instance_type_loader: 'c5.4xlarge'
 user_prefix: 'gemini-8h-large-num-columns'
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_include_filter: ['run_with_gemini']
+nemesis_selector: ['run_with_gemini']
 nemesis_interval: 5
 nemesis_seed: '023'
 

--- a/test-cases/longevity/longevity-100GB-48h-cloud-CloudLimitedChaosMonkey-tls.yaml
+++ b/test-cases/longevity/longevity-100GB-48h-cloud-CloudLimitedChaosMonkey-tls.yaml
@@ -16,7 +16,7 @@ post_behavior_loader_nodes: "destroy"
 post_behavior_monitor_nodes: "destroy"
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_include_filter: ['limited']
+nemesis_selector: ['limited']
 nemesis_interval: 30
 nemesis_during_prepare: false
 

--- a/test-cases/longevity/longevity-200GB-48h-network-monkey.yaml
+++ b/test-cases/longevity/longevity-200GB-48h-network-monkey.yaml
@@ -11,7 +11,7 @@ n_monitor_nodes: 1
 instance_type_db: 'i3.2xlarge'
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_include_filter: ['networking']
+nemesis_selector: ['networking']
 nemesis_seed: '002'
 nemesis_interval: 10
 nemesis_multiply_factor: 15

--- a/test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
+++ b/test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml
@@ -12,7 +12,7 @@ n_monitor_nodes: 1
 instance_type_db: 'i3.4xlarge'
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_include_filter: ['limited']
+nemesis_selector: ['limited']
 nemesis_seed: '003'
 nemesis_interval: 30
 nemesis_during_prepare: false

--- a/test-cases/longevity/longevity-50GB-12h-verifier-LimitedMonkey-tls.yaml
+++ b/test-cases/longevity/longevity-50GB-12h-verifier-LimitedMonkey-tls.yaml
@@ -11,7 +11,7 @@ n_monitor_nodes: 1
 instance_type_db: 'i3.4xlarge'
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_include_filter: ['limited']
+nemesis_selector: ['limited']
 nemesis_seed: '026'
 nemesis_interval: 30
 nemesis_during_prepare: false

--- a/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-large-cluster.yaml
+++ b/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-large-cluster.yaml
@@ -13,7 +13,7 @@ region_aware_loader: true
 n_monitor_nodes: 1
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_include_filter: ['topology_changes']
+nemesis_selector: ['topology_changes']
 nemesis_seed: '023'
 nemesis_interval: 5
 nemesis_add_node_cnt: 3

--- a/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-topology-changes.yaml
+++ b/test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-topology-changes.yaml
@@ -13,7 +13,7 @@ region_aware_loader: true
 n_monitor_nodes: 1
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_include_filter: ['topology_changes']
+nemesis_selector: ['topology_changes']
 nemesis_seed: '032'
 nemesis_interval: 5
 nemesis_add_node_cnt: 2

--- a/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
+++ b/test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml
@@ -11,7 +11,7 @@ n_monitor_nodes: 1
 instance_type_db: 'i3.4xlarge'
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_include_filter: ['limited']
+nemesis_selector: ['limited']
 nemesis_seed: '028'
 nemesis_interval: 5
 nemesis_during_prepare: false

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h.yaml
@@ -6,7 +6,7 @@ n_loaders: 2
 n_monitor_nodes: 1
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_include_filter: ['kubernetes']
+nemesis_selector: ['kubernetes']
 nemesis_seed: '026'
 nemesis_interval: 5
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-basic-12h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-basic-12h.yaml
@@ -18,7 +18,7 @@ instance_type_db: 'i3.4xlarge'
 gce_instance_type_db: 'n1-highmem-16'
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_include_filter: ['kubernetes']
+nemesis_selector: ['kubernetes']
 nemesis_seed: '026'
 nemesis_interval: 5
 

--- a/unit_tests/test_nemesis.py
+++ b/unit_tests/test_nemesis.py
@@ -143,7 +143,7 @@ def test_list_topology_changes_monkey():
         "disrupt_remove_node_then_add_node",
     ]
     tester = FakeTester()
-    tester.params["nemesis_include_filter"] = ['topology_changes']
+    tester.params["nemesis_selector"] = ['topology_changes']
     sisphus = FakeSisyphusMonkey(FakeTester(), None)
 
     collected_disrupt_methods_names = [disrupt.__name__ for disrupt in sisphus.disruptions_list]


### PR DESCRIPTION
Since there are cases we want to exclude nemesis by it's flag
now we can use `nemesis_selector` like this:

```
nemesis_selector: !disabled
```

it would remove any nemesis class tagged like this:

```python
class Monkey(Nemesis):
    disabled = True

    def disrupt():
        self.disrupt_something_100()
```

* Also fixes a bug in the filter, that ignroe nemesis methods
that has numbers in thier name

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
