### PR TITLE
improvement(collect kallsyms): Collect Seastar kallsyms on boot

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -43,7 +43,7 @@ from sdcm.utils.common import (
     filter_aws_instances_by_type,
     filter_gce_instances_by_type,
     get_sct_root_path,
-    normalize_ipv6_url,
+    normalize_ipv6_url, create_remote_storage_dir,
 )
 from sdcm.utils.auto_ssh import AutoSshContainerMixin
 from sdcm.utils.decorators import retrying
@@ -770,6 +770,8 @@ class ScyllaLogCollector(LogCollector):
     log_entities = [FileLog(name='system.log',
                             command="sudo journalctl --no-tail --no-pager -u scylla-ami-setup.service -u scylla-image-setup.service "
                                     "-u scylla-io-setup.service -u scylla-server.service -u scylla-jmx.service", search_locally=True),
+                    FileLog(name='kallsyms_*',
+                            search_locally=True),
                     CommandLog(name='cpu_info',
                                command='cat /proc/cpuinfo'),
                     CommandLog(name='mem_info',
@@ -787,8 +789,6 @@ class ScyllaLogCollector(LogCollector):
                                command='cat /etc/scylla.d/io_properties.yaml'),
                     CommandLog(name='dmesg.log',
                                command='dmesg -P'),
-                    CommandLog(name='kallsyms',
-                               command='sudo cat /proc/kallsyms')
                     ]
     cluster_log_type = "db-cluster"
     cluster_dir_prefix = "db-cluster"
@@ -797,6 +797,27 @@ class ScyllaLogCollector(LogCollector):
     def collect_logs(self, local_search_path=None) -> list[str]:
         self.collect_logs_for_inactive_nodes(local_search_path)
         return super().collect_logs(local_search_path)
+
+
+def save_kallsyms_map(node):
+
+    LOGGER.info('Saving kallsyms map from host: %s', node.name)
+    if remote_node_dir := create_remote_storage_dir(node):
+        uptime = datetime.datetime.strptime(node.remoter.run('uptime -s', ignore_status=True).stdout.strip(),
+                                            '%Y-%m-%d %H:%M:%S').strftime("%Y%m%d_%H%M%S")
+        kallsyms_name = f'kallsyms_{uptime}'
+        kallsyms_file_path = os.path.join(node.logdir, kallsyms_name)
+        if os.path.exists(kallsyms_file_path):
+            LOGGER.debug("The kallsyms file '%s' already exists and not changed. Not collecting it's map",
+                         kallsyms_file_path)
+            return
+        log_entity = CommandLog(name=kallsyms_name,
+                                command='sudo cat /proc/kallsyms')
+
+        try:
+            log_entity.collect(node, node.logdir, remote_node_dir)
+        except Exception as details:  # pylint: disable=broad-except
+            LOGGER.error("Error occurred during collecting kallsyms on host: %s\n%s", node.name, details)
 
 
 class LoaderLogCollector(LogCollector):

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1483,6 +1483,26 @@ def remove_files(path):
         LOGGER.info("Remove temporary data manually: \"%s\"", path)
 
 
+def create_remote_storage_dir(node, path='') -> Optional[str]:
+    node_remote_dir = '/tmp'
+    if not path:
+        path = node.name
+    try:
+        remote_dir = os.path.join(node_remote_dir, path)
+        result = node.remoter.run(f'mkdir -p {remote_dir}', ignore_status=True)
+
+        if result.exited > 0:
+            LOGGER.error(
+                'Remote storing folder not created.\n %s', result)
+            remote_dir = node_remote_dir
+
+    except Exception as details:  # pylint: disable=broad-except
+        LOGGER.error("Error during creating remote directory %s", details)
+        return None
+
+    return remote_dir
+
+
 def format_timestamp(timestamp):
     return datetime.datetime.utcfromtimestamp(timestamp).strftime('%Y-%m-%d %H:%M:%S')
 


### PR DESCRIPTION
	The kallsyms map for kernel debug should be collected
	dynamically every node boot.

This is a complementary PR to: https://github.com/scylladb/scylla-cluster-tests/pull/5093 since backporting to perf-v12 is not possible.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
