### PR TITLE
improvement(k8s): fail fast if latest tag not translated to specific one

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1782,7 +1782,12 @@ class SCTConfiguration(dict):
         scylla_version = self.get('scylla_version')
 
         if scylla_version == 'latest':
-            self['scylla_version'] = get_specific_tag_of_docker_image(docker_repo=docker_repo)
+            result = get_specific_tag_of_docker_image(docker_repo=docker_repo)
+            if result == 'latest':
+                raise ValueError(
+                    "scylla-operator expects semver-like tags for Scylla docker images. "
+                    "'latest' should not be used.")
+            self['scylla_version'] = result
 
     def _get_target_upgrade_version(self):
         # 10) update target_upgrade_version automatically

--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -457,6 +457,8 @@ def get_specific_tag_of_docker_image(docker_repo: str):
         else:
             break
 
+    LOGGER.warning(
+        "Could not to find a specific Scylla docker tag for the digest of the 'latest' one.")
     return 'latest'
 
 


### PR DESCRIPTION
Scylla-operator behaves incorrectly when non semver-like docker image
tag is used for Scylla pods.
So, if 'latest' Scylla version was provided and SCT fails to find
appropriate specific tag for the digest from it then fail fast
to avoid unpredictable behavior and errors.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
