### PR TITLE
fix(mini_k8s): `start_k8s_software()` was creating extra db node

### DIFF
--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -480,7 +480,7 @@ class LocalKindCluster(LocalMinimalClusterBase):
             labels:
               {POOL_LABEL_NAME}: {self.SCYLLA_POOL_NAME}
         """
-        for _ in range(self.params.get("n_db_nodes") + 1):
+        for _ in range(self.params.get("n_db_nodes")):
             script_start_part += scylla_node_definition
         script_end_part = """
         EndOfSpec


### PR DESCRIPTION
e3a6cc5d78761823a25a790722a6badfbadbbeb5 seperated the logic
of number of pods into `k8s_n_scylla_pods_per_cluster`
while `n_db_nodes` is the number of k8s node

`start_k8s_software()` was still appending one extra node
ontop of `n_db_nodes`, which casuse 5 node to be created,
while the code was waiting for 4.

```
> Wait for 4 node(s) in pool scylla-pool to be ready... [try #12]
> Running command "kubectl --cache-dir=...
  wait --timeout=10m -l minimal-k8s-nodepool=scylla-pool
  --for=condition=Ready node"...
> node/kind-worker condition met
> node/kind-worker2 condition met
> node/kind-worker3 condition met
> node/kind-worker5 condition met
> node/kind-worker7 condition met
> Command "kubectl --cache-dir=...
  wait --timeout=10m -l minimal-k8s-nodepool=scylla-pool
  --for=condition=Ready node" finished with status 0
> 'wait_nodes_are_ready': failed with 'RuntimeError('Not all nodes reported')',
  retrying [#12]
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
