### PR TITLE
Trigger job updates createTestJobPipeline:add automatic update for releng-testing and enterprise

### DIFF
--- a/vars/createTestJobPipeline.groovy
+++ b/vars/createTestJobPipeline.groovy
@@ -33,6 +33,15 @@ def call() {
             disableConcurrentBuilds()
             buildDiscarder(logRotator(numToKeepStr: '20'))
         }
+        triggers {
+            parameterizedCron (
+                '''
+                    H 01 * * 0 %branch="scylla-master/releng-testing"
+                    H 01 * * 0 %branch="enterprise"
+                    H 01 * * 0 %branch="scylla-master"
+                '''
+            )
+        }
         stages {
             stage('Checkout sct') {
                 steps {


### PR DESCRIPTION
Today when QA adding new jobs to master it is not automatically updated under `scylla-master/releng-testing` and `enterprise` , this is causing failures in the daily process and releng debug sessions which we can avoid.

Setting this job to run once a week and update the SCT jobs