### PR TITLE
fix(version_utils): make semver transformation function be safer

### DIFF
--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -420,9 +420,10 @@ def transform_non_semver_scylla_version_to_semver(scylla_version: str):
     if SEMVER_REGEX.match(scylla_version):
         return scylla_version
     version_parts = scylla_version.split(".")
-    new_scylla_version = f"{version_parts[0]}.{version_parts[1]}.0-{'.'.join(version_parts[2:])}"
-    if SEMVER_REGEX.match(new_scylla_version):
-        return new_scylla_version
+    if len(version_parts) > 2:
+        new_scylla_version = f"{version_parts[0]}.{version_parts[1]}.0-{'.'.join(version_parts[2:])}"
+        if SEMVER_REGEX.match(new_scylla_version):
+            return new_scylla_version
     raise ValueError("Cannot transform '%s' to semver-like string" % scylla_version)
 
 


### PR DESCRIPTION
If we call `transform_non_semver_scylla_version_to_semver` function
with `latest` tag then we get following error:

    new_scylla_version = f"{version_parts[0]}.{version_parts[1]}.0-{'.'.join(version_parts[2:])}"
    IndexError: list index out of range

So, make it be safer by checking the length of the `version_parts` var

The improper behavior was introduced here: https://github.com/scylladb/scylla-cluster-tests/pull/4746

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
