### PR TITLE
fix(sla test): wait for compactions finish and add pass/failed criteria

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -114,3 +114,7 @@ InstanceStatusEvent.POWER_OFF: WARNING
 CompactionEvent: NORMAL
 ScyllaHousekeepingServiceEvent: ERROR
 GceInstanceEvent: ERROR
+WorkloadPrioritisationEvent.CpuNotHighEnough: ERROR
+WorkloadPrioritisationEvent.RatioValidationEvent: ERROR
+WorkloadPrioritisationEvent.SlaTestResult: ERROR
+WorkloadPrioritisationEvent.EmptyPrometheusData: ERROR

--- a/sct.py
+++ b/sct.py
@@ -94,7 +94,7 @@ from sdcm.utils.aws_utils import AwsArchType
 from sdcm.utils.gce_utils import SUPPORTED_PROJECTS
 from utils.build_system.create_test_release_jobs import JenkinsPipelines  # pylint: disable=no-name-in-module,import-error
 from utils.get_supported_scylla_base_versions import UpgradeBaseVersion  # pylint: disable=no-name-in-module,import-error
-from utils.mocks.aws_mock import AwsMock  # pylint: disable=no-name-in-module
+from utils.mocks.aws_mock import AwsMock  # pylint: disable=no-name-in-module,import-error
 
 
 SUPPORTED_CLOUDS = ("aws", "gce", "azure",)
@@ -1147,7 +1147,7 @@ def send_email(test_id=None, test_status=None, start_time=None, started_by=None,
     else:
         LOGGER.warning("Failed to find test directory for %s", test_id)
     job_name = os.environ.get('JOB_NAME', '')
-    if 'latency' in job_name or 'throughput' in job_name or 'perf' in job_name:
+    if (('latency' in job_name or 'throughput' in job_name or 'perf' in job_name) and 'sla' not in job_name):
         logs = list_logs_by_test_id(test_results.get('test_id', test_id))
         if not test_results:
             LOGGER.error("Test Results file not found")

--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -318,7 +318,7 @@ class PrometheusDBStats:
         if not self._check_start_end_time(start_time, end_time):
             return {}
         # the query is taken from the Grafana Dashborad definition
-        query = 'avg(irate(scylla_scheduler_runtime_ms{group=~"service_level_.*", instance="%s"}  [30s] )) ' \
+        query = 'avg(irate(scylla_scheduler_runtime_ms{group=~"sl:.*", instance="%s"}  [30s] )) ' \
             'by (group, instance)' % node_ip
         results = self.query(query=query, start=start_time, end=end_time)
         res = defaultdict(dict)
@@ -336,7 +336,7 @@ class PrometheusDBStats:
         if not self._check_start_end_time(start_time, end_time):
             return {}
         # the query is taken from the Grafana Dashborad definition
-        query = 'avg(scylla_scheduler_shares{group=~"service_level_.*", instance="%s"} ) by (group, instance)' % node_ip
+        query = 'avg(scylla_scheduler_shares{group=~"sl:.*", instance="%s"} ) by (group, instance)' % node_ip
         results = self.query(query=query, start=start_time, end=end_time)
         res = {}
         for item in results:

--- a/sdcm/sct_events/workload_prioritisation.py
+++ b/sdcm/sct_events/workload_prioritisation.py
@@ -1,0 +1,44 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2021 ScyllaDB
+import logging
+from typing import Type, Optional
+
+from sdcm.sct_events import Severity, SctEventProtocol
+from sdcm.sct_events.base import InformationalEvent
+
+LOGGER = logging.getLogger(__name__)
+
+
+class WorkloadPrioritisationEvent(InformationalEvent, abstract=True):
+    CpuNotHighEnough: Type[SctEventProtocol]
+    RatioValidationEvent: Type[SctEventProtocol]
+    SlaTestResult: Type[SctEventProtocol]
+    EmptyPrometheusData: Type[SctEventProtocol]
+
+    def __init__(self,
+                 message: Optional[str] = None,
+                 severity=Severity.ERROR) -> None:
+        super().__init__(severity=severity)
+        self.message = message if message else ""
+
+    @property
+    def msgfmt(self) -> str:
+        return super().msgfmt + ": type={0.type} message={0.message}"
+
+
+WorkloadPrioritisationEvent.add_subevent_type("CpuNotHighEnough")
+WorkloadPrioritisationEvent.add_subevent_type("RatioValidationEvent")
+WorkloadPrioritisationEvent.add_subevent_type("SlaTestResult")
+WorkloadPrioritisationEvent.add_subevent_type("EmptyPrometheusData")
+
+__all__ = ("WorkloadPrioritisationEvent",)

--- a/sla_per_user_system_test.py
+++ b/sla_per_user_system_test.py
@@ -17,6 +17,8 @@ import time
 from longevity_test import LongevityTest
 from sdcm.db_stats import PrometheusDBStats
 from sdcm.es import ES
+from sdcm.sct_events import Severity
+from sdcm.sct_events.workload_prioritisation import WorkloadPrioritisationEvent
 from test_lib.sla import ServiceLevel, Role, User
 
 
@@ -52,7 +54,7 @@ class SlaPerUserTest(LongevityTest):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.prometheus_stats = None
-        self.num_of_partitions = 200000000
+        self.num_of_partitions = 50000000
         self.backgroud_task = None
         self.class_users = {}
         self.connection_cql = None
@@ -66,7 +68,7 @@ class SlaPerUserTest(LongevityTest):
         session = self.connection_cql.session
         return session
 
-    def create_test_data(self, rows_amount=None):
+    def create_test_data_and_wait_no_compaction(self, rows_amount=None):
         # Prefill data before tests
         if rows_amount is not None:
             self.num_of_partitions = rows_amount
@@ -78,84 +80,91 @@ class SlaPerUserTest(LongevityTest):
                                                    'prefix': 'preload-',
                                                    'stats_aggregate_cmds': False})
 
+        self.wait_no_compactions_running(n=120)
+
     @staticmethod
-    def user_to_scheduler_group(test_users, scheduler_shares):
-        for user, shares in test_users.items():
+    def role_to_scheduler_group(test_users, scheduler_shares):
+        for role, shares in test_users.items():
             for scheduler_group, sg_shares in scheduler_shares.items():
                 if shares[0] in sg_shares:
