### PR TITLE
test(manager): Added ubuntu 22 sanity and upgrade test scenarios

### DIFF
--- a/configurations/manager/ubuntu22.yaml
+++ b/configurations/manager/ubuntu22.yaml
@@ -1,0 +1,2 @@
+ami_id_monitor: 'ami-09db26f1ef0a9f406'  # Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2022-05-06
+ami_monitor_user: 'ubuntu'

--- a/jenkins-pipelines/manager/ubuntu22-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-sanity.jenkinsfile
@@ -1,0 +1,17 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+managerPipeline(
+    backend: 'aws',
+    region: '''["us-east-1", "us-west-2"]''',
+    test_name: 'mgmt_cli_test.MgmtCliTest.test_manager_sanity',
+    test_config: '''["test-cases/manager/manager-regression-multiDC-set-distro.yaml", "configurations/manager/ubuntu22.yaml"]''',
+
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy',
+
+    downstream_jobs_to_run: 'ubuntu22-upgrade-test'
+)

--- a/jenkins-pipelines/manager/ubuntu22-manager-upgrade.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-upgrade.jenkinsfile
@@ -1,0 +1,20 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+managerPipeline(
+    backend: 'aws',
+    region: 'us-east-1',
+
+    target_manager_version: 'master_latest',
+
+    manager_version: '3.0',
+
+    test_name: 'mgmt_upgrade_test.ManagerUpgradeTest.test_upgrade',
+    test_config: '''["test-cases/upgrades/manager-upgrade.yaml", "configurations/manager/ubuntu22.yaml"]''',
+
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy'
+)

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -857,7 +857,7 @@ class ScyllaManagerTool(ScyllaManagerBase):
         LOGGER.info("Initiating Scylla-Manager, version: {}".format(self.sctool.version))
         list_supported_distros = [Distro.CENTOS7,
                                   Distro.DEBIAN8, Distro.DEBIAN9, Distro.DEBIAN10, Distro.DEBIAN11,
-                                  Distro.UBUNTU16, Distro.UBUNTU18, Distro.UBUNTU20]
+                                  Distro.UBUNTU16, Distro.UBUNTU18, Distro.UBUNTU20, Distro.UBUNTU22]
         self.default_user = "centos"
         if manager_node.distro not in list_supported_distros:
             raise ScyllaManagerError(


### PR DESCRIPTION
Since scylla enterprise 2022.1 was released, and with it the support of ubuntu 22,
we can now create manager test scenarios for ubuntu 22

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
