### PR TITLE
fix(arm artifact tests): Enabled manager agent installation

### DIFF
--- a/jenkins-pipelines/artifacts-amazon2-arm.jenkinsfile
+++ b/jenkins-pipelines/artifacts-amazon2-arm.jenkinsfile
@@ -8,7 +8,6 @@ artifactsPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     provision_type: 'spot_low_price',
-    manager_version: '',  // scylla manager doesn't currently support arm processors
 
     timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'

--- a/jenkins-pipelines/artifacts-centos8-arm.jenkinsfile
+++ b/jenkins-pipelines/artifacts-centos8-arm.jenkinsfile
@@ -8,7 +8,6 @@ artifactsPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     provision_type: 'spot_low_price',
-    manager_version: '',  // scylla manager doesn't currently support arm processors
 
     timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'

--- a/jenkins-pipelines/artifacts-debian10-arm.jenkinsfile
+++ b/jenkins-pipelines/artifacts-debian10-arm.jenkinsfile
@@ -8,7 +8,6 @@ artifactsPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     provision_type: 'spot_low_price',
-    manager_version: '',  // scylla manager doesn't currently support arm processors
 
     timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'

--- a/jenkins-pipelines/artifacts-ubuntu2004-arm.jenkinsfile
+++ b/jenkins-pipelines/artifacts-ubuntu2004-arm.jenkinsfile
@@ -8,7 +8,6 @@ artifactsPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     provision_type: 'spot_low_price',
-    manager_version: '',  // scylla manager doesn't currently support arm processors
 
     timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'

--- a/jenkins-pipelines/artifacts-ubuntu2204-arm.jenkinsfile
+++ b/jenkins-pipelines/artifacts-ubuntu2204-arm.jenkinsfile
@@ -8,7 +8,6 @@ artifactsPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     provision_type: 'spot_low_price',
-    manager_version: '',  // scylla manager doesn't currently support arm processors
 
     timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'


### PR DESCRIPTION
Since manager 3.0 supports arm installation, we can now enable
manager agent installation in arm artifact tests.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
