### PR TITLE
feature(gce_project): switch the default project for gce

### DIFF
--- a/sdcm/keystore.py
+++ b/sdcm/keystore.py
@@ -47,14 +47,14 @@ class KeyStore:  # pylint: disable=too-many-public-methods
         return self.get_json("es.json")
 
     def get_gcp_credentials(self):
-        project = os.environ.get('SCT_GCE_PROJECT') or 'gcp'
+        project = os.environ.get('SCT_GCE_PROJECT') or 'gcp-sct-project-1'
         return self.get_json(f"{project}.json")
 
     def get_dbaaslab_gcp_credentials(self):
         return self.get_json("gcp-scylladbaaslab.json")
 
     def get_gcp_service_accounts(self):
-        project = os.environ.get('SCT_GCE_PROJECT') or 'gcp'
+        project = os.environ.get('SCT_GCE_PROJECT') or 'gcp-sct-project-1'
         return self.get_json(f"{project}_service_accounts.json")
 
     def get_scylladb_upload_credentials(self):

--- a/vars/getJenkinsLabels.groovy
+++ b/vars/getJenkinsLabels.groovy
@@ -15,7 +15,9 @@ def call(String backend, String region=null, String datacenter=null, String loca
 
     }
 
-    def gcp_project = params.gce_project?.trim() ?: 'gce-sct'
+    def gcp_project = params.gce_project?.trim() ?: 'gcp-sct-project-1'
+    gcp_project = gcp_project == 'gcp' ? 'gce-sct' : gcp_project
+
     def jenkins_labels = ['aws-eu-west-1': 'aws-sct-builders-eu-west-1-v2',
                           'aws-eu-west-2': 'aws-sct-builders-eu-west-2-v2',
                           'aws-eu-north-1': 'aws-sct-builders-eu-north-1-v2',


### PR DESCRIPTION
now that we have a new project up and running, we want
to switch all of the running jobs to it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
