### PR TITLE
fix(nemesis): avoid retrying after interrupt

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2591,7 +2591,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
     # pylint: disable=inconsistent-return-statements
     def run_nodetool(self, sub_cmd, args="", options="", timeout=None,
                      ignore_status=False, verbose=True, coredump_on_timeout=False,
-                     warning_event_on_exception=None, error_message="", publish_event=True):
+                     warning_event_on_exception=None, error_message="", publish_event=True, retry=1):
         """
             Wrapper for nodetool command.
             Command format: nodetool [options] command [args]
@@ -2620,7 +2620,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                            options=options,
                            publish_event=publish_event) as nodetool_event:
             try:
-                result = self.remoter.run(cmd, timeout=timeout, ignore_status=ignore_status, verbose=verbose)
+                result = \
+                    self.remoter.run(cmd, timeout=timeout, ignore_status=ignore_status, verbose=verbose, retry=retry)
                 self.log.debug("Command '%s' duration -> %s s" % (result.command, result.duration))
 
                 nodetool_event.duration = result.duration

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3031,7 +3031,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             return new_node
 
         trigger = partial(
-            self.target_node.run_nodetool, sub_cmd="decommission", warning_event_on_exception=(Exception,)
+            self.target_node.run_nodetool, sub_cmd="decommission", warning_event_on_exception=(Exception,), retry=0,
         )
 
         watcher = partial(
@@ -3056,7 +3056,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         """
         self._destroy_data_and_restart_scylla()
         trigger = partial(
-            self.target_node.run_nodetool, sub_cmd="repair", warning_event_on_exception=(Exception,)
+            self.target_node.run_nodetool, sub_cmd="repair", warning_event_on_exception=(Exception,), retry=0,
         )
 
         watcher = partial(
@@ -3079,7 +3079,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self._destroy_data_and_restart_scylla()
 
         trigger = partial(
-            self.target_node.run_nodetool, sub_cmd="rebuild", warning_event_on_exception=(Exception,)
+            self.target_node.run_nodetool, sub_cmd="rebuild", warning_event_on_exception=(Exception,), retry=0,
         )
         timeout = 1800 if self._is_it_on_kubernetes() else 300
 


### PR DESCRIPTION
In some cases nodetool command retried after node reboot during *StreamingErr nemeses.  Try to avoid such cases by disabling retrying.

Addressing https://github.com/scylladb/scylla-cluster-tests/issues/4954

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
