### PR TITLE
fix(rolling upgrade): ignored all 'abort requested' messages

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -164,6 +164,12 @@ def ignore_ycsb_connection_refused():
 
 
 @contextmanager
+def ignore_abort_requested_errors():
+    with DbEventsFilter(db_event=DatabaseLogEvent.RUNTIME_ERROR, line="abort requested"):
+        yield
+
+
+@contextmanager
 def ignore_scrub_invalid_errors():
     with ExitStack() as stack:
         stack.enter_context(DbEventsFilter(

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -33,7 +33,8 @@ from sdcm.stress_thread import CassandraStressThread
 from sdcm.utils.version_utils import is_enterprise, get_node_supported_sstable_versions
 from sdcm.sct_events.system import InfoEvent
 from sdcm.sct_events.database import IndexSpecialColumnErrorEvent
-from sdcm.sct_events.group_common_events import ignore_upgrade_schema_errors, ignore_ycsb_connection_refused
+from sdcm.sct_events.group_common_events import ignore_upgrade_schema_errors, ignore_ycsb_connection_refused, \
+    ignore_abort_requested_errors, decorate_with_context
 
 
 def truncate_entries(func):
@@ -148,6 +149,8 @@ class UpgradeTest(FillDatabaseData):
                                 msg='Expected truncated entry in the system.local table, but it\'s not found')
 
     @truncate_entries
+    @decorate_with_context(ignore_abort_requested_errors)
+    # https://github.com/scylladb/scylla/issues/10447#issuecomment-1194155163
     def upgrade_node(self, node, upgrade_sstables=True):
         # pylint: disable=too-many-branches,too-many-statements
         new_scylla_repo = self.params.get('new_scylla_repo')
@@ -247,6 +250,8 @@ class UpgradeTest(FillDatabaseData):
             self.upgradesstables_if_command_available(node)
 
     @truncate_entries
+    @decorate_with_context(ignore_abort_requested_errors)
+    # https://github.com/scylladb/scylla/issues/10447#issuecomment-1194155163
     def rollback_node(self, node, upgrade_sstables=True):
         # pylint: disable=too-many-branches,too-many-statements
 


### PR DESCRIPTION
According to https://github.com/scylladb/scylla/issues/10447#issuecomment-1194155163,
we should ignore all 'abort requested' error messages we see during the upgrade or
rollback procedures.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
