### PR TITLE
fix(nemesis): fix issues with start_stop compaction nemesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -74,8 +74,9 @@ from sdcm.utils import cdc
 from sdcm.utils.common import (get_db_tables, generate_random_string,
                                update_certificates, reach_enospc_on_node, clean_enospc_on_node,
                                parse_nodetool_listsnapshots,
-                               update_authenticator, ParallelObject)
-from sdcm.utils.compaction_ops import CompactionOps
+                               update_authenticator, ParallelObject,
+                               ParallelObjectResult)
+from sdcm.utils.compaction_ops import CompactionOps, StartStopCompactionArgs
 from sdcm.utils.decorators import retrying, latency_calculator_decorator
 from sdcm.utils.decorators import timeout as timeout_decor
 from sdcm.utils.docker_utils import ContainerManager
@@ -115,6 +116,14 @@ class LogContentNotFound(Exception):
 
 class LdapNotRunning(Exception):
     pass
+
+
+class TriggerCallableException(Exception):
+    """ raised when a trigger function in a trigger - watcher pair fails"""
+
+
+class WatcherCallableException(Exception):
+    """ raised when a watcher function in a trigger - watcher pair fails"""
 
 
 class UnsupportedNemesis(Exception):
@@ -497,60 +506,206 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.target_node.stop_scylla_server(verify_up=False, verify_down=True)
         self.target_node.start_scylla_server(verify_up=True, verify_down=False)
 
-    def disrupt_start_stop_major_compaction(self):
+    @staticmethod
+    def _handle_start_stop_compaction_results(trigger_and_watcher_futures: dict[str, ParallelObjectResult],
+                                              allow_trigger_exceptions: bool = True):
+        """
+        Handle the results from running in parallel a compaction
+        trigger and watcher / stop-compaction functions.
+        """
+        if trigger_and_watcher_futures["trigger"].exc:
+            LOGGER.warning("Trigger function failed with:\n%s", trigger_and_watcher_futures["trigger"].exc)
+
+        if trigger_and_watcher_futures["watcher"].exc:
+            raise WatcherCallableException from trigger_and_watcher_futures["watcher"].exc
+        return trigger_and_watcher_futures
+
+    def _get_random_non_system_ks_cf(self, filter_empty_tables: bool = True) -> tuple[str, str] | None:
+        """
+        Get a random (ks, cf) from the target node.
+        The get_non_system_ks_cf_list returns a list of strings
+        in the format 'keyspace_name.cf_name' so we need to
+        call split() on the output to get keyspace_name and
+        cf_name separately.
+        """
+        ks_cf = random.choice(self.cluster.get_non_system_ks_cf_list(
+            db_node=self.target_node, filter_empty_tables=filter_empty_tables))
+        return ks_cf.split(".") if ks_cf else None
+
+    def _prepare_start_stop_compaction(self) -> StartStopCompactionArgs:
         self.set_target_node()
-        node = self.target_node
-        compaction_ops = CompactionOps(cluster=self.cluster, node=node)
-        timeout = 360
-        trigger_func = partial(compaction_ops.trigger_major_compaction)
-        watch_func = partial(compaction_ops.stop_on_user_compaction_logged,
-                             node=node,
-                             mark=1,
+        ks, cf = self._get_random_non_system_ks_cf()
+
+        if not ks or not cf:
+            raise UnsupportedNemesis("No non-system keyspaces to run the nemesis with. Skipping.")
+
+        return StartStopCompactionArgs(
+            keyspace=ks,
+            columnfamily=cf,
+            timeout=360,
+            target_node=self.target_node,
+            compaction_ops=CompactionOps(cluster=self.cluster, node=self.target_node)
+        )
+
+    def disrupt_start_stop_major_compaction(self):
+        """
+        Start and stop a major compaction on a non-system columnfamily.
+
+        1. Query the target node for a non-system cf. If no cf is
+        found, skip the nemesis.
+
+        In parallel:
+        2.1 Start a major compaction using a REST API call (via a Remoter
+        curl call on the target node).
+        2.2. Watch for the major compaction to show up in logs.
+        3. Stop the running major compaction by issuing a <nodetool stop
+        COMPACTION> command after the watcher picks up the compaction
+        started.
+
+        The REST API call starting the compaction may not return, since
+        it returns on completing the compaction task (which we attempt
+        to interrupt). We ignore such timeouts and validate only the
+        success of the command in (4).
+        """
+        compaction_args = self._prepare_start_stop_compaction()
+        trigger_func = partial(compaction_args.compaction_ops.trigger_major_compaction,
+                               keyspace=compaction_args.keyspace,
+                               cf=compaction_args.columnfamily)
+        watch_func = partial(compaction_args.compaction_ops.stop_on_user_compaction_logged,
+                             node=compaction_args.target_node,
+                             mark=compaction_args.target_node.mark_log(),
                              watch_for="User initiated compaction started on behalf of",
-                             timeout=timeout,
-                             stop_func=compaction_ops.stop_major_compaction)
-        ParallelObject(objects=[trigger_func, watch_func], timeout=timeout).call_objects()
+                             timeout=compaction_args.timeout,
+                             stop_func=compaction_args.compaction_ops.stop_major_compaction)
+
+        results = ParallelObject.run_named_tasks_in_parallel(
+            tasks={"trigger": trigger_func, "watcher": watch_func},
+            timeout=compaction_args.timeout + 5,
+            ignore_exceptions=True
+        )
+
+        self._handle_start_stop_compaction_results(
+            trigger_and_watcher_futures=results,
+            allow_trigger_exceptions=True
+        )
 
     def disrupt_start_stop_scrub_compaction(self):
