### PR TITLE
fix(group_common_events.py): delete unused import making pylint be happy

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -16,7 +16,6 @@ from functools import wraps
 from typing import ContextManager, Callable, Sequence
 
 from sdcm.sct_events import Severity
-from sdcm.sct_events.base import LogEvent
 from sdcm.sct_events.filters import DbEventsFilter, EventsSeverityChangerFilter, EventsFilter
 from sdcm.sct_events.loaders import YcsbStressEvent
 from sdcm.sct_events.database import DatabaseLogEvent


### PR DESCRIPTION
SCT started having following pylint error:

    sdcm/sct_events/group_common_events.py:19:0: \
        W0611: Unused LogEvent imported from sdcm.sct_events.base (unused-import)

It was caused by the merge of 2 parallel PRs [1][2] which removed usage
of the 'LogEvent' object. So, each of them separately had no pylint
error, but both merged caused it.

So, just remove redundant import to make the pylint work.

[1] https://github.com/scylladb/scylla-cluster-tests/pull/4955
[2] https://github.com/scylladb/scylla-cluster-tests/pull/4956

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
