### PR TITLE
Split stress tools latencies panels

### DIFF
--- a/data_dir/scylla-dash-per-server-nemesis.master.json
+++ b/data_dir/scylla-dash-per-server-nemesis.master.json
@@ -4,7 +4,10 @@
       "list": [
         {
           "builtIn": 1,
-          "datasource": "-- Grafana --",
+          "datasource": {
+            "type": "datasource",
+            "uid": "grafana"
+          },
           "enable": true,
           "hide": true,
           "iconColor": "rgba(0, 211, 255, 1)",
@@ -18,7 +21,10 @@
           "type": "dashboard"
         },
         {
-          "datasource": "-- Grafana --",
+          "datasource": {
+            "type": "datasource",
+            "uid": "grafana"
+          },
           "enable": false,
           "hide": false,
           "iconColor": "#962d82",
@@ -32,7 +38,10 @@
           "type": "tags"
         },
         {
-          "datasource": "-- Grafana --",
+          "datasource": {
+            "type": "datasource",
+            "uid": "grafana"
+          },
           "enable": false,
           "hide": false,
           "iconColor": "#aaacad",
@@ -46,7 +55,10 @@
           "type": "tags"
         },
         {
-          "datasource": "-- Grafana --",
+          "datasource": {
+            "type": "datasource",
+            "uid": "grafana"
+          },
           "enable": false,
           "hide": false,
           "iconColor": "#badff4",
@@ -68,8 +80,11 @@
           "type": "tags"
         },
         {
-          "datasource": "-- Grafana --",
-          "enable": false,
+          "datasource": {
+            "type": "datasource",
+            "uid": "grafana"
+          },
+          "enable": true,
           "hide": false,
           "iconColor": "#eab839",
           "limit": 100,
@@ -89,8 +104,11 @@
           "type": "tags"
         },
         {
-          "datasource": "-- Grafana --",
-          "enable": false,
+          "datasource": {
+            "type": "datasource",
+            "uid": "grafana"
+          },
+          "enable": true,
           "hide": false,
           "iconColor": "#ef843c",
           "limit": 100,
@@ -102,7 +120,10 @@
           "type": "tags"
         },
         {
-          "datasource": "-- Grafana --",
+          "datasource": {
+            "type": "datasource",
+            "uid": "grafana"
+          },
           "enable": false,
           "hide": false,
           "iconColor": "rgba(255, 96, 96, 1)",
@@ -119,16 +140,17 @@
     },
     "editable": true,
     "fiscalYearStartMonth": 0,
-    "gnetId": null,
     "graphTooltip": 1,
-    "id": 9,
-    "iteration": 1636403705413,
+    "iteration": 1660573895324,
     "links": [],
     "liveNow": false,
     "panels": [
       {
         "class": "text_panel",
-        "datasource": null,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "editable": true,
         "error": false,
         "gridPos": {
@@ -137,18 +159,16 @@
           "x": 0,
           "y": 0
         },
-        "id": 1,
         "links": [],
         "options": {
           "content": "<img src=\"http://www.scylladb.com/wp-content/uploads/logo-scylla-white-simple.png\" height=\"70\">\n<hr style=\"border-top: 3px solid #5780c1;\">",
           "mode": "html"
         },
-        "pluginVersion": "8.2.3",
+        "pluginVersion": "8.5.2",
         "transparent": true,
         "type": "text"
       },
       {
-        "cacheTimeout": null,
         "datasource": "prometheus",
         "fieldConfig": {
           "defaults": {
@@ -189,8 +209,6 @@
           "x": 0,
           "y": 3
         },
-        "id": 2,
-        "interval": null,
         "links": [],
         "maxDataPoints": 100,
         "options": {
@@ -208,7 +226,7 @@
           "text": {},
           "textMode": "auto"
         },
-        "pluginVersion": "8.2.3",
+        "pluginVersion": "8.5.2",
         "targets": [
           {
             "expr": "count(up{job=\"scylla\", cluster=~\"$cluster|$^\"})",
@@ -223,7 +241,6 @@
         "type": "stat"
       },
       {
-        "cacheTimeout": null,
         "datasource": "prometheus",
         "fieldConfig": {
           "defaults": {
@@ -268,8 +285,6 @@
           "x": 2,
           "y": 3
         },
-        "id": 3,
-        "interval": null,
         "links": [],
         "maxDataPoints": 100,
         "options": {
@@ -287,7 +302,7 @@
           "text": {},
           "textMode": "auto"
         },
-        "pluginVersion": "8.2.3",
+        "pluginVersion": "8.5.2",
         "targets": [
           {
             "expr": "count(scrape_samples_scraped{job=\"scylla\", cluster=~\"$cluster|$^\"}==0) OR vector(0)",
@@ -303,7 +318,10 @@
       },
       {
         "class": "text_panel",
-        "datasource": null,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "editable": true,
         "error": false,
         "gridPos": {
@@ -312,13 +330,12 @@
           "x": 4,
           "y": 3
         },
-        "id": 4,
         "links": [],
         "options": {
           "content": "##  ",
           "mode": "markdown"
         },
-        "pluginVersion": "8.2.3",
+        "pluginVersion": "8.5.2",
         "style": {},
         "transparent": true,
         "type": "text"
@@ -342,7 +359,6 @@
           "y": 3
         },
         "hiddenSeries": false,
-        "id": 5,
         "legend": {
           "avg": false,
           "current": false,
@@ -360,7 +376,7 @@
           "alertThreshold": true
         },
         "percentage": false,
-        "pluginVersion": "8.2.3",
+        "pluginVersion": "8.5.2",
         "pointradius": 5,
         "points": false,
         "renderer": "flot",
@@ -380,9 +396,7 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
         "timeRegions": [],
-        "timeShift": null,
         "title": "Total Requests",
         "tooltip": {
           "msResolution": false,
@@ -392,9 +406,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -402,26 +414,25 @@
           {
             "format": "ops",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ],
         "yaxis": {
-          "align": false,
-          "alignLevel": null
+          "align": false
         }
       },
       {
         "class": "dashlist",
-        "datasource": null,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "editable": true,
         "error": false,
         "gridPos": {
@@ -430,7 +441,6 @@
           "x": 20,
           "y": 3
         },
-        "id": 30,
         "links": [],
         "options": {
           "maxItems": 10,
@@ -443,33 +453,12 @@
             "master"
           ]
         },
-        "pluginVersion": "8.2.3",
+        "pluginVersion": "8.5.2",
         "tags": [
           "master"
         ],
         "title": "Dashboards",
         "type": "dashlist"
-      },
-      {
-        "class": "text_panel",
-        "datasource": null,
-        "editable": true,
-        "error": false,
-        "gridPos": {
-          "h": 7,
-          "w": 4,
-          "x": 20,
-          "y": 3
-        },
-        "id": 30,
-        "links": [],
-        "options": {
-          "content": "",
-          "mode": "markdown"
-        },
-        "pluginVersion": "8.2.3",
-        "transparent": true,
-        "type": "text"
       },
       {
         "aliasColors": {},
@@ -490,7 +479,6 @@
           "y": 10
         },
         "hiddenSeries": false,
-        "id": 6,
         "legend": {
           "avg": false,
           "current": false,
@@ -508,7 +496,7 @@
           "alertThreshold": true
         },
         "percentage": false,
-        "pluginVersion": "8.2.3",
+        "pluginVersion": "8.5.2",
         "pointradius": 5,
         "points": false,
         "renderer": "flot",
@@ -528,9 +516,7 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
         "timeRegions": [],
-        "timeShift": null,
         "title": "Load per [[by]]",
         "tooltip": {
           "msResolution": false,
@@ -540,9 +526,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -557,14 +541,11 @@
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ],
         "yaxis": {
-          "align": false,
-          "alignLevel": null
+          "align": false
         }
       },
       {
@@ -587,7 +568,6 @@
           "y": 10
         },
         "hiddenSeries": false,
-        "id": 7,
         "legend": {
           "avg": false,
           "current": false,
@@ -605,7 +585,7 @@
           "alertThreshold": true
         },
         "percentage": false,
-        "pluginVersion": "8.2.3",
+        "pluginVersion": "8.5.2",
         "pointradius": 5,
         "points": false,
         "renderer": "flot",
@@ -638,9 +618,7 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
         "timeRegions": [],
-        "timeShift": null,
         "title": "Requests Served per [[by]]",
         "tooltip": {
           "msResolution": false,
@@ -650,9 +628,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -660,7 +636,6 @@
           {
             "format": "ops",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
@@ -669,24 +644,47 @@
             "label": "Nemesis",
             "logBase": 1,
             "max": "1",
-            "min": null,
             "show": true
           }
         ],
         "yaxis": {
-          "align": false,
-          "alignLevel": null
+          "align": false
         }
       },
       {
-        "datasource": null,
+        "class": "text_panel",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "editable": true,
+        "error": false,
+        "gridPos": {
+          "h": 7,
+          "w": 4,
+          "x": 20,
+          "y": 10
+        },
+        "links": [],
+        "options": {
+          "content": "",
+          "mode": "markdown"
+        },
+        "pluginVersion": "8.5.2",
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "gridPos": {
           "h": 13,
           "w": 24,
           "x": 0,
           "y": 17
         },
-        "id": 67,
         "links": [],
         "options": {
           "limit": 1000,
@@ -705,7 +703,10 @@
       },
       {
         "class": "text_panel",
-        "datasource": null,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "editable": true,
         "error": false,
         "gridPos": {
@@ -714,13 +715,1320 @@
           "x": 0,
           "y": 30
         },
-        "id": 63,
         "links": [],
         "options": {
-          "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Stress tools latency</h1>",
+          "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">C-S stress tool latency 95%</h1>",
           "mode": "html"
         },
-        "pluginVersion": "8.2.3",
+        "pluginVersion": "8.5.2",
+        "style": {},
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "datasource": "prometheus",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 0,
+          "y": 33
+        },
+        "links": [],
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "hidden",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "8.5.2",
+        "targets": [
+          {
+            "expr": "collectd_cassandra_stress_write_gauge{type=\"lat_perc_95\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "B"
+          },
+          {
+            "expr": "collectd_cassandra_stress_counter_write_gauge{type=\"lat_perc_95\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "D"
+          }
+        ],
+        "title": "C-S stress tools write latency 95%",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "prometheus",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "fillOpacity": 80,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 12,
+          "y": 33
+        },
+        "links": [],
+        "options": {
+          "bucketOffset": 0,
+          "bucketSize": 2,
+          "legend": {
+            "calcs": [],
+            "displayMode": "hidden",
+            "placement": "bottom"
+          }
+        },
+        "pluginVersion": "8.5.2",
+        "targets": [
+          {
+            "expr": "collectd_cassandra_stress_write_gauge{type=\"lat_perc_95\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "B"
+          },
+          {
+            "expr": "collectd_cassandra_stress_counter_write_gauge{type=\"lat_perc_95\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "D"
+          }
+        ],
+        "title": "C-S stress tools write latency 95% histogram",
+        "type": "histogram"
+      },
+      {
+        "datasource": "prometheus",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 0,
+          "y": 40
+        },
+        "links": [],
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "hidden",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "8.5.2",
+        "targets": [
+          {
+            "expr": "collectd_cassandra_stress_read_gauge{type=\"lat_perc_95\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "C"
+          },
+          {
+            "expr": "collectd_cassandra_stress_counter_read_gauge{type=\"lat_perc_95\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "E"
+          }
+        ],
+        "title": "C-S stress tool read latency 95%",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "prometheus",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "fillOpacity": 80,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 12,
+          "y": 40
+        },
+        "links": [],
+        "options": {
+          "bucketOffset": 0,
+          "bucketSize": 2,
+          "legend": {
+            "calcs": [],
+            "displayMode": "hidden",
+            "placement": "bottom"
+          }
+        },
+        "pluginVersion": "8.5.2",
+        "targets": [
+          {
+            "expr": "collectd_cassandra_stress_read_gauge{type=\"lat_perc_95\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "C"
+          },
+          {
+            "expr": "collectd_cassandra_stress_counter_read_gauge{type=\"lat_perc_95\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "E"
+          }
+        ],
+        "title": "C-S stress tool read latency 95% histogram",
+        "type": "histogram"
+      },
+      {
+        "datasource": "prometheus",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 0,
+          "y": 47
+        },
+        "links": [],
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "hidden",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "8.5.2",
+        "targets": [
+          {
+            "expr": "collectd_cassandra_stress_mixed_gauge{type=\"lat_perc_95\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "A"
+          }
+        ],
+        "title": "C-S stress tool mixed latency 95%",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "prometheus",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "fillOpacity": 80,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 12,
+          "y": 47
+        },
+        "links": [],
+        "options": {
+          "bucketOffset": 0,
+          "bucketSize": 2,
+          "legend": {
+            "calcs": [],
+            "displayMode": "hidden",
+            "placement": "bottom"
+          }
+        },
+        "pluginVersion": "8.5.2",
+        "targets": [
+          {
+            "expr": "collectd_cassandra_stress_mixed_gauge{type=\"lat_perc_95\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "A"
+          }
+        ],
+        "title": "C-S stress tool mixed latency 95% histogram",
+        "type": "histogram"
+      },
+      {
+        "datasource": "prometheus",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 0,
+          "y": 54
+        },
+        "links": [],
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "hidden",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "8.5.2",
+        "targets": [
+          {
+            "expr": "collectd_cassandra_stress_user_gauge{type=\"lat_perc_95\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "F"
+          }
+        ],
+        "title": "C-S stress tool user profile latency 95%",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "prometheus",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "fillOpacity": 80,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 12,
+          "y": 54
+        },
+        "links": [],
+        "options": {
+          "bucketOffset": 0,
+          "bucketSize": 2,
+          "legend": {
+            "calcs": [],
+            "displayMode": "hidden",
+            "placement": "bottom"
+          }
+        },
+        "pluginVersion": "8.5.2",
+        "targets": [
+          {
+            "expr": "collectd_cassandra_stress_user_gauge{type=\"lat_perc_95\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "F"
+          }
+        ],
+        "title": "C-S stress tool user profile latency 95% histogram",
+        "type": "histogram"
+      },
+      {
+        "class": "text_panel",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "editable": true,
+        "error": false,
+        "gridPos": {
+          "h": 3,
+          "w": 24,
+          "x": 0,
+          "y": 61
+        },
+        "links": [],
+        "options": {
+          "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">C-S Stress tool latency 99%</h1>",
+          "mode": "html"
+        },
+        "pluginVersion": "8.5.2",
+        "style": {},
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "datasource": "prometheus",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 0,
+          "y": 64
+        },
+        "links": [],
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "hidden",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "8.5.2",
+        "targets": [
+          {
+            "expr": "collectd_cassandra_stress_write_gauge{type=\"lat_perc_99\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "B"
+          },
+          {
+            "expr": "collectd_cassandra_stress_counter_write_gauge{type=\"lat_perc_99\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "D"
+          }
+        ],
+        "title": "C-S stress tools write latency 99%",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "prometheus",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "fillOpacity": 80,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 12,
+          "y": 64
+        },
+        "links": [],
+        "options": {
+          "bucketOffset": 0,
+          "bucketSize": 2,
+          "legend": {
+            "calcs": [],
+            "displayMode": "hidden",
+            "placement": "bottom"
+          }
+        },
+        "pluginVersion": "8.5.2",
+        "targets": [
+          {
+            "expr": "collectd_cassandra_stress_write_gauge{type=\"lat_perc_99\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "B"
+          },
+          {
+            "expr": "collectd_cassandra_stress_counter_write_gauge{type=\"lat_perc_99\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "D"
+          }
+        ],
+        "title": "C-S stress tools write latency 99% histogram",
+        "type": "histogram"
+      },
+      {
+        "datasource": "prometheus",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 0,
+          "y": 71
+        },
+        "links": [],
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "hidden",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "8.5.2",
+        "targets": [
+          {
+            "expr": "collectd_cassandra_stress_read_gauge{type=\"lat_perc_99\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "C"
+          },
+          {
+            "expr": "collectd_cassandra_stress_counter_read_gauge{type=\"lat_perc_99\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "E"
+          }
+        ],
+        "title": "C-S stress tool read latency 99%",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "prometheus",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "fillOpacity": 80,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 12,
+          "y": 71
+        },
+        "links": [],
+        "options": {
+          "bucketOffset": 0,
+          "bucketSize": 2,
+          "legend": {
+            "calcs": [],
+            "displayMode": "hidden",
+            "placement": "bottom"
+          }
+        },
+        "pluginVersion": "8.5.2",
+        "targets": [
+          {
+            "expr": "collectd_cassandra_stress_read_gauge{type=\"lat_perc_99\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "C"
+          },
+          {
+            "expr": "collectd_cassandra_stress_counter_read_gauge{type=\"lat_perc_99\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "E"
+          }
+        ],
+        "title": "C-S stress tool read latency 99% histogram",
+        "type": "histogram"
+      },
+      {
+        "datasource": "prometheus",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 0,
+          "y": 78
+        },
+        "links": [],
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "hidden",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "8.5.2",
+        "targets": [
+          {
+            "expr": "collectd_cassandra_stress_mixed_gauge{type=\"lat_perc_99\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "A"
+          }
+        ],
+        "title": "C-S stress tool mixed latency 99%",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "prometheus",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "fillOpacity": 80,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 12,
+          "y": 78
+        },
+        "links": [],
+        "options": {
+          "bucketOffset": 0,
+          "bucketSize": 2,
+          "legend": {
+            "calcs": [],
+            "displayMode": "hidden",
+            "placement": "bottom"
+          }
+        },
+        "pluginVersion": "8.5.2",
+        "targets": [
+          {
+            "expr": "collectd_cassandra_stress_mixed_gauge{type=\"lat_perc_99\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "A"
+          }
+        ],
+        "title": "C-S stress tool mixed latency 99% histogram",
+        "type": "histogram"
+      },
+      {
+        "datasource": "prometheus",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 0,
+          "y": 85
+        },
+        "links": [],
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "hidden",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "8.5.2",
+        "targets": [
+          {
+            "expr": "collectd_cassandra_stress_user_gauge{type=\"lat_perc_99\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "F"
+          }
+        ],
+        "title": "C-S stress tool user profile latency 99%",
+        "type": "timeseries"
+      },
+      {
+        "datasource": "prometheus",
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "fillOpacity": 80,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 12,
+          "y": 85
+        },
+        "links": [],
+        "options": {
+          "bucketOffset": 0,
+          "bucketSize": 2,
+          "legend": {
+            "calcs": [],
+            "displayMode": "hidden",
+            "placement": "bottom"
+          }
+        },
+        "pluginVersion": "8.5.2",
+        "targets": [
+          {
+            "expr": "collectd_cassandra_stress_user_gauge{type=\"lat_perc_99\"}",
+            "format": "time_series",
+            "interval": "15s",
+            "intervalFactor": 1,
+            "refId": "F"
+          }
+        ],
+        "title": "C-S stress tool user profile latency 99% histogram",
+        "type": "histogram"
+      },
+      {
+        "class": "text_panel",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "editable": true,
+        "error": false,
+        "gridPos": {
+          "h": 3,
+          "w": 24,
+          "x": 0,
+          "y": 92
+        },
+        "links": [],
+        "options": {
+          "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Other Stress tools latency</h1>",
+          "mode": "html"
+        },
+        "pluginVersion": "8.5.2",
         "style": {},
         "transparent": true,
         "type": "text"
@@ -742,10 +2050,9 @@
           "h": 7,
           "w": 12,
           "x": 0,
-          "y": 33
+          "y": 95
         },
         "hiddenSeries": false,
