### PR TITLE
fix(nemesis): ignore STREAM_MUTATION_FRAGMENTS during decommission

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -66,7 +66,8 @@ from sdcm.sct_events.database import DatabaseLogEvent
 from sdcm.sct_events.decorators import raise_event_on_failure
 from sdcm.sct_events.filters import DbEventsFilter, EventsSeverityChangerFilter
 from sdcm.sct_events.group_common_events import (ignore_alternator_client_errors, ignore_no_space_errors,
-                                                 ignore_scrub_invalid_errors, ignore_view_error_gate_closed_exception)
+                                                 ignore_scrub_invalid_errors, ignore_view_error_gate_closed_exception,
+                                                 ignore_stream_mutation_fragments_errors)
 from sdcm.sct_events.loaders import CassandraStressLogEvent
 from sdcm.sct_events.nemesis import DisruptionEvent
 from sdcm.sct_events.system import InfoEvent
@@ -2948,7 +2949,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             raise UnsupportedNemesis(
                 "This nemesis logic is not compatible with K8S approach "
                 "for handling Scylla member's decommissioning.")
-        self.start_and_interrupt_decommission_streaming()
+
+        with ignore_stream_mutation_fragments_errors():
+            self.start_and_interrupt_decommission_streaming()
 
     def disrupt_rebuild_streaming_err(self):
         """

--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -180,3 +180,15 @@ def ignore_scrub_invalid_errors():
 def ignore_view_error_gate_closed_exception():
     with EventsFilter(event_class=DatabaseLogEvent, regex='.*view - Error applying view update.*gate_closed_exception'):
         yield
+
+
+@contextmanager
+def ignore_stream_mutation_fragments_errors():
+    with ExitStack() as stack:
+        stack.enter_context(EventsSeverityChangerFilter(
+            new_severity=Severity.WARNING,
+            event_class=LogEvent,
+            regex=r".*Failed to handle STREAM_MUTATION_FRAGMENTS.*",
+            extra_time_to_expiration=30
+        ))
+        yield


### PR DESCRIPTION
Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/4936
Trello task: https://trello.com/c/kvaQ4PTB

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
