### PR TITLE
fix(user-data): user_data_format_version=3 when scylla isn't preinstall

### DIFF
--- a/sdcm/provision/common/configuration_script.py
+++ b/sdcm/provision/common/configuration_script.py
@@ -63,8 +63,6 @@ class ConfigurationScriptBuilder(AttrBuilder, metaclass=abc.ABCMeta):
         # 3. scylla image is running it in such mode that "echo -e" is not working
         # 4. There is race condition between sct and boot script, disable ssh to mitigate it
         # 5. Make sure that whenever you use "cat <<EOF >>/file", make sure that EOF has no spaces in front of it
-        if not self.syslog_host_port:
-            return ''
         script = ''
         if self.logs_transport == 'syslog-ng':
             script += install_syslogng_service()

--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -125,8 +125,8 @@ def configure_ssh_accept_rsa():
     if (( $(ssh -V 2>&1 | tr -d "[:alpha:][:blank:][:punct:]" | cut -c-2) >= 88 )); then
         systemctl stop sshd || true
         sed -i "s/#PubkeyAuthentication \(.*\)$/PubkeyAuthentication yes/" /etc/ssh/sshd_config || true
-        sed -i -e "$aPubkeyAcceptedAlgorithms +ssh-rsa" /etc/ssh/sshd_config || true
-        sed -i -e "$aHostKeyAlgorithms +ssh-rsa" /etc/ssh/sshd_config || true
+        sed -i -e "\\$aPubkeyAcceptedAlgorithms +ssh-rsa" /etc/ssh/sshd_config || true
+        sed -i -e "\\$aHostKeyAlgorithms +ssh-rsa" /etc/ssh/sshd_config || true
         systemctl restart sshd || true
     fi
     """)


### PR DESCRIPTION
PR #5035 started using `user_data_format_version=3` and was
working both on artifacts test and other tests, when specificed
exactly which version to use

later on that series reading of the value of `user_data_format_version`
from the images was introduced, and the default there was version=2
for competibility with older versions that missing the tagging

that was breaking the ubuntu22, since they need the patch for
enabling ssh rsa protocol.

this commit default `user_data_format_version=3` on cases
use don't have scylle pre-installed.

Fix: #5105

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
