### PR TITLE
fix(azure-list-images): fix scylla master latest images list

### DIFF
--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -69,6 +69,7 @@ SEMVER_REGEX = re.compile(
 )
 
 SCYLLA_VERSION_RE = re.compile(r"\d+(\.\d+)?\.[\d\w]+([.~][\d\w]+)?")
+SCYLLA_VERSION_GROUPED_RE = re.compile(r'(?P<version>[\w.~]+)-0?\.?(?P<date>[\d]+)\.(?P<commit_id>\w+)')
 SSTABLE_FORMAT_VERSION_REGEX = re.compile(r'Feature (.*)_SSTABLE_FORMAT is enabled')
 PRIMARY_XML_GZ_REGEX = re.compile(r'="(.*?primary.xml.gz)"')
 

--- a/unit_tests/provisioner/test_azure_get_scylla_images.py
+++ b/unit_tests/provisioner/test_azure_get_scylla_images.py
@@ -1,0 +1,63 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2022 ScyllaDB
+# pylint: disable=redefined-outer-name
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from sdcm.provision.azure.utils import get_scylla_images
+from sdcm.utils.azure_utils import AzureService
+from unit_tests.provisioner.fake_azure_service import FakeAzureService
+
+
+@pytest.fixture
+def azure_service():  # pytest: disable=redefined-outer-name
+    return FakeAzureService(Path(__file__).parent / "test_data")
+
+
+def test_can_get_scylla_images_based_on_branch(azure_service):
+    images = get_scylla_images("master:latest", "eastus", azure_service=azure_service)
+    assert images[0].name == "ScyllaDB-2022.1.rc9-0.20220721.9c95c3a8c-1-build-11"
+    assert len(images) == 1
+
+
+def test_can_get_scylla_images_based_on_scylla_version(azure_service):
+    images = get_scylla_images("4.6.4", "eastus", azure_service=azure_service)
+    assert images[0].name == "ScyllaDB-4.6.4-0.20220516.11f008e8f-1-build-27"
+    assert len(images) == 2
+
+
+def test_can_get_scylla_images_based_on_revision_id(azure_service):
+    images = get_scylla_images("11f008e8f<ignored>", "eastus", azure_service=azure_service)
+    assert len(images) == 1
+    assert images[0].name == "ScyllaDB-4.6.4-0.20220516.11f008e8f-1-build-27"
+
+
+def test_unparsable_scylla_versions_are_logged(azure_service, caplog):
+    with caplog.at_level(logging.WARNING):
+        get_scylla_images("unparsable:latest", "eastus", azure_service=azure_service)
+    assert "Couldn't parse scylla version from images: ['ScyllaDB-5.-98ad.1.dev_0']" in caplog.text
+
+
+def generate_images_json_file():
+    """generates azure_images_list.json based on real Azure images for unit tests purposes. """
+    resource_group = "SCYLLA-IMAGES"
+    images = AzureService().compute.images.list_by_resource_group(
+        resource_group_name=resource_group,
+    )
+    with open(Path(__file__).parent / "test_data" / resource_group / "azure_images_list.json", "w", encoding="utf-8") as images_file:
+        serialized_images = [image.serialize() | {"name": image.name} for image in images]
+        images_file.write(json.dumps(serialized_images, indent=2))

