### PR TITLE
fix(GrowShrinkClusterNemesis): don't assume `params.get()` has default

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3230,7 +3230,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         cur_num_nodes_in_dc = len([n for n in self.cluster.nodes if n.dc_idx == self.target_node.dc_idx])
         initial_db_size = self.tester.params.get("n_db_nodes")
         if self._is_it_on_kubernetes():
-            initial_db_size = self.tester.params.get("k8s_n_scylla_pods_per_cluster", initial_db_size)
+            initial_db_size = self.tester.params.get("k8s_n_scylla_pods_per_cluster") or initial_db_size
 
         if isinstance(initial_db_size, int):
             decommission_nodes_number = min(cur_num_nodes_in_dc - initial_db_size, add_nodes_number)


### PR DESCRIPTION
a2d988688a1be6b69f953e1a66572a2f6736347a assumed `get()` has default
argument, and failed like this:

```
initial_db_size = self.tester.params.get("k8s_n_scylla_pods_per_cluster", initial_db_size)
TypeError: SCTConfiguration.get() takes 2 positional arguments but 3 were given
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
