### PR TITLE
improvement(Gemini test): Add post prepare CQL command and gc-mode test

### DIFF
--- a/gemini_test.py
+++ b/gemini_test.py
@@ -58,7 +58,7 @@ class GeminiTest(ClusterTester):
         sleep_before_start = float(self.params.get('test_duration')) * 60 * .1
         self.log.info('Sleep interval {}'.format(sleep_before_start))
         time.sleep(sleep_before_start)
-
+        self.run_post_prepare_cql_cmds()
         self.db_cluster.start_nemesis()
 
         self.gemini_results.update(self.verify_gemini_results(queue=gemini_thread))

--- a/jenkins-pipelines/gemini-10h-with-nemesis-tombstone-gc-repair.jenkinsfile
+++ b/jenkins-pipelines/gemini-10h-with-nemesis-tombstone-gc-repair.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'us-east-1',
+    test_name: 'gemini_test.GeminiTest.test_load_random_with_nemesis',
+    test_config: 'test-cases/gemini/gemini-10h-with-nemesis-tombstone-gc-repair.yaml',
+
+    email_recipients: 'qa@scylladb.com'
+)

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -75,6 +75,70 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
         if self.params.get('pre_create_keyspace'):
             self._pre_create_keyspace()
 
+    def run_prepare_write_cmd(self):
+        # In some cases (like many keyspaces), we want to create the schema (all keyspaces & tables) before the load
+        # starts - due to the heavy load, the schema propogation can take long time and c-s fails.
+        prepare_write_cmd = self.params.get('prepare_write_cmd')
+        keyspace_num = self.params.get('keyspace_num')
+        write_queue = []
+        verify_queue = []
+
+        if not prepare_write_cmd:
+            self.log.debug("No prepare write commands are configured to run. Continue with stress commands")
+            return
+        # When the load is too heavy for one loader when using MULTI-KEYSPACES, the load is spreaded evenly across
+        # the loaders (round_robin).
+        if keyspace_num > 1 and self.params.get('round_robin'):
+            self.log.debug("Using round_robin for multiple Keyspaces...")
+            for i in range(1, keyspace_num + 1):
+                keyspace_name = self._get_keyspace_name(i)
+                self._run_all_stress_cmds(write_queue, params={'stress_cmd': prepare_write_cmd,
+                                                               'keyspace_name': keyspace_name,
+                                                               'round_robin': True})
+        # Not using round_robin and all keyspaces will run on all loaders
+        else:
+            self._run_all_stress_cmds(write_queue, params={'stress_cmd': prepare_write_cmd,
+                                                           'keyspace_num': keyspace_num,
+                                                           'round_robin': self.params.get('round_robin')})
+
+        # In some cases we don't want the nemesis to run during the "prepare" stage in order to be 100% sure that
+        # all keys were written succesfully
+        if self.params.get('nemesis_during_prepare'):
+            # Wait for some data (according to the param in the yaml) to be populated, for multi keyspace need to
+            # pay attention to the fact it checks only on keyspace1
+            self.db_cluster.wait_total_space_used_per_node(keyspace=None)
+            self.db_cluster.start_nemesis()
+
+        # Wait on the queue till all threads come back.
+        # todo: we need to improve this part for some cases that threads are being killed and we don't catch it.
+        for stress in write_queue:
+            self.verify_stress_thread(cs_thread_pool=stress)
+
+        # Run nodetool flush on all nodes to make sure nothing left in memory
+        # I decided to comment this out for now, when we found the data corruption bug, we wanted to be on the safe
+        # side, but I don't think we should continue with this approach.
+        # If we decided to add this back in the future, we need to wrap it with try-except because it can run
+        # in parallel to nemesis and it will fail on one of the nodes.
+        # self._flush_all_nodes()
+
+        # In case we would like to verify all keys were written successfully before we start other stress / nemesis
+        prepare_verify_cmd = self.params.get('prepare_verify_cmd')
+        if prepare_verify_cmd:
+            self._run_all_stress_cmds(verify_queue, params={'stress_cmd': prepare_verify_cmd,
+                                                            'keyspace_num': keyspace_num})
+
+            for stress in verify_queue:
+                self.verify_stress_thread(cs_thread_pool=stress)
+
+        self.run_post_prepare_cql_cmds()
+
+        prepare_wait_no_compactions_timeout = self.params.get('prepare_wait_no_compactions_timeout')
+        if prepare_wait_no_compactions_timeout:
+            for node in self.db_cluster.nodes:
+                node.run_nodetool("compact")
+            self.wait_no_compactions_running(n=prepare_wait_no_compactions_timeout)
+        self.log.info('Prepare finished')
+
     def test_custom_time(self):
         """
         Run cassandra-stress with params defined in data_dir/scylla.yaml
@@ -403,6 +467,10 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
                             session.execute(query)
                         except (AlreadyExists, InvalidRequest) as exc:
                             self.log.debug('extra definition for [{}] exists [{}]'.format(table_name, str(exc)))
+
+    def _pre_create_keyspace(self):
+        cmds = self.params.get('pre_create_keyspace')
+        self._run_cql_commands(cmds)
 
     def _flush_all_nodes(self):
         """

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -5186,6 +5186,7 @@ class ToggleGcModeMonkey(Nemesis):
     disruptive = False
     schema_changes = True
     free_tier_set = True
