### PR TITLE
feature(dynamodb): support running directly with Dynamodb

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -205,7 +205,7 @@ enable_argus: true
 
 stress_image:
   ndbench: 'scylladb/hydra-loaders:ndbench-jdk8-20210720'
-  ycsb: ' scylladb/hydra-loaders:ycsb-jdk8-20220911'
+  ycsb: 'scylladb/hydra-loaders:ycsb-jdk8-20220906'
   nosqlbench: 'scylladb/hydra-loaders:nosqlbench-4.15.49'
   cassandra-stress: '' # default would be same version as scylla under test
   scylla-bench: 'scylladb/hydra-loaders:scylla-bench-v0.1.10'

--- a/docker/ycsb/Dockerfile
+++ b/docker/ycsb/Dockerfile
@@ -1,10 +1,17 @@
 FROM openjdk:8 as builder
 
+ARG BRANCH
+ARG REPO
+
+ENV BRANCH=${BRANCH:-master}
+ENV REPO=${REPO:-https://github.com/scylladb/YCSB.git}
+
 RUN apt-get update && apt-get install -y \
     git \
     maven
 
-RUN git clone https://github.com/scylladb/YCSB.git -b master
+RUN git clone ${REPO} -b ${BRANCH}
+
 RUN cd YCSB; mvn -pl dynamodb -am clean package -DskipTests
 RUN cd /YCSB/dynamodb/target && mkdir -p YCSB && tar xvvf ycsb-dynamo*.tar.gz -C YCSB --strip-components 1
 

--- a/docker/ycsb/README.md
+++ b/docker/ycsb/README.md
@@ -1,6 +1,15 @@
+
+### build from scylla fork master
 ```
 export YCSB_DOCKER_IMAGE=scylladb/hydra-loaders:ycsb-jdk8-$(date +'%Y%m%d')
 docker build . -t ${YCSB_DOCKER_IMAGE}
 docker push ${YCSB_DOCKER_IMAGE}
-echo "${YCSB_DOCKER_IMAGE}" > image
+```
+
+
+### build from private fork/branch
+```
+export YCSB_DOCKER_IMAGE=scylladb/hydra-loaders:ycsb-jdk8-$(date +'%Y%m%d')
+docker build . -t ${YCSB_DOCKER_IMAGE} --build-arg REPO=https://github.com/fruch/YCSB.git --build-arg BRANCH=dynamodb_aws_sdk_v2
+docker push ${YCSB_DOCKER_IMAGE}
 ```

--- a/docker/ycsb/image
+++ b/docker/ycsb/image
@@ -1,1 +1,0 @@
-scylladb/hydra-loaders:ycsb-jdk8-20220904

--- a/docs/run_on_dynamodb.md
+++ b/docs/run_on_dynamodb.md
@@ -11,20 +11,37 @@ we have a profile we'll add by default to loader using dynamodb that would have
 access to dynamodb apis
 
 ### with docker backend
-```
+
+```bash
 # need to specify scylla version, since the docker loader node is base on scylla image
 export SCT_SCYLLA_VERSION=4.6.3
 export SCT_DOCKER_IMAGE=scylladb/scylla
+export SCT_REGION_NAME=eu-west-1
 
 hydra run-test longevity_test.LongevityTest.test_custom_time --backend docker --config test-cases/dynamodb/dynamodb.yaml
 ```
 
-# with AWS backend
-```
+### with AWS backend
+
+```bash
 # need those until we can fix the configurtion to be aware of it
 export SCT_INSTANCE_TYPE_DB=fake_type
 export SCT_SCYLLA_VERSION=4.6.3
-
+export SCT_REGION_NAME=eu-west-1
 export SCT_IP_SSH_CONNECTIONS=public
 hydra run-test longevity_test.LongevityTest.test_custom_time --backend aws --config test-cases/dynamodb/dynamodb.yaml
+```
+
+
+### run performance test with docker backend
+
+```bash
+export SCT_N_DB_NODES=0
+export SCT_N_MONITOR_NODES=0
+export SCT_REGION_NAME=eu-west-1
+export SCT_DB_TYPE=dynamodb
+export SCT_AWS_INSTANCE_PROFILE_NAME=qa-dynamodb-access-profile
+
+export SCT_CONFIG_FILES=test-cases/performance/perf-regression-alternator.100threads.30M-keys.yaml
+hydra run-test performance_regression_alternator_test.PerformanceRegressionAlternatorTest.test_write --backend docker
 ```

--- a/docs/run_on_dynamodb.md
+++ b/docs/run_on_dynamodb.md
@@ -1,0 +1,30 @@
+# running a YCSB based test with dynamodb
+
+A test that setup only loaders nodes, and run with dynamodb
+You need to specific the dynamodb table in the ycsb commands
+(at least for now, SCT won't create the tables)
+
+credentials can be pass using as defined in:
+https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
+
+we have a profile we'll add by default to loader using dynamodb that would have
+access to dynamodb apis
+
+### with docker backend
+```
+# need to specify scylla version, since the docker loader node is base on scylla image
+export SCT_SCYLLA_VERSION=4.6.3
+export SCT_DOCKER_IMAGE=scylladb/scylla
+
+hydra run-test longevity_test.LongevityTest.test_custom_time --backend docker --config test-cases/dynamodb/dynamodb.yaml
+```
+
+# with AWS backend
+```
+# need those until we can fix the configurtion to be aware of it
+export SCT_INSTANCE_TYPE_DB=fake_type
+export SCT_SCYLLA_VERSION=4.6.3
+
+export SCT_IP_SSH_CONNECTIONS=public
+hydra run-test longevity_test.LongevityTest.test_custom_time --backend aws --config test-cases/dynamodb/dynamodb.yaml
+```

--- a/sdcm/utils/alternator/api.py
+++ b/sdcm/utils/alternator/api.py
@@ -25,7 +25,10 @@ class Alternator:
         self.alternator_apis = {}
 
     def create_endpoint_url(self, node):
-        return 'http://{}:{}'.format(normalize_ipv6_url(node.external_address), self.params.get("alternator_port"))
+        if self.params.get("db_type") == 'dynamodb':
+            return 'dynamodb'
+        else:
+            return 'http://{}:{}'.format(normalize_ipv6_url(node.external_address), self.params.get("alternator_port"))
 
     def get_dynamodb_api(self, node) -> AlternatorApi:
         endpoint_url = self.create_endpoint_url(node=node)
@@ -33,6 +36,8 @@ class Alternator:
             aws_params = dict(endpoint_url=endpoint_url, aws_access_key_id=self.params.get("alternator_access_key_id"),
                               aws_secret_access_key=self.params.get("alternator_secret_access_key"),
                               region_name="None")
+            if endpoint_url == 'dynamodb':
+                aws_params = dict(region_name=self.params.region_names[0])
             resource: DynamoDBServiceResource = boto3.resource('dynamodb', **aws_params)
             client: DynamoDBClient = boto3.client('dynamodb', **aws_params)
             self.alternator_apis[endpoint_url] = AlternatorApi(resource=resource, client=client)

--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -150,6 +150,11 @@ class YcsbStressThread(DockerBasedStressThread):  # pylint: disable=too-many-ins
                     dynamodb.primaryKeyType = {alternator.enums.YCSBSchemaTypes.HASH_SCHEMA.value}
                 ''')
 
+            if self.params.get('region_name'):
+                dynamodb_teample += dedent(f'''
+                    dynamodb.region = {self.params.region_names[0]}
+                ''')
+
             if target_address:
                 dynamodb_teample += dedent(f'''
                     dynamodb.endpoint = http://{target_address}:{self.params.get('alternator_port')}

--- a/test-cases/dynamodb/dynamodb.yaml
+++ b/test-cases/dynamodb/dynamodb.yaml
@@ -1,0 +1,10 @@
+n_db_nodes: 0
+n_loaders: 1
+n_monitor_nodes: 0
+
+stress_cmd: [
+  "bin/ycsb run dynamodb -P workloads/workloadc -threads 20 -p readproportion=0.5 -p updateproportion=0.5 -p recordcount=6990500 -p fieldcount=10 -p fieldlength=512 -p operationcount=200200300 -p dataintegrity=true -p maxexecutiontime=10800",
+]
+
+db_type: "dynamodb"
+aws_instance_profile_name: 'qa-dynamodb-access-profile'


### PR DESCRIPTION
Adding support for running YCSB stress comamnd directly with
dynamodb, and not just with scylla alternator

* remove stop configure ycsb `dynamodb.endpoint` as needed
* configure the real AWS creds for ycsb (and not dummy ones)
* make sure we can run test with `n_db_nodes: 0`

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
