### PR TITLE
(fix):set region default value for aws backend

### DIFF
--- a/vars/artifactsPipeline.groovy
+++ b/vars/artifactsPipeline.groovy
@@ -42,8 +42,8 @@ def call(Map pipelineParams) {
             string(defaultValue: '',
                    description: 'a Azure Image to run against',
                    name: 'azure_image_db')
-            string(defaultValue: "${pipelineParams.get('region', '')}",
-                   description: 'AWS region with Scylla AMI (for AMI test, ignored otherwise)',
+            string(defaultValue: "${pipelineParams.get('region', 'us-east-1')}",
+                   description: 'AWS region with Scylla AMI (for AMI test)',
                    name: 'region')
             string(defaultValue: "${pipelineParams.get('gce_datacenter', 'us-east1')}",
                    description: 'GCE datacenter',


### PR DESCRIPTION
Seen in https://jenkins.scylladb.com/job/scylla-master/job/releng-testing/job/artifacts-offline-install/job/artifacts-ubuntu2204-arm-test/23/parameters/

when job is running on aws backend and no region was provided, the job failed with no real explanation.

Closes: https://github.com/scylladb/scylla-cluster-tests/issues/5292
