### PR TITLE
feature(longevity_pipeline): allow any sct test customization

### DIFF
--- a/vars/getJobTimeouts.groovy
+++ b/vars/getJobTimeouts.groovy
@@ -7,6 +7,7 @@ List<Integer> call(Map params, String region){
     #!/bin/bash
     export SCT_CLUSTER_BACKEND="${params.backend}"
     export SCT_CONFIG_FILES=${test_config}
+    ${params.config_customization_script ? params.config_customization_script: ''}
     ./docker/env/hydra.sh output-conf -b "${params.backend}"
     """
     def testData = sh(script: cmd, returnStdout: true).trim()

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -127,6 +127,11 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('gce_project', '')}",
                description: 'Gce project to use',
                name: 'gce_project')
+
+            string(defaultValue: "${pipelineParams.get('config_customization_script', '')}",
+               description: """Script that will be executed before running each phase. Used to modify sct configuration. E.g:
+               export SCT_INSTANCE_TYPE_DB=i3.4xlarge""",
+               name: 'config_customization_script')
         }
         options {
             timestamps()

--- a/vars/provisionResources.groovy
+++ b/vars/provisionResources.groovy
@@ -132,7 +132,7 @@ def call(Map params, String region){
     if [[ -n "${params.pytest_addopts ? params.pytest_addopts : ''}" ]] ; then
         export PYTEST_ADDOPTS="${params.pytest_addopts}"
     fi
-
+    ${params.config_customization_script ? params.config_customization_script: ''}
     echo "Starting to resource provision ..."
     RUNNER_IP=\$(cat sct_runner_ip||echo "")
     if [[ -n "\${RUNNER_IP}" ]] ; then

--- a/vars/runCleanupResource.groovy
+++ b/vars/runCleanupResource.groovy
@@ -39,6 +39,7 @@ def call(Map params, String region){
     if [[ -n "${params.post_behavior_k8s_cluster ? params.post_behavior_k8s_cluster : ''}" ]] ; then
         export SCT_POST_BEHAVIOR_K8S_CLUSTER="${params.post_behavior_k8s_cluster}"
     fi
+    ${params.config_customization_script ? params.config_customization_script: ''}
 
     echo "Starting to clean resources ..."
     RUNNER_IP=\$(cat sct_runner_ip||echo "")

--- a/vars/runCollectLogs.groovy
+++ b/vars/runCollectLogs.groovy
@@ -25,6 +25,7 @@ def call(Map params, String region){
         export SCT_AZURE_REGION_NAME=${params.azure_region_name}
     fi
     export SCT_CONFIG_FILES=${test_config}
+    ${params.config_customization_script ? params.config_customization_script: ''}
 
     echo "start collect logs ..."
     RUNNER_IP=\$(cat sct_runner_ip||echo "")

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -155,6 +155,7 @@ def call(Map params, String region, functional_test = false, Map pipelineParams 
     if [[ -n "${params.pytest_addopts ? params.pytest_addopts : ''}" ]] ; then
         export PYTEST_ADDOPTS="${params.pytest_addopts}"
     fi
+    ${params.config_customization_script ? params.config_customization_script: ''}
 
     echo "start test ......."
     RUNNER_IP=\$(cat sct_runner_ip||echo "")


### PR DESCRIPTION
Sometimes we need to customize some sct configuration parameter which is
not exposed by pipeline parameters.

This commit adds possibility to customize any sct parameter by running
bash script before sct runs the test. Script is defined in
`config_customization_script` parameter.

E.g. user might define different instance type for db by setting
`config_customization_script` param to:
`export SCT_INSTANCE_TYPE_DB=i3.4xlarge`

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
