### PR TITLE
improvement(availability zone): Fallback availability zones in AWS instance provisioning

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -200,3 +200,5 @@ raid_level: 0
 bare_loaders: false
 
 nemesis_exclude_disabled: true
+
+aws_fallback_to_next_availability_zone: false

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1222,6 +1222,10 @@ class SCTConfiguration(dict):
         dict(name="availability_zone", env="SCT_AVAILABILITY_ZONE",
              type=str,
              help="Availability zone to use. Same for multi-region scenario."),
+        dict(name="aws_fallback_to_next_availability_zone", env="SCT_AWS_FALLBACK_TO_NEXT_AVAILABILITY_ZONE",
+             type=boolean,
+             help="""Try all availability zones one by one in order to maximize the chances of getting
+                   the requested instance capacity."""),
 
         dict(name="num_nodes_to_rollback", env="SCT_NUM_NODES_TO_ROLLBACK",
              type=str,

--- a/sdcm/utils/aws_utils.py
+++ b/sdcm/utils/aws_utils.py
@@ -248,10 +248,11 @@ def init_db_info_from_params(db_info: dict, params: dict, regions: List, root_de
     return db_info
 
 
-def get_common_params(params: dict, regions: List, credentials: List, services: List) -> dict:
+def get_common_params(params: dict, regions: List, credentials: List, services: List, availability_zone: str = None) -> dict:
+    availability_zones = [availability_zone] if availability_zone else params.get('availability_zone').split(',')
     ec2_security_group_ids, ec2_subnet_ids = get_ec2_network_configuration(
         regions=regions,
-        availability_zones=params.get('availability_zone').split(','),
+        availability_zones=availability_zones,
         params=params
     )
     return dict(ec2_security_group_ids=ec2_security_group_ids,

--- a/test-cases/artifacts/ami.yaml
+++ b/test-cases/artifacts/ami.yaml
@@ -15,3 +15,4 @@ scylla_linux_distro: 'centos'
 test_duration: 60
 user_prefix: 'artifacts-ami'
 system_auth_rf: 1
+aws_fallback_to_next_availability_zone: true


### PR DESCRIPTION
        In order to avoid a specific AWS availability zone instance capacity limitation,
        SCT can try all availability zones one by one in order to maximize 
        the chances of getting the requested instance capacity.
Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/5119
https://trello.com/c/5rg6tNqD
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
