### PR TITLE
fix(decommission_streaming_err): run rebuild on a new node

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2887,8 +2887,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             delay=0
         )
         ParallelObject(objects=[trigger, watcher], timeout=600).call_objects()
-        decommission_post_action()
-        self.target_node.run_nodetool("rebuild")
+        if new_node := decommission_post_action():
+            new_node.run_nodetool("rebuild")
+        else:
+            self.target_node.run_nodetool("rebuild")
 
     def start_and_interrupt_repair_streaming(self):
         """


### PR DESCRIPTION
In the disrupt_decommission_streaming_err nemesis the target node is decommissioned and then new
node is join instead of descommissioned one. Then by scenario rebuild should be started on the new
node. But rebuild is started on the decommissioned node then the nodetool fails with:

```
Command: /usr/bin/nodetool -u cassandra -pw 'cassandra'  rebuild

Stdout:

Stderr:

Failed to connect in 60 seconds, last error: (ConnectError)Error connecting to host
'10.0.3.79:22' - No route to host
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
