### PR TITLE
test(functional): docker functional test with SctConfiguration

### DIFF
--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -25,6 +25,7 @@ from sdcm.provision import provisioner_factory
 from sdcm.remote import RemoteCmdRunnerBase
 from sdcm.sct_provision import region_definition_builder
 from sdcm.utils.docker_remote import RemoteDocker
+from sdcm.sct_config import SCTConfiguration
 
 
 from unit_tests.dummy_remote import LocalNode, LocalScyllaClusterDummy
@@ -47,6 +48,13 @@ def events():
 @pytest.fixture(scope='session')
 def prom_address():
     yield start_metrics_server()
+
+
+@pytest.fixture(name="params")
+def fixture_params():
+    os.environ["SCT_CLUSTER_BACKEND"] = "docker"
+    params = SCTConfiguration()
+    yield params
 
 
 @pytest.fixture(scope='session')

--- a/unit_tests/lib/alternator_utils.py
+++ b/unit_tests/lib/alternator_utils.py
@@ -1,0 +1,27 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2020 ScyllaDB
+from sdcm.utils import alternator
+
+ALTERNATOR_PORT = 8000
+TEST_PARAMS = dict(
+    dynamodb_primarykey_type="HASH_AND_RANGE",
+    alternator_use_dns_routing=True,
+    alternator_port=ALTERNATOR_PORT,
+)
+ALTERNATOR = alternator.api.Alternator(
+    sct_params={
+        "alternator_access_key_id": None,
+        "alternator_secret_access_key": None,
+        "alternator_port": ALTERNATOR_PORT,
+    }
+)

--- a/unit_tests/test_alternator_streams_kcl.py
+++ b/unit_tests/test_alternator_streams_kcl.py
@@ -20,32 +20,56 @@ from sdcm.ycsb_thread import YcsbStressThread
 from sdcm.kcl_thread import KclStressThread, CompareTablesSizesThread
 from unit_tests.dummy_remote import LocalLoaderSetDummy
 
-pytestmark = [pytest.mark.usefixtures('events'),
-              pytest.mark.skipif(True, reason="those are integration tests only")]
+pytestmark = [
+    pytest.mark.usefixtures("events"),
+    pytest.mark.skipif(True, reason="those are integration tests only"),
+]
 
 ALTERNATOR_PORT = 8000
-TEST_PARAMS = dict(dynamodb_primarykey_type='HASH',
-                   alternator_use_dns_routing=True, alternator_port=ALTERNATOR_PORT)
-ALTERNATOR = alternator.api.Alternator(sct_params={"alternator_access_key_id": None,
-                                                   "alternator_secret_access_key": None,
-                                                   "alternator_port": ALTERNATOR_PORT})
+TEST_PARAMS = dict(
+    dynamodb_primarykey_type="HASH",
+    alternator_use_dns_routing=True,
+    alternator_port=ALTERNATOR_PORT,
+)
+ALTERNATOR = alternator.api.Alternator(
+    sct_params={
+        "alternator_access_key_id": None,
+        "alternator_secret_access_key": None,
+        "alternator_port": ALTERNATOR_PORT,
+    }
+)
 
 
-def test_01_kcl_with_ycsb(request, docker_scylla, events, params):  # pylint: disable=too-many-locals
+def test_01_kcl_with_ycsb(
+    request, docker_scylla, events, params
+):  # pylint: disable=too-many-locals
     params.update(TEST_PARAMS)
     loader_set = LocalLoaderSetDummy()
     num_of_keys = 1000
     # 1. start kcl thread and ycsb at the same time
-    ycsb_cmd = f'bin/ycsb load dynamodb  -P workloads/workloada -p recordcount={num_of_keys} -p dataintegrity=true ' \
-               f'-p insertorder=uniform -p insertcount={num_of_keys} -p fieldcount=2 -p fieldlength=5'
-    ycsb_thread = YcsbStressThread(loader_set, ycsb_cmd, node_list=[docker_scylla], timeout=600, params=params)
+    ycsb_cmd = (
+        f"bin/ycsb load dynamodb  -P workloads/workloada -p recordcount={num_of_keys} -p dataintegrity=true "
+        f"-p insertorder=uniform -p insertcount={num_of_keys} -p fieldcount=2 -p fieldlength=5"
+    )
+    ycsb_thread = YcsbStressThread(
+        loader_set, ycsb_cmd, node_list=[docker_scylla], timeout=600, params=params
+    )
 
     kcl_cmd = f"hydra-kcl -t usertable -k {num_of_keys}"
-    kcl_thread = KclStressThread(loader_set, kcl_cmd, node_list=[docker_scylla], timeout=600, params=params)
-    stress_cmd = 'table_compare interval=20; src_table="alternator_usertable".usertable; ' \
-                 'dst_table="alternator_usertable-dest"."usertable-dest"'
+    kcl_thread = KclStressThread(
+        loader_set, kcl_cmd, node_list=[docker_scylla], timeout=600, params=params
+    )
+    stress_cmd = (
+        'table_compare interval=20; src_table="alternator_usertable".usertable; '
+        'dst_table="alternator_usertable-dest"."usertable-dest"'
+    )
     compare_sizes = CompareTablesSizesThread(
-        loader_set=loader_set, stress_cmd=stress_cmd, node_list=[docker_scylla], timeout=600, params=params)
+        loader_set=loader_set,
+        stress_cmd=stress_cmd,
+        node_list=[docker_scylla],
+        timeout=600,
+        params=params,
+    )
 
     def cleanup_thread():
         ycsb_thread.kill()
@@ -62,22 +86,26 @@ def test_01_kcl_with_ycsb(request, docker_scylla, events, params):  # pylint: di
     compare_sizes.get_results()
 
     output = ycsb_thread.get_results()
