### PR TITLE
fix(longevity-network): change default to `ip_ssh_connections: public`

### DIFF
--- a/jenkins-pipelines/longevity-200gb-48h-network-monkey.jenkinsfile
+++ b/jenkins-pipelines/longevity-200gb-48h-network-monkey.jenkinsfile
@@ -7,6 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-200GB-48h-network-monkey.yaml'
-
+    test_config: 'test-cases/longevity/longevity-200GB-48h-network-monkey.yaml',
+    ip_ssh_connections: 'public'
 )


### PR DESCRIPTION
since the move to the new VPC peering setup, the public addresses are not open by default, and this specific test case need to be working with public addresses.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