-        self.set_target_node()
-        node = self.target_node
-        compaction_ops = CompactionOps(cluster=self.cluster, node=node)
-        timeout = 360
-        trigger_func = partial(compaction_ops.trigger_scrub_compaction)
-        watch_func = partial(compaction_ops.stop_on_user_compaction_logged,
-                             node=node,
+        """
+        Start and stop a scrub compaction on a non-system columnfamily.
+
+        1. Query the target node for a non-system cf. If no cf is found,
+        skip the nemesis.
+
+        In parallel:
+        2.1 Start a scrub compaction using a REST API call (via a Remoter
+        curl call on the target node).
+        2.2. Watch for the scrub compaction to show up in logs.
+        3. Stop the running scrub compaction by issuing a <nodetool stop
+        SCRUB> command after the watcher picks up the compaction started.
+
+        The REST API call starting the compaction may not return, since it
+        returns on completing the compaction task (which we attempt to
+        interrupt). We ignore such timeouts and validate only the success
+        of the command in (4).
+        """
+        compaction_args = self._prepare_start_stop_compaction()
+        trigger_func = partial(compaction_args.compaction_ops.trigger_scrub_compaction)
+        watch_func = partial(compaction_args.compaction_ops.stop_on_user_compaction_logged,
+                             node=compaction_args.target_node,
+                             mark=compaction_args.target_node.mark_log(),
                              watch_for="Scrubbing",
-                             timeout=timeout,
-                             stop_func=compaction_ops.stop_scrub_compaction)
-        ParallelObject(objects=[trigger_func, watch_func], timeout=timeout).call_objects()
+                             timeout=compaction_args.timeout,
+                             stop_func=compaction_args.compaction_ops.stop_scrub_compaction)
+
+        results = ParallelObject.run_named_tasks_in_parallel(
+            tasks={"trigger": trigger_func, "watcher": watch_func},
+            timeout=compaction_args.timeout + 5,
+            ignore_exceptions=True
+        )
+
+        self._handle_start_stop_compaction_results(
+            trigger_and_watcher_futures=results,
+            allow_trigger_exceptions=True
+        )
 
     def disrupt_start_stop_cleanup_compaction(self):
-        self.set_target_node()
-        node = self.target_node
-        compaction_ops = CompactionOps(cluster=self.cluster, node=node)
-        timeout = 120
-        trigger_func = partial(compaction_ops.trigger_cleanup_compaction)
-        watch_func = partial(compaction_ops.stop_on_user_compaction_logged,
-                             node=node,
-                             mark=node.mark_log(),
-                             timeout=timeout,
+        """
+        Start and stop a cleanup compaction on a non-system columnfamily.
+
+        1. Query the target node for a non-system cf. If no cf is found,
+        skip the nemesis.
+
+        In parallel:
+        2.1 Start a cleanup compaction using a REST API call (via a Remoter
+        curl call on the target node).
+        2.2. Watch for the cleanup compaction to show up in logs.
+        3. Stop the running cleanup compaction by issuing a <nodetool stop
+        CLEANUP> command after the watcher picks up the compaction started.
+
+        The REST API call starting the compaction may not return, since it
+        returns on  completing the compaction task (which we attempt to
+        interrupt). We ignore such timeouts and validate only the success
+        of the command in (4).
+        """
+        compaction_args = self._prepare_start_stop_compaction()
+        trigger_func = partial(compaction_args.compaction_ops.trigger_cleanup_compaction)
+        watch_func = partial(compaction_args.compaction_ops.stop_on_user_compaction_logged,
+                             node=compaction_args.target_node,
+                             mark=compaction_args.target_node.mark_log(),
+                             timeout=compaction_args.timeout,
                              watch_for="Cleaning",
-                             stop_func=compaction_ops.stop_cleanup_compaction)
-        ParallelObject(objects=[trigger_func, watch_func], timeout=timeout).call_objects()
+                             stop_func=compaction_args.compaction_ops.stop_cleanup_compaction)
+
+        results = ParallelObject.run_named_tasks_in_parallel(
+            tasks={"trigger": trigger_func, "watcher": watch_func},
+            timeout=compaction_args.timeout + 5,
+            ignore_exceptions=True
+        )
+
+        self._handle_start_stop_compaction_results(
+            trigger_and_watcher_futures=results,
+            allow_trigger_exceptions=True
+        )
 
     def disrupt_start_stop_validation_compaction(self):
