### PR TITLE
fix(hydra_ssh): pass down tty lines/cols to the ssh command

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -268,6 +268,7 @@ function run_in_docker () {
         ${AWS_OPTIONS} \
         --env GIT_BRANCH \
         --env CHANGE_TARGET \
+        --env TERM \
         --net=host \
         --name="${SCT_TEST_ID}_$(date +%s)" \
         ${DOCKER_REPO}:${VERSION} \


### PR DESCRIPTION
since we didn't pass that explicitly, the defaults were used
and terminal size was smaller then the acutal terminal being
used, and problematic to use

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
