### PR TITLE
fix(hydra-show-monitor): add call to `hydra attach-test-sg`

### DIFF
--- a/jenkins-pipelines/hydra-show-monitor.jenkinsfile
+++ b/jenkins-pipelines/hydra-show-monitor.jenkinsfile
@@ -12,6 +12,7 @@ pipeline {
     environment {
         AWS_ACCESS_KEY_ID     = credentials('qa-aws-secret-key-id')
         AWS_SECRET_ACCESS_KEY = credentials('qa-aws-secret-access-key')
+        SCT_TEST_ID = UUID.randomUUID().toString()
     }
     parameters {
         string(defaultValue: 'master',
@@ -70,6 +71,13 @@ pipeline {
                     export RESTORED_TEST_ID="${params.test_id}"
 
                     ./docker/env/hydra.sh --execute-on-new-runner investigate show-monitor "${params.test_id}"
+                """
+            }
+        }
+        stage('Run hydra attach-test-sg') {
+            steps {
+                sctScript """
+                    ./docker/env/hydra.sh  attach-test-sg --test-id "${SCT_TEST_ID}"
                 """
             }
         }

--- a/sct_ssh.py
+++ b/sct_ssh.py
@@ -115,7 +115,7 @@ def select_instance(region: str = None, **tags) -> dict | None:
     return question.ask()
 
 
-def select_instance_group(region: str = None, **tags) -> dict | None:
+def select_instance_group(region: str = None, **tags) -> list:
     user = tags.get('user')
     test_id = tags.get('test_id')
     node_name = tags.get('node_name')
@@ -129,11 +129,11 @@ def select_instance_group(region: str = None, **tags) -> dict | None:
     vms = list_instances_aws(tags, running=True, region_name=region)
 
     if len(vms) == 1:
-        return vms[0]
+        return vms
 
     if not vms:
         click.echo(click.style("Found no matching instances", fg='red'))
-        return {}
+        return []
 
     choices = [
         Choice(f"{get_tags(vm).get('Name')} - {vm['PublicIpAddress']} {vm['PrivateIpAddress']} - {get_region(vm)}",


### PR DESCRIPTION
since we move to close security groups by default we need to create a security group, for the newly monitor node created in this pipeline

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
