### PR TITLE
improvement(print_kernel_callstack): add new flag

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -57,6 +57,7 @@ use_cloud_manager: false
 cloud_prom_bearer_token: ''
 
 backtrace_decoding: true
+print_kernel_callstack: false
 
 update_db_packages: ''
 

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -291,7 +291,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         self._init_port_mapping()
 
         self.set_keep_alive()
-        if self.node_type == "db" and not self.is_kubernetes():
+        if self.node_type == "db" and not self.is_kubernetes() \
+                and self.parent_cluster.params.get("print_kernel_callstack"):
             try:
                 self.remoter.sudo(shell_script_cmd("""\
                 echo 'kernel.perf_event_paranoid = 0' >> /etc/sysctl.conf

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -349,6 +349,10 @@ class SCTConfiguration(dict):
         dict(name="backtrace_decoding", env="SCT_BACKTRACE_DECODING", type=boolean,
              help="""If True, all backtraces found in db nodes would be decoded automatically"""),
 
+        dict(name="print_kernel_callstack", env="SCT_PRINT_KERNEL_CALLSTACK", type=boolean,
+             help="""Scylla will print kernel callstack to logs if True, otherwise, it will try and may print a message
+             that it failed to."""),
+
         dict(name="instance_provision", env="SCT_INSTANCE_PROVISION", type=str,
              help="instance_provision: spot|on_demand|spot_fleet"),
 

--- a/test-cases/performance/perf-regression-2mv.yaml
+++ b/test-cases/performance/perf-regression-2mv.yaml
@@ -23,3 +23,4 @@ store_perf_results: true
 send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com']
 backtrace_decoding: false
+print_kernel_callstack: true

--- a/test-cases/performance/perf-regression-alternator-latency-500gb-30min.yaml
+++ b/test-cases/performance/perf-regression-alternator-latency-500gb-30min.yaml
@@ -49,6 +49,7 @@ space_node_threshold: 644245094
 round_robin: true
 append_scylla_args: '--blocked-reactor-notify-ms 50'
 backtrace_decoding: false
+print_kernel_callstack: true
 
 store_perf_results: true
 send_email: true

--- a/test-cases/performance/perf-regression-alternator.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression-alternator.100threads.30M-keys.yaml
@@ -55,3 +55,5 @@ space_node_threshold: 644245094
 store_perf_results: true
 send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com', 'alternator@scylladb.com']
+
+print_kernel_callstack: true

--- a/test-cases/performance/perf-regression-latency-125gb.yaml
+++ b/test-cases/performance/perf-regression-latency-125gb.yaml
@@ -23,6 +23,7 @@ ami_id_db_scylla_desc: 'VERSION_DESC'
 round_robin: true
 append_scylla_args: '--blocked-reactor-notify-ms 5'
 backtrace_decoding: false
+print_kernel_callstack: true
 
 use_mgmt: true
 

--- a/test-cases/performance/perf-regression-latency-1TB.yaml
+++ b/test-cases/performance/perf-regression-latency-1TB.yaml
@@ -27,3 +27,4 @@ store_perf_results: true
 send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com']
 backtrace_decoding: false
+print_kernel_callstack: true

--- a/test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml
+++ b/test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml
@@ -28,6 +28,7 @@ ami_id_db_scylla_desc: 'VERSION_DESC'
 round_robin: true
 append_scylla_args: '--blocked-reactor-notify-ms 5'
 backtrace_decoding: false
+print_kernel_callstack: true
 
 store_perf_results: true
 send_email: true

--- a/test-cases/performance/perf-regression-latency-500gb-30min.yaml
+++ b/test-cases/performance/perf-regression-latency-500gb-30min.yaml
@@ -20,6 +20,7 @@ user_prefix: 'perf-regression-latency'
 space_node_threshold: 644245094
 ami_id_db_scylla_desc: 'VERSION_DESC'
 backtrace_decoding: false
+print_kernel_callstack: true
 
 round_robin: true
 append_scylla_args: '--blocked-reactor-notify-ms 4'

--- a/test-cases/performance/perf-regression-latency-cdc-mixed-poll-batching.yaml
+++ b/test-cases/performance/perf-regression-latency-cdc-mixed-poll-batching.yaml
@@ -27,3 +27,4 @@ append_scylla_args: '--blocked-reactor-notify-ms 50'
 send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com', 'cdc@scylladb.com']
 backtrace_decoding: false
+print_kernel_callstack: true

--- a/test-cases/performance/perf-regression-latency-in-memory.yaml
+++ b/test-cases/performance/perf-regression-latency-in-memory.yaml
@@ -29,3 +29,4 @@ store_perf_results: true
 send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com']
 backtrace_decoding: false
+print_kernel_callstack: true

--- a/test-cases/performance/perf-regression-latency-lwt-big.yaml
+++ b/test-cases/performance/perf-regression-latency-lwt-big.yaml
@@ -59,6 +59,8 @@ regions_data:
 append_scylla_args: '--blocked-reactor-notify-ms 400 --memory 4G --experimental 1 --experimental-features=lwt'
 
 backtrace_decoding: false
+print_kernel_callstack: true
+
 store_perf_results: true
 send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com', 'lwt@scylladb.com']

--- a/test-cases/performance/perf-regression-latency-lwt-small.yaml
+++ b/test-cases/performance/perf-regression-latency-lwt-small.yaml
@@ -60,6 +60,8 @@ regions_data:
 append_scylla_args: '--blocked-reactor-notify-ms 400 --memory 4G --experimental 1 --experimental-features=lwt'
 
 backtrace_decoding: false
+print_kernel_callstack: true
+
 store_perf_results: true
 send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com', 'lwt@scylladb.com']

--- a/test-cases/performance/perf-regression-throughput-125gb.yaml
+++ b/test-cases/performance/perf-regression-throughput-125gb.yaml
@@ -25,6 +25,7 @@ ami_id_db_scylla_desc: 'VERSION_DESC'
 round_robin: true
 append_scylla_args: '--blocked-reactor-notify-ms 5'
 backtrace_decoding: false
+print_kernel_callstack: true
 
 use_mgmt: true
 

--- a/test-cases/performance/perf-regression-throughput-cdc-mixed-poll-batching.yaml
+++ b/test-cases/performance/perf-regression-throughput-cdc-mixed-poll-batching.yaml
@@ -31,3 +31,4 @@ append_scylla_yaml: |
 send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com', 'cdc@scylladb.com']
 backtrace_decoding: false
+print_kernel_callstack: true

--- a/test-cases/performance/perf-regression-throughput-lwt-big.yaml
+++ b/test-cases/performance/perf-regression-throughput-lwt-big.yaml
@@ -62,6 +62,8 @@ regions_data:
 append_scylla_args: '--blocked-reactor-notify-ms 1000 --memory 4G --experimental 1 --experimental-features=lwt'
 
 backtrace_decoding: false
+print_kernel_callstack: true
+
 store_perf_results: true
 send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com', 'lwt@scylladb.com']

--- a/test-cases/performance/perf-regression-throughput-lwt-small.yaml
+++ b/test-cases/performance/perf-regression-throughput-lwt-small.yaml
@@ -61,6 +61,8 @@ regions_data:
 append_scylla_args: '--blocked-reactor-notify-ms 1000 --memory 4G --experimental 1 --experimental-features=lwt'
 
 backtrace_decoding: false
+print_kernel_callstack: true
+
 store_perf_results: true
 send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com', 'lwt@scylladb.com']

--- a/test-cases/performance/perf-regression-user-profiles.yaml
+++ b/test-cases/performance/perf-regression-user-profiles.yaml
@@ -36,5 +36,6 @@ store_perf_results: true
 append_scylla_args: '--blocked-reactor-notify-ms 4'
 
 backtrace_decoding: false
+print_kernel_callstack: true
 
 email_recipients: ['scylla-perf-results@scylladb.com']

--- a/test-cases/performance/perf-regression-write-latency-cdc.yaml
+++ b/test-cases/performance/perf-regression-write-latency-cdc.yaml
@@ -20,3 +20,4 @@ append_scylla_args: '--blocked-reactor-notify-ms 50'
 send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com', 'cdc@scylladb.com ']
 backtrace_decoding: false
+print_kernel_callstack: true

--- a/test-cases/performance/perf-regression-write-throughput-cdc.yaml
+++ b/test-cases/performance/perf-regression-write-throughput-cdc.yaml
@@ -24,3 +24,4 @@ append_scylla_yaml: |
 send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com', 'cdc@scylladb.com ']
 backtrace_decoding: false
+print_kernel_callstack: true

--- a/test-cases/performance/perf-regression.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys.yaml
@@ -17,6 +17,7 @@ user_prefix: 'perf-regression'
 space_node_threshold: 644245094
 
 backtrace_decoding: false
+print_kernel_callstack: true
 
 store_perf_results: true
 use_mgmt: false

--- a/test-cases/performance/perf-row-level-repair-1TB.yaml
+++ b/test-cases/performance/perf-row-level-repair-1TB.yaml
@@ -28,5 +28,6 @@ store_perf_results: true
 send_email: 'true'
 
 backtrace_decoding: false
+print_kernel_callstack: true
 
 email_recipients: ['scylla-perf-results@scylladb.com']

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -126,6 +126,7 @@ class TestBaseNode(unittest.TestCase, EventsUtilsMixin):
             assert event_b["line_number"] == 3
 
     def test_search_kernel_callstack(self):
+        self.node.parent_cluster = {'params': {'print_kernel_callstack': True}}
         self.node.system_log = os.path.join(os.path.dirname(__file__), 'test_data', 'kernel_callstack.log')
         self._read_and_publish_events()
         with self.get_raw_events_log().open() as events_file:


### PR DESCRIPTION
if flag will be set to `True`, then kernel callstack
will be printed in Scylla logs, otherwise (the default)
will be to NOT print it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
