### PR TITLE
fix(unit-tests): add 2022.1 to base versions

### DIFF
--- a/unit_tests/test_base_version.py
+++ b/unit_tests/test_base_version.py
@@ -76,7 +76,7 @@ class TestBaseVersion(unittest.TestCase):
             'unstable/scylla-enterprise/enterprise-2022.1/deb/unified/2022-06-03T00:22:55Z/scylladb-2022.1/scylla.list'
         linux_distro = 'centos-8'
         version_list = general_test(scylla_repo, linux_distro)
-        self.assertEqual(['5.0', '2021.1'], version_list)
+        self.assertEqual(['5.0', '2021.1', '2022.1'], version_list)
 
 
 if __name__ == "__main__":

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -262,7 +262,6 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         os.environ['SCT_CLUSTER_BACKEND'] = 'k8s-local-kind'
         os.environ['SCT_SCYLLA_LINUX_DISTRO'] = 'ubuntu-xenial'
         os.environ['SCT_SCYLLA_LINUX_DISTRO_LOADER'] = 'centos'
-        os.environ['SCT_SCYLLA_VERSION'] = 'latest'
         conf = sct_config.SCTConfiguration()
         conf.verify_configuration()
 


### PR DESCRIPTION
now that 2022.1 was released, we would get it as a base
version for 2022.1 runs

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
