### PR TITLE
fix(docker-stress): make sure params is passed

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1748,7 +1748,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             node_list=self.db_cluster.nodes,
             round_robin=round_robin,
             stop_test_on_failure=stop_test_on_failure,
-            credentials=self.db_cluster.get_db_auth()
+            credentials=self.db_cluster.get_db_auth(),
+            params=self.params,
         )
         bench_thread.run()
         scylla_encryption_options = self.params.get('scylla_encryption_options')

--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -229,7 +229,7 @@ class YcsbStressThread(DockerBasedStressThread):  # pylint: disable=too-many-ins
         if self.stress_num > 1:
             cpu_options = f'--cpuset-cpus="{cpu_idx}"'
 
-        docker = RemoteDocker(loader, self.params.get('stress_image.ycdb'),
+        docker = RemoteDocker(loader, self.params.get('stress_image.ycsb'),
                               extra_docker_opts=f'{dns_options} {cpu_options} --label shell_marker={self.shell_marker}')
         self.copy_template(docker)
         stress_cmd = self.build_stress_cmd()


### PR DESCRIPTION
changes 6d99d363fd501dec5292c05725870753cc69b910 had a two
bugs in it, fixing them:

* for scylla-bench make sure params are being passed down to
  the thread.

* fix typo in the key value in ycsb

Fix: #5217

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
