### PR TITLE
fix(scylla_bench_thread): add all available node to command

### DIFF
--- a/sdcm/scylla_bench_thread.py
+++ b/sdcm/scylla_bench_thread.py
@@ -175,7 +175,7 @@ class ScyllaBenchThread:  # pylint: disable=too-many-instance-attributes
 
         log_file_name = os.path.join(node.logdir, f'scylla-bench-l{loader_idx}-{uuid.uuid4()}.log')
         # Select first seed node to send the scylla-bench cmds
-        ips = node_list[0].cql_ip_address
+        ips = ",".join([n.cql_ip_address for n in node_list])
 
         with ScyllaBenchStressExporter(instance_name=node.cql_ip_address,
                                        metrics=nemesis_metrics_obj(),


### PR DESCRIPTION
Since in some cases when the stress command start, one of the
nodes might be down, and we need to make sure the stress command
can connect to any of the available nodes and start the stress.

Fixes: #4386

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
