### PR TITLE
fix(k8s-multitenant): run 7+ DB cluster really in parallel

### DIFF
--- a/performance_regression_operator_multi_tenant_test.py
+++ b/performance_regression_operator_multi_tenant_test.py
@@ -138,7 +138,9 @@ class PerformanceRegressionOperatorMultiTenantTest(PerformanceRegressionTest):
         self.log.info("Running preload operation in parallel on all the DB clusters")
         object_set = ParallelObject(
             timeout=self.load_iteration_timeout_sec,
-            objects=[[scs] for scs in self.scylla_clusters_stats])
+            objects=[[scs] for scs in self.scylla_clusters_stats],
+            num_workers=len(self.scylla_clusters_stats),
+        )
         object_set.run(func=_preload_data, unpack_objects=True, ignore_exceptions=False)
 
     def run_read_workload(self, nemesis=False):
@@ -146,8 +148,11 @@ class PerformanceRegressionOperatorMultiTenantTest(PerformanceRegressionTest):
             scylla_cluster_stats.run_read_workload(nemesis=nemesis)
 
         self.log.info("Running 'read' workload operation in parallel")
-        object_set = ParallelObject(timeout=self.load_iteration_timeout_sec, objects=[
-            [scs, nemesis] for scs in self.scylla_clusters_stats])
+        object_set = ParallelObject(
+            timeout=self.load_iteration_timeout_sec,
+            objects=[[scs, nemesis] for scs in self.scylla_clusters_stats],
+            num_workers=len(self.scylla_clusters_stats),
+        )
         object_set.run(func=_run_read_workload, unpack_objects=True, ignore_exceptions=False)
 
     def run_write_workload(self, nemesis=False):
@@ -155,8 +160,11 @@ class PerformanceRegressionOperatorMultiTenantTest(PerformanceRegressionTest):
             scylla_cluster_stats.run_write_workload(nemesis=nemesis)
 
         self.log.info("Running 'write' workload operation in parallel")
-        object_set = ParallelObject(timeout=self.load_iteration_timeout_sec, objects=[
-            [scs, nemesis] for scs in self.scylla_clusters_stats])
+        object_set = ParallelObject(
+            timeout=self.load_iteration_timeout_sec,
+            objects=[[scs, nemesis] for scs in self.scylla_clusters_stats],
+            num_workers=len(self.scylla_clusters_stats),
+        )
         object_set.run(func=_run_write_workload, unpack_objects=True, ignore_exceptions=False)
 
     def run_mixed_workload(self, nemesis: bool = False):
@@ -164,8 +172,11 @@ class PerformanceRegressionOperatorMultiTenantTest(PerformanceRegressionTest):
             scylla_cluster_stats.run_mixed_workload(nemesis=nemesis)
 
         self.log.info("Running 'mixed' workload operation in parallel")
-        object_set = ParallelObject(timeout=self.load_iteration_timeout_sec, objects=[
-            [scs, nemesis] for scs in self.scylla_clusters_stats])
+        object_set = ParallelObject(
+            timeout=self.load_iteration_timeout_sec,
+            objects=[[scs, nemesis] for scs in self.scylla_clusters_stats],
+            num_workers=len(self.scylla_clusters_stats),
+        )
         object_set.run(func=_run_mixed_workload, unpack_objects=True, ignore_exceptions=False)
 
     def run_workload(self, stress_cmd, nemesis=False, sub_type=None):
@@ -173,8 +184,11 @@ class PerformanceRegressionOperatorMultiTenantTest(PerformanceRegressionTest):
             scylla_cluster_stats.run_workload(stress_cmd=stress_cmd, nemesis=nemesis)
 
         self.log.info("Running workload in parallel with following command:\n%s", stress_cmd)
-        object_set = ParallelObject(timeout=self.load_iteration_timeout_sec, objects=[
-            [scs, stress_cmd, nemesis] for scs in self.scylla_clusters_stats])
+        object_set = ParallelObject(
+            timeout=self.load_iteration_timeout_sec,
+            objects=[[scs, stress_cmd, nemesis] for scs in self.scylla_clusters_stats],
+            num_workers=len(self.scylla_clusters_stats),
+        )
         object_set.run(func=_run_workload, unpack_objects=True, ignore_exceptions=False)
 
     def test_write(self):

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1243,7 +1243,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             cluster.add_nodes(count=count, enable_auto_bootstrap=cluster.auto_bootstrap)
 
         add_nodes_in_parallel = ParallelObject(
-            timeout=3600, objects=[[cluster] for cluster in clusters])
+            timeout=3600, objects=[[cluster] for cluster in clusters], num_workers=len(clusters))
         add_nodes_in_parallel.run(
             func=_add_and_wait_for_cluster_nodes,
             unpack_objects=True, ignore_exceptions=False)


### PR DESCRIPTION
By default, ParallelObject allows to run n+4 parallel threads
where 'n' is number of CPU cores.
In common case we have 2 cores on SCT runners.
So, using default values we are limited by 6 parallel threads
using 'ParallelObject' class.

And in case of measuring the K8S multitenant performance we
must run all the measures in parallel.

So, make all the multitenant threads run all at once specifying
the number of parallel workers explicitely.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
