### PR TITLE
fix(gke): make longevity CI jobs work

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1271,7 +1271,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     def get_cluster_k8s_gke(self):
         self.credentials.append(UserRemoteCredentials(key_file=self.params.get('user_credentials_path')))
 
-        services = get_gce_services(self.params.get('gce_datacenter').split())
+        gce_datacenters = self.params.get('gce_datacenter')
+        if isinstance(gce_datacenters, str):
+            gce_datacenters = gce_datacenters.split()
+        services = get_gce_services(gce_datacenters)
         assert len(services) == 1, "Doesn't support multi DC setup for `k8s-gke' backend"
 
         services, gce_datacenter = list(services.values()), list(services.keys())

--- a/vars/runCleanupResource.groovy
+++ b/vars/runCleanupResource.groovy
@@ -3,7 +3,7 @@
 def call(Map params, String region){
     def current_region = initAwsRegionParam(params.region, region)
     def current_gce_datacenter = ""
-    if (params.backend == "gce") {
+    if (params.gce_datacenter) {
         current_gce_datacenter = groovy.json.JsonOutput.toJson(params.gce_datacenter)
     }
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)

--- a/vars/runCollectLogs.groovy
+++ b/vars/runCollectLogs.groovy
@@ -4,7 +4,7 @@
 def call(Map params, String region){
     def current_region = initAwsRegionParam(params.region, region)
     def current_gce_datacenter = ""
-    if (params.backend == "gce") {
+    if (params.gce_datacenter) {
         current_gce_datacenter = groovy.json.JsonOutput.toJson(params.gce_datacenter)
     }
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -4,7 +4,7 @@ def call(Map params, String region, functional_test = false, Map pipelineParams 
     // handle params which can be a json list
     def current_region = initAwsRegionParam(params.region, region)
     def current_gce_datacenter = ""
-    if (params.backend == "gce") {
+    if (params.gce_datacenter) {
         current_gce_datacenter = groovy.json.JsonOutput.toJson(params.gce_datacenter)
     }
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)


### PR DESCRIPTION
After merge of the [1] the `gce_datacenter` may now be also list.
So, make the GKE logic in 'tester.py' be smart enough to handle
both possible types of that option - 'str' and 'list'.

Also, fix the groovy files which incorrectly handle the `gce_datacenter`
pipeline parameter when the GKE backend is used.

[1] https://github.com/scylladb/scylla-cluster-tests/pull/4978

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