-        "id": 64,
         "legend": {
           "avg": false,
           "current": false,
@@ -763,7 +2070,7 @@
           "alertThreshold": true
         },
         "percentage": false,
-        "pluginVersion": "8.2.3",
+        "pluginVersion": "8.5.2",
         "pointradius": 1,
         "points": false,
         "renderer": "flot",
@@ -772,48 +2079,6 @@
         "stack": false,
         "steppedLine": false,
         "targets": [
-          {
-            "expr": "collectd_cassandra_stress_write_gauge{type=\"lat_perc_95\"}",
-            "format": "time_series",
-            "interval": "15s",
-            "intervalFactor": 1,
-            "refId": "B"
-          },
-          {
-            "expr": "collectd_cassandra_stress_mixed_gauge{type=\"lat_perc_95\"}",
-            "format": "time_series",
-            "interval": "15s",
-            "intervalFactor": 1,
-            "refId": "A"
-          },
-          {
-            "expr": "collectd_cassandra_stress_read_gauge{type=\"lat_perc_95\"}",
-            "format": "time_series",
-            "interval": "15s",
-            "intervalFactor": 1,
-            "refId": "C"
-          },
-          {
-            "expr": "collectd_cassandra_stress_counter_write_gauge{type=\"lat_perc_95\"}",
-            "format": "time_series",
-            "interval": "15s",
-            "intervalFactor": 1,
-            "refId": "D"
-          },
-          {
-            "expr": "collectd_cassandra_stress_counter_read_gauge{type=\"lat_perc_95\"}",
-            "format": "time_series",
-            "interval": "15s",
-            "intervalFactor": 1,
-            "refId": "E"
-          },
-          {
-            "expr": "collectd_cassandra_stress_user_gauge{type=\"lat_perc_95\"}",
-            "format": "time_series",
-            "interval": "15s",
-            "intervalFactor": 1,
-            "refId": "F"
-          },
           {
             "expr": "avg(collectd_ycsb_read_gauge{type=\"p90\"}) by (instance)",
             "format": "time_series",
@@ -854,10 +2119,8 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
         "timeRegions": [],
-        "timeShift": null,
-        "title": "Stress tools latency 95%",
+        "title": "Other(YCSB/Scylla-bench) Stress tools latency 95%",
         "tooltip": {
           "msResolution": false,
           "shared": true,
@@ -866,9 +2129,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -876,21 +2137,17 @@
           {
             "format": "ms",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ],
         "yaxis": {
-          "align": false,
-          "alignLevel": null
+          "align": false
         }
       },
       {
@@ -910,10 +2167,9 @@
           "h": 7,
           "w": 12,
           "x": 12,
-          "y": 33
+          "y": 95
         },
         "hiddenSeries": false,
-        "id": 65,
         "legend": {
           "avg": false,
           "current": false,
@@ -931,7 +2187,7 @@
           "alertThreshold": true
         },
         "percentage": false,
-        "pluginVersion": "8.2.3",
+        "pluginVersion": "8.5.2",
         "pointradius": 1,
         "points": false,
         "renderer": "flot",
@@ -940,48 +2196,6 @@
         "stack": false,
         "steppedLine": false,
         "targets": [
-          {
-            "expr": "collectd_cassandra_stress_write_gauge{type=\"lat_perc_99\"}",
-            "format": "time_series",
-            "interval": "15s",
-            "intervalFactor": 1,
-            "refId": "B"
-          },
-          {
-            "expr": "collectd_cassandra_stress_mixed_gauge{type=\"lat_perc_99\"}",
-            "format": "time_series",
-            "interval": "15s",
-            "intervalFactor": 1,
-            "refId": "A"
-          },
-          {
-            "expr": "collectd_cassandra_stress_read_gauge{type=\"lat_perc_99\"}",
-            "format": "time_series",
-            "interval": "15s",
-            "intervalFactor": 1,
-            "refId": "C"
-          },
-          {
-            "expr": "collectd_cassandra_stress_counter_write_gauge{type=\"lat_perc_99\"}",
-            "format": "time_series",
-            "interval": "15s",
-            "intervalFactor": 1,
-            "refId": "D"
-          },
-          {
-            "expr": "collectd_cassandra_stress_counter_read_gauge{type=\"lat_perc_99\"}",
-            "format": "time_series",
-            "interval": "15s",
-            "intervalFactor": 1,
-            "refId": "E"
-          },
-          {
-            "expr": "collectd_cassandra_stress_user_gauge{type=\"lat_perc_99\"}",
-            "format": "time_series",
-            "interval": "15s",
-            "intervalFactor": 1,
-            "refId": "F"
-          },
           {
             "expr": "avg(collectd_ycsb_read_gauge{type=\"p99\"}) by (instance)",
             "format": "time_series",
@@ -1022,10 +2236,8 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
         "timeRegions": [],
-        "timeShift": null,
-        "title": "Stress tools latency 99%",
+        "title": "Other(YCSB/Scylla-bench) Stress tools latency 99%",
         "tooltip": {
           "msResolution": false,
           "shared": true,
@@ -1034,9 +2246,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -1044,64 +2254,64 @@
           {
             "format": "ms",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ],
         "yaxis": {
-          "align": false,
-          "alignLevel": null
+          "align": false
         }
       },
       {
         "class": "text_header_panel",
-        "datasource": null,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "editable": true,
         "error": false,
         "gridPos": {
           "h": 3,
           "w": 12,
           "x": 0,
-          "y": 40
+          "y": 102
         },
         "height": "30",
-        "id": 8,
         "links": [],
         "options": {
           "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Reads and Writes</h1>",
           "mode": "html"
         },
-        "pluginVersion": "8.2.3",
+        "pluginVersion": "8.5.2",
         "style": {},
         "transparent": true,
         "type": "text"
       },
       {
         "class": "text_header_panel",
-        "datasource": null,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "editable": true,
         "error": false,
         "gridPos": {
           "h": 3,
           "w": 12,
           "x": 12,
-          "y": 40
+          "y": 102
         },
-        "id": 9,
         "links": [],
         "options": {
           "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Timeouts and Errors</h1>",
           "mode": "html"
         },
-        "pluginVersion": "8.2.3",
+        "pluginVersion": "8.5.2",
         "style": {},
         "transparent": true,
         "type": "text"
@@ -1122,10 +2332,9 @@
           "h": 6,
           "w": 6,
           "x": 0,
-          "y": 43
+          "y": 105
         },
         "hiddenSeries": false,
-        "id": 10,
         "legend": {
           "avg": false,
           "current": false,
@@ -1143,7 +2352,7 @@
           "alertThreshold": true
         },
         "percentage": false,
-        "pluginVersion": "8.2.3",
+        "pluginVersion": "8.5.2",
         "pointradius": 5,
         "points": false,
         "renderer": "flot",
@@ -1161,9 +2370,7 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
         "timeRegions": [],
-        "timeShift": null,
         "title": "Foreground Writes per [[by]]",
         "tooltip": {
           "msResolution": false,
@@ -1173,9 +2380,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -1183,21 +2388,17 @@
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ],
         "yaxis": {
-          "align": false,
-          "alignLevel": null
+          "align": false
         }
       },
       {
@@ -1216,10 +2417,9 @@
           "h": 6,
           "w": 6,
           "x": 6,
-          "y": 43
+          "y": 105
         },
         "hiddenSeries": false,
-        "id": 11,
         "legend": {
           "avg": false,
           "current": false,
@@ -1237,7 +2437,7 @@
           "alertThreshold": true
         },
         "percentage": false,
-        "pluginVersion": "8.2.3",
+        "pluginVersion": "8.5.2",
         "pointradius": 5,
         "points": false,
         "renderer": "flot",
@@ -1256,9 +2456,7 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
         "timeRegions": [],
-        "timeShift": null,
         "title": "Foreground Reads per [[by]]",
         "tooltip": {
           "msResolution": false,
@@ -1268,9 +2466,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -1278,21 +2474,17 @@
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ],
         "yaxis": {
-          "align": false,
-          "alignLevel": null
+          "align": false
         }
       },
       {
@@ -1311,10 +2503,9 @@
           "h": 6,
           "w": 6,
           "x": 12,
-          "y": 43
+          "y": 105
         },
         "hiddenSeries": false,
-        "id": 12,
         "legend": {
           "avg": false,
           "current": false,
@@ -1332,7 +2523,7 @@
           "alertThreshold": true
         },
         "percentage": false,
-        "pluginVersion": "8.2.3",
+        "pluginVersion": "8.5.2",
         "pointradius": 5,
         "points": false,
         "renderer": "flot",
@@ -1350,9 +2541,7 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
         "timeRegions": [],
-        "timeShift": null,
         "title": "Write Timeouts per Second per [[by]]",
         "tooltip": {
           "msResolution": false,
@@ -1362,9 +2551,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -1372,21 +2559,17 @@
           {
             "format": "wps",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ],
         "yaxis": {
-          "align": false,
-          "alignLevel": null
+          "align": false
         }
       },
       {
@@ -1405,10 +2588,9 @@
           "h": 6,
           "w": 6,
           "x": 18,
-          "y": 43
+          "y": 105
         },
         "hiddenSeries": false,
-        "id": 13,
         "legend": {
           "avg": false,
           "current": false,
@@ -1426,7 +2608,7 @@
           "alertThreshold": true
         },
         "percentage": false,
-        "pluginVersion": "8.2.3",
+        "pluginVersion": "8.5.2",
         "pointradius": 5,
         "points": false,
         "renderer": "flot",
@@ -1444,9 +2626,7 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
         "timeRegions": [],
-        "timeShift": null,
         "title": "Write Unavailable per Second per [[by]]",
         "tooltip": {
           "msResolution": false,
@@ -1456,9 +2636,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -1466,21 +2644,17 @@
           {
             "format": "wps",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ],
         "yaxis": {
-          "align": false,
-          "alignLevel": null
+          "align": false
         }
       },
       {
@@ -1493,14 +2667,15 @@
         "editable": true,
         "error": false,
         "fill": 0,
+        "fillGradient": 0,
         "grid": {},
         "gridPos": {
           "h": 6,
           "w": 6,
           "x": 0,
-          "y": 49
+          "y": 111
         },
-        "id": 14,
+        "hiddenSeries": false,
         "legend": {
           "avg": false,
           "current": false,
@@ -1514,8 +2689,11 @@
         "linewidth": 2,
         "links": [],
         "nullPointMode": "connected",
+        "options": {
+          "alertThreshold": true
+        },
         "percentage": false,
-        "pluginVersion": "8.2.3",
+        "pluginVersion": "8.5.2",
         "pointradius": 5,
         "points": false,
         "renderer": "flot",
@@ -1533,8 +2711,7 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
+        "timeRegions": [],
         "title": "Background Writes per [[by]]",
         "tooltip": {
           "msResolution": false,
@@ -1544,9 +2721,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -1554,18 +2729,18 @@
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
-        ]
+        ],
+        "yaxis": {
+          "align": false
+        }
       },
       {
         "aliasColors": {},
@@ -1577,14 +2752,15 @@
         "editable": true,
         "error": false,
         "fill": 0,
+        "fillGradient": 0,
         "grid": {},
         "gridPos": {
           "h": 6,
           "w": 6,
           "x": 6,
-          "y": 49
+          "y": 111
         },
-        "id": 15,
+        "hiddenSeries": false,
         "legend": {
           "avg": false,
           "current": false,
@@ -1598,8 +2774,11 @@
         "linewidth": 2,
         "links": [],
         "nullPointMode": "connected",
+        "options": {
+          "alertThreshold": true
+        },
         "percentage": false,
-        "pluginVersion": "8.2.3",
+        "pluginVersion": "8.5.2",
         "pointradius": 5,
         "points": false,
         "renderer": "flot",
@@ -1617,8 +2796,7 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
+        "timeRegions": [],
         "title": "Background Reads per [[by]]",
         "tooltip": {
           "msResolution": false,
@@ -1628,9 +2806,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -1638,18 +2814,18 @@
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
-        ]
+        ],
+        "yaxis": {
+          "align": false
+        }
       },
       {
         "aliasColors": {},
@@ -1661,14 +2837,15 @@
         "editable": true,
         "error": false,
         "fill": 0,
+        "fillGradient": 0,
         "grid": {},
         "gridPos": {
           "h": 6,
           "w": 6,
           "x": 12,
-          "y": 49
+          "y": 111
         },
-        "id": 16,
+        "hiddenSeries": false,
         "legend": {
           "avg": false,
           "current": false,
@@ -1682,8 +2859,11 @@
         "linewidth": 2,
         "links": [],
         "nullPointMode": "connected",
+        "options": {
+          "alertThreshold": true
+        },
         "percentage": false,
-        "pluginVersion": "8.2.3",
+        "pluginVersion": "8.5.2",
         "pointradius": 5,
         "points": false,
         "renderer": "flot",
@@ -1701,8 +2881,7 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
+        "timeRegions": [],
         "title": "Read Timeouts per Second per [[by]]",
         "tooltip": {
           "msResolution": false,
@@ -1712,9 +2891,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -1722,18 +2899,18 @@
           {
             "format": "rps",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
-        ]
+        ],
+        "yaxis": {
+          "align": false
+        }
       },
       {
         "aliasColors": {},
@@ -1745,14 +2922,15 @@
         "editable": true,
         "error": false,
         "fill": 0,
+        "fillGradient": 0,
         "grid": {},
         "gridPos": {
           "h": 6,
           "w": 6,
           "x": 18,
-          "y": 49
+          "y": 111
         },
-        "id": 17,
+        "hiddenSeries": false,
         "legend": {
           "avg": false,
           "current": false,
@@ -1766,8 +2944,11 @@
         "linewidth": 2,
         "links": [],
         "nullPointMode": "connected",
+        "options": {
+          "alertThreshold": true
+        },
         "percentage": false,
-        "pluginVersion": "8.2.3",
+        "pluginVersion": "8.5.2",
         "pointradius": 5,
         "points": false,
         "renderer": "flot",
@@ -1786,8 +2967,7 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
+        "timeRegions": [],
         "title": "Read Unavailable per Second per [[by]]",
         "tooltip": {
           "msResolution": false,
@@ -1797,9 +2977,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -1807,38 +2985,40 @@
           {
             "format": "rps",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
-        ]
+        ],
+        "yaxis": {
+          "align": false
+        }
       },
       {
         "class": "plain_text",
-        "datasource": null,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "editable": true,
         "error": false,
         "gridPos": {
           "h": 3,
           "w": 24,
           "x": 0,
-          "y": 55
+          "y": 117
         },
         "height": "30",
-        "id": 18,
         "links": [],
         "options": {
           "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Replica</h1>",
           "mode": "html"
         },
-        "pluginVersion": "8.2.3",
+        "pluginVersion": "8.5.2",
         "style": {},
         "transparent": true,
         "type": "text"
@@ -1853,14 +3033,15 @@
         "editable": true,
         "error": false,
         "fill": 0,
+        "fillGradient": 0,
         "grid": {},
         "gridPos": {
           "h": 7,
           "w": 12,
           "x": 0,
-          "y": 58
+          "y": 120
         },
-        "id": 19,
+        "hiddenSeries": false,
         "legend": {
           "avg": false,
           "current": false,
@@ -1874,8 +3055,11 @@
         "linewidth": 2,
         "links": [],
         "nullPointMode": "connected",
+        "options": {
+          "alertThreshold": true
+        },
         "percentage": false,
-        "pluginVersion": "8.2.3",
+        "pluginVersion": "8.5.2",
         "pointradius": 5,
         "points": false,
         "renderer": "flot",
@@ -1893,8 +3077,7 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
+        "timeRegions": [],
         "title": "Reads",
         "tooltip": {
           "msResolution": false,
@@ -1904,9 +3087,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -1914,18 +3095,18 @@
           {
             "format": "rps",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
-        ]
+        ],
+        "yaxis": {
+          "align": false
+        }
       },
       {
         "aliasColors": {},
@@ -1937,14 +3118,15 @@
         "editable": true,
         "error": false,
         "fill": 0,
+        "fillGradient": 0,
         "grid": {},
         "gridPos": {
           "h": 7,
           "w": 12,
           "x": 12,
-          "y": 58
+          "y": 120
         },
-        "id": 20,
+        "hiddenSeries": false,
         "legend": {
           "avg": false,
           "current": false,
@@ -1958,8 +3140,11 @@
         "linewidth": 2,
         "links": [],
         "nullPointMode": "connected",
+        "options": {
+          "alertThreshold": true
+        },
         "percentage": false,
-        "pluginVersion": "8.2.3",
+        "pluginVersion": "8.5.2",
         "pointradius": 5,
         "points": false,
         "renderer": "flot",
@@ -1978,8 +3163,7 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
+        "timeRegions": [],
         "title": "Writes",
         "tooltip": {
           "msResolution": false,
@@ -1989,9 +3173,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -1999,18 +3181,18 @@
           {
             "format": "wps",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
-        ]
+        ],
+        "yaxis": {
+          "align": false
+        }
       },
       {
         "aliasColors": {},
@@ -2022,14 +3204,15 @@
         "editable": true,
         "error": false,
         "fill": 0,
+        "fillGradient": 0,
         "grid": {},
         "gridPos": {
           "h": 7,
           "w": 6,
           "x": 0,
-          "y": 65
+          "y": 127
         },
-        "id": 21,
+        "hiddenSeries": false,
         "legend": {
           "avg": false,
           "current": false,
@@ -2043,6 +3226,9 @@
         "linewidth": 2,
         "links": [],
         "nullPointMode": "connected",
+        "options": {
+          "alertThreshold": true
+        },
         "percentage": false,
         "pluginVersion": "8.2.3",
         "pointradius": 5,
@@ -2062,8 +3248,7 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
+        "timeRegions": [],
         "title": "Active sstable reads",
         "tooltip": {
           "msResolution": false,
@@ -2073,9 +3258,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -2083,18 +3266,18 @@
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
-        ]
+        ],
+        "yaxis": {
+          "align": false
+        }
       },
       {
         "aliasColors": {},
@@ -2106,14 +3289,15 @@
         "editable": true,
         "error": false,
         "fill": 0,
+        "fillGradient": 0,
         "grid": {},
         "gridPos": {
           "h": 7,
           "w": 6,
           "x": 6,
-          "y": 65
+          "y": 127
         },
-        "id": 22,
+        "hiddenSeries": false,
         "legend": {
           "avg": false,
           "current": false,
@@ -2127,6 +3311,9 @@
         "linewidth": 2,
         "links": [],
         "nullPointMode": "connected",
+        "options": {
+          "alertThreshold": true
+        },
         "percentage": false,
         "pluginVersion": "8.2.3",
         "pointradius": 5,
@@ -2146,8 +3333,7 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
+        "timeRegions": [],
         "title": "Queued sstable reads",
         "tooltip": {
           "msResolution": false,
@@ -2157,9 +3343,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -2167,18 +3351,18 @@
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
-        ]
+        ],
+        "yaxis": {
+          "align": false
+        }
       },
       {
         "aliasColors": {},
@@ -2190,14 +3374,15 @@
         "editable": true,
         "error": false,
         "fill": 0,
+        "fillGradient": 0,
         "grid": {},
         "gridPos": {
           "h": 7,
           "w": 6,
           "x": 12,
-          "y": 65
+          "y": 127
         },
-        "id": 23,
+        "hiddenSeries": false,
         "legend": {
           "avg": false,
           "current": false,
@@ -2211,6 +3396,9 @@
         "linewidth": 2,
         "links": [],
         "nullPointMode": "connected",
+        "options": {
+          "alertThreshold": true
+        },
         "percentage": false,
         "pluginVersion": "8.2.3",
         "pointradius": 5,
@@ -2230,8 +3418,7 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
+        "timeRegions": [],
         "title": "Writes currently blocked on dirty",
         "tooltip": {
           "msResolution": false,
@@ -2241,9 +3428,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -2251,18 +3436,18 @@
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
-        ]
+        ],
+        "yaxis": {
+          "align": false
+        }
       },
       {
         "aliasColors": {},
@@ -2274,14 +3459,15 @@
         "editable": true,
         "error": false,
         "fill": 0,
+        "fillGradient": 0,
         "grid": {},
         "gridPos": {
           "h": 7,
           "w": 6,
           "x": 18,
-          "y": 65
+          "y": 127
         },
-        "id": 24,
+        "hiddenSeries": false,
         "legend": {
           "avg": false,
           "current": false,
@@ -2295,6 +3481,9 @@
         "linewidth": 2,
         "links": [],
         "nullPointMode": "connected",
+        "options": {
+          "alertThreshold": true
+        },
         "percentage": false,
         "pluginVersion": "8.2.3",
         "pointradius": 5,
@@ -2314,8 +3503,7 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
+        "timeRegions": [],
         "title": "Writes currently blocked on commitlog",
         "tooltip": {
           "msResolution": false,
@@ -2325,9 +3513,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -2335,31 +3521,33 @@
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
-        ]
+        ],
+        "yaxis": {
+          "align": false
+        }
       },
       {
         "class": "text_panel",
-        "datasource": null,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "editable": true,
         "error": false,
         "gridPos": {
           "h": 7,
           "w": 6,
           "x": 0,
-          "y": 72
+          "y": 134
         },
-        "id": 25,
         "links": [],
         "options": {
           "content": "",
@@ -2379,14 +3567,15 @@
         "editable": true,
         "error": false,
         "fill": 0,
+        "fillGradient": 0,
         "grid": {},
         "gridPos": {
           "h": 7,
           "w": 6,
           "x": 6,
-          "y": 72
+          "y": 134
         },
-        "id": 26,
+        "hiddenSeries": false,
         "legend": {
           "avg": false,
           "current": false,
@@ -2400,6 +3589,9 @@
         "linewidth": 2,
         "links": [],
         "nullPointMode": "connected",
+        "options": {
+          "alertThreshold": true
+        },
         "percentage": false,
         "pluginVersion": "8.2.3",
         "pointradius": 5,
@@ -2419,8 +3611,7 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
+        "timeRegions": [],
         "title": "Reads failed",
         "tooltip": {
           "msResolution": false,
@@ -2430,9 +3621,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -2440,18 +3629,18 @@
           {
             "format": "rps",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
-        ]
+        ],
+        "yaxis": {
+          "align": false
+        }
       },
       {
         "aliasColors": {},
@@ -2463,14 +3652,15 @@
         "editable": true,
         "error": false,
         "fill": 0,
+        "fillGradient": 0,
         "grid": {},
         "gridPos": {
           "h": 7,
           "w": 6,
           "x": 12,
-          "y": 72
+          "y": 134
         },
-        "id": 27,
+        "hiddenSeries": false,
         "legend": {
           "avg": false,
           "current": false,
@@ -2484,6 +3674,9 @@
         "linewidth": 2,
         "links": [],
         "nullPointMode": "connected",
+        "options": {
+          "alertThreshold": true
+        },
         "percentage": false,
         "pluginVersion": "8.2.3",
         "pointradius": 5,
@@ -2503,8 +3696,7 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
+        "timeRegions": [],
         "title": "Writes blocked on dirty",
         "tooltip": {
           "msResolution": false,
@@ -2514,9 +3706,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -2524,18 +3714,18 @@
           {
             "format": "wps",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
-        ]
+        ],
+        "yaxis": {
+          "align": false
+        }
       },
       {
         "aliasColors": {},
@@ -2547,14 +3737,15 @@
         "editable": true,
         "error": false,
         "fill": 0,
+        "fillGradient": 0,
         "grid": {},
         "gridPos": {
           "h": 7,
           "w": 6,
           "x": 18,
-          "y": 72
+          "y": 134
         },
-        "id": 28,
+        "hiddenSeries": false,
         "legend": {
           "avg": false,
           "current": false,
@@ -2568,6 +3759,9 @@
         "linewidth": 2,
         "links": [],
         "nullPointMode": "connected",
+        "options": {
+          "alertThreshold": true
+        },
         "percentage": false,
         "pluginVersion": "8.2.3",
         "pointradius": 5,
@@ -2587,8 +3781,7 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
+        "timeRegions": [],
         "title": "Writes blocked on commitlog",
         "tooltip": {
           "msResolution": false,
@@ -2598,9 +3791,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -2608,31 +3799,33 @@
           {
             "format": "wps",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
-        ]
+        ],
+        "yaxis": {
+          "align": false
+        }
       },
       {
         "class": "text_panel",
-        "datasource": null,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "editable": true,
         "error": false,
         "gridPos": {
           "h": 7,
           "w": 6,
           "x": 0,
-          "y": 79
+          "y": 141
         },
-        "id": 29,
         "links": [],
         "options": {
           "content": "",
@@ -2657,9 +3850,8 @@
           "h": 7,
           "w": 6,
           "x": 12,
-          "y": 79
+          "y": 141
         },
-        "id": 31,
         "legend": {
           "avg": false,
           "current": false,
@@ -2692,8 +3884,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "Writes failed",
         "tooltip": {
           "msResolution": false,
@@ -2703,9 +3893,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -2713,15 +3901,12 @@
           {
             "format": "wps",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
@@ -2741,9 +3926,8 @@
           "h": 7,
           "w": 6,
           "x": 18,
-          "y": 79
+          "y": 141
         },
-        "id": 32,
         "legend": {
           "avg": false,
           "current": false,
@@ -2776,8 +3960,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "Writes timed out",
         "tooltip": {
           "msResolution": false,
@@ -2787,9 +3969,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -2797,31 +3977,30 @@
           {
             "format": "wps",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
       },
       {
         "class": "text_panel",
-        "datasource": null,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "editable": true,
         "error": false,
         "gridPos": {
           "h": 3,
           "w": 24,
           "x": 0,
-          "y": 86
+          "y": 148
         },
-        "id": 74,
         "links": [],
         "options": {
           "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Materialized views - Backpressure</h1>",
@@ -2847,9 +4026,8 @@
           "h": 7,
           "w": 12,
           "x": 0,
-          "y": 89
+          "y": 151
         },
-        "id": 75,
         "legend": {
           "avg": false,
           "current": false,
@@ -2884,8 +4062,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "View Update Backlog",
         "tooltip": {
           "msResolution": false,
@@ -2895,9 +4071,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -2912,8 +4086,6 @@
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
@@ -2934,9 +4106,8 @@
           "h": 7,
           "w": 12,
           "x": 12,
-          "y": 89
+          "y": 151
         },
-        "id": 76,
         "legend": {
           "avg": false,
           "current": false,
@@ -2984,8 +4155,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "View flow control delay",
         "tooltip": {
           "msResolution": false,
@@ -2995,9 +4164,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -3005,7 +4172,6 @@
           {
             "format": "ns",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
@@ -3014,23 +4180,24 @@
             "label": "Nemesis",
             "logBase": 1,
             "max": "1",
-            "min": null,
             "show": true
           }
         ]
       },
       {
         "class": "text_panel",
-        "datasource": null,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "editable": true,
         "error": false,
         "gridPos": {
           "h": 3,
           "w": 24,
           "x": 0,
-          "y": 96
+          "y": 158
         },
-        "id": 33,
         "links": [],
         "options": {
           "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Cache</h1>",
@@ -3056,9 +4223,8 @@
           "h": 7,
           "w": 12,
           "x": 0,
-          "y": 99
+          "y": 161
         },
-        "id": 34,
         "legend": {
           "avg": false,
           "current": false,
@@ -3091,8 +4257,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "Reads with no misses",
         "tooltip": {
           "msResolution": false,
@@ -3102,9 +4266,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -3112,15 +4274,12 @@
           {
             "format": "rps",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
@@ -3140,9 +4299,8 @@
           "h": 7,
           "w": 12,
           "x": 12,
-          "y": 99
+          "y": 161
         },
-        "id": 35,
         "legend": {
           "avg": false,
           "current": false,
@@ -3175,8 +4333,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "Reads with misses",
         "tooltip": {
           "msResolution": false,
@@ -3186,9 +4342,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -3196,15 +4350,12 @@
           {
             "format": "rps",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
@@ -3224,9 +4375,8 @@
           "h": 7,
           "w": 6,
           "x": 0,
-          "y": 106
+          "y": 168
         },
-        "id": 36,
         "legend": {
           "avg": false,
           "current": false,
@@ -3259,8 +4409,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "Row Hits",
         "tooltip": {
           "msResolution": false,
@@ -3270,9 +4418,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -3280,15 +4426,12 @@
           {
             "format": "rps",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
@@ -3308,9 +4451,8 @@
           "h": 7,
           "w": 6,
           "x": 6,
-          "y": 106
+          "y": 168
         },
-        "id": 37,
         "legend": {
           "avg": false,
           "current": false,
@@ -3343,8 +4485,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "Partition Hits",
         "tooltip": {
           "msResolution": false,
@@ -3354,9 +4494,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -3364,15 +4502,12 @@
           {
             "format": "rps",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
@@ -3392,9 +4527,8 @@
           "h": 7,
           "w": 6,
           "x": 12,
-          "y": 106
+          "y": 168
         },
-        "id": 38,
         "legend": {
           "avg": false,
           "current": false,
@@ -3427,8 +4561,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "Row Misses",
         "tooltip": {
           "msResolution": false,
@@ -3438,9 +4570,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -3448,15 +4578,12 @@
           {
             "format": "rps",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
@@ -3476,9 +4603,8 @@
           "h": 7,
           "w": 6,
           "x": 18,
-          "y": 106
+          "y": 168
         },
-        "id": 39,
         "legend": {
           "avg": false,
           "current": false,
@@ -3511,8 +4637,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "Partition Misses",
         "tooltip": {
           "msResolution": false,
@@ -3522,9 +4646,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -3532,15 +4654,12 @@
           {
             "format": "rps",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
@@ -3560,9 +4679,8 @@
           "h": 7,
           "w": 6,
           "x": 0,
-          "y": 113
+          "y": 175
         },
-        "id": 40,
         "legend": {
           "avg": false,
           "current": false,
@@ -3595,8 +4713,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "Row Insertions",
         "tooltip": {
           "msResolution": false,
@@ -3606,9 +4722,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -3616,15 +4730,12 @@
           {
             "format": "rps",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
@@ -3644,9 +4755,8 @@
           "h": 7,
           "w": 6,
           "x": 6,
-          "y": 113
+          "y": 175
         },
-        "id": 41,
         "legend": {
           "avg": false,
           "current": false,
@@ -3679,8 +4789,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "Partition Insertions",
         "tooltip": {
           "msResolution": false,
@@ -3690,9 +4798,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -3700,15 +4806,12 @@
           {
             "format": "rps",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
@@ -3728,9 +4831,8 @@
           "h": 7,
           "w": 6,
           "x": 12,
-          "y": 113
+          "y": 175
         },
-        "id": 42,
         "legend": {
           "avg": false,
           "current": false,
@@ -3765,8 +4867,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "Row Evictions",
         "tooltip": {
           "msResolution": false,
@@ -3776,9 +4876,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -3786,15 +4884,12 @@
           {
             "format": "ops",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
@@ -3814,9 +4909,8 @@
           "h": 7,
           "w": 6,
           "x": 18,
-          "y": 113
+          "y": 175
         },
-        "id": 43,
         "legend": {
           "avg": false,
           "current": false,
@@ -3851,8 +4945,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "Partition Evictions",
         "tooltip": {
           "msResolution": false,
@@ -3862,9 +4954,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -3872,15 +4962,12 @@
           {
             "format": "ops",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
@@ -3900,9 +4987,8 @@
           "h": 7,
           "w": 6,
           "x": 0,
-          "y": 120
+          "y": 182
         },
-        "id": 44,
         "legend": {
           "avg": false,
           "current": false,
@@ -3937,8 +5023,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "Row Merges",
         "tooltip": {
           "msResolution": false,
@@ -3948,9 +5032,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -3958,15 +5040,12 @@
           {
             "format": "ops",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
@@ -3986,9 +5065,8 @@
           "h": 7,
           "w": 6,
           "x": 6,
-          "y": 120
+          "y": 182
         },
-        "id": 45,
         "legend": {
           "avg": false,
           "current": false,
@@ -4023,8 +5101,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "Partition Merges",
         "tooltip": {
           "msResolution": false,
@@ -4034,9 +5110,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -4044,15 +5118,12 @@
           {
             "format": "ops",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
@@ -4072,9 +5143,8 @@
           "h": 7,
           "w": 6,
           "x": 12,
-          "y": 120
+          "y": 182
         },
-        "id": 46,
         "legend": {
           "avg": false,
           "current": false,
@@ -4109,8 +5179,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "Row Removals",
         "tooltip": {
           "msResolution": false,
@@ -4120,9 +5188,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -4130,15 +5196,12 @@
           {
             "format": "ops",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
@@ -4158,9 +5221,8 @@
           "h": 7,
           "w": 6,
           "x": 18,
-          "y": 120
+          "y": 182
         },
-        "id": 47,
         "legend": {
           "avg": false,
           "current": false,
@@ -4195,8 +5257,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "Partition Removals",
         "tooltip": {
           "msResolution": false,
@@ -4206,9 +5266,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -4216,15 +5274,12 @@
           {
             "format": "ops",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
@@ -4244,9 +5299,8 @@
           "h": 7,
           "w": 6,
           "x": 0,
-          "y": 127
+          "y": 189
         },
-        "id": 48,
         "legend": {
           "avg": false,
           "current": false,
@@ -4279,8 +5333,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "Rows",
         "tooltip": {
           "msResolution": false,
@@ -4290,9 +5342,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -4300,15 +5350,12 @@
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
@@ -4328,9 +5375,8 @@
           "h": 7,
           "w": 6,
           "x": 6,
-          "y": 127
+          "y": 189
         },
-        "id": 49,
         "legend": {
           "avg": false,
           "current": false,
@@ -4363,8 +5409,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "Partitions",
         "tooltip": {
           "msResolution": false,
@@ -4374,9 +5418,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -4384,15 +5426,12 @@
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
@@ -4412,9 +5451,8 @@
           "h": 7,
           "w": 6,
           "x": 12,
-          "y": 127
+          "y": 189
         },
-        "id": 50,
         "legend": {
           "avg": false,
           "current": false,
@@ -4447,8 +5485,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "Used Bytes",
         "tooltip": {
           "msResolution": false,
@@ -4458,9 +5494,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -4468,15 +5502,12 @@
           {
             "format": "bytes",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
@@ -4496,9 +5527,8 @@
           "h": 7,
           "w": 6,
           "x": 18,
-          "y": 127
+          "y": 189
         },
-        "id": 51,
         "legend": {
           "avg": false,
           "current": false,
@@ -4531,8 +5561,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "Total Bytes",
         "tooltip": {
           "msResolution": false,
@@ -4542,9 +5570,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -4552,31 +5578,30 @@
           {
             "format": "bytes",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
       },
       {
         "class": "text_panel",
-        "datasource": null,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "editable": true,
         "error": false,
         "gridPos": {
           "h": 3,
           "w": 12,
           "x": 0,
-          "y": 134
+          "y": 196
         },
-        "id": 52,
         "links": [],
         "options": {
           "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Memory</h1>",
@@ -4602,9 +5627,8 @@
           "h": 7,
           "w": 12,
           "x": 12,
-          "y": 134
+          "y": 196
         },
-        "id": 54,
         "legend": {
           "avg": false,
           "current": false,
@@ -4637,8 +5661,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "Non-LSA used memory",
         "tooltip": {
           "msResolution": false,
@@ -4648,9 +5670,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -4658,15 +5678,12 @@
           {
             "format": "bytes",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
@@ -4686,9 +5703,8 @@
           "h": 7,
           "w": 12,
           "x": 0,
-          "y": 137
+          "y": 199
         },
-        "id": 53,
         "legend": {
           "avg": false,
           "current": false,
@@ -4721,8 +5737,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "LSA total memory",
         "tooltip": {
           "msResolution": false,
@@ -4732,9 +5746,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -4742,31 +5754,30 @@
           {
             "format": "bytes",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
       },
       {
         "class": "text_panel",
-        "datasource": null,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "editable": true,
         "error": false,
         "gridPos": {
           "h": 3,
           "w": 24,
           "x": 0,
-          "y": 144
+          "y": 206
         },
-        "id": 55,
         "links": [],
         "options": {
           "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Compaction</h1>",
@@ -4792,9 +5803,8 @@
           "h": 7,
           "w": 24,
           "x": 0,
-          "y": 147
+          "y": 209
         },
-        "id": 56,
         "legend": {
           "avg": false,
           "current": false,
@@ -4828,8 +5838,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "Running Compactions",
         "tooltip": {
           "msResolution": false,
@@ -4839,9 +5847,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -4849,31 +5855,30 @@
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
       },
       {
         "class": "text_panel",
-        "datasource": null,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "editable": true,
         "error": false,
         "gridPos": {
           "h": 3,
           "w": 24,
           "x": 0,
-          "y": 154
+          "y": 216
         },
-        "id": 57,
         "links": [],
         "options": {
           "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">CQL</h1>",
@@ -4899,9 +5904,8 @@
           "h": 7,
           "w": 6,
           "x": 0,
-          "y": 157
+          "y": 219
         },
-        "id": 58,
         "legend": {
           "avg": false,
           "current": false,
@@ -4937,8 +5941,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "CQL Insert",
         "tooltip": {
           "msResolution": false,
@@ -4948,9 +5950,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -4958,15 +5958,12 @@
           {
             "format": "ops",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
@@ -4986,9 +5983,8 @@
           "h": 7,
           "w": 6,
           "x": 6,
-          "y": 157
+          "y": 219
         },
-        "id": 59,
         "legend": {
           "avg": false,
           "current": false,
@@ -5024,8 +6020,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "CQL Reads",
         "tooltip": {
           "msResolution": false,
@@ -5035,9 +6029,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -5045,15 +6037,12 @@
           {
             "format": "ops",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
@@ -5073,9 +6062,8 @@
           "h": 7,
           "w": 6,
           "x": 12,
-          "y": 157
+          "y": 219
         },
-        "id": 60,
         "legend": {
           "avg": false,
           "current": false,
@@ -5111,8 +6099,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "CQL Deletes",
         "tooltip": {
           "msResolution": false,
@@ -5122,9 +6108,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -5132,15 +6116,12 @@
           {
             "format": "ops",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
@@ -5160,9 +6141,8 @@
           "h": 7,
           "w": 6,
           "x": 18,
-          "y": 157
+          "y": 219
         },
-        "id": 61,
         "legend": {
           "avg": false,
           "current": false,
@@ -5198,8 +6178,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "CQL Updates",
         "tooltip": {
           "msResolution": false,
@@ -5209,9 +6187,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -5219,15 +6195,12 @@
           {
             "format": "ops",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
@@ -5248,9 +6221,8 @@
           "h": 7,
           "w": 6,
           "x": 0,
-          "y": 164
+          "y": 226
         },
-        "id": 62,
         "legend": {
           "avg": false,
           "current": false,
@@ -5284,8 +6256,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "Client CQL connections by [[by]]",
         "tooltip": {
           "msResolution": false,
@@ -5295,9 +6265,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -5305,31 +6273,30 @@
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
       },
       {
         "class": "text_panel",
-        "datasource": null,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "editable": true,
         "error": false,
         "gridPos": {
           "h": 3,
           "w": 24,
           "x": 0,
-          "y": 171
+          "y": 233
         },
-        "id": 69,
         "links": [],
         "options": {
           "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">Gemini metrics</h1>",
@@ -5356,9 +6323,8 @@
           "h": 7,
           "w": 12,
           "x": 0,
-          "y": 174
+          "y": 236
         },
-        "id": 70,
         "legend": {
           "avg": false,
           "current": false,
@@ -5390,8 +6356,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "Gemini metrics",
         "tooltip": {
           "msResolution": false,
@@ -5401,9 +6365,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -5411,31 +6373,30 @@
           {
             "format": "ops",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
       },
       {
         "class": "text_panel",
-        "datasource": null,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "editable": true,
         "error": false,
         "gridPos": {
           "h": 3,
           "w": 24,
           "x": 0,
-          "y": 181
+          "y": 243
         },
-        "id": 71,
         "links": [],
         "options": {
           "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">YCSB metrics</h1>",
@@ -5462,9 +6423,8 @@
           "h": 7,
           "w": 12,
           "x": 0,
-          "y": 184
+          "y": 246
         },
-        "id": 72,
         "legend": {
           "avg": false,
           "current": false,
@@ -5525,8 +6485,6 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
-        "timeShift": null,
         "title": "YCSB Error metrics",
         "tooltip": {
           "msResolution": false,
@@ -5536,9 +6494,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -5546,348 +6502,17 @@
           {
             "format": "opm",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
           {
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ]
       },
       {
-        "class": "text_panel",
-        "datasource": null,
-        "editable": true,
-        "error": false,
-        "gridPos": {
-          "h": 3,
-          "w": 24,
-          "x": 0,
-          "y": 191
-        },
-        "id": 73,
-        "links": [],
-        "options": {
-          "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">NoSQLBench metrics</h1>",
-          "mode": "html"
-        },
-        "pluginVersion": "8.2.3",
-        "style": {},
-        "transparent": true,
-        "type": "text"
-      },
-      {
-        "aliasColors": {},
-        "bars": false,
-        "class": "ops_panel",
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": "prometheus",
-        "description": "",
-        "editable": true,
-        "error": false,
-        "fill": 0,
-        "fillGradient": 0,
-        "grid": {},
-        "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 0,
-          "y": 194
-        },
-        "hiddenSeries": false,
-        "id": 77,
-        "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": false,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 2,
-        "links": [],
-        "nullPointMode": "connected",
-        "options": {
-          "alertThreshold": true
-        },
-        "percentage": false,
-        "pluginVersion": "8.2.3",
-        "pointradius": 1,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [],
-        "spaceLength": 10,
-        "stack": false,
-        "steppedLine": false,
-        "targets": [
-          {
-            "exemplar": true,
-            "expr": "result_success{type=\"pctile\"}",
-            "format": "time_series",
-            "hide": false,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "{{instance}}-{{step}}-p{{pctile}}",
-            "refId": "A"
-          }
-        ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
-        "title": "Service time distribution",
-        "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "$$hashKey": "object:125",
-            "format": "ns",
-            "logBase": 1,
-            "max": null,
-            "min": 0,
-            "show": true
-          },
-          {
-            "$$hashKey": "object:126",
-            "format": "short",
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
-      },
-      {
-        "aliasColors": {},
-        "bars": false,
-        "class": "ops_panel",
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": "prometheus",
-        "description": "",
-        "editable": true,
-        "error": false,
-        "fill": 2,
-        "fillGradient": 0,
-        "grid": {},
-        "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 8,
-          "y": 194
-        },
-        "hiddenSeries": false,
-        "id": 78,
-        "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": false,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 2,
-        "links": [],
-        "nullPointMode": "connected",
-        "options": {
-          "alertThreshold": true
-        },
-        "percentage": false,
-        "pluginVersion": "8.2.3",
-        "pointradius": 1,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [],
-        "spaceLength": 10,
-        "stack": false,
-        "steppedLine": false,
-        "targets": [
-          {
-            "exemplar": true,
-            "expr": "result_success{type=\"pctile\",pctile=\"0\"}",
-            "format": "time_series",
-            "hide": false,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "{{instance}}-{{step}}-min",
-            "refId": "A"
-          },
-          {
-            "exemplar": true,
-            "expr": "result_success{type=\"pctile\",pctile=\"100\"}",
-            "hide": false,
-            "interval": "",
-            "legendFormat": "{{instance}}-{{step}}-max",
-            "refId": "B"
-          }
-        ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
-        "title": "Service time range",
-        "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "$$hashKey": "object:177",
-            "format": "ns",
-            "logBase": 1,
-            "max": null,
-            "min": 0,
-            "show": true
-          },
-          {
-            "$$hashKey": "object:178",
-            "format": "short",
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
-      },
-      {
-        "aliasColors": {},
-        "bars": false,
-        "class": "ops_panel",
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": "prometheus",
-        "description": "",
-        "editable": true,
-        "error": false,
-        "fill": 2,
-        "fillGradient": 0,
-        "grid": {},
-        "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 16,
-          "y": 194
-        },
-        "hiddenSeries": false,
-        "id": 83,
-        "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": false,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 2,
-        "links": [],
-        "nullPointMode": "connected",
-        "options": {
-          "alertThreshold": true
-        },
-        "percentage": false,
-        "pluginVersion": "8.2.3",
-        "pointradius": 1,
-        "points": false,
-        "renderer": "flot",
-        "seriesOverrides": [],
-        "spaceLength": 10,
-        "stack": false,
-        "steppedLine": false,
-        "targets": [
-          {
-            "exemplar": true,
-            "expr": "result_success{type=\"pctile\",pctile=\"50\"}",
-            "hide": false,
-            "interval": "",
-            "legendFormat": "{{instance}}-{{step}}-median",
-            "refId": "B"
-          }
-        ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
-        "title": "Service time median",
-        "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "$$hashKey": "object:177",
-            "format": "ns",
-            "logBase": 1,
-            "max": null,
-            "min": 0,
-            "show": true
-          },
-          {
-            "$$hashKey": "object:178",
-            "format": "short",
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
-      },
-      {
         "aliasColors": {},
         "bars": false,
         "class": "ops_panel",
@@ -5902,228 +6527,11 @@
         "grid": {},
         "gridPos": {
           "h": 7,
-          "w": 8,
-          "x": 0,
-          "y": 201
+          "w": 12,
+          "x": 12,
+          "y": 246
         },
         "hiddenSeries": false,
-        "id": 85,
-        "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": false,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 2,
-        "links": [],
-        "nullPointMode": "connected",
-        "options": {
-          "alertThreshold": true
-        },
-        "percentage": false,
-        "pluginVersion": "8.2.3",
-        "pointradius": 1,
-        "points": true,
-        "renderer": "flot",
-        "seriesOverrides": [],
-        "spaceLength": 10,
-        "stack": false,
-        "steppedLine": false,
-        "targets": [
-          {
-            "exemplar": true,
-            "expr": "main_write__main_write__success{property=\"m1_rate\"}",
-            "format": "time_series",
-            "hide": false,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "{{instance}}-{{step}}",
-            "refId": "A"
-          },
-          {
-            "exemplar": true,
-            "expr": "main_write__main_write__error{property=\"m1_rate\"}",
-            "hide": false,
-            "interval": "",
-            "legendFormat": "{{instance}}-{{step}}",
-            "refId": "B"
-          }
-        ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
-        "title": "Write ops / minute",
-        "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "$$hashKey": "object:283",
-            "format": "short",
-            "logBase": 1,
-            "max": null,
-            "min": 0,
-            "show": true
-          },
-          {
-            "$$hashKey": "object:284",
-            "format": "short",
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
-      },
-      {
-        "aliasColors": {},
-        "bars": false,
-        "class": "ops_panel",
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": "prometheus",
-        "description": "",
-        "editable": true,
-        "error": false,
-        "fill": 1,
-        "fillGradient": 0,
-        "grid": {},
-        "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 8,
-          "y": 201
-        },
-        "hiddenSeries": false,
-        "id": 86,
-        "legend": {
-          "avg": false,
-          "current": false,
-          "max": false,
-          "min": false,
-          "show": false,
-          "total": false,
-          "values": false
-        },
-        "lines": true,
-        "linewidth": 2,
-        "links": [],
-        "nullPointMode": "connected",
-        "options": {
-          "alertThreshold": true
-        },
-        "percentage": false,
-        "pluginVersion": "8.2.3",
-        "pointradius": 1,
-        "points": true,
-        "renderer": "flot",
-        "seriesOverrides": [],
-        "spaceLength": 10,
-        "stack": false,
-        "steppedLine": false,
-        "targets": [
-          {
-            "exemplar": true,
-            "expr": "main_read__main_select_all__success{property=\"m1_rate\"}",
-            "format": "time_series",
-            "hide": false,
-            "interval": "",
-            "intervalFactor": 1,
-            "legendFormat": "{{instance}}-{{step}}",
-            "refId": "A"
-          },
-          {
-            "exemplar": true,
-            "expr": "main_read__main_select_all__error{property=\"m1_rate\"}",
-            "hide": false,
-            "interval": "",
-            "legendFormat": "{{instance}}-{{step}}",
-            "refId": "B"
-          }
-        ],
-        "thresholds": [],
-        "timeFrom": null,
-        "timeRegions": [],
-        "timeShift": null,
-        "title": "Read ops / minute",
-        "tooltip": {
-          "msResolution": false,
-          "shared": true,
-          "sort": 0,
-          "value_type": "individual"
-        },
-        "type": "graph",
-        "xaxis": {
-          "buckets": null,
-          "mode": "time",
-          "name": null,
-          "show": true,
-          "values": []
-        },
-        "yaxes": [
-          {
-            "$$hashKey": "object:283",
-            "format": "short",
-            "logBase": 1,
-            "max": null,
-            "min": 0,
-            "show": true
-          },
-          {
-            "$$hashKey": "object:284",
-            "format": "short",
-            "logBase": 1,
-            "max": null,
-            "min": null,
-            "show": true
-          }
-        ],
-        "yaxis": {
-          "align": false,
-          "alignLevel": null
-        }
-      },
-      {
-        "aliasColors": {},
-        "bars": false,
-        "class": "ops_panel",
-        "dashLength": 10,
-        "dashes": false,
-        "datasource": "prometheus",
-        "description": "",
-        "editable": true,
-        "error": false,
-        "fill": 1,
-        "fillGradient": 0,
-        "grid": {},
-        "gridPos": {
-          "h": 7,
-          "w": 8,
-          "x": 16,
-          "y": 201
-        },
-        "hiddenSeries": false,
-        "id": 84,
         "legend": {
           "avg": false,
           "current": false,
@@ -6170,9 +6578,7 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
         "timeRegions": [],
-        "timeShift": null,
         "title": "Ops vs successful ops / minute",
         "tooltip": {
           "msResolution": false,
@@ -6182,9 +6588,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -6193,7 +6597,6 @@
             "$$hashKey": "object:335",
             "format": "short",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
@@ -6201,14 +6604,314 @@
             "$$hashKey": "object:336",
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ],
         "yaxis": {
-          "align": false,
-          "alignLevel": null
+          "align": false
+        }
+      },
+      {
+        "class": "text_panel",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "editable": true,
+        "error": false,
+        "gridPos": {
+          "h": 3,
+          "w": 24,
+          "x": 0,
+          "y": 253
+        },
+        "links": [],
+        "options": {
+          "content": "<h1 style=\"color:#5881c2; border-bottom: 3px solid #5881c2;\">NoSQLBench metrics</h1>",
+          "mode": "html"
+        },
+        "pluginVersion": "8.2.3",
+        "style": {},
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "class": "ops_panel",
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "prometheus",
+        "description": "",
+        "editable": true,
+        "error": false,
+        "fill": 0,
+        "fillGradient": 0,
+        "grid": {},
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 0,
+          "y": 256
+        },
+        "hiddenSeries": false,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "connected",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.2.3",
+        "pointradius": 1,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "result_success{type=\"pctile\"}",
+            "format": "time_series",
+            "hide": false,
+            "interval": "",
+            "intervalFactor": 1,
+            "legendFormat": "{{instance}}-{{step}}-p{{pctile}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Service time distribution",
+        "tooltip": {
+          "msResolution": false,
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "mode": "time",
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:125",
+            "format": "ns",
+            "logBase": 1,
+            "min": 0,
+            "show": true
+          },
+          {
+            "$$hashKey": "object:126",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "class": "ops_panel",
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "prometheus",
+        "description": "",
+        "editable": true,
+        "error": false,
+        "fill": 2,
+        "fillGradient": 0,
+        "grid": {},
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 8,
+          "y": 256
+        },
+        "hiddenSeries": false,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "connected",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.2.3",
+        "pointradius": 1,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "result_success{type=\"pctile\",pctile=\"0\"}",
+            "format": "time_series",
+            "hide": false,
+            "interval": "",
+            "intervalFactor": 1,
+            "legendFormat": "{{instance}}-{{step}}-min",
+            "refId": "A"
+          },
+          {
+            "exemplar": true,
+            "expr": "result_success{type=\"pctile\",pctile=\"100\"}",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "{{instance}}-{{step}}-max",
+            "refId": "B"
+          }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Service time range",
+        "tooltip": {
+          "msResolution": false,
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "mode": "time",
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:177",
+            "format": "ns",
+            "logBase": 1,
+            "min": 0,
+            "show": true
+          },
+          {
+            "$$hashKey": "object:178",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "class": "ops_panel",
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "prometheus",
+        "description": "",
+        "editable": true,
+        "error": false,
+        "fill": 2,
+        "fillGradient": 0,
+        "grid": {},
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 16,
+          "y": 256
+        },
+        "hiddenSeries": false,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "connected",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.2.3",
+        "pointradius": 1,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "result_success{type=\"pctile\",pctile=\"50\"}",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "{{instance}}-{{step}}-median",
+            "refId": "B"
+          }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Service time median",
+        "tooltip": {
+          "msResolution": false,
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "mode": "time",
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:177",
+            "format": "ns",
+            "logBase": 1,
+            "min": 0,
+            "show": true
+          },
+          {
+            "$$hashKey": "object:178",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false
         }
       },
       {
@@ -6228,10 +6931,9 @@
           "h": 7,
           "w": 8,
           "x": 0,
-          "y": 208
+          "y": 263
         },
         "hiddenSeries": false,
-        "id": 79,
         "legend": {
           "avg": false,
           "current": false,
@@ -6260,20 +6962,26 @@
         "targets": [
           {
             "exemplar": true,
-            "expr": "{__name__=~\"read_input|bind|execute\",type=\"pctile\",pctile=\"99\"}",
+            "expr": "main_write__main_write__success{property=\"m1_rate\"}",
             "format": "time_series",
             "hide": false,
             "interval": "",
             "intervalFactor": 1,
-            "legendFormat": "{{instance}}-{{__name__}}-p{{pctile}}",
+            "legendFormat": "{{instance}}-{{step}}",
             "refId": "A"
+          },
+          {
+            "exemplar": true,
+            "expr": "main_write__main_write__error{property=\"m1_rate\"}",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "{{instance}}-{{step}}",
+            "refId": "B"
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
         "timeRegions": [],
-        "timeShift": null,
-        "title": "p99 client overhead",
+        "title": "Write ops / minute",
         "tooltip": {
           "msResolution": false,
           "shared": true,
@@ -6282,18 +6990,15 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
         "yaxes": [
           {
             "$$hashKey": "object:283",
-            "format": "ns",
-            "logBase": 10,
-            "max": null,
+            "format": "short",
+            "logBase": 1,
             "min": 0,
             "show": true
           },
@@ -6301,14 +7006,11 @@
             "$$hashKey": "object:284",
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ],
         "yaxis": {
-          "align": false,
-          "alignLevel": null
+          "align": false
         }
       },
       {
@@ -6328,10 +7030,9 @@
           "h": 7,
           "w": 8,
           "x": 8,
-          "y": 208
+          "y": 263
         },
         "hiddenSeries": false,
-        "id": 81,
         "legend": {
           "avg": false,
           "current": false,
@@ -6360,20 +7061,26 @@
         "targets": [
           {
             "exemplar": true,
-            "expr": "{__name__=~\"errorcounts.*\"}",
+            "expr": "main_read__main_select_all__success{property=\"m1_rate\"}",
             "format": "time_series",
             "hide": false,
             "interval": "",
             "intervalFactor": 1,
-            "legendFormat": "{{instance}}-{{error}}",
+            "legendFormat": "{{instance}}-{{step}}",
             "refId": "A"
+          },
+          {
+            "exemplar": true,
+            "expr": "main_read__main_select_all__error{property=\"m1_rate\"}",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "{{instance}}-{{step}}",
+            "refId": "B"
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
         "timeRegions": [],
-        "timeShift": null,
-        "title": "Errors",
+        "title": "Read ops / minute",
         "tooltip": {
           "msResolution": false,
           "shared": true,
@@ -6382,9 +7089,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -6393,7 +7098,6 @@
             "$$hashKey": "object:283",
             "format": "short",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
@@ -6401,14 +7105,11 @@
             "$$hashKey": "object:284",
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ],
         "yaxis": {
-          "align": false,
-          "alignLevel": null
+          "align": false
         }
       },
       {
@@ -6428,10 +7129,9 @@
           "h": 7,
           "w": 8,
           "x": 16,
-          "y": 208
+          "y": 263
         },
         "hiddenSeries": false,
-        "id": 82,
         "legend": {
           "avg": false,
           "current": false,
@@ -6470,9 +7170,7 @@
           }
         ],
         "thresholds": [],
-        "timeFrom": null,
         "timeRegions": [],
-        "timeShift": null,
         "title": "Cycle count",
         "tooltip": {
           "msResolution": false,
@@ -6482,9 +7180,7 @@
         },
         "type": "graph",
         "xaxis": {
-          "buckets": null,
           "mode": "time",
-          "name": null,
           "show": true,
           "values": []
         },
@@ -6493,7 +7189,6 @@
             "$$hashKey": "object:283",
             "format": "short",
             "logBase": 1,
-            "max": null,
             "min": 0,
             "show": true
           },
@@ -6501,19 +7196,198 @@
             "$$hashKey": "object:284",
             "format": "short",
             "logBase": 1,
-            "max": null,
-            "min": null,
             "show": true
           }
         ],
         "yaxis": {
-          "align": false,
-          "alignLevel": null
+          "align": false
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "class": "ops_panel",
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "prometheus",
+        "description": "",
+        "editable": true,
+        "error": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "grid": {},
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 0,
+          "y": 270
+        },
+        "hiddenSeries": false,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "connected",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.2.3",
+        "pointradius": 1,
+        "points": true,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "{__name__=~\"read_input|bind|execute\",type=\"pctile\",pctile=\"99\"}",
+            "format": "time_series",
+            "hide": false,
+            "interval": "",
+            "intervalFactor": 1,
+            "legendFormat": "{{instance}}-{{__name__}}-p{{pctile}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "p99 client overhead",
+        "tooltip": {
+          "msResolution": false,
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "mode": "time",
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:283",
+            "format": "ns",
+            "logBase": 10,
+            "min": 0,
+            "show": true
+          },
+          {
+            "$$hashKey": "object:284",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "class": "ops_panel",
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "prometheus",
+        "description": "",
+        "editable": true,
+        "error": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "grid": {},
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 8,
+          "y": 270
+        },
+        "hiddenSeries": false,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "connected",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "8.2.3",
+        "pointradius": 1,
+        "points": true,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "{__name__=~\"errorcounts.*\"}",
+            "format": "time_series",
+            "hide": false,
+            "interval": "",
+            "intervalFactor": 1,
+            "legendFormat": "{{instance}}-{{error}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Errors",
+        "tooltip": {
+          "msResolution": false,
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "mode": "time",
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:283",
+            "format": "short",
+            "logBase": 1,
+            "min": 0,
+            "show": true
+          },
+          {
+            "$$hashKey": "object:284",
+            "format": "short",
+            "logBase": 1,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false
         }
       }
     ],
     "refresh": false,
-    "schemaVersion": 31,
+    "schemaVersion": 36,
     "style": "dark",
     "tags": [
       "master"
@@ -6521,14 +7395,11 @@
     "templating": {
       "list": [
         {
-          "allValue": null,
           "current": {
             "selected": true,
             "text": "Instance",
             "value": "instance"
           },
-          "description": null,
-          "error": null,
           "hide": 0,
           "includeAll": false,
           "label": "by",
@@ -6561,7 +7432,6 @@
           "type": "custom"
         },
         {
-          "allValue": null,
           "class": "template_variable_single",
           "current": {
             "isNone": true,
@@ -6569,10 +7439,11 @@
             "text": "None",
             "value": ""
           },
-          "datasource": "prometheus",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
           "definition": "",
-          "description": null,
-          "error": null,
           "hide": 0,
           "includeAll": false,
           "label": "cluster",
@@ -6593,7 +7464,6 @@
           "useTags": false
         },
         {
-          "allValue": null,
           "class": "template_variable_all",
           "current": {
             "selected": true,
@@ -6604,10 +7474,11 @@
               "$__all"
             ]
           },
-          "datasource": "prometheus",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
           "definition": "",
-          "description": null,
-          "error": null,
           "hide": 0,
           "includeAll": true,
           "label": "dc",
@@ -6628,7 +7499,6 @@
           "useTags": false
         },
         {
-          "allValue": null,
           "class": "template_variable_all",
           "current": {
             "selected": true,
@@ -6639,10 +7509,11 @@
               "$__all"
             ]
           },
-          "datasource": "prometheus",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
           "definition": "",
-          "description": null,
-          "error": null,
           "hide": 0,
           "includeAll": true,
           "label": "node",
@@ -6663,7 +7534,6 @@
           "useTags": false
         },
         {
-          "allValue": null,
           "class": "template_variable_all",
           "current": {
             "selected": true,
@@ -6674,10 +7544,11 @@
               "$__all"
             ]
           },
-          "datasource": "prometheus",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
           "definition": "",
-          "description": null,
-          "error": null,
           "hide": 0,
           "includeAll": true,
           "label": "shard",
@@ -6698,17 +7569,13 @@
           "useTags": false
         },
         {
-          "allValue": null,
           "current": {
             "tags": [],
             "text": "",
             "value": []
           },
-          "description": null,
-          "error": null,
           "hide": 1,
           "includeAll": false,
-          "label": null,
           "multi": true,
           "name": "sct_tags",
           "options": [
@@ -6764,6 +7631,10 @@
         }
       ]
     },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
     "timepicker": {
       "now": true,
       "refresh_intervals": [
@@ -6792,6 +7663,7 @@
     },
     "timezone": "utc",
     "title": "[$test_name] Scylla Per Server Metrics Nemesis Master",
-    "version": 1
+    "version": 1,
+    "weekStart": ""
   }
 }


### PR DESCRIPTION
Trello: https://trello.com/c/YEn4IjEa
    
    When several stress tools running in parallel or different operations
    of same stress tool running in parallel, it is difficult to see on
    latancies panels, what operations trigger latency without disabling
    them per  pannel one by one.
    
    Splitting latency panels per tool and operation by modifying
    dashboard source file

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
