### PR TITLE
improvement(reactor stall): reduce detector and tolerable

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -15,7 +15,7 @@ scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/rpm/centos/
 experimental: true
 round_robin: false
 
-append_scylla_args: '--blocked-reactor-notify-ms 100 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1 --enable-sstable-key-validation 1'
+append_scylla_args: '--blocked-reactor-notify-ms 25 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1 --abort-on-ebadf 1 --enable-sstable-key-validation 1'
 append_scylla_setup_args: ''
 
 db_nodes_shards_selection: 'default'

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -23,7 +23,7 @@ from sdcm.sct_events.base import SctEvent, LogEvent, LogEventProtocol, T_log_eve
 from sdcm.sct_events.continuous_event import ContinuousEventsRegistry, ContinuousEvent
 from sdcm.sct_events.system import TestFrameworkEvent
 
-TOLERABLE_REACTOR_STALL: int = 1000  # ms
+TOLERABLE_REACTOR_STALL: int = 500  # ms
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
as part of the effort of reducing latency, reactor
stalls play a very important role in it, so since
we already had some improvements in Scylla side,
we are now reducing the thresholds in SCT as well,
to be able to catch easier anything that will deviate
from the expected.
the minimum threshold (also default in Scylla) is now
25 ms (it will raise `DEBUG` events in SCT), and from
500 ms we will raise `ERROR` events in SCT.

important to remind that every reactor stall event
with `ERROR` level, must be reported as an issue
in ScyllaDB repo.

Refs: scylladb/qa-tasks#366

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