-    assert 'latency mean' in output[0]
-    assert float(output[0]['latency mean']) > 0
+    assert "latency mean" in output[0]
+    assert float(output[0]["latency mean"]) > 0
 
-    assert 'latency 99th percentile' in output[0]
-    assert float(output[0]['latency 99th percentile']) > 0
+    assert "latency 99th percentile" in output[0]
+    assert float(output[0]["latency 99th percentile"]) > 0
 
     output = kcl_thread.get_results()
     logging.debug(output)
 
-    error_log_content_before = events.get_event_log_file('error.log')
+    error_log_content_before = events.get_event_log_file("error.log")
 
     # 2. do read with dataintegrity=true
-    cmd = f'bin/ycsb run dynamodb -P workloads/workloada -p recordcount={num_of_keys} -p insertorder=uniform ' \
-          f'-p insertcount={num_of_keys} -p fieldcount=2 -p fieldlength=5 -p dataintegrity=true ' \
-          f'-p operationcount={num_of_keys}'
-    ycsb_thread2 = YcsbStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=500, params=params)
+    cmd = (
+        f"bin/ycsb run dynamodb -P workloads/workloada -p recordcount={num_of_keys} -p insertorder=uniform "
+        f"-p insertcount={num_of_keys} -p fieldcount=2 -p fieldlength=5 -p dataintegrity=true "
+        f"-p operationcount={num_of_keys}"
+    )
+    ycsb_thread2 = YcsbStressThread(
+        loader_set, cmd, node_list=[docker_scylla], timeout=500, params=params
+    )
 
     def cleanup_thread2():
         ycsb_thread2.kill()
@@ -88,5 +116,5 @@ def test_01_kcl_with_ycsb(request, docker_scylla, events, params):  # pylint: di
     ycsb_thread2.get_results()
 
     # 3. check that events with errors weren't raised
-    error_log_content_after = events.get_event_log_file('error.log')
+    error_log_content_after = events.get_event_log_file("error.log")
     assert error_log_content_after == error_log_content_before

--- a/unit_tests/test_alternator_streams_kcl.py
+++ b/unit_tests/test_alternator_streams_kcl.py
@@ -15,29 +15,15 @@ import time
 import logging
 import pytest
 
-from sdcm.utils import alternator
 from sdcm.ycsb_thread import YcsbStressThread
 from sdcm.kcl_thread import KclStressThread, CompareTablesSizesThread
 from unit_tests.dummy_remote import LocalLoaderSetDummy
+from unit_tests.lib.alternator_utils import TEST_PARAMS
 
 pytestmark = [
     pytest.mark.usefixtures("events"),
     pytest.mark.skipif(True, reason="those are integration tests only"),
 ]
-
-ALTERNATOR_PORT = 8000
-TEST_PARAMS = dict(
-    dynamodb_primarykey_type="HASH",
-    alternator_use_dns_routing=True,
-    alternator_port=ALTERNATOR_PORT,
-)
-ALTERNATOR = alternator.api.Alternator(
-    sct_params={
-        "alternator_access_key_id": None,
-        "alternator_secret_access_key": None,
-        "alternator_port": ALTERNATOR_PORT,
-    }
-)
 
 
 def test_01_kcl_with_ycsb(

--- a/unit_tests/test_cassandra_harry.py
+++ b/unit_tests/test_cassandra_harry.py
@@ -16,8 +16,10 @@ import pytest
 from sdcm.cassandra_harry_thread import CassandraHarryThread
 from unit_tests.dummy_remote import LocalLoaderSetDummy
 
-pytestmark = [pytest.mark.usefixtures('events'),
-              pytest.mark.skip(reason="those are integration tests only")]
+pytestmark = [
+    pytest.mark.usefixtures("events"),
+    pytest.mark.skip(reason="those are integration tests only"),
+]
 
 
 def test_01_cassandra_harry(request, docker_scylla, events, params):
@@ -32,8 +34,10 @@ def test_01_cassandra_harry(request, docker_scylla, events, params):
     """
     loader_set = LocalLoaderSetDummy()
 
-    cmd = 'cassandra-harry -run-time 1 -run-time-unit MINUTES'
-    harry_thread = CassandraHarryThread(loader_set, cmd, node_list=[docker_scylla], timeout=5, params=params)
+    cmd = "cassandra-harry -run-time 1 -run-time-unit MINUTES"
+    harry_thread = CassandraHarryThread(
+        loader_set, cmd, node_list=[docker_scylla], timeout=5, params=params
+    )
 
     def cleanup_thread():
         harry_thread.kill()
@@ -46,6 +50,6 @@ def test_01_cassandra_harry(request, docker_scylla, events, params):
 
     # 5. check that events with the expected error were raised
     cat = file_logger.get_events_by_category()
-    assert len(cat['ERROR']) == 2
-    assert '=UNEXPECTED_STATE' in cat['ERROR'][0]
-    assert '=ERROR' in cat['ERROR'][1]
+    assert len(cat["ERROR"]) == 2
+    assert "=UNEXPECTED_STATE" in cat["ERROR"][0]
+    assert "=ERROR" in cat["ERROR"][1]

--- a/unit_tests/test_cassandra_harry.py
+++ b/unit_tests/test_cassandra_harry.py
@@ -20,7 +20,7 @@ pytestmark = [pytest.mark.usefixtures('events'),
               pytest.mark.skip(reason="those are integration tests only")]
 
 
-def test_01_cassandra_harry(request, docker_scylla, events):
+def test_01_cassandra_harry(request, docker_scylla, events, params):
     """
     Test to help integrated new version/docker images of cassandra-harry
 
@@ -33,7 +33,7 @@ def test_01_cassandra_harry(request, docker_scylla, events):
     loader_set = LocalLoaderSetDummy()
 
     cmd = 'cassandra-harry -run-time 1 -run-time-unit MINUTES'
-    harry_thread = CassandraHarryThread(loader_set, cmd, node_list=[docker_scylla], timeout=5)
+    harry_thread = CassandraHarryThread(loader_set, cmd, node_list=[docker_scylla], timeout=5, params=params)
 
     def cleanup_thread():
         harry_thread.kill()

--- a/unit_tests/test_gemini_thread.py
+++ b/unit_tests/test_gemini_thread.py
@@ -30,7 +30,7 @@ class DBCluster:  # pylint: disable=too-few-public-methods
         return [node.cql_ip_address for node in self.nodes]
 
 
-def test_01_gemini_thread(request, docker_scylla):
+def test_01_gemini_thread(request, docker_scylla, params):
     loader_set = LocalLoaderSetDummy()
     test_cluster = DBCluster([docker_scylla])
     cmd = (
@@ -44,6 +44,7 @@ def test_01_gemini_thread(request, docker_scylla):
         test_cluster=test_cluster,
         oracle_cluster=test_cluster,
         timeout=120,
+        params=params,
     )
 
     def cleanup_thread():

--- a/unit_tests/test_ndbench_thread.py
+++ b/unit_tests/test_ndbench_thread.py
@@ -5,18 +5,26 @@ import pytest
 from sdcm.ndbench_thread import NdBenchStressThread
 from unit_tests.dummy_remote import LocalLoaderSetDummy
 
-pytestmark = [pytest.mark.usefixtures('events'), pytest.mark.skip(reason="those are integration tests only")]
+pytestmark = [
+    pytest.mark.usefixtures("events"),
+    pytest.mark.skip(reason="those are integration tests only"),
+]
 
 
 def test_01_cql_api(request, docker_scylla, params):
     loader_set = LocalLoaderSetDummy()
-    cmd = 'ndbench cli.clientName=CassJavaDriverGeneric ; numKeys=20000000 ; ' \
-          'numReaders=8; numWriters=8 ; cass.writeConsistencyLevel=QUORUM ; ' \
-          'cass.readConsistencyLevel=QUORUM ; readRateLimit=7200 ; writeRateLimit=1800'
-    ndbench_thread = NdBenchStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=5, params=params)
+    cmd = (
+        "ndbench cli.clientName=CassJavaDriverGeneric ; numKeys=20000000 ; "
+        "numReaders=8; numWriters=8 ; cass.writeConsistencyLevel=QUORUM ; "
+        "cass.readConsistencyLevel=QUORUM ; readRateLimit=7200 ; writeRateLimit=1800"
+    )
+    ndbench_thread = NdBenchStressThread(
+        loader_set, cmd, node_list=[docker_scylla], timeout=5, params=params
+    )
 
     def cleanup_thread():
         ndbench_thread.kill()
