### PR TITLE
fix(sdcm/tester.py): Fix test stoppage on shard reporting failure

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3513,10 +3513,14 @@ def wait_for_init_wrap(method):  # pylint: disable=too-many-statements
             exception_details = None
             try:
                 cl_inst.node_setup(_node, **setup_kwargs)
-                _node.argus_resource_set_shards()
-                ArgusTestRun.get().save()
             except Exception as ex:  # pylint: disable=broad-except
                 exception_details = (str(ex), traceback.format_exc())
+            try:
+                _node.argus_resource_set_shards()
+                ArgusTestRun.get().save()
+            except Exception:  # pylint: disable=broad-except
+                LOGGER.warning("Failure settings shards for node %s in Argus.", _node)
+                LOGGER.debug("Exception details:\n", exc_info=True)
             _queue.put((_node, exception_details))
             _queue.task_done()
 


### PR DESCRIPTION
This fixes an issue where an exception occuring in argus client during
shard reporting would propagate to the events system and fail the test.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
