### PR TITLE
fix(scylla_monitoring_start): remove depricated single dash prom flag

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -5126,7 +5126,7 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
             -n `realpath "{self.monitoring_conf_dir}/node_exporter_servers.yml"` \
             {scylla_manager_servers_arg} \
             -d `realpath "{self.monitoring_data_dir}"` -l -v master,{self.monitoring_version} \
-            -b "-web.enable-admin-api -storage.tsdb.retention.time={self.prometheus_retention}" \
+            -b "--web.enable-admin-api --storage.tsdb.retention.time={self.prometheus_retention}" \
             -c 'GF_USERS_DEFAULT_THEME=dark'
         """)
         node.remoter.run("bash -ce '%s'" % run_script, verbose=True)


### PR DESCRIPTION
prometheus stop supporting single dash in parameter. It cause failed to start scylla-monitoring.
fix issue #5250

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
