### PR TITLE
Refactor stop compaction feature tests

### DIFF
--- a/sdcm/rest/compaction_manager_client.py
+++ b/sdcm/rest/compaction_manager_client.py
@@ -33,3 +33,10 @@ class CompactionManagerClient(RemoteCurlClient):
         params = {"type": compaction_type.upper()}
 
         return self.run_remoter_curl(method="POST", path="stop_compaction", params=params, timeout=360)
+
+    def stop_keyspace_compaction(self, keyspace: str, compaction_type: str, tables: list, timeout: int = 360):
+        LOGGER.debug("Stopping keyspace compaction via REST API")
+        params = {"type": compaction_type, "tables": tables}
+        path = f"stop_keyspace_compaction/{keyspace}"
+
+        return self.run_remoter_curl(method="POST", path=path, params=params, timeout=timeout)

--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -178,6 +178,16 @@ def ignore_scrub_invalid_errors():
 
 
 @contextmanager
+def ignore_compaction_stopped_exceptions():
+    with ExitStack() as stack:
+        stack.enter_context(DbEventsFilter(
+            db_event=DatabaseLogEvent.DATABASE_ERROR,
+            line="was stopped due to: user request"
+        ))
+        yield
+
+
+@contextmanager
 def ignore_view_error_gate_closed_exception():
     with EventsFilter(event_class=DatabaseLogEvent, regex='.*view - Error applying view update.*gate_closed_exception'):
         yield

--- a/sdcm/utils/compaction_ops.py
+++ b/sdcm/utils/compaction_ops.py
@@ -8,6 +8,14 @@ from sdcm.cluster import BaseNode, BaseCluster, BaseScyllaCluster
 from sdcm.rest.storage_service_client import StorageServiceClient
 
 
+class CompactionTypes(NamedTuple):
+    COMPACTION: str = "COMPACTION"
+    CLEANUP: str = "CLEANUP"
+    SCRUB: str = "SCRUB"
+    RESHAPE: str = "RESHAPE"
+    UPGRADE: str = "UPGRADE"
+
+
 class ScrubModes(NamedTuple):
     ABORT: str = "ABORT"
     SKIP: str = "SKIP"
@@ -113,3 +121,6 @@ class StartStopCompactionArgs(NamedTuple):
     timeout: int
     target_node: BaseNode
     compaction_ops: CompactionOps
+
+
+COMPACTION_TYPES = CompactionTypes()

--- a/stop_compaction_test.py
+++ b/stop_compaction_test.py
@@ -12,20 +12,35 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2021 ScyllaDB
+import functools
 import logging
 import re
 from functools import partial
+from typing import Callable
 
 from sdcm.cluster import BaseNode
 from sdcm.nemesis import StartStopMajorCompaction, StartStopScrubCompaction, StartStopCleanupCompaction, \
     StartStopValidationCompaction
 from sdcm.rest.compaction_manager_client import CompactionManagerClient
 from sdcm.rest.storage_service_client import StorageServiceClient
+from sdcm.sct_events.group_common_events import ignore_compaction_stopped_exceptions
+from sdcm.send_email import FunctionalEmailReporter
 from sdcm.tester import ClusterTester
 from sdcm.utils.common import ParallelObject
-from sdcm.utils.compaction_ops import CompactionOps
-
+from sdcm.utils.compaction_ops import CompactionOps, COMPACTION_TYPES
 LOGGER = logging.getLogger(__name__)
+
+
+def record_sub_test_result(func: Callable):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            func(*args, **kwargs)
+            return {kwargs["compaction_func"].__name__: ["SUCCESS"]}
+        except Exception as exc:  # pylint:disable=broad-except
+            LOGGER.error(exc)
+            return {kwargs["compaction_func"].__name__: ["FAILURE"]}
+    return wrapper
 
 
 class StopCompactionTest(ClusterTester):
@@ -37,6 +52,9 @@ class StopCompactionTest(ClusterTester):
         self.storage_service_client = StorageServiceClient(self.node)
         self.populate_data_parallel(size_in_gb=10, blocking=True)
         self.disable_autocompaction_on_all_nodes()
+        self.test_statuses = {}
+        self.email_reporter = FunctionalEmailReporter(email_recipients=self.params.get('email_recipients'),
+                                                      logdir=self.logdir)
 
     def disable_autocompaction_on_all_nodes(self):
         compaction_ops = CompactionOps(cluster=self.db_cluster)
@@ -67,6 +85,32 @@ class StopCompactionTest(ClusterTester):
         with self.subTest("Stop reshape on boot compaction test"):
             self.stop_reshape_compaction(reshape_on_boot=True)
 