-                    test_users[user].append(scheduler_group)
+                    test_users[role].append(scheduler_group)
                     break
         return test_users
 
     def validate_scheduler_runtime(self, start_time, end_time, read_users, expected_ratio):
-        users_with_shares = {user['user'].name: [user['service_level'].service_shares] for user in read_users}
+        roles_with_shares = {user['role'].name: [user['service_level'].shares] for user in read_users}
+        # TODO: ask Eliran do we really need validate it by node?
         for node_ip in self.db_cluster.get_node_private_ips():
             # Temporary solution
             scheduler_shares = self.prometheus_stats.get_scylla_scheduler_shares_per_sla(start_time, end_time, node_ip)
             self.log.debug('SCHEDULERS SHARES FROM PROMETHEUS: {}'.format(scheduler_shares))
-            if 'service_level_sg_0' in scheduler_shares:
-                scheduler_shares.pop('service_level_sg_0')
+            # this default scheduler that is not under test - ignore it
+            if 'sl:default' in scheduler_shares:
+                scheduler_shares.pop('sl:default')
 
-            test_users_to_sg = self.user_to_scheduler_group(test_users=users_with_shares,
+            test_users_to_sg = self.role_to_scheduler_group(test_users=roles_with_shares,
                                                             scheduler_shares=scheduler_shares)
-            self.log.debug('USER - SERVICE LEVEL - SCHEDULER: {}'.format(test_users_to_sg))
+            self.log.debug('ROLE - SERVICE LEVEL - SCHEDULER: {}'.format(test_users_to_sg))
             # End Temporary solution
 
             shards_time_per_sla = self.prometheus_stats.get_scylla_scheduler_runtime_ms(start_time, end_time, node_ip)
-            if not (shards_time_per_sla and scheduler_shares):
-                continue
+            # TODO: follow after this issue (prometheus return empty answer despite the data exists),
+            #  if it is reproduced
+            # if not (shards_time_per_sla and scheduler_shares):
+            #     # Set this message as WARNING because I found that prometheus return empty answer despite the data
+            #     # exists (I run this request manually and got data). Prometheus request doesn't fail, it succeeded but
+            #     # empty, like:
+            #     # {'status': 'success', 'data': {'resultType': 'matrix', 'result': []}}
+            #     WorkloadPrioritisationEvent.EmptyPrometheusData(message=f'Failed to get scheduler_runtime data from '
+            #                                                             f'Prometheus for node {node_ip}',
+            #                                                     severity=Severity.WARNING).publish()
+            #     continue
 
-            runtime_per_user = {}
-            for username, val in test_users_to_sg.items():
+            runtime_per_role = {}
+            for rolename, val in test_users_to_sg.items():
                 if val[1] in shards_time_per_sla[node_ip]:
-                    runtime_per_user[username] = sum(shards_time_per_sla[node_ip][val[1]]) / \
+                    runtime_per_role[rolename] = sum(shards_time_per_sla[node_ip][val[1]]) / \
                         len(shards_time_per_sla[node_ip][val[1]])
                 else:
-                    runtime_per_user[username] = 0
-            self.log.debug('RUN TIME PER USER: {}'.format(runtime_per_user))
+                    runtime_per_role[rolename] = 0
+            self.log.debug('RUN TIME PER ROLE: {}'.format(runtime_per_role))
             actual_shares_ratio = self.calculate_metrics_ratio_per_user(two_users_list=read_users,
-                                                                        metrics=runtime_per_user)
+                                                                        metrics=runtime_per_role)
             self.validate_deviation(expected_ratio=expected_ratio, actual_ratio=actual_shares_ratio,
-                                    msg='Validate scheduler CPU runtime on the node %s' % node_ip)
+                                    msg=f'Validate scheduler CPU runtime on the node {node_ip}. '
+                                        f'Run time per role: {runtime_per_role}')
 
     @staticmethod
-    def create_auths(entities_list_of_dict):
-        """
-        :param entities_list_of_dict: Expected structure:
-                    [{'user': User(), 'role': Role(), 'service_level': ServiceLevel()},
-                    OR
-                     {'user': User(), 'service_level': ServiceLevel()},
-                    OR
-                     {'role': Role(), 'service_level': ServiceLevel()}
-                    ]
-        """
-        for entity in entities_list_of_dict:
-            service_level = entity.get('service_level')
-            role = entity.get('role')
-            user = entity.get('user')
-            if service_level:
-                service_level.create()
-            if role:
-                role.create()
-                role.attach_service_level(service_level=service_level)
-            if user:
-                user.create()
-                if role:
-                    role.grant_me_to(grant_to=user)
-                else:
-                    user.attach_service_level(service_level=service_level)
+    def validate_ratio(expected_ratio, actual_ratio, msg):
+        if not (expected_ratio and actual_ratio):
+            WorkloadPrioritisationEvent.RatioValidationEvent(
+                message=f'Can\'t compare expected and actual shares ratio. Expected: {expected_ratio}. '
+                        f'Actual: {actual_ratio}', severity=Severity.ERROR).publish()
+
+        elif expected_ratio <= actual_ratio:
+            WorkloadPrioritisationEvent.RatioValidationEvent(
+                message=f'{msg}. Actual ratio ({actual_ratio}) is as expected (more or equal then expected ratio '
+                        f'{expected_ratio})',
+                severity=Severity.NORMAL).publish()
+        else:
+            WorkloadPrioritisationEvent.RatioValidationEvent(
+                message=f'{msg}. Actual ratio ({actual_ratio}) is less then expected ratio ({expected_ratio})',
+                severity=Severity.ERROR).publish()
 
     def validate_deviation(self, expected_ratio, actual_ratio, msg):
         dev = self.calculate_deviation(expected_ratio, actual_ratio)
