### PR TITLE
fix(nemesis): reduce sleep time in disrupt_no_corrupt_repair nemesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1394,7 +1394,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             try:
                 # drop test tables one by one during repair
                 for i in range(10):
-                    time.sleep(random.randint(0, 300))
+                    time.sleep(random.randint(2, 30))
                     with self.cluster.cql_connection_patient(self.target_node) as session:
                         session.execute(f'DROP TABLE drop_table_during_repair_ks_{i}.standard1')
             finally:


### PR DESCRIPTION
This nemesis runs repair in a separate thread and then tries to
drop 10 tables 1 by 1 sleeping for random time from 0 to 300 seconds.
The problem is that repair may get finished earlier than all the
drop table commands get run. And it can cause client call issues.

So, to minimize the probability of this problem reduce the time
we allow to sleep before makind a 'drop table' client call.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
