### PR TITLE
fix(version_utils): improve regexp for architecture part

### DIFF
--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -101,7 +101,7 @@ class ScyllaFileType(Enum):
 
 FILE_REGEX_DICT = {
     ScyllaFileType.DEBIAN: [
-        (re.compile(r"deb\s+\[arch=(?P<arch>.*?)\]\s(?P<url>http.*?)\s(?P<version_code_name>.*?)\s(?P<component>.*?)$"),
+        (re.compile(r"deb\s+\[arch=(?P<arch>[^\s]*).*?\].*\s(?P<url>http.*?)\s(?P<version_code_name>.*?)\s(?P<component>.*?)$"),
          "{url}/dists/{version_code_name}/{component}/binary-{arch}/Packages"),
     ],
     ScyllaFileType.YUM:


### PR DESCRIPTION
latest runs of rolling upgrade tests failed due to error:
Wrong url:
The following repository URL "...' is incorrect.
The generated URl contains wrong part of architecture regexp match:
'... /binary-arm64 signed-by=/etc/apt/keyrings/scylladb.gpg/Packages'
where string after space is wrongly added.

Fixing regexp to match only architecture types
Failed job: https://jenkins.scylladb.com/job/scylla-master/job/rolling-upgrade/job/rolling-upgrade-ubuntu18.04-test
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
