### PR TITLE
fix(CQL connection): Remove unused 'user' and 'password' parameters

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3249,7 +3249,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
                 return node
         return None
 
-    def _create_session(self, node, keyspace, user, password, compression,
+    def _create_session(self, node, keyspace, compression,
                         # pylint: disable=too-many-arguments, too-many-locals
                         protocol_version, load_balancing_policy=None,
                         port=None, ssl_opts=None, node_ips=None, connect_timeout=None,
@@ -3292,23 +3292,23 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
 
         return ScyllaCQLSession(session, cluster_driver, verbose)
 
-    def cql_connection(self, node, keyspace=None, user=None,  # pylint: disable=too-many-arguments
-                       password=None, compression=True, protocol_version=None,
+    def cql_connection(self, node, keyspace=None,  # pylint: disable=too-many-arguments
+                       compression=True, protocol_version=None,
                        port=None, ssl_opts=None, connect_timeout=100, verbose=True):
         node_ips = self.get_node_cql_ips()
         wlrr = WhiteListRoundRobinPolicy(node_ips)
-        return self._create_session(node=node, keyspace=keyspace, user=user, password=password,
+        return self._create_session(node=node, keyspace=keyspace,
                                     compression=compression, protocol_version=protocol_version,
                                     load_balancing_policy=wlrr, port=port, ssl_opts=ssl_opts, node_ips=node_ips,
                                     connect_timeout=connect_timeout, verbose=verbose)
 
-    def cql_connection_exclusive(self, node, keyspace=None, user=None,  # pylint: disable=too-many-arguments
-                                 password=None, compression=True,
+    def cql_connection_exclusive(self, node, keyspace=None,  # pylint: disable=too-many-arguments
+                                 compression=True,
                                  protocol_version=None, port=None,
                                  ssl_opts=None, connect_timeout=100, verbose=True):
         node_ips = [node.cql_ip_address]
         wlrr = WhiteListRoundRobinPolicy(node_ips)
-        return self._create_session(node=node, keyspace=keyspace, user=user, password=password,
+        return self._create_session(node=node, keyspace=keyspace,
                                     compression=compression, protocol_version=protocol_version,
                                     load_balancing_policy=wlrr, port=port, ssl_opts=ssl_opts, node_ips=node_ips,
                                     connect_timeout=connect_timeout, verbose=verbose)
@@ -3316,7 +3316,6 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
     @retrying(n=8, sleep_time=15, allowed_exceptions=(NoHostAvailable,))
     def cql_connection_patient(self, node, keyspace=None,
                                # pylint: disable=too-many-arguments,unused-argument
-                               user=None, password=None,
                                compression=True, protocol_version=None,
                                port=None, ssl_opts=None, connect_timeout=100, verbose=True):
         """
@@ -3331,7 +3330,6 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
     @retrying(n=8, sleep_time=15, allowed_exceptions=(NoHostAvailable,))
     def cql_connection_patient_exclusive(self, node, keyspace=None,
                                          # pylint: disable=invalid-name,too-many-arguments,unused-argument
-                                         user=None, password=None,
                                          compression=True,
                                          protocol_version=None,
                                          port=None, ssl_opts=None, connect_timeout=100, verbose=True):

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -755,9 +755,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         if system_auth_rf > 1 and not self.test_config.REUSE_CLUSTER:
             self.log.info('change RF of system_auth to %s', system_auth_rf)
             node = db_cluster.nodes[0]
-            credentials = db_cluster.get_db_auth()
-            username, password = credentials if credentials else (None, None)
-            with db_cluster.cql_connection_patient(node, user=username, password=password) as session:
+            with db_cluster.cql_connection_patient(node) as session:
                 session.execute("ALTER KEYSPACE system_auth WITH replication = "
                                 "{'class': 'org.apache.cassandra.locator.SimpleStrategy', "
                                 "'replication_factor': %s};" % system_auth_rf)

--- a/sla_per_user_system_test.py
+++ b/sla_per_user_system_test.py
@@ -61,8 +61,7 @@ class SlaPerUserTest(LongevityTest):
 
     def prepare_schema(self):
         self.prometheus_stats = PrometheusDBStats(host=self.monitors.nodes[0].public_ip_address)
-        self.connection_cql = self.db_cluster.cql_connection_patient(
-            node=self.db_cluster.nodes[0], user=self.DEFAULT_USER, password=self.DEFAULT_USER_PASSWORD)
+        self.connection_cql = self.db_cluster.cql_connection_patient(node=self.db_cluster.nodes[0])
         session = self.connection_cql.session
         return session
 


### PR DESCRIPTION
	The 'user' and 'password' parameters are not in use.
	They are explicitly set by get_db_auth() when creating a session.

This PR has a dependancy in https://github.com/scylladb/scylla-cluster-tests/pull/4895
And will only pass pylint after it is merged and rebased.
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
