### PR TITLE
improvement(EKS,GKE): use more recent K8S and cert manager versions

### DIFF
--- a/defaults/k8s_eks_config.yaml
+++ b/defaults/k8s_eks_config.yaml
@@ -9,7 +9,7 @@ availability_zone: 'a,b'
 instance_provision: 'on_demand'
 instance_type_db: 'i3.4xlarge'
 
-eks_cluster_version: '1.20'
+eks_cluster_version: '1.22'
 eks_role_arn: 'arn:aws:iam::797456418907:role/eksServicePolicy'
 eks_service_ipv4_cidr: '172.20.0.0/16'
 eks_nodegroup_role_arn: 'arn:aws:iam::797456418907:role/helm-test-worker-nodes-NodeInstanceRole-6ACHDYEKNN3I'
@@ -18,7 +18,7 @@ eks_vpc_cni_version: 'v1.11.3-eksbuild.1'
 
 scylla_version: '4.5.3'
 scylla_mgmt_agent_version: '3.0.0'
-k8s_cert_manager_version: '1.2.0'
+k8s_cert_manager_version: '1.8.0'
 
 k8s_deploy_monitoring: false
 

--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -3,7 +3,7 @@ gce_datacenter: 'us-east1-b'
 gce_network: 'qa-vpc'
 gce_image_username: 'scylla-test'
 
-gke_cluster_version: '1.20'
+gke_cluster_version: '1.22'
 gke_k8s_release_channel: ''
 
 gce_instance_type_db: 'n1-standard-8'
@@ -24,7 +24,7 @@ mgmt_docker_image: 'scylladb/scylla-manager:3.0.0'
 k8s_scylla_operator_docker_image: ''
 k8s_scylla_operator_helm_repo: 'https://storage.googleapis.com/scylla-operator-charts/latest'
 k8s_scylla_operator_chart_version: 'latest'
-k8s_cert_manager_version: '1.2.0'
+k8s_cert_manager_version: '1.8.0'
 k8s_deploy_monitoring: false
 
 # NOTE: GKE requires 'k8s_scylla_utils_docker_image' be defined to enterprise Scylla version 2021+


### PR DESCRIPTION
More recent K8S versions are required because the one we use now
is too old and soon will not be supported by EKS and GKE.
Update also cert-manager version because this old version we use
won't work on newer K8S versions due to API changes.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
