### PR TITLE
fix(upgrade): fix upgrade scylla enterprise

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -97,6 +97,7 @@ from sdcm.utils.health_checker import check_nodes_status, check_node_status_in_g
 from sdcm.utils.decorators import NoValue, retrying, log_run_info, optional_cached_property
 from sdcm.utils.remotewebbrowser import WebDriverContainerMixin
 from sdcm.test_config import TestConfig
+from sdcm.utils.scylla_install_utils import recover_config_files
 from sdcm.utils.version_utils import SCYLLA_VERSION_RE, get_gemini_version, get_systemd_version, assume_version
 from sdcm.sct_events import Severity
 from sdcm.sct_events.base import LogEvent
@@ -1905,6 +1906,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         else:
             self.remoter.sudo('rm -f /etc/apt/sources.list.d/scylla.list')
             self.remoter.sudo('apt-get remove -y scylla\\*', ignore_status=True)
+        recover_config_files(self)
         self.update_repo_cache()
         self.clean_scylla_data()
 

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1164,7 +1164,7 @@ class SCTConfiguration(dict):
          """,
              choices=("keep", "keep-on-failure", "destroy")),
 
-        dict(name="workaround_kernel_bug_for_iotune", env="SCT_WORKAROUND_KERNEL_BUG_FOR_IOTUNE", type=bool,
+        dict(name="workaround_kernel_bug_for_iotune", env="SCT_WORKAROUND_KERNEL_BUG_FOR_IOTUNE", type=boolean,
              help="Workaround a known kernel bug which causes iotune to fail in scylla_io_setup, "
                   "only effect GCE backend"),
         dict(name="internode_compression", env="SCT_INTERNODE_COMPRESSION", type=str,

--- a/sdcm/utils/scylla_install_utils.py
+++ b/sdcm/utils/scylla_install_utils.py
@@ -1,0 +1,10 @@
+def recover_config_files(node):
+    """Since Scylla 5.0 some config files on rhel get backed up upon Scylla uninstallation.
+    Default ones are used after installation.
+
+    Let's recover them so Scylla can start without requiring all the setup."""
+    if node.is_rhel_like():
+        node.remoter.run('sudo cp /etc/scylla.d/io.conf.rpmsave /etc/scylla.d/io.conf', ignore_status=True)
+        node.remoter.run('sudo cp /etc/scylla.d/memory.conf.rpmsave /etc/scylla.d/memory.conf', ignore_status=True)
+        node.remoter.run('sudo cp /etc/scylla.d/cpuset.conf.rpmsave /etc/scylla.d/cpuset.conf', ignore_status=True)
+        node.remoter.run('sudo cp /etc/scylla/scylla.yaml.rpmsave /etc/scylla/scylla.yaml', ignore_status=True)

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -29,6 +29,7 @@ from sdcm import wait
 from sdcm.cluster import BaseNode
 from sdcm.fill_db_data import FillDatabaseData
 from sdcm.stress_thread import CassandraStressThread
+from sdcm.utils.scylla_install_utils import recover_config_files
 from sdcm.utils.version_utils import is_enterprise, get_node_supported_sstable_versions
 from sdcm.sct_events.system import InfoEvent
 from sdcm.sct_events.database import IndexSpecialColumnErrorEvent
@@ -216,6 +217,7 @@ class UpgradeTest(FillDatabaseData):
                         r'sudo apt-get install {}{} -y '
                         r'-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" '.format(scylla_pkg, ver_suffix))
                 recover_conf(node)
+                recover_config_files(node)
                 node.remoter.run('sudo systemctl daemon-reload')
             else:
                 if node.is_rhel_like():
@@ -283,6 +285,7 @@ class UpgradeTest(FillDatabaseData):
                     r'sudo apt-get install %s\* -y '
                     r'-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" ' % node.scylla_pkg())
             recover_conf(node)
+            recover_config_files(node)
             node.remoter.run('sudo systemctl daemon-reload')
 
         elif self.upgrade_rollback_mode == 'minor_release':


### PR DESCRIPTION
When removing with yum, some scylla config files are backed up
(e.g. `io.conf` get moved to `io.conf.rpmsave`).
When installing Scylla, this files get
default values which don't work and require full scylla setup.

This fix recovers these config files from backup after removal.
Also fixes wrong type of `workaround_kernel_bug_for_iotune` param when
`false` string was coerced to python's `True` as it was treated as
string.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
