### PR TITLE
fix(Full-Partition-Scan): Increase scan interval

### DIFF
--- a/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
@@ -72,4 +72,4 @@ stop_test_on_stress_failure: false
 
 # Temporarily downgrade scylla_bench to a stable version
 scylla_bench_version: v0.1.3
-run_full_partition_scan: '{"ks_cf": "scylla_bench.test", "interval": 90, "pk_name":"pk", "rows_count": 100000, "validate_data": "true"}' # 'ks.cf, interval(sec), partition-key name, number-of-rows-per-partition, validate reversed query output, include data-column or only validate pk + ck'
+run_full_partition_scan: '{"ks_cf": "scylla_bench.test", "interval": 300, "pk_name":"pk", "rows_count": 100000, "validate_data": "true"}' # 'ks.cf, interval(sec), partition-key name, number-of-rows-per-partition, validate reversed query output, include data-column or only validate pk + ck'

--- a/test-cases/longevity/longevity-large-partition-3h.yaml
+++ b/test-cases/longevity/longevity-large-partition-3h.yaml
@@ -44,4 +44,4 @@ space_node_threshold: 644245094
 
 run_fullscan: '{"ks_cf": "scylla_bench.test", "interval": 10}' # 'ks.cf|random, interval(min)'
 
-run_full_partition_scan: '{"ks_cf": "scylla_bench.test", "interval": 2, "pk_name":"pk", "rows_count": 5000, "validate_data": "true", "include_data_column": "true"}' # 'ks.cf, interval(sec), partition-key name, number-of-rows-per-partition, validate reversed query output, include data-column or only validate pk + ck'
+run_full_partition_scan: '{"ks_cf": "scylla_bench.test", "interval": 300, "pk_name":"pk", "rows_count": 5000, "validate_data": "true", "include_data_column": "true"}' # 'ks.cf, interval(sec), partition-key name, number-of-rows-per-partition, validate reversed query output, include data-column or only validate pk + ck'

--- a/test-cases/longevity/longevity-large-partition-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-4days.yaml
@@ -42,4 +42,4 @@ primary_key_column: "pk"
 
 # Temporarily downgrade scylla_bench to a stable version
 scylla_bench_version: v0.1.3
-run_full_partition_scan: '{"ks_cf": "scylla_bench.test", "interval": 180, "pk_name":"pk", "rows_count": 10000000, "validate_data": "true"}' # 'ks.cf, interval(sec), partition-key name, number-of-rows-per-partition, validate reversed query output, include data-column or only validate pk + ck'
+run_full_partition_scan: '{"ks_cf": "scylla_bench.test", "interval": 300, "pk_name":"pk", "rows_count": 10000000, "validate_data": "true"}' # 'ks.cf, interval(sec), partition-key name, number-of-rows-per-partition, validate reversed query output, include data-column or only validate pk + ck'

--- a/test-cases/longevity/longevity-large-partition-8h.yaml
+++ b/test-cases/longevity/longevity-large-partition-8h.yaml
@@ -48,4 +48,4 @@ user_prefix: 'longevity-large-partitions-8h'
 
 space_node_threshold: 644245094
 
-run_full_partition_scan: '{"ks_cf": "scylla_bench.test", "interval": 2, "pk_name":"pk", "rows_count": 5555, "validate_data": "true"}' # 'ks.cf, interval(sec), partition-key name, number-of-rows-per-partition, validate reversed query output, include data-column or only validate pk + ck'
+run_full_partition_scan: '{"ks_cf": "scylla_bench.test", "interval": 300, "pk_name":"pk", "rows_count": 5555, "validate_data": "true"}' # 'ks.cf, interval(sec), partition-key name, number-of-rows-per-partition, validate reversed query output, include data-column or only validate pk + ck'


### PR DESCRIPTION
	In order to decrease connection requests load on cluster by scan thread.
	Intervals of 4 large-partitions longevities are increased to 5 minutes.
	Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/4960

Notes:
1) I'm not sure whether this should be backported or not (not a must).
2) The interval unit is not changed from seconds to minutes in order to keep future ability to test this lower granularity if needed.
That is since it is an important feature to an important customer (Discord) and scylla-bench doesn't have a stable supporting version for that.

https://trello.com/c/U3bhzNUL
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
