### PR TITLE
fix(get_specific_tag_of_docker_image): get tag from build info

### DIFF
--- a/unit_tests/test_version_utils.py
+++ b/unit_tests/test_version_utils.py
@@ -370,7 +370,7 @@ def test_scylla_versions_decorator_negative_latest_scylla_no_attr():
 @pytest.mark.integration
 @pytest.mark.need_network
 @pytest.mark.skip(reason="those are integration tests only")
-@pytest.mark.parametrize('docker_repo', ['scylladb/scylla-nightly', 'scylladb/scylla', 'scylladb/scylla-enterprise'])
+@pytest.mark.parametrize('docker_repo', ['scylladb/scylla-nightly', 'scylladb/scylla-enterprise-nightly'])
 def test_get_specific_tag_of_docker_image(docker_repo):
     assert get_specific_tag_of_docker_image(docker_repo=docker_repo) != 'latest'
 


### PR DESCRIPTION
Since we can't trust that the lastest image in dockerhub
would have an identical sha versioned image, (since multiple
images of the same git sha can be built in the same day)

we are switching to get the lastest docker tag from the
relocatable latest folder on s3 (same as dtest is doing
to get the latest versions)

only downside that this is before the docker artifact test
is running, and not from the same time an image get promated
into dockerhub.

once we'll have an equvielent location for the docker image
promoation, we could move to that.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
