### PR TITLE
Revert "fix(syslog-ng): add support for multi-line logs"

### DIFF
--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -60,7 +60,7 @@ def configure_syslogng_target_script(host: str, port: int, throttle_per_second: 
         if ! grep "destination remote_sct" /etc/syslog-ng/syslog-ng.conf; then
             cat <<EOF >>/etc/syslog-ng/syslog-ng.conf
         destination remote_sct {{
-            syslog(
+            network(
                 "{host}"
                 transport("tcp")
                 port({port})

--- a/sdcm/utils/syslogng.py
+++ b/sdcm/utils/syslogng.py
@@ -91,9 +91,10 @@ options {{
 }};
 
 source s_network_tcp {{
-  syslog(
+  network(
     transport("tcp")
     port({port})
+    flags(syslog-protocol)
     max-connections(1000)
   );
 }};


### PR DESCRIPTION
Seem like when running older versions of scylla 4.6 and lower
which we still use as oracles for gemini tests.

we fail to install syslog-ng, and fallback to using rsyslog
the way we configure rsyslog isn't comptible with syslog-ng
rsyslog driver.

we need to maybe put it behind a configuration option,
or invest in removing the rsyslog support completly
and fixing the install issues syslog-ng had, across the board

This reverts commit a11dbb24f9e9754872b1c47138aed5fe4badae85.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
