### PR TITLE
fix(sct_runner): reduce error to warning for no runners

### DIFF
--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -1060,7 +1060,9 @@ def update_sct_runner_tags(test_runner_ip: str = None, test_id: str = None, tags
         runner_to_update = [runner for runner in listed_runners if runner.test_id == test_id]
 
     if not runner_to_update:
-        raise RuntimeError(f"Could not find SCT runner with IP: {test_runner_ip} to update tags for.")
+        LOGGER.warning("Could not find SCT runner with IP: %s, test_id: %s to update tags for.",
+                       test_runner_ip, test_id)
+        return
 
     try:
         runner_to_update = runner_to_update[0]


### PR DESCRIPTION
update_sct_runner_tags() should not raise an error
when no runners are found, it should just print out
the warning. We call this method after collecting
logs, which we also do for artifact jobs, which run
on builders, so there are no runners for these tests.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
