### PR TITLE
fix(kill_stress_thread): remove scylla-bench/gemini kills

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4539,8 +4539,6 @@ class BaseLoaderSet():
 
     def kill_stress_thread(self):
         self.kill_cassandra_stress_thread()
-        self.kill_stress_thread_bench()
-        self.kill_gemini_thread()
         self.kill_docker_loaders()
 
     def kill_cassandra_stress_thread(self):
@@ -4679,23 +4677,6 @@ class BaseLoaderSet():
                 results['lat999'].append(lat999)
                 results['latmax'].append(latmax)
         return results
-
-    def kill_stress_thread_bench(self):
-        for loader in self.nodes:
-            sb_active = loader.remoter.run(cmd='pgrep -f scylla-bench', verbose=False, ignore_status=True)
-            if sb_active.exit_status == 0:
-                kill_result = loader.remoter.run('pkill -f -SIGINT scylla-bench', ignore_status=True)
-                if kill_result.exit_status != 0:
-                    self.log.warning('Terminate scylla-bench on node %s:\n%s',
-                                     loader, kill_result)
-
-    def kill_gemini_thread(self):
-        for loader in self.nodes:
-            sb_active = loader.remoter.run(cmd='pgrep -f gemini', verbose=False, ignore_status=True)
-            if sb_active.exit_status == 0:
-                kill_result = loader.remoter.run('pkill -f -SIGINT gemini', ignore_status=True)
-                if kill_result.exit_status != 0:
-                    self.log.warning('Terminate gemini on node %s:\n%s', loader, kill_result)
 
 
 class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instance-attributes


### PR DESCRIPTION
now the scylla-bench and gemini are running inside docker we don't need to kill them directly, there's a docker kill command that should stop them.

Fixes: #5264

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
