### PR TITLE
fix(create_session): remove redundant debug message

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3223,8 +3223,6 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
                                        port=port, ssl_options=ssl_opts,
                                        connect_timeout=connect_timeout)
         session = cluster_driver.connect()
-        LOGGER.debug("Session authorization provider: user '%s', password '%s'", cluster_driver.auth_provider.username,
-                     cluster_driver.auth_provider.password)
 
         # temporarily increase client-side timeout to 1m to determine
         # if the cluster is simply responding slowly to requests


### PR DESCRIPTION
This debug message was not removed mistakenly.
Also if 'auth_provider' is None, it will fail

This debug message was added by https://github.com/scylladb/scylla-cluster-tests/pull/5259/commits/a25333c89c3034f2b2931bd4644a99bfc4575351

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