+
     request.addfinalizer(cleanup_thread)
     ndbench_thread.run()
     ndbench_thread.get_results()
@@ -27,13 +35,18 @@ def test_02_cql_kill(request, docker_scylla, params):
     verifies that kill command on the NdBenchStressThread is working
     """
     loader_set = LocalLoaderSetDummy()
-    cmd = 'ndbench cli.clientName=CassJavaDriverGeneric ; numKeys=20000000 ; ' \
-          'numReaders=8; numWriters=8 ; cass.writeConsistencyLevel=QUORUM ; ' \
-          'cass.readConsistencyLevel=QUORUM ; readRateLimit=7200 ; writeRateLimit=1800'
-    ndbench_thread = NdBenchStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=500, params=params)
+    cmd = (
+        "ndbench cli.clientName=CassJavaDriverGeneric ; numKeys=20000000 ; "
+        "numReaders=8; numWriters=8 ; cass.writeConsistencyLevel=QUORUM ; "
+        "cass.readConsistencyLevel=QUORUM ; readRateLimit=7200 ; writeRateLimit=1800"
+    )
+    ndbench_thread = NdBenchStressThread(
+        loader_set, cmd, node_list=[docker_scylla], timeout=500, params=params
+    )
 
     def cleanup_thread():
         ndbench_thread.kill()
+
     request.addfinalizer(cleanup_thread)
     ndbench_thread.run()
     time.sleep(3)
@@ -45,56 +58,74 @@ def test_03_dynamodb_api(request, docker_scylla, events, params):
     """
     this test isn't working yet, since we didn't figured out a way to use ndbench with dynamodb
     """
-    critical_log_content_before = events.get_event_log_file('critical.log')
+    critical_log_content_before = events.get_event_log_file("critical.log")
 
     # start a command that would yield errors
     loader_set = LocalLoaderSetDummy()
-    cmd = f'ndbench cli.clientName=DynamoDBKeyValue ; numKeys=20000000 ; ' \
-          f'numReaders=8; numWriters=8 ; readRateLimit=7200 ; writeRateLimit=1800; ' \
-          f'dynamodb.autoscaling=false; dynamodb.endpoint=http://{docker_scylla.internal_ip_address}:8000'
-    ndbench_thread = NdBenchStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=20, params=params)
+    cmd = (
+        f"ndbench cli.clientName=DynamoDBKeyValue ; numKeys=20000000 ; "
+        f"numReaders=8; numWriters=8 ; readRateLimit=7200 ; writeRateLimit=1800; "
+        f"dynamodb.autoscaling=false; dynamodb.endpoint=http://{docker_scylla.internal_ip_address}:8000"
+    )
+    ndbench_thread = NdBenchStressThread(
+        loader_set, cmd, node_list=[docker_scylla], timeout=20, params=params
+    )
 
     def cleanup_thread():
         ndbench_thread.kill()
+
     request.addfinalizer(cleanup_thread)
 
     ndbench_thread.run()
     ndbench_thread.get_results()
 
     # check that events with the errors were sent out
-    critical_log_content_after = events.wait_for_event_log_change('critical.log', critical_log_content_before)
+    critical_log_content_after = events.wait_for_event_log_change(
+        "critical.log", critical_log_content_before
+    )
 
-    assert 'Encountered an exception when driving load' in critical_log_content_after
-    assert 'BUILD FAILED' in critical_log_content_after
+    assert "Encountered an exception when driving load" in critical_log_content_after
+    assert "BUILD FAILED" in critical_log_content_after
 
 
 def test_04_verify_data(request, docker_scylla, events, params):
     loader_set = LocalLoaderSetDummy()
-    cmd = 'ndbench cli.clientName=CassJavaDriverGeneric ; numKeys=30 ; ' \
-          'readEnabled=false; numReaders=0; numWriters=1 ; cass.writeConsistencyLevel=QUORUM ; ' \
-          'cass.readConsistencyLevel=QUORUM ; generateChecksum=false'
-    ndbench_thread = NdBenchStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=30, params=params)
+    cmd = (
+        "ndbench cli.clientName=CassJavaDriverGeneric ; numKeys=30 ; "
+        "readEnabled=false; numReaders=0; numWriters=1 ; cass.writeConsistencyLevel=QUORUM ; "
+        "cass.readConsistencyLevel=QUORUM ; generateChecksum=false"
+    )
+    ndbench_thread = NdBenchStressThread(
+        loader_set, cmd, node_list=[docker_scylla], timeout=30, params=params
+    )
 
     def cleanup_thread():
         ndbench_thread.kill()
+
     request.addfinalizer(cleanup_thread)
 
     ndbench_thread.run()
     ndbench_thread.get_results()
 
-    cmd = 'ndbench cli.clientName=CassJavaDriverGeneric ; numKeys=30 ; ' \
-          'writeEnabled=false; numReaders=1; numWriters=0 ; cass.writeConsistencyLevel=QUORUM ; ' \
-          'cass.readConsistencyLevel=QUORUM ; validateChecksum=true ;'
-    ndbench_thread2 = NdBenchStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=30, params=params)
+    cmd = (
+        "ndbench cli.clientName=CassJavaDriverGeneric ; numKeys=30 ; "
+        "writeEnabled=false; numReaders=1; numWriters=0 ; cass.writeConsistencyLevel=QUORUM ; "
+        "cass.readConsistencyLevel=QUORUM ; validateChecksum=true ;"
+    )
+    ndbench_thread2 = NdBenchStressThread(
+        loader_set, cmd, node_list=[docker_scylla], timeout=30, params=params
+    )
 
     def cleanup_thread2():
         ndbench_thread2.kill()
 
     request.addfinalizer(cleanup_thread2)
 
-    critical_log_content_before = events.get_event_log_file('critical.log')
+    critical_log_content_before = events.get_event_log_file("critical.log")
     ndbench_thread2.run()
 
     time.sleep(15)
-    critical_log_content_after = events.wait_for_event_log_change('critical.log', critical_log_content_before)
-    assert 'Failed to process NdBench read operation' in critical_log_content_after
+    critical_log_content_after = events.wait_for_event_log_change(
+        "critical.log", critical_log_content_before
+    )
+    assert "Failed to process NdBench read operation" in critical_log_content_after

--- a/unit_tests/test_ndbench_thread.py
+++ b/unit_tests/test_ndbench_thread.py
@@ -8,12 +8,12 @@ from unit_tests.dummy_remote import LocalLoaderSetDummy
 pytestmark = [pytest.mark.usefixtures('events'), pytest.mark.skip(reason="those are integration tests only")]
 
 
-def test_01_cql_api(request, docker_scylla):
+def test_01_cql_api(request, docker_scylla, params):
     loader_set = LocalLoaderSetDummy()
     cmd = 'ndbench cli.clientName=CassJavaDriverGeneric ; numKeys=20000000 ; ' \
           'numReaders=8; numWriters=8 ; cass.writeConsistencyLevel=QUORUM ; ' \
           'cass.readConsistencyLevel=QUORUM ; readRateLimit=7200 ; writeRateLimit=1800'
-    ndbench_thread = NdBenchStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=5)
+    ndbench_thread = NdBenchStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=5, params=params)
 
     def cleanup_thread():
         ndbench_thread.kill()
@@ -22,7 +22,7 @@ def test_01_cql_api(request, docker_scylla):
     ndbench_thread.get_results()
 
 
-def test_02_cql_kill(request, docker_scylla):
+def test_02_cql_kill(request, docker_scylla, params):
     """
     verifies that kill command on the NdBenchStressThread is working
     """
@@ -30,7 +30,7 @@ def test_02_cql_kill(request, docker_scylla):
     cmd = 'ndbench cli.clientName=CassJavaDriverGeneric ; numKeys=20000000 ; ' \
           'numReaders=8; numWriters=8 ; cass.writeConsistencyLevel=QUORUM ; ' \
           'cass.readConsistencyLevel=QUORUM ; readRateLimit=7200 ; writeRateLimit=1800'
-    ndbench_thread = NdBenchStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=500)
+    ndbench_thread = NdBenchStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=500, params=params)
 
     def cleanup_thread():
         ndbench_thread.kill()
@@ -41,7 +41,7 @@ def test_02_cql_kill(request, docker_scylla):
     ndbench_thread.get_results()
 
 
-def test_03_dynamodb_api(request, docker_scylla, events):
+def test_03_dynamodb_api(request, docker_scylla, events, params):
     """
     this test isn't working yet, since we didn't figured out a way to use ndbench with dynamodb
     """
@@ -52,7 +52,7 @@ def test_03_dynamodb_api(request, docker_scylla, events):
     cmd = f'ndbench cli.clientName=DynamoDBKeyValue ; numKeys=20000000 ; ' \
           f'numReaders=8; numWriters=8 ; readRateLimit=7200 ; writeRateLimit=1800; ' \
           f'dynamodb.autoscaling=false; dynamodb.endpoint=http://{docker_scylla.internal_ip_address}:8000'
-    ndbench_thread = NdBenchStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=20)
+    ndbench_thread = NdBenchStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=20, params=params)
 
     def cleanup_thread():
         ndbench_thread.kill()
@@ -68,12 +68,12 @@ def test_03_dynamodb_api(request, docker_scylla, events):
     assert 'BUILD FAILED' in critical_log_content_after
 
 
-def test_04_verify_data(request, docker_scylla, events):
+def test_04_verify_data(request, docker_scylla, events, params):
     loader_set = LocalLoaderSetDummy()
     cmd = 'ndbench cli.clientName=CassJavaDriverGeneric ; numKeys=30 ; ' \
           'readEnabled=false; numReaders=0; numWriters=1 ; cass.writeConsistencyLevel=QUORUM ; ' \
           'cass.readConsistencyLevel=QUORUM ; generateChecksum=false'
-    ndbench_thread = NdBenchStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=30)
+    ndbench_thread = NdBenchStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=30, params=params)
 
     def cleanup_thread():
         ndbench_thread.kill()
@@ -85,7 +85,7 @@ def test_04_verify_data(request, docker_scylla, events):
     cmd = 'ndbench cli.clientName=CassJavaDriverGeneric ; numKeys=30 ; ' \
           'writeEnabled=false; numReaders=1; numWriters=0 ; cass.writeConsistencyLevel=QUORUM ; ' \
           'cass.readConsistencyLevel=QUORUM ; validateChecksum=true ;'
-    ndbench_thread2 = NdBenchStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=30)
+    ndbench_thread2 = NdBenchStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=30, params=params)
 
     def cleanup_thread2():
         ndbench_thread2.kill()

--- a/unit_tests/test_scylla_bench_thread.py
+++ b/unit_tests/test_scylla_bench_thread.py
@@ -49,7 +49,7 @@ def create_cql_ks_and_table(docker_scylla):
         session.execute(create_table_query)
 
 
-def test_01_scylla_bench(request, docker_scylla):
+def test_01_scylla_bench(request, docker_scylla, params):
     loader_set = LocalLoaderSetDummy()
 
     cmd = (
@@ -58,7 +58,7 @@ def test_01_scylla_bench(request, docker_scylla):
         + "-connection-count=10 -consistency-level=one -rows-per-request=10 -timeout=60s -duration=1m"
     )
     bench_thread = ScyllaBenchThread(
-        loader_set=loader_set, stress_cmd=cmd, node_list=[docker_scylla], timeout=120
+        loader_set=loader_set, stress_cmd=cmd, node_list=[docker_scylla], timeout=120, params=params
     )
 
     def cleanup_thread():

--- a/unit_tests/test_scylla_bench_thread.py
+++ b/unit_tests/test_scylla_bench_thread.py
@@ -58,7 +58,11 @@ def test_01_scylla_bench(request, docker_scylla, params):
         + "-connection-count=10 -consistency-level=one -rows-per-request=10 -timeout=60s -duration=1m"
     )
     bench_thread = ScyllaBenchThread(
-        loader_set=loader_set, stress_cmd=cmd, node_list=[docker_scylla], timeout=120, params=params
+        loader_set=loader_set,
+        stress_cmd=cmd,
+        node_list=[docker_scylla],
+        timeout=120,
+        params=params,
     )
 
     def cleanup_thread():

--- a/unit_tests/test_ycsb_thread.py
+++ b/unit_tests/test_ycsb_thread.py
@@ -22,25 +22,12 @@ from sdcm.utils.decorators import timeout
 from sdcm.utils.docker_utils import running_in_docker
 from sdcm.ycsb_thread import YcsbStressThread
 from unit_tests.dummy_remote import LocalLoaderSetDummy
+from unit_tests.lib.alternator_utils import ALTERNATOR_PORT, ALTERNATOR, TEST_PARAMS
 
 pytestmark = [
     pytest.mark.usefixtures("events", "create_table", "create_cql_ks_and_table"),
     pytest.mark.skip(reason="those are integration tests only"),
 ]
-
-ALTERNATOR_PORT = 8000
-TEST_PARAMS = dict(
-    dynamodb_primarykey_type="HASH_AND_RANGE",
-    alternator_use_dns_routing=True,
-    alternator_port=ALTERNATOR_PORT,
-)
-ALTERNATOR = alternator.api.Alternator(
-    sct_params={
-        "alternator_access_key_id": None,
-        "alternator_secret_access_key": None,
-        "alternator_port": ALTERNATOR_PORT,
-    }
-)
 
 
 @pytest.fixture(scope="session")

--- a/unit_tests/test_ycsb_thread.py
+++ b/unit_tests/test_ycsb_thread.py
@@ -77,12 +77,13 @@ def create_cql_ks_and_table(docker_scylla):
                         field9 varchar);""")
 
 
