### PR TITLE
feature(nemesis): parametrize nemesis cycles count

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4084,11 +4084,12 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         self.nemesis = []
 
     @log_run_info("Start nemesis threads on cluster")
-    def start_nemesis(self, interval=None):
+    def start_nemesis(self, interval=None, cycles_count: int = -1):
         self.log.info('Clear _nemesis_termination_event')
         self.nemesis_termination_event.clear()
         for nemesis in self.nemesis:
-            nemesis_thread = threading.Thread(target=nemesis.run, name='NemesisThread', args=(interval,), daemon=True)
+            nemesis_thread = threading.Thread(target=nemesis.run, name='NemesisThread',
+                                              args=(interval, cycles_count), daemon=True)
             nemesis_thread.start()
             self.nemesis_threads.append(nemesis_thread)
 

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -324,12 +324,16 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                       self.target_node, self.target_node.running_nemesis)
 
     @raise_event_on_failure
-    def run(self, interval=None):
+    def run(self, interval=None, cycles_count: int = -1):
         self.es_publisher.create_es_connection()
         if interval:
             self.interval = interval * 60
         self.log.info('Interval: %s s', self.interval)
         while not self.termination_event.is_set():
+            if cycles_count == 0:
+                self.log.info("Defined number of Nemesis cycles completed. Stopping Nemesis thread.")
+                break
+            cycles_count -= 1
             cur_interval = self.interval
             try:
                 self.disrupt()


### PR DESCRIPTION
In some cases we want to run certain number of nemesis cycles.
This is the case in e.g. perf test where we run just once.

This commit parametrize number of nemesis cycles to be executed during
the test.

task: https://trello.com/c/Xp2q7SfX

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
