### PR TITLE
fix(aws): randomly select availabilty zone

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -27,7 +27,7 @@ regions_data:
     ami_id_loader: 'ami-0cc124517d1f5710e' # Loader dedicated AMI v18
     ami_id_monitor: 'ami-04cf43aca3e6f3de3' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
 
-availability_zone: 'a'
+availability_zone: 'a,b,c'
 aws_root_disk_size_monitor: 50  # GB, remove this field if default disk size should be used
 aws_root_disk_size_db: 30  # GB, increase root disk for larger swap (maximum: 16G)
 aws_root_disk_size_loader: 30  # GB, Increase loader disk in order to have extra space for a larger swap

--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -123,7 +123,7 @@ class EksNodePool(CloudK8sNodePool):
             BlockDeviceMappings=block_devices,
             NetworkInterfaces=[{
                 "DeviceIndex": 0,
-                "SubnetId": self.ec2_subnet_ids[0],
+                "SubnetId": self.ec2_subnet_ids[0][0],
             }],
         )
         if self.user_data:
@@ -151,7 +151,7 @@ class EksNodePool(CloudK8sNodePool):
             },
             # subnets controls AZ placement, if you specify subnets from multiple AZ
             # nodes will be spread across these AZ evenly, which can lead to failures and/or slowdowns
-            'subnets': [self.ec2_subnet_ids[0]],
+            'subnets': [self.ec2_subnet_ids[0][0]],
             'instanceTypes': [self.instance_type],
             'amiType': self.image_type,
             'nodeRole': self.role_arn,
@@ -274,7 +274,7 @@ class EksCluster(KubernetesCluster, EksClusterCleanupMixin):
             roleArn=self.ec2_role_arn,
             resourcesVpcConfig={
                 'securityGroupIds': self.ec2_security_group_ids[0],
-                'subnetIds': self.ec2_subnet_ids,
+                'subnetIds': self.ec2_subnet_ids[0],
                 'endpointPublicAccess': True,
                 'endpointPrivateAccess': True,
                 'publicAccessCidrs': [

--- a/sdcm/sct_provision/aws/instance_parameters_builder.py
+++ b/sdcm/sct_provision/aws/instance_parameters_builder.py
@@ -129,7 +129,7 @@ class AWSInstanceParamsBuilder(AWSInstanceParamsBuilderBase, metaclass=abc.ABCMe
     @property
     def _network_interface_params(self):
         return {
-            'SubnetId': self._ec2_subnet_ids[self.region_id],  # pylint: disable=invalid-sequence-index
+            'SubnetId': self._ec2_subnet_ids[self.region_id][0],  # pylint: disable=invalid-sequence-index
             'Groups': self._ec2_security_group_ids[self.region_id],  # pylint: disable=invalid-sequence-index
         }
 

--- a/sdcm/utils/aws_utils.py
+++ b/sdcm/utils/aws_utils.py
@@ -267,13 +267,15 @@ def get_ec2_network_configuration(regions, availability_zones):
     ec2_subnet_ids = []
     for region in regions:
         aws_region = AwsRegion(region_name=region)
+        subnets_ids = []
         for availability_zone in availability_zones:
             sct_subnet = aws_region.sct_subnet(region_az=region + availability_zone)
             assert sct_subnet, f"No SCT subnet configured for {region}! Run 'hydra prepare-aws-region'"
-            ec2_subnet_ids.append(sct_subnet.subnet_id)
-            sct_sg = aws_region.sct_security_group
-            assert sct_sg, f"No SCT security group configured for {region}! Run 'hydra prepare-aws-region'"
-            ec2_security_group_ids.append([sct_sg.group_id])
+            subnets_ids.append(sct_subnet.subnet_id)
+        ec2_subnet_ids.append(subnets_ids)
+        sct_sg = aws_region.sct_security_group
+        assert sct_sg, f"No SCT security group configured for {region}! Run 'hydra prepare-aws-region'"
+        ec2_security_group_ids.append([sct_sg.group_id])
     return ec2_security_group_ids, ec2_subnet_ids
 
 


### PR DESCRIPTION
Since we are have some issue once in a while of
having enough capacity, let randomize the usage
of availablity zones, since we can work on any of them.

Ref: #4753

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