-def test_01_dynamodb_api(request, docker_scylla, prom_address):
+def test_01_dynamodb_api(request, docker_scylla, prom_address, params):
     loader_set = LocalLoaderSetDummy()
+    params.update(TEST_PARAMS)
 
     cmd = 'bin/ycsb run dynamodb -P workloads/workloada -threads 5 -p recordcount=1000000 ' \
           '-p fieldcount=10 -p fieldlength=1024 -p operationcount=200200300 -s'
-    ycsb_thread = YcsbStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=5, params=TEST_PARAMS)
+    ycsb_thread = YcsbStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=5, params=params)
 
     def cleanup_thread():
         ycsb_thread.kill()
@@ -111,13 +112,14 @@ def test_01_dynamodb_api(request, docker_scylla, prom_address):
     assert float(output[0]['latency 99th percentile']) > 0
 
 
-def test_02_dynamodb_api_dataintegrity(request, docker_scylla, prom_address, events):
+def test_02_dynamodb_api_dataintegrity(request, docker_scylla, prom_address, events, params):
     loader_set = LocalLoaderSetDummy()
+    params.update(TEST_PARAMS)
 
     # 2. do write without dataintegrity=true
     cmd = 'bin/ycsb load dynamodb -P workloads/workloada -threads 5 ' \
           '-p recordcount=50 -p fieldcount=1 -p fieldlength=100'
