### PR TITLE
fix(scylla-bench): upgrade to version v0.1.10

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -208,7 +208,7 @@ stress_image:
   ycsb: 'scylladb/hydra-loaders:ycsb-jdk8-20220904'
   nosqlbench: 'scylladb/hydra-loaders:nosqlbench-4.15.49'
   cassandra-stress: '' # default would be same version as scylla under test
-  scylla-bench: 'scylladb/hydra-loaders:scylla-bench-v0.1.9'
+  scylla-bench: 'scylladb/hydra-loaders:scylla-bench-v0.1.10'
   gemini: 'scylladb/hydra-loaders:gemini-1.7.7'
   alternator-dns: 'scylladb/hydra-loaders:alternator-dns-0.1'
   cdc-stresser: 'scylladb/hydra-loaders:cdc-stresser-20210630'

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -109,15 +109,12 @@ def fake_region_definition_builder():  # pylint: disable=no-self-use
 
 @pytest.fixture(scope="function", name="params")
 def fixture_params(request: pytest.FixtureRequest):
-    config_files = request.node.get_closest_marker("sct_config").kwargs.get('files')
-    if config_files:
+    if sct_config_marker := request.node.get_closest_marker("sct_config"):
+        config_files = sct_config_marker.kwargs.get('files')
         os.environ['SCT_CONFIG_FILES'] = config_files
 
-    os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
-    os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-06f919eb'
-    os.environ['SCT_INSTANCE_TYPE_DB'] = 'i3.large'
+    os.environ['SCT_CLUSTER_BACKEND'] = 'docker'
     params = sct_config.SCTConfiguration()  # pylint: disable=attribute-defined-outside-init
-    params.verify_configuration()
 
     yield params
 

--- a/unit_tests/test_scylla_bench_thread.py
+++ b/unit_tests/test_scylla_bench_thread.py
@@ -20,7 +20,7 @@ from unit_tests.dummy_remote import LocalLoaderSetDummy
 from test_lib.scylla_bench_tools import create_scylla_bench_table_query
 
 pytestmark = [
-    pytest.mark.usefixtures("events", "create_cql_ks_and_table"),
+    pytest.mark.usefixtures("events",),
     pytest.mark.skip(reason="those are integration tests only"),
 ]
 


### PR DESCRIPTION
* https://github.com/scylladb/scylla-bench/pull/101

fixes errors like the following:
```
Keyspace 'ks_truncate_large_partition' does not exist
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
