### PR TITLE
feature(tags): add `CreatedBy: SCT` tag

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -271,6 +271,7 @@ def clean_resources(ctx, post_behavior, user, test_id, logdir, dry_run, backend)
 
     if not post_behavior and user and not test_id and not logdir:
         click.echo(f"Clean all resources belong to user `{user}'")
+        user_param["CreatedBy"] = "SCT"
         params = (user_param, )
     else:
         if not logdir and (post_behavior or not test_id):

--- a/sdcm/test_config.py
+++ b/sdcm/test_config.py
@@ -171,7 +171,8 @@ class TestConfig(metaclass=Singleton):  # pylint: disable=too-many-public-method
         tags = dict(RunByUser=get_username(),
                     TestName=str(cls.test_name()),
                     TestId=str(cls.test_id()),
-                    version=job_name.split('/', 1)[0] if job_name else "unknown")
+                    version=job_name.split('/', 1)[0] if job_name else "unknown",
+                    CreatedBy="SCT")
 
         build_tag = os.environ.get('BUILD_TAG')
         if build_tag:


### PR DESCRIPTION
to avoid `hydra clean-resources` from cleaning a user instances
which aren't created by hydra/sct commands.

it's still preferable to clean the resources by test_id
but we still want this safe guard in place

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
