### PR TITLE
improvement(k8s-upgrade): run preload and load

### DIFF
--- a/configurations/operator/k8s-upgrade-gke.yaml
+++ b/configurations/operator/k8s-upgrade-gke.yaml
@@ -1,0 +1,1 @@
+stress_during_entire_upgrade: "cassandra-stress read no-warmup cl=QUORUM duration=90m -schema 'replication(factor=3)' -mode cql3 native -rate 'threads=100 throttle=5000/s' -col 'size=FIXED(1024) n=FIXED(1)' -pop 'dist=gauss(1..40000000,30000000,15000000)' -log interval=5"

--- a/jenkins-pipelines/operator/upgrade/upgrade-platform-k8s-gke.jenkinsfile
+++ b/jenkins-pipelines/operator/upgrade/upgrade-platform-k8s-gke.jenkinsfile
@@ -6,5 +6,5 @@ rollingOperatorUpgradePipeline(
     backend: 'k8s-gke',
     region: 'us-east1',
     test_name: 'upgrade_test.UpgradeTest.test_kubernetes_platform_upgrade',
-    test_config: 'test-cases/scylla-operator/kubernetes-platform-upgrade.yaml',
+    test_config: '''["test-cases/scylla-operator/kubernetes-platform-upgrade.yaml", "configurations/operator/k8s-upgrade-gke.yaml"]''',
 )

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -15,7 +15,6 @@
 import json
 import os
 import re
-import time
 import string
 import tempfile
 import itertools
@@ -23,68 +22,16 @@ import itertools
 import yaml
 from cassandra import AlreadyExists, InvalidRequest
 
-
 from sdcm.tester import ClusterTester
+from sdcm.utils import loader_utils
 
 
-class LongevityTest(ClusterTester):
+class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
     """
     Test a Scylla cluster stability over a time period.
     """
 
-    def _run_all_stress_cmds(self, stress_queue, params):
-        stress_cmds = params['stress_cmd']
-        if not isinstance(stress_cmds, list):
-            stress_cmds = [stress_cmds]
-        # In some cases we want the same stress_cmd to run several times (can be used with round_robin or not).
-        stress_multiplier = self.params.get('stress_multiplier')
-        if stress_multiplier > 1:
-            stress_cmds *= stress_multiplier
-
-        for stress_cmd in stress_cmds:
-            params.update({'stress_cmd': stress_cmd})
-            self._parse_stress_cmd(stress_cmd, params)
-
-            # Run all stress commands
-            self.log.debug('stress cmd: {}'.format(stress_cmd))
-            if stress_cmd.startswith('scylla-bench'):
-                stress_queue.append(self.run_stress_thread(stress_cmd=stress_cmd,
-                                                           stats_aggregate_cmds=False,
-                                                           round_robin=self.params.get('round_robin')))
-            elif stress_cmd.startswith('cassandra-harry'):
-                stress_queue.append(self.run_stress_thread(**params))
-            else:
-                stress_queue.append(self.run_stress_thread(**params))
-
-            time.sleep(10)
-
-            # Remove "user profile" param for the next command
-            if 'profile' in params:
-                del params['profile']
-
-            if 'keyspace_name' in params:
-                del params['keyspace_name']
-
-        return stress_queue
-
-    def _parse_stress_cmd(self, stress_cmd, params):
-        # Due to an issue with scylla & cassandra-stress - we need to create the counter table manually
-        if 'counter_' in stress_cmd:
-            self._create_counter_table()
-
-        if 'compression' in stress_cmd:
-            if 'keyspace_name' not in params:
-                compression_prefix = re.search('compression=(.*)Compressor', stress_cmd).group(1)
-                keyspace_name = "keyspace_{}".format(compression_prefix.lower())
-                params.update({'keyspace_name': keyspace_name})
-
-        return params
-
     default_params = {'timeout': 650000}
-
-    @staticmethod
-    def _get_keyspace_name(ks_number, keyspace_pref='keyspace'):
-        return '{}{}'.format(keyspace_pref, ks_number)
 
     def _get_scan_operation_params(self, scan_operation: str) -> dict:
         params = {}
@@ -103,75 +50,6 @@ class LongevityTest(ClusterTester):
     def run_pre_create_keyspace(self):
         if self.params.get('pre_create_keyspace'):
             self._pre_create_keyspace()
