### PR TITLE
fix(list-images): make enterprise version work without prefixing

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1254,7 +1254,7 @@ def get_scylla_ami_versions(region_name: str, arch: AwsArchType = 'x86_64', vers
     name_filter = "ScyllaDB *"
 
     if version and version != "all":
-        name_filter = f"ScyllaDB {version.replace('enterprise', 'Enterprise').replace('-', ' ')}*"
+        name_filter = f"ScyllaDB *{version.replace('enterprise-', 'Enterprise ')}*"
 
     if _SCYLLA_AMI_CACHE[region_name]:
         return _SCYLLA_AMI_CACHE[region_name]
@@ -1287,7 +1287,7 @@ def get_scylla_gce_images_versions(project: str = SCYLLA_GCE_IMAGES_PROJECT, ver
         filters = "(family eq 'scylla(-enterprise)?')(name ne .+-build-.+)"
 
         if version and version != "all":
-            filters += f"(name eq .*scylla-{version.replace('.', '-')}.*)"
+            filters += f"(name eq '.*scylla(-enterprise)?-{version.replace('.', '-')}.*')"
 
         compute_engine = get_gce_driver()
         _SCYLLA_GCE_IMAGE_CACHE.extend(sorted(


### PR DESCRIPTION
Currently you needed to prefix the version if you wanted enterpise

```bash
list-images -v enterprise-2022.1
list-images -c gce -r us-west4 -v enterprise-2022.1.rc9
```

now you would be able to call without `enterprise-` prefix:

```bash
list-images -v 2022.2.0.rc0
list-images -c gce -r us-west4 -v 2022.2.0.rc0
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
