### PR TITLE
feature(cassandra-harry): move to run on docker base image

### DIFF
--- a/docker/cassandra-harry/Dockerfile
+++ b/docker/cassandra-harry/Dockerfile
@@ -1,0 +1,14 @@
+FROM maven:3-jdk-11 as builder
+RUN apt -y update && apt -y install make \
+&& git clone --depth 1 https://github.com/apache/cassandra-harry.git \
+&& cd cassandra-harry \
+&& make standalone
+
+FROM openjdk:11 as app
+COPY --from=builder /cassandra-harry /cassandra-harry
+
+RUN sed -i '2s;^;HARRY_HOME=/cassandra-harry\n;'  /cassandra-harry/scripts/cassandra-harry
+RUN sed -i 's/external-.*-SNAPSHOT.jar/external-*-SNAPSHOT.jar/' /cassandra-harry/scripts/cassandra-harry
+RUN ln -svf /cassandra-harry/scripts/cassandra-harry /usr/bin/cassandra-harry
+
+WORKDIR /cassandra-harry

--- a/docker/cassandra-harry/README.md
+++ b/docker/cassandra-harry/README.md
@@ -1,0 +1,6 @@
+```
+export HARRY_DOCKER_IMAGE=scylladb/hydra-loaders:cassandra-harry-jdk11-$(date +'%Y%m%d')
+docker build . -t ${HARRY_DOCKER_IMAGE}
+docker push ${HARRY_DOCKER_IMAGE}
+echo "${HARRY_DOCKER_IMAGE}" > image
+```

--- a/docker/cassandra-harry/image
+++ b/docker/cassandra-harry/image
@@ -1,0 +1,1 @@
+scylladb/hydra-loaders:cassandra-harry-jdk11-20220816

--- a/sdcm/cassandra_harry_thread.py
+++ b/sdcm/cassandra_harry_thread.py
@@ -15,13 +15,13 @@ import os
 import uuid
 import time
 import logging
-import concurrent.futures
 
 from sdcm.loader import CassandraHarryStressExporter
 from sdcm.prometheus import nemesis_metrics_obj
 from sdcm.sct_events.loaders import CassandraHarryEvent, CASSANDRA_HARRY_ERROR_EVENTS_PATTERNS
-from sdcm.utils.common import FileFollowerThread, generate_random_string
-from sdcm.stress_thread import format_stress_cmd_error
+from sdcm.utils.docker_remote import RemoteDocker
+from sdcm.stress_thread import format_stress_cmd_error, DockerBasedStressThread
+from sdcm.utils.common import FileFollowerThread
 
 
 LOGGER = logging.getLogger(__name__)
@@ -50,118 +50,52 @@ class CassandraHarryStressEventsPublisher(FileFollowerThread):
 
 
 #  pylint: disable=too-many-instance-attributes
-class CassandraHarryThread:
+class CassandraHarryThread(DockerBasedStressThread):
     #  pylint: disable=too-many-arguments
-    def __init__(self, stress_cmd, loader_set, timeout, node_list=None, round_robin=False, use_single_loader=False,
-                 stop_test_on_failure=False, stress_num=1, credentials=None):
-        self.stress_cmd = stress_cmd
+    def __init__(self, *args, **kwargs):
+        credentials = kwargs.pop('credentials', None)
+
+        super().__init__(*args, **kwargs)
+
         if credentials and "username=" not in self.stress_cmd:
             self.stress_cmd += " -username {} -password {}".format(*credentials)
-        self.loader_set = loader_set
-        self.timeout = timeout
-        self.node_list = node_list or []
-        self.round_robin = round_robin
-        self.use_single_loader = use_single_loader
-        self.stop_test_on_failure = stop_test_on_failure
-        self.stress_num = stress_num
 
