### PR TITLE
test(perf_with_ops): add new test to run on i3en

### DIFF
--- a/configurations/aws/i3en_2xlarge.yaml
+++ b/configurations/aws/i3en_2xlarge.yaml
@@ -1,0 +1,1 @@
+instance_type_db: 'i3en.2xlarge'

--- a/jenkins-pipelines/perf-regression-latency-250gb-with-nemesis-i3en.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-250gb-with-nemesis-i3en.jenkinsfile
@@ -7,7 +7,5 @@ perfRegressionParallelPipeline(
     backend: "aws",
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: '''["test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml", "configurations/aws/i3en_2xlarge.yaml"]''',
-    sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"],
-
-    timeout: [time: 1600, unit: "MINUTES"]
+    sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"]
 )

--- a/jenkins-pipelines/perf-regression-latency-250gb-with-nemesis-i3en.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-250gb-with-nemesis-i3en.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    test_name: "performance_regression_test.PerformanceRegressionTest",
+    test_config: '''["test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml", "configurations/aws/i3en_2xlarge.yaml"]''',
+    sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"],
+
+    timeout: [time: 1600, unit: "MINUTES"]
+)

--- a/jenkins-pipelines/perf-regression-latency-250gb-with-nemesis.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-250gb-with-nemesis.jenkinsfile
@@ -7,7 +7,5 @@ perfRegressionParallelPipeline(
     backend: "aws",
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: "test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml",
-    sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"],
-
-    timeout: [time: 1600, unit: "MINUTES"]
+    sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"]
 )


### PR DESCRIPTION
we want to start benchmarking runs on i3en.2xlarge
instances, and we aim to do in a separated test.
Adding the needed files in here, so we can create
a new job in Jenkins to call it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
