### PR TITLE
fix(sct_runner): remove setting alive tag for runners

### DIFF
--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -1097,13 +1097,6 @@ def _manage_runner_keep_tag_value(utc_now: datetime,
             sct_runner_info.keep = new_keep_value
         return sct_runner_info
 
-    if test_status is not None and test_status != "RUNNING" and not sct_runner_info.logs_collected:
-        if not dry_run:
-            sct_runner_info.sct_runner_class.set_tags(sct_runner_info, {"keep": "alive", "keep_action": "keep"})
-        sct_runner_info.keep = "alive"
-        sct_runner_info.keep_action = "keep"
-        return sct_runner_info
-
     LOGGER.info("No changes to make to runner tags.")
     return sct_runner_info
 


### PR DESCRIPTION
When we have issues with log collection, SCT runners are kept as "alive".
This leads to lots of runners being kept when a class of our jobs have
issues with log collection. This PR removes that behavior.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
