### PR TITLE
fix(upgrade test): extend the time to ignore cdc error

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -10,7 +10,6 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2020 ScyllaDB
-
 from contextlib import contextmanager, ExitStack
 
 from sdcm.sct_events import Severity
@@ -102,15 +101,18 @@ def ignore_upgrade_schema_errors():
 
 
 @contextmanager
-def ignore_upgrade_cdc_errors(version=None):
+def ignore_upgrade_cdc_errors():
     with ExitStack() as stack:
-        if version and '2020.1' in version:
-            stack.enter_context(EventsSeverityChangerFilter(
-                new_severity=Severity.WARNING,
-                event_class=LogEvent,
-                regex="Could not retrieve CDC streams with timestamp",
-                extra_time_to_expiration=60
-            ))
+        stack.enter_context(DbEventsFilter(
+            db_event=DatabaseLogEvent.RUNTIME_ERROR,
+            line="Could not retrieve CDC streams with timestamp",
+        ))
+        stack.enter_context(EventsSeverityChangerFilter(
+            new_severity=Severity.WARNING,
+            event_class=DatabaseLogEvent,
+            regex=r".*Could not retrieve CDC streams with timestamp*",
+            extra_time_to_expiration=60
+        ))
         yield
 
 

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -123,7 +123,7 @@ class TestBaseNode(unittest.TestCase, EventsUtilsMixin):
 
     def test_search_cdc_invalid_request_2021_1(self):
         self.node.system_log = os.path.join(os.path.dirname(__file__), 'test_data', 'system_cdc_invalid_request.log')
-        with ignore_upgrade_cdc_errors('2021.1'):
+        with ignore_upgrade_cdc_errors():
             self.node._read_system_log_and_publish_events(start_from_beginning=True)
 
         retry_max = 20
@@ -139,7 +139,7 @@ class TestBaseNode(unittest.TestCase, EventsUtilsMixin):
 
     def test_search_cdc_invalid_request_2020_1(self):
         self.node.system_log = os.path.join(os.path.dirname(__file__), 'test_data', 'system_cdc_invalid_request.log')
-        with ignore_upgrade_cdc_errors('2020.1'):
+        with ignore_upgrade_cdc_errors():
             self.node._read_system_log_and_publish_events(start_from_beginning=True)
 
         with self.get_events_logger().events_logs_by_severity[Severity.ERROR].open() as events_file:


### PR DESCRIPTION
In one upgraded test, the cdc error (Could not find CDC generation with
timestamp) raised before 9042 is ready, but the SCT event was delayed 3+ mins,
it's after db is up, so it won't be ignored.

This patch tried to extend the time to ignore cdc error, I know it's not
a grace solution.

Fixes: #4451

Signed-off-by: Amos Kong <amos@scylladb.com>
(cherry picked from commit 4c9a7dd2719fcab8c9da01d051ec0d1368993fa1)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
