### PR TITLE
test(artifacts): add nonroot offline for ubuntu 22

### DIFF
--- a/jenkins-pipelines/nonroot-offline-install/artifacts-ubuntu2204.jenkinsfile
+++ b/jenkins-pipelines/nonroot-offline-install/artifacts-ubuntu2204.jenkinsfile
@@ -1,0 +1,15 @@
+#! groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+artifactsPipeline(
+    test_config: 'test-cases/artifacts/ubuntu2204.yaml',
+    backend: 'gce',
+    nonroot_offline_install: true,
+    provision_type: 'spot',
+    manager_version: '',
+
+    timeout: [time: 30, unit: 'MINUTES'],
+    post_behavior_db_nodes: 'destroy'
+)


### PR DESCRIPTION
Follow up to https://github.com/scylladb/scylla-pkg/pull/2935 Adding Nonroot Offline Install pipeline for Ubuntu 22.04, which I missed in the previous PR.


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
