### PR TITLE
fix(error): ignore view update gate_closed_exception during reboot

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -66,7 +66,7 @@ from sdcm.sct_events.database import DatabaseLogEvent
 from sdcm.sct_events.decorators import raise_event_on_failure
 from sdcm.sct_events.filters import DbEventsFilter, EventsSeverityChangerFilter
 from sdcm.sct_events.group_common_events import (ignore_alternator_client_errors, ignore_no_space_errors,
-                                                 ignore_scrub_invalid_errors)
+                                                 ignore_scrub_invalid_errors, ignore_view_error_gate_closed_exception)
 from sdcm.sct_events.loaders import CassandraStressLogEvent
 from sdcm.sct_events.nemesis import DisruptionEvent
 from sdcm.sct_events.system import InfoEvent
@@ -590,7 +590,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         time.sleep(60)
 
     def disrupt_hard_reboot_node(self):
-        self.target_node.reboot(hard=True)
+        self.reboot_node(target_node=self.target_node, hard=True)
         self.log.info('Waiting scylla services to start after node reboot')
         self.target_node.wait_db_up()
         self.log.info('Waiting JMX services to start after node reboot')
@@ -614,7 +614,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.log.debug("Rebooting %s out of %s times", i + 1, num_of_reboots)
             cdc_expected_error = self.target_node.follow_system_log(patterns=cdc_expected_error_patterns)
             cdc_success_msg = self.target_node.follow_system_log(patterns=cdc_success_msg_patterns)
-            self.target_node.reboot(hard=True)
+            self.reboot_node(target_node=self.target_node, hard=True)
             if random.choice([True, False]):
                 self.log.info('Waiting scylla services to start after node reboot')
                 self.target_node.wait_db_up()
@@ -637,7 +637,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             time.sleep(sleep_time)
 
     def disrupt_soft_reboot_node(self):
-        self.target_node.reboot(hard=False)
+        self.reboot_node(target_node=self.target_node, hard=False)
         self.log.info('Waiting scylla services to start after node reboot')
         self.target_node.wait_db_up()
         self.log.info('Waiting JMX services to start after node reboot')
@@ -2770,6 +2770,11 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 self.log.debug(f"{name}: failed to execute cleanup command "
                                f"{cmd} on node {node} due to the following error: {str(exc)}")
 
+    @staticmethod
+    def reboot_node(target_node, hard=True, verify_ssh=True):
+        with ignore_view_error_gate_closed_exception():
+            target_node.reboot(hard=hard, verify_ssh=verify_ssh)
+
     def disrupt_network_start_stop_interface(self):  # pylint: disable=invalid-name
         if not self.cluster.extra_network_interface:
             raise UnsupportedNemesis("for this nemesis to work, you need to set `extra_network_interface: True`")
@@ -2859,8 +2864,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         watcher = partial(
             self._call_disrupt_func_after_expression_logged,
             expression="DECOMMISSIONING: unbootstrap starts",
-            disrupt_func=self.target_node.reboot,
-            disrupt_func_kwargs={"hard": True, "verify_ssh": True},
+            disrupt_func=self.reboot_node,
+            disrupt_func_kwargs={"target_node": self.target_node, "hard": True, "verify_ssh": True},
             delay=0
         )
         ParallelObject(objects=[trigger, watcher], timeout=600).call_objects()
@@ -2882,8 +2887,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         watcher = partial(
             self._call_disrupt_func_after_expression_logged,
             expression="Repair 1 out of",
-            disrupt_func=self.target_node.reboot,
-            disrupt_func_kwargs={"hard": True, "verify_ssh": True},
+            disrupt_func=self.reboot_node,
+            disrupt_func_kwargs={"target_node": self.target_node, "hard": True, "verify_ssh": True},
             delay=1
         )
         ParallelObject(objects=[trigger, watcher], timeout=600).call_objects()
@@ -2906,8 +2911,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         watcher = partial(
             self._call_disrupt_func_after_expression_logged,
             expression="Rebuild starts",
-            disrupt_func=self.target_node.reboot,
-            disrupt_func_kwargs={"hard": True, "verify_ssh": True},
+            disrupt_func=self.reboot_node,
+            disrupt_func_kwargs={"target_node": self.target_node, "hard": True, "verify_ssh": True},
             timeout=timeout,
             delay=1
         )

--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -174,3 +174,9 @@ def ignore_scrub_invalid_errors():
             line="Skipping invalid partition",
         ))
         yield
+
+
+@contextmanager
+def ignore_view_error_gate_closed_exception():
+    with EventsFilter(event_class=DatabaseLogEvent, regex='.*view - Error applying view update.*gate_closed_exception'):
+        yield


### PR DESCRIPTION
Issue https://github.com/scylladb/scylla/issues/10217

Expected error, we need to ignore it (Roy's request):
 http://13.48.103.68/test/e924afae-c3b6-4e75-b4f2-05d5ead176aa/runs?additionalRuns[]=1bb24db5-ff03-42fb-b3c5-595d885b91f2

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
