### PR TITLE
fix(SCTDashboard): increase screenshot size

### DIFF
--- a/sdcm/monitorstack/ui.py
+++ b/sdcm/monitorstack/ui.py
@@ -166,7 +166,7 @@ class ServerMetricsNemesisDashboard(Dashboard):
     name = f'{test_name}scylla-per-server-metrics-nemesis'
     title = 'Scylla Per Server Metrics Nemesis'
     path = 'dashboard/db/{dashboard_name}-{version}'
-    resolution = '1920px*8000px'
+    resolution = '1920px*15000px'
     panels = [Panel("Total Requests"),
               Panel("Load per Instance"),
               Panel("Requests Served per Instance"),


### PR DESCRIPTION
 After new panels were added to sct dashboard,
 the old size of screenshot is not enough,
 because several first panels are scroll out
 from view.

refers to: https://github.com/scylladb/scylla-cluster-tests/issues/5224
    
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
