### PR TITLE
feature(azure): use new Ls generation instance for 10gb test

### DIFF
--- a/test-cases/longevity/longevity-10gb-3h.yaml
+++ b/test-cases/longevity/longevity-10gb-3h.yaml
@@ -9,7 +9,7 @@ n_monitor_nodes: 1
 instance_type_db: 'i3.4xlarge'
 gce_instance_type_db: 'n1-highmem-16'
 gce_instance_type_loader: 'e2-standard-4'
-azure_instance_type_db: 'Standard_L8s_v2'
+azure_instance_type_db: 'Standard_L8s_v3'
 run_fullscan: '{"ks_cf": "keyspace1.standard1", "interval": 5}' # 'ks.cf|random, interval(min)'
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '111'


### PR DESCRIPTION
Due low quota limit we cannot use stronger machines on Azure in
longevity-10gb-3h test. Currently we use equivalent of i3.2xlarge, while
aws test uses i3.4xlarge.

To reduce load, which now hits 80-100% most of the test time, lets try
using new generation of Ls machines and make Azure test a bit easier.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
