### PR TITLE
fix(ldap authorization): add missing ldap property of role_manager

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1610,33 +1610,6 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
     def remote_manager_agent_yaml(self):
         return self._remote_yaml(path=SCYLLA_MANAGER_AGENT_YAML_PATH)
 
-    def get_openldap_config(self):
-        if self.test_config.LDAP_ADDRESS is None:
-            return {}
-        ldap_server_ip = '127.0.0.1' if self.test_config.IP_SSH_CONNECTIONS == 'public' \
-            else self.test_config.LDAP_ADDRESS[0]
-        ldap_port = LDAP_SSH_TUNNEL_LOCAL_PORT if self.test_config.IP_SSH_CONNECTIONS == 'public' \
-            else self.test_config.LDAP_ADDRESS[1]
-        return {'role_manager': 'com.scylladb.auth.LDAPRoleManager',
-                'ldap_url_template': f'ldap://{ldap_server_ip}:{ldap_port}/'
-                                     f'{LDAP_BASE_OBJECT}?cn?sub?(uniqueMember='
-                                     f'uid={{USER}},ou=Person,{LDAP_BASE_OBJECT})',
-                'ldap_attr_role': 'cn',
-                'ldap_bind_dn': f'cn=admin,{LDAP_BASE_OBJECT}',
-                'ldap_bind_passwd': LDAP_PASSWORD}
-
-    def get_ldap_ms_ad_config(self):
-        if self.test_config.LDAP_ADDRESS is None:
-            return {}
-        ldap_ms_ad_credentials = KeyStore().get_ldap_ms_ad_credentials()
-        return {'ldap_attr_role': 'cn',
-                'ldap_bind_dn': ldap_ms_ad_credentials['ldap_bind_dn'],
-                'ldap_bind_passwd': ldap_ms_ad_credentials['admin_password'],
-                'ldap_url_template':
-                    f'ldap://{ldap_ms_ad_credentials["server_address"]}:{LDAP_PORT}/{LDAP_BASE_OBJECT}?cn?sub?'
-                    f'(member=CN={{USER}},DC=scylla-qa,DC=com)',
-                'role_manager': 'com.scylladb.auth.LDAPRoleManager'}
-
     def get_saslauthd_config(self):
         if self.test_config.LDAP_ADDRESS is None:
             return {}

--- a/sdcm/provision/scylla_yaml/cluster_builder.py
+++ b/sdcm/provision/scylla_yaml/cluster_builder.py
@@ -105,6 +105,10 @@ class ScyllaYamlClusterAttrBuilder(ScyllaYamlAttrBuilderBase):
         return None
 
     @property
+    def role_manager(self) -> Optional[str]:
+        return 'com.scylladb.auth.LDAPRoleManager' if self._is_ldap_authorization else None
+
+    @property
     def ldap_bind_passwd(self) -> Optional[str]:
         if self._is_msldap_authorization:
             return self._ms_ldap_bind_passwd

--- a/unit_tests/test_scylla_yaml_builders.py
+++ b/unit_tests/test_scylla_yaml_builders.py
@@ -129,6 +129,7 @@ class ScyllaYamlClusterAttrBuilderTest(ScyllaYamlClusterAttrBuilderBase):
                 'ldap_bind_dn': 'cn=admin,dc=scylla-qa,dc=com', 'ldap_bind_passwd': 'scylla-0',
                 'ldap_url_template': 'ldap://1.1.1.1:389/dc=scylla-qa,dc=com?cn?sub?'
                                      '(uniqueMember=uid={USER},ou=Person,dc=scylla-qa,dc=com)',
+                'role_manager': 'com.scylladb.auth.LDAPRoleManager',
                 'saslauthd_socket_path': '/run/saslauthd/mux'
             },
         )
@@ -165,6 +166,7 @@ class ScyllaYamlClusterAttrBuilderTest(ScyllaYamlClusterAttrBuilderBase):
                 'ldap_bind_passwd': 'scylla-0',
                 'ldap_url_template': 'ldap://1.1.1.1:389/dc=scylla-qa,dc=com?cn?sub?'
                                      '(uniqueMember=uid={USER},ou=Person,dc=scylla-qa,dc=com)',
+                'role_manager': 'com.scylladb.auth.LDAPRoleManager',
                 'saslauthd_socket_path': '/run/saslauthd/mux'
             }
         )
@@ -205,6 +207,7 @@ class ScyllaYamlClusterAttrBuilderTest(ScyllaYamlClusterAttrBuilderBase):
                 'hinted_handoff_enabled': 'enabled',
                 'ldap_attr_role': 'cn', 'ldap_bind_dn': 'SOMEDN', 'ldap_bind_passwd': 'PASSWORD',
                 'ldap_url_template': 'ldap://3.3.3.3:389/dc=scylla-qa,dc=com?cn?sub?(member=CN={USER},dc=scylla-qa,dc=com)',
+                'role_manager': 'com.scylladb.auth.LDAPRoleManager',
                 'saslauthd_socket_path': '/run/saslauthd/mux',
             }
         )


### PR DESCRIPTION
            The 'role_manager' Ldap property was missed in past refactor.

Trello: https://trello.com/c/pf2BS8G8
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
