### PR TITLE
Fix gke provisioning

### DIFF
--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -451,6 +451,7 @@ class MonitorSetGKE(MonitorSetGCE):
         self.json_file_params_for_replace = {
             "$test_name": f"{get_test_name()}--{self.targets['db_cluster'].scylla_cluster_name}",
         }
+        self.tags["monitorid"] = self.monitor_id
 
     def install_scylla_manager(self, node):
         pass
@@ -478,10 +479,3 @@ class MonitorSetGKE(MonitorSetGCE):
 
         instances = sorted(instances, key=sort_by_index)
         return instances
-
-    # pylint: disable=protected-access
-    def _create_node(self, instance, node_index, dc_idx):
-        node = super()._create_node(instance=instance, node_index=node_index, dc_idx=dc_idx)
-        node._instance_wait_safe(
-            node._gce_service.ex_set_node_labels, node._instance, {"monitorid": self.monitor_id})
-        return node

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -667,6 +667,11 @@ class GceSctRunner(SctRunner):
                 "block-project-ssh-keys": "true",
                 "ssh-keys": f"{self.LOGIN_USER}:{self.key_pair.public_key.decode()}",
             },
+            # NOTE: following is needed for the possibility to use the K8S/GKE APIs
+            ex_service_accounts=[{
+                'email': KeyStore().get_gcp_credentials()['client_email'],
+                'scopes': ['cloud-platform'],
+            }],
         )
         time.sleep(30)  # wait until the public IPs are available.
 


### PR DESCRIPTION
Currently, the GKE provisioning is broken in 2 places.

1) `GKE monitoring node label setting`

If we run a test on GKE backend then we get following error creating monitoring node:
    
```
sdcm.cluster.NodeError: Timeout while running 'ex_set_node_labels' method on GCE instance '3260019724311279728'
```
    
So, fix it by adding the required 'monitorid' label to the 'tags' attribute that will be added
by the common code and remove the failing part from the GKE's monitoring class.

2) `GKE cluster creation`

For the moment, if we try to create a GKE cluster we get following error:
    
```
ERROR: (gcloud.container.clusters.create) ResponseError:  code=403, message=Request had insufficient authentication scopes.
```
    
The root cause for it is absence of enabled `cloud-platform` scope for the SCT runner isntance.
So, fix it by specifying this scope creating GCE instance.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
