### PR TITLE
fix(k8s): use proper number of loaders in K8S with single DB cluster

### DIFF
--- a/defaults/k8s_eks_config.yaml
+++ b/defaults/k8s_eks_config.yaml
@@ -40,8 +40,8 @@ k8s_scylla_rack: 'us-east1'
 k8s_minio_storage_size: '60Gi'
 
 n_monitor_nodes: 1
+# NOTE: if we do not specify 'k8s_n_loader_pods_per_cluster' then value of the 'n_loaders' is used
 n_loaders: 1
-k8s_n_loader_pods_per_cluster: 1
 n_db_nodes: 4
 k8s_n_scylla_pods_per_cluster: 3
 

--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -41,8 +41,8 @@ k8s_minio_storage_size: '60Gi'
 k8s_loader_cluster_name: 'sct-loaders'
 gce_instance_type_loader: 'e2-standard-4'
 
+# NOTE: if we do not specify 'k8s_n_loader_pods_per_cluster' then value of the 'n_loaders' is used
 n_loaders: 1
-k8s_n_loader_pods_per_cluster: 1
 
 gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
 gce_instance_type_monitor: 'e2-medium'

--- a/defaults/k8s_local_kind_config.yaml
+++ b/defaults/k8s_local_kind_config.yaml
@@ -22,8 +22,8 @@ k8s_scylla_disk_gi: 5
 k8s_scylla_disk_class: 'local-raid-disks'
 k8s_minio_storage_size: '20Gi'
 
+# NOTE: if we do not specify 'k8s_n_loader_pods_per_cluster' then value of the 'n_loaders' is used
 n_loaders: 1
-k8s_n_loader_pods_per_cluster: 1
 n_monitor_nodes: 1
 
 user_credentials_path: '~/.ssh/scylla-test'


### PR DESCRIPTION
For the moment we have default value for the `k8s_n_loader_pods_per_cluster`
option be defined to 1 without regards to the `n_loaders`.

It leads to the situation that in each CI job that was not updated
like the multi-tenant ones we get only 1 loader pod.
But in lots of cases we have 2 or 4.

So, fix it by removing default value, in such a case SCT will use
value of the `n_loaders` option which is exactly what we need.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
