### PR TITLE
fix(nemesis): disrupt_run_unique_sequence sleep in the end

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3332,6 +3332,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         InfoEvent(message='Starting grow_shrink disruption').publish()
         self.disrupt_grow_shrink_cluster()
         InfoEvent(message="Finished grow_shrink disruption").publish()
+        time.sleep(sleep_time_between_ops)  # to be sure latency spikes are related to end of test and not to nemesis
 
     def disrupt_memory_stress(self):
         """


### PR DESCRIPTION
we saw in some tests that after the last part of this
nemesis, we have huge latency spikes, and to isolate
the cause of it, we want to have a little sleep after the
3 decommissions are done, to verify if that spike will
continue to happen, and we are missing it because
we consider the test to be done.
this is something that most likely doesn't have to
stay in there forever, but only for some time, until
we confirm these spikes are related to the end of
the test, or to the 3 decommissions.
Fixes: #5063

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