-    ycsb_thread1 = YcsbStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=30, params=TEST_PARAMS)
+    ycsb_thread1 = YcsbStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=30, params=params)
 
     def cleanup_thread1():
         ycsb_thread1.kill()
@@ -131,7 +133,7 @@ def test_02_dynamodb_api_dataintegrity(request, docker_scylla, prom_address, eve
     # 3. do read with dataintegrity=true
     cmd = 'bin/ycsb run dynamodb -P workloads/workloada -threads 5 -p recordcount=100 ' \
           '-p fieldcount=10 -p fieldlength=512 -p dataintegrity=true -p operationcount=30000'
-    ycsb_thread2 = YcsbStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=30, params=TEST_PARAMS)
+    ycsb_thread2 = YcsbStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=30, params=params)
 
     def cleanup_thread2():
         ycsb_thread2.kill()
@@ -163,12 +165,13 @@ def test_02_dynamodb_api_dataintegrity(request, docker_scylla, prom_address, eve
     assert '=ERROR' in cat['ERROR'][1]
 
 
-def test_03_cql(request, docker_scylla, prom_address):
+def test_03_cql(request, docker_scylla, prom_address, params):
     loader_set = LocalLoaderSetDummy()
+    params.update(TEST_PARAMS)
 
     cmd = 'bin/ycsb load scylla -P workloads/workloada -threads 5 -p recordcount=1000000 ' \
           f'-p fieldcount=10 -p fieldlength=1024 -p operationcount=200200300 -p scylla.hosts={docker_scylla.ip_address} -s'
-    ycsb_thread = YcsbStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=5, params=TEST_PARAMS)
+    ycsb_thread = YcsbStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=5, params=params)
 
     def cleanup_thread():
         ycsb_thread.kill()

