### PR TITLE
fix(jdk issue): adding case where artifacts starts from AMI

### DIFF
--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -506,6 +506,11 @@ class UpgradeTest(FillDatabaseData):
                 not is_enterprise(target_upgrade_version):
             self.truncate_entries_flag = True
 
+        if self.params.get('use_preinstalled_scylla'):
+            InfoEvent(message='WORKAROUND to issue #10442 - installing SDKMAN to every node')
+            for node in self.db_cluster.nodes:
+                node.install_sdkman_workaround()
+
         InfoEvent(message='pre-test - prepare test keyspaces and tables').publish()
         # prepare test keyspaces and tables before upgrade to avoid schema change during mixed cluster.
         self.prepare_keyspaces_and_tables()


### PR DESCRIPTION
following commit 4aa15e3b43c4b2bfe4cdc0df01cbc0c77c1d804c we still
needed
to address case where we start from an image (AMI), so
in here, we are adding it to the beginning of the upgrade
test, so we can go over each node and install SDKMAN.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
