### PR TITLE
Fullscan support in sla longevity

### DIFF
--- a/longevity_sla_test.py
+++ b/longevity_sla_test.py
@@ -43,7 +43,8 @@ class LongevitySlaTest(LongevityTest):
                 self.roles.append(self.create_sla_auth(session=session, shares=shares, index=index))
 
             if self.params.get("run_fullscan"):
-                self.fullscan_role = self.create_sla_auth(session=session, shares=self.FULLSCAN_SERVICE_LEVEL_SHARES)
+                self.fullscan_role = self.create_sla_auth(session=session, shares=self.FULLSCAN_SERVICE_LEVEL_SHARES,
+                                                          index=0)
 
         self.add_sla_credentials_to_stress_cmds()
         super().test_custom_time()

--- a/longevity_sla_test.py
+++ b/longevity_sla_test.py
@@ -26,10 +26,12 @@ class LongevitySlaTest(LongevityTest):
     STRESS_ROLE_NAME_TEMPLATE = 'role%d_%d'
     STRESS_ROLE_PASSWORD_TEMPLATE = 'rolep%d'
     SERVICE_LEVEL_NAME_TEMPLATE = 'sl%d_%d'
+    FULLSCAN_SERVICE_LEVEL_SHARES = 600
 
     def __init__(self, *args):
         super().__init__(*args)
         self.service_level_shares = self.params.get("service_level_shares")
+        self.fullscan_role = None
         self.roles = []
 
     def test_custom_time(self):
@@ -39,6 +41,9 @@ class LongevitySlaTest(LongevityTest):
             # it unique and prevent failure when try to create role/SL with same name
             for index, shares in enumerate(self.service_level_shares):
                 self.roles.append(self.create_sla_auth(session=session, shares=shares, index=index))
+
+            if self.params.get("run_fullscan"):
+                self.fullscan_role = self.create_sla_auth(session=session, shares=self.FULLSCAN_SERVICE_LEVEL_SHARES)
 
         self.add_sla_credentials_to_stress_cmds()
         super().test_custom_time()

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3182,8 +3182,9 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
         if protocol_version is None:
             protocol_version = 3
 
-        credentials = self.get_db_auth()
-        user, password = credentials if credentials else (None, None)
+        if user is None and password is None:
+            credentials = self.get_db_auth()
+            user, password = credentials if credentials else (None, None)
 
         if user is not None:
             auth_provider = PlainTextAuthProvider(username=user, password=password)
@@ -3201,6 +3202,8 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
                                        port=port, ssl_options=ssl_opts,
                                        connect_timeout=connect_timeout)
         session = cluster_driver.connect()
+        LOGGER.debug("Session authorization provider: user '%s', password '%s'", cluster_driver.auth_provider.username,
+                     cluster_driver.auth_provider.password)
 
         # temporarily increase client-side timeout to 1m to determine
         # if the cluster is simply responding slowly to requests

--- a/sdcm/scan_operation_thread.py
+++ b/sdcm/scan_operation_thread.py
@@ -45,6 +45,8 @@ class ScanOperationThread:
         self.scan_event = scan_event
         self.termination_event = termination_event
         self.log = logging.getLogger(self.__class__.__name__)
+        self.user = kwargs.get("user", None)
+        self.password = kwargs.get("password", None)
         self._thread = threading.Thread(daemon=True, name=self.__class__.__name__, target=self.run)
 
     def wait_until_user_table_exists(self, db_node, table_name: str = 'random', timeout_min: int = 20):
@@ -103,7 +105,8 @@ class ScanOperationThread:
             cmd = cmd or self.randomly_form_cql_statement()
             if not cmd:
                 return
-            with self.db_cluster.cql_connection_patient(node=db_node, connect_timeout=300) as session:
+            with self.db_cluster.cql_connection_patient(node=db_node, connect_timeout=300,
+                                                        user=self.user, password=self.password) as session:
 
                 if self.termination_event.is_set():
                     return

