### PR TITLE
fix(k8s-functional): make prefill_cluster not run when we reuse cluster

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2518,6 +2518,10 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
         test_keyspaces = self.get_test_keyspaces()
         # If 'keyspace1' does not exist, create a schema and load a data.
         create_schema = not (test_keyspace_name in test_keyspaces)  # pylint: disable=superfluous-parens
+        if not create_schema:
+            # NOTE: if keyspace exists and has data then just exit
+            if int(SstableLoadUtils.validate_data_count_after_upload(node=node)) > 0:
+                return
 
         for node in self.nodes:
             with self.cql_connection_exclusive(node) as session:


### PR DESCRIPTION
If we run K8S functional tests with `SCT_REUSE_CLUSTER=1` config option then we get following error:
```
    sdcm/cluster_k8s/__init__.py:2532: in prefill_cluster
        SstableLoadUtils.run_refresh(node, test_data=test_data[0])
    sdcm/utils/sstable/load_utils.py:113: in run_refresh
        system_log_follower = node.follow_system_log(patterns=[r'Resharded.*'])
    sdcm/cluster.py:1454: in follow_system_log
        stream = File(self.system_log)
    sdcm/utils/file.py:48: in __init__
        self._io = self._open()
    ...
    E  FileNotFoundError: [Errno 2] No such file or directory: '%path-to%/system.log'
```
The failed part must not even run when we already have populated data.
So, fix the pre-fill data logic by making it end as soon as possible.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
