### PR TITLE
fix(manager tests): removed unnecessary timeout jenkinsfile param

### DIFF
--- a/jenkins-pipelines/manager/centos-manager-backup-200gb.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-backup-200gb.jenkinsfile
@@ -10,7 +10,6 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_backup_feature',
     test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/200gb_dataset.yaml"]''',
 
-    timeout: [time: 1400, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy'

--- a/jenkins-pipelines/manager/centos-manager-backup-azure.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-backup-azure.jenkinsfile
@@ -11,7 +11,6 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_backup_feature',
     test_config: 'test-cases/manager/manager-regression-multiDC-set-distro.yaml',
 
-    timeout: [time: 500, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy'

--- a/jenkins-pipelines/manager/centos-manager-backup-gce-1tb.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-backup-gce-1tb.jenkinsfile
@@ -10,7 +10,6 @@ longevityPipeline(
     test_name: 'longevity_test.LongevityTest.test_custom_time',
     test_config: 'test-cases/manager/manager-backup-1TB-gce.yaml',
 
-    timeout: [time: 750, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy'

--- a/jenkins-pipelines/manager/centos-manager-backup-gce.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-backup-gce.jenkinsfile
@@ -11,7 +11,6 @@ managerPipeline(
     // Therefore, I set scylla_version to be empty for this run, and instead set a predetermined scylla machine image
     gce_image_db: 'https://www.googleapis.com/compute/v1/projects/scylla-images/global/images/3864288805022866043',  // scylla 4.6.1
 
-    timeout: [time: 500, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy'

--- a/jenkins-pipelines/manager/centos-manager-backup.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-backup.jenkinsfile
@@ -10,7 +10,6 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_backup_feature',
     test_config: 'test-cases/manager/manager-regression-multiDC-set-distro.yaml',
 
-    timeout: [time: 500, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy'

--- a/jenkins-pipelines/manager/centos-manager-repair-control.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-repair-control.jenkinsfile
@@ -11,7 +11,6 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_repair_control',
     test_config: 'test-cases/manager/manager-repair-control.yaml',
 
-    timeout: [time: 1260, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy'

--- a/jenkins-pipelines/manager/centos-manager-repair-intensity-multiple-repaired-nodes.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-repair-intensity-multiple-repaired-nodes.jenkinsfile
@@ -11,7 +11,6 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_repair_intensity_feature_on_multiple_node',
     test_config: 'test-cases/manager/manager-repair-intensity-multiple-repaired-nodes.yaml',
 
-    timeout: [time: 1260, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy'

--- a/jenkins-pipelines/manager/centos-manager-repair-intensity-single-repaired-nodes.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-repair-intensity-single-repaired-nodes.jenkinsfile
@@ -11,7 +11,6 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_repair_intensity_feature_on_single_node',
     test_config: 'test-cases/manager/manager-repair-intensity-single-repaired-nodes.yaml',
 
-    timeout: [time: 1620, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy'

--- a/jenkins-pipelines/manager/centos-manager-sanity-ipv6.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-sanity-ipv6.jenkinsfile
@@ -10,7 +10,6 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: 'test-cases/manager/manager-regression-ipv6.yaml',
 
-    timeout: [time: 240, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy'

--- a/jenkins-pipelines/manager/centos-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-sanity.jenkinsfile
@@ -11,7 +11,6 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: 'test-cases/manager/manager-regression-multiDC-set-distro.yaml',
 
-    timeout: [time: 240, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',

--- a/jenkins-pipelines/manager/centos-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-upgrade.jenkinsfile
@@ -15,7 +15,6 @@ managerPipeline(
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: 'test-cases/upgrades/manager-upgrade.yaml',
 
-    timeout: [time: 360, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy'

--- a/jenkins-pipelines/manager/debian10-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/debian10-manager-sanity.jenkinsfile
@@ -10,7 +10,6 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/debian10.yaml"]''',
 
-    timeout: [time: 240, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',

--- a/jenkins-pipelines/manager/debian10-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian10-manager-upgrade.jenkinsfile
@@ -15,7 +15,6 @@ managerPipeline(
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/debian10.yaml"]''',
 
-    timeout: [time: 360, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy'

--- a/jenkins-pipelines/manager/debian11-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/debian11-manager-sanity.jenkinsfile
@@ -10,7 +10,6 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/debian11.yaml"]''',
 
-    timeout: [time: 240, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',

--- a/jenkins-pipelines/manager/debian11-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/debian11-manager-upgrade.jenkinsfile
@@ -15,7 +15,6 @@ managerPipeline(
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/debian11.yaml"]''',
 
-    timeout: [time: 360, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy'

--- a/jenkins-pipelines/manager/enterprise-ami-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/enterprise-ami-manager-sanity.jenkinsfile
@@ -13,7 +13,6 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: 'test-cases/manager/manager-regression-multiDC-set-distro.yaml',
 
-    timeout: [time: 240, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',

--- a/jenkins-pipelines/manager/enterprise-ami-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/enterprise-ami-manager-upgrade.jenkinsfile
@@ -17,7 +17,6 @@ managerPipeline(
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: 'test-cases/upgrades/manager-upgrade.yaml',
 
-    timeout: [time: 360, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy'

--- a/jenkins-pipelines/manager/ubuntu18-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu18-manager-sanity.jenkinsfile
@@ -10,7 +10,6 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/ubuntu18.yaml"]''',
 
-    timeout: [time: 240, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',

--- a/jenkins-pipelines/manager/ubuntu18-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu18-manager-upgrade.jenkinsfile
@@ -15,7 +15,6 @@ managerPipeline(
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/ubuntu18.yaml"]''',
 
-    timeout: [time: 360, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy'

--- a/jenkins-pipelines/manager/ubuntu20-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu20-manager-sanity.jenkinsfile
@@ -10,7 +10,6 @@ managerPipeline(
     test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
     test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/ubuntu20.yaml"]''',
 
-    timeout: [time: 240, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',

--- a/jenkins-pipelines/manager/ubuntu20-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu20-manager-upgrade.jenkinsfile
@@ -15,7 +15,6 @@ managerPipeline(
     test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
     test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/ubuntu20.yaml"]''',
 
-    timeout: [time: 360, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy'

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -397,20 +397,6 @@ def call(Map pipelineParams) {
         post {
             always {
                 script {
-                    // jenkins artifacts are not available anymore - so we need to copy them
-                    try {
-
-                        dir('scylla-cluster-tests') {
-                            sh "rm -rf logs"
-                            copyLogsFromSctRunner('logs')
-                            archiveArtifacts artifacts: 'logs/**'
-                            sh "rm -rf logs"
-                        }
-                    } catch (Exception err) {
-                        echo err.getMessage()
-                        echo "Error detected during archiveArtifacts, but we will continue."
-                    }
-
                     def collect_logs = completed_stages['collect_logs']
                     def clean_resources = completed_stages['clean_resources']
                     def send_email = completed_stages['send_email']

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -300,6 +300,9 @@ def call(Map pipelineParams) {
                 }
             }
             stage('Running Downstream Jobs') {  // Specifically placed after test stage, since downstream jobs should still be triggered when stages like collect logs fail.
+                options {
+                    timeout(time: 5, unit: 'MINUTES')
+                }
                 steps {
                     script {
                         if (currentBuild.currentResult == 'SUCCESS') {

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -147,7 +147,6 @@ def call(Map pipelineParams) {
         options {
             timestamps()
             disableConcurrentBuilds()
-            timeout(pipelineParams.timeout)
             buildDiscarder(logRotator(numToKeepStr: '20'))
         }
         stages {


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
