### PR TITLE
fix(azure): fix list instances when missing az

### DIFF
--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -980,10 +980,11 @@ class AzureSctRunner(SctRunner):
                 except ValueError as exc:
                     LOGGER.warning("Value of `launch_time' tag is invalid: %s", exc)
                     launch_time = None
+            region_az = instance.location + "" if not instance.zones else instance.zones[0]
             sct_runners.append(SctRunnerInfo(
                 sct_runner_class=cls,
                 cloud_service_instance=azure_service,
-                region_az=f"{instance.location}-{instance.zones[0]}",
+                region_az=region_az,
                 instance=instance,
                 instance_name=instance.name,
                 public_ips=[azure_service.get_virtual_machine_ips(virtual_machine=instance).public_ip],


### PR DESCRIPTION
After recent change for handling availability zone in Azure, SCT fails
when listing sct-runners for tests from old branches where az is not
set.

This commit fixes it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
