### PR TITLE
fix(upgrade): fix base version for 2022.1

### DIFF
--- a/unit_tests/test_base_version.py
+++ b/unit_tests/test_base_version.py
@@ -76,7 +76,7 @@ class TestBaseVersion(unittest.TestCase):
             'unstable/scylla-enterprise/enterprise-2022.1/deb/unified/2022-06-03T00:22:55Z/scylladb-2022.1/scylla.list'
         linux_distro = 'centos-8'
         version_list = general_test(scylla_repo, linux_distro)
-        self.assertEqual(['4.6', '2021.1'], version_list)
+        self.assertEqual(['5.0', '2021.1'], version_list)
 
 
 if __name__ == "__main__":

--- a/utils/get_supported_scylla_base_versions.py
+++ b/utils/get_supported_scylla_base_versions.py
@@ -15,7 +15,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 # We support to migrate from specific OSS version to enterprise
-supported_src_oss = {'2022.1': '4.6', '2021.1': '4.3', '2020.1': '4.0', '2019.1': '3.0'}
+supported_src_oss = {'2022.1': '5.0', '2021.1': '4.3', '2020.1': '4.0', '2019.1': '3.0'}
 # If new support distro shared repo with others, we need to assign the start support versions. eg: centos8
 start_support_versions = {'centos-8': {'scylla': '4.1', 'enterprise': '2021.1'}}
 


### PR DESCRIPTION
It was decided to use 5.0 as a base version for rolling-upgrade test for
2022.1 instead of 4.6:
https://github.com/scylladb/scylla-enterprise-machine-image/issues/50

This commit adapts upgrade test to this decision.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