-
-    def run_prepare_write_cmd(self):
-        # In some cases (like many keyspaces), we want to create the schema (all keyspaces & tables) before the load
-        # starts - due to the heavy load, the schema propogation can take long time and c-s fails.
-        prepare_write_cmd = self.params.get('prepare_write_cmd')
-        keyspace_num = self.params.get('keyspace_num')
-        write_queue = []
-        verify_queue = []
-
-        if not prepare_write_cmd:
-            self.log.debug("No prepare write commands are configured to run. Continue with stress commands")
-            return
-        # When the load is too heavy for one loader when using MULTI-KEYSPACES, the load is spreaded evenly across
-        # the loaders (round_robin).
-        if keyspace_num > 1 and self.params.get('round_robin'):
-            self.log.debug("Using round_robin for multiple Keyspaces...")
-            for i in range(1, keyspace_num + 1):
-                keyspace_name = self._get_keyspace_name(i)
-                self._run_all_stress_cmds(write_queue, params={'stress_cmd': prepare_write_cmd,
-                                                               'keyspace_name': keyspace_name,
-                                                               'round_robin': True})
-        # Not using round_robin and all keyspaces will run on all loaders
-        else:
-            self._run_all_stress_cmds(write_queue, params={'stress_cmd': prepare_write_cmd,
-                                                           'keyspace_num': keyspace_num,
-                                                           'round_robin': self.params.get('round_robin')})
-
-        # In some cases we don't want the nemesis to run during the "prepare" stage in order to be 100% sure that
-        # all keys were written succesfully
-        if self.params.get('nemesis_during_prepare'):
-            # Wait for some data (according to the param in the yaml) to be populated, for multi keyspace need to
-            # pay attention to the fact it checks only on keyspace1
-            self.db_cluster.wait_total_space_used_per_node(keyspace=None)
-            self.db_cluster.start_nemesis()
-
-        # Wait on the queue till all threads come back.
-        # todo: we need to improve this part for some cases that threads are being killed and we don't catch it.
-        for stress in write_queue:
-            self.verify_stress_thread(cs_thread_pool=stress)
-
-        # Run nodetool flush on all nodes to make sure nothing left in memory
-        # I decided to comment this out for now, when we found the data corruption bug, we wanted to be on the safe
-        # side, but I don't think we should continue with this approach.
-        # If we decided to add this back in the future, we need to wrap it with try-except because it can run
-        # in parallel to nemesis and it will fail on one of the nodes.
-        # self._flush_all_nodes()
-
-        # In case we would like to verify all keys were written successfully before we start other stress / nemesis
-        prepare_verify_cmd = self.params.get('prepare_verify_cmd')
-        if prepare_verify_cmd:
-            self._run_all_stress_cmds(verify_queue, params={'stress_cmd': prepare_verify_cmd,
-                                                            'keyspace_num': keyspace_num})
-
-            for stress in verify_queue:
-                self.verify_stress_thread(cs_thread_pool=stress)
-
-        self.run_post_prepare_cql_cmds()
-
-        prepare_wait_no_compactions_timeout = self.params.get('prepare_wait_no_compactions_timeout')
-        if prepare_wait_no_compactions_timeout:
-            for node in self.db_cluster.nodes:
-                node.run_nodetool("compact")
-            self.wait_no_compactions_running(n=prepare_wait_no_compactions_timeout)
-        self.log.info('Prepare finished')
-
-    def run_post_prepare_cql_cmds(self):
-        if post_prepare_cql_cmds := self.params.get('post_prepare_cql_cmds'):
-            self.log.debug("Execute post prepare queries: %s", post_prepare_cql_cmds)
-            self._run_cql_commands(post_prepare_cql_cmds)
 
     def test_custom_time(self):
         """
@@ -422,41 +300,6 @@ class LongevityTest(ClusterTester):
     def all_node_ips_for_stress_command(self):
         return f' -node {",".join([n.cql_ip_address for n in self.db_cluster.nodes])}'
 
-    def _create_counter_table(self):
-        """
-        workaround for the issue https://github.com/scylladb/scylla-tools-java/issues/32
-        remove when resolved
-        """
-        node = self.db_cluster.nodes[0]
-        with self.db_cluster.cql_connection_patient(node) as session:
-            session.execute("""
-                CREATE KEYSPACE IF NOT EXISTS keyspace1
-                WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'} AND durable_writes = true;
-            """)
-            session.execute("""
-                CREATE TABLE IF NOT EXISTS keyspace1.counter1 (
-                    key blob PRIMARY KEY,
-                    "C0" counter,
-                    "C1" counter,
-                    "C2" counter,
-                    "C3" counter,
-                    "C4" counter
-                ) WITH COMPACT STORAGE
-                    AND bloom_filter_fp_chance = 0.01
-                    AND caching = '{"keys":"ALL","rows_per_partition":"ALL"}'
-                    AND comment = ''
-                    AND compaction = {'class': 'SizeTieredCompactionStrategy'}
-                    AND compression = {}
-                    AND gc_grace_seconds = 864000
-                    AND default_time_to_live = 0
-                    AND max_index_interval = 2048
-                    AND min_index_interval = 128
-                    AND read_repair_chance = 0.0
-                    AND dclocal_read_repair_chance = 0.1
-                    AND memtable_flush_period_in_ms = 0
-                    AND speculative_retry = '99.0PERCENTILE';
-            """)
-
     @staticmethod
     def _get_columns_num_of_single_stress(single_stress_cmd):
         if '-col' not in single_stress_cmd:
@@ -547,21 +390,6 @@ class LongevityTest(ClusterTester):
                             session.execute(query)
                         except (AlreadyExists, InvalidRequest) as exc:
                             self.log.debug('extra definition for [{}] exists [{}]'.format(table_name, str(exc)))
-
-    def _pre_create_keyspace(self):
-        cmds = self.params.get('pre_create_keyspace')
-        self._run_cql_commands(cmds)
-
-    def _run_cql_commands(self, cmds, node=None):
-        node = node if node else self.db_cluster.nodes[0]
-
-        if not isinstance(cmds, list):
-            cmds = [cmds]
-
-        for cmd in cmds:
-            # pylint: disable=no-member
-            with self.db_cluster.cql_connection_patient(node) as session:
-                session.execute(cmd)
 
     def _flush_all_nodes(self):
         """

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1532,6 +1532,10 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
                 pod_readiness_timeout_minutes=pod_readiness_timeout_minutes)
             LOGGER.info("The '%s' pod is ready, refresh IP addresses", pod_object.name)
             pod_object.refresh_ip_address()