--- a/sdcm/scan_operation_thread.py
+++ b/sdcm/scan_operation_thread.py
@@ -101,7 +101,8 @@ class ScanOperationThread:
         self.wait_until_user_table_exists(db_node=db_node, table_name=self.ks_cf)
         if self.ks_cf.lower() == 'random':
             self.ks_cf = random.choice(self.db_cluster.get_non_system_ks_cf_list(db_node))
-        with self.scan_event(node=db_node.name, ks_cf=self.ks_cf, message="") as operation_event:
+        with self.scan_event(node=db_node.name, ks_cf=self.ks_cf, message="",
+                             user=self.user, password=self.password) as operation_event:
             cmd = cmd or self.randomly_form_cql_statement()
             if not cmd:
                 return

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -278,9 +278,12 @@ class BootstrapEvent(ScyllaDatabaseContinuousEvent):
 
 
 class FullScanEvent(ScyllaDatabaseContinuousEvent):
-    def __init__(self, node: str, ks_cf: str, message: Optional[str] = None, severity=Severity.NORMAL, **__):
+    def __init__(self, node: str, ks_cf: str, message: Optional[str] = None, severity=Severity.NORMAL,
+                 **kwargs):
         self.ks_cf = ks_cf
         self.message = message
+        self.user = kwargs.get("user", None)
+        self.password = kwargs.get("password", None)
         super().__init__(node=node, severity=severity)
 
     @property
@@ -288,6 +291,10 @@ class FullScanEvent(ScyllaDatabaseContinuousEvent):
         fmt = super().msgfmt + " select_from={0.ks_cf}"
         if self.message:
             fmt += " message={0.message}"
+        if self.user:
+            fmt += " user={0.user}"
+        if self.password:
+            fmt += " password={0.password}"
         return fmt
 
 

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1975,12 +1975,19 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             interval {number} -- interval between requests in min (default: {1})
             duration {int} -- duration of running thread in min (default: {None})
         """
+        sla_role_name, sla_role_password = None, None
+        if fullscan_role := getattr(self, "fullscan_role", None):
+            sla_role_name = fullscan_role.name
+            sla_role_password = fullscan_role.password
+
         FullScanThread(
             db_cluster=self.db_cluster,
             ks_cf=ks_cf,
             duration=self.get_duration(duration),
             interval=interval * 60,
             termination_event=self.db_cluster.nemesis_termination_event,
+            user=sla_role_name,
+            password=sla_role_password,
         ).start()
 
     def run_full_partition_scan_thread(self, duration=None, interval=1, **kwargs):

--- a/test-cases/longevity/longevity-sla-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-sla-100gb-4h.yaml
@@ -16,6 +16,7 @@ round_robin: true
 
 instance_type_db: 'i3.4xlarge'
 
+run_fullscan: '{"ks_cf": "keyspace1.standard1", "interval": 5}' # 'ks.cf|random, interval(min)'
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '032'
 nemesis_interval: 5

--- a/test_lib/sla.py
+++ b/test_lib/sla.py
@@ -193,7 +193,7 @@ class UserRoleBase:
     AUTHENTICATION_ENTITY = ''
 
     def __init__(self, session, name, password=None, superuser=None, verbose=False, **kwargs):
-        self._name = f'{name}'
+        self._name = name
         self.password = password
         self.session = session
         self.superuser = superuser


### PR DESCRIPTION
Add support running full scan with SLA credentials

Event example:
```
2022-09-14 12:39:06.985: (FullScanEvent Severity.NORMAL) period_type=begin event_id=87b59479-7eab-4a22-937f-446f64acc547 node=longevity-sla-100gb-4h-test-ful-db-node-476e317f-2 select_from=keyspace1.standard1 user=role600_0 password=rolep600
```

Test passed:
https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/staging-sla-fullscan-100gb-4h/9/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
