### PR TITLE
fix(nemesis): increase timeout in 'disrupt_decommission_streaming_err'

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3042,7 +3042,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             disrupt_func_kwargs={"target_node": self.target_node, "hard": True, "verify_ssh": True},
             delay=0
         )
-        ParallelObject(objects=[trigger, watcher], timeout=600).call_objects()
+        ParallelObject(objects=[trigger, watcher], timeout=1200).call_objects()
         if new_node := decommission_post_action():
             new_node.run_nodetool("rebuild")
         else:


### PR DESCRIPTION
Increase the timeout in the `disrupt_decommission_streaming_err` nemesis
from 10 to 20 minutes because it happens that repair takes more than 10
minutes (current timeout).

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
