### PR TITLE
refactor(rolling_upgrade): machine image as base for ubuntu 20.04

### DIFF
--- a/jenkins-pipelines/rolling-upgrade-ubuntu20.04.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-ubuntu20.04.jenkinsfile
@@ -7,8 +7,7 @@ rollingUpgradePipeline(
     backend: 'gce',
     base_versions: '',  // auto mode
     linux_distro: 'ubuntu-focal',
-    gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2004-lts',
-
+    use_preinstalled_scylla: true,
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
     test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
     workaround_kernel_bug_for_iotune: false,

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -188,10 +188,13 @@ def call(Map pipelineParams) {
                                                             if [[ -n "${params.post_behavior_k8s_cluster ? params.post_behavior_k8s_cluster : ''}" ]] ; then
                                                                 export SCT_POST_BEHAVIOR_K8S_CLUSTER="${params.post_behavior_k8s_cluster}"
                                                             fi
+
+                                                            if [[ -n "${params.use_preinstalled_scylla ? params.use_preinstalled_scylla : false}" ]] ; then
+                                                                export SCT_USE_PREINSTALLED_SCYLLA="${params.use_preinstalled_scylla}"
+                                                            fi
                                                             export SCT_INSTANCE_PROVISION="${params.provision_type}"
                                                             export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$GIT_BRANCH | sed -E 's+(origin/|origin/branch-)++')
                                                             export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$SCT_AMI_ID_DB_SCYLLA_DESC | tr ._ - | cut -c1-8 )
-
                                                             export SCT_GCE_IMAGE_DB=${pipelineParams.gce_image_db}
                                                             export SCT_SCYLLA_LINUX_DISTRO=${pipelineParams.linux_distro}
                                                             export SCT_AMI_ID_DB_SCYLLA_DESC="\$SCT_AMI_ID_DB_SCYLLA_DESC-\$SCT_SCYLLA_LINUX_DISTRO"


### PR DESCRIPTION
This PR switches the rolling-upgrade for Ubuntu 20.04 from installing Scylla from package to using a GCE machine image.

Trello task: https://trello.com/c/DdGNfOXx
Jenkins job using the GCE images for db nodes: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/maciej/job/ubuntu-20-machine-image/22


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
