### PR TITLE
fix(longevity): adjust assymetric 12h test

### DIFF
--- a/jenkins-pipelines/longevity-150gb-asymmetric-cluster-12h.jenkinsfile
+++ b/jenkins-pipelines/longevity-150gb-asymmetric-cluster-12h.jenkinsfile
@@ -7,5 +7,5 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-50GB-12h-verifier-LimitedMonkey-tls.yaml", "configurations/db-nodes-shards-random.yaml"]'''
+    test_config: '''["test-cases/longevity/longevity-150GB-12h-autorization-LimitedMonkey.yaml", "configurations/db-nodes-shards-random.yaml"]'''
 )

--- a/test-cases/longevity/longevity-150GB-12h-autorization-LimitedMonkey.yaml
+++ b/test-cases/longevity/longevity-150GB-12h-autorization-LimitedMonkey.yaml
@@ -1,8 +1,8 @@
 test_duration: 750
 prepare_write_cmd: "cassandra-stress write cl=ALL n=50050075  -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=1000 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..50050075 -log interval=15"
 
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=360m  -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=250  -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=400200300..600200300 -log interval=15"]
-stress_read_cmd: ["cassandra-stress read cl=ONE duration=360m -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=250  -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..50050075 -log interval=5"]
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=11h  -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=250  -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=400200300..600200300 -log interval=15"]
+stress_read_cmd: ["cassandra-stress read cl=ONE duration=11h -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=250  -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..50050075 -log interval=5"]
 run_fullscan: '{"ks_cf": "keyspace1.standard1", "interval": 5}' # 'ks.cf|random, interval(min)'
 n_db_nodes: 4
 n_loaders: 1


### PR DESCRIPTION
Now test runs 7 hours instead of 12. Fix it.

@roydahan @fruch 
The data set is about 140GB on every node is created. Should I decrease it or rename the test?

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
