### PR TITLE
fix(results_analyze): make multitenant K8S results not fail

### DIFF
--- a/sdcm/results_analyze/__init__.py
+++ b/sdcm/results_analyze/__init__.py
@@ -710,7 +710,10 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
         }
         self.log.debug('Regression analysis:')
         self.log.debug(PP.pformat(results))
-        test_name = full_test_name.split('.', 1)[1]  # Example: longevity_test.LongevityTest.test_custom_time
+        try:
+            test_name = full_test_name.split('.', 1)[1]  # Example: longevity_test.LongevityTest.test_custom_time
+        except IndexError:
+            test_name = full_test_name
         subject = f'Performance Regression Compare Results - {test_name} - {test_version} - {str(test_start_time)}'
         if ycsb:
             if ycsb_engine := ycsb.get('raw_cmd', "").split():


### PR DESCRIPTION
For now, running multitenant K8S tests we get following error
on the 'analyze results' step:

    Traceback (most recent call last):
      File "sdcm/tester.py", line 2840, in check_regression
        results_analyzer.check_regression(self._test_id, is_gce,
      File "sdcm/results_analyze/__init__.py", line 713, in check_regression
        # Example: longevity_test.LongevityTest.test_custom_time
        test_name = full_test_name.split('.', 1)[1]
    IndexError: list index out of range

In case of multitenant K8S tests the full test name really doesn't
contain dots.
So, make this code not fail when there are no dots.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
