### PR TITLE
fix(longevity-10gb-3h): switch AWS instance type to `i4i.2xlarge`

### DIFF
--- a/test-cases/longevity/longevity-10gb-3h.yaml
+++ b/test-cases/longevity/longevity-10gb-3h.yaml
@@ -6,7 +6,7 @@ n_db_nodes: 6
 n_loaders: 2
 n_monitor_nodes: 1
 
-instance_type_db: 'i3.4xlarge'
+instance_type_db: 'i4i.2xlarge'
 gce_instance_type_db: 'n1-highmem-16'
 gce_instance_type_loader: 'e2-standard-4'
 azure_instance_type_db: 'Standard_L8s_v3'


### PR DESCRIPTION
recently we start getting too much spot termination, an out of
capacity for this job, it was decided to change it to use
`i4i.2xlarge`

data from spot advisor
```
type            cpu     mem   saving    chances for distruption
--------------------------------------------------------------
i3.4xlarge	16	122	57%	>20%

i4i.2xlarge	8	64	70%	<5%
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
