### PR TITLE
fix(snitch test): Specified the datacenter regions in the jenkinsfile

### DIFF
--- a/jenkins-pipelines/features-google-cloud-snitch-mutli-dc.jenkinsfile
+++ b/jenkins-pipelines/features-google-cloud-snitch-mutli-dc.jenkinsfile
@@ -5,6 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 longevityPipeline(
     backend: 'gce',
+    gce_datacenter: '''["us-east1", "us-west1"]''',
     test_name: 'snitch_test.SnitchTest.test_cloud_snitch',
     test_config: 'test-cases/features/google-cloud-snitch-multi-dc.yaml'
 )


### PR DESCRIPTION
Without specifing the datacenters in the jenkinsfile, when the job is triggered
the value used for gce_datacenter is the default in the pipeline, which is not a one fitting
for this test

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
