### PR TITLE
fix(log_reader): off by one error when saving offset in log file

### DIFF
--- a/sdcm/db_log_reader.py
+++ b/sdcm/db_log_reader.py
@@ -157,7 +157,7 @@ class DbLogReader(Process):
 
             if index:
                 self._last_line_no = index
-                self._last_log_position = db_file.tell() + 1
+                self._last_log_position = db_file.tell()
 
         traces_count = 0
         for backtrace in backtraces:


### PR DESCRIPTION
log reader thread read a file every 30sec, so in case it finished
reading exactly at the end of a line, it would have started reading
from the 2nd char in the line.

Fixes: #5016

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
