### PR TITLE
fix(k8s): make append_scylla_args not break multi-tenant setup

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1016,7 +1016,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
         if self.params.get('append_scylla_args'):
             data = {"spec": {"scyllaArgs": self.params.get('append_scylla_args')}}
             self.kubectl(
-                f"patch scyllaclusters {self.k8s_scylla_cluster_name} --type merge "
+                f"patch scyllaclusters {cluster_name} --type merge "
                 f"-p '{json.dumps(data)}'",
                 namespace=namespace,
             )


### PR DESCRIPTION
In K8S multi-tenant setups we use separate Scylla clusters with unique
names. So, fix the variable we use setting the scylla binary args.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
