### PR TITLE
fix(upgrade-test): fix recover backup config files

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -89,13 +89,13 @@ def recover_conf(node):
         node.remoter.run(
             r'for conf in $( rpm -qc $(rpm -qa | grep scylla) | grep -v contains ) '
             r'/etc/systemd/system/{var-lib-scylla,var-lib-systemd-coredump}.mount; '
-            r'do test -e $conf.autobackup || sudo cp -v $conf.autobackup $conf; done')
+            r'do test -e $conf.autobackup && sudo cp -v $conf.autobackup $conf; done')
     else:
         node.remoter.run(
             r'for conf in $(cat /var/lib/dpkg/info/scylla-*server.conffiles '
             r'/var/lib/dpkg/info/scylla-*conf.conffiles '
             r'/var/lib/dpkg/info/scylla-*jmx.conffiles | grep -v init ); do '
-            r'sudo cp -v $conf.backup $conf; done')
+            r'test -e $conf.backup && sudo cp -v $conf.backup $conf; done')
 
 
 class UpgradeTest(FillDatabaseData):


### PR DESCRIPTION
Autobackup config files are not recovered on RHEL system. This causes
error when upgrading from OSS to Enterprise.

Fix is correcting files recover command.

fixes https://github.com/scylladb/scylla-cluster-tests/issues/4987

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
