### PR TITLE
fix(log-collection): fix dmesg log collection

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -797,7 +797,7 @@ class ScyllaLogCollector(LogCollector):
                     CommandLog(name='io-properties.yaml',
                                command='cat /etc/scylla.d/io_properties.yaml'),
                     CommandLog(name='dmesg.log',
-                               command='dmesg -P'),
+                               command='sudo dmesg -P'),
                     CommandLog(name='kallsyms',
                                command='sudo cat /proc/kallsyms'),
                     CommandLog(name='systemctl.status',


### PR DESCRIPTION
It looks that `dmesg -P` command used requires sudo permissions.

This commit adds `sudo` prefix for `dmesg` command in logcollector.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
