### PR TITLE
fix(gce-spot-termination): prolong wait time on logs fetch error

### DIFF
--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -147,7 +147,7 @@ class GCENode(cluster.BaseNode):
                         GceInstanceEvent(entry, severity=Severity.WARNING).publish()
         except Exception as details:  # pylint: disable=broad-except
             self.log.warning('Error during getting spot termination notification %s', details)
-            return 0
+            self._last_logs_fetch_time = since
         return SPOT_TERMINATION_CHECK_DELAY
 
     def restart(self):


### PR DESCRIPTION
In case of error during getting logs from gce logging api, next logs
fetch is done immediately. In case of too many queries/min error, this
will fail even more.

This commit fixes this behavior by not making immediate logs fetch
again. Also if there was a failure, make next query to ask for logs from
failed period too.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
