### PR TITLE
fix(SSHScyllaSystemdLogger): install python3 to remove if needed

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4164,6 +4164,10 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             node.remoter.sudo('systemctl disable iptables', ignore_status=True)
             node.remoter.sudo('systemctl stop firewalld', ignore_status=True)
             node.remoter.sudo('systemctl disable firewalld', ignore_status=True)
+
+        if self.params.get('logs_transport') == 'ssh':
+            node.install_package('python3')
+
         node.update_repo_cache()
 
         install_scylla = True


### PR DESCRIPTION
seem like on some distro we don't have python3 installed by
default anymore, so we need to make sure we installed it
before we start using it for the logger.

we would be able to remove this once we user cloud-init
configuration across the board, and we'll be able to make sure
this package is installed there.

Fix: #5043

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
