### PR TITLE
test(mulitenant longevity): add new longevity test

### DIFF
--- a/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-mulitenant-eks.jenkinsfile
+++ b/jenkins-pipelines/operator/eks/longevity-scylla-operator-3h-mulitenant-eks.jenkinsfile
@@ -1,0 +1,16 @@
+#!groovy
+
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'k8s-eks',
+    region: 'eu-north-1',
+    test_name: 'longevity_operator_multi_tenant_test.LongevityOperatorMulitiTenantTest.test_custom_time',
+    test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h-multitenant.yaml',
+    email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
+    availability_zone: 'a,b',
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy',
+    post_behavior_k8s_cluster: 'destroy',
+)

--- a/longevity_operator_multi_tenant_test.py
+++ b/longevity_operator_multi_tenant_test.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2022 ScyllaDB
+
+import copy
+import logging
+import time
+
+from longevity_test import LongevityTest
+
+from sdcm.utils.common import ParallelObject
+
+
+from sdcm.utils.operator.miltitenant_common import set_stress_command_to_tenant
+
+
+class MulitiTenantBase(LongevityTest):
+    _testMethodName = "runTest"
+
+
+# pylint: disable=too-many-instance-attributes
+class ScyllaClusterStats(MulitiTenantBase):
+    # pylint: disable=too-many-arguments,super-init-not-called
+    def __init__(self, db_cluster, loaders, monitors, prometheus_db, params, test_config, cluster_index):
+        self.db_cluster = db_cluster
+        self.loaders = loaders
+        self.monitors = monitors
+        self.prometheus_db = prometheus_db
+        self.params = copy.deepcopy(params)
+        self.test_config = test_config
+        self._duration = self.params.get(key='test_duration')
+        self.log = logging.getLogger(self.__class__.__name__)
+        self.create_stats = self.params.get(key='store_perf_results')
+        self.status = "RUNNING"
+        self.cluster_index = str(cluster_index)
+        self._test_id = self.test_config.test_id() + f"--{cluster_index}"
+        self._test_index = self.get_str_index()
+        self.start_time = time.time()
+        self._duration = self.params.get(key='test_duration')
+        self.timeout_thread = self._init_test_timeout_thread()
+        self.test_config.reuse_cluster(False)
+
+    def get_str_index(self):
+        return f"k8s-longevity-{self.db_cluster.k8s_cluster.tenants_number}-tenants"
+
+    def id(self):  # pylint: disable=invalid-name
+        return self.test_config.test_id() + f"-{self._test_index}"
+
+    def __str__(self) -> str:
+        return self._test_index + f"--{self.cluster_index}"
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+
+class LongevityOperatorMulitiTenantTest(MulitiTenantBase):
+    scylla_clusters_stats = []
+
+    def setUp(self):
+        super().setUp()
+        for i, db_cluster in enumerate(self.db_clusters_multitenant):  # pylint: disable=no-member
+            self.scylla_clusters_stats.append(ScyllaClusterStats(
+                db_cluster=db_cluster,
+                loaders=self.loaders_multitenant[i],  # pylint: disable=no-member
+                monitors=self.monitors_multitenant[i],  # pylint: disable=no-member
+                prometheus_db=self.prometheus_db_multitenant[i],  # pylint: disable=no-member
+                params=self.params,
+                test_config=self.test_config,
+                cluster_index=i + 1,
+            ))
+
+            current_stress_cmds = set_stress_command_to_tenant(params=self.params, tenant_number=i)
+            for stress_cmd_param, stress_cmds in current_stress_cmds.items():
+                self.scylla_clusters_stats[i].params[stress_cmd_param] = stress_cmds
+
+            self.log.debug("stress_cmd for cluster %s: %s", self.db_cluster.name,
+                           self.scylla_clusters_stats[i].params["stress_cmd"])
+            self.log.debug("stress_read_cmd for cluster %s: %s", self.db_cluster.name,
+                           self.scylla_clusters_stats[i].params["stress_read_cmd"])
+            self.log.debug("prepare_write_cmd for cluster %s: %s", self.db_cluster.name,
+                           self.scylla_clusters_stats[i].params["prepare_write_cmd"])
+
+    def test_custom_time(self):
+        def _run_test_on_one_tenant(scylla_cluster_stats):
+            self.log.info("Longevity test for cluster %s with parameters: %s", scylla_cluster_stats.db_cluster,
+                          scylla_cluster_stats.params)
+            scylla_cluster_stats.test_custom_time()
+
+        self.log.info("Starting tests worker threads")
+
+        self.log.info("Clusters count: %s", self.k8s_cluster.tenants_number)
+        object_set = ParallelObject(
+            timeout=int(self.test_duration) * 60,
+            objects=[[scs] for scs in self.scylla_clusters_stats],
+            num_workers=self.k8s_cluster.tenants_number
+        )
+        object_set.run(func=_run_test_on_one_tenant, unpack_objects=True, ignore_exceptions=False)

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -262,7 +262,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     db_cluster: BaseScyllaCluster = None
     k8s_cluster: Union[eks.EksCluster, gke.GkeCluster, mini_k8s.LocalKindCluster, None] = None
 
