### PR TITLE
test(stop-upgrade): disable stop upgrade compaction test

### DIFF
--- a/stop_compaction_test.py
+++ b/stop_compaction_test.py
@@ -43,8 +43,11 @@ class StopCompactionTest(ClusterTester):
         compaction_ops.disable_autocompaction_on_ks_cf(node=self.node)
 
     def test_stop_compaction(self):
-        with self.subTest("Stop upgrade compaction test"):
-            self.stop_upgrade_compaction()
+
+        # skip due to missing support
+        # to be enabled when https://github.com/scylladb/scylla/issues/10676 is fixed
+        # with self.subTest("Stop upgrade compaction test"):
+        #     self.stop_upgrade_compaction()
 
         with self.subTest("Stop major compaction test"):
             self.stop_major_compaction()


### PR DESCRIPTION
Disable stop upgrade compaction test as it's unsupported.
To be reenabled when https://github.com/scylladb/scylla/issues/10676 is
fixed.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