-        self.assertIsNotNone(dev, 'Can\'t compare expected and actual shares ratio. Expected: '
-                                  '{expected_ratio}. Actual: {actual_ratio}'
-                             .format(expected_ratio=expected_ratio, actual_ratio=actual_ratio)
-                             )
-        # TODO: formulate error message
-        self.assertTrue(dev <= self.VALID_DEVIATION_PRC, '{msg}. Actual shares ratio ({actual_ratio}) is not '
-                                                         'as expected ({expected_ratio})'
-                        .format(msg=msg, actual_ratio=actual_ratio, expected_ratio=expected_ratio)
-                        )
+        if dev is None:
+            WorkloadPrioritisationEvent.RatioValidationEvent(
+                message=f'Can\'t compare expected and actual shares ratio. Expected: {expected_ratio}. '
+                        f'Actual: {actual_ratio}', severity=Severity.ERROR).publish()
+        elif dev > self.VALID_DEVIATION_PRC:
+            WorkloadPrioritisationEvent.RatioValidationEvent(
+                message=f'{msg}. Actual ratio ({actual_ratio}) is not as expected ({expected_ratio})',
+                severity=Severity.ERROR).publish()
+        else:
+            WorkloadPrioritisationEvent.RatioValidationEvent(
+                message=f'{msg}. Actual ratio ({actual_ratio}) is as expected ({expected_ratio})',
+                severity=Severity.NORMAL).publish()
 
     @staticmethod
     def calculate_deviation(first, second):
@@ -171,7 +180,7 @@ class SlaPerUserTest(LongevityTest):
         :param metrics: calculate ratio for specific Scylla or cassandra-stress metrics (ops, scheduler_runtime etc..).
                         If metrics name is not defined - ration will be calculated for service_shares
         """
-        if two_users_list[0]['service_level'].service_shares > two_users_list[1]['service_level'].service_shares:
+        if two_users_list[0]['service_level'].shares > two_users_list[1]['service_level'].shares:
             high_shares_user = two_users_list[0]
             low_shares_user = two_users_list[1]
         else:
@@ -179,11 +188,11 @@ class SlaPerUserTest(LongevityTest):
             low_shares_user = two_users_list[0]
 
         if metrics:
-            high_shares_metrics = metrics[high_shares_user['user'].name]
-            low_shares_metrics = metrics[low_shares_user['user'].name]
+            high_shares_metrics = metrics[high_shares_user['role'].name]
+            low_shares_metrics = metrics[low_shares_user['role'].name]
         else:
-            high_shares_metrics = high_shares_user['service_level'].service_shares
-            low_shares_metrics = low_shares_user['service_level'].service_shares
+            high_shares_metrics = high_shares_user['service_level'].shares
+            low_shares_metrics = low_shares_user['service_level'].shares
 
         if not high_shares_metrics or not low_shares_metrics:
             return None
@@ -199,23 +208,33 @@ class SlaPerUserTest(LongevityTest):
 
         return read_queue
 
+    def one_run_c_s_stats(self, read_run, user_name, statistic_name):
+        res = self.get_stress_results(queue=read_run, store_results=False)
+        stat_rate, username = None, None
+        if res:
+            stat_rate = res[0].get(statistic_name)
+            username = res[0].get('username')
+
+        if not (stat_rate and username):
+            self.log.error("Stress statistics are not received for user %s. Can't complete the test", user_name)
+            return None
+
+        return stat_rate, username
+
     def get_c_s_stats(self, read_queue, users, statistic_name):
-        users_names = [user['user'].name for user in users]
+        role_names = [user['role'].name for user in users]
 
         results = {}
         for i, read in enumerate(read_queue):
-            res = self.get_stress_results(queue=read, store_results=False)
-            stat_rate, username = None, None
-            if res:
-                stat_rate = res[0].get(statistic_name)
-                username = res[0].get('username')
+            stat_rate, username = self.one_run_c_s_stats(read_run=read, user_name=role_names[i],
+                                                         statistic_name=statistic_name)
 
-            if not (stat_rate and username):
-                self.log.error('Stress statistics are not received for user {}. Can\'t complete the test'
-                               .format(users_names[i]))
-                return None
-            self.assertEqual(username, users_names[i], msg='Expected that stress was run with user "{}" but it was "{}"'
-                             .format(users_names[i], username))
+            if stat_rate is None:
+                return stat_rate
+
+            self.assertEqual(username, role_names[i],
+                             msg=f'Expected that stress was run with user "{role_names[i]}" but it was "{username}"')
+
             results[username] = float(stat_rate)
 
         return results
@@ -224,8 +243,13 @@ class SlaPerUserTest(LongevityTest):
         end_time = int(time.time())
         scylla_load = self.prometheus_stats.get_scylla_reactor_utilization(start_time=start_time, end_time=end_time)
 
-        self.assertTrue(scylla_load >= wait_cpu_utilization,
-                        msg='Load isn\'t high enough. The test results may be not correct')
+        if scylla_load < wait_cpu_utilization:
+            WorkloadPrioritisationEvent.CpuNotHighEnough(
+                f"Load {scylla_load} isn't high enough(expected at least {wait_cpu_utilization}). "
+                f"The test results may be not correct.", severity=Severity.ERROR).publish()
+            return False
+
+        return True
 
     def clean_auth(self, entities_list_of_dict):
         for entity in entities_list_of_dict:
@@ -302,17 +326,22 @@ class SlaPerUserTest(LongevityTest):
 
         return c_s_cmd
 
+    @staticmethod
+    def attach_service_level(auths_list):
+        for auth in auths_list:
+            auth["role"].attach_service_level(auth["service_level"])
+
     def test_read_throughput_1to5_ratio(self):
         """
         Basic test
         - Add SLA and grant to user (before any load)
         - user190 with 190 shares
-        - user950 qith 950 shares
+        - user950 with 950 shares
         - Each user runs load from own loader (round robin)
         - Expect OPS ratio between two loads is 1:5 (e.g. 190:950)
         - Expect scheduler run time between two loads is 1:5 (e.g. 190:950)
 