--- a/unit_tests/test_ycsb_thread.py
+++ b/unit_tests/test_ycsb_thread.py
@@ -15,6 +15,7 @@ import re
 
 import pytest
 import requests
+from cassandra.cluster import Cluster  # pylint: disable=no-name-in-module
 
 from sdcm.utils import alternator
 from sdcm.utils.decorators import timeout
@@ -22,25 +23,34 @@ from sdcm.utils.docker_utils import running_in_docker
 from sdcm.ycsb_thread import YcsbStressThread
 from unit_tests.dummy_remote import LocalLoaderSetDummy
 
-pytestmark = [pytest.mark.usefixtures('events', 'create_table', 'create_cql_ks_and_table'),
-              pytest.mark.skip(reason="those are integration tests only")]
+pytestmark = [
+    pytest.mark.usefixtures("events", "create_table", "create_cql_ks_and_table"),
+    pytest.mark.skip(reason="those are integration tests only"),
+]
 
 ALTERNATOR_PORT = 8000
-TEST_PARAMS = dict(dynamodb_primarykey_type='HASH_AND_RANGE',
-                   alternator_use_dns_routing=True, alternator_port=ALTERNATOR_PORT)
-ALTERNATOR = alternator.api.Alternator(sct_params={"alternator_access_key_id": None,
-                                                   "alternator_secret_access_key": None,
-                                                   "alternator_port": ALTERNATOR_PORT})
+TEST_PARAMS = dict(
+    dynamodb_primarykey_type="HASH_AND_RANGE",
+    alternator_use_dns_routing=True,
+    alternator_port=ALTERNATOR_PORT,
+)
+ALTERNATOR = alternator.api.Alternator(
+    sct_params={
+        "alternator_access_key_id": None,
+        "alternator_secret_access_key": None,
+        "alternator_port": ALTERNATOR_PORT,
+    }
+)
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def create_table(docker_scylla):
     def create_endpoint_url(node):
         if running_in_docker():
-            endpoint_url = f'http://{node.internal_ip_address}:{ALTERNATOR_PORT}'
+            endpoint_url = f"http://{node.internal_ip_address}:{ALTERNATOR_PORT}"
         else:
-            address = node.get_port(f'{ALTERNATOR_PORT}')
-            endpoint_url = f'http://{address}'
+            address = node.get_port(f"{ALTERNATOR_PORT}")
+            endpoint_url = f"http://{address}"
         return endpoint_url
 
     setattr(docker_scylla, "name", "mock-node")
@@ -49,21 +59,22 @@ def create_table(docker_scylla):
     ALTERNATOR.create_table(node=docker_scylla, table_name=alternator.consts.TABLE_NAME)
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def create_cql_ks_and_table(docker_scylla):
     if running_in_docker():
-        address = f'{docker_scylla.internal_ip_address}:9042'
+        address = f"{docker_scylla.internal_ip_address}:9042"
     else:
-        address = docker_scylla.get_port('9042')
-    node_ip, port = address.split(':')
+        address = docker_scylla.get_port("9042")
+    node_ip, port = address.split(":")
     port = int(port)
 
