### PR TITLE
fix(ParallelObject): log a full tracebacks on failures

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -37,6 +37,7 @@ import uuid
 import zipfile
 import io
 import tempfile
+import traceback
 from typing import Iterable, List, Callable, Optional, Dict, Union, Literal, Any
 from urllib.parse import urlparse
 from unittest.mock import Mock
@@ -534,7 +535,7 @@ class ParallelObjectException(Exception):
         ex_str = ""
         for res in self.results:
             if res.exc:
-                ex_str += f"{res.obj}: {res.exc}"
+                ex_str += f"{res.obj}:\n {''.join(traceback.format_exception(type(res.exc), res.exc, res.exc.__traceback__))}"
         return ex_str
 
 
@@ -2642,6 +2643,6 @@ class RemoteTemporaryFolder:
         self.folder_name = result.stdout.strip()
         return self
 
-    def __exit__(self, exit_type, value, traceback):
+    def __exit__(self, exit_type, value, _traceback):
         # remove the temporary folder as `sudo` to cover the case when the folder owner was changed during test
         self.node.remoter.sudo(f'rm -rf {self.folder_name}')


### PR DESCRIPTION
when threads are raising exceptions, currently only the
string of the exception is printed to the log, and it's not
really helpful in most situations

code is changed to pring a full backtrace of the exception

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
