### PR TITLE
improvement(collect kallsyms): Collect Seastar kallsyms on boot

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -105,7 +105,8 @@ from sdcm.sct_events.nodetool import NodetoolEvent
 from sdcm.sct_events.decorators import raise_event_on_failure
 from sdcm.utils.auto_ssh import AutoSshContainerMixin
 from sdcm.monitorstack.ui import AlternatorDashboard
-from sdcm.logcollector import GrafanaSnapshot, GrafanaScreenShot, PrometheusSnapshots, upload_archive_to_s3
+from sdcm.logcollector import GrafanaSnapshot, GrafanaScreenShot, PrometheusSnapshots, upload_archive_to_s3, \
+    save_kallsyms_map
 from sdcm.utils.ldap import LDAP_SSH_TUNNEL_LOCAL_PORT, LDAP_BASE_OBJECT, LDAP_PASSWORD, LDAP_USERS, \
     LDAP_PORT, DEFAULT_PWD_SUFFIX
 from sdcm.utils.remote_logger import get_system_logging_thread
@@ -4136,6 +4137,8 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                 self.log.info("Done waiting for preinstalled Scylla")
                 if self.params.get('workaround_kernel_bug_for_iotune'):
                     self.copy_preconfigured_iotune_files(node)
+            if self.params.get('print_kernel_callstack'):
+                save_kallsyms_map(node=node)
             if node.is_nonroot_install:
                 self.scylla_configure_non_root_installation(node=node, devname=nic_devname,
                                                             verbose=verbose, timeout=timeout)

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -54,6 +54,7 @@ from sdcm.cluster_k8s import PodCluster, ScyllaPodCluster
 from sdcm.cluster_k8s.mini_k8s import LocalKindCluster
 from sdcm.db_stats import PrometheusDBStats
 from sdcm.log import SDCMAdapter
+from sdcm.logcollector import save_kallsyms_map
 from sdcm.mgmt import TaskStatus
 from sdcm.nemesis_publisher import NemesisElasticSearchPublisher
 from sdcm.paths import SCYLLA_YAML_PATH
@@ -3006,7 +3007,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def reboot_node(self, target_node, hard=True, verify_ssh=True):
         with ignore_view_error_gate_closed_exception():
             target_node.reboot(hard=hard, verify_ssh=verify_ssh)
-
+            if self.tester.params.get('print_kernel_callstack'):
+                save_kallsyms_map(node=target_node)
             # pods can change their ip address during the process,
             # so we update the monitor at this point
             if self._is_it_on_kubernetes():

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1788,6 +1788,26 @@ def remove_files(path):
         LOGGER.info("Remove temporary data manually: \"%s\"", path)
 
 
+def create_remote_storage_dir(node, path='') -> Optional[str, None]:
+    node_remote_dir = '/tmp'
+    if not path:
+        path = node.name
+    try:
+        remote_dir = os.path.join(node_remote_dir, path)
+        result = node.remoter.run(f'mkdir -p {remote_dir}', ignore_status=True)
+
+        if result.exited > 0:
+            LOGGER.error(
+                'Remote storing folder not created.\n %s', result)
+            remote_dir = node_remote_dir
+
+    except Exception as details:  # pylint: disable=broad-except
+        LOGGER.error("Error during creating remote directory %s", details)
+        return None
+
+    return remote_dir
+
+
 def format_timestamp(timestamp):
     return datetime.datetime.utcfromtimestamp(timestamp).strftime('%Y-%m-%d %H:%M:%S')
 


### PR DESCRIPTION
	The kallsyms map for kernel debug should be collected
	dynamically every node boot.

Trello: https://trello.com/c/lokjpJC7
Extending requested support of: https://github.com/scylladb/scylla-cluster-tests/issues/4054#issuecomment-1057300552

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
