### PR TITLE
feature(events): add to event nemesis sub-context

### DIFF
--- a/sdcm/sct_events/continuous_event.py
+++ b/sdcm/sct_events/continuous_event.py
@@ -64,6 +64,9 @@ class ContinuousEventsRegistry(metaclass=Singleton):
         if event in hash_bucket:
             hash_bucket.remove(event)
 
+    def cleanup_registry(self):
+        self.hashed_continuous_events.clear()
+
     def find_continuous_events_by_hash(self, continuous_hash: int) -> list[ContinuousEvent]:
         return self.hashed_continuous_events.get(continuous_hash, []).copy()
 

--- a/sdcm/sct_events/loaders.py
+++ b/sdcm/sct_events/loaders.py
@@ -21,7 +21,7 @@ import dateutil.parser
 from invoke.runners import Result
 
 from sdcm.sct_events import Severity, SctEventProtocol
-from sdcm.sct_events.base import SctEvent, LogEvent, LogEventProtocol, T_log_event
+from sdcm.sct_events.base import LogEvent, LogEventProtocol, T_log_event
 from sdcm.sct_events.stress_events import BaseStressEvent, StressEvent, StressEventProtocol
 
 LOGGER = logging.getLogger(__name__)
@@ -260,7 +260,7 @@ class GeminiStressLogEvent(LogEvent[T_log_event], abstract=True):  # pylint: dis
 
     @property
     def msgfmt(self) -> str:
-        fmt = SctEvent.msgfmt + ":"
+        fmt = super(LogEvent, self).msgfmt + ":"
         if self.type:
             fmt += " type={0.type}"
         fmt += " line_number={0.line_number} node={0.node}"

--- a/sdcm/sct_events/nemesis.py
+++ b/sdcm/sct_events/nemesis.py
@@ -10,6 +10,8 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2020 ScyllaDB
+from functools import cached_property
+
 from sdcm.sct_events import Severity
 from sdcm.sct_events.continuous_event import ContinuousEvent
 
@@ -25,6 +27,14 @@ class DisruptionEvent(ContinuousEvent):
         self.duration = None
         self.full_traceback = ""
         super().__init__(severity=severity, publish_event=publish_event)
+
+    @cached_property
+    def subcontext_fields(self) -> list:
+        return ['event_id', 'base', 'nemesis_name', 'node', 'timestamp']
+
+    @cached_property
+    def subcontext_fmt(self):
+        return {'nemesis_name': self.nemesis_name}
 
     @property
     def msgfmt(self) -> str:

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -23,6 +23,7 @@ from sdcm.cluster import BaseNode
 from sdcm.prometheus import start_metrics_server
 from sdcm.provision import provisioner_factory
 from sdcm.remote import RemoteCmdRunnerBase
+from sdcm.sct_events.continuous_event import ContinuousEventsRegistry
 from sdcm.sct_provision import region_definition_builder
 from sdcm.utils.docker_remote import RemoteDocker
 
@@ -121,3 +122,8 @@ def fixture_params(request: pytest.FixtureRequest):
     for k in os.environ:
         if k.startswith('SCT_'):
             del os.environ[k]
+
+
+@pytest.fixture(scope='function', autouse=True)
+def fixture_cleanup_continuous_events_registry():
+    ContinuousEventsRegistry().cleanup_registry()

--- a/unit_tests/test_sct_events_base.py
+++ b/unit_tests/test_sct_events_base.py
@@ -154,7 +154,8 @@ class TestSctEvent(SctEventTestCase):
         y.event_id = "fa4a84a2-968b-474c-b188-b3bac4be8527"
         self.assertEqual(
             y.to_json(),
-            f'{{"base": "Y", "type": null, "subtype": null, "event_timestamp": {y.event_timestamp}, "source_timestamp": null, '
+            f'{{"base": "Y", "type": null, "subtype": null, "event_timestamp": {y.event_timestamp}, '
+            f'"source_timestamp": null, '
             f'"severity": "UNKNOWN", "event_id": "fa4a84a2-968b-474c-b188-b3bac4be8527", "log_level": 30}}'
         )
 


### PR DESCRIPTION
If an error event happens during nemesis, attach the nemesis information to the event.

Event message example:
```
2022-09-14 08:44:14.893: (FullScanEvent Severity.ERROR) period_type=end event_id=d23078b5-732c-4649-a909-25144eb22af8 during_nemesis=RestartWithResharding duration=7m27s node=longevity-10gb-3h-test-add-db-node-8ca92eee-2 select_from=keyspace1.standard1 message=FullScanThread operation ended successfully
```

in raw event:
```
{"base": "FullScanEvent", "type": null, "subtype": null, "ks_cf": "keyspace1.standard1", "message": "FullScanThread operation ended successfully", "node": "longevity-10gb-3h-test-add-db-node-8ca92eee-2", "shard": null, "event_timestamp": 1663145054.893798, "source_timestamp": null, "severity": "NORMAL", "event_id": "d23078b5-732c-4649-a909-25144eb22af8", "log_level": 20, "subcontext": [{"event_id": "f3ac8255-5df4-401e-935d-1d1fccc3300a", "base": "DisruptionEvent", "nemesis_name": "RestartWithResharding", "node": "Node longevity-10gb-3h-test-add-db-node-8ca92eee-2 [13.48.84.78 | 10.0.3.238] (seed: False)", "timestamp": 1663144652.646285}], "errors": [], "publish_event": true, "begin_timestamp": 1663144606.9619968, "end_timestamp": 1663145054.893798, "is_skipped": false, "skip_reason": "", "period_type": "end"}
```

Refs: https://github.com/scylladb/qa-tasks/issues/341

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
