### PR TITLE
fix(k8s): always set proper number of CPUs for Scylla pods

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -981,12 +981,11 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
             - COMMON_CONTAINERS_RESOURCES['cpu']
             - SCYLLA_MANAGER_AGENT_RESOURCES['cpu'] * self.tenants_number
         )
-        if self.is_performance_tuning_enabled:
-            # NOTE: we should use at max 7 from each 8 cores.
-            #       i.e 28/32 , 21/24 , 14/16 and 7/8
-            new_cpu_limit = math.ceil(cpu_limit / 8) * 7
-            if new_cpu_limit < cpu_limit:
-                cpu_limit = new_cpu_limit
+        # NOTE: we should use at max 7 from each 8 cores.
+        #       i.e 28/32 , 21/24 , 14/16 and 7/8
+        new_cpu_limit = math.ceil(cpu_limit / 8) * 7
+        if new_cpu_limit < cpu_limit:
+            cpu_limit = new_cpu_limit
         cpu_limit = cpu_limit // self.tenants_number or 1
         memory_limit = (
             memory_limit


### PR DESCRIPTION
Setting of 7 CPU cores from each 8 available must be done always
not only when the performance tuning is enabled.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
