### PR TITLE
fix(disrupt_multiple_hard_reboot_node): waiting for cdc success messages

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -791,18 +791,24 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 self.target_node.wait_jmx_up()
             self.cluster.wait_for_nodes_up_and_normal(nodes=[self.target_node])
             found_cdc_error = list(cdc_expected_error)
-            found_success_info = list(cdc_success_msg)
-            if found_cdc_error and not found_success_info:
+            if found_cdc_error:
                 # if cdc error message "cdc - Could not update CDC description..."
                 # was found in log during reboot, but after that success messages:
                 # "streams description updated" or "CDC desc table updated" were not
                 # found in logs, raise the exception to fail the nemesis.
-                raise CdcStreamsWasNotUpdated(
-                    f"After '{found_cdc_error[0]}', messages '{' or '.join(cdc_success_msg)}' were not found")
+                self._check_for_cdc_success_messages(found_cdc_error, cdc_success_msg)
 
             sleep_time = random.randint(0, 100)
             self.log.info("Sleep %s seconds after hard reboot and service-up for node %s", sleep_time, self.target_node)
             time.sleep(sleep_time)
+
+    @staticmethod
+    @retrying(n=5, sleep_time=25, allowed_exceptions=(CdcStreamsWasNotUpdated,))
+    def _check_for_cdc_success_messages(found_cdc_error, cdc_success_msg):
+        found_success_info = list(cdc_success_msg)
+        if not found_success_info:
+            raise CdcStreamsWasNotUpdated(
+                f"After '{found_cdc_error[0]}', messages '{' or '.join(cdc_success_msg)}' were not found")
 
     def disrupt_soft_reboot_node(self):
         self.reboot_node(target_node=self.target_node, hard=False)


### PR DESCRIPTION
After the node reboot, it's possible it would take a little longer than previously expected for
the CDC desctiption to be updated. As such, I added a short retry after the reboot so that the
nemesis will wait for the CDC generation to be updated a short time after scylla is UN.
https://github.com/scylladb/scylla/issues/10973#issuecomment-1193986759

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
