### PR TITLE
feature(azure): handle availability zone

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3860,7 +3860,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         status = {}
         res = verification_node.run_nodetool('status', publish_event=False)
 
-        data_centers = res.stdout.strip().split("Datacenter: ")
+        data_centers = res.stdout.split("Datacenter: ")
         # see TestNodetoolStatus test in test_cluster.py
         pattern = re.compile(
             r"(?P<state>\w{2})\s+"

--- a/sdcm/cluster_azure.py
+++ b/sdcm/cluster_azure.py
@@ -70,7 +70,7 @@ class AzureNode(cluster.BaseNode):
         return super()._set_keep_alive()
 
     def _refresh_instance_state(self):
-        ip_tuple = (self._instance.public_ip_address, self._instance.private_ip_address)
+        ip_tuple = ([self._instance.public_ip_address], [self._instance.private_ip_address])
         return ip_tuple
 
     @property

--- a/sdcm/provision/azure/ip_provider.py
+++ b/sdcm/provision/azure/ip_provider.py
@@ -28,6 +28,7 @@ LOGGER = logging.getLogger(__name__)
 class IpAddressProvider:
     _resource_group_name: str
     _region: str
+    _az: str
     _azure_service: AzureService = AzureService()
     _cache: Dict[str, PublicIPAddress] = field(default_factory=dict)
 
@@ -55,6 +56,7 @@ class IpAddressProvider:
                 public_ip_address_name=ip_name,
                 parameters={
                     "location": self._region,
+                    "zones": [self._az],
                     "sku": {
                         "name": "Standard",
                     },

--- a/sdcm/provision/azure/resource_group_provider.py
+++ b/sdcm/provision/azure/resource_group_provider.py
@@ -29,6 +29,7 @@ class ResourceGroupProvider:
     """Class for providing resource groups and taking care about discovery existing ones."""
     _name: str
     _region: str
+    _az: str
     _azure_service: AzureService = AzureService()
     _cache: Optional[ResourceGroup] = field(default=None)
 
@@ -51,7 +52,7 @@ class ResourceGroupProvider:
             resource_group_name=self._name,
             parameters={
                 "location": self._region,
-                "tags": {"creation_time": datetime.now().isoformat(sep=" ", timespec="seconds")}
+                "tags": {"creation_time": datetime.now().isoformat(sep=" ", timespec="seconds"), "_az": self._az}
             },
         )
         LOGGER.info("Provisioned resource group %s in the %s region", resource_group.name, resource_group.location)

--- a/sdcm/provision/azure/virtual_machine_provider.py
+++ b/sdcm/provision/azure/virtual_machine_provider.py
@@ -33,6 +33,7 @@ LOGGER = logging.getLogger(__name__)
 class VirtualMachineProvider:
     _resource_group_name: str
     _region: str
+    _az: str
     _azure_service: AzureService = AzureService()
     _cache: Dict[str, VirtualMachine] = field(default_factory=dict)
 
@@ -61,6 +62,7 @@ class VirtualMachineProvider:
             LOGGER.info("Instance params: %s", definition)
             params = {
                 "location": self._region,
+                "zones": [self._az],
                 "tags": definition.tags | {"ssh_user": definition.user_name, "ssh_key": definition.ssh_key.name,
                                            "creation_time": datetime.now().isoformat(sep=" ", timespec="seconds")},
                 "hardware_profile": {

--- a/sdcm/provision/azure/virtual_network_provider.py
+++ b/sdcm/provision/azure/virtual_network_provider.py
@@ -28,6 +28,7 @@ LOGGER = logging.getLogger(__name__)
 class VirtualNetworkProvider:
     _resource_group_name: str
     _region: str
+    _az: str
     _azure_service: AzureService = AzureService()
     _cache: Dict[str, VirtualNetwork] = field(default_factory=dict)
 
@@ -50,6 +51,7 @@ class VirtualNetworkProvider:
             virtual_network_name=name,
             parameters={
                 "location": self._region,
+                "zones": [self._az],
                 "address_space": {
                     "address_prefixes": ["10.0.0.0/16"],
                 }

--- a/sdcm/sct_provision/instances_provider.py
+++ b/sdcm/sct_provision/instances_provider.py
@@ -66,6 +66,7 @@ def provision_sct_resources(params: SCTConfiguration, test_config: TestConfig, *
         provisioner = provisioner_factory.create_provisioner(backend=request.backend,
                                                              test_id=request.test_id,
                                                              region=request.region,
+                                                             availability_zone=request.availability_zone,
                                                              **provisioner_config)
         provision_instances_with_fallback(provisioner=provisioner,
                                           definitions=request.definitions,

--- a/sdcm/sct_provision/region_definition_builder.py
+++ b/sdcm/sct_provision/region_definition_builder.py
@@ -35,6 +35,7 @@ class RegionDefinition:
     backend: str
     test_id: str
     region: str
+    availability_zone: str
     definitions: List[InstanceDefinition]
 
 
@@ -88,7 +89,8 @@ class DefinitionBuilder(abc.ABC):
                                   user_data=user_data
                                   )
 
-    def build_region_definition(self, region: str, n_db_nodes: int, n_loader_nodes: int, n_monitor_nodes: int) -> RegionDefinition:
+    def build_region_definition(self, region: str, availability_zone: str, n_db_nodes: int,  # pylint: disable=too-many-arguments
+                                n_loader_nodes: int, n_monitor_nodes: int) -> RegionDefinition:
         """Builds instances definitions for given region"""
         definitions = []
         for idx in range(n_db_nodes):
@@ -103,17 +105,19 @@ class DefinitionBuilder(abc.ABC):
             definitions.append(
                 self.build_instance_definition(region=region, node_type="monitor", index=idx + 1)
             )
-        return RegionDefinition(backend=self.BACKEND, test_id=self.test_id, region=region, definitions=definitions)
+        return RegionDefinition(backend=self.BACKEND, test_id=self.test_id, region=region,
+                                availability_zone=availability_zone, definitions=definitions)
 
     def build_all_region_definitions(self) -> List[RegionDefinition]:
         """Builds all instances definitions in all regions based on SCT test configuration."""
         region_definitions = []
+        availability_zone = self.params.get("availability_zone")
         n_db_nodes = self._get_node_count_for_each_region(str(self.params.get("n_db_nodes")))
         n_loader_nodes = self._get_node_count_for_each_region(str(self.params.get("n_loaders")))
         n_monitor_nodes = self._get_node_count_for_each_region(str(self.params.get("n_monitor_nodes")))
         for region, db_nodes, loader_nodes, monitor_nodes in zip(self.regions, n_db_nodes, n_loader_nodes, n_monitor_nodes):
             region_definitions.append(
-                self.build_region_definition(region=region, n_db_nodes=db_nodes,
+                self.build_region_definition(region=region, availability_zone=availability_zone, n_db_nodes=db_nodes,
                                              n_loader_nodes=loader_nodes, n_monitor_nodes=monitor_nodes)
             )
         return region_definitions

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -957,7 +957,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         provisioners: List[AzureProvisioner] = []
         for region in regions:
             provisioners.append(provisioner_factory.create_provisioner(backend="azure", test_id=test_id,
-                                region=region))
+                                region=region, availability_zone=self.params.get('availability_zone')))
         if db_info['n_nodes'] is None:
             n_db_nodes = self.params.get('n_db_nodes')
             if isinstance(n_db_nodes, int):  # legacy type

--- a/unit_tests/lib/fake_provisioner.py
+++ b/unit_tests/lib/fake_provisioner.py
@@ -20,15 +20,16 @@ class FakeProvisioner(Provisioner):
     """Fake provisioner for tests purposes. Imitates provisioner api by creating fake provisioners in memory."""
     _provisioners = {}
 
-    def __new__(cls, test_id: str, region: str, **kwargs) -> Provisioner:  # pylint: disable=unused-argument
-        if provisioner := cls._provisioners.get(test_id, {}).get(region):
+    def __new__(cls, test_id: str, region: str, availability_zone: str, **_) -> Provisioner:
+        region_az = region + availability_zone
+        if provisioner := cls._provisioners.get(test_id, {}).get(region_az):
             return provisioner
         provisioner = super().__new__(cls)
-        cls._provisioners[test_id] = cls._provisioners.get(test_id, {}) | {region: provisioner}
+        cls._provisioners[test_id] = cls._provisioners.get(test_id, {}) | {region_az: provisioner}
         return provisioner
 
-    def __init__(self, test_id: str, region: str, **kwargs) -> None:  # pylint: disable=unused-argument
-        super().__init__(test_id, region)
+    def __init__(self, test_id: str, region: str, availability_zone: str, **_) -> None:
+        super().__init__(test_id, region, availability_zone)
         self._instances: Dict[str, VmInstance] = getattr(self, "_instances", {})
 
     def get_or_create_instance(self,

--- a/unit_tests/lib/fake_resources.py
+++ b/unit_tests/lib/fake_resources.py
@@ -26,8 +26,9 @@ def prepare_fake_region(test_id: str, region: str, n_db_nodes: int = 3, n_loader
               "root_disk_size_monitor": 15,
               "fake_region_name": ["eastus"], "cluster_backend": "fake"}
     builder = region_definition_builder.get_builder(params=params, test_config=TestConfig())
-    region_definition = builder.build_region_definition(region, n_db_nodes, n_loaders, n_monitor_nodes)
+    region_definition = builder.build_region_definition(region, "a", n_db_nodes, n_loaders, n_monitor_nodes)
     provisioner = provisioner_factory.create_provisioner(backend=region_definition.backend,
                                                          test_id=region_definition.test_id,
-                                                         region=region_definition.region)
+                                                         region=region_definition.region,
+                                                         availability_zone="a")
     provisioner.get_or_create_instances(region_definition.definitions, PricingModel.SPOT)

--- a/unit_tests/provisioner/conftest.py
+++ b/unit_tests/provisioner/conftest.py
@@ -48,16 +48,18 @@ def params():
     EnvConfig = namedtuple('EnvConfig',
                            ["SCT_CLUSTER_BACKEND", "SCT_TEST_ID", "SCT_CONFIG_FILES", "SCT_AZURE_REGION_NAME",
                             "SCT_N_DB_NODES",
-                            "SCT_AZURE_IMAGE_DB", "SCT_N_LOADERS", "SCT_N_MONITORS_NODES"])
+                            "SCT_AZURE_IMAGE_DB", "SCT_N_LOADERS", "SCT_N_MONITORS_NODES", "SCT_AVAILABILITY_ZONE"])
     env_config = EnvConfig(
         SCT_CLUSTER_BACKEND="azure",
         SCT_TEST_ID=f"unit-test-{str(uuid.uuid4())}",
         SCT_CONFIG_FILES=f'["{Path(__file__).parent.absolute()}/azure_default_config.yaml"]',
         SCT_AZURE_REGION_NAME="['eastus', 'easteu']",
         SCT_N_DB_NODES="3 1",
-        SCT_AZURE_IMAGE_DB="/subscriptions/some_image_id",
+        SCT_AZURE_IMAGE_DB="/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/scylla-images/providers/"
+                           "Microsoft.Compute/images/scylla-5.2.0-dev-x86_64-2022-08-22T04-18-36Z",
         SCT_N_LOADERS="2 0",
-        SCT_N_MONITORS_NODES="1"
+        SCT_N_MONITORS_NODES="1",
+        SCT_AVAILABILITY_ZONE="a"
     )
     os.environ.update(env_config._asdict())
     return SCTConfiguration()

--- a/unit_tests/provisioner/test_azure_region_definition_builder.py
+++ b/unit_tests/provisioner/test_azure_region_definition_builder.py
@@ -35,7 +35,8 @@ def test_can_create_basic_scylla_instance_definition_from_sct_config():
         SCT_AZURE_REGION_NAME="['eastus', 'easteu']",
         SCT_N_DB_NODES="3 1",
         SCT_USER_PREFIX="unit-test",
-        SCT_AZURE_IMAGE_DB="some_image_id",
+        SCT_AZURE_IMAGE_DB="/subscriptions/6c268694-47ab-43ab-b306-3c5514bc4112/resourceGroups/scylla-images/providers/"
+                           "Microsoft.Compute/images/scylla-5.2.0-dev-x86_64-2022-08-22T04-18-36Z",
         SCT_N_LOADERS="2 0",
         SCT_N_MONITORS_NODES="1"
     )

--- a/unit_tests/provisioner/test_provision_sct_resources.py
+++ b/unit_tests/provisioner/test_provision_sct_resources.py
@@ -24,7 +24,7 @@ def test_can_provision_instances_according_to_sct_configuration(params, test_con
     tags = TestConfig.common_tags()
     provision_sct_resources(params=params, test_config=test_config, azure_service=azure_service)
     provisioner_eastus = provisioner_factory.create_provisioner(
-        backend="azure", test_id=params.get("test_id"), region="eastus", azure_service=azure_service)
+        backend="azure", test_id=params.get("test_id"), region="eastus", availability_zone="1", azure_service=azure_service)
     eastus_instances = provisioner_eastus.list_instances()
     db_nodes = [node for node in eastus_instances if node.tags['NodeType'] == "scylla-db"]
     loader_nodes = [node for node in eastus_instances if node.tags['NodeType'] == "loader"]
@@ -39,7 +39,7 @@ def test_can_provision_instances_according_to_sct_configuration(params, test_con
     assert db_node.pricing_model == PricingModel.SPOT
 
     provisioner_easteu = provisioner_factory.create_provisioner(backend="azure", test_id=params.get("test_id"),
-                                                                region="easteu", azure_service=azure_service)
+                                                                region="easteu", availability_zone="1", azure_service=azure_service)
     easteu_instances = provisioner_easteu.list_instances()
     db_nodes = [node for node in easteu_instances if node.tags['NodeType'] == "scylla-db"]
     loader_nodes = [node for node in easteu_instances if node.tags['NodeType'] == "loader"]
@@ -60,7 +60,7 @@ def test_fallback_on_demand_when_spot_fails(fallback_on_demand, params, test_con
                                r"ls /tmp/cloud-init": Result(stdout="done", exited=0)}
     provision_sct_resources(params=params, test_config=test_config, azure_service=azure_service)
     provisioner_eastus = provisioner_factory.create_provisioner(
-        backend="azure", test_id=params.get("test_id"), region="eastus", azure_service=azure_service)
+        backend="azure", test_id=params.get("test_id"), region="eastus", availability_zone="1", azure_service=azure_service)
     eastus_instances = provisioner_eastus.list_instances()
     db_nodes = [node for node in eastus_instances if node.tags['NodeType'] == "scylla-db"]
     loader_nodes = [node for node in eastus_instances if node.tags['NodeType'] == "loader"]

