### PR TITLE
fix(dashboard): scheduler runtime query

### DIFF
--- a/data_dir/scylla-dash-per-server-nemesis.2021.1.json
+++ b/data_dir/scylla-dash-per-server-nemesis.2021.1.json
@@ -1170,7 +1170,7 @@
                       "steppedLine": false,
                       "targets": [
                         {
-                          "expr": "avg(irate(scylla_scheduler_runtime_ms{group=~\"service_level_.*\"} [30s] )) by (group, instance)",
+                          "expr": "avg(irate(scylla_scheduler_runtime_ms{group=~\"sl:.*\"} [30s] )) by (group, instance)",
                           "format": "time_series",
                           "interval": "15s",
                           "intervalFactor": 1,


### PR DESCRIPTION
Group format in 'scylla_scheduler_runtime_ms' metrix has been changed.
Fix the query accordingly

![Screenshot from 2022-08-31 16-49-13](https://user-images.githubusercontent.com/34435448/187696130-0f2c03ed-b75f-496d-9936-c49fc71a4f3b.png)


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
