### PR TITLE
fix(longevityPipeline): add support for passing down `docker_image`

### DIFF
--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -119,6 +119,9 @@ def call(Map pipelineParams) {
                    description: 'Scylla Operator docker image',
                    name: 'k8s_scylla_operator_docker_image')
 
+            string(defaultValue: "${pipelineParams.get('docker_image', '')}",
+                   description: 'Scylla docker image repo',
+                   name: 'docker_image')
         }
         options {
             timestamps()

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -69,6 +69,10 @@ def call(Map params, String region, functional_test = false, Map pipelineParams 
         export SCT_K8S_LOG_API_CALLS=${pipelineParams.k8s_log_api_calls}
     fi
 
+    if [[ -n "${params.docker_image ? params.docker_image : ''}" ]] ; then
+        export SCT_DOCKER_IMAGE=${params.docker_image}
+    fi
+
     if [[ -n "${params.scylla_mgmt_agent_version ? params.scylla_mgmt_agent_version : ''}" ]] ; then
         export SCT_SCYLLA_MGMT_AGENT_VERSION=${params.scylla_mgmt_agent_version}
     fi


### PR DESCRIPTION
Since in k8s longevity we want to be able to control the
source dockerhub project source to pull the scylla image from

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