-    from cassandra.cluster import Cluster  # pylint: disable=no-name-in-module,import-outside-toplevel
     cluster_driver = Cluster([node_ip], port=port)
     session = cluster_driver.connect()
     session.execute(
-        """create keyspace ycsb WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor': 1 };""")
-    session.execute("""CREATE TABLE ycsb.usertable (
+        """create keyspace ycsb WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor': 1 };"""
+    )
+    session.execute(
+        """CREATE TABLE ycsb.usertable (
                         y_id varchar primary key,
                         field0 varchar,
                         field1 varchar,
@@ -74,16 +85,21 @@ def create_cql_ks_and_table(docker_scylla):
                         field6 varchar,
                         field7 varchar,
                         field8 varchar,
-                        field9 varchar);""")
+                        field9 varchar);"""
+    )
 
 
 def test_01_dynamodb_api(request, docker_scylla, prom_address, params):
     loader_set = LocalLoaderSetDummy()
     params.update(TEST_PARAMS)
 
-    cmd = 'bin/ycsb run dynamodb -P workloads/workloada -threads 5 -p recordcount=1000000 ' \
-          '-p fieldcount=10 -p fieldlength=1024 -p operationcount=200200300 -s'
-    ycsb_thread = YcsbStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=5, params=params)
+    cmd = (
+        "bin/ycsb run dynamodb -P workloads/workloada -threads 5 -p recordcount=1000000 "
+        "-p fieldcount=10 -p fieldlength=1024 -p operationcount=200200300 -s"
+    )
+    ycsb_thread = YcsbStressThread(
+        loader_set, cmd, node_list=[docker_scylla], timeout=5, params=params
+    )
 
     def cleanup_thread():
         ycsb_thread.kill()
@@ -95,9 +111,9 @@ def test_01_dynamodb_api(request, docker_scylla, prom_address, params):
     @timeout(timeout=60)
     def check_metrics():
         output = requests.get("http://{}/metrics".format(prom_address)).text
-        regex = re.compile(r'^collectd_ycsb_read_gauge.*?([0-9\.]*?)$', re.MULTILINE)
-        assert 'collectd_ycsb_read_gauge' in output
-        assert 'collectd_ycsb_update_gauge' in output
+        regex = re.compile(r"^collectd_ycsb_read_gauge.*?([0-9\.]*?)$", re.MULTILINE)
+        assert "collectd_ycsb_read_gauge" in output
+        assert "collectd_ycsb_update_gauge" in output
 
         matches = regex.findall(output)
         assert all(float(i) > 0 for i in matches), output
@@ -105,21 +121,27 @@ def test_01_dynamodb_api(request, docker_scylla, prom_address, params):
     check_metrics()
 
     output = ycsb_thread.get_results()
-    assert 'latency mean' in output[0]
-    assert float(output[0]['latency mean']) > 0
+    assert "latency mean" in output[0]
+    assert float(output[0]["latency mean"]) > 0
 
-    assert 'latency 99th percentile' in output[0]
-    assert float(output[0]['latency 99th percentile']) > 0
+    assert "latency 99th percentile" in output[0]
+    assert float(output[0]["latency 99th percentile"]) > 0
 
 
-def test_02_dynamodb_api_dataintegrity(request, docker_scylla, prom_address, events, params):
+def test_02_dynamodb_api_dataintegrity(
+    request, docker_scylla, prom_address, events, params
+):
     loader_set = LocalLoaderSetDummy()
     params.update(TEST_PARAMS)
 
     # 2. do write without dataintegrity=true
-    cmd = 'bin/ycsb load dynamodb -P workloads/workloada -threads 5 ' \
-          '-p recordcount=50 -p fieldcount=1 -p fieldlength=100'
-    ycsb_thread1 = YcsbStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=30, params=params)
+    cmd = (
+        "bin/ycsb load dynamodb -P workloads/workloada -threads 5 "
+        "-p recordcount=50 -p fieldcount=1 -p fieldlength=100"
+    )
+    ycsb_thread1 = YcsbStressThread(
+        loader_set, cmd, node_list=[docker_scylla], timeout=30, params=params
+    )
 
     def cleanup_thread1():
         ycsb_thread1.kill()
@@ -131,9 +153,13 @@ def test_02_dynamodb_api_dataintegrity(request, docker_scylla, prom_address, eve
     ycsb_thread1.kill()
 
     # 3. do read with dataintegrity=true
-    cmd = 'bin/ycsb run dynamodb -P workloads/workloada -threads 5 -p recordcount=100 ' \
-          '-p fieldcount=10 -p fieldlength=512 -p dataintegrity=true -p operationcount=30000'
-    ycsb_thread2 = YcsbStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=30, params=params)
+    cmd = (
+        "bin/ycsb run dynamodb -P workloads/workloada -threads 5 -p recordcount=100 "
+        "-p fieldcount=10 -p fieldlength=512 -p dataintegrity=true -p operationcount=30000"
+    )
+    ycsb_thread2 = YcsbStressThread(
+        loader_set, cmd, node_list=[docker_scylla], timeout=30, params=params
+    )
 
     def cleanup_thread2():
         ycsb_thread2.kill()
@@ -144,9 +170,9 @@ def test_02_dynamodb_api_dataintegrity(request, docker_scylla, prom_address, eve
     @timeout(timeout=120)
     def check_metrics():
         output = requests.get("http://{}/metrics".format(prom_address)).text
-        regex = re.compile(r'^collectd_ycsb_verify_gauge.*?([0-9\.]*?)$', re.MULTILINE)
+        regex = re.compile(r"^collectd_ycsb_verify_gauge.*?([0-9\.]*?)$", re.MULTILINE)
 
-        assert 'collectd_ycsb_verify_gauge' in output
+        assert "collectd_ycsb_verify_gauge" in output
         assert 'type="UNEXPECTED_STATE"' in output
         assert 'type="ERROR"' in output
         matches = regex.findall(output)
@@ -160,18 +186,22 @@ def test_02_dynamodb_api_dataintegrity(request, docker_scylla, prom_address, eve
 
     # 5. check that events with the expected error were raised
     cat = file_logger.get_events_by_category()
-    assert len(cat['ERROR']) == 2
-    assert '=UNEXPECTED_STATE' in cat['ERROR'][0]
-    assert '=ERROR' in cat['ERROR'][1]
+    assert len(cat["ERROR"]) == 2
+    assert "=UNEXPECTED_STATE" in cat["ERROR"][0]
+    assert "=ERROR" in cat["ERROR"][1]
 
 
 def test_03_cql(request, docker_scylla, prom_address, params):
     loader_set = LocalLoaderSetDummy()
     params.update(TEST_PARAMS)
 
-    cmd = 'bin/ycsb load scylla -P workloads/workloada -threads 5 -p recordcount=1000000 ' \
-          f'-p fieldcount=10 -p fieldlength=1024 -p operationcount=200200300 -p scylla.hosts={docker_scylla.ip_address} -s'
-    ycsb_thread = YcsbStressThread(loader_set, cmd, node_list=[docker_scylla], timeout=5, params=params)
+    cmd = (
+        "bin/ycsb load scylla -P workloads/workloada -threads 5 -p recordcount=1000000 "
+        f"-p fieldcount=10 -p fieldlength=1024 -p operationcount=200200300 -p scylla.hosts={docker_scylla.ip_address} -s"
+    )
+    ycsb_thread = YcsbStressThread(
+        loader_set, cmd, node_list=[docker_scylla], timeout=5, params=params
+    )
 
     def cleanup_thread():
         ycsb_thread.kill()
@@ -183,9 +213,9 @@ def test_03_cql(request, docker_scylla, prom_address, params):
     @timeout(timeout=60)
     def check_metrics():
         output = requests.get("http://{}/metrics".format(prom_address)).text
-        regex = re.compile(r'^collectd_ycsb_read_gauge.*?([0-9\.]*?)$', re.MULTILINE)
-        assert 'collectd_ycsb_read_gauge' in output
-        assert 'collectd_ycsb_update_gauge' in output
+        regex = re.compile(r"^collectd_ycsb_read_gauge.*?([0-9\.]*?)$", re.MULTILINE)
+        assert "collectd_ycsb_read_gauge" in output
+        assert "collectd_ycsb_update_gauge" in output
 
         matches = regex.findall(output)
         assert all(float(i) > 0 for i in matches), output
@@ -197,18 +227,23 @@ def test_03_cql(request, docker_scylla, prom_address, params):
 def test_04_insert_new_data(docker_scylla):
     schema = alternator.schemas.HASH_AND_STR_RANGE_SCHEMA
     schema_keys = [key_details["AttributeName"] for key_details in schema["KeySchema"]]
-    new_items = [{schema_keys[0]: 'test_0', schema_keys[1]: 'NFinQpNuCnaNOxsAkyrZ'},
-                 {schema_keys[0]: 'test_1', schema_keys[1]: 'hScfTVnCctqqTQcLrIQd'},
-                 {schema_keys[0]: 'test_2', schema_keys[1]: 'OpvrbHJNNMHptWYQSWvm'},
-                 {schema_keys[0]: 'test_3', schema_keys[1]: 'nzxHPebRwNaxLlXUbbCW'},
-                 {schema_keys[0]: 'test_4', schema_keys[1]: 'WfHQIwRNHflFHYWwOcFA'},
-                 {schema_keys[0]: 'test_5', schema_keys[1]: 'ipcTlIvLbcbrOFDynEBU'},
-                 {schema_keys[0]: 'test_6', schema_keys[1]: 'judYKbqgDAejlpPdqLdx'},
-                 {schema_keys[0]: 'test_7', schema_keys[1]: 'mMYdekljccLeOMWLBTLL'},
-                 {schema_keys[0]: 'test_8', schema_keys[1]: 'NqsNVTtJeWRzrjHmOwop'},
-                 {schema_keys[0]: 'test_9', schema_keys[1]: 'YrRvsqXAtppgCLiHhiQn'}]
+    new_items = [
+        {schema_keys[0]: "test_0", schema_keys[1]: "NFinQpNuCnaNOxsAkyrZ"},
+        {schema_keys[0]: "test_1", schema_keys[1]: "hScfTVnCctqqTQcLrIQd"},
+        {schema_keys[0]: "test_2", schema_keys[1]: "OpvrbHJNNMHptWYQSWvm"},
+        {schema_keys[0]: "test_3", schema_keys[1]: "nzxHPebRwNaxLlXUbbCW"},
+        {schema_keys[0]: "test_4", schema_keys[1]: "WfHQIwRNHflFHYWwOcFA"},
+        {schema_keys[0]: "test_5", schema_keys[1]: "ipcTlIvLbcbrOFDynEBU"},
+        {schema_keys[0]: "test_6", schema_keys[1]: "judYKbqgDAejlpPdqLdx"},
+        {schema_keys[0]: "test_7", schema_keys[1]: "mMYdekljccLeOMWLBTLL"},
+        {schema_keys[0]: "test_8", schema_keys[1]: "NqsNVTtJeWRzrjHmOwop"},
+        {schema_keys[0]: "test_9", schema_keys[1]: "YrRvsqXAtppgCLiHhiQn"},
+    ]
 
-    ALTERNATOR.batch_write_actions(node=docker_scylla, new_items=new_items,
-                                   schema=alternator.schemas.HASH_AND_STR_RANGE_SCHEMA)
+    ALTERNATOR.batch_write_actions(
+        node=docker_scylla,
+        new_items=new_items,
+        schema=alternator.schemas.HASH_AND_STR_RANGE_SCHEMA,
+    )
     diff = ALTERNATOR.compare_table_data(node=docker_scylla, table_data=new_items)
     assert diff


### PR DESCRIPTION
since now all those docker based tests are reading the docker
images from configuration, it should have the default configuration
to get any of the docker images

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
