### PR TITLE
fix(azure): adapt to scylla version new tag name

### DIFF
--- a/unit_tests/provisioner/test_azure_get_scylla_images.py
+++ b/unit_tests/provisioner/test_azure_get_scylla_images.py
@@ -49,7 +49,7 @@ def test_can_get_scylla_images_based_on_revision_id(azure_service):
 def test_unparsable_scylla_versions_are_logged(azure_service, caplog):
     with caplog.at_level(logging.WARNING):
         get_scylla_images("unparsable:latest", "eastus", azure_service=azure_service)
-    assert "Couldn't parse scylla version from images: ['ScyllaDB-5.-98ad.1.dev_0']" in caplog.text
+    assert "Couldn't parse scylla version from images: ['ScyllaDB-5.-98ad.1.dev_0: ScyllaDB-5.']" in caplog.text
 
 
 def generate_images_json_file():

--- a/unit_tests/provisioner/test_data/SCYLLA-IMAGES/azure_images_list.json
+++ b/unit_tests/provisioner/test_data/SCYLLA-IMAGES/azure_images_list.json
@@ -272,7 +272,7 @@
       "ScyllaMachineImageVersion": "ScyllaDB-5.1.dev0",
       "ScyllaPython3Version": "ScyllaDB-5.1.dev0",
       "ScyllaToolsVersion": "ScyllaDB-5.1.dev0",
-      "ScyllaVersion": "ScyllaDB-5.1.dev0",
+      "ScyllaVersion": "ScyllaDB-5.",
       "arch": "x86_64",
       "branch": "unparsable",
       "build_id": "155",


### PR DESCRIPTION
Recently there was a change with tag names, they were renamed from
CamelCase to snake_case e.g.`ScyllaVersion` to `scylla_version`.

Azure list images needs to be adapted to this change.
fixes: https://github.com/scylladb/scylla-cluster-tests/issues/5068

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
