### PR TITLE
fix(upgrade_test): Create s-b keyspace before run stress

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -3343,7 +3343,10 @@ class FillDatabaseData(ClusterTester):
         with self.db_cluster.cql_connection_patient(node) as session:
             # override driver consistency level
             session.default_consistency_level = ConsistencyLevel.QUORUM
-
+            session.execute("""
+                CREATE KEYSPACE IF NOT EXISTS scylla_bench
+                WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'} AND durable_writes = true;
+                """)
             session.execute(f"""
                 CREATE KEYSPACE IF NOT EXISTS {self.base_ks}
                 WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': '3'}} AND durable_writes = true;


### PR DESCRIPTION
Fix in sb: commit e2193213e7eed48f128e55a4b1dbff7ad9e62fe0 require that keyspace have to be created for creating session

Create keyspaces for scylla-bench tool on upgrade tests

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
