### PR TITLE
feature(multi-part): centerlize the creation of user-data for AWS

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -40,7 +40,6 @@ from sdcm import ec2_client, cluster, wait
 from sdcm.ec2_client import CreateSpotInstancesError
 from sdcm.provision.aws.utils import configure_set_preserve_hostname_script
 from sdcm.provision.common.utils import configure_hosts_set_hostname_script
-from sdcm.provision.helpers.cloud_init import get_cloud_init_config
 from sdcm.provision.scylla_yaml import SeedProvider
 from sdcm.sct_provision.aws.user_data import ScyllaUserDataBuilder
 
@@ -374,10 +373,6 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
                                                   user_data_format_version=user_data_format_version, params=self.params,
                                                   syslog_host_port=self.test_config.get_logging_service_host_port())
         ec2_user_data = user_data_builder.to_string()
-
-        #  replace user_data json with cloud-init content if preinstalled scylla is not used
-        if not self.params.get("use_preinstalled_scylla"):
-            ec2_user_data = get_cloud_init_config()
 
         instances = self._create_or_find_instances(count=count, ec2_user_data=ec2_user_data, dc_idx=dc_idx)
         added_nodes = [self._create_node(instance, self._ec2_ami_username,

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -370,6 +370,7 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
 
         user_data_format_version = self.params.get('user_data_format_version') or '3'
         user_data_builder = ScyllaUserDataBuilder(cluster_name=self.name,
+                                                  bootstrap=enable_auto_bootstrap,
                                                   user_data_format_version=user_data_format_version, params=self.params,
                                                   syslog_host_port=self.test_config.get_logging_service_host_port())
         ec2_user_data = user_data_builder.to_string()

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -12,7 +12,6 @@
 # Copyright (c) 2020 ScyllaDB
 
 import os
-import json
 import time
 import logging
 from typing import Dict, Any, ParamSpec, TypeVar
@@ -24,7 +23,6 @@ import tenacity
 from libcloud.common.google import GoogleBaseError, ResourceNotFoundError, InvalidRequestError
 
 from sdcm import cluster
-from sdcm.provision.helpers.cloud_init import get_cloud_init_config
 from sdcm.sct_events import Severity
 from sdcm.sct_events.gce_events import GceInstanceEvent
 from sdcm.utils.gce_utils import GceLoggingClient
@@ -33,6 +31,7 @@ from sdcm.keystore import pub_key_from_private_key_file
 from sdcm.sct_events.system import SpotTerminationEvent
 from sdcm.utils.common import list_instances_gce, gce_meta_to_dict
 from sdcm.utils.decorators import retrying
+from sdcm.sct_provision.aws.user_data import ScyllaUserDataBuilder
 
 
 SPOT_TERMINATION_CHECK_DELAY = 5 * 60
@@ -297,12 +296,11 @@ class GCECluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
         return gce_disk_struct
 
     def _prepare_user_data(self):
-        if not self.params.get("use_preinstalled_scylla"):
-            return get_cloud_init_config()
-        else:
-            return json.dumps(dict(scylla_yaml=dict(cluster_name=self.name),
-                                   start_scylla_on_first_boot=False,
-                                   raid_level=self.params.get("raid_level")))
+        user_data_format_version = self.params.get('user_data_format_version') or '3'
+        user_data_builder = ScyllaUserDataBuilder(cluster_name=self.name,
+                                                  user_data_format_version=user_data_format_version, params=self.params,
+                                                  syslog_host_port=self.test_config.get_logging_service_host_port())
+        return user_data_builder.to_string()
 
     def _create_instance(self, node_index, dc_idx, spot=False):
         def set_tags_as_labels(_instance):
@@ -325,7 +323,7 @@ class GCECluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
         # Name must start with a lowercase letter followed by up to 63
         # lowercase letters, numbers, or hyphens, and cannot end with a hyphen
         assert len(name) <= 63, "Max length of instance name is 63"
-        startup_script = self.test_config.get_startup_script()
+        startup_script = ""
 
         if self.params.get("scylla_linux_distro") in ("ubuntu-bionic", "ubuntu-xenial", "ubuntu-focal",):
             # we need to disable sshguard to prevent blocking connections from the builder

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -295,14 +295,15 @@ class GCECluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
         self.log.debug(gce_disk_struct)
         return gce_disk_struct
 
-    def _prepare_user_data(self):
+    def _prepare_user_data(self, enable_auto_bootstrap=False):
         user_data_format_version = self.params.get('user_data_format_version') or '3'
         user_data_builder = ScyllaUserDataBuilder(cluster_name=self.name,
+                                                  bootstrap=enable_auto_bootstrap,
                                                   user_data_format_version=user_data_format_version, params=self.params,
                                                   syslog_host_port=self.test_config.get_logging_service_host_port())
         return user_data_builder.to_string()
 
-    def _create_instance(self, node_index, dc_idx, spot=False):
+    def _create_instance(self, node_index, dc_idx, spot=False, enable_auto_bootstrap=False):
         def set_tags_as_labels(_instance):
             self.log.debug(f"Expected tags are {self.tags}")
             lower_tags = dict((k.lower(), v.lower().replace('.', '-')) for k, v in self.tags.items())
@@ -342,7 +343,7 @@ class GCECluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
                                                "Name": name,
                                                "NodeIndex": node_index,
                                                "startup-script": startup_script,
-                                               "user-data": self._prepare_user_data(),
+                                               "user-data": self._prepare_user_data(enable_auto_bootstrap),
                                                "block-project-ssh-keys": "true",
                                                "ssh-keys": f"{username}:ssh-rsa {public_key}", },
                                   ex_service_accounts=self._service_accounts,
@@ -392,11 +393,11 @@ class GCECluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
 
             raise gbe
 
-    def _create_instances(self, count, dc_idx=0):
+    def _create_instances(self, count, dc_idx=0, enable_auto_bootstrap=False):
         spot = 'spot' in self.instance_provision
         instances = []
         for node_index in range(self._node_index + 1, self._node_index + count + 1):
-            instances.append(self._create_instance(node_index, dc_idx, spot))
+            instances.append(self._create_instance(node_index, dc_idx, spot, enable_auto_bootstrap))
         return instances
 
     def _destroy_instance(self, name: str, dc_idx: int) -> bool:
@@ -463,7 +464,7 @@ class GCECluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
             if not instances:
                 raise RuntimeError("No nodes found for testId %s " % (self.test_config.test_id(),))
         else:
-            instances = self._create_instances(count, dc_idx)
+            instances = self._create_instances(count, dc_idx, enable_auto_bootstrap)
 
         self.log.debug('instances: %s', instances)
         if instances:

--- a/sdcm/provision/azure/utils.py
+++ b/sdcm/provision/azure/utils.py
@@ -11,6 +11,7 @@
 #
 # Copyright (c) 2022 ScyllaDB
 import logging
+import re
 from contextlib import suppress
 
 from azure.core.exceptions import ResourceNotFoundError as AzureResourceNotFoundError
@@ -85,3 +86,13 @@ def get_scylla_images(  # pylint: disable=too-many-branches,too-many-locals
     if only_latest:
         return output[-1:]
     return output
+
+
+IMAGE_URL_REGEX = re.compile(
+    r'.*/resourceGroups/(?P<resource_group_name>.*)/providers/Microsoft.Compute/images/(?P<image_name>.*)')
+
+
+def get_image_tags(link: str) -> dict:
+    params = IMAGE_URL_REGEX.search(link).groupdict()
+    azure_image: GalleryImageVersion = AzureService().compute.images.get(**params)
+    return azure_image.tags

--- a/sdcm/provision/common/configuration_script.py
+++ b/sdcm/provision/common/configuration_script.py
@@ -17,7 +17,7 @@ from sdcm.provision.common.builders import AttrBuilder
 from sdcm.provision.common.utils import (
     configure_rsyslog_target_script, configure_sshd_script, restart_sshd_service, restart_rsyslog_service,
     install_syslogng_service, configure_syslogng_target_script, restart_syslogng_service,
-    configure_rsyslog_rate_limits_script, configure_rsyslog_set_hostname_script)
+    configure_rsyslog_rate_limits_script, configure_rsyslog_set_hostname_script, configure_ssh_accept_rsa)
 
 
 RSYSLOG_SSH_TUNNEL_LOCAL_PORT = 5000
@@ -84,6 +84,7 @@ class ConfigurationScriptBuilder(AttrBuilder, metaclass=abc.ABCMeta):
 
         if self.configure_sshd:
             script += configure_sshd_script()
+            script += configure_ssh_accept_rsa()
             script += restart_sshd_service()
         elif self.disable_ssh_while_running:
             script += 'systemctl start sshd || true\n'

--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -120,6 +120,18 @@ def configure_sshd_script():
     """)
 
 
+def configure_ssh_accept_rsa():
+    return dedent("""
+    if (( $(ssh -V 2>&1 | tr -d "[:alpha:][:blank:][:punct:]" | cut -c-2) >= 88 )); then
+        systemctl stop sshd || true
+        sed -i "s/#PubkeyAuthentication \(.*\)$/PubkeyAuthentication yes/" /etc/ssh/sshd_config || true
+        sed -i -e "$aPubkeyAcceptedAlgorithms +ssh-rsa" /etc/ssh/sshd_config || true
+        sed -i -e "$aHostKeyAlgorithms +ssh-rsa" /etc/ssh/sshd_config || true
+        systemctl restart sshd || true
+    fi
+    """)
+
+
 def restart_sshd_service():
     return "systemctl restart sshd || true\n"
 

--- a/sdcm/sct_provision/aws/cluster.py
+++ b/sdcm/sct_provision/aws/cluster.py
@@ -242,7 +242,7 @@ class DBCluster(ClusterBase):
         return ScyllaUserDataBuilder(
             params=self.params,
             cluster_name=self.cluster_name,
-            old_format=False,
+            user_data_format_version=self.params.get('user_data_format_version'),
             syslog_host_port=self._test_config.get_logging_service_host_port(),
         ).to_string()
 
@@ -260,7 +260,7 @@ class OracleDBCluster(ClusterBase):
         return ScyllaUserDataBuilder(
             params=self.params,
             cluster_name=self.cluster_name,
-            old_format=False,
+            user_data_format_version=self.params.get('oracle_user_data_format_version'),
             syslog_host_port=self._test_config.get_logging_service_host_port(),
         ).to_string()
 

--- a/sdcm/sct_provision/aws/user_data.py
+++ b/sdcm/sct_provision/aws/user_data.py
@@ -18,7 +18,7 @@ class ScyllaUserDataBuilder(ScyllaUserDataBuilderBase):
     bootstrap: bool = Field(default=None, as_dict=False)
     user_data_format_version: str = Field(default='2', as_dict=False)
     scylla_yaml_raw: ScyllaYaml = Field(default=None, as_dict=False)
-    syslog_host_port: tuple[str, int] = Field(default=False, as_dict=False)
+    syslog_host_port: tuple[str, int] = Field(default=None, as_dict=False)
 
     @property
     def scylla_yaml(self) -> dict:

--- a/sdcm/sct_provision/user_data_objects/sshd.py
+++ b/sdcm/sct_provision/user_data_objects/sshd.py
@@ -12,7 +12,7 @@
 # Copyright (c) 2022 ScyllaDB
 from dataclasses import dataclass
 
-from sdcm.provision.common.utils import configure_sshd_script, restart_sshd_service
+from sdcm.provision.common.utils import configure_sshd_script, restart_sshd_service, configure_ssh_accept_rsa
 from sdcm.sct_provision.user_data_objects import SctUserDataObject
 
 
@@ -26,5 +26,6 @@ class SshdUserDataObject(SctUserDataObject):
     @property
     def script_to_run(self) -> str:
         script = configure_sshd_script()
+        script = configure_ssh_accept_rsa()
         script += restart_sshd_service()
         return script


### PR DESCRIPTION
after scylladb/scylla-machine-image#363 is a while now in master
we want to be able to utilized it, to seperate our boot scripts
from the scylla-machine-image into cloud-init script.

running some of those scripts in the context of
scylla-machine-image are causing use issue like repo/list of apt/yum
not being correct, since we are doing it before cloud-init
finish all it's work. waiting for cloud-init to finish is also
problemtic, since scylla-machine-image it's is holding it
for getting to it's final stage.

### AWS:
- [x] artifact: https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-centos8-arm-test/9/
- [x] longevity: https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity/job/longevity-10gb-3h/58/

### GCE: 
- [x] artifact: https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2004-test/23/
- [x] longevity: https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-10gb-3h-gce-test/7

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
