### PR TITLE
fix(fill_db_data.py): Parse scylla version with tilde sign

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -3141,7 +3141,7 @@ class FillDatabaseData(ClusterTester):
 
     @property
     def parsed_scylla_version(self):
-        return parse_version(self.db_cluster.nodes[0].scylla_version)
+        return parse_version(self.db_cluster.nodes[0].scylla_version.replace('~', '-'))
 
     @property
     def is_enterprise(self) -> bool:


### PR DESCRIPTION
	The '~' character like in "5.1.0~rc0" was incorrectly parsed
	by pkg_resources parse_version
	Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/5164

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
