### PR TITLE
fix(artifacts_docker): remove unnecessary param

### DIFF
--- a/test-cases/artifacts/docker.yaml
+++ b/test-cases/artifacts/docker.yaml
@@ -7,7 +7,6 @@ n_loaders: 0
 n_monitor_nodes: 0
 nemesis_class_name: 'NoOpMonkey'
 scylla_linux_distro: 'ubuntu'
-scylla_version: 'latest'
 test_duration: 60
 user_prefix: 'artifacts-docker'
 system_auth_rf: 1


### PR DESCRIPTION
this unnecessary parameter was causing collect_logs
stage to fail.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
