### PR TITLE
fix(tls-ssl-1dis-2nondis-nemesis longevity): pre create schema

### DIFF
--- a/test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
+++ b/test-cases/longevity/longevity-2TB-48h-authorization-and-tls-ssl-1dis-2nondis-nemesis.yaml
@@ -9,6 +9,14 @@ stress_cmd: ["cassandra-stress mixed cl=QUORUM duration=2460m -schema 'replicati
 
 stress_read_cmd: ["cassandra-stress read cl=QUORUM duration=2460m -mode cql3 native  -rate threads=10 -pop seq=1..2147483648  -log interval=5 -col 'size=FIXED(64) n=FIXED(16)'"]
 
+pre_create_schema: True
+pre_create_keyspace: [
+    "CREATE KEYSPACE mview WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};",
+    "CREATE TABLE mview.users (username text, first_name text, last_name text, password text, email text, last_access timeuuid, PRIMARY KEY(username));",
+    "CREATE MATERIALIZED VIEW mview.users_by_first_name AS SELECT * FROM mview.users WHERE first_name IS NOT NULL and username IS NOT NULL PRIMARY KEY (first_name, username);",
+    "CREATE MATERIALIZED VIEW mview.users_by_last_name AS SELECT * FROM mview.users WHERE last_name IS NOT NULL and username IS NOT NULL PRIMARY KEY (last_name, username);"
+]
+
 run_fullscan: '{"ks_cf": "random", "interval": 240}' # 'ks.cf|random, interval(min)'
 round_robin: true
 


### PR DESCRIPTION
Because of the multiple schema changes happening at the same time, this scenario can fail right after the prepare stage. As such, I amended the scenario's yaml config to pre create the schema.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
