### PR TITLE
fix(nemesis): ignore ycsb `Connection refused` on terminating a node

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1104,6 +1104,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         raise UnsupportedNemesis(f"Backend {self.cluster.params.get('cluster_backend')} "
                                  f"does not support node termination")
 
+    @decorate_with_context(ignore_ycsb_connection_refused)
     def _terminate_cluster_node(self, node):
         self.cluster.terminate_node(node)
         self.monitoring_set.reconfigure_scylla_monitoring()


### PR DESCRIPTION
`disrupt_terminate_and_replace_node` was getting `Connection refused`
which is to be excpected since the dynamodb client isn't node aware
and we don't have loadblancers

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
