### PR TITLE
test(k8s): add flush and reshard functional test

### DIFF
--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -70,11 +70,20 @@ class MinimalK8SNodePool(CloudK8sNodePool):
 
     @cached_property
     def cpu_and_memory_capacity(self) -> Tuple[float, float]:
+        cpu_per_member = 1
+        # NOTE: Setting '1' to 'memory_for_cpu_multiplier' we will get failure incresing CPUs
+        #       Setting '2' to 'memory_for_cpu_multiplier' we will be able to add 1 CPU per member
+        #       And so on... Useful for tests with change of CPU for Scylla pods.
+        memory_for_cpu_multiplier = 2
+        memory_for_cpu = memory_for_cpu_multiplier * cpu_per_member
+        memory_base = 1.5
         return (
-            1 + COMMON_CONTAINERS_RESOURCES['cpu']
+            cpu_per_member
+            + COMMON_CONTAINERS_RESOURCES['cpu']
             + OPERATOR_CONTAINERS_RESOURCES['cpu']
             + SCYLLA_MANAGER_AGENT_RESOURCES['cpu'],
-            2.5 + COMMON_CONTAINERS_RESOURCES['memory']
+            memory_base + memory_for_cpu
+            + COMMON_CONTAINERS_RESOURCES['memory']
             + OPERATOR_CONTAINERS_RESOURCES['memory']
             + SCYLLA_MANAGER_AGENT_RESOURCES['memory'],
         )


### PR DESCRIPTION
Add a functional test case that does the same steps as
the `disrupt_nodetool_flush_and_reshard_on_kubernetes` nemesis does to cover the bug [1].

[1] https://github.com/scylladb/scylladb/issues/11353

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
