### PR TITLE
fix(sct_runner): add force option

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1422,9 +1422,10 @@ def set_runner_tags(runner_ip, tags):
 @click.option("-ip", "--runner-ip", required=False, type=str, default="")
 @click.option("-ts", "--test-status", type=str, help="The result of the test run")
 @click.option('--dry-run', is_flag=True, default=False, help='dry run')
-def clean_runner_instances(runner_ip, test_status, dry_run):
+@click.option("--force", is_flag=True, default=False, help="Skip cleaning logic and terminate the instance")
+def clean_runner_instances(runner_ip, test_status, dry_run, force):
     add_file_logger()
-    clean_sct_runners(test_runner_ip=runner_ip, test_status=test_status, dry_run=dry_run)
+    clean_sct_runners(test_runner_ip=runner_ip, test_status=test_status, dry_run=dry_run, force=force)
 
 
 @cli.command("run-aws-mock", help="Start AWS Mock server Docker container")

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -1105,12 +1105,19 @@ def _manage_runner_keep_tag_value(utc_now: datetime,
 
 def clean_sct_runners(test_status: str,
                       test_runner_ip: str = None,
-                      dry_run: bool = False) -> None:
+                      dry_run: bool = False,
+                      force: bool = False) -> None:
     # pylint: disable=too-many-branches
     sct_runners_list = list_sct_runners(test_runner_ip=test_runner_ip)
     timeout_flag = False
     runners_terminated = 0
     end_message = ""
+
+    if not dry_run and test_runner_ip and force:
+        sct_runner_info = sct_runners_list[0]
+        sct_runner_info.terminate()
+        LOGGER.info("Forcibly terminated runner: %s", sct_runner_info)
+        return
 
     for sct_runner_info in sct_runners_list:
         LOGGER.info("Managing SCT runner: %s in region: %s",


### PR DESCRIPTION
Allow the users to specify the use the --force flag, which
allows to remove the runner without running any logic for
tag values.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
