### PR TITLE
feature(cloud_monitor): add support for showing multiple projects

### DIFF
--- a/sdcm/utils/cloud_monitor/resources/__init__.py
+++ b/sdcm/utils/cloud_monitor/resources/__init__.py
@@ -7,7 +7,7 @@ CLOUD_PROVIDERS = ("aws", "gce")
 class CloudInstance:  # pylint: disable=too-few-public-methods,too-many-instance-attributes
     pricing = None  # need to be set in the child class
 
-    def __init__(self, cloud, name, instance_id, region_az, state, lifecycle, instance_type, owner, create_time, keep):  # pylint: disable=too-many-arguments
+    def __init__(self, cloud, name, instance_id, region_az, state, lifecycle, instance_type, owner, create_time, keep, project='N/A'):  # pylint: disable=too-many-arguments
         self.cloud = cloud
         self.name = name
         self.instance_id = instance_id
@@ -18,6 +18,7 @@ class CloudInstance:  # pylint: disable=too-few-public-methods,too-many-instance
         self.owner = owner.lower()
         self.create_time = create_time
         self.keep = keep  # keep alive
+        self.project = project
         self.price = self.pricing.get_instance_price(region=self.region, instance_type=self.instance_type,
                                                      state=self.state, lifecycle=self.lifecycle)
 

--- a/sdcm/utils/cloud_monitor/resources/instances.py
+++ b/sdcm/utils/cloud_monitor/resources/instances.py
@@ -1,3 +1,5 @@
+import os
+
 from logging import getLogger
 from datetime import datetime
 from boto3 import client as boto3_client
@@ -73,6 +75,7 @@ class GCEInstance(CloudInstance):
             owner=tags.get("RunByUser", NA) if tags else NA,
             create_time=datetime.fromisoformat(instance.extra['creationTimestamp']),
             keep=self.get_keep_alive_gce_instance(instance),
+            project=instance.driver.project
         )
 
     @property
@@ -101,8 +104,12 @@ class CloudInstances(CloudResources):
         self.all.extend(self["aws"])
 
     def get_gce_instances(self):
-        gce_instances = list_instances_gce(verbose=True)
-        self["gce"] = [GCEInstance(instance) for instance in gce_instances]
+        projects = ['', 'gcp-sct-project-1']
+        self["gce"] = []
+        for project in projects:
+            os.environ['SCT_GCE_PROJECT'] = project
+            gce_instances = list_instances_gce(verbose=True)
+            self["gce"] += [GCEInstance(instance) for instance in gce_instances]
         self.all.extend(self["gce"])
 
     def get_all(self):

--- a/sdcm/utils/cloud_monitor/templates/per_qa_user.html
+++ b/sdcm/utils/cloud_monitor/templates/per_qa_user.html
@@ -8,6 +8,7 @@
                     <table id="results_table">
                         <tr>
                             <th>Cloud</th>
+                            <th>Project</th>
                             <th>Region-AZ</th>
                             <th>Name</th>
                             <th>State</th>
@@ -16,6 +17,7 @@
                         {% for instance in instances|sort(attribute="create_time") %}
                         <tr>
                             <td>{{ instance.cloud }}</td>
+                            <td>{{ instance.project }}</td>
                             <td>{{ instance.region_az }}</td>
                             <td>{{ instance.name }}</td>
                             <td>{{ instance.state }}</td>

--- a/sdcm/utils/cloud_monitor/templates/per_user.html
+++ b/sdcm/utils/cloud_monitor/templates/per_user.html
@@ -26,6 +26,7 @@
     <table id="results_table">
         <tr>
             <th>Cloud</th>
+            <th>Project</th>
             <th>Region-AZ</th>
             <th>Name</th>
             <th>ID</th>
@@ -40,6 +41,7 @@
         {% for instance in instances %}
         <tr>
             <td>{{ instance.cloud }}</td>
+            <td>{{ instance.project }}</td>
             <td>{{ instance.region_az }}</td>
             <td>{{ instance.name }}</td>
             <td>{{ instance.instance_id }}</td>


### PR DESCRIPTION
now that we have multiple project for GCE, we need to show and report
them all

New project column for GCE instances:
![image](https://user-images.githubusercontent.com/340979/181460932-c9a536e4-4e9c-4af2-a380-f8a74ebe5bfe.png)


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