+    def test_stop_compaction_ks_cf(self):
+        with ignore_compaction_stopped_exceptions():
+            with self.subTest("Stop SCRUB compaction on c-s keyspace and cf"):
+                compaction_ops = CompactionOps(cluster=self.db_cluster, node=self.node)
+                self._stop_compaction_on_ks_cf_base_scenario(
+                    compaction_func=compaction_ops.trigger_scrub_compaction,
+                    watcher_expression="Scrubbing in abort mode",
+                    compaction_type=COMPACTION_TYPES.SCRUB
+                )
+
+            with self.subTest("Stop CLEANUP compaction on c-s keyspace and cf"):
+                compaction_ops = CompactionOps(cluster=self.db_cluster, node=self.node)
+                self._stop_compaction_on_ks_cf_base_scenario(
+                    compaction_func=compaction_ops.trigger_cleanup_compaction,
+                    watcher_expression="Cleaning",
+                    compaction_type=COMPACTION_TYPES.CLEANUP
+                )
+
+            with self.subTest("Stop VALIDATE compaction on c-s keyspace and cf"):
+                compaction_ops = CompactionOps(cluster=self.db_cluster, node=self.node)
+                self._stop_compaction_on_ks_cf_base_scenario(
+                    compaction_func=compaction_ops.trigger_validation_compaction,
+                    watcher_expression="Scrubbing in validate mode",
+                    compaction_type=COMPACTION_TYPES.SCRUB
+                )
+
     def stop_major_compaction(self):
         """
         Test that we can stop a major compaction with <nodetool stop COMPACTION>.
@@ -78,7 +122,7 @@ class StopCompactionTest(ClusterTester):
         3. Assert that we found the line we were grepping for.
         """
         self._stop_compaction_base_test_scenario(
-            compaction_nemesis=StartStopMajorCompaction(
+            compaction_func=StartStopMajorCompaction(
                 tester_obj=self,
                 termination_event=self.db_cluster.nemesis_termination_event))
 
@@ -93,7 +137,7 @@ class StopCompactionTest(ClusterTester):
         3. Assert that we found the line we were grepping for.
         """
         self._stop_compaction_base_test_scenario(
-            compaction_nemesis=StartStopScrubCompaction(
+            compaction_func=StartStopScrubCompaction(
                 tester_obj=self,
                 termination_event=self.db_cluster.nemesis_termination_event))
 
@@ -108,7 +152,7 @@ class StopCompactionTest(ClusterTester):
         3. Assert that we found the line we were grepping for.
         """
         self._stop_compaction_base_test_scenario(
-            compaction_nemesis=StartStopCleanupCompaction(
+            compaction_func=StartStopCleanupCompaction(
                 tester_obj=self,
                 termination_event=self.db_cluster.nemesis_termination_event))
 
@@ -124,7 +168,7 @@ class StopCompactionTest(ClusterTester):
         3. Assert that we found the line we were grepping for.
         """
         self._stop_compaction_base_test_scenario(
-            compaction_nemesis=StartStopValidationCompaction(
+            compaction_func=StartStopValidationCompaction(
                 tester_obj=self,
                 termination_event=self.db_cluster.nemesis_termination_event))
 
@@ -247,12 +291,13 @@ class StopCompactionTest(ClusterTester):
         finally:
             self._grep_log_and_assert(node)
 
+    @record_sub_test_result
     def _stop_compaction_base_test_scenario(self,
-                                            compaction_nemesis):
+                                            compaction_func):
         try:
             self.wait_no_compactions_running()
-            compaction_nemesis.disrupt()
-            node = compaction_nemesis.target_node
+            compaction_func.disrupt()
+            node = compaction_func.target_node
             self._grep_log_and_assert(node)
         finally:
             node.running_nemesis = False
@@ -267,6 +312,44 @@ class StopCompactionTest(ClusterTester):
 
         self.assertTrue(found_grepped_expression, msg=f'Did not find the expected "{self.GREP_PATTERN}" '
                                                       f'expression in the logs.')
+
+    @record_sub_test_result
+    def _stop_compaction_on_ks_cf_base_scenario(self,
+                                                compaction_func: Callable,
+                                                watcher_expression: str,
+                                                compaction_type: str):
+        c_s_keyspace = "keyspace1"
+        c_s_cf = "standard1"
+        LOGGER.info("Running a start / stop compaction test for compaction type: %s", compaction_type)
+        self.wait_no_compactions_running()
+        compaction_ops = CompactionOps(cluster=self.db_cluster, node=self.node)
+        compaction_manager_client = CompactionManagerClient(self.node)
+        stop_func = partial(compaction_manager_client.stop_keyspace_compaction,
+                            keyspace=c_s_keyspace, compaction_type=compaction_type,
+                            tables=[c_s_cf])
+        timeout = 360
+        trigger_func = partial(compaction_func)
+        watch_func = partial(compaction_ops.stop_on_user_compaction_logged,
+                             node=self.node,
+                             watch_for=watcher_expression,
+                             timeout=timeout,
+                             stop_func=stop_func)
+
+        ParallelObject(objects=[trigger_func, watch_func], timeout=timeout).call_objects()
+        self._grep_log_and_assert(self.node)
+
+    def get_email_data(self):
+        self.log.info("Prepare data for email")
+        email_data = {}
+
+        try:
+            email_data = self._get_common_email_data()
+        except Exception as error:  # pylint: disable=broad-except
+            self.log.error("Error in gathering common email data: Error:\n%s", error)
+
+        email_data.update({"test_statuses": self.test_statuses,
+                           "scylla_ami_id": self.params.get("ami_id_db_scylla") or "-", })
+        return email_data
 
 
 class StopCompactionTestICS(ClusterTester):


### PR DESCRIPTION
This PR introduces a few changes to the `StopCompaction` test:

- new REST API command for stopping a compaction on a given ks / cf is added
- new tests are added to cover the above API changes (mirroring the previous tests for stopping compaction)
- email reporter is switched to `FunctionalTestReporter`
- a decorator is added to collect subtest results for the functional tests template
- previously created tests are also decorated with the new decorator

Trello task: https://trello.com/c/onlJj6Nm
Jenkins runs:
https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/maciej/job/mc-longevity/job/mc-byo-new-test/265
https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/maciej/job/mc-longevity/job/mc-byo-new-test/266


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
