### PR TITLE
improvement(upgrade): scylla_sysconfig_setup on upgrade / rollback

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -119,3 +119,4 @@ WorkloadPrioritisationEvent.CpuNotHighEnough: ERROR
 WorkloadPrioritisationEvent.RatioValidationEvent: ERROR
 WorkloadPrioritisationEvent.SlaTestResult: ERROR
 WorkloadPrioritisationEvent.EmptyPrometheusData: ERROR
+ScyllaSysconfigSetupEvent: NORMAL

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1495,6 +1495,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def disrupt_nodetool_enospc(self, sleep_time=30, all_nodes=False):
         raise UnsupportedNemesis('disabling ENOSPC nemesis until #11245 will be fixed')
 
+        # pylint: disable=unreachable
         if isinstance(self.cluster, LocalKindCluster):
             # Kind cluster has shared file system, it is shared not only among cluster nodes, but
             # also among kubernetes services which make kubernetes inoperational once enospc is reached.

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -373,10 +373,19 @@ class JMXServiceEvent(ScyllaDatabaseContinuousEvent):
         super().__init__(node=node, severity=severity)
 
 
+class ScyllaSysconfigSetupEvent(ScyllaDatabaseContinuousEvent):
+    begin_pattern = r'Move current config files before running scylla_sysconfig setup'
+    end_pattern = r'Finished running scylla_sysconfig_setup'
+
+    def __init__(self, node: str, severity=Severity.NORMAL, **__):
+        super().__init__(node=node, severity=severity, publish_event=True)
+
+
 SCYLLA_DATABASE_CONTINUOUS_EVENTS = [
     ScyllaServerStatusEvent,
     BootstrapEvent,
     JMXServiceEvent,
+    ScyllaSysconfigSetupEvent
 ]
 
 

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -244,7 +244,9 @@ class UpgradeTest(FillDatabaseData):
         check_reload_systemd_config(node)
         # Current default 300s aren't enough for upgrade test of Debian 9.
         # Related issue: https://github.com/scylladb/scylla-cluster-tests/issues/1726
+        node.run_scylla_sysconfig_setup()
         node.start_scylla_server(verify_up_timeout=500)
+        self.db_cluster.get_db_nodes_cpu_mode()
         result = node.remoter.run('scylla --version')
         new_ver = result.stdout
         assert self.orig_ver != new_ver, "scylla-server version isn't changed"
@@ -329,6 +331,7 @@ class UpgradeTest(FillDatabaseData):
             node.remoter.run('sudo sed -i -e "s/authorizer:/#authorizer:/g" /etc/scylla/scylla.yaml')
         # Current default 300s aren't enough for upgrade test of Debian 9.
         # Related issue: https://github.com/scylladb/scylla-cluster-tests/issues/1726
+        node.run_scylla_sysconfig_setup()
         node.start_scylla_server(verify_up_timeout=500)
         result = node.remoter.run('scylla --version')
         new_ver = result.stdout


### PR DESCRIPTION
Recent changes to queue management in Seastar (https://github.com/scylladb/seastar/pull/949)
mean that more powerful nodes should be configured to use the sq_split mode rather than mq.
Changes in this commit are designed to make sure we run the scylla_sysconfig_setup script,
which in turn should runs perftune configures the queue values, on node upgrade and rollbacks.


Trello task: https://trello.com/c/xljGRtoW

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
