### PR TITLE
improvement(k8s): make 'append_scylla_args' option work in K8S

### DIFF
--- a/defaults/k8s_eks_config.yaml
+++ b/defaults/k8s_eks_config.yaml
@@ -44,7 +44,10 @@ n_loaders: 1
 k8s_n_loader_pods_per_cluster: 1
 n_db_nodes: 3
 
-append_scylla_args: ''
+# TODO: add '--abort-on-seastar-bad-alloc' arg to the 'append_scylla_args' option when
+#       following operator bug gets fixed: https://github.com/scylladb/scylla-operator/issues/991
+#       '--blocked-reactor-notify-ms 100' cannot be set, because it gets set by operator itself
+append_scylla_args: '--abort-on-lsa-bad-alloc 1 --abort-on-internal-error 1 --abort-on-ebadf 1 --enable-sstable-key-validation 1'
 docker_image: ''
 mgmt_docker_image: 'scylladb/scylla-manager:2.6.0'
 

--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -55,7 +55,10 @@ user_credentials_path: '~/.ssh/scylla-test'
 use_preinstalled_scylla: true
 backtrace_decoding: true
 
-append_scylla_args: ''
+# TODO: add '--abort-on-seastar-bad-alloc' arg to the 'append_scylla_args' option when
+#       following operator bug gets fixed: https://github.com/scylladb/scylla-operator/issues/991
+#       '--blocked-reactor-notify-ms 100' cannot be set, because it gets set by operator itself
+append_scylla_args: '--abort-on-lsa-bad-alloc 1 --abort-on-internal-error 1 --abort-on-ebadf 1 --enable-sstable-key-validation 1'
 docker_image: ''
 backup_bucket_backend: 's3'
 backup_bucket_location: 'minio-bucket'

--- a/defaults/k8s_local_kind_config.yaml
+++ b/defaults/k8s_local_kind_config.yaml
@@ -29,6 +29,9 @@ user_credentials_path: '~/.ssh/scylla-test'
 use_preinstalled_scylla: true
 backtrace_decoding: false
 
-append_scylla_args: ''
+# TODO: add '--abort-on-seastar-bad-alloc' arg to the 'append_scylla_args' option when
+#       following operator bug gets fixed: https://github.com/scylladb/scylla-operator/issues/991
+#       '--blocked-reactor-notify-ms 100' cannot be set, because it gets set by operator itself
+append_scylla_args: '--abort-on-lsa-bad-alloc 1 --abort-on-internal-error 1 --abort-on-ebadf 1 --enable-sstable-key-validation 1'
 docker_image: ''
 backup_bucket_location: 'minio-bucket'


### PR DESCRIPTION
We can define arguments for a scylla binary in K8S
via 'scyllaArgs' option of the 'scyllacluster' custom resource
defined by scylla-operator.
So, make values of the 'append_scylla_args' SCT option be used
as 'scyllaArgs' in K8S if it is defined.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
