### PR TITLE
fix(docker): enable running docker based tests with latest tag

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -46,6 +46,7 @@ from sdcm.utils.version_utils import (
     get_branch_version_for_multiple_repositories,
     get_scylla_docker_repo_from_version,
     resolve_latest_repo_symlink,
+    get_specific_tag_of_docker_image,
 )
 from sdcm.sct_events.base import add_severity_limit_rules, print_critical_events
 
@@ -1475,6 +1476,7 @@ class SCTConfiguration(dict):
                     "docker", "k8s-eks", "k8s-gke",
                     "k8s-local-kind", "k8s-local-kind-aws", "k8s-local-kind-gce"):
                 self.log.info("Assume that Scylla Docker image has repo file pre-installed.")
+                self._replace_docker_image_latest_tag()
             elif not self.get('ami_id_db_scylla') and self.get('cluster_backend') == 'aws':
                 aws_arch = get_arch_from_instance_type(self.get('instance_type_db'))
                 # ami.name format examples: ScyllaDB 4.4.0 or ScyllaDB Enterprise 2019.1.1
@@ -1758,6 +1760,13 @@ class SCTConfiguration(dict):
             raise ValueError("extra_network_interface isn't supported for multi region use cases")
         self._check_partition_range_with_data_validation_correctness()
         self._verify_scylla_bench_mode_and_workload_parameters()
+
+    def _replace_docker_image_latest_tag(self):
+        docker_repo = self.get('docker_image')
+        scylla_version = self.get('scylla_version')
+
+        if scylla_version == 'latest':
+            self['scylla_version'] = get_specific_tag_of_docker_image(docker_repo=docker_repo)
 
     def _get_target_upgrade_version(self):
         # 10) update target_upgrade_version automatically

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -105,6 +105,8 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         conf = sct_config.SCTConfiguration()
         conf.verify_configuration()
 
+        assert conf['scylla_version'] != 'latest'
+
     @staticmethod
     def test_06b_docker_development():
         os.environ['SCT_CLUSTER_BACKEND'] = 'docker'

--- a/unit_tests/test_version_utils.py
+++ b/unit_tests/test_version_utils.py
@@ -19,6 +19,7 @@ from sdcm.utils.version_utils import (
     scylla_versions,
     assume_version,
     VERSION_NOT_FOUND_ERROR,
+    get_specific_tag_of_docker_image,
 )
 
 BASE_S3_DOWNLOAD_URL = 'https://s3.amazonaws.com/downloads.scylladb.com'
@@ -363,3 +364,11 @@ def test_scylla_versions_decorator_negative_latest_scylla_no_attr():
                 cls_instance.__class__.__name__) in str(exc)
         else:
             assert False, f"Versioned method must have been not found for the '{scylla_version}' scylla version"
+
+
+@pytest.mark.integration
+@pytest.mark.need_network
+@pytest.mark.skip(reason="those are integration tests only")
+@pytest.mark.parametrize('docker_repo', ['scylladb/scylla-nightly', 'scylladb/scylla', 'scylladb/scylla-enterprise'])
+def test_get_specific_tag_of_docker_image(docker_repo):
+    assert get_specific_tag_of_docker_image(docker_repo=docker_repo) != 'latest'


### PR DESCRIPTION
since fa857997681195f1a4323c86a8004f3b86fc1440 is trying to assume
the version based on `scylla_version`, we need to populate
it with a real version, now when latest is taken, we can find the
versioned tag that equals to latests, and use that for the
workaround.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
