### PR TITLE
fix(longevity-scylla-operator): enlarge number of nodes/pods

### DIFF
--- a/test-cases/scylla-operator/longevity-scylla-operator-3h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h.yaml
@@ -1,8 +1,8 @@
 test_duration: 300
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
              ]
-n_db_nodes: 4
-k8s_n_scylla_pods_per_cluster: 3
+n_db_nodes: 5
+k8s_n_scylla_pods_per_cluster: 4
 
 n_loaders: 2
 n_monitor_nodes: 1

--- a/test-cases/scylla-operator/longevity-scylla-operator-basic-12h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-basic-12h.yaml
@@ -10,8 +10,8 @@ prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=35123456 -schema 'replic
 
 stress_cmd: ["cassandra-stress write cl=QUORUM duration=720m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=100 throttle=5000/s -pop seq=1..10000000 -log interval=5"
              ]
-n_db_nodes: 4
-k8s_n_scylla_pods_per_cluster: 3
+n_db_nodes: 5
+k8s_n_scylla_pods_per_cluster: 4
 
 n_loaders: 2
 n_monitor_nodes: 1


### PR DESCRIPTION
Since we only have 3 pods by default, any destructive nemesis
is taking us to a QUORUM issue, for example killing one of the scylla
processes, when we only have 3 of them.

```
Cassandra timeout during SIMPLE write query at consistency QUORUM
(2 replica were required but only 1 acknowledged the write)
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
