### PR TITLE
fix(RepairStreamingErr): filter stream-not-found during reboot

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2632,6 +2632,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                             node=self.target_node), \
             DbEventsFilter(db_event=DatabaseLogEvent.RUNTIME_ERROR,
                            line="Fail to send STREAM_MUTATION_DONE",
+                           node=self.target_node), \
+            DbEventsFilter(db_event=DatabaseLogEvent.DATABASE_ERROR,
+                           line=r"rpc stream id .* not found",
                            node=self.target_node):
             self.target_node.reboot(hard=True, verify_ssh=True)
             streaming_thread.join(60)

--- a/sdcm/sct_events/filters.py
+++ b/sdcm/sct_events/filters.py
@@ -43,7 +43,8 @@ class DbEventsFilter(BaseFilter):
         result = bool(self.filter_type) and self.filter_type == event.type
 
         if self.filter_line:
-            result &= self.filter_line in getattr(event, "line", "")
+            event_line = getattr(event, "line", "")
+            result &= bool(re.search(self.filter_line, event_line))
 
         if self.filter_node:
             result &= self.filter_node == getattr(event, "node", "")


### PR DESCRIPTION
	A repair stream on node gets an expected error of
	"stream id 1 not found" during reboot, so it
	has to be filtered out.
	Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/5187
Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/5187
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
