### PR TITLE
test(longevity): add sla basic longevity test

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -213,3 +213,5 @@ stress_image:
   alternator-dns: 'scylladb/hydra-loaders:alternator-dns-0.1'
   cdc-stresser: 'scylladb/hydra-loaders:cdc-stresser-20210630'
   kcl: 'scylladb/hydra-loaders:kcl-jdk8-20210526-ShardSyncStrategyType-PERIODIC'
+
+service_level_shares: [1000]

--- a/jenkins-pipelines/longevity-sla-100gb-4h.jenkinsfile
+++ b/jenkins-pipelines/longevity-sla-100gb-4h.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_sla_test.LongevitySlaTest.test_custom_time',
+    test_config: 'test-cases/longevity/longevity-sla-100gb-4h.yaml'
+
+)

--- a/longevity_sla_test.py
+++ b/longevity_sla_test.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2022 ScyllaDB
+import re
+
+from longevity_test import LongevityTest
+from sdcm.sct_events import Severity
+from sdcm.sct_events.system import TestFrameworkEvent
+from test_lib.sla import Role, ServiceLevel
+
+
+class LongevitySlaTest(LongevityTest):
+    DEFAULT_USER = "cassandra"
+    DEFAULT_USER_PASSWORD = "cassandra"
+    STRESS_ROLE_NAME_TEMPLATE = 'role%d_%d'
+    STRESS_ROLE_PASSWORD_TEMPLATE = 'rolep%d'
+    SERVICE_LEVEL_NAME_TEMPLATE = 'sl%d_%d'
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.service_level_shares = self.params.get("service_level_shares")
+        self.roles = []
+
+    def test_custom_time(self):
+        with self.db_cluster.cql_connection_patient(node=self.db_cluster.nodes[0], user=self.DEFAULT_USER,
+                                                    password=self.DEFAULT_USER_PASSWORD) as session:
+            # Add index (shares position in the self.service_level_shares list) to role and service level names to do
+            # it unique and prevent failure when try to create role/SL with same name
+            for index, shares in enumerate(self.service_level_shares):
+                self.roles.append(self.create_sla_auth(session=session, shares=shares, index=index))
+
+        self.add_sla_credentials_to_stress_cmds()
+        super().test_custom_time()
+
+    def create_sla_auth(self, session, shares: int, index: int):
+        role = Role(session=session, name=self.STRESS_ROLE_NAME_TEMPLATE % (shares, index),
+                    password=self.STRESS_ROLE_PASSWORD_TEMPLATE % shares, login=True).create()
+        role.attach_service_level(ServiceLevel(session=session, name=self.SERVICE_LEVEL_NAME_TEMPLATE % (shares, index),
+                                               shares=shares).create())
+
+        return role
+
+    def add_sla_credentials_to_stress_cmds(self):
+        def _set_credentials_to_cmd(cmd):
+            if self.roles and "<sla credentials " in cmd:
+                if 'user=' in cmd:
+                    # if stress command is not defined as expected, stop the tests and fix it. Then re-run
+                    TestFrameworkEvent(
+                        source=self.__class__.__name__,
+                        message="Stress command is defined wrong. Credentials already applied. Remove unnecessary "
+                                f"and re-run the test. Command: {cmd}",
+                        severity=Severity.CRITICAL
+                    ).publish()
+
+                index = re.search(r"<sla credentials (\d+)>", cmd)
+                role_index = int(index.groups(0)[0]) if index else None
+                if role_index is None:
+                    # if stress command is not defined as expected, stop the tests and fix it. Then re-run
+                    TestFrameworkEvent(
+                        source=self.__class__.__name__,
+                        message="Stress command is defined wrong. Expected pattern '<credentials \\d>' was not found. "
+                                f"Fix the command and re-run the test. Command: {cmd}",
+                        severity=Severity.CRITICAL
+                    ).publish()
+                sla_role_name = self.roles[role_index].name.replace('"', '')
+                sla_role_password = self.roles[role_index].password
+                return re.sub(r'<sla credentials \d+>', f'user={sla_role_name} password={sla_role_password}', cmd)
+            return cmd
+
+        for stress_op in ['prepare_write_cmd', 'stress_cmd', 'stress_read_cmd']:
+            stress_cmds = []
+            stress_params = self.params.get(stress_op)
+            if isinstance(stress_params, str):
+                stress_params = [stress_params]
+
+            if not stress_params:
+                continue
+
+            for stress_cmd in stress_params:
+                # cover multitenant test
+                if isinstance(stress_cmd, list):
+                    cmds = []
+                    for current_cmd in stress_cmd:
+                        cmds.append(_set_credentials_to_cmd(cmd=current_cmd))
+                    stress_cmds.append(cmds)
+                else:
+                    stress_cmds.append(_set_credentials_to_cmd(cmd=stress_cmd))
+
+            self.params[stress_op] = stress_cmds

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -469,6 +469,10 @@ class SCTConfiguration(dict):
         dict(name="system_auth_rf", env="SCT_SYSTEM_AUTH_RF", type=int,
              help="Replication factor will be set to system_auth"),
 
+        dict(name="service_level_shares", env="SCT_SERVICE_LEVEL_SHARES", type=list,
+             help="List if service level shares - how many server levels to create and test. Uses in SLA test."
+                  "list of int, like: [100, 200]"),
+
         dict(name="alternator_port", env="SCT_ALTERNATOR_PORT", type=int,
              help="Port to configure for alternator in scylla.yaml"),
         dict(name="dynamodb_primarykey_type", env="SCT_DYNAMODB_PRIMARYKEY_TYPE", type=str,

--- a/test-cases/longevity/longevity-sla-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-sla-100gb-4h.yaml
@@ -1,0 +1,36 @@
+test_duration: 360
+
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=20971520 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
+
+# option <sla credentials 0> - where "0" is first element of "service_level_shares" test parameter. This option will be replaced with user and password of the role name that assigned to service level with shares=service_level_shares[0]
+# option <sla credentials 1> - where "1" is second element of "service_level_shares" test parameter. This option will be replaced with user and password of the role name that assigned to service level with shares=service_level_shares[1]
+stress_cmd: ["cassandra-stress read cl=QUORUM duration=240m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native <sla credentials 0> -rate threads=40 -pop seq=1..10485760 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=240m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native <sla credentials 1> -rate threads=40 -pop seq=10485761..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
+             ]
+
+n_db_nodes: 6
+n_loaders: 2
+n_monitor_nodes: 1
+seeds_num: 3
+round_robin: true
+
+instance_type_db: 'i3.4xlarge'
+
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_seed: '032'
+nemesis_interval: 5
+nemesis_filter_seeds: false
+nemesis_during_prepare: false
+
+user_prefix: 'longevity-sla-100gb-4h'
+space_node_threshold: 64424
+
+pre_create_schema: True
+sstable_size: 100
+
+authenticator: 'PasswordAuthenticator'
+authenticator_user: cassandra
+authenticator_password: cassandra
+authorizer: 'ScyllaAuthorizer'
+
+service_level_shares: [200, 800]


### PR DESCRIPTION
Configure two SLA roles and run two stress threads with these roles.

This is first basic longevity test. Run different nemeses including disruptive (terminate and replace node, restart scylla server, decommission etc)

Refs https://github.com/scylladb/qa-tasks/issues/387

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
