### PR TITLE
fix(gke): use non-deprecated config option for the logging

### DIFF
--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -236,7 +236,7 @@ class GkeCluster(KubernetesCluster):
                        f" --image-type UBUNTU"
                        f" --disk-type {self.gce_disk_type}"
                        f" --disk-size {self.gce_disk_size}"
-                       f" --enable-stackdriver-kubernetes"
+                       f" --logging=SYSTEM,WORKLOAD --monitoring=SYSTEM"
                        f"{'' if self.gke_k8s_release_channel else ' --no-enable-autoupgrade'}"
                        f"{'' if self.gke_k8s_release_channel else ' --no-enable-autorepair'}"
                        f" --metadata {tags}")


### PR DESCRIPTION
The one we currently use - `--enable-stackdriver-kubernetes` is deprecated already.
So, replace with with the actual following analog:

    '--logging=SYSTEM,WORKLOAD --monitoring=SYSTEM'

Info: https://cloud.google.com/stackdriver/docs/solutions/gke/installing#deprecated_configuration_parameters

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
