### PR TITLE
fix(cluster_aws): added missing import

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -22,9 +22,6 @@ import re
 import tempfile
 import time
 import uuid
-from contextlib import ExitStack
-from datetime import datetime
-from functools import cached_property
 from math import floor
 from typing import Dict, Optional, ParamSpec, TypeVar
 from datetime import datetime

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -38,6 +38,7 @@ import botocore.exceptions
 import yaml
 import tenacity
 from mypy_boto3_ec2 import EC2Client
+from sdcm.ec2_client import CreateSpotInstancesError
 from pkg_resources import parse_version
 
 from sdcm import ec2_client, cluster, wait


### PR DESCRIPTION
for some reason, that import disappeared
from that file, and when we had a fallback
from `spot` to `on_demand`, test failed
with syntax error.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