--- a/unit_tests/provisioner/test_provisioner.py
+++ b/unit_tests/provisioner/test_provisioner.py
@@ -80,7 +80,7 @@ def definition(image_id, image_type):
 
 @pytest.fixture(scope='module')
 def provisioner_params(test_id, region, azure_service):
-    return {"test_id": test_id, "region": region, "azure_service": azure_service}
+    return {"test_id": test_id, "region": region, "availability_zone": "a", "azure_service": azure_service}
 
 
 @pytest.fixture(scope="function")

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -487,8 +487,9 @@ class TestNodetoolStatus(unittest.TestCase):
                           "|/ State=Normal/Leaving/Joining/Moving",
                           "--  Address   Load       Tokens       Owns    Host ID                               Rack",
                           "UN  10.0.0.4  431 KB     256          ?       ed6af9a0-8c22-4813-ac9b-6fbeb462b687  ",
-                          "UN  10.0.0.5  612 KB     256          ?       caa15869-cfb4-4229-85d7-0f4832986237  ",
-                          "UN  10.0.0.6  806 KB     256          ?       3046ded9-ce17-4a3a-ac44-a3ada6916972  "
+                          "UN  10.0.0.5  612 KB     256          ?       caa15869-cfb4-4229-85d7-0f4832986237  1",
+                          "UN  10.0.0.6  806 KB     256          ?       3046ded9-ce17-4a3a-ac44-a3ada6916972  ",
+                          ""
                           ]
                          )
         node = NodetoolDummyNode(resp=resp)
@@ -505,6 +506,14 @@ class TestNodetoolStatus(unittest.TestCase):
                                      '10.0.0.5': {'host_id': 'caa15869-cfb4-4229-85d7-0f4832986237',
                                                   'load': '612KB',
                                                   'owns': '?',
+                                                  'rack': '1',
+                                                  'state': 'UN',
+                                                  'tokens': '256'},
+                                     '10.0.0.6': {'host_id': '3046ded9-ce17-4a3a-ac44-a3ada6916972',
+                                                  'load': '806KB',
+                                                  'owns': '?',
                                                   'rack': '',
                                                   'state': 'UN',
-                                                  'tokens': '256'}}}
+                                                  'tokens': '256'}
+                                     }
+                          }


### PR DESCRIPTION
SCT does not support availability zones for Azure backend.

This commit adds handling it for Azure (and unified provisioning).

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
