### PR TITLE
fix(get_email_data): add trackbacks to log in case of failure

### DIFF
--- a/longevity_test.py
+++ b/longevity_test.py
@@ -576,13 +576,14 @@ class LongevityTest(ClusterTester):
         try:
             email_data = self._get_common_email_data()
         except Exception as error:  # pylint: disable=broad-except
-            self.log.error("Error in gathering common email data: Error:\n%s", error)
+            self.log.exception("Error in gathering common email data: Error:\n%s", error, exc_info=error)
 
         try:
             grafana_dataset = self.monitors.get_grafana_screenshot_and_snapshot(
                 self.start_time) if self.monitors else {}
         except Exception as error:  # pylint: disable=broad-except
-            self.log.error("Error in gathering Grafana screenshots and snapshots. Error:\n%s", error)
+            self.log.exception("Error in gathering Grafana screenshots and snapshots. Error:\n%s",
+                               error, exc_info=error)
 
         benchmarks_results = self.db_cluster.get_node_benchmarks_results() if self.db_cluster else {}
         # If cluster was not created, not need to collect nemesis stats - they do not exist


### PR DESCRIPTION
recently we started getting empty emails, and the logs
were not enough to figure out why the email data collection
was breaking

```
Error in gathering common email data: Error:
list index out of range
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
