### PR TITLE
improvement(data validator): improve investigation ability

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -7,7 +7,7 @@ ClusterHealthValidatorEvent.ScyllaCloudClusterServerDiagnostic: CRITICAL
 ClusterHealthValidatorEvent: NORMAL
 DataValidatorEvent.DataValidator: ERROR
 DataValidatorEvent.ImmutableRowsValidator: ERROR
-DataValidatorEvent.UpdatedRowsValidator: WARNING
+DataValidatorEvent.UpdatedRowsValidator: CRITICAL
 DataValidatorEvent.DeletedRowsValidator: ERROR
 ScyllaHelpErrorEvent.duplicate: WARNING
 ScyllaHelpErrorEvent.filtered: WARNING

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -958,6 +958,8 @@ class SCTLogCollector(LogCollector):
                 search_locally=True),
         FileLog(name='argus.log',
                 search_locally=True),
+        FileLog(name=r'*debug.json',
+                search_locally=True),
     ]
     cluster_log_type = 'sct-runner'
     cluster_dir_prefix = 'sct-runner'


### PR DESCRIPTION
Now if rows with unexpected data found while the test, it's impossible to investigate why it happens and where is the problem. This commit present analyzing of failed data and save the result into files.

Refs: https://github.com/scylladb/qa-tasks/issues/348

Tests:
1. With missed rows: https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/staging-4.1-longevity-lwt-3h/61/
2. no missed rows: https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/staging-4.1-longevity-lwt-3h/62/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
