### PR TITLE
fix(cluster_healthcheck): lookup all addresses

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3104,7 +3104,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
 
     def find_node_by_ip(self, node_ip):
         for node in self.nodes:
-            if node_ip in [node.private_ip_address, node.public_ip_address, node.ipv6_ip_address]:
+            if node_ip in node.get_all_ip_addresses():
                 return node
 
         return None


### PR DESCRIPTION
`find_node_by_ip` wasn't looking in all the addresses available
since in k8s we might have multiple private network, it was
missing one of them (the cluster ip), and failing in the
health check casue of that

```
host ip: 10.0.1.35 (public_ip)
service ip: 10.0.1.8 (private_ip)
cluster ip: 172.20.132.155

Node sct-cluster-us-east1-b-us-east1-2 [10.0.1.35 | 10.0.1.8]
Get gossip info. Failed to find a node with status NORMAL in the cluster by IP: 172.20.132.155
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