-        Load from both cache and disk
+        Load from cache
         """
         # In ideal expected ratio between two users is 5.0.
         # Based on reality change it to 3.5
@@ -322,34 +351,39 @@ class SlaPerUserTest(LongevityTest):
 
     def _two_users_load_througput_workload(self, shares, load, expected_shares_ratio=None):
         session = self.prepare_schema()
-        self.create_test_data()
+        self.create_test_data_and_wait_no_compaction()
 
         # Define Service Levels/Roles/Users
 
         read_users = []
         for share in shares:
-            read_users.append({'user': User(session=session, name='user%d' % share, password='user%d' % share),
-                               'role': Role(session=session, name='role%d' % share),
+            read_users.append({'user': User(session=session, name='user%d' % share, password='user%d' % share).create(),
+                               'role': Role(session=session, name='role%d' % share, password='role%d' % share,
+                                            login=True).create(),
                                'service_level': ServiceLevel(session=session, name='sla%d' % share,
-                                                             shares=share)})
+                                                             shares=share).create()})
+
+        self.attach_service_level(auths_list=read_users)
 
         expected_shares_ratio = (expected_shares_ratio or
                                  self.calculate_metrics_ratio_per_user(two_users_list=read_users))
 
-        # Create Service Levels/Roles/Users
-        self.create_auths(entities_list_of_dict=read_users)
-
         stress_duration = 10  # minutes
-        read_cmds = [self.define_read_cassandra_stress_command(role=read_users[0]["role"], load_type=load,
-                                                               c_s_workload_type=self.WORKLOAD_THROUGHPUT, threads=250,
+        read_cmds = [self.define_read_cassandra_stress_command(role=read_users[0]["role"],
+                                                               load_type=load,
+                                                               c_s_workload_type=self.WORKLOAD_THROUGHPUT,
+                                                               threads=1000,
                                                                stress_duration_min=stress_duration),
-                     self.define_read_cassandra_stress_command(role=read_users[1]["role"], load_type=load,
-                                                               c_s_workload_type=self.WORKLOAD_THROUGHPUT, threads=250,
+                     self.define_read_cassandra_stress_command(role=read_users[1]["role"],
+                                                               load_type=load,
+                                                               c_s_workload_type=self.WORKLOAD_THROUGHPUT,
+                                                               threads=1000,
                                                                stress_duration_min=stress_duration)
                      ]
 
         try:
-            start_time = time.time()
+            # Let to cassandra-stress to warm up the load before get statistics (add 60 sec to start time)
+            start_time = time.time() + 60
 
             read_queue = self.run_stress_and_verify_threads(params={'stress_cmd': read_cmds, 'round_robin': True})
 
@@ -365,8 +399,8 @@ class SlaPerUserTest(LongevityTest):
 
             self.log.debug('Validate cassandra-stress ops deviation')
             actual_shares_ratio = self.calculate_metrics_ratio_per_user(two_users_list=read_users, metrics=results)
-            self.validate_deviation(expected_ratio=expected_shares_ratio,
-                                    actual_ratio=actual_shares_ratio, msg='Validate cassandra-stress ops.')
+            self.validate_ratio(expected_ratio=expected_shares_ratio,
+                                actual_ratio=actual_shares_ratio, msg='Validate cassandra-stress ops')
 
         finally:
             self.clean_auth(entities_list_of_dict=read_users)
@@ -375,7 +409,7 @@ class SlaPerUserTest(LongevityTest):
         """
         Test when one user run load with high latency and another  - with high througput
         The load is run on the full data set (that is read from both the cache and the disk)
-        Troughput - latency test:
+        Throughput - latency test:
         - Add SLA and grant to user (before any load)
         - user190 with 190 shares
         - user950 qith 950 shares
@@ -386,43 +420,60 @@ class SlaPerUserTest(LongevityTest):
         Expected results: latency 99th of user950 workload when it runs in parallel with workload of user190 is not
                           significant increased relatively to latency of runed alone user950 workload
         """
-        stress_duration = 10  # minutes
+        stress_duration = 5  # minutes
         shares = [190, 950]
         read_users = []
+        # Select part of the record to warm the cache (all this data will be in the cache).
+        # This amount of data will be read during the test from cache
+        max_key_for_read = int(self.num_of_partitions*0.5)
 
         session = self.prepare_schema()
-        self.create_test_data()
+        self.create_test_data_and_wait_no_compaction()
 
         # Define Service Levels/Roles/Users
         for share in shares:
-            read_users.append({'user': User(session=session, name='user%d' % share, password='user%d' % share),
-                               'role': Role(session=session, name='role%d' % share),
+            read_users.append({'user': User(session=session, name='user%d' % share, password='user%d' % share).create(),
+                               'role': Role(session=session, name='role%d' % share, password='role%d' % share,
+                                            login=True).create(),
                                'service_level': ServiceLevel(session=session, name='sla%d' % share,
-                                                             shares=share)})
+                                                             shares=share).create()})
 
-        # Create Service Levels/Roles/Users
-        self.create_auths(entities_list_of_dict=read_users)
+        self.attach_service_level(auths_list=read_users)
 
         # Define stress commands
-        read_cmds = {'troughput': self.define_read_cassandra_stress_command(role=read_users[0]["role"],
-                                                                            load_type=self.MIXED_LOAD,
-                                                                            c_s_workload_type=self.WORKLOAD_THROUGHPUT,
-                                                                            threads=200,
-                                                                            stress_duration_min=stress_duration),
+        read_cmds = {'throughput': self.define_read_cassandra_stress_command(role=read_users[0]["role"],
+                                                                             load_type=self.MIXED_LOAD,
+                                                                             c_s_workload_type=self.WORKLOAD_THROUGHPUT,
+                                                                             threads=200,
+                                                                             stress_duration_min=stress_duration,
+                                                                             max_rows_for_read=max_key_for_read),
                      'latency': self.define_read_cassandra_stress_command(role=read_users[1]["role"],
                                                                           load_type=self.MIXED_LOAD,
                                                                           c_s_workload_type=self.WORKLOAD_LATENCY,
                                                                           threads=250,
-                                                                          stress_duration_min=stress_duration)
+                                                                          stress_duration_min=stress_duration,
+                                                                          max_rows_for_read=max_key_for_read),
+                     'latency_throughput': self.define_read_cassandra_stress_command(
+                         role=read_users[1]["role"],
+                         load_type=self.MIXED_LOAD,
+                         c_s_workload_type=self.WORKLOAD_THROUGHPUT,
+                         threads=1000,
+                         stress_duration_min=stress_duration,
+                         max_rows_for_read=max_key_for_read)
                      }
 
-        self._throughput_latency_tests_run(read_users=read_users, read_cmds=read_cmds, latency_user=read_users[1])
+        # TODO: improvement_expected number and calculation of actual improvement was set by Eliran for cache only
+        #  test. Should be adjusted for this test
+        improvement_expected = 1.8
+
+        self._throughput_latency_tests_run(read_users=read_users, read_cmds=read_cmds,
+                                           latency_user=read_users[1], improvement_expected=improvement_expected)
 
     def test_read_throughput_vs_latency_cache_only(self):  # pylint: disable=invalid-name
         """
         Test when one user run load with high latency and another  - with high througput
         The load is run on the data set that fully exists in the cache