--- a/unit_tests/provisioner/test_data/SCYLLA-IMAGES/azure_images_list.json
+++ b/unit_tests/provisioner/test_data/SCYLLA-IMAGES/azure_images_list.json
@@ -1,0 +1,306 @@
+[
+  {
+    "location": "eastus",
+    "tags": {
+      "ScyllaJMXVersion": "2022.1~rc9-0.20220721.9c95c3a8c-1",
+      "ScyllaMachineImageVersion": "2022.1~rc9-20220721.6898190db82-1",
+      "ScyllaPython3Version": "2022.1~rc9-0.20220721.9c95c3a8c-1",
+      "ScyllaToolsVersion": "2022.1~rc9-0.20220721.9c95c3a8c-1",
+      "ScyllaVersion": "2022.1.rc9-0.20220721.9c95c3a8c-1",
+      "arch": "x86_64",
+      "branch": "master",
+      "build_id": "11",
+      "build_tag": "",
+      "operating_system": "ubuntu20.04",
+      "scylla_build_sha_id": "",
+      "user_data_format_version": "2"
+    },
+    "properties": {
+      "sourceVirtualMachine": {
+        "id": "/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/pkr-Resource-Group-sbovs864k6/providers/Microsoft.Compute/virtualMachines/pkrvmsbovs864k6"
+      },
+      "storageProfile": {
+        "osDisk": {
+          "managedDisk": {
+            "id": "/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/pkr-Resource-Group-sbovs864k6/providers/Microsoft.Compute/disks/pkrossbovs864k6"
+          },
+          "caching": "ReadWrite",
+          "diskSizeGB": 30,
+          "storageAccountType": "Standard_LRS",
+          "osType": "Linux",
+          "osState": "Generalized"
+        },
+        "dataDisks": [],
+        "zoneResilient": false
+      },
+      "hyperVGeneration": "V2"
+    },
+    "name": "ScyllaDB-2022.1.rc9-0.20220721.9c95c3a8c-1-build-11"
+  },
+  {
+    "location": "eastus",
+    "tags": {
+      "ScyllaJMXVersion": "4.6.4-0.20220718.b60f14601-1",
+      "ScyllaMachineImageVersion": "4.6.4-20220718.e7fe58c3aca-1",
+      "ScyllaPython3Version": "4.6.4-0.20220718.b60f14601-1",
+      "ScyllaToolsVersion": "4.6.4-0.20220718.b60f14601-1",
+      "ScyllaVersion": "4.6.4-0.20220718.b60f14601-1",
+      "arch": "x86_64",
+      "branch": "master",
+      "build_id": "28",
+      "build_tag": "",
+      "operating_system": "ubuntu20.04",
+      "scylla_build_sha_id": "",
+      "user_data_format_version": "2"
+    },
+    "properties": {
+      "sourceVirtualMachine": {
+        "id": "/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/pkr-Resource-Group-ej97l1yry3/providers/Microsoft.Compute/virtualMachines/pkrvmej97l1yry3"
+      },
+      "storageProfile": {
+        "osDisk": {
+          "managedDisk": {
+            "id": "/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/pkr-Resource-Group-ej97l1yry3/providers/Microsoft.Compute/disks/pkrosej97l1yry3"
+          },
+          "caching": "ReadWrite",
+          "diskSizeGB": 30,
+          "storageAccountType": "Standard_LRS",
+          "osType": "Linux",
+          "osState": "Generalized"
+        },
+        "dataDisks": [],
+        "zoneResilient": false
+      },
+      "hyperVGeneration": "V2"
+    },
+    "name": "ScyllaDB-4.6.4-0.20220718.b60f14601-1-build-28"
+  },
+  {
+    "location": "eastus",
+    "tags": {
+      "ScyllaJMXVersion": "4.6.5-0.20220719.2ec293ab0-1",
+      "ScyllaMachineImageVersion": "4.6.5-20220720.88bfd85ee19-1",
+      "ScyllaPython3Version": "4.6.5-0.20220719.2ec293ab0-1",
+      "ScyllaToolsVersion": "4.6.5-0.20220719.2ec293ab0-1",
+      "ScyllaVersion": "4.6.5-0.20220719.2ec293ab0-1",
+      "arch": "x86_64",
+      "branch": "master",
+      "build_id": "30",
+      "build_tag": "",
+      "operating_system": "ubuntu20.04",
+      "scylla_build_sha_id": "",
+      "user_data_format_version": "2"
+    },
+    "properties": {
+      "sourceVirtualMachine": {
+        "id": "/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/pkr-Resource-Group-oru0no79m4/providers/Microsoft.Compute/virtualMachines/pkrvmoru0no79m4"
+      },
+      "storageProfile": {
+        "osDisk": {
+          "managedDisk": {
+            "id": "/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/pkr-Resource-Group-oru0no79m4/providers/Microsoft.Compute/disks/pkrosoru0no79m4"
+          },
+          "caching": "ReadWrite",
+          "diskSizeGB": 30,
+          "storageAccountType": "Standard_LRS",
+          "osType": "Linux",
+          "osState": "Generalized"
+        },
+        "dataDisks": [],
+        "zoneResilient": false
+      },
+      "hyperVGeneration": "V2"
+    },
+    "name": "ScyllaDB-4.6.5-0.20220719.2ec293ab0-1-build-30"
+  },
+  {
+    "location": "eastus",
+    "tags": {
+      "ScyllaJMXVersion": "2022.2.dev-0.20220328.eef4cbb20a51-1",
+      "ScyllaMachineImageVersion": "2021.2.dev-20220329.61e74fd-1",
+      "ScyllaPython3Version": "2022.2.dev-0.20220328.eef4cbb20a51-1",
+      "ScyllaToolsVersion": "2022.2.dev-0.20220328.eef4cbb20a51-1",
+      "ScyllaVersion": "2022.2.dev-0.20220328.eef4cbb20a51-1",
+      "arch": "x86_64",
+      "branch": "master",
+      "build_id": "2",
+      "build_tag": "",
+      "operating_system": "ubuntu20.04",
+      "scylla_build_sha_id": "",
+      "user_data_format_version": "2"
+    },
+    "properties": {
+      "sourceVirtualMachine": {
+        "id": "/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/pkr-Resource-Group-ppnpyr0zf3/providers/Microsoft.Compute/virtualMachines/pkrvmppnpyr0zf3"
+      },
+      "storageProfile": {
+        "osDisk": {
+          "managedDisk": {
+            "id": "/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/pkr-Resource-Group-ppnpyr0zf3/providers/Microsoft.Compute/disks/pkrosppnpyr0zf3"
+          },
+          "caching": "ReadWrite",
+          "diskSizeGB": 30,
+          "storageAccountType": "Standard_LRS",
+          "osType": "Linux",
+          "osState": "Generalized"
+        },
+        "dataDisks": [],
+        "zoneResilient": false
+      },
+      "hyperVGeneration": "V2"
+    },
+    "name": "ScyllaDB-2022.2.dev-0.20220328.eef4cbb20a51-1-build-2"
+  },
+  {
+    "location": "eastus",
+    "tags": {
+      "ScyllaJMXVersion": "4.6.4-0.20220516.11f008e8f-1",
+      "ScyllaMachineImageVersion": "4.6.4-20220517.e7fe58c-1",
+      "ScyllaPython3Version": "4.6.4-0.20220516.11f008e8f-1",
+      "ScyllaToolsVersion": "4.6.4-0.20220516.11f008e8f-1",
+      "ScyllaVersion": "4.6.4-0.20220516.11f008e8f-1",
+      "arch": "x86_64",
+      "branch": "master",
+      "build_id": "27",
+      "build_tag": "",
+      "operating_system": "ubuntu20.04",
+      "scylla_build_sha_id": "",
+      "user_data_format_version": "2"
+    },
+    "properties": {
+      "sourceVirtualMachine": {
+        "id": "/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/pkr-Resource-Group-rkmyrhd79q/providers/Microsoft.Compute/virtualMachines/pkrvmrkmyrhd79q"
+      },
+      "storageProfile": {
+        "osDisk": {
+          "managedDisk": {
+            "id": "/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/pkr-Resource-Group-rkmyrhd79q/providers/Microsoft.Compute/disks/pkrosrkmyrhd79q"
+          },
+          "caching": "ReadWrite",
+          "diskSizeGB": 30,
+          "storageAccountType": "Standard_LRS",
+          "osType": "Linux",
+          "osState": "Generalized"
+        },
+        "dataDisks": [],
+        "zoneResilient": false
+      },
+      "hyperVGeneration": "V2"
+    },
+    "name": "ScyllaDB-4.6.4-0.20220516.11f008e8f-1-build-27"
+  },
+  {
+    "location": "eastus",
+    "tags": {
+      "ScyllaJMXVersion": "5.1.dev-0.20220531.e85bd37c6e5c-1",
+      "ScyllaMachineImageVersion": "5.1.dev-20220531.90340275b80-1",
+      "ScyllaPython3Version": "5.1.dev-0.20220531.e85bd37c6e5c-1",
+      "ScyllaToolsVersion": "5.1.dev-0.20220531.e85bd37c6e5c-1",
+      "ScyllaVersion": "5.1.dev-0.20220531.e85bd37c6e5c-1",
+      "arch": "x86_64",
+      "branch": "",
+      "build_id": "154",
+      "build_tag": "",
+      "operating_system": "ubuntu20.04",
+      "scylla_build_sha_id": "",
+      "user_data_format_version": "2"
+    },
+    "properties": {
+      "sourceVirtualMachine": {
+        "id": "/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/pkr-Resource-Group-41k5855hg9/providers/Microsoft.Compute/virtualMachines/pkrvm41k5855hg9"
+      },
+      "storageProfile": {
+        "osDisk": {
+          "managedDisk": {
+            "id": "/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/pkr-Resource-Group-41k5855hg9/providers/Microsoft.Compute/disks/pkros41k5855hg9"
+          },
+          "caching": "ReadWrite",
+          "diskSizeGB": 30,
+          "storageAccountType": "Standard_LRS",
+          "osType": "Linux",
+          "osState": "Generalized"
+        },
+        "dataDisks": [],
+        "zoneResilient": false
+      },
+      "hyperVGeneration": "V2"
+    },
+    "name": "ScyllaDB-5.1.dev-0.20220531.e85bd37c6e5c-1-build-154"
+  },
+  {
+    "location": "eastus",
+    "tags": {
+      "ScyllaJMXVersion": "5.1.dev-0.20220601.adda43edc75b-1",
+      "ScyllaMachineImageVersion": "5.1.dev-20220601.90340275b80-1",
+      "ScyllaPython3Version": "5.1.dev-0.20220601.adda43edc75b-1",
+      "ScyllaToolsVersion": "5.1.dev-0.20220601.adda43edc75b-1",
+      "ScyllaVersion": "5.1.dev-0.20220601.adda43edc75b-1",
+      "arch": "x86_64",
+      "branch": "",
+      "build_id": "155",
+      "build_tag": "",
+      "operating_system": "ubuntu20.04",
+      "scylla_build_sha_id": "",
+      "user_data_format_version": "2"
+    },
+    "properties": {
+      "sourceVirtualMachine": {
+        "id": "/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/pkr-Resource-Group-992pburkvj/providers/Microsoft.Compute/virtualMachines/pkrvm992pburkvj"
+      },
+      "storageProfile": {
+        "osDisk": {
+          "managedDisk": {
+            "id": "/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/pkr-Resource-Group-992pburkvj/providers/Microsoft.Compute/disks/pkros992pburkvj"
+          },
+          "caching": "ReadWrite",
+          "diskSizeGB": 30,
+          "storageAccountType": "Standard_LRS",
+          "osType": "Linux",
+          "osState": "Generalized"
+        },
+        "dataDisks": [],
+        "zoneResilient": false
+      },
+      "hyperVGeneration": "V2"
+    },
+    "name": "ScyllaDB-5.1.dev-0.20220601.adda43edc75b-1-build-155"
+  },
+   {
+    "location": "eastus",
+    "tags": {
+      "ScyllaJMXVersion": "ScyllaDB-5.1.dev0",
+      "ScyllaMachineImageVersion": "ScyllaDB-5.1.dev0",
+      "ScyllaPython3Version": "ScyllaDB-5.1.dev0",
+      "ScyllaToolsVersion": "ScyllaDB-5.1.dev0",
+      "ScyllaVersion": "ScyllaDB-5.1.dev0",
+      "arch": "x86_64",
+      "branch": "unparsable",
+      "build_id": "155",
+      "build_tag": "",
+      "operating_system": "ubuntu20.04",
+      "scylla_build_sha_id": "",
+      "user_data_format_version": "2"
+    },
+    "properties": {
+      "sourceVirtualMachine": {
+        "id": "/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/pkr-Resource-Group-992pburkvj/providers/Microsoft.Compute/virtualMachines/pkrvm992pburkvj"
+      },
+      "storageProfile": {
+        "osDisk": {
+          "managedDisk": {
+            "id": "/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/pkr-Resource-Group-992pburkvj/providers/Microsoft.Compute/disks/pkros992pburkvj"
+          },
+          "caching": "ReadWrite",
+          "diskSizeGB": 30,
+          "storageAccountType": "Standard_LRS",
+          "osType": "Linux",
+          "osState": "Generalized"
+        },
+        "dataDisks": [],
+        "zoneResilient": false
+      },
+      "hyperVGeneration": "V2"
+    },
+    "name": "ScyllaDB-5.-98ad.1.dev_0"
+  }
+]

