### PR TITLE
fix(circular dependency): remove DEFAULT_USER_PREFIX

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -14,7 +14,6 @@
 # pylint: disable=too-many-lines
 import contextlib
 import queue
-import getpass
 import logging
 import os
 import shutil
@@ -128,7 +127,6 @@ from sdcm.paths import (
 from sdcm.sct_provision.aws.user_data import ScyllaUserDataBuilder
 
 
-DEFAULT_USER_PREFIX = getpass.getuser()
 # Test duration (min). Parameter used to keep instances produced by tests that
 # are supposed to run longer than 24 hours from being killed
 SCYLLA_DIR = "/var/lib/scylla"
@@ -178,9 +176,7 @@ class NodeStayInClusterAfterDecommission(Exception):
     """ raise after decommission finished but node stay in cluster"""
 
 
-def prepend_user_prefix(user_prefix, base_name):
-    if not user_prefix:
-        user_prefix = DEFAULT_USER_PREFIX
+def prepend_user_prefix(user_prefix: str, base_name: str):
     return '%s-%s' % (user_prefix, base_name)
 
 

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1593,13 +1593,12 @@ class SCTConfiguration(dict):
                 self[repo_key] = resolve_latest_repo_symlink(self[repo_key])
 
         # 9) append username or ami_id_db_scylla_desc to the user_prefix
-        version_tag = self.get('ami_id_db_scylla_desc')
-        user_prefix = self.get('user_prefix')
-        if user_prefix:
-            if not version_tag:
-                version_tag = getpass.getuser()
-
+        version_tag = self.get('ami_id_db_scylla_desc') or getpass.getuser()
+        user_prefix = self.get('user_prefix') or getpass.getuser()
+        if version_tag != user_prefix:
             self['user_prefix'] = "{}-{}".format(user_prefix, version_tag)[:35]
+        else:
+            self['user_prefix'] = user_prefix[:35]
 
         # 11) validate that supported instance_provision selected
         if self.get('instance_provision') not in ['spot', 'on_demand', 'spot_fleet', 'spot_low_price', 'spot_duration']:

--- a/sdcm/sct_provision/region_definition_builder.py
+++ b/sdcm/sct_provision/region_definition_builder.py
@@ -15,7 +15,6 @@ from dataclasses import dataclass
 from functools import cache
 from typing import List, Dict, Type
 
-from sdcm.cluster import DEFAULT_USER_PREFIX
 from sdcm.keystore import KeyStore, SSHKey
 from sdcm.provision.provisioner import InstanceDefinition
 from sdcm.sct_config import SCTConfiguration
@@ -69,7 +68,7 @@ class DefinitionBuilder(abc.ABC):
 
     def build_instance_definition(self, region: str, node_type: NodeTypeType, index: int) -> InstanceDefinition:
         """Builds one instance definition of given type and index for given region"""
-        user_prefix = self.params.get('user_prefix') or DEFAULT_USER_PREFIX
+        user_prefix = self.params.get('user_prefix')
         common_tags = TestConfig.common_tags()
         node_type_short = "db" if "db" in node_type else node_type
         name = f"{user_prefix}-{node_type_short}-node-{region}-{index}".lower()

--- a/sdcm/sct_provision/user_data_objects/scylla.py
+++ b/sdcm/sct_provision/user_data_objects/scylla.py
@@ -13,7 +13,6 @@
 import json
 from dataclasses import dataclass
 
-from sdcm.cluster import DEFAULT_USER_PREFIX
 from sdcm.provision.scylla_yaml import ScyllaYaml
 from sdcm.sct_provision.user_data_objects import SctUserDataObject
 
@@ -33,7 +32,7 @@ class ScyllaUserDataObject(SctUserDataObject):
         else:
             data_device = 'instance_store'
         scylla_yaml = ScyllaYaml()
-        scylla_yaml.cluster_name = f"{self.params.get('user_prefix') or DEFAULT_USER_PREFIX}-{self.test_config.test_id()[:8]}"
+        scylla_yaml.cluster_name = f"{self.params.get('user_prefix')}-{self.test_config.test_id()[:8]}"
         smi_payload = {
             "start_scylla_on_first_boot": False,
             "data_device": data_device,

--- a/unit_tests/provisioner/test_scylla_machine_image_payload.py
+++ b/unit_tests/provisioner/test_scylla_machine_image_payload.py
@@ -1,6 +1,5 @@
 import json
 
-from sdcm.cluster import DEFAULT_USER_PREFIX
 from sdcm.sct_provision.user_data_objects.scylla import ScyllaUserDataObject
 from sdcm.test_config import TestConfig
 
@@ -19,7 +18,9 @@ def test_can_generate_valid_scylla_machine_image_payload_with_minimum_params():
     test_config = TestConfig()
     test_config.set_test_id("12345678-87654321")
     test_id_short = test_config.test_id()[:8]
-    sud = ScyllaUserDataObject(test_config=test_config, params={}, instance_name="test-instance", node_type="scylla-db")
+    params = {'user_prefix': 'test_user'}
+    sud = ScyllaUserDataObject(test_config=test_config, params=params,
+                               instance_name="test-instance", node_type="scylla-db")
     assert sud.scylla_machine_image_json == json.dumps({"start_scylla_on_first_boot": False, "data_device": "instance_store",
                                                         "raid_level": 0,
-                                                        "scylla_yaml": {"cluster_name": f"{DEFAULT_USER_PREFIX}-{test_id_short}"}})
+                                                        "scylla_yaml": {"cluster_name": f"test_user-{test_id_short}"}})


### PR DESCRIPTION
DEFAULT_USER_PREFIX was imported in modules that was imported
from scdm.cluster causing circular dependency, and failing
when running unittest via pycharm.

move the handling of that default into `sct_config.py`
where there's already logic for appending the version into it
when needed.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
