### PR TITLE
improvement(latency during ops): report colors

### DIFF
--- a/sdcm/report_templates/results_latency_during_ops_short.html
+++ b/sdcm/report_templates/results_latency_during_ops_short.html
@@ -55,10 +55,16 @@
                         {% set lat_type_list = ['c-s P99'] %}
 
                         {% for lat_type in lat_type_list|sort %}
-                                {% if 'color' in results and lat_type in results['color'] and results['color'][lat_type] == 'red' %}
-                                    <tr style ="background-color: red">
+                                {% if 'color' in results and lat_type in results['color'] %}
+                                    {% if results['color'][lat_type] == 'red' %}
+                                        <tr style ="background-color: red">
+                                    {% elif results['color'][lat_type] == 'yellow' %}
+                                        <tr style ="background-color: yellow">
+                                    {% else %}
+                                        <tr>
+                                    {% endif %}
                                 {% else %}
-                                       <tr>
+                                    <tr>
                                 {% endif %}
                                     <td> current build </td>
                                     <td>{{ lat_type }}</td>

--- a/sdcm/utils/latency.py
+++ b/sdcm/utils/latency.py
@@ -115,8 +115,10 @@ def calculate_latency(latency_results):
                         float(format((average - steady_val), '.2f'))
                 if 'color' not in result_dict[key]:
                     result_dict[key]['color'] = {}
-                if average >= 3 * steady_val:  # right now it is only a 10% difference, to test if it works
+                if average - steady_val >= 10:
                     result_dict[key]['color'][temp_key] = 'red'
+                elif average - steady_val >= 5:
+                    result_dict[key]['color'][temp_key] = 'yellow'
                 else:
                     result_dict[key]['color'][temp_key] = 'blue'
 


### PR DESCRIPTION
we were requested to improve the report, but improving
the colors of the lines, when the difference between
steady state and the avg cycle will be bigger than
10ms it will be marked in red, else, if it will be
bigger than 5ms it will be marked as yellow, and
in any other case, it will not be colored.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
