### PR TITLE
fix(sct_config): remove `scylla_bench_version` configuration option

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -175,8 +175,6 @@ backup_bucket_region: ''  # use the same region as a cluster
 
 events_limit_in_email: 10
 
-scylla_bench_version: v0.1.8
-
 data_volume_disk_num: 0
 data_volume_disk_type: ''
 data_volume_disk_size: 0

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -82,7 +82,6 @@
 | **<a href="#user-content-fullscan" name="fullscan">fullscan</a>**  | If true would kill the fullscan thread in the test teardown | N/A | SCT_FULLSCAN
 | **<a href="#user-content-experimental" name="experimental">experimental</a>**  | when enabled scylla will use it's experimental features | True | SCT_EXPERIMENTAL
 | **<a href="#user-content-server_encrypt" name="server_encrypt">server_encrypt</a>**  | when enable scylla will use encryption on the server side | N/A | SCT_SERVER_ENCRYPT
-| **<a href="#user-content-scylla_bench_version" name="scylla_bench_version">scylla_bench_version</a>**  | A valid tag under the scylla bench repo: https://github.com/scylladb/scylla-bench | v0.1.8 | SCT_SCYLLA_BENCH_VERSION
 | **<a href="#user-content-client_encrypt" name="client_encrypt">client_encrypt</a>**  | when enable scylla will use encryption on the client side | N/A | SCT_CLIENT_ENCRYPT
 | **<a href="#user-content-hinted_handoff" name="hinted_handoff">hinted_handoff</a>**  | when enable or disable scylla hinted handoff (enabled/disabled) | enabled | SCT_HINTED_HANDOFF
 | **<a href="#user-content-authenticator" name="authenticator">authenticator</a>**  | which authenticator scylla will use AllowAllAuthenticator/PasswordAuthenticator | N/A | SCT_AUTHENTICATOR

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -443,9 +443,6 @@ class SCTConfiguration(dict):
         dict(name="server_encrypt", env="SCT_SERVER_ENCRYPT", type=boolean,
              help="when enable scylla will use encryption on the server side"),
 
-        dict(name="scylla_bench_version", env="SCT_SCYLLA_BENCH_VERSION", type=str,
-             help="A valid tag under the scylla bench repo: https://github.com/scylladb/scylla-bench"),
-
         dict(name="client_encrypt", env="SCT_CLIENT_ENCRYPT", type=boolean,
              help="when enable scylla will use encryption on the client side"),
 

--- a/test-cases/longevity/longevity-counters-multidc.yaml
+++ b/test-cases/longevity/longevity-counters-multidc.yaml
@@ -24,4 +24,5 @@ internode_encryption: 'dc'
 use_legacy_cluster_init: false
 
 # Temporarily downgrade scylla_bench to a stable version
-scylla_bench_version: v0.1.3
+stress_image:
+  scylla-bench: 'scylladb/hydra-loaders:scylla-bench-v0.1.3'

--- a/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
@@ -71,5 +71,7 @@ space_node_threshold: 644245094
 stop_test_on_stress_failure: false
 
 # Temporarily downgrade scylla_bench to a stable version
-scylla_bench_version: v0.1.3
+stress_image:
+  scylla-bench: 'scylladb/hydra-loaders:scylla-bench-v0.1.3'
+
 run_full_partition_scan: '{"ks_cf": "scylla_bench.test", "interval": 300, "pk_name":"pk", "rows_count": 100000, "validate_data": "true"}' # 'ks.cf, interval(sec), partition-key name, number-of-rows-per-partition, validate reversed query output, include data-column or only validate pk + ck'

--- a/test-cases/longevity/longevity-large-partition-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-4days.yaml
@@ -41,5 +41,7 @@ table_name: "scylla_bench.test"
 primary_key_column: "pk"
 
 # Temporarily downgrade scylla_bench to a stable version
-scylla_bench_version: v0.1.3
+stress_image:
+  scylla-bench: 'scylladb/hydra-loaders:scylla-bench-v0.1.3'
+
 run_full_partition_scan: '{"ks_cf": "scylla_bench.test", "interval": 300, "pk_name":"pk", "rows_count": 10000000, "validate_data": "true"}' # 'ks.cf, interval(sec), partition-key name, number-of-rows-per-partition, validate reversed query output, include data-column or only validate pk + ck'

--- a/test-cases/longevity/longevity-twcs-48h.yaml
+++ b/test-cases/longevity/longevity-twcs-48h.yaml
@@ -28,6 +28,7 @@ user_prefix: 'longevity-twcs-48h'
 post_prepare_cql_cmds: "ALTER TABLE scylla_bench.test with gc_grace_seconds = 15000 and default_time_to_live = 21600 and compaction = {'class':'TimeWindowCompactionStrategy', 'compaction_window_size': 60, 'compaction_window_unit': 'MINUTES'};"
 
 # Temporarily downgrade scylla_bench to a stable version
-scylla_bench_version: v0.1.3
+stress_image:
+  scylla-bench: 'scylladb/hydra-loaders:scylla-bench-v0.1.3'
 
 round_robin: true


### PR DESCRIPTION
Since we move to using docker based scylla-bench, we don't use that configuration option any more, and need to use a docker image to overide to a diffrent scylla-bench version

scylladb/scylla-bench#92 still need to be investigated and bisected regardless of this change.

Ref: scylladb/scylla-bench#92

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
