### PR TITLE
feature(uda): add User Defined Aggregations support

### DIFF
--- a/sdcm/utils/uda.py
+++ b/sdcm/utils/uda.py
@@ -1,0 +1,106 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2022 ScyllaDB
+from __future__ import annotations
+from pathlib import Path
+from typing import Optional
+
+import yaml
+from pydantic import BaseModel
+
+from sdcm.utils.udf import UDF, UDFS
+
+
+class UDA(BaseModel):
+    """
+    Provides the representation for User Defined Aggregates in SCT,
+    and the interface for creating queries for them.
+
+    User Defined Aggregates work very much the same as regular CQL aggregate functions,
+    and can be defined via CQL, e.g. :
+
+        CREATE FUNCTION accumulate_len(acc tuple<bigint,bigint>, a text)
+        RETURNS NULL ON NULL INPUT
+        RETURNS tuple<bigint,bigint>
+        LANGUAGE lua as 'return {acc[1] + 1, acc[2] + #a}';
+
+        CREATE OR REPLACE FUNCTION present(res tuple<bigint,bigint>)
+        RETURNS NULL ON NULL INPUT
+        RETURNS text
+        LANGUAGE lua as 'return "The average string length is " .. res[2]/res[1] .. "!"';
+
+        CREATE OR REPLACE AGGREGATE avg_length(text)
+        SFUNC accumulate_len
+        STYPE tuple<bigint,bigint>
+        FINALFUNC present INITCOND (0,0);
+
+    (Optionally you can also add a REDUCEFUNC <reduce_func_name> if running a
+    map-reduce style distributed workload.)
+    As UDAs are made up of UDFs, the referenced UDFs need to be created before attempting
+    to create a UDA.
+    UDAs are bound to keyspaces, i.e. they cannot be used outside the keyspace they were
+    created in.
+
+    Using the custom UDA is similar to usual CQL functions. Assuming we're using the keyspace
+    the UDA was created in:
+
+        SELECT avg_length(word) FROM words;
+
+    UDF/UDA presentation from 2019 summit: https://www.scylladb.com/tech-talk/udf-uda-and-whats-in-the-future/
+    UDF/UDA testing desing doc: https://docs.google.com/document/d/16GTe1bLmMBC5IVCjC_nY-UNnMCLr_3V2C6K6tiYPstQ
+    /edit?usp=sharing
+    """
+    name: str
+    args: str
+    return_type: str
+    accumulator_udf: UDF
+    reduce_udf: Optional[UDF]
+    final_udf: UDF
+    initial_condition: str
+
+    def get_create_query_string(self, ks: str) -> str:
+        query_string = f"CREATE AGGREGATE {ks}.{self.name}" \
+                       f"({self.args}) SFUNC {self.accumulator_udf.name} " \
+                       f'STYPE {self.accumulator_udf.return_type} '
+        if self.reduce_udf:
+            query_string += f"REDUCEFUNC {self.reduce_udf.name} "
+
+        query_string += f"FINALFUNC {self.final_udf.name} " \
+                        f"INITCOND {self.initial_condition};"
+        return query_string
+
+    @classmethod
+    def from_yaml(cls, uda_yaml_file_path: str) -> UDA:
+        with Path(uda_yaml_file_path).open(mode="r", encoding="utf-8") as uda_yaml:
+            input_yaml = yaml.safe_load(uda_yaml)
+            accumulator_udf = UDFS.get((input_yaml.get("accumulator_udf_name", None)))
+            reduce_udf = UDFS.get((input_yaml.get("reduce_udf_name", None)))
+            final_udf = UDFS.get((input_yaml.get("final_udf_name", None)))
+            return UDA(
+                accumulator_udf=accumulator_udf,
+                reduce_udf=reduce_udf,
+                final_udf=final_udf,
+                **input_yaml
+            )
+
+
+def _load_all_udas() -> dict[str, UDA]:
+    """Convenience functions for loading all the existing UDA scripts from /sdcm/utils/udas"""
+    udas = {}
+    yaml_file_paths = Path("sdcm/utils/udas").glob("*.yaml")
+    for script in yaml_file_paths:
+        uda = UDA.from_yaml(str(script))
+        udas.update({script.stem: uda})
+    return udas
+
+
+UDAS = _load_all_udas()

