### PR TITLE
Revert "fix(install_scylla): adding workaround to JDK"

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2041,21 +2041,6 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 'sudo apt-get install -y '
                 ' {} '.format(self.scylla_pkg()))
 
-        # THIS IS A WORKAROUND FOR ISSUE https://github.com/scylladb/scylla/issues/10442
-        # the issue is related to JDK version, and the fix was added to later patches of multiple base versions,
-        # hence this is a temporary workaround to make the rolling upgrade tests to pass, until the latest
-        # patch of the supported releases will include the fix.
-        package_manager = 'yum' if self.is_rhel_like() else 'apt'
-        self.remoter.sudo(f'{package_manager} install zip unzip -y')
-        self.remoter.run('curl -s "https://get.sdkman.io" | bash')
-        self.remoter.run(shell_script_cmd("""
-            source "/home/$USER/.sdkman/bin/sdkman-init.sh"
-            sed -i s/sdkman_auto_answer=false/sdkman_auto_answer=true/  ~/.sdkman/etc/config
-            sed -i s/sdkman_auto_env=false/sdkman_auto_env=true/  ~/.sdkman/etc/config
-            sdk install java 8.0.302-open
-            sdk default java 8.0.302-open
-        """))
-
     def offline_install_scylla(self, unified_package, nonroot):
         """
         Offline install scylla by unified package.


### PR DESCRIPTION
This reverts commit 4aa15e3b43c4b2bfe4cdc0df01cbc0c77c1d804c.
the fix was released in all supported based versions, hence
this workaround is not necessary anymore.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
