### PR TITLE
fix(artifacts_test): install python2.7 for older ubuntu distros

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1977,7 +1977,10 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             additional_pkgs = 'xfsprogs mdadm'
 
         # scylla current cqlsh still need python2 to work
-        additional_pkgs += ' python2'
+        if self.distro.is_ubuntu18:
+            additional_pkgs += ' python2.7'
+        else:
+            additional_pkgs += ' python2'
 
         # Offline install does't provide openjdk-8, it has to be installed in advance
         # https://github.com/scylladb/scylla-jmx/issues/127


### PR DESCRIPTION
older ubuntu distros doesn't have `python2` package, they only have `python2.7` one. so we need to play along.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