--- a/sdcm/utils/udas/my_avg.yaml
+++ b/sdcm/utils/udas/my_avg.yaml
@@ -1,0 +1,9 @@
+# UDA: creates a custom function calculating the average of int values
+
+name: "my_avg"
+args: "int"
+return_type: "int"
+accumulator_udf_name: "xwasm_plus"
+reduce_udf_name: null
+final_udf_name: "lua_div"
+initial_condition: "(0, 0)"

--- a/sdcm/utils/udas/my_counter.yaml
+++ b/sdcm/utils/udas/my_counter.yaml
@@ -1,0 +1,9 @@
+# UDA: creates a custom function returning the sum of character lengths in a column
+
+name: "my_char_counter"
+args: "text"
+return_type: "bigint"
+accumulator_udf_name: "lua_var_length_counter_accumulator"
+reduce_udf_name: null
+final_udf_name: "lua_simple_return"
+initial_condition: "(0, 0)"

--- a/sdcm/utils/udf.py
+++ b/sdcm/utils/udf.py
@@ -10,6 +10,7 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2022 ScyllaDB
+from __future__ import annotations
 from pathlib import Path
 from typing import Literal
 
@@ -18,14 +19,36 @@ from pydantic import BaseModel
 
 
 class UDF(BaseModel):
+    """
+    Provides the representation for User Defined Functions in SCT,
+    and the interface for creating queries for them.
+
+    User Defined Functions work very much the same as regular CQL functions, and can be defined via CQL,
+    e.g. :
+
+        CREATE FUNCTION accumulate_len(acc tuple<bigint,bigint>, a text)
+        RETURNS NULL ON NULL INPUT
+        RETURNS tuple<bigint,bigint>
+        LANGUAGE lua as 'return {acc[1] + 1, acc[2] + #a}';
+
+    The scripting languages supported as of 2022.1 / 5.0 are:
+    - Lua
+    - WASM
+
+    UDF/UDA presentation from 2019 summit: https://www.scylladb.com/tech-talk/udf-uda-and-whats-in-the-future/
+    UDFs initial commit: https://github.com/scylladb/scylladb/commit/1fe062aed4b1ceb5a97b4333ae6c1901854a7f39
+    WASM support design doc: https://github.com/scylladb/scylladb/blob/master/docs/dev/wasm.md
+    WASM blog post: https://www.scylladb.com/2022/04/14/wasmtime/
+    UDF/UDA testing desing doc: https://docs.google.com/document/d/16GTe1bLmMBC5IVCjC_nY-UNnMCLr_3V2C6K6tiYPstQ/edit?usp=sharing
+    """
     name: str
-    args: str  # e.g. ((name text, age int)) - needs to be stringified
-    called_on_null_input_returns: str  # e.g. int
-    return_type: str  # e.g. int
+    args: str
+    called_on_null_input_returns: str
+    return_type: str
     language: Literal["lua", "xwasm"]
     script: str
 
-    def get_create_query(self, ks: str, create_or_replace: bool = True):
+    def get_create_query(self, ks: str, create_or_replace: bool = True) -> str:
         create_part = "CREATE OR REPLACE" if create_or_replace else "CREATE"
         return f"{create_part} {ks}.{self.name}{self.args} " \
                f"RETURNS {self.called_on_null_input_returns} ON NULL INPUT " \
@@ -34,17 +57,18 @@ class UDF(BaseModel):
                f"AS '{self.script}'"
 
     @classmethod
