### PR TITLE
feature(udf): udf class, loader, scripts and unit tests

### DIFF
--- a/sdcm/utils/udf.py
+++ b/sdcm/utils/udf.py
@@ -1,0 +1,51 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2022 ScyllaDB
+from pathlib import Path
+from typing import Literal
+
+import yaml
+from pydantic import BaseModel
+
+
+class UDF(BaseModel):
+    name: str
+    args: str  # e.g. ((name text, age int)) - needs to be stringified
+    called_on_null_input_returns: str  # e.g. int
+    return_type: str  # e.g. int
+    language: Literal["lua", "xwasm"]
+    script: str
+
+    def get_create_query(self, ks: str, create_or_replace: bool = True):
+        create_part = "CREATE OR REPLACE" if create_or_replace else "CREATE"
+        return f"{create_part} {ks}.{self.name}{self.args} " \
+               f"RETURNS {self.called_on_null_input_returns} ON NULL INPUT " \
+               f"RETURNS {self.return_type} " \
+               f"LANGUAGE {self.language} " \
+               f"AS '{self.script}'"
+
+    @classmethod
+    def from_yaml(cls, udf_yaml_filename: str):
+        with Path(udf_yaml_filename).open(mode="r", encoding="utf-8") as udf_yaml:
+            return cls(**yaml.safe_load(udf_yaml))
+
+
+def _load_all_udfs():
+    udfs = {}
+    yaml_file_paths = Path("sdcm/utils/udf_scripts").glob("*.yaml")
+    for script in yaml_file_paths:
+        udf = UDF.from_yaml(str(script))
+        udfs.update({udf.name: udf})
+    return udfs
+
+
+UDFS = _load_all_udfs()

--- a/sdcm/utils/udf_scripts/lua_var_length_counter.yaml
+++ b/sdcm/utils/udf_scripts/lua_var_length_counter.yaml
@@ -1,0 +1,8 @@
+# UDF script: returns the string length of the provided text var
+
+name: 'var_length_counter'
+args: '(var text)'
+called_on_null_input_returns: 'NULL'
+return_type: 'int'
+language: 'lua'
+script: 'return #var'

--- a/sdcm/utils/udf_scripts/xwasm_fib.yaml
+++ b/sdcm/utils/udf_scripts/xwasm_fib.yaml
@@ -1,0 +1,162 @@
+# UDF script: returns the string length of the provided text var
+
+name: 'fib'
+args: '(inout bigint)'
+called_on_null_input_returns: 'bigint'
+return_type: 'int'
+language: 'xwasm'
+script: |-
+  (module
+  (type (;0;) (func (param i64) (result i64)))
+  (func (;0;) (type 0) (param i64) (result i64)
+    (local i64 i32)
+    local.get 0
+    i64.const 2
+    i64.lt_s
+    if  ;; label = @1
+      local.get 0
+      return
+    end
+    loop  ;; label = @1
+      local.get 0
+      i64.const 1
+      i64.sub
+      call 0
+      local.get 1
+      i64.add
+      local.set 1
+      local.get 0
+      i64.const 3
+      i64.gt_s
+      local.set 2
+      local.get 0
+      i64.const 2
+      i64.sub
+      local.set 0
+      local.get 2
+      br_if 0 (;@1;)
+    end
+    local.get 0
+    local.get 1
+    i64.add)
+  (func (;1;) (type 0) (param i64) (result i64)
+    (local i32 i64)
+    memory.size
+    local.set 1
+    i32.const 1
+    memory.grow
+    drop
+    i64.const 3026418949592973312
+    local.set 2
+    local.get 1
+    i32.const 16
+    i32.shl
+    local.tee 1
+    local.get 0
+    i64.const -4294967297
+    i64.le_u
+    if (result i64)  ;; label = @1
+      local.get 0
+      i32.wrap_i64
+      i64.load
+      local.tee 0
+      i64.const 56
+      i64.shl
+      local.get 0
+      i64.const 40
+      i64.shl
+      i64.const 71776119061217280
+      i64.and
+      i64.or
+      local.get 0
+      i64.const 24
+      i64.shl
+      i64.const 280375465082880
+      i64.and
+      local.get 0
+      i64.const 8
+      i64.shl
+      i64.const 1095216660480
+      i64.and
+      i64.or
+      i64.or
+      local.get 0
+      i64.const 8
+      i64.shr_u
+      i64.const 4278190080
+      i64.and
+      local.get 0
+      i64.const 24
+      i64.shr_u
+      i64.const 16711680
+      i64.and
+      i64.or
+      local.get 0
+      i64.const 40
+      i64.shr_u
+      i64.const 65280
+      i64.and
+      local.get 0
+      i64.const 56
+      i64.shr_u
+      i64.or
+      i64.or
+      i64.or
+      call 0
+      local.tee 0
+      i64.const 56
+      i64.shl
+      local.get 0
+      i64.const 40
+      i64.shl
+      i64.const 71776119061217280
+      i64.and
+      i64.or
+      local.get 0
+      i64.const 24
+      i64.shl
+      i64.const 280375465082880
+      i64.and
+      local.get 0
+      i64.const 8
+      i64.shl
+      i64.const 1095216660480
+      i64.and
+      i64.or
+      i64.or
+      local.get 0
+      i64.const 8
+      i64.shr_u
+      i64.const 4278190080
+      i64.and
+      local.get 0
+      i64.const 24
+      i64.shr_u
+      i64.const 16711680
+      i64.and
+      i64.or
+      local.get 0
+      i64.const 40
+      i64.shr_u
+      i64.const 65280
+      i64.and
+      local.get 0
+      i64.const 56
+      i64.shr_u
+      i64.or
+      i64.or
+      i64.or
+    else
+      local.get 2
+    end
+    i64.store
+    local.get 1
+    i64.extend_i32_u
+    i64.const 34359738368
+    i64.or)
+  (memory (;0;) 2)
+  (global (;0;) i32 (i32.const 1024))
+  (export "memory" (memory 0))
+  (export "fib" (func 1))
+  (export "_scylla_abi" (global 0))
+  (data (;0;) (i32.const 1024) "\01"))

