### PR TITLE
fix(functional): wait for system.log file exists on every node

### DIFF
--- a/functional_tests/scylla_operator/conftest.py
+++ b/functional_tests/scylla_operator/conftest.py
@@ -116,6 +116,7 @@ def fixture_db_cluster(tester: ScyllaOperatorFunctionalClusterTester):
     if dataset_name := tester.db_cluster.params.get("k8s_functional_test_dataset"):
         tester.db_cluster.wait_for_nodes_up_and_normal(nodes=tester.db_cluster.nodes,
                                                        verification_node=tester.db_cluster.nodes[0])
+        tester.db_cluster.wait_for_init(node_list=tester.db_cluster.nodes, wait_for_db_logs=True)
         tester.db_cluster.prefill_cluster(dataset_name)
     yield tester.db_cluster
 

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3447,7 +3447,8 @@ def wait_for_init_wrap(method):  # pylint: disable=too-many-statements
         node_list = kwargs.get('node_list', None) or cl_inst.nodes
         timeout = kwargs.get('timeout', None)
         # remove all arguments which is not supported by BaseScyllaCluster.node_setup method
-        setup_kwargs = {k: v for k, v in kwargs.items() if k not in ["node_list", "check_node_health"]}
+        setup_kwargs = {k: v for k, v in kwargs.items()
+                        if k not in ["node_list", "check_node_health", "wait_for_db_logs"]}
 
         _queue = queue.Queue()
 

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2260,9 +2260,13 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
         super().check_nodes_up_and_normal(nodes=nodes, verification_node=verification_node)
 
     @cluster.wait_for_init_wrap
-    def wait_for_init(self, *_, node_list=None, verbose=False, timeout=None, **__):  # pylint: disable=arguments-differ
+    def wait_for_init(self, *_, node_list=None, verbose=False, timeout=None, wait_for_db_logs=False, **__):  # pylint: disable=arguments-differ
         node_list = node_list if node_list else self.nodes
         self.wait_for_nodes_up_and_normal(nodes=node_list)
+
+        if wait_for_db_logs:
+            super().wait_for_init(node_list=node_list, check_node_health=False)
+
         if self.scylla_restart_required:
             self.restart_scylla()
             self.scylla_restart_required = False


### PR DESCRIPTION
Functional Eks test failed with error:
```
FileNotFoundError: [Errno 2] No such file or directory: 'sct-cluster-us-east1-b-us-east1-0/system.log' sdcm/utils/file.py:66: FileNotFoundError
```

Add waiting for the system.log file creation.

Failed test:
https://jenkins.scylladb.com/job/scylla-operator/job/operator-master/job/functional/job/functional-eks/12/

Test with fix passed:
https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/operator/job/functional-eks/8/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