-        Troughput - latency test:
+        Throughput - latency test:
         - Add SLA and grant to user (before any load)
         - user190 with 190 shares
         - user950 qith 950 shares
@@ -431,7 +482,7 @@ class SlaPerUserTest(LongevityTest):
            - user190 runs load with high throughput
 
         Expected results: latency 99th of user950 workload when it runs in parallel with workload of user190 is not
-                          significant increased relatively to latency of runed alone user950 workload
+                          significant increased relatively to latency of run alone user950 workload
         """
         stress_duration = 5  # minutes
         shares = [190, 950]
@@ -441,42 +492,53 @@ class SlaPerUserTest(LongevityTest):
         read_users = []
 
         session = self.prepare_schema()
-        self.create_test_data()
+        self.create_test_data_and_wait_no_compaction()
 
         # Warm up the cache to guarantee the read will be from disk
         self.warm_up_cache_before_test(max_key_for_read=max_key_for_read, stress_duration=30)
 
         # Define Service Levels/Roles/Users
         for share in shares:
-            read_users.append({'user': User(session=session, name='user%d' % share, password='user%d' % share),
-                               'role': Role(session=session, name='role%d' % share),
+            read_users.append({'user': User(session=session, name='user%d' % share, password='user%d' % share).create(),
+                               'role': Role(session=session, name='role%d' % share,
+                                            password='role%d' % share, login=True).create(),
                                'service_level': ServiceLevel(session=session, name='sla%d' % share,
-                                                             shares=share)})
+                                                             shares=share).create()})
 
-        # Create Service Levels/Roles/Users
-        self.create_auths(entities_list_of_dict=read_users)
+        self.attach_service_level(auths_list=read_users)
 
-        read_cmds = {'troughput': self.define_read_cassandra_stress_command(role=read_users[0]["role"],
-                                                                            load_type=self.CACHE_ONLY_LOAD,
-                                                                            c_s_workload_type=self.WORKLOAD_THROUGHPUT,
-                                                                            threads=200,
-                                                                            stress_duration_min=stress_duration,
-                                                                            max_rows_for_read=max_key_for_read),
+        read_cmds = {'throughput': self.define_read_cassandra_stress_command(role=read_users[0]["role"],
+                                                                             load_type=self.CACHE_ONLY_LOAD,
+                                                                             c_s_workload_type=self.WORKLOAD_THROUGHPUT,
+                                                                             threads=950,
+                                                                             stress_duration_min=stress_duration,
+                                                                             max_rows_for_read=max_key_for_read),
                      'latency': self.define_read_cassandra_stress_command(role=read_users[1]["role"],
                                                                           load_type=self.CACHE_ONLY_LOAD,
                                                                           c_s_workload_type=self.WORKLOAD_LATENCY,
-                                                                          threads=250,
+                                                                          threads=1000,
                                                                           stress_duration_min=stress_duration,
-                                                                          max_rows_for_read=max_key_for_read)
+                                                                          max_rows_for_read=max_key_for_read),
+                     'latency_throughput': self.define_read_cassandra_stress_command(
+                         role=read_users[1]["role"],
+                         load_type=self.CACHE_ONLY_LOAD,
+                         c_s_workload_type=self.WORKLOAD_THROUGHPUT,
+                         threads=1000,
+                         stress_duration_min=stress_duration,
+                         max_rows_for_read=max_key_for_read)
                      }
 
-        self._throughput_latency_tests_run(read_users=read_users, read_cmds=read_cmds, latency_user=read_users[1])
+        # improvement_expected number and calculation of actual improvement was set by Eliran
+        improvement_expected = 1.8
+
+        self._throughput_latency_tests_run(read_users=read_users, read_cmds=read_cmds,
+                                           latency_user=read_users[1], improvement_expected=improvement_expected)
 
     def test_read_throughput_vs_latency_disk_only(self):  # pylint: disable=invalid-name
         """
         Test when one user run load with high latency and another  - with high througput
         The load is run on the data set that fully exists in the cache
-        Troughput - latency test:
+        Throughput - latency test:
         - Add SLA and grant to user (before any load)
         - user190 with 190 shares
         - user950 qith 950 shares
@@ -490,7 +552,7 @@ class SlaPerUserTest(LongevityTest):
         stress_duration = 5  # minutes
 
         session = self.prepare_schema()
-        self.create_test_data()
+        self.create_test_data_and_wait_no_compaction()
 
         for node in self.db_cluster.nodes:
             node.stop_scylla_server(verify_up=False, verify_down=True)
@@ -499,89 +561,181 @@ class SlaPerUserTest(LongevityTest):
         # Select part of the record to warm the cache (all this data will be in the cache).
         # cassandra-stress "-pop" parameter will start from more then "max_key_for_cache" row number
         # (for read from the disk)
-        max_key_for_cache = int(self.num_of_partitions*0.25)
+        max_key_for_read = int(self.num_of_partitions*0.25)
         # Warm up the cache to guarantee the read will be from disk
-        self.warm_up_cache_before_test(max_key_for_read=max_key_for_cache, stress_duration=30)
+        self.warm_up_cache_before_test(max_key_for_read=max_key_for_read, stress_duration=30)
 
         # Define Service Levels/Roles/Users
         shares = [190, 950]
         read_users = []
         for share in shares:
