### PR TITLE
fix(flush_and_reshard_on_k8s): identify the scylla pod base on it's name

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1076,7 +1076,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             #     ...
             target_pod_stats = {}
             for container in node._pod_status.container_statuses:  # pylint: disable=protected-access
-                if container.image.split(":")[0].endswith("scylla"):
+                if container.name == "scylla":
                     target_pod_stats["started"] = container.started
                     target_pod_stats["restart_count"] = container.restart_count
                     target_pod_stats["ready"] = container.ready


### PR DESCRIPTION
Currently the code in `_check_pod_stats` assumed that the name of the
image repo ends with `scylla`, it's not always true, since we have
nightly and enterprise repos.

switching to checking the pod name equals `scylla`

Fixes: #4941

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
