### PR TITLE
fix(rsyslog): change template to RSYSLOG_SyslogProtocol23Format

### DIFF
--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -34,7 +34,8 @@ def configure_rsyslog_rate_limits_script(interval: int, burst: int) -> str:
 
 
 def configure_rsyslog_target_script(host: str, port: int) -> str:
-    return f'echo "action(type=\\"omfwd\\" Target=\\"{host}\\" Port=\\"{port}\\" Protocol=\\"tcp\\")" >> /etc/rsyslog.conf\n'
+    return f'echo "action(type=\\"omfwd\\" Target=\\"{host}\\" Port=\\"{port}\\" Protocol=\\"tcp\\" ' \
+           f'TCP_Framing=\\"octet-counted\\" Template=\\"RSYSLOG_SyslogProtocol23Format\\")" >> /etc/rsyslog.conf\n'
 
 
 def configure_syslogng_target_script(host: str, port: int, throttle_per_second: int, hostname: str = "") -> str:

--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -60,7 +60,7 @@ def configure_syslogng_target_script(host: str, port: int, throttle_per_second: 
         if ! grep "destination remote_sct" /etc/syslog-ng/syslog-ng.conf; then
             cat <<EOF >>/etc/syslog-ng/syslog-ng.conf
         destination remote_sct {{
-            network(
+            syslog(
                 "{host}"
                 transport("tcp")
                 port({port})

--- a/sdcm/utils/syslogng.py
+++ b/sdcm/utils/syslogng.py
@@ -91,10 +91,9 @@ options {{
 }};
 
 source s_network_tcp {{
-  network(
+  syslog(
     transport("tcp")
     port({port})
-    flags(syslog-protocol)
     max-connections(1000)
   );
 }};


### PR DESCRIPTION
since we changed in https://github.com/scylladb/scylla-cluster-tests/pull/5026 syslog-ng to use the `syslog` protocol
we need to match the rsyslog configuration to match the
`RFC5424` protocol

we need this since in some cases we still have a fallback that
uses rsyslog, if syslog-ng wasn't installed correctly.
(happens mostly with older scylla images which are centos8 based,
but we need those for upgrades or oracle in gemini tests)

we also need to add the `octet-counted` TCP_Framing, to support
the multiline messages, see [1] for more details

1: https://www.rsyslog.com/doc/v8-stable/configuration/modules/omfwd.html#tcp-framing

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
