### PR TITLE
fix(gce): make cleanup work correctly

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -869,16 +869,14 @@ def list_test_security_groups(tags_dict=None, region_name=None, group_as_region=
     """
     security_groups = {}
     aws_regions = [region_name] if region_name else all_aws_regions()
-    tags_dict.pop('NodeType', None)
 
     def get_security_groups_ips(region):
         if verbose:
             LOGGER.info('Going to list aws region "%s"', region)
         time.sleep(random.random())
         client: EC2Client = boto3.client('ec2', region_name=region)
-        custom_filter = []
-        if tags_dict:
-            custom_filter = [{'Name': 'tag:{}'.format(key), 'Values': [value]} for key, value in tags_dict.items()]
+        custom_filter = [{'Name': 'tag:{}'.format(key), 'Values': [value]}
+                         for key, value in tags_dict.items() if key != 'NodeType']
         response = client.describe_security_groups(Filters=custom_filter)
         security_groups[region] = response['SecurityGroups']
         if verbose:


### PR DESCRIPTION
After the merge of the `vpc-peering` feature [1] the GCE backend's cleanup
started working incorrectly.
The `get_security_groups_ips` function, which gets called in the middle
of all the cleanup functions, removes `NodeType` tag from the shared
dictionary object and it leads to the situation that all of the test run
nodes including SCT runner get deleted as part of the `DB nodes` cleanup.

As a result, the connection to the SCT runner, obviously, gets lost
and job always fails on the `cleanup-resources` stage.

So, fix it by making the mentioned function not change the shared
dictionary object with tags.

[1] https://github.com/scylladb/scylla-cluster-tests/pull/4742

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
