### PR TITLE
fix(nemesis): revert using wrapped_disruptive_methods list

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -169,14 +169,11 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     limited: bool = False           # flag that signal that nemesis are belong to limited set of nemesises
     has_steady_run: bool = False    # flag that signal that nemesis should be run with perf tests with steady run
 
-    wrapped_disruptive_methods = []
-
     def __new__(cls, tester_obj, termination_event, *args):  # pylint: disable=unused-argument
         for name, member in inspect.getmembers(cls, lambda x: inspect.isfunction(x) or inspect.ismethod(x)):
-            if name.startswith(cls.DISRUPT_NAME_PREF) and name not in cls.wrapped_disruptive_methods:
+            if name.startswith(cls.DISRUPT_NAME_PREF):
                 # add "disrupt_method_wrapper" decorator to all methods are started with "disrupt_"
                 setattr(cls, name, disrupt_method_wrapper(member))
-                cls.wrapped_disruptive_methods.append(name)
         return object.__new__(cls)
 
     def __init__(self, tester_obj, termination_event, *args):  # pylint: disable=unused-argument


### PR DESCRIPTION
Issue: https://github.com/scylladb/scylla-cluster-tests/issues/5179
When run a few parallel nemesis threads, first thread disruption methods
are wrapped only. In other threads disruption methods are not wrapped.
Revert using wrapped_disruptive_methods list. Need find better solution

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
