### PR TITLE
fix(longevity pipelines): removed redundant param

### DIFF
--- a/jenkins-pipelines/EaR-longevity-kmip-200gb-6h.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-kmip-200gb-6h.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml", "configurations/hytrust-kmip-ear.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml", "configurations/hytrust-kmip-ear.yaml"]'''
 
-    timeout: [time: 550, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/EaR-longevity-kmip-50gb-4d.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-kmip-50gb-4d.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "configurations/hytrust-kmip-ear.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "configurations/hytrust-kmip-ear.yaml"]'''
 
-    timeout: [time: 6550, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/EaR-longevity-local-200gb-6h.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-local-200gb-6h.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml", "configurations/local-ear.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml", "configurations/local-ear.yaml"]'''
 
-    timeout: [time: 550, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/EaR-longevity-local-50gb-4d.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-local-50gb-4d.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "configurations/local-ear.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "configurations/local-ear.yaml"]'''
 
-    timeout: [time: 6550, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/EaR-longevity-replicated-200gb-6h.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-replicated-200gb-6h.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml", "configurations/replicated-ear.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml", "configurations/replicated-ear.yaml"]'''
 
-    timeout: [time: 550, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/EaR-longevity-replicated-50gb-4d.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-replicated-50gb-4d.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "configurations/replicated-ear.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "configurations/replicated-ear.yaml"]'''
 
-    timeout: [time: 6550, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/feature-ldap-authorization-and-audit-longevity-100gb-4h.jenkinsfile
+++ b/jenkins-pipelines/feature-ldap-authorization-and-audit-longevity-100gb-4h.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/ldap-authorization.yaml", "configurations/audit.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/ldap-authorization.yaml", "configurations/audit.yaml"]'''
 
-    timeout: [time: 360, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/feature-ldap-authorization-longevity-100gb-4h.jenkinsfile
+++ b/jenkins-pipelines/feature-ldap-authorization-longevity-100gb-4h.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/ldap-authorization.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/ldap-authorization.yaml"]'''
 
-    timeout: [time: 360, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/feature-ldap-authorization-longevity-200gb-48h.jenkinsfile
+++ b/jenkins-pipelines/feature-ldap-authorization-longevity-200gb-48h.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml", "configurations/ldap-authorization.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml", "configurations/ldap-authorization.yaml"]'''
 
-    timeout: [time: 3060, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/feature-ldap-authorization-longevity-50gb-3days.jenkinsfile
+++ b/jenkins-pipelines/feature-ldap-authorization-longevity-50gb-3days.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "configurations/ldap-authorization.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "configurations/ldap-authorization.yaml"]'''
 
-    timeout: [time: 5000, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/feature-ms-ad-ldap-longevity-100gb-4h.jenkinsfile
+++ b/jenkins-pipelines/feature-ms-ad-ldap-longevity-100gb-4h.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-north-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/ms-ad-ldap.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/ms-ad-ldap.yaml"]'''
 
-    timeout: [time: 360, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/ics-longevity-100gb-4h.jenkinsfile
+++ b/jenkins-pipelines/ics-longevity-100gb-4h.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "test-cases/enterprise-features/ics/longevity/ics-longevity-100gb-4h.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "test-cases/enterprise-features/ics/longevity/ics-longevity-100gb-4h.yaml"]'''
 
-    timeout: [time: 360, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/ics-longevity-10gb-3h.jenkinsfile
+++ b/jenkins-pipelines/ics-longevity-10gb-3h.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-10gb-3h.yaml", "test-cases/enterprise-features/ics/longevity/ics-longevity-10gb-3h.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-10gb-3h.yaml", "test-cases/enterprise-features/ics/longevity/ics-longevity-10gb-3h.yaml"]'''
 
-    timeout: [time: 300, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/ics-longevity-1tb-7days.jenkinsfile
+++ b/jenkins-pipelines/ics-longevity-1tb-7days.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml", "test-cases/enterprise-features/ics/longevity/ics-longevity-1TB-7days-authorization-and-tls-ssl.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml", "test-cases/enterprise-features/ics/longevity/ics-longevity-1TB-7days-authorization-and-tls-ssl.yaml"]'''
 
-    timeout: [time: 10960, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/ics-longevity-200gb-48h.jenkinsfile
+++ b/jenkins-pipelines/ics-longevity-200gb-48h.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml", "test-cases/enterprise-features/ics/longevity/ics-longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml", "test-cases/enterprise-features/ics/longevity/ics-longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml"]'''
 
-    timeout: [time: 3060, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/ics-longevity-50gb-4days.jenkinsfile
+++ b/jenkins-pipelines/ics-longevity-50gb-4days.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "test-cases/enterprise-features/ics/longevity/ics-longevity-50GB-4days-authorization-and-tls-ssl.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "test-cases/enterprise-features/ics/longevity/ics-longevity-50GB-4days-authorization-and-tls-ssl.yaml"]'''
 
-    timeout: [time: 6600, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/ics-longevity-large-partition-4days.jenkinsfile
+++ b/jenkins-pipelines/ics-longevity-large-partition-4days.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
-    test_config: '''["test-cases/longevity/longevity-large-partition-4days.yaml", "test-cases/enterprise-features/ics/longevity/ics-longevity-large-partition-4days.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-large-partition-4days.yaml", "test-cases/enterprise-features/ics/longevity/ics-longevity-large-partition-4days.yaml"]'''
 
-    timeout: [time: 6540, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/ics-longevity-mv-si-4days.jenkinsfile
+++ b/jenkins-pipelines/ics-longevity-mv-si-4days.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-mv-si-4days.yaml", "test-cases/enterprise-features/ics/longevity/ics-longevity-mv-si-4days.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-mv-si-4days.yaml", "test-cases/enterprise-features/ics/longevity/ics-longevity-mv-si-4days.yaml"]'''
 
-    timeout: [time: 6610, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/ics-longevity-toggle-strategy-large-partitions-24h.jenkinsfile
+++ b/jenkins-pipelines/ics-longevity-toggle-strategy-large-partitions-24h.jenkinsfile
@@ -7,6 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
-    test_config: '''["test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml", "test-cases/enterprise-features/ics/longevity/ics-longevity-toggle-strategy-large-partitions-24h.yaml"]''',
-    timeout: [time: 6540, unit: 'MINUTES'],
+    test_config: '''["test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml", "test-cases/enterprise-features/ics/longevity/ics-longevity-toggle-strategy-large-partitions-24h.yaml"]'''
+
 )

--- a/jenkins-pipelines/longevity-100gb-4h-arm.jenkinsfile
+++ b/jenkins-pipelines/longevity-100gb-4h-arm.jenkinsfile
@@ -8,7 +8,5 @@ longevityPipeline(
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/arm_instance_types/im4gn_4xlarge.yaml"]''',
-    availability_zone: 'c',
-
-    timeout: [time: 360, unit: 'MINUTES']
+    availability_zone: 'c'
 )

--- a/jenkins-pipelines/longevity-100gb-4h-ebs-gp3.jenkinsfile
+++ b/jenkins-pipelines/longevity-100gb-4h-ebs-gp3.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml","configurations/ebs/ebs-gp3-2v-4tb-16k-iops.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml","configurations/ebs/ebs-gp3-2v-4tb-16k-iops.yaml"]'''
 
-    timeout: [time: 360, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-100gb-4h-ldap-authorization-authenticator-ms-ad.jenkinsfile
+++ b/jenkins-pipelines/longevity-100gb-4h-ldap-authorization-authenticator-ms-ad.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/ms-ad-ldap-authorization-and-authentication.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/ms-ad-ldap-authorization-and-authentication.yaml"]'''
 
-    timeout: [time: 360, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-100gb-4h-ldap-authorization-authenticator.jenkinsfile
+++ b/jenkins-pipelines/longevity-100gb-4h-ldap-authorization-authenticator.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/ldap-authorization-and-authentication.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/ldap-authorization-and-authentication.yaml"]'''
 
-    timeout: [time: 360, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-100gb-4h.jenkinsfile
+++ b/jenkins-pipelines/longevity-100gb-4h.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-100gb-4h.yaml',
+    test_config: 'test-cases/longevity/longevity-100gb-4h.yaml'
 
-    timeout: [time: 360, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-10gb-3h-azure.jenkinsfile
+++ b/jenkins-pipelines/longevity-10gb-3h-azure.jenkinsfile
@@ -6,5 +6,5 @@ longevityPipeline(
     backend: 'azure',
     azure_region_name: 'eastus',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-10gb-3h.yaml',
+    test_config: 'test-cases/longevity/longevity-10gb-3h.yaml'
 )

--- a/jenkins-pipelines/longevity-10gb-3h-gce.jenkinsfile
+++ b/jenkins-pipelines/longevity-10gb-3h-gce.jenkinsfile
@@ -7,5 +7,5 @@ longevityPipeline(
     backend: 'gce',
     region: 'us-east1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-10gb-3h.yaml',
+    test_config: 'test-cases/longevity/longevity-10gb-3h.yaml'
 )

--- a/jenkins-pipelines/longevity-10gb-3h-ipv6.jenkinsfile
+++ b/jenkins-pipelines/longevity-10gb-3h-ipv6.jenkinsfile
@@ -8,7 +8,6 @@ longevityPipeline(
     region: 'eu-west-1',
     ip_ssh_connections: 'ipv6',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-10gb-3h.yaml',
+    test_config: 'test-cases/longevity/longevity-10gb-3h.yaml'
 
-    timeout: [time: 300, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-10gb-3h-nosqlbench.jenkinsfile
+++ b/jenkins-pipelines/longevity-10gb-3h-nosqlbench.jenkinsfile
@@ -7,5 +7,5 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-nosqlbench-3h.yaml',
+    test_config: 'test-cases/longevity/longevity-nosqlbench-3h.yaml'
 )

--- a/jenkins-pipelines/longevity-10gb-3h-saslauthd-authenticator-ms-ad.jenkinsfile
+++ b/jenkins-pipelines/longevity-10gb-3h-saslauthd-authenticator-ms-ad.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-10gb-3h.yaml", "configurations/ms-ad-ldap-authenticator.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-10gb-3h.yaml", "configurations/ms-ad-ldap-authenticator.yaml"]'''
 
-    timeout: [time: 300, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-10gb-3h-saslauthd-authenticator.jenkinsfile
+++ b/jenkins-pipelines/longevity-10gb-3h-saslauthd-authenticator.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-10gb-3h.yaml", "configurations/ldap-authenticator.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-10gb-3h.yaml", "configurations/ldap-authenticator.yaml"]'''
 
-    timeout: [time: 300, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-10gb-3h.jenkinsfile
+++ b/jenkins-pipelines/longevity-10gb-3h.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-10gb-3h.yaml',
+    test_config: 'test-cases/longevity/longevity-10gb-3h.yaml'
 
-    timeout: [time: 300, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-1tb-7days-gce.jenkinsfile
+++ b/jenkins-pipelines/longevity-1tb-7days-gce.jenkinsfile
@@ -6,5 +6,5 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 longevityPipeline(
     backend: 'gce',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml',
+    test_config: 'test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml'
 )

--- a/jenkins-pipelines/longevity-1tb-7days.jenkinsfile
+++ b/jenkins-pipelines/longevity-1tb-7days.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml',
+    test_config: 'test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml'
 
-    timeout: [time: 10960, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-200gb-48h-arm.jenkinsfile
+++ b/jenkins-pipelines/longevity-200gb-48h-arm.jenkinsfile
@@ -8,7 +8,6 @@ longevityPipeline(
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml", "configurations/arm_instance_types/im4gn_4xlarge.yaml"]''',
-    availability_zone: 'c',
+    availability_zone: 'c'
 
-    timeout: [time: 3060, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-200gb-48h-network-monkey.jenkinsfile
+++ b/jenkins-pipelines/longevity-200gb-48h-network-monkey.jenkinsfile
@@ -8,7 +8,6 @@ longevityPipeline(
     ip_ssh_connections: 'public',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-200GB-48h-network-monkey.yaml',
+    test_config: 'test-cases/longevity/longevity-200GB-48h-network-monkey.yaml'
 
-    timeout: [time: 2940, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-200gb-48h.jenkinsfile
+++ b/jenkins-pipelines/longevity-200gb-48h.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml',
+    test_config: 'test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml'
 
-    timeout: [time: 3060, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.jenkinsfile
+++ b/jenkins-pipelines/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml',
+    test_config: 'test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml'
 
-    timeout: [time: 3180, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-50gb-3days-arm.jenkinsfile
+++ b/jenkins-pipelines/longevity-50gb-3days-arm.jenkinsfile
@@ -8,7 +8,6 @@ longevityPipeline(
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "configurations/arm_instance_types/im4gn_4xlarge.yaml"]''',
-    availability_zone: 'c',
+    availability_zone: 'c'
 
-    timeout: [time: 5000, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-50gb-3days-aws-i4i.jenkinsfile
+++ b/jenkins-pipelines/longevity-50gb-3days-aws-i4i.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "configurations/aws/i4i_4xlarge.yaml"]',
+    test_config: '["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "configurations/aws/i4i_4xlarge.yaml"]'
 
-    timeout: [time: 5000, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-50gb-3days-ebs-gp3.jenkinsfile
+++ b/jenkins-pipelines/longevity-50gb-3days-ebs-gp3.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml","configurations/ebs/ebs-gp3-2v-4tb-16k-iops.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml","configurations/ebs/ebs-gp3-2v-4tb-16k-iops.yaml"]'''
 
-    timeout: [time: 5000, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-50gb-3days.jenkinsfile
+++ b/jenkins-pipelines/longevity-50gb-3days.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml',
+    test_config: 'test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml'
 
-    timeout: [time: 5000, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-alternator-200gb-48h.jenkinsfile
+++ b/jenkins-pipelines/longevity-alternator-200gb-48h.jenkinsfile
@@ -9,6 +9,5 @@ longevityPipeline(
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-alternator-200GB-48h.yaml',
 
-    timeout: [time: 3200, unit: 'MINUTES'],
     email_recipients: 'qa@scylladb.com'
 )

--- a/jenkins-pipelines/longevity-alternator-3h.jenkinsfile
+++ b/jenkins-pipelines/longevity-alternator-3h.jenkinsfile
@@ -9,6 +9,5 @@ longevityPipeline(
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/longevity/longevity-alternator-3h.yaml',
 
-    timeout: [time: 300, unit: 'MINUTES'],
     email_recipients: 'qa@scylladb.com'
 )

--- a/jenkins-pipelines/longevity-alternator-streams-12h.jenkinsfile
+++ b/jenkins-pipelines/longevity-alternator-streams-12h.jenkinsfile
@@ -7,5 +7,5 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-alternator-streams-100gb-12h.yaml',
+    test_config: 'test-cases/longevity/longevity-alternator-streams-100gb-12h.yaml'
 )

--- a/jenkins-pipelines/longevity-alternator-streams-4h-nemesis.jenkinsfile
+++ b/jenkins-pipelines/longevity-alternator-streams-4h-nemesis.jenkinsfile
@@ -7,5 +7,5 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-alternator-streams-100gb-4h.yaml", "configurations/alternator/streams-with-nemesis.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-alternator-streams-100gb-4h.yaml", "configurations/alternator/streams-with-nemesis.yaml"]'''
 )

--- a/jenkins-pipelines/longevity-cdc-3d-400gb.jenkinsfile
+++ b/jenkins-pipelines/longevity-cdc-3d-400gb.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-cdc-3d-400gb.yaml',
+    test_config: 'test-cases/longevity/longevity-cdc-3d-400gb.yaml'
 
-    timeout: [time: 4600, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-cdc-4h.jenkinsfile
+++ b/jenkins-pipelines/longevity-cdc-4h.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-cdc-100gb-4h.yaml',
+    test_config: 'test-cases/longevity/longevity-cdc-100gb-4h.yaml'
 
-    timeout: [time: 360, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-cdc-8h-multi-dc-large-cluster.jenkinsfile
+++ b/jenkins-pipelines/longevity-cdc-8h-multi-dc-large-cluster.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: '''["eu-west-1", "us-east-1", "eu-west-2"]''',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-large-cluster.yaml',
+    test_config: 'test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-large-cluster.yaml'
 
-    timeout: [time: 800, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-cdc-8h-multi-dc-topology-changes.jenkinsfile
+++ b/jenkins-pipelines/longevity-cdc-8h-multi-dc-topology-changes.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: '''["eu-west-1", "us-east-1"]''',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-topology-changes.yaml',
+    test_config: 'test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-topology-changes.yaml'
 
-    timeout: [time: 560, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-counters-3h.jenkinsfile
+++ b/jenkins-pipelines/longevity-counters-3h.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-counters-3h.yaml',
+    test_config: 'test-cases/longevity/longevity-counters-3h.yaml'
 
-    timeout: [time: 400, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-counters-multidc.jenkinsfile
+++ b/jenkins-pipelines/longevity-counters-multidc.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: '''["eu-west-1", "us-west-2", "us-east-1"]''',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-counters-multidc.yaml',
+    test_config: 'test-cases/longevity/longevity-counters-multidc.yaml'
 
-    timeout: [time: 550, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-harry-2h.jenkinsfile
+++ b/jenkins-pipelines/longevity-harry-2h.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-harry-2h.yaml',
+    test_config: 'test-cases/longevity/longevity-harry-2h.yaml'
 
-    timeout: [time: 240, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-in-memory-36gb-1d.jenkinsfile
+++ b/jenkins-pipelines/longevity-in-memory-36gb-1d.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_in_memory_test.InMemoryLongevityTest.test_in_mem_longevity',
-    test_config: 'test-cases/longevity/longevity-in-memory-36GB-1day.yaml',
+    test_config: 'test-cases/longevity/longevity-in-memory-36GB-1day.yaml'
 
-    timeout: [time: 1560, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-large-collections-12h.jenkinsfile
+++ b/jenkins-pipelines/longevity-large-collections-12h.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-large-collections-12h.yaml',
+    test_config: 'test-cases/longevity/longevity-large-collections-12h.yaml'
 
-    timeout: [time: 870, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-large-partition-200k-pks-4days-aws-i4i.jenkinsfile
+++ b/jenkins-pipelines/longevity-large-partition-200k-pks-4days-aws-i4i.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
-    test_config: '["test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml", "configurations/aws/i4i_4xlarge.yaml"]',
+    test_config: '["test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml", "configurations/aws/i4i_4xlarge.yaml"]'
 
-    timeout: [time: 6540, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-large-partition-200k-pks-4days.jenkinsfile
+++ b/jenkins-pipelines/longevity-large-partition-200k-pks-4days.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
-    test_config: 'test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml',
+    test_config: 'test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml'
 
-    timeout: [time: 6540, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-large-partition-4days-arm.jenkinsfile
+++ b/jenkins-pipelines/longevity-large-partition-4days-arm.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
-    test_config: '''["test-cases/longevity/longevity-large-partition-4days.yaml", "configurations/arm_instance_types/is4gen_4xlarge.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-large-partition-4days.yaml", "configurations/arm_instance_types/is4gen_4xlarge.yaml"]'''
 
-    timeout: [time: 6540, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-large-partition-4days.jenkinsfile
+++ b/jenkins-pipelines/longevity-large-partition-4days.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
-    test_config: 'test-cases/longevity/longevity-large-partition-4days.yaml',
+    test_config: 'test-cases/longevity/longevity-large-partition-4days.yaml'
 
-    timeout: [time: 6540, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-large-partition-8h-aws-i4i.jenkinsfile
+++ b/jenkins-pipelines/longevity-large-partition-8h-aws-i4i.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
-    test_config: '''["test-cases/longevity/longevity-large-partition-8h.yaml", "configurations/aws/i4i_2xlarge.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-large-partition-8h.yaml", "configurations/aws/i4i_2xlarge.yaml"]'''
 
-    timeout: [time: 610, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-large-partition-8h-ebs-gp3.jenkinsfile
+++ b/jenkins-pipelines/longevity-large-partition-8h-ebs-gp3.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
-    test_config: '''["test-cases/longevity/longevity-large-partition-8h.yaml","configurations/ebs/ebs-gp3-2v-4tb-16k-iops.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-large-partition-8h.yaml","configurations/ebs/ebs-gp3-2v-4tb-16k-iops.yaml"]'''
 
-    timeout: [time: 610, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-large-partition-8h.jenkinsfile
+++ b/jenkins-pipelines/longevity-large-partition-8h.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
-    test_config: 'test-cases/longevity/longevity-large-partition-8h.yaml',
+    test_config: 'test-cases/longevity/longevity-large-partition-8h.yaml'
 
-    timeout: [time: 610, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-large-partition-asymmetric-cluster-3h-aws-i4i.jenkinsfile
+++ b/jenkins-pipelines/longevity-large-partition-asymmetric-cluster-3h-aws-i4i.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
-    test_config: '''["test-cases/longevity/longevity-large-partition-3h.yaml", "configurations/db-nodes-shards-random.yaml", "configurations/aws/i4i_2xlarge.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-large-partition-3h.yaml", "configurations/db-nodes-shards-random.yaml", "configurations/aws/i4i_2xlarge.yaml"]'''
 
-    timeout: [time: 240, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-large-partition-asymmetric-cluster-3h.jenkinsfile
+++ b/jenkins-pipelines/longevity-large-partition-asymmetric-cluster-3h.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
-    test_config: '''["test-cases/longevity/longevity-large-partition-3h.yaml", "configurations/db-nodes-shards-random.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-large-partition-3h.yaml", "configurations/db-nodes-shards-random.yaml"]'''
 
-    timeout: [time: 240, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-lwt-1loader-3h.jenkinsfile
+++ b/jenkins-pipelines/longevity-lwt-1loader-3h.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_lwt_test.LWTLongevityTest.test_lwt_longevity',
-    test_config: 'test-cases/longevity/longevity-lwt-1loader-3h.yaml',
+    test_config: 'test-cases/longevity/longevity-lwt-1loader-3h.yaml'
 
-    timeout: [time: 300, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-lwt-24h-1dis-2nondis.jenkinsfile
+++ b/jenkins-pipelines/longevity-lwt-24h-1dis-2nondis.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_lwt_test.LWTLongevityTest.test_lwt_longevity',
-    test_config: 'test-cases/longevity/longevity-lwt-basic-24h-1dis-2nondis.yaml',
+    test_config: 'test-cases/longevity/longevity-lwt-basic-24h-1dis-2nondis.yaml'
 
-    timeout: [time: 2000, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-lwt-24h-multidc.jenkinsfile
+++ b/jenkins-pipelines/longevity-lwt-24h-multidc.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: '''["eu-west-1", "us-west-2", "us-east-1"]''',
     test_name: 'longevity_lwt_test.LWTLongevityTest.test_lwt_longevity',
-    test_config: 'test-cases/longevity/longevity-lwt-24h-multidc.yaml',
+    test_config: 'test-cases/longevity/longevity-lwt-24h-multidc.yaml'
 
-    timeout: [time: 1600, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-lwt-24h.jenkinsfile
+++ b/jenkins-pipelines/longevity-lwt-24h.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_lwt_test.LWTLongevityTest.test_lwt_longevity',
-    test_config: 'test-cases/longevity/longevity-lwt-basic-24h.yaml',
+    test_config: 'test-cases/longevity/longevity-lwt-basic-24h.yaml'
 
-    timeout: [time: 2000, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-lwt-3h.jenkinsfile
+++ b/jenkins-pipelines/longevity-lwt-3h.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_lwt_test.LWTLongevityTest.test_lwt_longevity',
-    test_config: 'test-cases/longevity/longevity-lwt-basic-3h.yaml',
+    test_config: 'test-cases/longevity/longevity-lwt-basic-3h.yaml'
 
-    timeout: [time: 300, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-lwt-500G-3d.jenkinsfile
+++ b/jenkins-pipelines/longevity-lwt-500G-3d.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_lwt_test.LWTLongevityTest.test_lwt_longevity',
-    test_config: 'test-cases/longevity/longevity-lwt-500G-3d.yaml',
+    test_config: 'test-cases/longevity/longevity-lwt-500G-3d.yaml'
 
-    timeout: [time: 5000, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-lwt-parallel-schema-changes-with-disruptive-24h.jenkinsfile
+++ b/jenkins-pipelines/longevity-lwt-parallel-schema-changes-with-disruptive-24h.jenkinsfile
@@ -7,6 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_lwt_test.LWTLongevityTest.test_lwt_longevity',
-    test_config: 'test-cases/longevity/longevity-lwt-parallel-24h.yaml',
+    test_config: 'test-cases/longevity/longevity-lwt-parallel-24h.yaml'
 
 )

--- a/jenkins-pipelines/longevity-mini-test-1h.jenkinsfile
+++ b/jenkins-pipelines/longevity-mini-test-1h.jenkinsfile
@@ -9,7 +9,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-mini-test-1h.yaml',
+    test_config: 'test-cases/longevity/longevity-mini-test-1h.yaml'
 
-    timeout: [time: 90, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-multi-keyspaces-60h.jenkinsfile
+++ b/jenkins-pipelines/longevity-multi-keyspaces-60h.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_batch_custom_time',
-    test_config: 'test-cases/longevity/longevity-multi-keyspaces.yaml',
+    test_config: 'test-cases/longevity/longevity-multi-keyspaces.yaml'
 
-    timeout: [time: 3660, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-mv-si-4days.jenkinsfile
+++ b/jenkins-pipelines/longevity-mv-si-4days.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-mv-si-4days.yaml',
+    test_config: 'test-cases/longevity/longevity-mv-si-4days.yaml'
 
-    timeout: [time: 6610, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-twcs-3h.jenkinsfile
+++ b/jenkins-pipelines/longevity-twcs-3h.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_twcs_test.TWCSLongevityTest.test_twcs_longevity',
-    test_config: 'test-cases/longevity/longevity-twcs-3h.yaml',
+    test_config: 'test-cases/longevity/longevity-twcs-3h.yaml'
 
-    timeout: [time: 300, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/longevity-twcs-48h.jenkinsfile
+++ b/jenkins-pipelines/longevity-twcs-48h.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_twcs_test.TWCSLongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-twcs-48h.yaml',
+    test_config: 'test-cases/longevity/longevity-twcs-48h.yaml'
 
-    timeout: [time: 3060, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-add-remove-rack.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-add-remove-rack.jenkinsfile
@@ -12,6 +12,5 @@ longevityPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-    post_behavior_k8s_cluster: 'destroy',
-    timeout: [time: 400, unit: 'MINUTES']
+    post_behavior_k8s_cluster: 'destroy'
 )

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-backup.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-backup.jenkinsfile
@@ -12,6 +12,5 @@ longevityPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-    post_behavior_k8s_cluster: 'destroy',
-    timeout: [time: 400, unit: 'MINUTES']
+    post_behavior_k8s_cluster: 'destroy'
 )

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-cluster-rolling.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-cluster-rolling.jenkinsfile
@@ -12,6 +12,5 @@ longevityPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-    post_behavior_k8s_cluster: 'destroy',
-    timeout: [time: 400, unit: 'MINUTES']
+    post_behavior_k8s_cluster: 'destroy'
 )

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-grow-shrink.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-grow-shrink.jenkinsfile
@@ -12,6 +12,5 @@ longevityPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-    post_behavior_k8s_cluster: 'destroy',
-    timeout: [time: 400, unit: 'MINUTES']
+    post_behavior_k8s_cluster: 'destroy'
 )

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-repair.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-repair.jenkinsfile
@@ -12,6 +12,5 @@ longevityPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-    post_behavior_k8s_cluster: 'destroy',
-    timeout: [time: 400, unit: 'MINUTES']
+    post_behavior_k8s_cluster: 'destroy'
 )

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-replace.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-replace.jenkinsfile
@@ -12,6 +12,5 @@ longevityPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-    post_behavior_k8s_cluster: 'destroy',
-    timeout: [time: 400, unit: 'MINUTES']
+    post_behavior_k8s_cluster: 'destroy'
 )

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-scylla-enterprise.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-scylla-enterprise.jenkinsfile
@@ -12,5 +12,5 @@ longevityPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-    post_behavior_k8s_cluster: 'destroy',
+    post_behavior_k8s_cluster: 'destroy'
 )

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-stop-start.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-stop-start.jenkinsfile
@@ -12,6 +12,5 @@ longevityPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-    post_behavior_k8s_cluster: 'destroy',
-    timeout: [time: 400, unit: 'MINUTES']
+    post_behavior_k8s_cluster: 'destroy'
 )

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-terminate-decommission-add.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-terminate-decommission-add.jenkinsfile
@@ -12,6 +12,5 @@ longevityPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-    post_behavior_k8s_cluster: 'destroy',
-    timeout: [time: 400, unit: 'MINUTES']
+    post_behavior_k8s_cluster: 'destroy'
 )

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-terminate-replace.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks-terminate-replace.jenkinsfile
@@ -12,6 +12,5 @@ longevityPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-    post_behavior_k8s_cluster: 'destroy',
-    timeout: [time: 400, unit: 'MINUTES']
+    post_behavior_k8s_cluster: 'destroy'
 )

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-eks.jenkinsfile
@@ -12,6 +12,5 @@ longevityPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-    post_behavior_k8s_cluster: 'destroy',
-    timeout: [time: 400, unit: 'MINUTES']
+    post_behavior_k8s_cluster: 'destroy'
 )

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-basic-12h-eks-scylla-enterprise.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-basic-12h-eks-scylla-enterprise.jenkinsfile
@@ -12,5 +12,5 @@ longevityPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-    post_behavior_k8s_cluster: 'destroy',
+    post_behavior_k8s_cluster: 'destroy'
 )

--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-basic-12h-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-basic-12h-eks.jenkinsfile
@@ -12,5 +12,5 @@ longevityPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-    post_behavior_k8s_cluster: 'destroy',
+    post_behavior_k8s_cluster: 'destroy'
 )

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-add-remove-rack.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-add-remove-rack.jenkinsfile
@@ -10,5 +10,5 @@ longevityPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-    post_behavior_k8s_cluster: 'destroy',
+    post_behavior_k8s_cluster: 'destroy'
 )

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-backup.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-backup.jenkinsfile
@@ -10,5 +10,5 @@ longevityPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-    post_behavior_k8s_cluster: 'destroy',
+    post_behavior_k8s_cluster: 'destroy'
 )

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-cluster-rolling.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-cluster-rolling.jenkinsfile
@@ -10,5 +10,5 @@ longevityPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-    post_behavior_k8s_cluster: 'destroy',
+    post_behavior_k8s_cluster: 'destroy'
 )

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-grow-shrink.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-grow-shrink.jenkinsfile
@@ -10,5 +10,5 @@ longevityPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-    post_behavior_k8s_cluster: 'destroy',
+    post_behavior_k8s_cluster: 'destroy'
 )

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-nodetool-flush-and-reshard.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-nodetool-flush-and-reshard.jenkinsfile
@@ -10,5 +10,5 @@ longevityPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-    post_behavior_k8s_cluster: 'destroy',
+    post_behavior_k8s_cluster: 'destroy'
 )

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-repair.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-repair.jenkinsfile
@@ -10,5 +10,5 @@ longevityPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-    post_behavior_k8s_cluster: 'destroy',
+    post_behavior_k8s_cluster: 'destroy'
 )

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-replace.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-replace.jenkinsfile
@@ -10,5 +10,5 @@ longevityPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-    post_behavior_k8s_cluster: 'destroy',
+    post_behavior_k8s_cluster: 'destroy'
 )

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-scylla-enterprise.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-scylla-enterprise.jenkinsfile
@@ -10,5 +10,5 @@ longevityPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-    post_behavior_k8s_cluster: 'destroy',
+    post_behavior_k8s_cluster: 'destroy'
 )

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-stop-start.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-stop-start.jenkinsfile
@@ -10,5 +10,5 @@ longevityPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-    post_behavior_k8s_cluster: 'destroy',
+    post_behavior_k8s_cluster: 'destroy'
 )

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-terminate-decommission-add.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-terminate-decommission-add.jenkinsfile
@@ -10,5 +10,5 @@ longevityPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-    post_behavior_k8s_cluster: 'destroy',
+    post_behavior_k8s_cluster: 'destroy'
 )

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-terminate-replace.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke-terminate-replace.jenkinsfile
@@ -10,5 +10,5 @@ longevityPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-    post_behavior_k8s_cluster: 'destroy',
+    post_behavior_k8s_cluster: 'destroy'
 )

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke.jenkinsfile
@@ -10,5 +10,5 @@ longevityPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-    post_behavior_k8s_cluster: 'destroy',
+    post_behavior_k8s_cluster: 'destroy'
 )

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-basic-12h-gke-scylla-enterprise.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-basic-12h-gke-scylla-enterprise.jenkinsfile
@@ -10,5 +10,5 @@ longevityPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-    post_behavior_k8s_cluster: 'destroy',
+    post_behavior_k8s_cluster: 'destroy'
 )

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-basic-12h-gke.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-basic-12h-gke.jenkinsfile
@@ -10,5 +10,5 @@ longevityPipeline(
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
-    post_behavior_k8s_cluster: 'destroy',
+    post_behavior_k8s_cluster: 'destroy'
 )

--- a/jenkins-pipelines/raft/longevity-100gb-4h-with-raft.jenkinsfile
+++ b/jenkins-pipelines/raft/longevity-100gb-4h-with-raft.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/raft/enable_raft_experimental.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "configurations/raft/enable_raft_experimental.yaml"]'''
 
-    timeout: [time: 360, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/raft/longevity-50gb-3days-raft.jenkinsfile
+++ b/jenkins-pipelines/raft/longevity-50gb-3days-raft.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: ["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml","configurations/raft/enable_raft_experimental.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml","configurations/raft/enable_raft_experimental.yaml"]''',
 
-    timeout: [time: 5000, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/raft/longevity-cdc-8h-multi-dc-topology-changes-raft.jenkinsfile
+++ b/jenkins-pipelines/raft/longevity-cdc-8h-multi-dc-topology-changes-raft.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: '''["eu-west-1", "us-east-1"]''',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: ["test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-topology-changes.yaml", "configurations/raft/enable_raft_experimental.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-cdc-100gb-8h-multi-dc-topology-changes.yaml", "configurations/raft/enable_raft_experimental.yaml"]'''
 
-    timeout: [time: 560, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/raft/longevity-lwt-parallel-schema-changes-with-disruptive-24h-raft.jenkinsfile
+++ b/jenkins-pipelines/raft/longevity-lwt-parallel-schema-changes-with-disruptive-24h-raft.jenkinsfile
@@ -7,6 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_lwt_test.LWTLongevityTest.test_lwt_longevity',
-    test_config: '''["test-cases/longevity/longevity-lwt-parallel-24h.yaml", "configurations/raft/enable_raft_experimental.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-lwt-parallel-24h.yaml", "configurations/raft/enable_raft_experimental.yaml"]'''
 
 )

--- a/jenkins-pipelines/repair-based-operation/longevity-100gb-4h-Decommission.jenkinsfile
+++ b/jenkins-pipelines/repair-based-operation/longevity-100gb-4h-Decommission.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     aws_region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "test-cases/features/repair-based-operations/longevity-100gb-4h-Decommission.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "test-cases/features/repair-based-operations/longevity-100gb-4h-Decommission.yaml"]'''
 
-    timeout: [time: 360, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/repair-based-operation/longevity-100gb-4h-RemoveNode.jenkinsfile
+++ b/jenkins-pipelines/repair-based-operation/longevity-100gb-4h-RemoveNode.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     aws_region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "test-cases/features/repair-based-operations/longevity-100gb-4h-RemoveNode.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "test-cases/features/repair-based-operations/longevity-100gb-4h-RemoveNode.yaml"]'''
 
-    timeout: [time: 360, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/repair-based-operation/longevity-100gb-4h-ReplaceNode.jenkinsfile
+++ b/jenkins-pipelines/repair-based-operation/longevity-100gb-4h-ReplaceNode.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     aws_region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "test-cases/features/repair-based-operations/longevity-100gb-4h-ReplaceNode.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-100gb-4h.yaml", "test-cases/features/repair-based-operations/longevity-100gb-4h-ReplaceNode.yaml"]'''
 
-    timeout: [time: 360, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/repair-based-operation/longevity-1tb-12h-GrowShrink.jenkinsfile
+++ b/jenkins-pipelines/repair-based-operation/longevity-1tb-12h-GrowShrink.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     aws_region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "test-cases/features/repair-based-operations/longevity-1TB-12h-GrowShrink.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "test-cases/features/repair-based-operations/longevity-1TB-12h-GrowShrink.yaml"]'''
 
-    timeout: [time: 800, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/repair-based-operation/longevity-200gb-48h-Decommission.jenkinsfile
+++ b/jenkins-pipelines/repair-based-operation/longevity-200gb-48h-Decommission.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     aws_region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml", "test-cases/features/repair-based-operations/longevity-200GB-48h-Decommission.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-200GB-48h-verifier-LimitedMonkey-tls.yaml", "test-cases/features/repair-based-operations/longevity-200GB-48h-Decommission.yaml"]'''
 
-    timeout: [time: 3060, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/repair-based-operation/longevity-50gb-12h-RemoveNode.jenkinsfile
+++ b/jenkins-pipelines/repair-based-operation/longevity-50gb-12h-RemoveNode.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     aws_region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "test-cases/features/repair-based-operations/longevity-50GB-12h-RemoveNode.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "test-cases/features/repair-based-operations/longevity-50GB-12h-RemoveNode.yaml"]'''
 
-    timeout: [time: 800, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/repair-based-operation/longevity-50gb-12h-ReplaceNode.jenkinsfile
+++ b/jenkins-pipelines/repair-based-operation/longevity-50gb-12h-ReplaceNode.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     aws_region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "test-cases/features/repair-based-operations/longevity-50GB-12h-ReplaceNode.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml", "test-cases/features/repair-based-operations/longevity-50GB-12h-ReplaceNode.yaml"]'''
 
-    timeout: [time: 800, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/repair-based-operation/longevity-cdc-4h-Decommission.jenkinsfile
+++ b/jenkins-pipelines/repair-based-operation/longevity-cdc-4h-Decommission.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     aws_region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-cdc-100gb-4h.yaml", "test-cases/features/repair-based-operations/longevity-cdc-100gb-4h-Decommission.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-cdc-100gb-4h.yaml", "test-cases/features/repair-based-operations/longevity-cdc-100gb-4h-Decommission.yaml"]'''
 
-    timeout: [time: 360, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/repair-based-operation/longevity-cdc-4h-RemoveNode.jenkinsfile
+++ b/jenkins-pipelines/repair-based-operation/longevity-cdc-4h-RemoveNode.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     aws_region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-cdc-100gb-4h.yaml", "test-cases/features/repair-based-operations/longevity-cdc-100gb-4h-RemoveNode.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-cdc-100gb-4h.yaml", "test-cases/features/repair-based-operations/longevity-cdc-100gb-4h-RemoveNode.yaml"]'''
 
-    timeout: [time: 360, unit: 'MINUTES']
 )

--- a/jenkins-pipelines/repair-based-operation/longevity-cdc-4h-ReplaceNode.jenkinsfile
+++ b/jenkins-pipelines/repair-based-operation/longevity-cdc-4h-ReplaceNode.jenkinsfile
@@ -7,7 +7,6 @@ longevityPipeline(
     backend: 'aws',
     aws_region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-cdc-100gb-4h.yaml", "test-cases/features/repair-based-operations/longevity-cdc-100gb-4h-ReplaceNode.yaml"]''',
+    test_config: '''["test-cases/longevity/longevity-cdc-100gb-4h.yaml", "test-cases/features/repair-based-operations/longevity-cdc-100gb-4h-ReplaceNode.yaml"]'''
 
-    timeout: [time: 360, unit: 'MINUTES']
 )


### PR DESCRIPTION
timeout param for longevity jobs is now calculated
by function `getJobTimeouts` making the param
in the `jenkinsfile` obsolete.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
