### PR TITLE
feature(scylla-bench): move to run on docker base image

### DIFF
--- a/docker/scylla-bench/Dockerfile
+++ b/docker/scylla-bench/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.18
+
+ARG version
+ARG fork
+ENV version=${version}
+ENV fork=${fork:-scylladb/scylla-bench}
+
+RUN apt-get update; apt-get -y install unzip curl
+
+RUN curl -Lo sb.zip https://github.com/${fork}/archive/refs/${version}.zip ;\
+    unzip sb.zip ;\
+    cd ./scylla-bench-* ;\
+    GO111MODULE=on go install .

--- a/docker/scylla-bench/README.md
+++ b/docker/scylla-bench/README.md
@@ -1,0 +1,17 @@
+
+### build release
+```
+export SCYLLA_BENCH_VERSION=tags/v0.1.8
+export SCYLLA_BENCH_DOCKER_IMAGE=scylladb/hydra-loaders:scylla-bench-$SCYLLA_BENCH_VERSION
+docker build . -t ${SCYLLA_BENCH_DOCKER_IMAGE} --build-arg version=$SCYLLA_BENCH_VERSION
+docker push ${SCYLLA_BENCH_DOCKER_IMAGE}
+```
+
+### build from fork
+```
+export SCYLLA_BENCH_BRANCH=heads/some_fixes
+export SCYLLA_BENCH_FORK=fruch/scylla-bench
+export SCYLLA_BENCH_DOCKER_IMAGE=scylladb/hydra-loaders:scylla-bench-${SCYLLA_BENCH_BRANCH}
+docker build . -t ${SCYLLA_BENCH_DOCKER_IMAGE} --build-arg version=${SCYLLA_BENCH_BRANCH} --build-arg fork=${SCYLLA_BENCH_FORK}
+docker push ${SCYLLA_BENCH_DOCKER_IMAGE}
+```

--- a/performance_regression_row_level_repair_test.py
+++ b/performance_regression_row_level_repair_test.py
@@ -147,7 +147,7 @@ class PerformanceRegressionRowLevelRepairTest(ClusterTester):
         self.log.info('Updating cluster data only for {}'.format(node.name))
         self.log.info("Run stress command of: {}".format(stress_cmd))
         stress_queue = self.run_stress_thread_bench(stress_cmd=stress_cmd, stats_aggregate_cmds=False,
-                                                    use_single_loader=True)
+                                                    round_robin=True)
         self.get_stress_results_bench(queue=stress_queue)
         self.start_all_nodes()
 
@@ -272,7 +272,7 @@ class PerformanceRegressionRowLevelRepairTest(ClusterTester):
                 [base_cmd, str_additional_args, str_offset])
             self.log.debug('Scylla-bench stress command to execute: {}'.format(stress_cmd))
             write_queue.append(self.run_stress_thread_bench(stress_cmd=stress_cmd, stats_aggregate_cmds=False,
-                                                            use_single_loader=True))
+                                                            round_robin=True))
             offset += partitions_per_loader
             time.sleep(0.2)
 

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -352,10 +352,6 @@ class LoaderSetDocker(cluster.BaseLoaderSet, DockerCluster):
 
     def node_setup(self, node, verbose=False, db_node_address=None, **kwargs):
 
-        if 'scylla-bench' in self.params.list_of_stress_tools:
-            if not node.is_scylla_bench_installed:
-                node.install_scylla_bench()
-
         if self.params.get('client_encrypt'):
             node.config_client_encrypt()
 

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2646,10 +2646,6 @@ class LoaderPodCluster(cluster.BaseLoaderSet, PodCluster):
                    db_node_address: Optional[str] = None,
                    **kwargs) -> None:
 
-        if 'scylla-bench' in self.params.list_of_stress_tools:
-            if not node.is_scylla_bench_installed:
-                node.install_scylla_bench()
-
         if self.params.get('client_encrypt'):
             node.config_client_encrypt()
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1662,7 +1662,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
     # pylint: disable=too-many-arguments,too-many-return-statements
     def run_stress_thread(self, stress_cmd, duration=None, stress_num=1, keyspace_num=1, profile=None, prefix='',
-                          round_robin=False, stats_aggregate_cmds=True, keyspace_name=None, use_single_loader=False,
+                          round_robin=False, stats_aggregate_cmds=True, keyspace_name=None,
                           stop_test_on_failure=True):
         # We want to prevent situation when stress command starts on not ready cluster (no all nodes are UP).
         # It may cause to stress failure and as result the test will be stopped and failed