-            read_users.append({'user': User(session=session, name='user%d' % share, password='user%d' % share),
-                               'role': Role(session=session, name='role%d' % share),
+            read_users.append({'user': User(session=session, name='user%d' % share, password='user%d' % share).create(),
+                               'role': Role(session=session, name='role%d' % share, password='role%d' % share,
+                                            login=True).create(),
                                'service_level': ServiceLevel(session=session, name='sla%d' % share,
-                                                             shares=share)})
+                                                             shares=share).create()})
 
-        # Create Service Levels/Roles/Users
-        self.create_auths(entities_list_of_dict=read_users)
+        self.attach_service_level(auths_list=read_users)
 
-        read_cmds = {'troughput': self.define_read_cassandra_stress_command(role=read_users[0]["role"],
-                                                                            load_type=self.DISK_ONLY_LOAD,
-                                                                            c_s_workload_type=self.WORKLOAD_THROUGHPUT,
-                                                                            threads=200,
-                                                                            stress_duration_min=stress_duration,
-                                                                            max_rows_for_read=max_key_for_cache*2),
+        read_cmds = {'throughput': self.define_read_cassandra_stress_command(role=read_users[0]["role"],
+                                                                             load_type=self.DISK_ONLY_LOAD,
+                                                                             c_s_workload_type=self.WORKLOAD_THROUGHPUT,
+                                                                             threads=200,
+                                                                             stress_duration_min=stress_duration,
+                                                                             max_rows_for_read=max_key_for_read * 2),
                      'latency': self.define_read_cassandra_stress_command(role=read_users[1]["role"],
                                                                           load_type=self.DISK_ONLY_LOAD,
                                                                           c_s_workload_type=self.WORKLOAD_LATENCY,
                                                                           threads=250,
                                                                           stress_duration_min=stress_duration,
-                                                                          max_rows_for_read=max_key_for_cache*3),
+                                                                          max_rows_for_read=max_key_for_read*3),
                      'latency_only': self.define_read_cassandra_stress_command(role=read_users[1]["role"],
                                                                                load_type=self.DISK_ONLY_LOAD,
                                                                                c_s_workload_type=self.WORKLOAD_LATENCY,
                                                                                threads=250,
                                                                                stress_duration_min=stress_duration,
-                                                                               max_rows_for_read=max_key_for_cache)
+                                                                               max_rows_for_read=max_key_for_read),
+                     'latency_throughput': self.define_read_cassandra_stress_command(
+                         role=read_users[1]["role"],
+                         load_type=self.DISK_ONLY_LOAD,
+                         c_s_workload_type=self.WORKLOAD_THROUGHPUT,
+                         threads=1000,
+                         stress_duration_min=stress_duration,
+                         max_rows_for_read=max_key_for_read)
                      }
 
-        self._throughput_latency_tests_run(read_users=read_users, read_cmds=read_cmds, latency_user=read_users[1])
+        # TODO: improvement_expected number and calculation of actual improvement was set by Eliran for chache only
+        #  TODO: test. Should be adjusted for this test
+        improvement_expected = 1.8
+
+        self._throughput_latency_tests_run(read_users=read_users, read_cmds=read_cmds,
+                                           latency_user=read_users[1], improvement_expected=improvement_expected)
 
     def test_read_50perc_write_50perc_load(self):
         """
         Test scenario:
         - Add SLA and grant to user (before any load)
         - user190 with 190 shares
-        - user950 qith 950 shares
+        - user950 with 950 shares
         - Each user runs load from own loader (round robin)
         - Expect OPS ratio between two loads is 1:5 (e.g. 190:950)
         - Expect scheduler run time between two loads is 1:5 (e.g. 190:950)
         """
 
-        session = self.prepare_schema()
-        self.create_test_data()
+        stress_duration = 5  # minutes
 
-        stress_duration_min = 10
+        # Select part of the record to warm the cache (all this data will be in the cache).
+        # This amount of data will be read during the test from cache
+        max_key_for_read = int(self.num_of_partitions * 0.5)
+
+        session = self.prepare_schema()
+        self.create_test_data_and_wait_no_compaction()
+
+        # Warm up the cache to guarantee the read will be from disk
+        self.warm_up_cache_before_test(max_key_for_read=max_key_for_read, stress_duration=30)
 
         # Define Service Levels/Roles/Users
         shares = [190, 950]
         read_users = []
         for share in shares:
-            read_users.append({'user': User(session=session, name='user%d' % share, password='user%d' % share),
-                               'role': Role(session=session, name='role%d' % share),
+            read_users.append({'user': User(session=session, name='user%d' % share, password='user%d' % share).create(),
+                               'role': Role(session=session, name='role%d' % share, password='role%d' % share,
+                                            login=True).create(),
                                'service_level': ServiceLevel(session=session, name='sla%d' % share,
-                                                             shares=share)})
+                                                             shares=share).create()})
 
-        # Create Service Levels/Roles/Users
-        self.create_auths(entities_list_of_dict=read_users)
+        self.attach_service_level(auths_list=read_users)
 
-        read_cmds = {'troughput': self.define_read_cassandra_stress_command(role=read_users[0]["role"],
-                                                                            load_type=self.MIXED_LOAD,
-                                                                            c_s_workload_type=self.WORKLOAD_THROUGHPUT,
-                                                                            threads=120,
-                                                                            stress_duration_min=stress_duration_min,
-                                                                            stress_command=self.STRESS_MIXED_CMD,
-                                                                            kwargs={'write_ratio': 1, 'read_ratio': 1}),
+        read_cmds = {'throughput': self.define_read_cassandra_stress_command(role=read_users[0]["role"],
+                                                                             load_type=self.MIXED_LOAD,
+                                                                             c_s_workload_type=self.WORKLOAD_THROUGHPUT,
+                                                                             threads=120,
+                                                                             stress_duration_min=stress_duration,
+                                                                             stress_command=self.STRESS_MIXED_CMD,
+                                                                             kwargs={'write_ratio': 1,
+                                                                                     'read_ratio': 1}),
                      'latency': self.define_read_cassandra_stress_command(role=read_users[1]["role"],
                                                                           load_type=self.MIXED_LOAD,
                                                                           c_s_workload_type=self.WORKLOAD_LATENCY,
                                                                           threads=120,
-                                                                          stress_duration_min=stress_duration_min,
+                                                                          stress_duration_min=stress_duration,
                                                                           stress_command=self.STRESS_MIXED_CMD,
-                                                                          kwargs={'write_ratio': 1, 'read_ratio': 1})
+                                                                          kwargs={'write_ratio': 1, 'read_ratio': 1}),
+                     'latency_throughput': self.define_read_cassandra_stress_command(
+                         role=read_users[1]["role"],
+                         load_type=self.MIXED_LOAD,
+                         c_s_workload_type=self.WORKLOAD_THROUGHPUT,
+                         threads=1000,
+                         stress_duration_min=stress_duration,
+                         max_rows_for_read=max_key_for_read,
+                         stress_command=self.STRESS_MIXED_CMD,
+                         kwargs={'write_ratio': 1,
+                                 'read_ratio': 1})
                      }
