### PR TITLE
fix(common.py): add ubuntu 22 to `get_distro_name`

### DIFF
--- a/sdcm/mgmt/common.py
+++ b/sdcm/mgmt/common.py
@@ -21,6 +21,7 @@ def get_distro_name(distro_object):
         Distro.UBUNTU16: "ubuntu16",
         Distro.UBUNTU18: "ubuntu18",
         Distro.UBUNTU20: "ubuntu20",
+        Distro.UBUNTU22: "ubuntu22",
         Distro.OEL7: "centos7",
         Distro.OEL8: "centos8",
         Distro.ROCKY8: "centos8",


### PR DESCRIPTION
from previous work, seems like ubuntu 22 was still
missing from this function, and artifacts test was
failing because of it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