@@ -1670,7 +1670,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
         params = dict(stress_cmd=stress_cmd, duration=duration, stress_num=stress_num, keyspace_num=keyspace_num,
                       keyspace_name=keyspace_name, profile=profile, prefix=prefix, round_robin=round_robin,
-                      stats_aggregate_cmds=stats_aggregate_cmds, use_single_loader=use_single_loader)
+                      stats_aggregate_cmds=stats_aggregate_cmds)
 
         if 'cassandra-stress' in stress_cmd:  # cs cmdline might started with JVM_OPTION
             params['stop_test_on_failure'] = stop_test_on_failure
@@ -1730,7 +1730,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
     # pylint: disable=too-many-arguments,unused-argument
     def run_stress_thread_bench(self, stress_cmd, duration=None, round_robin=False, stats_aggregate_cmds=True,
-                                use_single_loader=False, stop_test_on_failure=True, **_):
+                                stop_test_on_failure=True, **_):
 
         if duration:
             timeout = self.get_duration(duration)
@@ -1747,7 +1747,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             stress_cmd, loader_set=self.loaders, timeout=timeout,
             node_list=self.db_cluster.nodes,
             round_robin=round_robin,
-            use_single_loader=use_single_loader,
             stop_test_on_failure=stop_test_on_failure,
             credentials=self.db_cluster.get_db_auth()
         )

--- a/unit_tests/test_scylla_bench_thread.py
+++ b/unit_tests/test_scylla_bench_thread.py
@@ -1,0 +1,74 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2022 ScyllaDB
+
+import pytest
+from cassandra.cluster import Cluster  # pylint: disable=no-name-in-module
+
+from sdcm.scylla_bench_thread import ScyllaBenchThread
+from sdcm.utils.docker_utils import running_in_docker
+from unit_tests.dummy_remote import LocalLoaderSetDummy
+from test_lib.scylla_bench_tools import create_scylla_bench_table_query
+
+pytestmark = [
+    pytest.mark.usefixtures("events", "create_cql_ks_and_table"),
+    pytest.mark.skip(reason="those are integration tests only"),
+]
+
+
+@pytest.fixture(scope="session")
+def create_cql_ks_and_table(docker_scylla):
+    if running_in_docker():
+        address = f"{docker_scylla.internal_ip_address}:9042"
+    else:
+        address = docker_scylla.get_port("9042")
+    node_ip, port = address.split(":")
+    port = int(port)
+
+    cluster_driver = Cluster([node_ip], port=port)
+    create_table_query = create_scylla_bench_table_query(
+        compaction_strategy="SizeTieredCompactionStrategy", seed=None
+    )
+
+    with cluster_driver.connect() as session:
+        # pylint: disable=no-member
+        session.execute(
+            """
+                CREATE KEYSPACE IF NOT EXISTS scylla_bench WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}
+        """
+        )
+        session.execute(create_table_query)
+
+
+def test_01_scylla_bench(request, docker_scylla):
+    loader_set = LocalLoaderSetDummy()
+
+    cmd = (
+        "scylla-bench -workload=sequential -mode=write -replication-factor=1 -partition-count=10 "
+        + "-clustering-row-count=5555 -clustering-row-size=uniform:10..20 -concurrency=10 "
+        + "-connection-count=10 -consistency-level=one -rows-per-request=10 -timeout=60s -duration=1m"
+    )
+    bench_thread = ScyllaBenchThread(
+        loader_set=loader_set, stress_cmd=cmd, node_list=[docker_scylla], timeout=120
+    )
+
+    def cleanup_thread():
+        bench_thread.kill()
+
+    request.addfinalizer(cleanup_thread)
+
+    bench_thread.run()
+
+    summaries, errors = bench_thread.verify_results()
+
+    assert not errors
+    assert summaries[0]["Clustering row size"] == "Uniform(min=10, max=20)"


### PR DESCRIPTION
As part of the plan to move all stress tools/loaders into docker
images, we move `scylla-bench` into a docker image
we'll create/maintine.

* part of the move we removed the `use_single_loader` option
  since it's identical to round_robin, for the usage needed
  to run stress on one node.


- [x] scylla-bench only job - https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longd/2
- [x] k8s short job- https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-scylla-operator-3h-eks/19/
- [x] waiting for confirmation from @yarongilor about the features-ics-space-amplification-goal-test-sb-docker

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
