### PR TITLE
fix(SMI): parametrize smi payload for unified provisioning

### DIFF
--- a/unit_tests/provisioner/test_scylla_machine_image_payload.py
+++ b/unit_tests/provisioner/test_scylla_machine_image_payload.py
@@ -1,0 +1,25 @@
+import json
+
+from sdcm.cluster import DEFAULT_USER_PREFIX
+from sdcm.sct_provision.user_data_objects.scylla import ScyllaUserDataObject
+from sdcm.test_config import TestConfig
+
+
+def test_can_generate_valid_scylla_machine_image_payload():
+    test_config = TestConfig()
+    test_config.set_test_id("12345678-87654321")
+    test_id_short = test_config.test_id()[:8]
+    sud = ScyllaUserDataObject(test_config=test_config, params={"data_volume_disk_num": 2, "user_prefix": "unit-test"},
+                               instance_name="test-instance", node_type="scylla-db")
+    assert sud.scylla_machine_image_json == json.dumps({"start_scylla_on_first_boot": False, "data_device": "attached", "raid_level": 0,
+                                                        "scylla_yaml": {"cluster_name": f"unit-test-{test_id_short}"}})
+
+
+def test_can_generate_valid_scylla_machine_image_payload_with_minimum_params():
+    test_config = TestConfig()
+    test_config.set_test_id("12345678-87654321")
+    test_id_short = test_config.test_id()[:8]
+    sud = ScyllaUserDataObject(test_config=test_config, params={}, instance_name="test-instance", node_type="scylla-db")
+    assert sud.scylla_machine_image_json == json.dumps({"start_scylla_on_first_boot": False, "data_device": "instance_store",
+                                                        "raid_level": 0,
+                                                        "scylla_yaml": {"cluster_name": f"{DEFAULT_USER_PREFIX}-{test_id_short}"}})


### PR DESCRIPTION
Currently for unified provisioner SMI payload was hardcoded.

This commit parametrizes it according to SCT configuration.

https://trello.com/c/k4C1quCP
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
