### PR TITLE
feature(issue-template): add relocatable pkg url to report and argus

### DIFF
--- a/sdcm/report_templates/results_base.html
+++ b/sdcm/report_templates/results_base.html
@@ -307,7 +307,7 @@
 {% endblock %}
 
 {% block links %}
-    {% if kibana_url or job_url or grafana_screenshots or grafana_snapshots or parallel_timelines_report %}
+    {% if kibana_url or job_url or grafana_screenshots or grafana_snapshots or parallel_timelines_report or relocatable_pkg %}
     <h3>Links:</h3>
     <ul>
         {% if kibana_url %}
@@ -340,6 +340,9 @@
         {% endif %}
         {% if parallel_timelines_report %}
             <li><a href={{ parallel_timelines_report }}>Download Parallel Timelines report</a></li>
+        {% endif %}
+        {% if relocatable_pkg %}
+            <li><a href={{ relocatable_pkg }}>Relocatable package url</a></li>
         {% endif %}
     </ul>
         {% if grafana_screenshots %}

--- a/sdcm/report_templates/results_base_custom.html
+++ b/sdcm/report_templates/results_base_custom.html
@@ -160,7 +160,7 @@
 {%- endblock -%}
 
 {%- block links -%}
-    {% if kibana_url or job_url or grafana_screenshots or grafana_snapshots %}
+    {% if kibana_url or job_url or grafana_screenshots or grafana_snapshots or relocatable_pkg %}
     <h3>Links:</h3>
     <ul>
         {% if kibana_url %}
@@ -190,6 +190,9 @@
             {% if grafana_snapshots[2] %}
                 <li><a href={{  grafana_snapshots[2] }}>Shared "Alternator metrics" Grafana Snapshot</a></li>
             {% endif %}
+        {% if relocatable_pkg %}
+            <li><a href={{ relocatable_pkg }}>Relocatable package url</a></li>
+        {% endif %}
         {% endif %}
     </ul>
     {% if logs_links %}

--- a/sdcm/report_templates/results_issue_template.html
+++ b/sdcm/report_templates/results_issue_template.html
@@ -4,6 +4,9 @@
         *Installation details*<br>
         Kernel version: `{{ kernel_version }}`<br>
         Scylla version (or git commit hash): `{{ scylla_version }}`<br>
+        {% if relocatable_pkg %}
+        Relocatable package url: {{ relocatable_pkg }}<br>
+        {% endif %}
         Cluster size: {{ number_of_db_nodes }} nodes ({{ scylla_instance_type }})<br>
         {% if live_nodes_shards %}
             Scylla running with shards number (live nodes):<br>

--- a/sdcm/send_email.py
+++ b/sdcm/send_email.py
@@ -142,6 +142,7 @@ class BaseEmailReporter:
         "region_name",
         "scylla_instance_type",
         "scylla_version",
+        "relocatable_pkg",
         "kernel_version",
         "start_time",
         "subject",


### PR DESCRIPTION
Developers requested for relocatable pkg url in issues.

This commit adds relocatable url into email report and sends this info to Argus as additional package.

refs: https://github.com/scylladb/qa-tasks/issues/356

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
