### PR TITLE
fix(install_scylla): Added a retry when installing sdkman

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2018,7 +2018,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         # patch of the supported releases will include the fix.
         package_manager = 'yum' if self.is_rhel_like() else 'apt'
         self.remoter.sudo(f'{package_manager} install zip unzip -y')
-        self.remoter.run('curl -s "https://get.sdkman.io" | bash')
+        self.remoter.run('curl -s "https://get.sdkman.io" | bash', retry=5)
         self.remoter.run(shell_script_cmd("""
             source "/home/$USER/.sdkman/bin/sdkman-init.sh"
             sed -i s/sdkman_auto_answer=false/sdkman_auto_answer=true/  ~/.sdkman/etc/config


### PR DESCRIPTION
Since sometimes sdkman.io can be unavailable, I added a retry for the command

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
