### PR TITLE
refactor(azure config): Changed backup backend to azure instead of s3

### DIFF
--- a/defaults/azure_config.yaml
+++ b/defaults/azure_config.yaml
@@ -30,7 +30,7 @@ ami_id_db_oracle: ''
 
 use_preinstalled_scylla: true
 
-backup_bucket_backend: 's3'
+backup_bucket_backend: 'azure'
 backup_bucket_location: 'manager-backup-tests-us-east-1'
 backup_bucket_region: 'us-east-1'
 


### PR DESCRIPTION
Since in real azure clusters customers will most likely use azure as the backup backend
as well, our scenarios should match it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
