### PR TITLE
feature(k8s_nemesis): move to use SisyphusMonkey for longvity

### DIFF
--- a/configurations/operator/1tb-7days-no-tls.yaml
+++ b/configurations/operator/1tb-7days-no-tls.yaml
@@ -1,4 +1,5 @@
 user_prefix: 'longevity-operator-1tb-7d'
+nemesis_include_filter: ['kubernetes']
 k8s_minio_storage_size: '2048Gi'
 
 # NOTE: operator doesn't support encryption as of January 2022

--- a/configurations/operator/200GB-no-tls.yaml
+++ b/configurations/operator/200GB-no-tls.yaml
@@ -1,4 +1,6 @@
 user_prefix: 'longevity-operator-200gb-48h'
+nemesis_include_filter: ['kubernetes']
+
 k8s_minio_storage_size: '4608Gi'
 
 # NOTE: operator doesn't support encryption as of January 2022

--- a/configurations/operator/50GB-no-tls.yaml
+++ b/configurations/operator/50GB-no-tls.yaml
@@ -1,4 +1,6 @@
 user_prefix: 'longevity-operator-50gb-3d'
+nemesis_include_filter: ['kubernetes']
+
 k8s_minio_storage_size: '1024Gi'
 
 # NOTE: operator doesn't support encryption as of January 2022

--- a/configurations/operator/cdc-3d-400gb.yaml
+++ b/configurations/operator/cdc-3d-400gb.yaml
@@ -1,2 +1,4 @@
 user_prefix: 'longevity-operator-cdc-3d-400gb'
+nemesis_include_filter: ['kubernetes']
+
 k8s_minio_storage_size: '4608Gi'

--- a/configurations/operator/large-collections-12h.yaml
+++ b/configurations/operator/large-collections-12h.yaml
@@ -1,1 +1,2 @@
 user_prefix: 'longevity-operator-large-collections-12h'
+nemesis_include_filter: ['kubernetes']

--- a/configurations/operator/large-partition-200k-pks-4days.yaml
+++ b/configurations/operator/large-partition-200k-pks-4days.yaml
@@ -1,2 +1,4 @@
 user_prefix: 'long-operator-large-partitions-200k-pks-4d'
+nemesis_include_filter: ['kubernetes']
+
 k8s_minio_storage_size: '7168Gi'

--- a/configurations/operator/lwt-basic-24h.yaml
+++ b/configurations/operator/lwt-basic-24h.yaml
@@ -1,1 +1,2 @@
 user_prefix: 'longevity-operator-lwt-24h'
+nemesis_include_filter: ['kubernetes']

--- a/configurations/operator/twcs-basic-48h.yaml
+++ b/configurations/operator/twcs-basic-48h.yaml
@@ -1,1 +1,2 @@
 user_prefix: 'longevity-operator-twcs-48h'
+nemesis_include_filter: ['kubernetes']

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -4325,22 +4325,6 @@ class GeminiNonDisruptiveChaosMonkey(Nemesis):
         self.call_random_disrupt_method(disrupt_methods=self.disrupt_methods_list)
 
 
-class KubernetesScyllaOperatorMonkey(Nemesis):
-    # All Nemesis that could be run on kubernetes backend
-    disruptive = True
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        ignore_methods = (
-            # NOTE: placeholder for methods which must not run on K8S backends
-        )
-        self.disrupt_methods_list = list(
-            set(self.get_list_of_methods_compatible_with_backend()) - set(ignore_methods))
-
-    def disrupt(self):
-        self.call_random_disrupt_method(disrupt_methods=self.disrupt_methods_list)
-
-
 class ScyllaOperatorBasicOperationsMonkey(Nemesis):
     """
     Selected number of nemesis that is focused on scylla-operator functionality
@@ -4445,7 +4429,7 @@ COMPLEX_NEMESIS = [NoOpMonkey, ChaosMonkey,
                    ScyllaCloudLimitedChaosMonkey,
                    AllMonkey, MdcChaosMonkey,
                    DisruptiveMonkey, NonDisruptiveMonkey, GeminiNonDisruptiveChaosMonkey,
-                   GeminiChaosMonkey, NetworkMonkey, KubernetesScyllaOperatorMonkey, SisyphusMonkey,
+                   GeminiChaosMonkey, NetworkMonkey, SisyphusMonkey,
                    CategoricalMonkey]
 
 

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h.yaml
@@ -5,7 +5,9 @@ n_db_nodes: 3
 n_loaders: 2
 n_monitor_nodes: 1
 
-nemesis_class_name: 'KubernetesScyllaOperatorMonkey'
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_include_filter: ['kubernetes']
+nemesis_seed: '026'
 nemesis_interval: 5
 
 user_prefix: 'longevity-scylla-operator-3h'

--- a/test-cases/scylla-operator/longevity-scylla-operator-basic-12h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-basic-12h.yaml
@@ -17,7 +17,9 @@ n_monitor_nodes: 1
 instance_type_db: 'i3.4xlarge'
 gce_instance_type_db: 'n1-highmem-16'
 
-nemesis_class_name: 'ScyllaOperatorBasicOperationsMonkey'
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_include_filter: ['kubernetes']
+nemesis_seed: '026'
 nemesis_interval: 5
 
 space_node_threshold: 100246000000


### PR DESCRIPTION
Since almost all longvity moved to use SisyphusMonkey, moving
also the k8s ones, so we can get predictible ordering of nemesis.

* removed `KubernetesScyllaOperatorMonkey` since it's just
  using the `kubernetes` flag which `SisyphusMonkey` supports.

* add correct `nemesis_include_filter` to all longevity overwide
  configurations.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
