### PR TITLE
Revert breakage commit for ubuntu2204

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -375,7 +375,6 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
             user_data_format_version = self.params.get('oracle_user_data_format_version') or user_data_format_version
 
         user_data_builder = ScyllaUserDataBuilder(cluster_name=self.name,
-                                                  bootstrap=enable_auto_bootstrap,
                                                   user_data_format_version=user_data_format_version, params=self.params,
                                                   syslog_host_port=self.test_config.get_logging_service_host_port())
         ec2_user_data = user_data_builder.to_string()


### PR DESCRIPTION
Closes https://github.com/scylladb/scylla-cluster-tests/issues/5105

Revert commit that breaks SSH'ing to Ubuntu 22.04 in SCT while the proper working for all supported distros solution is not implemented.
Also, revert one more commit that blocks the revert of the target one.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
