### PR TITLE
fix(GrowShrinkClusterNemesis): use `k8s_n_scylla_pods_per_cluster`

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3224,6 +3224,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         # Check that number of nodes is enough for decommission:
         cur_num_nodes_in_dc = len([n for n in self.cluster.nodes if n.dc_idx == self.target_node.dc_idx])
         initial_db_size = self.tester.params.get("n_db_nodes")
+        if self._is_it_on_kubernetes():
+            initial_db_size = self.tester.params.get("k8s_n_scylla_pods_per_cluster", initial_db_size)
+
         if isinstance(initial_db_size, int):
             decommission_nodes_number = min(cur_num_nodes_in_dc - initial_db_size, add_nodes_number)
         else:


### PR DESCRIPTION
since recently `k8s_n_scylla_pods_per_cluster` was introduced,
the nemesis was reading `n_db_nodes` to assume the inital number of
nodes, for k8s the number is now set in `k8s_n_scylla_pods_per_cluster`

it was failing like this, and the next time there a nemesis that
need to add a node, there's no room for it on the k8s cluster.

```
2022-07-10 00:24:02.644: (DisruptionEvent Severity.ERROR) period_type=end
event_id=4010e8f4-4cd2-4a4a-ba99-b6f0aad39e28 duration=13m32s:
nemesis_name=GrowShrinkCluster target_node=Node sct-cluster-us-east1-b-us-east1-2
[10.0.1.52 | 10.0.1.195] (seed: False) errors=Not enough nodes for decommission
Traceback (most recent call last):
  File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 3599, in wrapper
    result = method(*args, **kwargs)
  File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 3188, in disrupt_grow_shrink_cluster
    self._shrink_cluster(rack=0)
  File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 3229, in _shrink_cluster
    raise Exception(error)
Exception: Not enough nodes for decommission
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