-        self.executor = None
-        self.results_futures = []
-        self.shell_marker = generate_random_string(20)
-        self.max_workers = 0
-
-    def get_stress_results_bench(self):
-        ret = []
-        results = []
-
-        LOGGER.debug('Wait for stress threads results')
-        for future in concurrent.futures.as_completed(self.results_futures, timeout=self.timeout):
-            results.append(future.result())
-
-        for _, result in results:
-            if not result:
-                # Silently skip if stress command throwed error, since it was already reported in _run_stress
-                continue
-            output = result.stdout + result.stderr
-            try:
-                lines = output.splitlines()
-                node_cs_res = self._parse_harry_summary(lines)  # pylint: disable=protected-access
-                if node_cs_res:
-                    ret.append(node_cs_res)
-            except Exception as exc:  # pylint: disable=broad-except
-                CassandraHarryEvent.error(node="",
-                                          stress_cmd=self.stress_cmd,
-                                          errors=[f"Failed to proccess stress summary due to {exc}"]).publish()
-
-        return ret
-
-    def verify_results(self):
-        harry_summary = []
-        results = []
-        errors = []
-
-        LOGGER.debug('Wait for stress threads results')
-        for future in concurrent.futures.as_completed(self.results_futures, timeout=self.timeout):
-            results.append(future.result())
-
-        for node, result in results:
-            if not result:
-                # Silently skip if stress command throwed error, since it was already reported in _run_stress
-                continue
-            output = result.stdout + result.stderr
-
-            lines = output.splitlines()
-            node_cs_res = self._parse_harry_summary(lines)  # pylint: disable=protected-access
-
-            if node_cs_res:
-                harry_summary.append(node_cs_res)
-
-            for line in lines:
-                if 'java.io.IOException' in line:
-                    errors += ['%s: %s' % (node, line.strip())]
-
-        return harry_summary, errors
-
-    def run(self):
-        if self.round_robin:
-            loaders = [self.loader_set.get_loader()]
-        else:
-            loaders = self.loader_set.nodes if not self.use_single_loader else [self.loader_set.nodes[0]]
-        LOGGER.debug("Round-Robin through loaders, Selected loader is {} ".format(loaders))
-
-        self.max_workers = (os.cpu_count() or 1) * 5
-        LOGGER.debug("Starting %d cassandra-harry Worker threads", self.max_workers)
-        # pylint: disable=consider-using-with
-        self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=self.max_workers)
-
-        for loader_idx, loader in enumerate(loaders):
-            self.results_futures += [self.executor.submit(self._run_stress_harry,
-                                                          *(loader, loader_idx, self.stress_cmd, self.node_list))]
-            time.sleep(60)
-
-        return self
-
-    def _run_stress_harry(self, node, loader_idx, stress_cmd, node_list):
-
-        CassandraHarryEvent.start(node=node, stress_cmd=stress_cmd).publish()
-        os.makedirs(node.logdir, exist_ok=True)
-
-        log_file_name = os.path.join(node.logdir, f'cassandra-harry-l{loader_idx}-{uuid.uuid4()}.log')
+    def _run_stress(self, loader, loader_idx, cpu_idx):
         # Select first seed node to send the scylla-harry cmds
-        ip = node_list[0].cql_ip_address
+        ip = self.node_list[0].cql_ip_address
 
