### PR TITLE
fix(gemini_thread): enable docker host networking

### DIFF
--- a/sdcm/gemini_thread.py
+++ b/sdcm/gemini_thread.py
@@ -105,7 +105,7 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
             cpu_options = f'--cpuset-cpus="{cpu_idx}"'
 
         docker = RemoteDocker(loader, f"scylladb/hydra-loaders:gemini-{self.gemini_version}",
-                              extra_docker_opts=f'{cpu_options} --label shell_marker={self.shell_marker}')
+                              extra_docker_opts=f'{cpu_options} --label shell_marker={self.shell_marker} --network=host')
 
         if not os.path.exists(loader.logdir):
             os.makedirs(loader.logdir, exist_ok=True)


### PR DESCRIPTION
since we have metrics being read by the monitor directly
from gemini process, we should move to use host networking for
that metric to be working (some upgarde test are using that metric
to understand that the gemini command started)

one note is, that this mean that running multiple gemini commands
on the same loader at the same time, only the first is sending
metrics (it's not related to docker, seem like it always was the
case).

Fixes: #5214

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
