### PR TITLE
fix(scylla-bench): switch to v0.1.11

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -208,7 +208,7 @@ stress_image:
   ycsb: ' scylladb/hydra-loaders:ycsb-jdk8-20220911'
   nosqlbench: 'scylladb/hydra-loaders:nosqlbench-4.15.49'
   cassandra-stress: '' # default would be same version as scylla under test
-  scylla-bench: 'scylladb/hydra-loaders:scylla-bench-v0.1.10'
+  scylla-bench: 'scylladb/hydra-loaders:scylla-bench-v0.1.11'
   gemini: 'scylladb/hydra-loaders:gemini-1.7.7'
   alternator-dns: 'scylladb/hydra-loaders:alternator-dns-0.1'
   cdc-stresser: 'scylladb/hydra-loaders:cdc-stresser-20210630'


### PR DESCRIPTION
scylladb/scylla-bench#103:

   Since we want by default to have retries across the board in SCT
   we now set the default as: -retry-number 10 -retry-interval 80ms,1s

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