-        with CassandraHarryStressExporter(instance_name=node.cql_ip_address,
+        if not os.path.exists(loader.logdir):
+            os.makedirs(loader.logdir, exist_ok=True)
+        log_file_name = os.path.join(loader.logdir, f'cassandra-harry-l{loader_idx}-{uuid.uuid4()}.log')
+        LOGGER.debug('cassandra-harry local log: %s', log_file_name)
+
+        LOGGER.debug("running: %s", self.stress_cmd)
+
+        if self.stress_num > 1:
+            node_cmd = f'taskset -c {cpu_idx} bash -c "{self.stress_cmd}"'
+        else:
+            node_cmd = self.stress_cmd
+
+        docker = RemoteDocker(loader, 'scylladb/hydra-loaders:cassandra-harry-jdk11-20220816',
+                              extra_docker_opts=f' --label shell_marker={self.shell_marker}')
+
+        node_cmd = f'STRESS_TEST_MARKER={self.shell_marker}; {node_cmd}'
+
+        CassandraHarryEvent.start(node=loader, stress_cmd=self.stress_cmd).publish()
+
+        with CassandraHarryStressExporter(instance_name=loader.cql_ip_address,
                                           metrics=nemesis_metrics_obj(),
                                           stress_operation='write',
                                           stress_log_filename=log_file_name,
                                           loader_idx=loader_idx), \
-                CassandraHarryStressEventsPublisher(node=node, harry_log_filename=log_file_name):
+                CassandraHarryStressEventsPublisher(node=loader, harry_log_filename=log_file_name):
             result = None
             try:
-                result = node.remoter.run(
-                    cmd=f"{stress_cmd} -node {ip}",
-                    timeout=self.timeout,
-                    log_file=log_file_name)
+                docker_run_result = docker.run(cmd=f"{node_cmd} -node {ip}",
+                                               timeout=self.timeout + self.shutdown_timeout,
+                                               log_file=log_file_name,
+                                               verbose=True)
+                result = self._parse_harry_summary(docker_run_result.stdout.splitlines())
             except Exception as exc:  # pylint: disable=broad-except
                 errors_str = format_stress_cmd_error(exc)
                 if "timeout" in errors_str:
@@ -171,21 +105,22 @@ class CassandraHarryThread:
                 else:
                     event_type = CassandraHarryEvent.error
                 event_type(
-                    node=node,
-                    stress_cmd=stress_cmd,
+                    node=loader,
+                    stress_cmd=self.stress_cmd,
                     log_file_name=log_file_name,
                     errors=[errors_str, ],
                 ).publish()
             else:
-                CassandraHarryEvent.finish(node=node, stress_cmd=stress_cmd, log_file_name=log_file_name).publish()
+                CassandraHarryEvent.finish(node=loader, stress_cmd=self.stress_cmd,
+                                           log_file_name=log_file_name).publish()
 
-        return node, result
+        return result
 
     @staticmethod
     def _parse_harry_summary(lines):  # pylint: disable=too-many-branches
         """
         Currently we only check if it succeeds or not.
-        A succeed sample:
+        succeed sample:
 
         INFO  [pool-6-thread-1] instance_id_IS_UNDEFINED 2021-01-19 13:46:49,835 Runner.java:255 - Completed
         """

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1708,11 +1708,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self.alter_test_tables_encryption(scylla_encryption_options=scylla_encryption_options)
         return bench_thread
 
-    def run_stress_thread_harry(self, stress_cmd, duration=None, stress_num=1, keyspace_num=1, profile=None, prefix='',
+    def run_stress_thread_harry(self, stress_cmd, duration=None,
                                 # pylint: disable=too-many-arguments,unused-argument
-                                round_robin=False, stats_aggregate_cmds=True, keyspace_name=None,
-                                use_single_loader=False,
-                                stop_test_on_failure=True):  # pylint: disable=too-many-arguments,unused-argument
+                                round_robin=False, stats_aggregate_cmds=True,
+                                stop_test_on_failure=True, **_):  # pylint: disable=too-many-arguments,unused-argument
 
         timeout = self.get_duration(duration)
 
@@ -1722,12 +1721,11 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         if self.create_stats:
             self.update_stress_cmd_details(stress_cmd, stresser="cassandra-harry", aggregate=stats_aggregate_cmds)
         harry_thread = CassandraHarryThread(
-            stress_cmd,
             loader_set=self.loaders,
+            stress_cmd=stress_cmd,
             timeout=timeout,
             node_list=self.db_cluster.nodes,
             round_robin=round_robin,
-            use_single_loader=use_single_loader,
             stop_test_on_failure=stop_test_on_failure,
             credentials=self.db_cluster.get_db_auth()
         )

--- a/test-cases/longevity/longevity-harry-2h.yaml
+++ b/test-cases/longevity/longevity-harry-2h.yaml
@@ -9,7 +9,7 @@ instance_type_db: 'i3.large'
 
 root_disk_size_loader: 80 # enlarge loader disk, cause of cassandra-harry operation.log that can't be disabled
 
-nemesis_class_name: 'SisyphusMonkey'
+# nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '001'
 nemesis_interval: 2
 ssh_transport: 'libssh2'

--- a/unit_tests/test_cassandra_harry.py
+++ b/unit_tests/test_cassandra_harry.py
@@ -1,0 +1,51 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2022 ScyllaDB
+
+import pytest
+
+from sdcm.cassandra_harry_thread import CassandraHarryThread
+from unit_tests.dummy_remote import LocalLoaderSetDummy
+
+pytestmark = [pytest.mark.usefixtures('events'),
+              pytest.mark.skip(reason="those are integration tests only")]
+
+
+def test_01_cassandra_harry(request, docker_scylla, events):
+    """
+    Test to help integrated new version/docker images of cassandra-harry
+
+    TODO: Test isn't really running cassandra-harry correctly, since there only one node
+
+    DEBUG    LocalCmdRunner:base.py:222 com.datastax.driver.core.exceptions.NoHostAvailableException:
+    All host(s) tried for query failed (tried: /172.17.0.2:9042 (com.datastax.driver.core.exceptions.UnavailableException:
+    Not enough replicas available for query at consistency QUORUM (2 required but only 1 alive)))
+    """
+    loader_set = LocalLoaderSetDummy()
+
+    cmd = 'cassandra-harry -run-time 1 -run-time-unit MINUTES'
+    harry_thread = CassandraHarryThread(loader_set, cmd, node_list=[docker_scylla], timeout=5)
+
+    def cleanup_thread():
+        harry_thread.kill()
+
+    request.addfinalizer(cleanup_thread)
+
+    file_logger = events.get_events_logger()
+    with events.wait_for_n_events(file_logger, count=2, timeout=120):
+        harry_thread.run()
+
+    # 5. check that events with the expected error were raised
+    cat = file_logger.get_events_by_category()
+    assert len(cat['ERROR']) == 2
+    assert '=UNEXPECTED_STATE' in cat['ERROR'][0]
+    assert '=ERROR' in cat['ERROR'][1]


### PR DESCRIPTION
As part of the plan to move all stress tools/loaders into docker
images, we move `cassandra-harry` into a docker image
we'll create/maintine.

there an intergation test for it, but it's not complate, since
we don't yet have a setup to run a docker base cluster for those
integration tests, and harry can't work with one node.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
