### PR TITLE
fix(gemini): pin gemini version to the stable one

### DIFF
--- a/test-cases/gemini/gemini-3h-with-nemesis.yaml
+++ b/test-cases/gemini/gemini-3h-with-nemesis.yaml
@@ -21,7 +21,7 @@ gemini_cmd: "gemini -d --duration 3h --warmup 30m \
 --replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '3'}\" \
 --oracle-replication-strategy \"{'class': 'SimpleStrategy', 'replication_factor': '1'}\""
 
-gemini_version: 'latest'
+gemini_version: '1.7.5'
 gemini_schema_url: 'https://s3.amazonaws.com/scylla-gemini/Binaries/schema.json' # currently is not used
 
 db_type: mixed_scylla


### PR DESCRIPTION
	In 2021.1 maintanence releases no need for updates
	of Gemini tool version.
Previous 2021.1 Gemini runs failed with: https://github.com/scylladb/gemini/issues/273
It shouldn't reproduce with 1.7.5.
Trello: https://trello.com/c/PNnpLS8L

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
