### PR TITLE
fix(azure): unset az for basic longevity job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,7 @@ def createRunConfiguration(String backend) {
         configuration.gce_datacenter = "us-east1"
     } else if (backend == 'azure') {
         configuration.azure_region_name = 'eastus'
+        configuration.availability_zone = ''
     } else if (backend == 'docker') {
         configuration.test_config = "test-cases/PR-provision-test-docker.yaml"
     } else if (backend == 'k8s-local-kind-aws') {

--- a/jenkins-pipelines/artifacts-azure-image.jenkinsfile
+++ b/jenkins-pipelines/artifacts-azure-image.jenkinsfile
@@ -9,6 +9,7 @@ artifactsPipeline(
     test_config: 'test-cases/artifacts/azure-image.yaml',
     backend: 'azure',
     instance_provision: 'spot',
+    availability_zone: '',
 
     timeout: [time: 145, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy',

--- a/jenkins-pipelines/longevity-10gb-3h-azure.jenkinsfile
+++ b/jenkins-pipelines/longevity-10gb-3h-azure.jenkinsfile
@@ -6,5 +6,6 @@ longevityPipeline(
     backend: 'azure',
     azure_region_name: 'eastus',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-10gb-3h.yaml'
+    test_config: 'test-cases/longevity/longevity-10gb-3h.yaml',
+    availability_zone: ''
 )

--- a/sdcm/provision/azure/ip_provider.py
+++ b/sdcm/provision/azure/ip_provider.py
@@ -56,7 +56,7 @@ class IpAddressProvider:
                 public_ip_address_name=ip_name,
                 parameters={
                     "location": self._region,
-                    "zones": [self._az],
+                    "zones": [self._az] if self._az else [],
                     "sku": {
                         "name": "Standard",
                     },

--- a/sdcm/provision/azure/virtual_machine_provider.py
+++ b/sdcm/provision/azure/virtual_machine_provider.py
@@ -62,7 +62,7 @@ class VirtualMachineProvider:
             LOGGER.info("Instance params: %s", definition)
             params = {
                 "location": self._region,
-                "zones": [self._az],
+                "zones": [self._az] if self._az else [],
                 "tags": definition.tags | {"ssh_user": definition.user_name, "ssh_key": definition.ssh_key.name,
                                            "creation_time": datetime.now().isoformat(sep=" ", timespec="seconds")},
                 "hardware_profile": {

--- a/sdcm/provision/azure/virtual_network_provider.py
+++ b/sdcm/provision/azure/virtual_network_provider.py
@@ -51,7 +51,7 @@ class VirtualNetworkProvider:
             virtual_network_name=name,
             parameters={
                 "location": self._region,
-                "zones": [self._az],
+                "zones": [self._az] if self._az else [],
                 "address_space": {
                     "address_prefixes": ["10.0.0.0/16"],
                 }


### PR DESCRIPTION
Azure struggles with providing spot instances for basic 10gb longevity test when we set availability zone.

Idea is to unset AZ for 10gb 3h longevity and artifact test, so we don't hit provision issue that often. In that case VM's may be created in different AZ's leading to increased costs.

Cost for between zones transfer is 0.01$/GB. Should not apply to artifact test, as it uses just one VM.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