--- a/unit_tests/test_version_utils.py
+++ b/unit_tests/test_version_utils.py
@@ -19,6 +19,7 @@ from sdcm.utils.version_utils import (
     scylla_versions,
     assume_version,
     VERSION_NOT_FOUND_ERROR,
+    SCYLLA_VERSION_GROUPED_RE,
     get_specific_tag_of_docker_image,
 )
 
@@ -372,3 +373,18 @@ def test_scylla_versions_decorator_negative_latest_scylla_no_attr():
 @pytest.mark.parametrize('docker_repo', ['scylladb/scylla-nightly', 'scylladb/scylla', 'scylladb/scylla-enterprise'])
 def test_get_specific_tag_of_docker_image(docker_repo):
     assert get_specific_tag_of_docker_image(docker_repo=docker_repo) != 'latest'
+
+
+@pytest.mark.parametrize("full_version,version,date,commit_id", (
+    ("5.1.dev-0.20220713.15ed0a441e18", "5.1.dev", "20220713", "15ed0a441e18"),
+    ("5.0.1-20220719.b177dacd3", "5.0.1", "20220719", "b177dacd3"),
+    ("5.0.1-20220719.b177dacd3 with build-id 217f31634f8c8722cadcfe57ade8da58af05d415", "5.0.1", "20220719", "b177dacd3"),
+    ("2022.1~rc5-20220515.6a1e89fbb", "2022.1~rc5", "20220515", "6a1e89fbb"),
+    ("2022.2.dev-20220715.6fd8d82112e1", "2022.2.dev", "20220715", "6fd8d82112e1"),
+    ("4.6.rc2-20220102.e8a1cfb6f", "4.6.rc2", "20220102", "e8a1cfb6f")
+))
+def test_scylla_version_grouped_regexp(full_version, version, date, commit_id):
+    parsed_version = SCYLLA_VERSION_GROUPED_RE.match(full_version)
+    assert parsed_version.group("version") == version
+    assert parsed_version.group("date") == date
+    assert parsed_version.group("commit_id") == commit_id


### PR DESCRIPTION
Due changes in Scylla build jobs, ordering by build-id is not working
correctly.

This commit fixes ordering by sorting by build date (and build id when
date is the same) taken from ScyllaVersion tag.

fixes: #5041

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
