### PR TITLE
fix(_run_stress_in_batches): treat stress_cmd as a list or a string

### DIFF
--- a/longevity_test.py
+++ b/longevity_test.py
@@ -410,7 +410,10 @@ class LongevityTest(ClusterTester):
         for batch in range(0, num_of_batches):
             for i in range(1 + batch * batch_size, (batch + 1) * batch_size + 1):
                 keyspace_name = self._get_keyspace_name(i)
-                self._run_all_stress_cmds(stress_queue, params={'stress_cmd': stress_cmd + self.all_node_ips_for_stress_command,
+                if not isinstance(stress_cmd, list):
+                    stress_cmd = [stress_cmd]
+                stress_cmds_with_all_ips = [cmd + self.all_node_ips_for_stress_command for cmd in stress_cmd]
+                self._run_all_stress_cmds(stress_queue, params={'stress_cmd': stress_cmds_with_all_ips,
                                                                 'keyspace_name': keyspace_name, 'round_robin': True})
             for stress in stress_queue:
                 self.verify_stress_thread(cs_thread_pool=stress)


### PR DESCRIPTION
Before, stress_cmd was treated as a string, when in reality it could be either a string or a list.
I modified the method to be able to handle stress_cmd whether it's a list or a string.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
