### PR TITLE
feature(SisyphusMonkey): Introduce nemesis_exclude_disabled

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -195,3 +195,5 @@ scylla_apt_keys:
 raid_level: 0
 
 bare_loaders: false
+
+nemesis_exclude_disabled: true

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1570,7 +1570,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         Here it kept for future usages and unit testing ability.
         more about nemesis_selector behaviour in sct_config.py
         """
-        nemesis_selector = self.cluster.params.get('nemesis_selector')
+        nemesis_selector = self.nemesis_selector_list
         if nemesis_selector:
             subclasses = self.get_list_of_subclasses_by_property_name(
                 list_of_properties_to_include=nemesis_selector)
@@ -1589,6 +1589,13 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.disruptions_list.extend(disruptions)
         self.log.debug("This is the list of callable disruptions {}".format(self.disruptions_list))
         return self.disruptions_list
+
+    @property
+    def nemesis_selector_list(self) -> list:
+        nemesis_selector = self.cluster.params.get('nemesis_selector') or []
+        if self.cluster.params.get('nemesis_exclude_disabled'):
+            nemesis_selector.append('!disabled')
+        return nemesis_selector
 
     @property
     def _disruption_list_names(self):

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1283,6 +1283,12 @@ class SCTConfiguration(dict):
              ALL the properties in that list which are set to true (the intersection of all properties).
              (In other words filters out all nemesis that doesn't ONE of these properties set to true)
              IMPORTANT: If a property doesn't exist, ALL the nemesis will be included."""),
+        dict(name="nemesis_exclude_disabled", env="SCT_NEMESIS_EXCLUDE_DISABLED",
+             type=boolean,
+             help="""nemesis_exclude_disabled determines whether 'disabled' nemeses are filtered out from list
+             or are allowed to be used. This allows to easily disable too 'risky' or 'extreme' nemeses by default,
+             for all longevities. For example: it is unwanted to run the ToggleGcModeMonkey in standard longevities
+             that runs a stress with data validation."""),
 
         dict(name="nemesis_multiply_factor", env="SCT_NEMESIS_MULTIPLY_FACTOR",
              type=int,


### PR DESCRIPTION
	This new parameter allows filtering out all 'disabled' Nemeses by default.
	The default value could be overridden as 'false' in a specific test so that
	'risky' disabled Nemeses will be used carefully only there.

This is a complementary PR, following https://github.com/scylladb/scylla-cluster-tests/pull/4902 .
It should be used, for example, in the new nemesis settings of https://github.com/scylladb/scylla-cluster-tests/pull/4755

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