--- a/sdcm/utils/udf_scripts/xwasm_plus.yaml
+++ b/sdcm/utils/udf_scripts/xwasm_plus.yaml
@@ -1,0 +1,23 @@
+# UDF script: returns the string length of the provided text var
+
+name: 'plus'
+args: '(input1 tinyint, input2 tinyint)'
+called_on_null_input_returns: 'NULL'
+return_type: 'tinyint'
+language: 'xwasm'
+script: |-
+  (module
+  (type (;0;) (func (param i32 i32) (result i32)))
+  (func ${plus_name} (type 0) (param i32 i32) (result i32)
+    local.get 1
+    local.get 0
+    i32.add)
+  (table (;0;) 1 1 funcref)
+  (table (;1;) 32 externref)
+  (memory (;0;) 17)
+  (export "memory" (memory 0))
+  (export "{plus_name}" (func ${plus_name}))
+  (elem (;0;) (i32.const 0) func)
+  (global (;0;) i32 (i32.const 1024))
+  (export "_scylla_abi" (global 0))
+  (data $.rodata (i32.const 1024) "\\01"))

--- a/unit_tests/test_udf.py
+++ b/unit_tests/test_udf.py
@@ -1,0 +1,126 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2022 ScyllaDB
+from unittest import TestCase
+
+from pydantic import ValidationError
+
+from sdcm.utils.udf import UDF, UDFS
+
+
+class TestUDF(TestCase):
+    MOCK_LUA_UDF_VALS = {
+        "name": "var_length_counter",
+        "args": "(var text)",
+        "called_on_null_input_returns": "NULL",
+        "return_type": "int",
+        "language": "lua",
+        "script": "return #var"
+    }
+
+    MOCK_XWASM_UDF_VALS = {
+        "name": 'plus',
+        "args": '(input1 tinyint, input2 tinyint)',
+        "called_on_null_input_returns": 'NULL',
+        "return_type": 'tinyint',
+        "language": 'xwasm',
+        "script": r"""(module
+(type (;0;) (func (param i32 i32) (result i32)))
+(func ${plus_name} (type 0) (param i32 i32) (result i32)
+  local.get 1
+  local.get 0
+  i32.add)
+(table (;0;) 1 1 funcref)
+(table (;1;) 32 externref)
+(memory (;0;) 17)
+(export "memory" (memory 0))
+(export "{plus_name}" (func ${plus_name}))
+(elem (;0;) (i32.const 0) func)
+(global (;0;) i32 (i32.const 1024))
+(export "_scylla_abi" (global 0))
+(data $.rodata (i32.const 1024) "\\01"))"""
+    }
+
+    def test_create_udf_instance(self):
+        expected_vals = self.MOCK_LUA_UDF_VALS
+
+        udf = UDF(**expected_vals)
+
+        for key, value in expected_vals.items():
+            self.assertEqual(value, getattr(udf, key), f"Did not find expected value for {key} in the udf class.")
+
+    def test_get_create_query_from_udf(self):
+        expected_query = "CREATE mock_keyspace.var_length_counter(var text) RETURNS NULL ON NULL INPUT " \
+                         "RETURNS int LANGUAGE lua AS 'return #var'"
+        udf = UDF(**self.MOCK_LUA_UDF_VALS)
+        actual_query = udf.get_create_query(ks="mock_keyspace", create_or_replace=False)
+
+        self.assertEqual(expected_query, actual_query)
+
+    def test_get_create_or_replace_query_from_udf(self):
+        expected_query = "CREATE OR REPLACE mock_keyspace.var_length_counter(var text) RETURNS NULL ON NULL INPUT " \
+                         "RETURNS int LANGUAGE lua AS 'return #var'"
+        udf = UDF(**self.MOCK_LUA_UDF_VALS)
+        actual_query = udf.get_create_query(ks="mock_keyspace")
+
+        self.assertEqual(expected_query, actual_query)
+
+    def test_creating_udf_with_missing_required_argument(self):
+        required_arg_names = ["name", "args", "called_on_null_input_returns", "return_type", "script"]
+
+        for arg_name in required_arg_names:
+            udf_args = self.MOCK_LUA_UDF_VALS.copy()
+            udf_args.update({arg_name: None})
+
+            with self.assertRaises(ValidationError,
+                                   msg=f"Creating a udf without providing {arg_name} did not raise a ValidationError."):
+                UDF(**udf_args)
+
+    def test_creating_udf_class_with_invalid_language(self):
+        udf_vals = self.MOCK_LUA_UDF_VALS.copy()
+        udf_vals.update({"language": "Java"})
+
+        with self.assertRaises(ValidationError,
+                               msg="Creating UDF class with invalid language did not raise ValidationError."):
+            UDF(**udf_vals)
+
+    def test_loading_udfs_with_lua_scripts(self):
+        expected_vals = self.MOCK_LUA_UDF_VALS.copy()
+
+        udf_yaml_filename = "./sdcm/utils/udf_scripts/lua_var_length_counter.yaml"
+        udf = UDF.from_yaml(udf_yaml_filename)
+
+        self.assertIsNotNone(udf)
+
+        for key, value in expected_vals.items():
+            self.assertEqual(value, getattr(udf, key), f"Did not find expected value for {key} in the udf class.")
+
+    def test_loading_udfs_with_xwasm_scripts(self):
+        expected_vals = self.MOCK_XWASM_UDF_VALS.copy()
+
+        udf_yaml_filename = "./sdcm/utils/udf_scripts/xwasm_plus.yaml"
+        udf = UDF.from_yaml(udf_yaml_filename)
+
+        self.assertIsNotNone(udf)
+
+        for key, value in expected_vals.items():
+            self.assertEqual(value, getattr(udf, key), f"Did not find expected value for {key} in the udf class.")
+
+    def test_load_all_udfs(self):
+        self.assertIsNotNone(UDFS)
+        for udf in UDFS.values():
+            self.assertTrue(udf.name)
+            self.assertTrue(udf.args)
+            self.assertTrue(udf.called_on_null_input_returns)
+            self.assertTrue(udf.return_type)
+            self.assertTrue(udf.language)
+            self.assertTrue(udf.script)


### PR DESCRIPTION
To allow us to use user defined functions in SCT
we need a way to store, load and handle UDFs.
This PR introduces some sample scripts in Lua
and WASM along with the infrastructure for loading,
 representing and handling them. The UDF class
allows to represent a UDF and create queries for
creating the UDF in Scylla.

https://github.com/scylladb/qa-tasks/issues/406

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
