### PR TITLE
fix(artifact-test): verify write_back_cache is never set

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -209,11 +209,7 @@ class ArtifactsTest(ClusterTester):
                             )
 
     def verify_write_back_cache_param(self) -> None:
-        if self.params["cluster_backend"] in ("gce", "azure") and self.params["use_preinstalled_scylla"]:
-            expected_write_back_cache_param = 0
-        else:
-            expected_write_back_cache_param = None
-        self.assertEqual(self.write_back_cache, expected_write_back_cache_param)
+        self.assertEqual(self.write_back_cache, None)
 
     def verify_docker_locale_settings(self) -> None:
         run = self.node.remoter.run


### PR DESCRIPTION
write_back_cache is considered bogus and should never be set (see https://github.com/scylladb/seastar/issues/1008).
When https://github.com/scylladb/scylla-pkg/issues/3099 is fixed we should start veryfing this setting is not set at all (like on AWS).

Should be merged when https://github.com/scylladb/scylla-pkg/issues/3099 is fixed.
refs: https://github.com/scylladb/qa-tasks/issues/435

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
