### PR TITLE
fix(rollingUpgrade): gce_image_db use_preinstalled_scylla can be null

### DIFF
--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -192,14 +192,15 @@ def call(Map pipelineParams) {
                                                             if [[ -n "${params.post_behavior_k8s_cluster ? params.post_behavior_k8s_cluster : ''}" ]] ; then
                                                                 export SCT_POST_BEHAVIOR_K8S_CLUSTER="${params.post_behavior_k8s_cluster}"
                                                             fi
-
-                                                            if [[ -n "${params.use_preinstalled_scylla ? params.use_preinstalled_scylla : false}" ]] ; then
-                                                                export SCT_USE_PREINSTALLED_SCYLLA="${params.use_preinstalled_scylla}"
+                                                            if [[ ${pipelineParams.use_preinstalled_scylla} != null ]] ; then
+                                                                export SCT_USE_PREINSTALLED_SCYLLA="${pipelineParams.use_preinstalled_scylla}"
                                                             fi
                                                             export SCT_INSTANCE_PROVISION="${params.provision_type}"
                                                             export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$GIT_BRANCH | sed -E 's+(origin/|origin/branch-)++')
                                                             export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$SCT_AMI_ID_DB_SCYLLA_DESC | tr ._ - | cut -c1-8 )
-                                                            export SCT_GCE_IMAGE_DB=${pipelineParams.gce_image_db}
+                                                            if [[ ${pipelineParams.gce_image_db} != null ]] ; then
+                                                                export SCT_GCE_IMAGE_DB=${pipelineParams.gce_image_db}
+                                                            fi
                                                             export SCT_SCYLLA_LINUX_DISTRO=${pipelineParams.linux_distro}
                                                             export SCT_AMI_ID_DB_SCYLLA_DESC="\$SCT_AMI_ID_DB_SCYLLA_DESC-\$SCT_SCYLLA_LINUX_DISTRO"
 


### PR DESCRIPTION
Since either of those params can be null in a rolling upgrade run,
the pipeline must be prepared to ignore either of them if their value is
indeed 'null'.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
### if #5019 is backported, this pr should backported as well
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
