### PR TITLE
fix(get_gossip_info): implement `_refresh_instance_state` for AWSNode

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -551,7 +551,12 @@ class AWSNode(cluster.BaseNode):
         return self._instance.network_interfaces[0].ipv6_addresses[0]["Ipv6Address"]
 
     def _refresh_instance_state(self):
-        raise NotImplementedError()
+        self._wait_public_ip()
+        public_ipv4_addresses = [self._instance.public_ip_address]
+        private_ipv4_addresses = [self._instance.private_ip_address]
+        if self._eth1_private_ip_address:
+            private_ipv4_addresses += [self._eth1_private_ip_address]
+        return public_ipv4_addresses, private_ipv4_addresses
 
     def allocate_and_attach_elastic_ip(self, parent_cluster, dc_idx):
         primary_interface = [


### PR DESCRIPTION
since in #4923 we move to use `get_all_ip_addresses`, it was
implemented in a way it's working for all backends beside AWS one

and was causing the following errors:
```
'get_gossip_info': failed with 'NotImplementedError()', retrying [#3]
```

Ref: #4923

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
