### PR TITLE
feature(stress-thread): set timeout based on duration

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -77,7 +77,7 @@ from sdcm.sct_events.system import InfoEvent, TestFrameworkEvent, TestResultEven
 from sdcm.sct_events.file_logger import get_events_grouped_by_category, get_logger_event_summary
 from sdcm.sct_events.events_analyzer import stop_events_analyzer
 from sdcm.sct_events.grafana import start_posting_grafana_annotations
-from sdcm.stress_thread import CassandraStressThread
+from sdcm.stress_thread import CassandraStressThread, get_timeout_from_stress_cmd
 from sdcm.gemini_thread import GeminiStressThread
 from sdcm.utils.log_time_consistency import DbLogTimeConsistencyAnalyzer
 from sdcm.utils.threads_and_processes_alive import gather_live_processes_and_dump_to_file, \
@@ -1629,7 +1629,11 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self, stress_cmd, duration=None, stress_num=1, keyspace_num=1, profile=None, prefix='', round_robin=False,
             stats_aggregate_cmds=True, keyspace_name=None, stop_test_on_failure=True, **_):
         # stress_cmd = self._cs_add_node_flag(stress_cmd)
-        timeout = self.get_duration(duration)
+        if duration:
+            timeout = self.get_duration(duration)
+        else:
+            timeout = get_timeout_from_stress_cmd(stress_cmd) or self.get_duration(duration)
+
         if self.create_stats:
             self.update_stress_cmd_details(stress_cmd, prefix, stresser="cassandra-stress",
                                            aggregate=stats_aggregate_cmds)
@@ -1657,7 +1661,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     def run_stress_thread_bench(self, stress_cmd, duration=None, round_robin=False, stats_aggregate_cmds=True,
                                 use_single_loader=False, stop_test_on_failure=True, **_):
 
-        timeout = self.get_duration(duration)
+        if duration:
+            timeout = self.get_duration(duration)
+        else:
+            timeout = get_timeout_from_stress_cmd(stress_cmd) or self.get_duration(duration)
         stop_test_on_failure = False if not self.params.get("stop_test_on_stress_failure") else stop_test_on_failure
 
         if self.params.get("client_encrypt") and ' -tls' not in stress_cmd:
@@ -1806,8 +1813,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                                   round_robin=round_robin, params=self.params).run()
 
     def run_gemini(self, cmd, duration=None):
-
-        timeout = self.get_duration(duration)
+        if duration:
+            timeout = self.get_duration(duration)
+        else:
+            timeout = get_timeout_from_stress_cmd(cmd) or self.get_duration(duration)
         if self.create_stats:
             self.update_stress_cmd_details(cmd, stresser="gemini", aggregate=False)
         return GeminiStressThread(test_cluster=self.db_cluster,

--- a/unit_tests/test_stress_thread_functions.py
+++ b/unit_tests/test_stress_thread_functions.py
@@ -1,0 +1,38 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2022 ScyllaDB
+
+import pytest
+
+from sdcm.stress_thread import time_period_str_to_seconds, get_timeout_from_stress_cmd
+
+
+@pytest.mark.parametrize("duration,seconds", (
+    ("1h1m20s", 3680),
+    ("1m20s", 80),
+    ("1h20s", 3620),
+    ("25m", 1500),
+    ("10h", 36000),
+    ("25s", 25),
+))
+def test_duration_str_to_seconds_function(duration, seconds):
+    assert time_period_str_to_seconds(duration) == seconds
+
+
+@pytest.mark.parametrize("stress_cmd, timeout", (
+    ("cassandra-stress counter_write cl=QUORUM duration=20m -schema 'replication(factor=3)' no-warmup", 1200 + 600),
+    ("scylla-bench -workload=uniform -concurrency 64 -duration 1h -validate-data", 3600 + 600),
+    ("scylla-bench -partition-count=20000 -duration=250s", 250 + 600),
+    ("gemini -d --duration 10m --warmup 10s -c 5 -m write", 610 + 600)
+))
+def test_get_timeout_from_stress_cmd(stress_cmd, timeout):
+    assert get_timeout_from_stress_cmd(stress_cmd) == timeout


### PR DESCRIPTION
Sometimes we face freeze of c-s thread blocking the test flow.

This commit adds automatic timeout to stress threads (c-s, sb and
gemini) when duration in stress cmd is specified. 
Timeout is calculated as this:
warmup + duration + 600 (all in seconds).

https://trello.com/c/wZoe5pd3

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
