### PR TITLE
fix(rolling upgrade): Create scylla-bench tables in advance

### DIFF
--- a/longevity_large_partition_test.py
+++ b/longevity_large_partition_test.py
@@ -1,6 +1,6 @@
 from longevity_test import LongevityTest
 from test_lib.compaction import CompactionStrategy
-from test_lib.scylla_bench_tools import create_scylla_bench_table_query
+from test_lib.scylla_bench_tools import create_scylla_bench_test_table_query
 
 
 class LargePartitionLongevityTest(LongevityTest):
@@ -13,8 +13,8 @@ class LargePartitionLongevityTest(LongevityTest):
     def pre_create_large_partitions_schema(self, compaction_strategy=CompactionStrategy.SIZE_TIERED.value):
         node = self.db_cluster.nodes[0]
         table_setup_seed = self.params.get('cql_schema_seed')
-        create_table_query = create_scylla_bench_table_query(compaction_strategy=compaction_strategy,
-                                                             seed=table_setup_seed)
+        create_table_query = create_scylla_bench_test_table_query(compaction_strategy=compaction_strategy,
+                                                                  seed=table_setup_seed)
         with self.db_cluster.cql_connection_patient(node) as session:
             # pylint: disable=no-member
             session.execute("""

--- a/performance_regression_row_level_repair_test.py
+++ b/performance_regression_row_level_repair_test.py
@@ -20,7 +20,7 @@ import six
 
 from sdcm.tester import ClusterTester
 from sdcm.utils.decorators import measure_time, retrying
-from test_lib.scylla_bench_tools import create_scylla_bench_table_query
+from test_lib.scylla_bench_tools import create_scylla_bench_test_table_query
 
 THOUSAND = 1000
 MILLION = THOUSAND ** 2
@@ -133,7 +133,7 @@ class PerformanceRegressionRowLevelRepairTest(ClusterTester):
 
     def _pre_create_schema_scylla_bench(self):
         node = self.db_cluster.nodes[0]
-        create_table_query = create_scylla_bench_table_query()
+        create_table_query = create_scylla_bench_test_table_query()
         # pylint: disable=no-member
         with self.db_cluster.cql_connection_patient(node) as session:
             session.execute("""

--- a/test_lib/scylla_bench_tools.py
+++ b/test_lib/scylla_bench_tools.py
@@ -4,7 +4,7 @@ import random
 LOGGER = logging.getLogger(__name__)
 
 
-def create_scylla_bench_table_query(compaction_strategy=None, seed: int = None):
+def create_scylla_bench_test_table_query(compaction_strategy=None, seed: int = None):
     """
 
     :return: cql create table query for scylla-bench
@@ -38,3 +38,31 @@ def create_scylla_bench_table_query(compaction_strategy=None, seed: int = None):
                     """
     LOGGER.debug("Generated a create-table query with a seed of [%s]: %s", seed, scylla_bench_table_query)
     return scylla_bench_table_query
+
+
+SCYLLA_BENCH_TEST_COUNTERS_TABLE_QUERY = """
+                    CREATE TABLE scylla_bench.test_counters (
+                    pk bigint,
+                    ck bigint,
+                    c1 counter,
+                    c2 counter,
+                    c3 counter,
+                    c4 counter,
+                    c5 counter,
+                    PRIMARY KEY (pk, ck)
+                ) WITH CLUSTERING ORDER BY (ck ASC)
+                    AND bloom_filter_fp_chance = 0.01
+                    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
+                    AND comment = ''
+                    AND compaction = {'class': 'SizeTieredCompactionStrategy'}
+                    AND compression = {{}}
+                    AND crc_check_chance = 1.0
+                    AND dclocal_read_repair_chance = 0.0
+                    AND default_time_to_live = 0
+                    AND gc_grace_seconds = 864000
+                    AND max_index_interval = 2048
+                    AND memtable_flush_period_in_ms = 0
+                    AND min_index_interval = 128
+                    AND read_repair_chance = 0.0
+                    AND speculative_retry = '99.0PERCENTILE';
+                    """

--- a/unit_tests/test_scylla_bench_thread.py
+++ b/unit_tests/test_scylla_bench_thread.py
@@ -17,7 +17,7 @@ from cassandra.cluster import Cluster  # pylint: disable=no-name-in-module
 from sdcm.scylla_bench_thread import ScyllaBenchThread
 from sdcm.utils.docker_utils import running_in_docker
 from unit_tests.dummy_remote import LocalLoaderSetDummy
-from test_lib.scylla_bench_tools import create_scylla_bench_table_query
+from test_lib.scylla_bench_tools import create_scylla_bench_test_table_query
 
 pytestmark = [
     pytest.mark.usefixtures("events",),
@@ -35,7 +35,7 @@ def create_cql_ks_and_table(docker_scylla):
     port = int(port)
 
     cluster_driver = Cluster([node_ip], port=port)
-    create_table_query = create_scylla_bench_table_query(
+    create_table_query = create_scylla_bench_test_table_query(
         compaction_strategy="SizeTieredCompactionStrategy", seed=None
     )
 


### PR DESCRIPTION
	In order to avoid creating it during a mixed scylla versions mode
	of cluster nodes (not supported).

 This is tested to be the root cause of: https://github.com/scylladb/scylladb/issues/11459
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
