### PR TITLE
feature(azure): add creation time to rg and vm's

### DIFF
--- a/sdcm/provision/azure/provisioner.py
+++ b/sdcm/provision/azure/provisioner.py
@@ -12,6 +12,7 @@
 # Copyright (c) 2022 ScyllaDB
 
 import logging
+from datetime import datetime
 from typing import Dict, List
 
 from azure.mgmt.compute.models import VirtualMachine, VirtualMachinePriorityTypes
@@ -157,12 +158,13 @@ class AzureProvisioner(Provisioner):  # pylint: disable=too-many-instance-attrib
         tags = v_m.tags.copy()
         ssh_user = tags.pop("ssh_user")
         ssh_key = tags.pop("ssh_key")
+        creation_time = datetime.fromisoformat(tags.pop("creation_time")) if 'creation_time' in tags else None
         image = str(v_m.storage_profile.image_reference)
         pricing_model = self._get_pricing_model(v_m)
 
         return VmInstance(name=v_m.name, region=v_m.location, user_name=ssh_user, ssh_key_name=ssh_key, public_ip_address=pub_address,
                           private_ip_address=priv_address, tags=tags, pricing_model=pricing_model,
-                          image=image, _provisioner=self)
+                          image=image, creation_time=creation_time, _provisioner=self)
 
     @staticmethod
     def _get_pricing_model(v_m: VirtualMachine) -> PricingModel:

--- a/sdcm/provision/azure/resource_group_provider.py
+++ b/sdcm/provision/azure/resource_group_provider.py
@@ -13,6 +13,7 @@
 
 import logging
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Optional
 
 from azure.core.exceptions import ResourceNotFoundError
@@ -49,7 +50,8 @@ class ResourceGroupProvider:
         resource_group = self._azure_service.resource.resource_groups.create_or_update(
             resource_group_name=self._name,
             parameters={
-                "location": self._region
+                "location": self._region,
+                "tags": {"creation_time": datetime.now().isoformat(sep=" ", timespec="seconds")}
             },
         )
         LOGGER.info("Provisioned resource group %s in the %s region", resource_group.name, resource_group.location)

--- a/sdcm/provision/azure/virtual_machine_provider.py
+++ b/sdcm/provision/azure/virtual_machine_provider.py
@@ -11,6 +11,7 @@
 #
 # Copyright (c) 2022 ScyllaDB
 import base64
+from datetime import datetime
 import logging
 import os
 from dataclasses import dataclass, field
@@ -60,7 +61,8 @@ class VirtualMachineProvider:
             LOGGER.info("Instance params: %s", definition)
             params = {
                 "location": self._region,
-                "tags": definition.tags | {"ssh_user": definition.user_name, "ssh_key": definition.ssh_key.name},
+                "tags": definition.tags | {"ssh_user": definition.user_name, "ssh_key": definition.ssh_key.name,
+                                           "creation_time": datetime.now().isoformat(sep=" ", timespec="seconds")},
                 "hardware_profile": {
                     "vm_size": definition.type,
                 },

--- a/sdcm/provision/provisioner.py
+++ b/sdcm/provision/provisioner.py
@@ -13,6 +13,7 @@
 
 from abc import ABC
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import Enum
 from typing import List, Dict
 
@@ -77,6 +78,7 @@ class VmInstance:  # pylint: disable=too-many-instance-attributes
     tags: Dict[str, str]
     pricing_model: PricingModel
     image: str
+    creation_time: datetime | None
     _provisioner: "Provisioner"
 
     def terminate(self, wait: bool = True) -> None:

--- a/unit_tests/lib/fake_provisioner.py
+++ b/unit_tests/lib/fake_provisioner.py
@@ -10,7 +10,7 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2022 ScyllaDB
-
+import datetime
 from typing import List, Dict
 
 from sdcm.provision.provisioner import Provisioner, VmInstance, InstanceDefinition, PricingModel
@@ -44,6 +44,7 @@ class FakeProvisioner(Provisioner):
                          private_ip_address='10.10.10.10', tags=definition.tags,
                          pricing_model=pricing_model,
                          image=definition.image_id,
+                         creation_time=datetime.datetime.now(),
                          _provisioner=self)
         self._instances[definition.name] = v_m
         return v_m

--- a/unit_tests/provisioner/test_provisioner.py
+++ b/unit_tests/provisioner/test_provisioner.py
@@ -12,6 +12,7 @@
 # Copyright (c) 2022 ScyllaDB
 # pylint: disable=redefined-outer-name
 import uuid
+from datetime import datetime
 
 import pytest
 
@@ -88,6 +89,7 @@ def provisioner(backend, provisioner_params):
 
 
 def test_can_provision_scylla_vm(region, definition, provisioner, backend, provisioner_params):
+    creation_time = datetime.now().replace(microsecond=0)
     v_m = provisioner.get_or_create_instances(definitions=[definition])[0]
     assert v_m.name == definition.name
     assert v_m.region == region
@@ -95,6 +97,7 @@ def test_can_provision_scylla_vm(region, definition, provisioner, backend, provi
     assert v_m.public_ip_address
     assert v_m.private_ip_address
     assert v_m.tags == definition.tags
+    assert v_m.creation_time >= creation_time
 
     assert v_m == provisioner.list_instances()[0]
 


### PR DESCRIPTION
Azure does not provide a way of retrieving creation time of resources.
We often need to see when were created, including list-resources
command.

This commit adds `creation_time` tag to VM's and RG's on Azure. Extended
also `VmInstance` class with this information for `list-resources` use.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
