### PR TITLE
fix(batched_tests): convert node list into comma separated list

### DIFF
--- a/longevity_test.py
+++ b/longevity_test.py
@@ -420,7 +420,7 @@ class LongevityTest(ClusterTester):
 
     @property
     def all_node_ips_for_stress_command(self):
-        return f' -node {[n.cql_ip_address for n in self.db_cluster.nodes]}'
+        return f' -node {",".join([n.cql_ip_address for n in self.db_cluster.nodes])}'
 
     def _create_counter_table(self):
         """


### PR DESCRIPTION
Both #5061, #4684, tried to add the list of nodes to the stress commmand, but both wasn't tested with the actuall test case

so we ened up with python list, and not comma seperated list that is expected:
```
cassandra-stress user profile=/tmp/templated_tables_mvz4no57b5.yaml
cl=QUORUM 'ops(insert=1, read1=5)' duration=55m -rate threads=2 -errors
skip-unsupported-columns ignore -node ['10.4.3.37', '10.4.0.123',
'10.4.2.11', '10.4.0.153', '10.4.2.45', '10.4.0.188']
```

Ref: #5061, #4684

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
