### PR TITLE
fix(unit-tests): update AMI ids in the tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,3 +44,4 @@ repos:
   hooks:
       - id: commitlint
         stages: [commit-msg]
+        language_version: 16.15.1

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1513,19 +1513,21 @@ def get_branched_ami(scylla_version: str, region_name: str, arch: AwsArchType = 
         {"Name": "tag:branch", "Values": [branch, ], },
         {"Name": "architecture", "Values": [arch, ], },
     ]
-    if build_id not in ("latest", "all",):
-        filters.append({'Name': 'tag:build-id', 'Values': [build_id, ], })
 
     LOGGER.info("Looking for AMIs match [%s]", scylla_version)
     ec2_resource: EC2ServiceResource = boto3.resource("ec2", region_name=region_name)
-    images = sorted(
-        ec2_resource.images.filter(Filters=filters),
-        key=lambda x: x.creation_date,
-        reverse=True,
-    )
+    if build_id not in ("latest", "all",):
+        images = [
+            ec2_resource.images.filter(Filters=filters + [{'Name': 'tag:build-id', 'Values': [build_id, ], }]),
+            ec2_resource.images.filter(Filters=filters + [{'Name': 'tag:build_id', 'Values': [build_id, ], }]),
+        ]
+    else:
+        images = [ec2_resource.images.filter(Filters=filters), ]
+    images = sorted(itertools.chain.from_iterable(images), key=lambda x: x.creation_date, reverse=True)
     images = [image for image in images if not image.name.startswith('debug-image')]
 
     assert images, f"AMIs for {scylla_version=} with {arch} architecture not found in {region_name}"
+
     if build_id == "all":
         return images
     return images[:1]

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -174,7 +174,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         conf = sct_config.SCTConfiguration()
         conf.verify_configuration()
 
-        self.assertEqual(conf.get('ami_id_db_scylla'), 'ami-0f1aa8afb878fed2b ami-027c1337dcb46da50')
+        self.assertEqual(conf.get('ami_id_db_scylla'), 'ami-05f62259c7715e1a6 ami-027c1337dcb46da50')
 
     @staticmethod
     def test_12_scylla_version_ami_case1():  # pylint: disable=invalid-name
@@ -272,12 +272,12 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
     def test_13_scylla_version_ami_branch(self):  # pylint: disable=invalid-name
         os.environ.pop('SCT_AMI_ID_DB_SCYLLA', None)
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
-        os.environ['SCT_SCYLLA_VERSION'] = 'branch-4.2:100'
+        os.environ['SCT_SCYLLA_VERSION'] = 'branch-5.0:32'
         os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/multi_region_dc_test_case.yaml'
         conf = sct_config.SCTConfiguration()
         conf.verify_configuration()
 
-        self.assertEqual(conf.get('ami_id_db_scylla'), 'ami-07d3138defbd9a2cf ami-0f703fdc8e06723f0')
+        self.assertEqual(conf.get('ami_id_db_scylla'), 'ami-076a213c791dc19cd ami-0625f2d18e05bf206')
 
     def test_13_scylla_version_ami_branch_latest(self):  # pylint: disable=invalid-name
         os.environ.pop('SCT_AMI_ID_DB_SCYLLA', None)

--- a/unit_tests/test_utils_common.py
+++ b/unit_tests/test_utils_common.py
@@ -30,7 +30,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 class TestUtils(unittest.TestCase):
     def test_tag_ami_01(self):  # pylint: disable=no-self-use
-        tag_ami(ami_id='ami-0876bfff890e17a06',
+        tag_ami(ami_id='ami-076a213c791dc19cd',
                 tags_dict={'JOB_longevity-multi-keyspaces-60h': 'PASSED'}, region_name='eu-west-1')
 
     def test_scylla_bench_metrics_conversion(self):  # pylint: disable=no-self-use


### PR DESCRIPTION
Some tests started to fail after a cleanup in eu-west-1 region.
Also, releng created some mess with changing tag `build-id` to `build_id`.

Plus, fix problem with commitlint pre-commit check and old glibc.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
