### PR TITLE
fix(k8s-upgrade): provision 4 K8S Scylla nodes

### DIFF
--- a/test-cases/scylla-operator/kubernetes-operator-upgrade.yaml
+++ b/test-cases/scylla-operator/kubernetes-operator-upgrade.yaml
@@ -4,7 +4,7 @@ test_duration: 300
 stress_cmd_r: cassandra-stress read no-warmup cl=QUORUM n=2010020 -schema 'keyspace=keyspace_entire_test replication(factor=3) compression=LZ4Compressor' -mode cql3 native compression=lz4 -rate threads=100 -pop seq=1..2010020 -log interval=5
 stress_cmd_w: cassandra-stress write no-warmup cl=QUORUM n=2010020 -schema 'keyspace=keyspace_entire_test replication(factor=3) compression=LZ4Compressor' -mode cql3 native compression=lz4 -rate threads=100 -pop seq=1..2010020 -log interval=5
 
-n_db_nodes: 3
+n_db_nodes: 4
 k8s_n_scylla_pods_per_cluster: 3
 
 n_loaders: 1

--- a/test-cases/scylla-operator/kubernetes-platform-upgrade.yaml
+++ b/test-cases/scylla-operator/kubernetes-platform-upgrade.yaml
@@ -4,7 +4,7 @@ test_duration: 300
 stress_cmd_r: cassandra-stress read no-warmup cl=QUORUM n=2010020 -schema 'keyspace=keyspace_entire_test replication(factor=3) compression=LZ4Compressor' -mode cql3 native compression=lz4 -rate threads=100 -pop seq=1..2010020 -log interval=5
 stress_cmd_w: cassandra-stress write no-warmup cl=QUORUM n=2010020 -schema 'keyspace=keyspace_entire_test replication(factor=3) compression=LZ4Compressor' -mode cql3 native compression=lz4 -rate threads=100 -pop seq=1..2010020 -log interval=5
 
-n_db_nodes: 3
+n_db_nodes: 4
 k8s_n_scylla_pods_per_cluster: 3
 
 n_loaders: 1


### PR DESCRIPTION
After implementation of the `k8s_n_scylla_pods_per_cluster` config
option the following 2 config files started being wrong:
  - test-cases/scylla-operator/kubernetes-operator-upgrade.yaml
  - test-cases/scylla-operator/kubernetes-platform-upgrade.yaml

So, fix it by making the `n_db_nodes` config option have `4` value
instead of `3`. It will allow the operator and K8S platform tests
pass through the step where 4th Scylla member(pod) gets created.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
