### PR TITLE
fix(schema-agreement): print proper error messages

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2616,21 +2616,34 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
     @retrying(n=5, sleep_time=5, raise_on_exceeded=False)
     def get_peers_info(self):
-        cql_result = self.run_cqlsh('select peer, data_center, host_id, rack, release_version, '
-                                    'rpc_address, schema_version, supported_features from system.peers',
-                                    split=True, verbose=False)
+        columns = (
+            'peer', 'data_center', 'host_id', 'rack', 'release_version',
+            'rpc_address', 'schema_version', 'supported_features',
+        )
+        cql_result = self.run_cqlsh(
+            f"select {', '.join(columns)} from system.peers", split=True, verbose=False)
         # peer | data_center | host_id | rack | release_version | rpc_address | schema_version | supported_features
         # ------+-------------+---------+------+-----------------+-------------+----------------+--------------------
 
         peers_details = {}
+        err = ''
         for line in cql_result:
+            if '|' not in line or all(column in line for column in columns):
+                # NOTE: skip non-rows and header lines
+                continue
             line_splitted = line.split('|')
-            if len(line_splitted) < 8:
+            if len(line_splitted) != len(columns):
+                current_err = f"Failed to parse the cqlsh command output line: \n{line}\n"
+                LOGGER.warning(current_err)
+                err += current_err
                 continue
             peer = line_splitted[0].strip()
             try:
                 ipaddress.ip_address(peer)
-            except ValueError:
+            except ValueError as exc:
+                current_err = f"Peer '{peer}' is not an IP address, err: {exc}\n"
+                LOGGER.warning(current_err)
+                err += current_err
                 continue
 
             if node := self.parent_cluster.find_node_by_ip(peer):
@@ -2644,9 +2657,14 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                     'supported_features': line_splitted[7].strip(),
                 }
             else:
-                if peer:
-                    LOGGER.error("Get peers info. Failed to find a node in the cluster by IP: %s", peer)
+                current_err = f"'get_peers_info' failed to find a node by IP: {peer}\n"
+                LOGGER.error(current_err)
+                err += current_err
 
+        if not (peers_details or err):
+            LOGGER.error(
+                "No data, no errors. Check the output from the cqlsh for the correctness:\n%s",
+                cql_result)
         return peers_details
 
     @retrying(n=5, sleep_time=10, raise_on_exceeded=False)
@@ -3895,7 +3913,8 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
     def wait_for_schema_agreement(self):
 
         for node in self.nodes:
-            assert check_schema_agreement_in_gossip_and_peers(node), 'Schema agreement is not reached'
+            err = check_schema_agreement_in_gossip_and_peers(node)
+            assert not err, err
         self.log.debug('Schema agreement is reached')
         return True
 


### PR DESCRIPTION
For the moment, if we fail to get the peers info for some reason, then we get 'Schema agreement is not reached' error running the 'ToggleTableIcs' nemesis.
So, detect specific problems and report correct messages not hiding valueable info.

Closes: https://github.com/scylladb/scylla-cluster-tests/issues/5265

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
