### PR TITLE
fix(loader_user_data): bring back user-data for loader nodes

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -367,8 +367,13 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
 
     # pylint: disable=too-many-arguments
     def add_nodes(self, count, ec2_user_data='', dc_idx=0, rack=0, enable_auto_bootstrap=False):
+        user_data_format_version = '3'
 
-        user_data_format_version = self.params.get('user_data_format_version') or '3'
+        if self.node_type == 'scylla-db':
+            user_data_format_version = self.params.get('user_data_format_version') or user_data_format_version
+        elif self.node_type == 'oracle-db':
+            user_data_format_version = self.params.get('oracle_user_data_format_version') or user_data_format_version
+
         user_data_builder = ScyllaUserDataBuilder(cluster_name=self.name,
                                                   bootstrap=enable_auto_bootstrap,
                                                   user_data_format_version=user_data_format_version, params=self.params,


### PR DESCRIPTION
in 05e3544b43ce0c99e2bcaa88d6a6588d6ec093f7 the user-data for AWS
was centelized, but the support for sending user-data for node
other then the db was broken, and SMI user-data was sent to all
of them, breaking some test cases which depends on it, ipv6 cases
for example

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
