### PR TITLE
fix(load utils): untar snapshot

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -2634,9 +2634,10 @@ class RemoteTemporaryFolder:
         self.folder_name = ""
 
     def __enter__(self):
-        result = self.node.remoter.sudo('mktemp -d')
+        result = self.node.remoter.run('mktemp -d')
         self.folder_name = result.stdout.strip()
         return self
 
     def __exit__(self, exit_type, value, traceback):
+        # remove the temporary folder as `sudo` to cover the case when the folder owner was changed during test
         self.node.remoter.sudo(f'rm -rf {self.folder_name}')


### PR DESCRIPTION
The issue was represented  by https://github.com/scylladb/scylla-cluster-tests/pull/4968

NodetoolRefresh nemesis failed with error:

```
File '/home/ubuntu/scylla-cluster-tests/sdcm/utils/sstable/load_utils.py', line 68,
in upload_sstables
node.remoter.sudo(f'tar xvfz {test_data.sstable_file} -C {tmp_folder.folder_name}/', user='scylla')

tar: /tmp/tmp.wUtrdYx7bd: Cannot open: Permission denied
tar: Error is not recoverable: exiting now
```

Temporary folder was created as root, but run untar is run as 'scylla'.
Also temporary folder shouldn't be owned by root.

Use temporary folder in case when schema should be created.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
