### PR TITLE
feature(github-actions): switch to different actions for auto assign

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,4 +1,0 @@
-# Set addAssignees to 'author' to set the PR creator as the assignee.
-addAssignees: author
-
-runOnDraft: true

--- a/.github/workflows/auto_assign.yaml
+++ b/.github/workflows/auto_assign.yaml
@@ -1,10 +1,13 @@
 name: 'Auto Assign'
 on:
-  pull_request_target:
-    types: [opened, ready_for_review]
-
+  pull_request:
+    types: [opened]
+  issues:
+    types: [opened]
 jobs:
-  add-reviews:
+  assignAuthor:
+    name: Assign author to PR/issue
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v1.2.2
+      - name: Assign author to PR/issue
+        uses: technote-space/assign-author@v1


### PR DESCRIPTION
move to action that can handle both PRs and issues

Ref: https://github.com/marketplace/actions/assign-author

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
