### PR TITLE
fix(gce): fix warning flood in GCE tests about ipv6

### DIFF
--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -17,7 +17,7 @@ import time
 import logging
 from typing import Dict, Any, ParamSpec, TypeVar
 from textwrap import dedent
-from functools import cached_property
+from functools import cached_property, cache
 from collections.abc import Callable
 
 import tenacity
@@ -177,6 +177,7 @@ class GCENode(cluster.BaseNode):
         self.log.warning('Method is not implemented for GCENode')
         return b''
 
+    @cache
     def _get_ipv6_ip_address(self):
         self.log.warning('On GCE, VPC networks only support IPv4 unicast traffic. '
                          'They do not support IPv6 traffic within the network.')


### PR DESCRIPTION
When running tests with GCE there's flood of warning messages like:
`On GCE, VPC networks only support IPv4 unicast traffic...`.
It is enough to have only one warning about it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
