### PR TITLE
fix(k8s-multitenant): use non-unique values for storing test names

### DIFF
--- a/performance_regression_operator_multi_tenant_test.py
+++ b/performance_regression_operator_multi_tenant_test.py
@@ -47,7 +47,7 @@ class ScyllaClusterStats(PerformanceRegressionTest):
         return f"k8s-perf-{self.db_cluster.k8s_cluster.tenants_number}-tenants"
 
     def id(self):  # pylint: disable=invalid-name
-        return self.test_config.test_id() + f"-{self._test_index}"
+        return self._test_index
 
     def __str__(self) -> str:
         return self._test_index + f"--{self.cluster_index}"


### PR DESCRIPTION
For now we have following values:

    4fbe38d0-e78c-4105-be68-5e70c56574a6-k8s-perf-7-tenants_write-prepare
    4fbe38d0-e78c-4105-be68-5e70c56574a6-k8s-perf-7-tenants_read
    4fbe38d0-e78c-4105-be68-5e70c56574a6-k8s-perf-7-tenants_write
    4fbe38d0-e78c-4105-be68-5e70c56574a6-k8s-perf-7-tenants_mixed

Stored in ES as the test names in case of K8S multitenant setups.
But we need to have it be non-unique.
So, remove the UUID part from it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
