### PR TITLE
feature(list/clean-resources): support multiple gce project

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -89,6 +89,7 @@ from sdcm.send_email import get_running_instances_for_email_report, read_email_d
     send_perf_email
 from sdcm.parallel_timeline_report.generate_pt_report import ParallelTimelinesReportGenerator
 from sdcm.utils.aws_utils import AwsArchType
+from sdcm.utils.gce_utils import SUPPORTED_PROJECTS
 from utils.build_system.create_test_release_jobs import JenkinsPipelines  # pylint: disable=no-name-in-module,import-error
 from utils.get_supported_scylla_base_versions import UpgradeBaseVersion  # pylint: disable=no-name-in-module,import-error
 from utils.mocks.aws_mock import AwsMock  # pylint: disable=no-name-in-module
@@ -396,25 +397,27 @@ def list_resources(ctx, user, test_id, get_all, get_all_running, verbose):
     else:
         click.secho("Nothing found for selected filters in GKE!", fg="yellow")
 
-    click.secho("Checking GCE...", fg='green')
-    gce_instances = list_instances_gce(tags_dict=params, running=get_all_running, verbose=verbose)
-    if gce_instances:
-        gce_table = PrettyTable(table_header)
-        gce_table.align = "l"
-        gce_table.sortby = 'LaunchTime'
-        for instance in gce_instances:
-            tags = gce_meta_to_dict(instance.extra['metadata'])
-            public_ips = ", ".join(instance.public_ips) if None not in instance.public_ips else "N/A"
-            gce_table.add_row([instance.name,
-                               instance.extra["zone"].name,
-                               public_ips if get_all_running else instance.state,
-                               tags.get('TestId', 'N/A') if tags else "N/A",
-                               tags.get('RunByUser', 'N/A') if tags else "N/A",
-                               instance.extra['creationTimestamp'],
-                               ])
-        click.echo(gce_table.get_string(title="Resources used on GCE"))
-    else:
-        click.secho("Nothing found for selected filters in GCE!", fg="yellow")
+    for project in SUPPORTED_PROJECTS:
+        os.environ['SCT_GCE_PROJECT'] = project
+        click.secho(f"Checking GCE ({project})...", fg='green')
+        gce_instances = list_instances_gce(tags_dict=params, running=get_all_running, verbose=verbose)
+        if gce_instances:
+            gce_table = PrettyTable(table_header)
+            gce_table.align = "l"
+            gce_table.sortby = 'LaunchTime'
+            for instance in gce_instances:
+                tags = gce_meta_to_dict(instance.extra['metadata'])
+                public_ips = ", ".join(instance.public_ips) if None not in instance.public_ips else "N/A"
+                gce_table.add_row([instance.name,
+                                   instance.extra["zone"].name,
+                                   public_ips if get_all_running else instance.state,
+                                   tags.get('TestId', 'N/A') if tags else "N/A",
+                                   tags.get('RunByUser', 'N/A') if tags else "N/A",
+                                   instance.extra['creationTimestamp'],
+                                   ])
+            click.echo(gce_table.get_string(title="Resources used on GCE"))
+        else:
+            click.secho("Nothing found for selected filters in GCE!", fg="yellow")
 
     click.secho("Checking EKS...", fg='green')
     eks_clusters = list_clusters_eks(tags_dict=params, verbose=verbose)

--- a/sdcm/utils/cloud_monitor/resources/instances.py
+++ b/sdcm/utils/cloud_monitor/resources/instances.py
@@ -7,7 +7,7 @@ from sdcm.utils.cloud_monitor.common import InstanceLifecycle, NA
 from sdcm.utils.cloud_monitor.resources import CloudInstance, CloudResources
 from sdcm.utils.common import aws_tags_to_dict, gce_meta_to_dict, list_instances_aws, list_instances_gce
 from sdcm.utils.pricing import AWSPricing, GCEPricing
-
+from sdcm.utils.gce_utils import SUPPORTED_PROJECTS
 
 LOGGER = getLogger(__name__)
 
@@ -104,9 +104,8 @@ class CloudInstances(CloudResources):
         self.all.extend(self["aws"])
 
     def get_gce_instances(self):
-        projects = ['', 'gcp-sct-project-1']
         self["gce"] = []
-        for project in projects:
+        for project in SUPPORTED_PROJECTS:
             os.environ['SCT_GCE_PROJECT'] = project
             gce_instances = list_instances_gce(verbose=True)
             self["gce"] += [GCEInstance(instance) for instance in gce_instances]

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -75,6 +75,8 @@ from sdcm.utils.docker_utils import ContainerManager
 from sdcm.utils.gce_utils import GcloudContainerMixin
 from sdcm.remote import LocalCmdRunner
 from sdcm.remote import RemoteCmdRunnerBase
+from sdcm.utils.gce_utils import SUPPORTED_PROJECTS
+
 
 LOGGER = logging.getLogger('utils')
 DEFAULT_AWS_REGION = "eu-west-1"
@@ -552,7 +554,9 @@ def clean_cloud_resources(tags_dict, dry_run=False):
     clean_clusters_gke(tags_dict, dry_run=dry_run)
     clean_orphaned_gke_disks(dry_run=dry_run)
     clean_clusters_eks(tags_dict, dry_run=dry_run)
-    clean_instances_gce(tags_dict, dry_run=dry_run)
+    for project in SUPPORTED_PROJECTS:
+        os.environ['SCT_GCE_PROJECT'] = project
+        clean_instances_gce(tags_dict, dry_run=dry_run)
     clean_instances_azure(tags_dict, dry_run=dry_run)
     clean_resources_docker(tags_dict, dry_run=dry_run)
     return True

--- a/sdcm/utils/gce_utils.py
+++ b/sdcm/utils/gce_utils.py
@@ -40,6 +40,9 @@ SUPPORTED_REGIONS = {
     'us-west1': 'abc'}
 
 
+SUPPORTED_PROJECTS = {'gcp', 'gcp-sct-project-1'} | {os.environ.get('SCT_GCE_PROJECT', 'gcp-sct-project-1')}
+
+
 def append_zone(region: str) -> str:
     dash_count = region.count("-")
     if dash_count == 2:


### PR DESCRIPTION
now that we can use multiple gce project, we want to make sure we
list and clean resouces on all the available projects.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
