### PR TITLE
feature(docker_backend): support running docker based loaders

### DIFF
--- a/docker/scylla-sct/ubuntu/Dockerfile
+++ b/docker/scylla-sct/ubuntu/Dockerfile
@@ -12,6 +12,10 @@ SHELL ["/bin/bash", "-c"]
 #    00hzYw5m.HyAY
 #
 # For more details see man page for useradd(8)
+RUN apt-get update && apt-get install -y --no-install-recommends apt-transport-https gnupg2 software-properties-common curl
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+
 RUN apt-get update && \
     echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
     apt install -y sudo && \
@@ -19,11 +23,12 @@ RUN apt-get update && \
     usermod -aG sudo $USER && \
     sudo -Hu $USER sh -c "mkdir -m 700 ~/.ssh" && \
     echo "$USER  ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers && \
-    apt install -y \
+    apt install --no-install-recommends -y \
         iproute2 \
         collectd \
         syslog-ng \
-        rsync && \
+        rsync \
+        docker-ce-cli && \
     rm -rf /var/lib/apt/lists/* && \
     echo $'[program:collectd]\n\
 command=/usr/sbin/collectd\n\

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -49,9 +49,13 @@ class NodeContainerMixin:
                     labels=self.parent_cluster.tags)
 
     def node_container_run_args(self, seed_ip):
+        volumes = {
+            '/var/run/docker.sock': {"bind": '/var/run/docker.sock', "mode": "rw"},
+        }
         return dict(name=self.name,
                     image=self.node_container_image_tag,
                     command=f'--seeds="{seed_ip}"' if seed_ip else None,
+                    volumes=volumes,
                     nano_cpus=10**9)  # Same as `docker run --cpus=1 ...' CLI command.
 
 
@@ -87,6 +91,11 @@ class DockerNode(cluster.BaseNode, NodeContainerMixin):  # pylint: disable=abstr
 
     def _get_private_ip_address(self) -> Optional[str]:
         return self.public_ip_address
+
+    def _refresh_instance_state(self):
+        public_ipv4_addresses = [self._get_public_ip_address()]
+        private_ipv4_addresses = [self._get_private_ip_address()]
+        return public_ipv4_addresses, private_ipv4_addresses
 
     def _get_ipv6_ip_address(self):
         self.log.warning("We don't support IPv6 for Docker backend")

--- a/sdcm/utils/docker_remote.py
+++ b/sdcm/utils/docker_remote.py
@@ -1,5 +1,6 @@
 import logging
 import shlex
+from functools import cached_property
 
 from sdcm.cluster import BaseNode
 
@@ -13,7 +14,7 @@ class RemoteDocker(BaseNode):
         self.log = LOGGER
         ports = " ".join([f'-p {port}:{port}' for port in ports]) if ports else ""
         res = self.node.remoter.run(
-            f'docker run {extra_docker_opts} -d {ports} {image_name} {command_line}', verbose=True)
+            f'{self.sudo_needed} docker run {extra_docker_opts} -d {ports} {image_name} {command_line}', verbose=True)
         self.docker_id = res.stdout.strip()
         self.image_name = image_name
         super().__init__(name=image_name, parent_cluster=node.parent_cluster)
@@ -41,6 +42,16 @@ class RemoteDocker(BaseNode):
     def cql_ip_address(self):
         return self.internal_ip_address
 
+    @cached_property
+    def running_in_docker(self):
+        ok = self.node.remoter.run("test /.dockerenv", ignore_status=True).ok
+        ok |= 'docker' in self.node.remoter.run('ls /proc/self/cgroup', ignore_status=True).stdout
+        return ok
+
+    @cached_property
+    def sudo_needed(self):
+        return 'sudo ' if self.running_in_docker else ''
+
     def get_port(self, internal_port):
         """
         get specific port mapping
@@ -52,24 +63,24 @@ class RemoteDocker(BaseNode):
         return external_port.splitlines()[0]
 
     def get_log(self):
-        return self.node.remoter.run(f"docker logs {self.docker_id}").stdout.strip()
+        return self.node.remoter.run(f"{self.sudo_needed} docker logs {self.docker_id}").stdout.strip()
 
     def run(self, cmd, *args, **kwargs):
-        return self.node.remoter.run(f'docker exec {self.docker_id} /bin/sh -c {shlex.quote(cmd)}', *args, **kwargs)
+        return self.node.remoter.run(f'{self.sudo_needed} docker exec {self.docker_id} /bin/sh -c {shlex.quote(cmd)}', *args, **kwargs)
 
     def kill(self):
-        return self.node.remoter.run(f"docker rm -f {self.docker_id}", verbose=False, ignore_status=True)
+        return self.node.remoter.run(f"{self.sudo_needed} docker rm -f {self.docker_id}", verbose=False, ignore_status=True)
 
     def send_files(self, src, dst, **kwargs):
         result = self.node.remoter.send_files(src, src, **kwargs)
-        result &= self.node.remoter.run(f"docker cp {src} {self.docker_id}:{dst}",
+        result &= self.node.remoter.run(f"{self.sudo_needed} docker cp {src} {self.docker_id}:{dst}",
                                         verbose=kwargs.get('verbose'), ignore_status=True).ok
         return result
 
     def receive_files(self, src, dst, **kwargs):  # pylint: disable=unused-argument
         remote_tempfile = self.node.remoter.run("mktemp").stdout.strip()
 
-        result = self.node.remoter.run(f"docker cp {self.docker_id}:{src} {remote_tempfile}",
+        result = self.node.remoter.run(f"{self.sudo_needed} docker cp {self.docker_id}:{src} {remote_tempfile}",
                                        verbose=kwargs.get('verbose'), ignore_status=True).ok
         result &= self.node.remoter.receive_files(remote_tempfile, dst, **kwargs)
         return result

--- a/sdcm/utils/remotewebbrowser.py
+++ b/sdcm/utils/remotewebbrowser.py
@@ -43,7 +43,8 @@ class WebDriverContainerMixin:
 
     @property
     def web_driver_docker_client(self) -> Optional[DockerClient]:
-        if not self.ssh_login_info:
+        if not self.ssh_login_info or self.ssh_login_info["key_file"] is None:
+            # running with docker backend, no real monitor node, fallback to use local docker
             return None
         SSHAgent.add_keys((self.ssh_login_info["key_file"], ))
         # since a bug in docker package https://github.com/docker-library/python/issues/517 that need to explicitly


### PR DESCRIPTION
Since we are trying to use only docker for the stress tools,
we need the docker backend loader node to be able to spin up dockers

so we mount the docker socket file, and run the commands with `sudo`
since the `scylla-test` user we use doesn't have premission on the
host docker. right now it mean it won't be working ontop of podman.

later we could consider remove the loader nodes, and run everything
local as we do for the monitoring node

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
