### PR TITLE
improvement(k8s): disable k8s monitoring as redundant

### DIFF
--- a/defaults/k8s_eks_config.yaml
+++ b/defaults/k8s_eks_config.yaml
@@ -19,9 +19,7 @@ scylla_version: '4.5.3'
 scylla_mgmt_agent_version: '3.0.0'
 k8s_cert_manager_version: '1.2.0'
 
-# Currently k8s monitoring does not work properly
-# https://trello.com/c/8Hwc0nUB/3061-eks-k8s-monitoring-stack-health-monitoring-fails
-k8s_deploy_monitoring: true
+k8s_deploy_monitoring: false
 
 k8s_loader_cluster_name: 'sct-loaders'
 

--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -25,7 +25,7 @@ k8s_scylla_operator_docker_image: ''
 k8s_scylla_operator_helm_repo: 'https://storage.googleapis.com/scylla-operator-charts/latest'
 k8s_scylla_operator_chart_version: 'latest'
 k8s_cert_manager_version: '1.2.0'
-k8s_deploy_monitoring: true
+k8s_deploy_monitoring: false
 
 # NOTE: GKE requires 'k8s_scylla_utils_docker_image' be defined to enterprise Scylla version 2021+
 #       to have more performant configuration of disks.


### PR DESCRIPTION
For the moment we have 2 monitorings - main one on VMs and additional one on K8S.
So, the latter one is not used now, takes some time for installation and may cause test run failures.
So, just disable it for all K8S jobs.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
