### PR TITLE
test(unittest): data validator

### DIFF
--- a/sdcm/utils/data_validator.py
+++ b/sdcm/utils/data_validator.py
@@ -461,6 +461,14 @@ class LongevityDataValidator:
                     LOGGER.debug('Verify immutable rows. Actual dataset length: %s, Expected dataset length: %s',
                                  len(actual_result), len(expected_result))
 
+    def list_of_view_names_for_update_test(self):
+        # List of tuples of correlated  view names for validation: before update, after update, expected data
+        return list(zip(self.view_names_for_updated_data,
+                        self.view_names_after_updated_data,
+                        [self.set_expected_data_table_name(view) for view in
+                         self.view_names_for_updated_data],
+                        self._validate_updated_per_view, ))
+
     def validate_range_expected_to_change(self, session, during_nemesis=False):
         """
         In user profile 'data_dir/c-s_lwt_basic.yaml' LWT updates the lwt_indicator and author columns with hard coded
@@ -487,13 +495,7 @@ class LongevityDataValidator:
 
         partition_keys = ', '.join(self.base_table_partition_keys)
 
-        # List of tuples of correlated  view names for validation: before update, after update, expected data
-        views_list = list(zip(self.view_names_for_updated_data,
-                              self.view_names_after_updated_data,
-                              [self.set_expected_data_table_name(view) for view in
-                               self.view_names_for_updated_data],
-                              self._validate_updated_per_view, ))
-        for views_set in views_list:
+        for views_set in self.list_of_view_names_for_update_test():
             # views_set[0] - view name with rows before update
             # views_set[1] - view name with rows after update
             # views_set[2] - view name with all expected partition keys

--- a/unit_tests/test_data/test_data_validator/lwt-basic-3h.yaml
+++ b/unit_tests/test_data/test_data_validator/lwt-basic-3h.yaml
@@ -1,0 +1,12 @@
+test_duration: 300
+prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml n=10000000 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=30",
+                    "cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml n=10000000 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=30",
+                    "cassandra-stress user profile=/tmp/lwt_builtin_functions.yaml n=1000000 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=20"]
+stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=QUORUM duration=160m -mode native cql3 -rate threads=20",
+             "cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=QUORUM duration=160m -mode native cql3 -rate threads=20",
+             "cassandra-stress user profile=/tmp/lwt_builtin_functions.yaml ops'(lwt_update_by_pk=1,lwt_update_by_ck=1)' cl=QUORUM duration=160m -mode native cql3 -rate threads=10"
+            ]
+stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(select=1)' cl=SERIAL duration=160m -mode native cql3 -rate threads=20" ]
+
+user_prefix: 'longevity-sla-3h'
+n_db_nodes: 4

--- a/unit_tests/test_data/test_data_validator/no-validation-views-lwt-basic-3h.yaml
+++ b/unit_tests/test_data/test_data_validator/no-validation-views-lwt-basic-3h.yaml
@@ -1,0 +1,10 @@
+test_duration: 300
+prepare_write_cmd: ["cassandra-stress user profile=/tmp/lwt_builtin_functions.yaml n=1000000 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=20"]
+stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=QUORUM duration=160m -mode native cql3 -rate threads=20",
+             "cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1)' cl=QUORUM duration=160m -mode native cql3 -rate threads=20",
+             "cassandra-stress user profile=/tmp/lwt_builtin_functions.yaml ops'(lwt_update_by_pk=1,lwt_update_by_ck=1)' cl=QUORUM duration=160m -mode native cql3 -rate threads=10"
+            ]
+stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_basic.yaml ops'(select=1)' cl=SERIAL duration=160m -mode native cql3 -rate threads=20" ]
+
+user_prefix: 'longevity-sla-3h'
+n_db_nodes: 4

--- a/unit_tests/test_utils_data_validator.py
+++ b/unit_tests/test_utils_data_validator.py
@@ -1,0 +1,49 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2022 ScyllaDB
+from dataclasses import dataclass
+
+import pytest
+
+from sdcm.utils.data_validator import LongevityDataValidator
+from sdcm import sct_config
+
+
+@dataclass
+class MockLongevityTest:
+    params: sct_config.SCTConfiguration
+
+
+@pytest.mark.sct_config(files='unit_tests/test_data/test_data_validator/lwt-basic-3h.yaml')
+def test_view_names_for_updated_data(params):
+    data_validator = LongevityDataValidator(longevity_self_object=MockLongevityTest(params=params),
+                                            user_profile_name='c-s_lwt',
+                                            base_table_partition_keys=['domain', 'published_date'])
+    data_validator._validate_updated_per_view = [True, True]  # pylint: disable=protected-access
+    views_list = data_validator.list_of_view_names_for_update_test()
+    assert views_list == [('blogposts_update_one_column_lwt_indicator',
+                           'blogposts_update_one_column_lwt_indicator_after_update',
+                           'blogposts_update_one_column_lwt_indicator_expect', True),
+                          ('blogposts_update_2_columns_lwt_indicator',
+                           'blogposts_update_2_columns_lwt_indicator_after_update',
+                           'blogposts_update_2_columns_lwt_indicator_expect', True)]
+
+
+@pytest.mark.sct_config(files='unit_tests/test_data/test_data_validator/no-validation-views-lwt-basic-3h.yaml')
+def test_view_names_for_updated_data_not_found(params):
+
+    data_validator = LongevityDataValidator(longevity_self_object=MockLongevityTest(params=params),
+                                            user_profile_name='c-s_lwt',
+                                            base_table_partition_keys=['domain', 'published_date'])
+    data_validator._validate_updated_per_view = [True, True]  # pylint: disable=protected-access
+    views_list = data_validator.list_of_view_names_for_update_test()
+    assert views_list == []


### PR DESCRIPTION
Add unit test to check list of tuples of correlated view names for
validation of update columns test

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
