### PR TITLE
fix(aws_config): re-created loader v9

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -14,7 +14,7 @@ regions_data:
   eu-west-1:
     security_group_ids: 'sg-059a7f66a947d4b5c'
     subnet_id: 'subnet-088fddaf520e4c7a8'
-    ami_id_loader: 'ami-0cdfd6050090ab044' # Loader dedicated AMI v9 with golang 1.13
+    ami_id_loader: 'ami-0396fc0c3458abca9' # Loader dedicated AMI v9 with golang 1.13
     ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
     backup_bucket_location: 'manager-backup-tests-eu-west-1'
   us-west-2:


### PR DESCRIPTION
Trello: https://trello.com/c/t4c3uWxg/5226-copy-loader-images-from-us-east-1-to-required-regions-and-update-sct-branches-with-new-ami-ids

these loaders were removed by mistake
making all the runs using them (specifically
`branch-perf-v8`) to fail, as loader
images couldn't be found.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