-    def __init__(self, *args):  # pylint: disable=too-many-statements,too-many-locals,too-many-branches
+    def __init__(self, *args, **kwargs):  # pylint: disable=too-many-statements,too-many-locals,too-many-branches
         super().__init__(*args)
         self.result = None
         self._results = []
@@ -345,7 +345,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         if self.params.get("use_ldap"):
             self._init_ldap()
 
-        start_events_device(log_dir=self.logdir, _registry=self.events_processes_registry)
+        # Cover multi-tenant configuration. Prevent event device double initiate
+        start_events_device(log_dir=self.logdir,
+                            _registry=getattr(self, "_registry", None) or self.events_processes_registry)
+
         time.sleep(0.5)
         InfoEvent(message=f"TEST_START test_id={self.test_config.test_id()}").publish()
 

--- a/sdcm/utils/operator/miltitenant_common.py
+++ b/sdcm/utils/operator/miltitenant_common.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2022 ScyllaDB
+
+
+def set_stress_command_to_tenant(params, tenant_number: int):
+    tenant_stress_cmds = {}
+    for stress_cmd_param in params.stress_cmd_params:
+        current_stress_cmd = params.get(stress_cmd_param)
+
+        if not isinstance(current_stress_cmd, list):
+            continue
+
+        if all((isinstance(current_stress_cmd_element, list)
+                for current_stress_cmd_element in current_stress_cmd)):
+            tenant_stress_cmds[stress_cmd_param] = current_stress_cmd[tenant_number]
+        else:
+            tenant_stress_cmds[stress_cmd_param] = current_stress_cmd
+
+    return tenant_stress_cmds

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-multitenant.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-multitenant.yaml
@@ -1,0 +1,40 @@
+test_duration: 300
+prepare_write_cmd:  [
+                     ["cassandra-stress write cl=QUORUM n=209715 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"],
+                     ["cassandra-stress write cl=QUORUM n=209715 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"]
+                    ]
+
+stress_cmd: [
+             ["cassandra-stress write cl=QUORUM duration=150m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=150m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
+             ],
+             [ "cassandra-stress write cl=QUORUM duration=150m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+               "cassandra-stress read  cl=QUORUM duration=150m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
+             ]
+            ]
+
+stress_read_cmd: [
+                  ["cassandra-stress read  cl=QUORUM duration=150m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"],
+                  ["cassandra-stress read  cl=QUORUM duration=150m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"]
+                 ]
+
+# NOTE: we disable second type of monitoring - K8S based one. It is redundant while we use standalone ones.
+k8s_deploy_monitoring: false
+
+n_db_nodes: 4
+k8s_n_scylla_pods_per_cluster: 3
+n_monitor_nodes: 1
+
+# NOTE: we deploy here 4 K8S nodes of the 'loader' type and going to create 2 pairs of loader pods.
+n_loaders: 4
+k8s_n_loader_pods_per_cluster: 2
+
+
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_interval: 5
+
+user_prefix: 'longevity-scylla-operator-3h-multitenant'
+
+space_node_threshold: 64424
+
+cluster_health_check: false

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -18,6 +18,7 @@ import unittest
 from collections import namedtuple
 
 from sdcm import sct_config
+from sdcm.utils.operator.miltitenant_common import set_stress_command_to_tenant
 
 RPM_URL = 'https://s3.amazonaws.com/downloads.scylladb.com/enterprise/rpm/unstable/centos/' \
           '9f724fedb93b4734fcfaec1156806921ff46e956-2bdfa9f7ef592edaf15e028faf3b7f695f39ebc1' \
