### PR TITLE
Revert "fix(artifacts): workaround - increase timeout"

### DIFF
--- a/jenkins-pipelines/artifacts-amazon2-arm.jenkinsfile
+++ b/jenkins-pipelines/artifacts-amazon2-arm.jenkinsfile
@@ -10,6 +10,6 @@ artifactsPipeline(
     provision_type: 'spot_low_price',
     manager_version: '',  // scylla manager doesn't currently support arm processors
 
-    timeout: [time: 35, unit: 'MINUTES'],
+    timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'
 )

--- a/jenkins-pipelines/artifacts-centos7.jenkinsfile
+++ b/jenkins-pipelines/artifacts-centos7.jenkinsfile
@@ -8,6 +8,6 @@ artifactsPipeline(
     backend: 'gce',
     provision_type: 'spot',
 
-    timeout: [time: 35, unit: 'MINUTES'],
+    timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'
 )

--- a/jenkins-pipelines/artifacts-centos8-arm.jenkinsfile
+++ b/jenkins-pipelines/artifacts-centos8-arm.jenkinsfile
@@ -10,6 +10,6 @@ artifactsPipeline(
     provision_type: 'spot_low_price',
     manager_version: '',  // scylla manager doesn't currently support arm processors
 
-    timeout: [time: 35, unit: 'MINUTES'],
+    timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'
 )

--- a/jenkins-pipelines/artifacts-centos8-selinux.jenkinsfile
+++ b/jenkins-pipelines/artifacts-centos8-selinux.jenkinsfile
@@ -8,6 +8,6 @@ artifactsPipeline(
     backend: 'gce',
     provision_type: 'spot',
 
-    timeout: [time: 35, unit: 'MINUTES'],
+    timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'
 )

--- a/jenkins-pipelines/artifacts-centos8-web.jenkinsfile
+++ b/jenkins-pipelines/artifacts-centos8-web.jenkinsfile
@@ -9,6 +9,6 @@ artifactsPipeline(
     provision_type: 'spot',
     scylla_mgmt_repo: '',
 
-    timeout: [time: 35, unit: 'MINUTES'],
+    timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'
 )

--- a/jenkins-pipelines/artifacts-centos8.jenkinsfile
+++ b/jenkins-pipelines/artifacts-centos8.jenkinsfile
@@ -8,6 +8,6 @@ artifactsPipeline(
     backend: 'gce',
     provision_type: 'spot',
 
-    timeout: [time: 35, unit: 'MINUTES'],
+    timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'
 )

--- a/jenkins-pipelines/artifacts-debian10-arm.jenkinsfile
+++ b/jenkins-pipelines/artifacts-debian10-arm.jenkinsfile
@@ -10,6 +10,6 @@ artifactsPipeline(
     provision_type: 'spot_low_price',
     manager_version: '',  // scylla manager doesn't currently support arm processors
 
-    timeout: [time: 35, unit: 'MINUTES'],
+    timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'
 )

--- a/jenkins-pipelines/artifacts-debian10.jenkinsfile
+++ b/jenkins-pipelines/artifacts-debian10.jenkinsfile
@@ -8,6 +8,6 @@ artifactsPipeline(
     backend: 'gce',
     provision_type: 'spot',
 
-    timeout: [time: 35, unit: 'MINUTES'],
+    timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'
 )

--- a/jenkins-pipelines/artifacts-debian11.jenkinsfile
+++ b/jenkins-pipelines/artifacts-debian11.jenkinsfile
@@ -8,6 +8,6 @@ artifactsPipeline(
     backend: 'gce',
     provision_type: 'spot',
 
-    timeout: [time: 35, unit: 'MINUTES'],
+    timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'
 )

--- a/jenkins-pipelines/artifacts-docker.jenkinsfile
+++ b/jenkins-pipelines/artifacts-docker.jenkinsfile
@@ -7,6 +7,6 @@ artifactsPipeline(
     test_config: 'test-cases/artifacts/docker.yaml',
     backend: 'docker',
 
-    timeout: [time: 35, unit: 'MINUTES'],
+    timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'
 )

--- a/jenkins-pipelines/artifacts-rocky8.jenkinsfile
+++ b/jenkins-pipelines/artifacts-rocky8.jenkinsfile
@@ -8,6 +8,6 @@ artifactsPipeline(
     backend: 'gce',
     provision_type: 'spot',
 
-    timeout: [time: 35, unit: 'MINUTES'],
+    timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'
 )

--- a/jenkins-pipelines/artifacts-ubuntu1804.jenkinsfile
+++ b/jenkins-pipelines/artifacts-ubuntu1804.jenkinsfile
@@ -8,6 +8,6 @@ artifactsPipeline(
     backend: 'gce',
     provision_type: 'spot',
 
-    timeout: [time: 35, unit: 'MINUTES'],
+    timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'
 )

--- a/jenkins-pipelines/artifacts-ubuntu2004-arm.jenkinsfile
+++ b/jenkins-pipelines/artifacts-ubuntu2004-arm.jenkinsfile
@@ -10,6 +10,6 @@ artifactsPipeline(
     provision_type: 'spot_low_price',
     manager_version: '',  // scylla manager doesn't currently support arm processors
 
-    timeout: [time: 35, unit: 'MINUTES'],
+    timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'
 )