+        # TODO: improvement_expected number and calculation of actual improvement was set by Eliran for chache only
+        #  TODO: test. Should be adjusted for this test
+        improvement_expected = 1.8
 
-        self._throughput_latency_tests_run(read_users=read_users, read_cmds=read_cmds, latency_user=read_users[1])
+        self._throughput_latency_tests_run(read_users=read_users, read_cmds=read_cmds,
+                                           latency_user=read_users[1], improvement_expected=improvement_expected)
+
+    def _throughput_latency_tests_run(self, read_cmds, read_users, latency_user, improvement_expected):
+        # pylint: disable=too-many-locals
+
+        # Run latency workload
+        test_start_time = time.time()
+        self.log.debug('Start latency only workload')
+        read_queue = self.run_stress_and_verify_threads(params={'stress_cmd': [read_cmds.get('latency_only')
+                                                                               or read_cmds['latency']],
+                                                                'round_robin': True})
+
+        latency_99_for_latency_workload = self.get_c_s_stats(read_queue=read_queue, users=[latency_user],
+                                                             statistic_name='latency 99th percentile')
+
+        self.assertTrue(latency_99_for_latency_workload, msg='Not received cassandra-stress results for latency '
+                        'workload')
+
+        # Run throughput (user950) and latency (user950) workloads
+        latency_workload_same_user, throughput_user950_workload, user950_result_print_str = \
+            self._throughput_latency_parallel_run(read_cmds=read_cmds,
+                                                  test_start_time=test_start_time,
+                                                  latency_99_for_latency_workload=latency_99_for_latency_workload,
+                                                  latency_user=latency_user,
+                                                  throughput_user=latency_user,
+                                                  throughput_cmd_name='latency_throughput',
+                                                  latency_cmd_name='latency')
+
+        # Run throughput (user150) and latency (user950) workloads
+        throughput_user = [user for user in read_users if user != latency_user][0]
+        latency_workload_mixed_users, throughput_user150_workload, user150_result_print_str = \
+            self._throughput_latency_parallel_run(read_cmds=read_cmds,
+                                                  test_start_time=test_start_time,
+                                                  latency_99_for_latency_workload=latency_99_for_latency_workload,
+                                                  latency_user=latency_user,
+                                                  throughput_user=throughput_user,
+                                                  throughput_cmd_name='throughput',
+                                                  latency_cmd_name='latency')
+
+        self.log.info("Result of run with user950 throughput and user950 latency workloads: %s",
+                      user950_result_print_str)
+
+        self.log.info("Result of run with user150 throughput and user950 latency workloads: %s",
+                      user150_result_print_str)
+
+        improvement_actual = (throughput_user950_workload * latency_workload_mixed_users) / \
+                             (throughput_user150_workload * latency_workload_same_user)
+        if improvement_actual >= improvement_expected:
+            WorkloadPrioritisationEvent.SlaTestResult(
+                message=f'Actual improvement is {improvement_actual} more/equal then {improvement_expected} '
+                        f'as expected.',
+                severity=Severity.NORMAL).publish()
+
+        else:
+            WorkloadPrioritisationEvent.SlaTestResult(
+                message=f'Actual improvement is {improvement_actual} less then expected {improvement_expected}',
+                severity=Severity.ERROR).publish()
+
+        self.clean_auth(entities_list_of_dict=read_users)
 
     def test_workload_types(self):
         """
@@ -591,7 +745,7 @@ class SlaPerUserTest(LongevityTest):
         within the expected margins.
         """
         session = self.prepare_schema()
-        self.create_test_data(rows_amount=100_000)
+        self.create_test_data_and_wait_no_compaction(rows_amount=100_000)
         stress_duration_min = 180
 
         # Define Service Levels/Roles/Users
@@ -638,59 +792,6 @@ class SlaPerUserTest(LongevityTest):
             self.upload_c_s_comparison_to_es()
         finally:
             pass
