### PR TITLE
fix(k8s): refresh ip addresses on hard/soft reboot

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1748,12 +1748,18 @@ class BasePodContainer(cluster.BaseNode):  # pylint: disable=too-many-public-met
             namespace=self.parent_cluster.namespace,
             timeout=self.pod_terminate_timeout * 60 + 10)
 
+        self.wait_for_pod_readiness()
+        self.refresh_ip_address()
+
     def soft_reboot(self):
         # Kubernetes brings pods back to live right after it is deleted
         self.parent_cluster.k8s_cluster.kubectl(
             f'delete pod {self.name} --grace-period={self.pod_terminate_timeout * 60}',
             namespace=self.parent_cluster.namespace,
             timeout=self.pod_terminate_timeout * 60 + 10)
+
+        self.wait_for_pod_readiness()
+        self.refresh_ip_address()
 
     # On kubernetes there is no stop/start, closest analog of node restart would be soft_restart
     restart = soft_reboot


### PR DESCRIPTION
since in both cases we delete a pod, the next pod
replacing it won't have the same addresses anymore,
and we need to update our node cache of them.

since it's breaking the healthcheck code, and compares
to wrong address

covering all the places inside nemesis that are calling
`node.restart()` or `node.reboot()`

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