+    run_with_gemini = False
 
     def disrupt(self):
         self.disrupt_toggle_table_gc_mode()

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -942,6 +942,22 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 self.alternator.update_table_ttl(node=node, table_name=alternator.consts.TABLE_NAME)
                 self.alternator.update_table_ttl(node=node, table_name=alternator.consts.NO_LWT_TABLE_NAME)
 
+    def run_post_prepare_cql_cmds(self):
+        if post_prepare_cql_cmds := self.params.get('post_prepare_cql_cmds'):
+            self.log.debug("Execute post prepare queries: %s", post_prepare_cql_cmds)
+            self._run_cql_commands(post_prepare_cql_cmds)
+
+    def _run_cql_commands(self, cmds, node=None):
+        node = node if node else self.db_cluster.nodes[0]
+
+        if not isinstance(cmds, list):
+            cmds = [cmds]
+
+        for cmd in cmds:
+            # pylint: disable=no-member
+            with self.db_cluster.cql_connection_patient(node) as session:
+                session.execute(cmd)
+
     def get_nemesis_class(self):
         """
         Get a Nemesis class from parameters.

--- a/test-cases/gemini/gemini-10h-with-nemesis-tombstone-gc-repair.yaml
+++ b/test-cases/gemini/gemini-10h-with-nemesis-tombstone-gc-repair.yaml
@@ -1,0 +1,30 @@
+test_duration: 750
+n_db_nodes: 3
+n_test_oracle_db_nodes: 1
+n_loaders: 1
+n_monitor_nodes: 1
+instance_type_db: 'i3.large'
+
+user_prefix: 'gemini-with-nemesis-10h-tombstone'
+
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_selector: ['run_with_gemini', '!networking', '!kubernetes']
+nemesis_interval: 5
+nemesis_seed: '032'
+
+# gemini
+# cmd: gemini -d -n [NUM_OF_TEST_ITERATIONS] -c [NUM_OF_THREADS] -p [NUM_OF_PARTITION_KEYS_PER_THREAD] -m mixed -f
+#--async-objects-stabilization-backoff duration   Duration between attempts to validate result sets from MV and SI for example 10ms or 1s (default 10ms)
+# the below cmd runs about 10 hours
+gemini_cmd: "gemini -d --duration 10h --warmup 30m \
+-c 50 -m mixed -f --non-interactive --cql-features normal \
+--max-mutation-retries 5 --max-mutation-retries-backoff 500ms \
+--async-objects-stabilization-attempts 5 --async-objects-stabilization-backoff 500ms \
+--replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '3'}\" \
+--oracle-replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '1'}\""
+
+db_type: mixed_scylla
+instance_type_db_oracle: 'i3.8xlarge'
+
+post_prepare_cql_cmds: "ALTER TABLE ks1.table1 WITH tombstone_gc = {'mode': 'repair'};"
+nemesis_multiply_factor: 1


### PR DESCRIPTION
	CQL command allows more flexible configure Gemini table.
	Used in a new test that configurea tombstone-gc-mode.

Trello: https://trello.com/c/ifxQKAtH

The General idea for this new added test is:
Configure and run with:
Gemini
tombstone-gc-mode repair (in post-prepare-cql)
SisyphusMonkey + nemesis_selector: ['run_with_gemini', '!networking', '!kubernetes']
==> to verify we get no data validation error due to data resurrection and the 'repair' works ok.
count and verify reasonable number of nemesis selected by SisyphusMonkey. Possibly lower the SisyphusMonkey multiplication factor. Out of a total number of 60 nemesis, we expect to have ~ < 30 nemesis used here.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