@@ -636,6 +637,42 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         # I would expect master:latest to be version 3 now, but azure.utils.get_scylla_images
         # returns something from 5 months ago.
         self.assertIn('user_data_format_version', conf)
+
+    def test_21_verify_unique_stress_cmds_per_tenant(self):
+        os.environ['SCT_CONFIG_FILES'] = 'unit_tests/test_data/test_config/multitenant/unique_stress_cmd_per_tenant.yaml'
+        os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
+        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-06f919eb'
+        os.environ['SCT_INSTANCE_TYPE_DB'] = 'i3.large'
+        conf = sct_config.SCTConfiguration()
+        conf.verify_configuration()
+
+        tenant_stress_cmds = set_stress_command_to_tenant(conf, 0)
+        self.assertEqual(tenant_stress_cmds['stress_cmd'], ['threads=50', 'threads=30'])
+        self.assertEqual(tenant_stress_cmds['stress_read_cmd'], ['threads=70'])
+        self.assertEqual(tenant_stress_cmds['prepare_write_cmd'], ['threads=90'])
+
+        tenant_stress_cmds = set_stress_command_to_tenant(conf, 1)
+        self.assertEqual(tenant_stress_cmds['stress_cmd'], ['threads=60', 'threads=20'])
+        self.assertEqual(tenant_stress_cmds['stress_read_cmd'], ['threads=10'])
+        self.assertEqual(tenant_stress_cmds['prepare_write_cmd'], ['threads=70'])
+
+    def test_22_verify_same_stress_cmds_for_all_tenants(self):
+        os.environ['SCT_CONFIG_FILES'] = 'unit_tests/test_data/test_config/multitenant/same_stress_cmd_for_all_tenants.yaml'
+        os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
+        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-06f919eb'
+        os.environ['SCT_INSTANCE_TYPE_DB'] = 'i3.large'
+        conf = sct_config.SCTConfiguration()
+        conf.verify_configuration()
+
+        tenant_stress_cmds_0 = set_stress_command_to_tenant(conf, 0)
+        self.assertEqual(tenant_stress_cmds_0['stress_cmd'], ["threads=50", "threads=30"])
+        self.assertEqual(tenant_stress_cmds_0['stress_read_cmd'], ["threads=70", "threads=10"])
+        self.assertEqual(tenant_stress_cmds_0['prepare_write_cmd'], ["threads=90", "threads=70"])
+
+        tenant_stress_cmds_1 = set_stress_command_to_tenant(conf, 1)
+        self.assertEqual(tenant_stress_cmds_0['stress_cmd'], tenant_stress_cmds_1['stress_cmd'])
+        self.assertEqual(tenant_stress_cmds_0['stress_read_cmd'], tenant_stress_cmds_1['stress_read_cmd'])
+        self.assertEqual(tenant_stress_cmds_0['prepare_write_cmd'], tenant_stress_cmds_1['prepare_write_cmd'])
 
 
 if __name__ == "__main__":

--- a/unit_tests/test_data/test_config/multitenant/same_stress_cmd_for_all_tenants.yaml
+++ b/unit_tests/test_data/test_config/multitenant/same_stress_cmd_for_all_tenants.yaml
@@ -1,0 +1,9 @@
+test_duration: 300
+prepare_write_cmd:  ["threads=90", "threads=70"]
+
+stress_cmd: ["threads=50", "threads=30"]
+
+stress_read_cmd: ["threads=70", "threads=10"]
+
+user_prefix: 'longevity-scylla-operator-3h-multitenant'
+n_db_nodes: 4

--- a/unit_tests/test_data/test_config/multitenant/unique_stress_cmd_per_tenant.yaml
+++ b/unit_tests/test_data/test_config/multitenant/unique_stress_cmd_per_tenant.yaml
@@ -1,0 +1,22 @@
+test_duration: 300
+prepare_write_cmd:  [
+                     ["threads=90"],
+                     ["threads=70"]
+                    ]
+
+stress_cmd: [
+             ["threads=50",
+             "threads=30"
+             ],
+             [ "threads=60",
+               "threads=20"
+             ]
+            ]
+
+stress_read_cmd: [
+                  ["threads=70"],
+                  ["threads=10"]
+                 ]
+
+user_prefix: 'longevity-scylla-operator-3h-multitenant'
+n_db_nodes: 4


### PR DESCRIPTION
This commit is part of support operator multi-tenant longevity.
Add new multitenant longevity test

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