-
-    def _throughput_latency_tests_run(self, read_cmds, read_users, latency_user):
-        # pylint: disable=too-many-locals
-        try:
-            # Run latency workload
-            test_start_time = time.time()
-            self.log.debug('Start latency only workload')
-            read_queue = self.run_stress_and_verify_threads(params={'stress_cmd': [read_cmds.get('latency_only')
-                                                                                   or read_cmds['latency']],
-                                                                    'round_robin': True})
-
-            latency_99_for_latency_workload = self.get_c_s_stats(read_queue=read_queue, users=[latency_user],
-                                                                 statistic_name='latency 99th percentile')
-
-            self.assertTrue(latency_99_for_latency_workload, msg='Not received cassandra-stress results for latency '
-                            'workload')
-
-            # Run throughput and latency workloads
-            self.log.debug('Start latency workload in parallel with throughput workload')
-            read_queue = self.run_stress_and_verify_threads(params={'stress_cmd': [read_cmds['troughput'],
-                                                                                   read_cmds['latency']],
-                                                                    'round_robin': True})
-            latency_99_for_mixed_workload = self.get_c_s_stats(read_queue=read_queue, users=read_users,
-                                                               statistic_name='latency 99th percentile')
-
-            self.assertTrue(latency_99_for_mixed_workload, msg='Not received cassandra-stress for latency workload')
-
-            grafana_dataset = self.monitors.get_grafana_screenshot_and_snapshot(test_start_time=test_start_time)
-
-            grafana_screenshots = grafana_dataset.get('screenshots', [])
-            grafana_snapshots = grafana_dataset.get('snapshots', [])
-
-            self.log.debug('GRAFANA SCREENSHOTS: {}'.format(grafana_screenshots))
-            self.log.debug('GRAFANA SNAPSHOTS: {}'.format(grafana_snapshots))
-
-            # Compare latency of two runs
-            self.log.debug('Test results:\n---------------------\n')
-            latency_99_latency_workload = latency_99_for_latency_workload[latency_user['user'].name]
-            latency_99_mixed_workload = latency_99_for_mixed_workload[latency_user['user'].name]
-            deviation = self.calculate_deviation(latency_99_latency_workload, latency_99_mixed_workload)
-            latency_change = 'increased' if latency_99_mixed_workload > latency_99_latency_workload else 'decreased'
-
-            result_print_str = '\nTest results:\n---------------------\n'
-            result_print_str += '\nWorkload                  |      Latency 99%'
-            result_print_str += '\n========================= | ================='
-            result_print_str += '\nLatency only              |      {}'.format(latency_99_latency_workload)
-            result_print_str += '\nLatency and throughput    |      {}'.format(latency_99_mixed_workload)
-            result_print_str += '\n------------------------- | -----------------'
-            result_print_str += '\nLatency 99 is {} in {}%'.format(latency_change, deviation)
-
-            self.log.info(result_print_str)
-        finally:
-            self.clean_auth(entities_list_of_dict=read_users)
 
     def _compare_workloads_c_s_metrics(self, workloads_queue: list) -> dict:
         comparison_axis = {"latency 95th percentile": 2.0,
@@ -779,3 +880,61 @@ class SlaPerUserTest(LongevityTest):
             except KeyError as exc:
                 self.log.error("Exception on attempting to check workload comparison results:\n%s", exc)
                 return super().get_test_status()
+        else:
+            return super().get_test_status()
+
+    def _throughput_latency_parallel_run(self, read_cmds, test_start_time, latency_99_for_latency_workload,
+                                         latency_user, throughput_user, throughput_cmd_name, latency_cmd_name):
+        def __get_stat_for_user(read, user_name):
+            # This is handle case when both loads (latency and throughput) are run for the same user
+            stat_rate, _ = self.one_run_c_s_stats(read_run=read, user_name=user_name,
+                                                  statistic_name='latency 99th percentile')
+
+            if stat_rate:
+                latency_99_for_mixed_workload[user_name] = float(stat_rate)
+
+        self.log.debug('Start latency workload (user %s) in parallel with throughput workload '
+                       '(user %s)', latency_user, throughput_user)
+        read_queue = self.run_stress_and_verify_threads(params={'stress_cmd': [read_cmds[throughput_cmd_name],
+                                                                               read_cmds[latency_cmd_name]],
+                                                                'round_robin': True})
+
+        latency_99_for_mixed_workload = {}
+
+        # Get stats for throughput user load
+        __get_stat_for_user(read=read_queue[0], user_name=throughput_cmd_name)
+
+        # Get stats for latency user load
+        __get_stat_for_user(read=read_queue[1], user_name=latency_cmd_name)
+
+        self.assertTrue(latency_99_for_mixed_workload, msg='Not received cassandra-stress for mixed workload')
+
+        grafana_dataset = self.monitors.get_grafana_screenshot_and_snapshot(test_start_time=test_start_time)
+
+        grafana_screenshots = grafana_dataset.get('screenshots', [])
+        grafana_snapshots = grafana_dataset.get('snapshots', [])
+
+        self.log.debug('GRAFANA SCREENSHOTS: {}'.format(grafana_screenshots))
+        self.log.debug('GRAFANA SNAPSHOTS: {}'.format(grafana_snapshots))
+
+        # Compare latency of two runs
+        self.log.debug('Test results:\n---------------------\n')
+        latency_99_latency_workload = latency_99_for_latency_workload[latency_user['role'].name]
+        latency_99_mixed_workload = latency_99_for_mixed_workload[latency_cmd_name]
+        deviation = self.calculate_deviation(latency_99_latency_workload, latency_99_mixed_workload)
+        if latency_99_mixed_workload > latency_99_latency_workload:
+            latency_change = 'increased'
+        elif latency_99_mixed_workload == latency_99_latency_workload:
+            latency_change = 'not changed'
+        else:
+            latency_change = 'decreased'
+
+        result_print_str = '\nTest results:\n---------------------\n'
+        result_print_str += '\nWorkload                  |      Latency 99%'
+        result_print_str += '\n========================= | ================='
+        result_print_str += '\nLatency only              |      {}'.format(latency_99_latency_workload)
+        result_print_str += '\nLatency and throughput    |      {}'.format(latency_99_mixed_workload)
+        result_print_str += '\n------------------------- | -----------------'
+        result_print_str += '\nLatency 99 is {} in {}%'.format(latency_change, deviation)
+
+        return latency_99_latency_workload, latency_99_mixed_workload, result_print_str

--- a/test_lib/sla.py
+++ b/test_lib/sla.py
@@ -192,7 +192,7 @@ class UserRoleBase:
     AUTHENTICATION_ENTITY = ''
 
     def __init__(self, session, name, password=None, superuser=None, verbose=False, **kwargs):
-        self._name = f'"{name}"'
+        self._name = f'{name}'
         self.password = password
         self.session = session
         self.superuser = superuser


### PR DESCRIPTION
1. After data preparing wait for compactions finish, before start test
2. Add pass/failed criteria for cache only test.

Event example:
```
2022-08-10 09:51:18.017: (WorkloadPrioritisationEvent Severity.NORMAL) period_type=not-set event_id=beaadf2d-5419-47e2-90f7-be5403833c32: type=SlaTestResult message=Actual improvement is 31.35185185185185 more then 1.8 as expected.
```

Tested with 3 scenarios:

- [features-sla-read-50perc-write-50perc-load-test](https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/features-sla-read-50perc-write-50perc-load-test/4/)
- [features-sla-read-throughput-1to5-ratio](https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/yulia-sla-read-throughput-1to5-ratio-2021.1/37/)
- [features-sla-read-throughput-vs-latency-cache-only-test](https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/yulia-features-sla-read-throughput-vs-latency-cache-only-test/52/)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