+            # NOTE: update monitoring after each pod update
+            #       to minimize the loss of monitoring data
+            if monitors := self.test_config.tester_obj().monitors:
+                monitors.reconfigure_scylla_monitoring()
 
     @contextlib.contextmanager
     def scylla_config_map(self, namespace: str = SCYLLA_NAMESPACE) -> dict:

--- a/sdcm/utils/loader_utils.py
+++ b/sdcm/utils/loader_utils.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2022 ScyllaDB
+
+import re
+import time
+
+
+class LoaderUtilsMixin:
+    """This mixin can be added to any class that inherits the 'ClusterTester' one"""
+
+    def _parse_stress_cmd(self, stress_cmd, params):
+        # Due to an issue with scylla & cassandra-stress - we need to create the counter table manually
+        if 'counter_' in stress_cmd:
+            self._create_counter_table()
+
+        if 'compression' in stress_cmd:
+            if 'keyspace_name' not in params:
+                compression_prefix = re.search('compression=(.*)Compressor', stress_cmd).group(1)
+                keyspace_name = "keyspace_{}".format(compression_prefix.lower())
+                params.update({'keyspace_name': keyspace_name})
+
+        return params
+
+    def _create_counter_table(self):
+        """
+        workaround for the issue https://github.com/scylladb/scylla-tools-java/issues/32
+        remove when resolved
+        """
+        node = self.db_cluster.nodes[0]
+        with self.db_cluster.cql_connection_patient(node) as session:
+            session.execute("""
+                CREATE KEYSPACE IF NOT EXISTS keyspace1
+                WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'} AND durable_writes = true;
+            """)
+            session.execute("""
+                CREATE TABLE IF NOT EXISTS keyspace1.counter1 (
+                    key blob PRIMARY KEY,
+                    "C0" counter,
+                    "C1" counter,
+                    "C2" counter,
+                    "C3" counter,
+                    "C4" counter
+                ) WITH COMPACT STORAGE
+                    AND bloom_filter_fp_chance = 0.01
+                    AND caching = '{"keys":"ALL","rows_per_partition":"ALL"}'
+                    AND comment = ''
+                    AND compaction = {'class': 'SizeTieredCompactionStrategy'}
+                    AND compression = {}
+                    AND gc_grace_seconds = 864000
+                    AND default_time_to_live = 0
+                    AND max_index_interval = 2048
+                    AND min_index_interval = 128
+                    AND read_repair_chance = 0.0
+                    AND dclocal_read_repair_chance = 0.1
+                    AND memtable_flush_period_in_ms = 0
+                    AND speculative_retry = '99.0PERCENTILE';
+            """)
+
+    def _run_all_stress_cmds(self, stress_queue, params):
+        stress_cmds = params['stress_cmd']
+        if not isinstance(stress_cmds, list):
+            stress_cmds = [stress_cmds]
+        # In some cases we want the same stress_cmd to run several times (can be used with round_robin or not).
+        stress_multiplier = self.params.get('stress_multiplier')
+        if stress_multiplier > 1:
+            stress_cmds *= stress_multiplier
+
+        for stress_cmd in stress_cmds:
+            params.update({'stress_cmd': stress_cmd})
+            self._parse_stress_cmd(stress_cmd, params)
+
+            # Run all stress commands
+            self.log.debug('stress cmd: {}'.format(stress_cmd))
+            if stress_cmd.startswith('scylla-bench'):
+                stress_queue.append(self.run_stress_thread(stress_cmd=stress_cmd,
+                                                           stats_aggregate_cmds=False,
+                                                           round_robin=self.params.get('round_robin')))
+            elif stress_cmd.startswith('cassandra-harry'):
+                stress_queue.append(self.run_stress_thread(**params))
+            else:
+                stress_queue.append(self.run_stress_thread(**params))
+
+            time.sleep(10)
+
+            # Remove "user profile" param for the next command
+            if 'profile' in params:
+                del params['profile']
+
+            if 'keyspace_name' in params:
+                del params['keyspace_name']
+
+        return stress_queue
+
+    @staticmethod
+    def _get_keyspace_name(ks_number, keyspace_pref='keyspace'):
+        return '{}{}'.format(keyspace_pref, ks_number)
+
+    def _run_cql_commands(self, cmds, node=None):
+        node = node if node else self.db_cluster.nodes[0]
+
+        if not isinstance(cmds, list):
+            cmds = [cmds]
+
+        for cmd in cmds:
+            # pylint: disable=no-member
+            with self.db_cluster.cql_connection_patient(node) as session:
+                session.execute(cmd)
+
+    def _pre_create_keyspace(self):
+        cmds = self.params.get('pre_create_keyspace')
+        self._run_cql_commands(cmds)
+
+    def run_post_prepare_cql_cmds(self):
+        if post_prepare_cql_cmds := self.params.get('post_prepare_cql_cmds'):
+            self.log.debug("Execute post prepare queries: %s", post_prepare_cql_cmds)
+            self._run_cql_commands(post_prepare_cql_cmds)
+
+    def run_prepare_write_cmd(self):
+        # In some cases (like many keyspaces), we want to create the schema (all keyspaces & tables) before the load
+        # starts - due to the heavy load, the schema propogation can take long time and c-s fails.
+        prepare_write_cmd = self.params.get('prepare_write_cmd')
+        keyspace_num = self.params.get('keyspace_num')
+        write_queue = []
+        verify_queue = []
+
+        if not prepare_write_cmd:
+            self.log.debug("No prepare write commands are configured to run. Continue with stress commands")
+            return
+        # When the load is too heavy for one loader when using MULTI-KEYSPACES, the load is spreaded evenly across
+        # the loaders (round_robin).
+        if keyspace_num > 1 and self.params.get('round_robin'):
+            self.log.debug("Using round_robin for multiple Keyspaces...")
+            for i in range(1, keyspace_num + 1):
+                keyspace_name = self._get_keyspace_name(i)
+                self._run_all_stress_cmds(write_queue, params={'stress_cmd': prepare_write_cmd,
+                                                               'keyspace_name': keyspace_name,
+                                                               'round_robin': True})
+        # Not using round_robin and all keyspaces will run on all loaders
+        else:
+            self._run_all_stress_cmds(write_queue, params={'stress_cmd': prepare_write_cmd,
+                                                           'keyspace_num': keyspace_num,
+                                                           'round_robin': self.params.get('round_robin')})
+
+        # In some cases we don't want the nemesis to run during the "prepare" stage in order to be 100% sure that
+        # all keys were written succesfully
+        if self.params.get('nemesis_during_prepare'):
+            # Wait for some data (according to the param in the yaml) to be populated, for multi keyspace need to
+            # pay attention to the fact it checks only on keyspace1
+            self.db_cluster.wait_total_space_used_per_node(keyspace=None)
+            self.db_cluster.start_nemesis()
+
+        # Wait on the queue till all threads come back.
+        # todo: we need to improve this part for some cases that threads are being killed and we don't catch it.
+        for stress in write_queue:
+            self.verify_stress_thread(cs_thread_pool=stress)
+
+        # Run nodetool flush on all nodes to make sure nothing left in memory
+        # I decided to comment this out for now, when we found the data corruption bug, we wanted to be on the safe
+        # side, but I don't think we should continue with this approach.
+        # If we decided to add this back in the future, we need to wrap it with try-except because it can run
+        # in parallel to nemesis and it will fail on one of the nodes.
+        # self._flush_all_nodes()
+
+        # In case we would like to verify all keys were written successfully before we start other stress / nemesis
+        prepare_verify_cmd = self.params.get('prepare_verify_cmd')
+        if prepare_verify_cmd:
+            self._run_all_stress_cmds(verify_queue, params={'stress_cmd': prepare_verify_cmd,
+                                                            'keyspace_num': keyspace_num})
+
+            for stress in verify_queue:
+                self.verify_stress_thread(cs_thread_pool=stress)
+
+        self.run_post_prepare_cql_cmds()
+
+        prepare_wait_no_compactions_timeout = self.params.get('prepare_wait_no_compactions_timeout')
+        if prepare_wait_no_compactions_timeout:
+            for node in self.db_cluster.nodes:
+                node.run_nodetool("compact")
+            self.wait_no_compactions_running(n=prepare_wait_no_compactions_timeout)
+        self.log.info('Prepare finished')

