### PR TITLE
fix(nemesis): skip 'disrupt_restart_with_resharding' nemesis for K8S

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -882,6 +882,11 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             node.restart_scylla_server()
 
     def disrupt_restart_with_resharding(self):
+        if self._is_it_on_kubernetes():
+            raise UnsupportedNemesis(
+                "Not supported on K8S. "
+                "Run 'disrupt_nodetool_flush_and_reshard_on_kubernetes' instead")
+
         murmur3_partitioner_ignore_msb_bits = 15  # pylint: disable=invalid-name
         self.log.info(f'Restart node with resharding. New murmur3_partitioner_ignore_msb_bits value: '
                       f'{murmur3_partitioner_ignore_msb_bits}')


### PR DESCRIPTION
The case of the `disrupt_restart_with_resharding` nemesis is covered
with the K8S-specific nemesis called `disrupt_nodetool_flush_and_reshard_on_kubernetes`.

So, just skip `disrupt_restart_with_resharding` when running on K8S.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
