### PR TITLE
fix(ycsb): upload image that has python2 installed

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -205,7 +205,7 @@ enable_argus: true
 
 stress_image:
   ndbench: 'scylladb/hydra-loaders:ndbench-jdk8-20210720'
-  ycsb: 'scylladb/hydra-loaders:ycsb-jdk8-20220904'
+  ycsb: ' scylladb/hydra-loaders:ycsb-jdk8-20220911'
   nosqlbench: 'scylladb/hydra-loaders:nosqlbench-4.15.49'
   cassandra-stress: '' # default would be same version as scylla under test
   scylla-bench: 'scylladb/hydra-loaders:scylla-bench-v0.1.10'


### PR DESCRIPTION
PR #5238 wrongly didn't pushed out the correct working docker image hence it was failing to run, casue it hase missing python2 inside the image

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
