### PR TITLE
fix(SnapshotOperations): filter out SI/MV tables

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2511,16 +2511,16 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
             self.log.info("Take few tables snapshot")
             # Prefer to take snapshot of test table. Try to find it
-            ks_cf = self.cluster.get_non_system_ks_cf_list(db_node=self.target_node)
+            ks_cf = self.cluster.get_non_system_ks_cf_list(db_node=self.target_node, filter_out_mv=True)
 
             if not ks_cf or len(ks_cf) == 1:
                 # If test table wasn't found - take system table snapshot
-                ks_cf = self.cluster.get_any_ks_cf_list(db_node=self.target_node)
+                ks_cf = self.cluster.get_any_ks_cf_list(db_node=self.target_node, filter_out_mv=True)
 
             ks_with_few_tables = get_ks_with_few_tables(ks_cf)
             if not ks_with_few_tables:
                 # If non-system keyspace with few tables wasn't found - take system table snapshot
-                ks_cf = self.cluster.get_any_ks_cf_list(db_node=self.target_node)
+                ks_cf = self.cluster.get_any_ks_cf_list(db_node=self.target_node, filter_out_mv=True)
                 ks_with_few_tables = get_ks_with_few_tables(ks_cf)
 
             if not ks_with_few_tables:


### PR DESCRIPTION
we need to filter SI/MV since we can't take
snapshots of those kind of tables:

```
nodetool: Scylla API server HTTP POST to URL '/storage_service/snapshots' failed:
std::invalid_argument (Do not take a snapshot of a materialized view or a
secondary index by itself. Run snapshot on the base table instead.)
```

since this nemesis is randomlly select which snapshot
to take (and not all of our cases has SI/MV), we rarly seen this
happening

Fixes: #4775

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
