### PR TITLE
fix(group_common_events): don't use LogEvent in SeverityChangerFilter

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -56,13 +56,13 @@ def ignore_operation_errors():
     with ExitStack() as stack:
         stack.enter_context(EventsSeverityChangerFilter(
             new_severity=Severity.WARNING,
-            event_class=LogEvent,
+            event_class=DatabaseLogEvent,
             regex=r".*Operation timed out.*",
             extra_time_to_expiration=30,
         ))
         stack.enter_context(EventsSeverityChangerFilter(
             new_severity=Severity.WARNING,
-            event_class=LogEvent,
+            event_class=DatabaseLogEvent,
             regex=r".*Operation failed for system.paxos.*",
             extra_time_to_expiration=30,
         ))
@@ -137,19 +137,19 @@ def ignore_mutation_write_errors():
     with ExitStack() as stack:
         stack.enter_context(EventsSeverityChangerFilter(
             new_severity=Severity.WARNING,
-            event_class=LogEvent,
+            event_class=DatabaseLogEvent,
             regex=r".*mutation_write_",
             extra_time_to_expiration=30
         ))
         stack.enter_context(EventsSeverityChangerFilter(
             new_severity=Severity.WARNING,
-            event_class=LogEvent,
+            event_class=DatabaseLogEvent,
             regex=r".*Operation timed out for system.paxos.*",
             extra_time_to_expiration=30,
         ))
         stack.enter_context(EventsSeverityChangerFilter(
             new_severity=Severity.WARNING,
-            event_class=LogEvent,
+            event_class=DatabaseLogEvent,
             regex=r".*Operation failed for system.paxos.*",
             extra_time_to_expiration=30,
         ))


### PR DESCRIPTION
The follow-up for https://github.com/scylladb/scylla-cluster-tests/pull/4955
It turned out we must use the name of the event class instead of the event class itself to make `EventsSeverityChangerFilter` work properly.
`LogEvent` does not define the real events, and we never have the event with the name `LogEvent` in practice.
Hence we cannot use it while calling `EventsSeverityChangerFilter`.
This commit changed values passing to `event_class` to more appropriate ones.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
