### PR TITLE
fix(k8s): make cql_ip_address not be cached forever

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -883,8 +883,6 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
     @cached_property
     def cql_ip_address(self):
-        if self.is_kubernetes():
-            return self.ip_address
         with self.remote_scylla_yaml() as scylla_yaml:
             return scylla_yaml.broadcast_rpc_address if scylla_yaml.broadcast_rpc_address else self.ip_address
 

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1673,6 +1673,10 @@ class BasePodContainer(cluster.BaseNode):  # pylint: disable=too-many-public-met
             return next((x for x in pod_status.container_statuses if x.name == self.parent_cluster.container), None)
         return None
 
+    @property
+    def cql_ip_address(self):
+        return self.ip_address
+
     def _refresh_instance_state(self):
         public_ips = []
         private_ips = []


### PR DESCRIPTION
For the moment, if we run `_refresh_instance_state()` method,
the `cql_ip_address` property won't be updated like
the `public_ip_address` and `private_ip_address` ones.
This is the problem because `cql_ip_address` stops refering
to really existing IP address.
As of now, it makes all the consumer classes/functions of this
attribute fail in a strange way. One of the directions is the
`scylla-bench load nemesis's` which run after
`disrupt_nodetool_flush_and_reshard_on_kubernetes` one.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
