### PR TITLE
fix(offline_artifacts_test): install python2

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -333,8 +333,9 @@ class ArtifactsTest(ClusterTester):  # pylint: disable=too-many-public-methods
         with self.subTest("check Scylla server after installation"):
             self.check_scylla()
 
-        with self.subTest("check cqlsh installation"):
-            self.check_cqlsh()
+        if not self.node.is_nonroot_install:
+            with self.subTest("check cqlsh installation"):
+                self.check_cqlsh()
 
         if backend == "docker":
             with self.subTest("check locale settings in the docker image"):

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1976,6 +1976,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         else:
             additional_pkgs = 'xfsprogs mdadm'
 
+        # scylla current cqlsh still need python2 to work
+        additional_pkgs += ' python2'
+
         # Offline install does't provide openjdk-8, it has to be installed in advance
         # https://github.com/scylladb/scylla-jmx/issues/127
         if self.is_rhel_like():


### PR DESCRIPTION
335432fadc74bd16130fd6428155651d2a665027 introduced a new check of cqlsh to the artifact tests, seem like the offline test weren't installing python2, and started failing like that:

```
raise UnexpectedExit(result)
sdcm.remote.libssh2_client.exceptions.UnexpectedExit:
Encountered a bad command exit code!
Command: 'cqlsh --no-color   --request-timeout=120 --connect-timeout=60
-e "desc keyspaces" 10.142.0.29 9042'
Exit code: 1
Stdout:
Stderr:
No appropriate python interpreter found.
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