--- a/test-cases/scylla-operator/kubernetes-platform-upgrade.yaml
+++ b/test-cases/scylla-operator/kubernetes-platform-upgrade.yaml
@@ -1,15 +1,30 @@
-test_duration: 300
+test_duration: 360
 
-# workloads
-stress_cmd_r: cassandra-stress read no-warmup cl=QUORUM n=2010020 -schema 'keyspace=keyspace_entire_test replication(factor=3) compression=LZ4Compressor' -mode cql3 native compression=lz4 -rate threads=100 -pop seq=1..2010020 -log interval=5
-stress_cmd_w: cassandra-stress write no-warmup cl=QUORUM n=2010020 -schema 'keyspace=keyspace_entire_test replication(factor=3) compression=LZ4Compressor' -mode cql3 native compression=lz4 -rate threads=100 -pop seq=1..2010020 -log interval=5
+prepare_write_cmd: [
+    "cassandra-stress write no-warmup cl=ALL    n=10000000 -schema 'replication(factor=3)' -mode cql3 native -rate threads=100 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..10000000",
+    "cassandra-stress write no-warmup cl=ALL    n=10000000 -schema 'replication(factor=3)' -mode cql3 native -rate threads=100 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=10000001..20000000",
+    "cassandra-stress write no-warmup cl=ALL    n=10000000 -schema 'replication(factor=3)' -mode cql3 native -rate threads=100 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=20000001..30000000",
+    "cassandra-stress write no-warmup cl=ALL    n=10000000 -schema 'replication(factor=3)' -mode cql3 native -rate threads=100 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=30000001..40000000"
+]
+stress_during_entire_upgrade: "cassandra-stress read no-warmup cl=QUORUM duration=90m -schema 'replication(factor=3)' -mode cql3 native -rate 'threads=100 throttle=10000/s' -col 'size=FIXED(1024) n=FIXED(1)' -pop 'dist=gauss(1..40000000,30000000,15000000)' -log interval=5"
+stress_cmd_r: [
+    "cassandra-stress read  no-warmup cl=QUORUM n=10000000 -schema 'replication(factor=3)' -mode cql3 native -rate threads=100 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=30000001..40000000 -log interval=5",
+    "cassandra-stress read  no-warmup cl=QUORUM n=10000000 -schema 'replication(factor=3)' -mode cql3 native -rate threads=100 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=20000001..30000000 -log interval=5",
+    "cassandra-stress read  no-warmup cl=QUORUM n=10000000 -schema 'replication(factor=3)' -mode cql3 native -rate threads=100 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=10000001..20000000 -log interval=5",
+    "cassandra-stress read  no-warmup cl=QUORUM n=10000000 -schema 'replication(factor=3)' -mode cql3 native -rate threads=100 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..10000000 -log interval=5"
+]
+round_robin: true
 
 n_db_nodes: 4
 k8s_n_scylla_pods_per_cluster: 3
 
-n_loaders: 1
+n_loaders: 4
+k8s_n_loader_pods_per_cluster: 4
+k8s_loader_run_type: 'dynamic'
+
 n_monitor_nodes: 1
 
+k8s_enable_performance_tuning: true
 k8s_scylla_operator_helm_repo: 'https://storage.googleapis.com/scylla-operator-charts/latest'
 k8s_scylla_operator_chart_version: 'latest'
 k8s_scylla_operator_docker_image: ''  # default value from the Helm chart will be used


### PR DESCRIPTION
Update the 'upgrade K8S platform' test with the possibility
to pre-load data and run stress commands during the upgrade.
Such an approach is much closer to the real world.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
