### PR TITLE
fix(grafana_sct_dashboard): clear default list flags

### DIFF
--- a/data_dir/scylla-dash-per-server-nemesis.master.json
+++ b/data_dir/scylla-dash-per-server-nemesis.master.json
@@ -47,7 +47,7 @@
         },
         {
           "datasource": "-- Grafana --",
-          "enable": true,
+          "enable": false,
           "hide": false,
           "iconColor": "#badff4",
           "limit": 100,
@@ -69,7 +69,7 @@
         },
         {
           "datasource": "-- Grafana --",
-          "enable": true,
+          "enable": false,
           "hide": false,
           "iconColor": "#eab839",
           "limit": 100,


### PR DESCRIPTION
for some reason, `Normal` and `Warning` events
are being listed automatically, and it is
distubring the usage of Grafana, showing many
information in the charts while not required
(specially during screenshots).
disabling these options so we will have a clean
dashboard when opening it, as the ability
to re-set it, is in there.

giving it a try [in here](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fabio/job/grafana_changes/job/longevity-10gb-3h/4/)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
