### PR TITLE
improvement(k8s): run fstrim command with retry

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -44,6 +44,7 @@ import kubernetes as k8s
 from kubernetes.client import exceptions as k8s_exceptions
 from kubernetes.client import V1ConfigMap
 from kubernetes.dynamic.resource import Resource, ResourceField, ResourceInstance, ResourceList, Subresource
+import invoke
 from invoke.exceptions import CommandTimedOut
 
 from sdcm import sct_abs_path, cluster
@@ -1960,6 +1961,9 @@ class BaseScyllaPodContainer(BasePodContainer):  # pylint: disable=abstract-meth
 
         self._init_port_mapping()
 
+    @retrying(n=60, sleep_time=10,
+              allowed_exceptions=(k8s_exceptions.ApiException, invoke.exceptions.UnexpectedExit),
+              message="Failed to run fstrim command...")
     def fstrim_scylla_disks(self):
         # NOTE: to be able to run 'fstrim' command in a pod, it must have direct device mount and
         # appropriate priviledges.


### PR DESCRIPTION
It happens that pod which is going to be used for running
`fstrim` command may be temporary unavailable and fail a `kubectl` call.
So, decrease the probability of the false failure by making it run with the retry mechanism.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
