### PR TITLE
fix(cluster.py): Remove command of yum makecache

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1905,10 +1905,11 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
     def update_repo_cache(self):
         try:
             if self.is_rhel_like():
-                # try to avoid ERROR 404 of yum, reference https://wiki.centos.org/yum-errors
+                # The yum makecache command was removed from here since not needed and recommended.
+                # In the past it also caused ERROR 404 of yum, reference https://wiki.centos.org/yum-errors
+                # This fixes https://github.com/scylladb/scylla-cluster-tests/issues/4977
                 self.remoter.sudo('yum clean all')
                 self.remoter.sudo('rm -rf /var/cache/yum/')
-                self.remoter.sudo('yum makecache', retry=3)
             elif self.distro.is_sles:
                 self.remoter.sudo('zypper clean all')
                 self.remoter.sudo('rm -rf /var/cache/zypp/')


### PR DESCRIPTION
	This command fails frequently and is
	not a must to use.
Fixes: #4977 
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
