### PR TITLE
fix(upload_sstables): use `scylla` user only when copying snapshot

### DIFF
--- a/sdcm/utils/sstable/load_utils.py
+++ b/sdcm/utils/sstable/load_utils.py
@@ -62,10 +62,7 @@ class SstableLoadUtils:
 
         with RemoteTemporaryFolder(node=node) as tmp_folder:
 
-            if node.is_docker():
-                node.remoter.run(f'tar xvfz {test_data.sstable_file} -C {tmp_folder.folder_name}/')
-            else:
-                node.remoter.sudo(f'tar xvfz {test_data.sstable_file} -C {tmp_folder.folder_name}/', user='scylla')
+            node.remoter.run(f'tar xvfz {test_data.sstable_file} -C {tmp_folder.folder_name}/')
 
             if create_schema:
                 SstableLoadUtils.create_keyspace(node=node,
@@ -81,9 +78,9 @@ class SstableLoadUtils:
             # Scylla Enterprise 2019.1 doesn't support to load schema.cql and manifest.json, let's remove them
             node.remoter.sudo(f'rm -f {tmp_folder.folder_name}/schema.cql')
             node.remoter.sudo(f'rm -f {tmp_folder.folder_name}/manifest.json')
-
+            params = {} if node.is_docker() else {'user': 'scylla'}
             node.remoter.sudo(
-                f'mv {tmp_folder.folder_name}/* /var/lib/scylla/data/{keyspace_name}/{upload_dir}/upload/')
+                f'mv {tmp_folder.folder_name}/* /var/lib/scylla/data/{keyspace_name}/{upload_dir}/upload/', **params)
 
     @classmethod
     def run_load_and_stream(cls, node, keyspace_name: str = 'keyspace1', table_name: str = 'standard1'):

--- a/test-cases/longevity/longevity-10gb-3h.yaml
+++ b/test-cases/longevity/longevity-10gb-3h.yaml
@@ -11,7 +11,7 @@ gce_instance_type_db: 'n1-highmem-16'
 gce_instance_type_loader: 'e2-standard-4'
 azure_instance_type_db: 'Standard_L8s_v3'
 run_fullscan: '{"ks_cf": "keyspace1.standard1", "interval": 5}' # 'ks.cf|random, interval(min)'
-nemesis_class_name: 'SisyphusMonkey'
+nemesis_class_name: 'RefreshMonkey'
 nemesis_seed: '111'
 nemesis_interval: 2
 ssh_transport: 'libssh2'


### PR DESCRIPTION
We wrongly use `scylla` user when extracting the tarball to the tmp
directory, and not when copying snapshot into upload direcorty

Fix: #5083

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