-    def from_yaml(cls, udf_yaml_filename: str):
+    def from_yaml(cls, udf_yaml_filename: str) -> UDF:
         with Path(udf_yaml_filename).open(mode="r", encoding="utf-8") as udf_yaml:
             return cls(**yaml.safe_load(udf_yaml))
 
 
-def _load_all_udfs():
+def _load_all_udfs() -> dict[str, UDF]:
+    """Convenience functions for loading all the existing UDF scripts from /sdcm/utils/udf_scripts"""
     udfs = {}
     yaml_file_paths = Path("sdcm/utils/udf_scripts").glob("*.yaml")
     for script in yaml_file_paths:
         udf = UDF.from_yaml(str(script))
-        udfs.update({udf.name: udf})
+        udfs.update({script.stem: udf})
     return udfs
 
 

--- a/sdcm/utils/udf_scripts/lua_div.yaml
+++ b/sdcm/utils/udf_scripts/lua_div.yaml
@@ -1,0 +1,8 @@
+# UDF script: divides two integers
+
+name: 'div'
+args: '(acc tuple<int, int>)'
+called_on_null_input_returns: 'NULL'
+return_type: 'int'
+language: 'lua'
+script: 'return acc[1] // acc[2]'

--- a/sdcm/utils/udf_scripts/lua_simple_return.yaml
+++ b/sdcm/utils/udf_scripts/lua_simple_return.yaml
@@ -1,0 +1,8 @@
+# UDF script: return the arg
+
+name: 'simple_return'
+args: '(acc tuple<int, int>)'
+called_on_null_input_returns: 'NULL'
+return_type: 'int'
+language: 'lua'
+script: 'return acc[1]'

--- a/sdcm/utils/udf_scripts/lua_var_length_counter_accumulator.yaml
+++ b/sdcm/utils/udf_scripts/lua_var_length_counter_accumulator.yaml
@@ -1,0 +1,8 @@
+# UDF script: accumulator function counting up the number of chars in a given column
+
+name: 'var_length_counter'
+args: '(acc tuple<int, int>, characters text)'
+called_on_null_input_returns: 'NULL'
+return_type: 'tuple<int, int>'
+language: 'lua'
+script: 'return {acc[1] + #characters, acc[2] + 1}'