-        self.set_target_node()
-        node = self.target_node
-        compaction_ops = CompactionOps(cluster=self.cluster, node=node)
-        timeout = 360
-        trigger_func = partial(compaction_ops.trigger_validation_compaction)
-        watch_func = partial(compaction_ops.stop_on_user_compaction_logged,
-                             node=node,
-                             mark=node.mark_log(),
+        """
+        Start and stop a validation compaction on a non-system columnfamily.
+
+        1. Query the target node for a non-system cf. If no cf is found,
+        skip the nemesis.
+
+        In parallel:
+        2.1 Start a validation compaction using a REST API call (via a
+        Remoter curl call on the target node).
+        2.2. Watch for the validation compaction to show up in logs.
+        3. Stop the running validation compaction by issuing a <nodetool
+        stop SCRUB> command after the watcher picks up the compaction
+        started.
+
+        The REST API call starting the compaction may not return, since
+        it returns on completing the compaction task (which we attempt
+        to interrupt). We ignore such timeouts and validate only the
+        success of the command in (4).
+        """
+        compaction_args = self._prepare_start_stop_compaction()
+        trigger_func = partial(compaction_args.compaction_ops.trigger_validation_compaction)
+        watch_func = partial(compaction_args.compaction_ops.stop_on_user_compaction_logged,
+                             node=compaction_args.target_node,
+                             mark=compaction_args.target_node.mark_log(),
                              watch_for="Scrubbing ",
-                             timeout=timeout,
-                             stop_func=compaction_ops.stop_validation_compaction)
-        ParallelObject(objects=[trigger_func, watch_func], timeout=timeout).call_objects()
+                             timeout=compaction_args.timeout,
+                             stop_func=compaction_args.compaction_ops.stop_validation_compaction)
+
+        results = ParallelObject.run_named_tasks_in_parallel(
+            tasks={"trigger": trigger_func, "watcher": watch_func},
+            timeout=compaction_args.timeout + 5,
+            ignore_exceptions=True
+        )
+
+        self._handle_start_stop_compaction_results(
+            trigger_and_watcher_futures=results,
+            allow_trigger_exceptions=True
+        )
 
     # This nemesis should be run with "private" ip_ssh_connections till the issue #665 is not fixed
 

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -13,7 +13,7 @@
 
 # pylint: disable=too-many-lines
 
-from __future__ import absolute_import
+from __future__ import absolute_import, annotations
 
 import atexit
 import itertools
@@ -439,7 +439,7 @@ class ParallelObject:
             raise ParallelObjectException(results=results)
         return results
 
-    def call_objects(self) -> "ParallelObjectResult":
+    def call_objects(self, ignore_exceptions: bool = False) -> list["ParallelObjectResult"]:
         """
         Use the ParallelObject run() method to call a list of
         callables in parallel. Rather than running a single function
@@ -457,7 +457,7 @@ class ParallelObject:
         This can be useful if we need to tightly synchronise the
         execution of multiple functions.
         """
-        return self.run(lambda x: x())
+        return self.run(lambda x: x(), ignore_exceptions=ignore_exceptions)
 
     def clean_up(self, futures):
         # if there are futures that didn't run  we cancel them
@@ -466,6 +466,47 @@ class ParallelObject:
         self._thread_pool.shutdown(wait=False)
         # we need to unregister internal function that waits for all threads to finish when interpreter exits
         atexit.unregister(_python_exit)
+
+    @staticmethod
+    def run_named_tasks_in_parallel(tasks: dict[str, Callable],
+                                    timeout: int,
+                                    ignore_exceptions: bool = False) -> dict[str, ParallelObjectResult]:
+        """
+        Allows calling multiple Callables in parallel using Parallel
+        Object. Returns a dict with the results. Will raise an exception
+        if:
+        - ignore_exceptions is set to False and an exception was raised
+        during execution
+        - timeout is set and timeout was reached
+
+        Example:
+
+        Given:
+        tasks = {
+            "trigger": partial(time.sleep, 10))
+            "interrupt": partial(random.random)
+        }
+
+        Result:
+
+        {
+            "trigger": ParallelObjectResult >>> time.sleep result
+            "interrupt": ParallelObjectResult >>> random.random result
+        }
+        """
+        task_id_map = {str(id(task)): task_name for task_name, task in tasks.items()}
+        results_map = {}
+
+        task_results = ParallelObject(
+            objects=tasks.values(),
+            timeout=timeout if timeout else None
+        ).call_objects(ignore_exceptions=ignore_exceptions)
+
+        for result in task_results:
+            task_name = task_id_map.get(str(id(result.obj)))
+            results_map.update({task_name: result})
+
+        return results_map
 
 
 class ParallelObjectResult:  # pylint: disable=too-few-public-methods


### PR DESCRIPTION
This commit fixes a few issues with the StartStopCompaction nemesis methods.

* no longer assumes a non-system keyspace for the compaction,
will skip if no non-system keyspace is available
* Fixes: #4870 related to a REST API call left "hanging"
and triggering the nemesis method's timeout
* add docstrings for the nemesis' methods

Fixes: #4870 

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
