### PR TITLE
fix(k8s): run reconfigure_scylla_monitoring in flush and reshard nemesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1224,6 +1224,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             # NOTE: refresh scylla pods IP addresses because it may get changed here
             for node in nodes_data:
                 node[0].refresh_ip_address()
+            self.monitoring_set.reconfigure_scylla_monitoring()
 
         self.log.info("Resharding has successfully ended on whole Scylla cluster.")
 


### PR DESCRIPTION
We know that the `disrupt_nodetool_flush_and_reshard_on_kubernetes`
nemesis makes some Scylla pods change IP addresses.
So, call `reconfigure_scylla_monitoring` method after we refresh IP
addresses.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
