### PR TITLE
fix(data validator): fix order of views list

### DIFF
--- a/sdcm/utils/data_validator.py
+++ b/sdcm/utils/data_validator.py
@@ -205,13 +205,8 @@ class LongevityDataValidator:
         """
         if not self._mvs_for_updated_data:
             mvs_names = self.get_view_name_from_profile(self.SUFFIX_FOR_VIEW_AFTER_UPDATE, all_entries=True)
-            # Cover the case when there are 2 MVs in the profile with same prefix in the name. After replacing of
-            # SUFFIX_FOR_VIEW_AFTER_UPDATE from the name, two views with same names will be in the list. In this case
-            # creation table failure will be received.
-            # Example:
-            # blogposts_update_one_column_lwt_indicator AND blogposts_update_one_column_lwt_indicator_after_update
-            self._mvs_for_updated_data = list(set(view_name.replace(self.SUFFIX_FOR_VIEW_AFTER_UPDATE, '')
-                                                  for view_name in mvs_names))
+            self._mvs_for_updated_data = [view_name.replace(self.SUFFIX_FOR_VIEW_AFTER_UPDATE, '')
+                                          for view_name in mvs_names]
         return self._mvs_for_updated_data
 
     @property
@@ -270,7 +265,7 @@ class LongevityDataValidator:
 
         if not cs_profile:
             stress_cmd = self.longevity_self_object.params.get(self.stress_cmds_part) or []
-            cs_profile = [cmd for cmd in stress_cmd if self.user_profile_name in cmd]
+            cs_profile = list(set(cmd for cmd in stress_cmd if self.user_profile_name in cmd))
 
         if not cs_profile:
             return mv_names
@@ -289,9 +284,7 @@ class LongevityDataValidator:
                     if not all_entries:
                         break
 
-        # If same user profile is called in parallel, the same MVs will be included few time in the list and test data
-        # will be copied a few times. Return list of unique MVs to prevent to duplicate of copying test data
-        return list(set(mv_names))
+        return mv_names
 
     @staticmethod
     def get_view_cmd_from_profile(profile_content, name_substr, all_entries=False):


### PR DESCRIPTION
Order of views that is taken from user profile have to be same for views before update and after update.
Set() is used to prevent names duplication. But set is unordered data structure, so it does not preserve the insertion order. It may cause the validation problem - compare data with not expected view.

Test passed:
https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/staging-4.1-longevity-lwt-3h/53/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
