### PR TITLE
fix(database event): reduce severity ScyllaHelpErrorEvent

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -9,8 +9,8 @@ DataValidatorEvent.DataValidator: ERROR
 DataValidatorEvent.ImmutableRowsValidator: ERROR
 DataValidatorEvent.UpdatedRowsValidator: WARNING
 DataValidatorEvent.DeletedRowsValidator: ERROR
-ScyllaHelpErrorEvent.duplicate: ERROR
-ScyllaHelpErrorEvent.filtered: ERROR
+ScyllaHelpErrorEvent.duplicate: WARNING
+ScyllaHelpErrorEvent.filtered: WARNING
 FullScanEvent: ERROR
 FullPartitionScanReversedOrderEvent: ERROR
 FullPartitionScanEvent: ERROR

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -186,7 +186,7 @@ class ScyllaHelpErrorEvent(SctEvent, abstract=True):
     filtered: Type[SctEventProtocol]
     message: str
 
-    def __init__(self, message: Optional[str] = None, severity=Severity.ERROR):
+    def __init__(self, message: Optional[str] = None, severity=Severity.WARNING):
         super().__init__(severity=severity)
 
         # Don't include `message' to the state if it's None.


### PR DESCRIPTION
following issue on https://github.com/scylladb/scylla-enterprise/issues/2183
we are experiencing multiple jobs failing, so for now,
and until this issue will be fixed, we are reducing the
event from ERROR to WARNING, so we will save
in investigation times for this silly error.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