--- a/unit_tests/test_uda.py
+++ b/unit_tests/test_uda.py
@@ -1,0 +1,130 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2022 ScyllaDB
+
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+
+import yaml
+
+from sdcm.utils.uda import UDA, UDAS
+from sdcm.utils.udf import UDF, UDFS
+
+
+class TestUDA(TestCase):
+    UDFS = {
+        "accumulator": UDF(
+            name="my_acc",
+            args="(acc tuple<int, int>, val int)",
+            called_on_null_input_returns="NULL",
+            return_type="tuple<int, int>",
+            language="lua",
+            script="return {acc[1] + val, acc[2] + 1}"
+        ),
+        "negator": UDF(
+            name="my_negator",
+            args="(acc bigint)",
+            called_on_null_input_returns="NULL",
+            return_type="bigint",
+            language="lua",
+            script="return -acc"
+        ),
+        "reducer": UDF(
+            name="sum_reductor",
+            args="(acc1 bigint, acc2 bigint)",
+            called_on_null_input_returns="NULL",
+            return_type="bigint",
+            language="lua",
+            script="return acc1 + acc2"
+        )
+    }
+
+    def test_create_uda_instance(self):
+        new_uda = UDA(
+            name="my_uda",
+            args="int",
+            return_type="int",
+            accumulator_udf=self.UDFS["accumulator"],
+            reduce_udf=self.UDFS["reducer"],
+            final_udf=self.UDFS["negator"],
+            initial_condition="(0, 0)"
+        )
+
+        self.assertIsInstance(new_uda, UDA)
+
+    def test_get_create_query_string(self):
+        expected_create_query_string = "CREATE AGGREGATE testing.my_uda(int) " \
+                                       "SFUNC my_acc " \
+                                       "STYPE tuple<int, int> " \
+                                       "REDUCEFUNC sum_reductor " \
+                                       "FINALFUNC my_negator " \
+                                       "INITCOND (0, 0);"
+
+        new_uda = UDA(
+            name="my_uda",
+            args="int",
+            return_type="int",
+            accumulator_udf=self.UDFS["accumulator"],
+            reduce_udf=self.UDFS["reducer"],
+            final_udf=self.UDFS["negator"],
+            initial_condition="(0, 0)"
+        )
+
+        actual_create_query_string = new_uda.get_create_query_string(ks="testing")
+        self.assertEqual(actual_create_query_string, expected_create_query_string)
+
+    def test_load_uda_from_yaml(self):
+        expected_create_string = "CREATE AGGREGATE testing.my_uda(int) " \
+                                 "SFUNC plus " \
+                                 "STYPE tinyint " \
+                                 "REDUCEFUNC plus " \
+                                 "FINALFUNC fib " \
+                                 "INITCOND (0, 0);"
+
+        data = {
+            "name": "my_uda",
+            "args": "int",
+            "return_type": "int",
+            "accumulator_udf_name": "xwasm_plus",
+            "reduce_udf_name": "xwasm_plus",
+            "final_udf_name": "xwasm_fib",
+            "initial_condition": "(0, 0)"
+        }
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp_yaml_path = Path(tempdir) / "new.yaml"
+            with temp_yaml_path.open(mode="w") as outfile:
+                yaml.safe_dump(data=data, stream=outfile)
+
+            uda = UDA.from_yaml(uda_yaml_file_path=str(temp_yaml_path))
+            create_string = uda.get_create_query_string(ks="testing")
+            self.assertIsInstance(uda, UDA)
+            self.assertEqual(expected_create_string, create_string)
+            self.assertEqual(uda.args, data["args"])
+            self.assertEqual(uda.return_type, data["return_type"])
+            self.assertIsInstance(uda.accumulator_udf, UDF)
+            self.assertEqual(uda.accumulator_udf.name, data["accumulator_udf_name"].split("_")[1])
+            self.assertIsInstance(uda.reduce_udf, UDF)
+            self.assertEqual(uda.reduce_udf.name, data["reduce_udf_name"].split("_")[1])
+            self.assertIsInstance(uda.final_udf, UDF)
+            self.assertEqual(uda.final_udf.name, data["final_udf_name"].split("_")[1])
+            self.assertEqual(uda.initial_condition, data["initial_condition"])
+
+    def test_load_all_udas(self):
+        self.assertGreater(len(UDFS.keys()), 1, "UDF count was not greater than 1.")
+        for uda in UDAS.values():
+            self.assertTrue(uda.name)
+            self.assertTrue(uda.args)
+            self.assertTrue(uda.return_type)
+            self.assertIsInstance(uda.accumulator_udf, UDF)
+            self.assertIsInstance(uda.final_udf, UDF)

--- a/unit_tests/test_udf.py
+++ b/unit_tests/test_udf.py
@@ -116,7 +116,7 @@ class TestUDF(TestCase):
             self.assertEqual(value, getattr(udf, key), f"Did not find expected value for {key} in the udf class.")
 
     def test_load_all_udfs(self):
-        self.assertIsNotNone(UDFS)
+        self.assertGreater(len(UDFS.keys()), 1, "UDF count was not greater than 1.")
         for udf in UDFS.values():
             self.assertTrue(udf.name)
             self.assertTrue(udf.args)


### PR DESCRIPTION
This commit introduces infrastructure for handling User Defined Aggregations
in SCT. This includes the UDA class, loader new dir for UDA definitions and
unit tests.

As UDAs are basically made up of UDFs - an accumulator UDF for iterating over
the rows, a final UDF for processing the final result and an optional reducer
UDF for doing a map-reduce style distributed aggregation - UDAs can be
defined via a yaml file in /sdcm/utils/udas dir. Example definitions are
included in this commit.

Task: https://github.com/scylladb/qa-tasks/issues/406

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
