### PR TITLE
fix(cfstats): remove flush from get_cfstats method

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1288,9 +1288,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
     def get_cfstats(self, keyspace, tcpdump=False):
         def keyspace_available():
-            self.run_nodetool("flush", ignore_status=True, timeout=60)
-            res = self.run_nodetool(sub_cmd='cfstats', args=keyspace, ignore_status=True, timeout=60)
-            return res.exit_status == 0
+            return keyspace in self.run_cqlsh("describe keyspaces").stdout.split()
+
         tcpdump_id = uuid.uuid4()
         if tcpdump:
             self.log.info('START tcpdump thread uuid: %s', tcpdump_id)


### PR DESCRIPTION
get_cfstats method have side effect of flushing memtables to disk.
This method is executed in a loop right after starting stress thread
until some disk use threshold is reached.
So we're fragmenting sstables unnecesarily and possibly causing some
timeout issues as described in https://github.com/scylladb/scylla/issues/10692

Fix is about removing flush before running cfstats command.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
