### PR TITLE
fix(RebuildStreamingErr): ingore STREAM_MUTATION_FRAGMENTS errors

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3112,7 +3112,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         """
         Stop rebuild in middle to trigger some streaming fails, then rebuild the data on the node.
         """
-        self.start_and_interrupt_rebuild_streaming()
+        with ignore_stream_mutation_fragments_errors():
+            self.start_and_interrupt_rebuild_streaming()
 
     def disrupt_repair_streaming_err(self):
         """

--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -187,7 +187,7 @@ def ignore_stream_mutation_fragments_errors():
     with ExitStack() as stack:
         stack.enter_context(EventsSeverityChangerFilter(
             new_severity=Severity.WARNING,
-            event_class=LogEvent,
+            event_class=DatabaseLogEvent,
             regex=r".*Failed to handle STREAM_MUTATION_FRAGMENTS.*",
             extra_time_to_expiration=30
         ))


### PR DESCRIPTION
Added a fix for the issue https://github.com/scylladb/scylla-cluster-tests/issues/4936 in the nemesis `disrupt_rebuild_streaming_err`.
The follow-up for the PR https://github.com/scylladb/scylla-cluster-tests/pull/4940

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