--- a/jenkins-pipelines/artifacts-ubuntu2004-web.jenkinsfile
+++ b/jenkins-pipelines/artifacts-ubuntu2004-web.jenkinsfile
@@ -9,6 +9,6 @@ artifactsPipeline(
     provision_type: 'spot',
     scylla_mgmt_repo: '',
 
-    timeout: [time: 35, unit: 'MINUTES'],
+    timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'
 )

--- a/jenkins-pipelines/artifacts-ubuntu2004.jenkinsfile
+++ b/jenkins-pipelines/artifacts-ubuntu2004.jenkinsfile
@@ -8,6 +8,6 @@ artifactsPipeline(
     backend: 'gce',
     provision_type: 'spot',
 
-    timeout: [time: 35, unit: 'MINUTES'],
+    timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'
 )

--- a/jenkins-pipelines/artifacts-ubuntu2204-arm.jenkinsfile
+++ b/jenkins-pipelines/artifacts-ubuntu2204-arm.jenkinsfile
@@ -10,6 +10,6 @@ artifactsPipeline(
     provision_type: 'spot_low_price',
     manager_version: '',  // scylla manager doesn't currently support arm processors
 
-    timeout: [time: 35, unit: 'MINUTES'],
+    timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'
 )

--- a/jenkins-pipelines/artifacts-ubuntu2204-web.jenkinsfile
+++ b/jenkins-pipelines/artifacts-ubuntu2204-web.jenkinsfile
@@ -9,6 +9,6 @@ artifactsPipeline(
     provision_type: 'spot',
     scylla_mgmt_repo: '',
 
-    timeout: [time: 35, unit: 'MINUTES'],
+    timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'
 )

--- a/jenkins-pipelines/nonroot-offline-install/artifacts-centos8.jenkinsfile
+++ b/jenkins-pipelines/nonroot-offline-install/artifacts-centos8.jenkinsfile
@@ -10,6 +10,6 @@ artifactsPipeline(
     provision_type: 'spot',
     manager_version: '',
 
-    timeout: [time: 35, unit: 'MINUTES'],
+    timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'
 )

--- a/jenkins-pipelines/nonroot-offline-install/artifacts-debian10.jenkinsfile
+++ b/jenkins-pipelines/nonroot-offline-install/artifacts-debian10.jenkinsfile
@@ -10,6 +10,6 @@ artifactsPipeline(
     provision_type: 'spot',
     manager_version: '',
 
-    timeout: [time: 35, unit: 'MINUTES'],
+    timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'
 )

--- a/jenkins-pipelines/nonroot-offline-install/artifacts-debian11.jenkinsfile
+++ b/jenkins-pipelines/nonroot-offline-install/artifacts-debian11.jenkinsfile
@@ -10,6 +10,6 @@ artifactsPipeline(
     provision_type: 'spot',
     manager_version: '',
 
-    timeout: [time: 35, unit: 'MINUTES'],
+    timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'
 )

--- a/jenkins-pipelines/nonroot-offline-install/artifacts-rocky8.jenkinsfile
+++ b/jenkins-pipelines/nonroot-offline-install/artifacts-rocky8.jenkinsfile
@@ -10,6 +10,6 @@ artifactsPipeline(
     provision_type: 'spot',
     manager_version: '',
 
-    timeout: [time: 35, unit: 'MINUTES'],
+    timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'
 )

--- a/jenkins-pipelines/nonroot-offline-install/artifacts-ubuntu1804.jenkinsfile
+++ b/jenkins-pipelines/nonroot-offline-install/artifacts-ubuntu1804.jenkinsfile
@@ -10,6 +10,6 @@ artifactsPipeline(
     provision_type: 'spot',
     manager_version: '',
 
-    timeout: [time: 35, unit: 'MINUTES'],
+    timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'
 )

--- a/jenkins-pipelines/nonroot-offline-install/artifacts-ubuntu2004.jenkinsfile
+++ b/jenkins-pipelines/nonroot-offline-install/artifacts-ubuntu2004.jenkinsfile
@@ -10,6 +10,6 @@ artifactsPipeline(
     provision_type: 'spot',
     manager_version: '',
 
-    timeout: [time: 35, unit: 'MINUTES'],
+    timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'
 )

--- a/jenkins-pipelines/nonroot-offline-install/artifacts-ubuntu2204.jenkinsfile
+++ b/jenkins-pipelines/nonroot-offline-install/artifacts-ubuntu2204.jenkinsfile
@@ -10,6 +10,6 @@ artifactsPipeline(
     provision_type: 'spot',
     manager_version: '',
 
-    timeout: [time: 35, unit: 'MINUTES'],
+    timeout: [time: 30, unit: 'MINUTES'],
     post_behavior_db_nodes: 'destroy'
 )


### PR DESCRIPTION
This reverts commit 5a7d937145bc44b541f863d00c0b162e1d5449ce. following https://github.com/scylladb/scylla-cluster-tests/issues/5247#issuecomment-1250939839 we should have the test running and passing within the default timeout.

Fixes: #5247

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
