### PR TITLE
fix(cluster.py): replaced fstring with format

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1765,7 +1765,7 @@ server_encryption_options:
         # hence this is a temporary workaround to make the rolling upgrade tests to pass, until the latest
         # patch of the supported releases will include the fix.
         package_manager = 'yum' if self.is_rhel_like() else 'apt'
-        self.remoter.run(f'sudo {package_manager} install zip unzip -y')
+        self.remoter.run('sudo {} install zip unzip -y'.format(package_manager))
         self.remoter.run('curl -s "https://get.sdkman.io" | bash')
         self.remoter.run(dedent("""
             source "/home/$USER/.sdkman/bin/sdkman-init.sh"


### PR DESCRIPTION
Since python 2.7 doesn't support fstrings

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
