### PR TITLE
test(scylla-bench): add new integration test for ssl

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -206,7 +206,7 @@ stress_image:
   ycsb: 'scylladb/hydra-loaders:ycsb-jdk8-20220918'
   nosqlbench: 'scylladb/hydra-loaders:nosqlbench-4.15.49'
   cassandra-stress: '' # default would be same version as scylla under test
-  scylla-bench: 'scylladb/hydra-loaders:scylla-bench-v0.1.11'
+  scylla-bench: 'scylladb/hydra-loaders:scylla-bench-v0.1.12'
   gemini: 'scylladb/hydra-loaders:gemini-1.7.7'
   alternator-dns: 'scylladb/hydra-loaders:alternator-dns-0.1'
   cdc-stresser: 'scylladb/hydra-loaders:cdc-stresser-20210630'

--- a/docker/scylla-sct/entry_ssl.sh
+++ b/docker/scylla-sct/entry_ssl.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [[ ! $(grep 'skip_wait_for_gossip_to_settle' /etc/scylla/scylla.yaml) ]]; then echo "skip_wait_for_gossip_to_settle: 0" >> /etc/scylla/scylla.yaml ; fi
+
+cat <<EOM >> /etc/scylla/scylla.yaml
+
+client_encryption_options:
+  certificate: /etc/scylla/ssl_conf/client/test.crt
+  enabled: true
+  keyfile: /etc/scylla/ssl_conf/client/test.key
+  truststore: /etc/scylla/ssl_conf/client/catest.pem
+EOM
+
+/docker-entrypoint.py $*

--- a/sdcm/utils/docker_remote.py
+++ b/sdcm/utils/docker_remote.py
@@ -85,27 +85,6 @@ class RemoteDocker(BaseNode):
         result &= self.node.remoter.receive_files(remote_tempfile, dst, **kwargs)
         return result
 
-    def is_port_used(self, port: int, service_name: str) -> bool:
-        try:
-            # Path to `ss' is /usr/sbin/ss for RHEL-like distros and /bin/ss for Debian-based.  Unfortunately,
-            # /usr/sbin is not always in $PATH, so need to set it explicitly.
-            #
-            # Output of `ss -ln' command in case of used port:
-            #   $ ss -ln '( sport = :8000 )'
-            #   Netid State      Recv-Q Send-Q     Local Address:Port                    Peer Address:Port
-            #   tcp   LISTEN     0      5                      *:8000                               *:*
-            #
-            # And if there are no processes listening on the port:
-            #   $ ss -ln '( sport = :8001 )'
-            #   Netid State      Recv-Q Send-Q     Local Address:Port                    Peer Address:Port
-            #
-            # Can't avoid the header by using `-H' option because of ss' core on Ubuntu 18.04.
-            cmd = f"PATH=/bin:/usr/sbin ss -ln '( sport = :{port} )'"
-            return len(self.remoter.run(cmd, verbose=False).stdout.splitlines()) > 1
-        except Exception as details:  # pylint: disable=broad-except
-            self.log.error("Error checking for '%s' on port %s: %s", service_name, port, details)
-            return False
-
     def _get_ipv6_ip_address(self):
         pass
 

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -58,7 +58,7 @@ def docker_scylla():
     entryfile_path = entryfile_path.joinpath('./docker/scylla-sct/entry.sh')
 
     alternator_flags = "--alternator-port 8000 --alternator-write-isolation=always"
-    docker_version = "scylladb/scylla-nightly:666.development-0.20201015.8068272b466"
+    docker_version = "scylladb/scylla-nightly:5.2.0-dev-0.20220820.516089beb0b8"
     cluster = LocalScyllaClusterDummy()
     scylla = RemoteDocker(LocalNode("scylla", cluster), image_name=docker_version,
                           command_line=f"--smp 1 --experimental 1 {alternator_flags}",

--- a/unit_tests/dummy_remote.py
+++ b/unit_tests/dummy_remote.py
@@ -80,6 +80,10 @@ class LocalLoaderSetDummy:
     def get_db_auth():
         return None
 
+    @staticmethod
+    def is_kubernetes():
+        return False
+
 
 class LocalScyllaClusterDummy(BaseScyllaCluster):
     # pylint: disable=super-init-not-called

--- a/unit_tests/test_scylla_bench_thread.py
+++ b/unit_tests/test_scylla_bench_thread.py
@@ -49,11 +49,14 @@ def create_cql_ks_and_table(docker_scylla):
         session.execute(create_table_query)
 
 
-def test_01_scylla_bench(request, docker_scylla, params):
+@pytest.mark.parametrize("extra_cmd", argvalues=[
+    pytest.param('', id="regular"),
+    pytest.param('-tls', id="tls", marks=[pytest.mark.docker_scylla_args(ssl=True)])])
+def test_01_scylla_bench(request, docker_scylla, params, extra_cmd):
     loader_set = LocalLoaderSetDummy()
 
     cmd = (
-        "scylla-bench -workload=sequential -mode=write -replication-factor=1 -partition-count=10 "
+        f"scylla-bench -workload=sequential {extra_cmd} -mode=write -replication-factor=1 -partition-count=10 "
         + "-clustering-row-count=5555 -clustering-row-size=uniform:10..20 -concurrency=10 "
         + "-connection-count=10 -consistency-level=one -rows-per-request=10 -timeout=60s -duration=1m"
     )


### PR DESCRIPTION
ssl seems broken in scylla-bench==0.1.9 and onwards,
gocql update the ssl package, and now the default in
to enable verification of host, we'll need to disable
it on scylla-bench `InsecureSkipVerify: true`

Ref: https://github.com/scylladb/scylla-cluster-tests/issues/5291

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
