### PR TITLE
fix(aws_config): re-created loader v16

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -11,19 +11,19 @@ regions_data:
     ami_id_loader: 'ami-08516c9b78d5d6d1e' # Loader dedicated AMI v16
     ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
   us-west-2: # US West (Oregon)
-    ami_id_loader: 'ami-06adafd91151c1334' # Loader dedicated AMI v16
+    ami_id_loader: 'ami-0eb4cd542c09d69de' # Loader dedicated AMI v16
     ami_id_monitor: 'ami-01ed306a12b7d1c96' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
   eu-west-1: # Europe (Ireland)
-    ami_id_loader: 'ami-0c58e9a952081d5d9' # Loader dedicated AMI v16
+    ami_id_loader: 'ami-09897b3eee9220fce' # Loader dedicated AMI v16
     ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
   eu-west-2: # Europe (London)
-    ami_id_loader: 'ami-03071e9f413b8e2bd' # Loader dedicated AMI v16
+    ami_id_loader: 'ami-0165be7f48ae744ea' # Loader dedicated AMI v16
     ami_id_monitor: 'ami-0eab3a90fc693af19' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
   eu-north-1: # Europe (Stockholm)
-    ami_id_loader: 'ami-0e7be192027c68454' # Loader dedicated AMI v16
+    ami_id_loader: 'ami-08eb4917bbcc079ce' # Loader dedicated AMI v16
     ami_id_monitor: 'ami-5ee66f20' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
   eu-central-1: # Europe (Frankfurt)
-    ami_id_loader: 'ami-01765997963d20e38' # Loader dedicated AMI v16
+    ami_id_loader: 'ami-0b3072d87f3c0d0d3' # Loader dedicated AMI v16
     ami_id_monitor: 'ami-04cf43aca3e6f3de3' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
 
 availability_zone: 'a'


### PR DESCRIPTION
Trello: https://trello.com/c/t4c3uWxg/5226-copy-loader-images-from-us-east-1-to-required-regions-and-update-sct-branches-with-new-ami-ids

these loaders were removed by mistake
making all the runs using them (specifically
`branch-perf-v12`) to fail, as loader
images couldn't be found.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
