### PR TITLE
fix(nemesis): add_remove_dc keyspace cleanup

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3545,30 +3545,41 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         node = self.cluster.nodes[0]
         system_keyspaces = ["system_auth", "system_distributed", "system_traces"]
         self._switch_to_network_replication_strategy(self.cluster.get_test_keyspaces() + system_keyspaces)
-        with temporary_replication_strategy_setter(node) as replication_strategy_setter:
-            new_node = self._add_new_node_in_new_dc()
-            datacenters = list(self.tester.db_cluster.get_nodetool_status().keys())
-            status = self.tester.db_cluster.get_nodetool_status()
-            new_dc_list = [dc for dc in list(status.keys()) if dc.endswith("_nemesis_dc")]
-            assert new_dc_list, "new datacenter was not registered"
-            new_dc_name = new_dc_list[0]
-            for keyspace in system_keyspaces:
-                strategy = ReplicationStrategy.get(node, keyspace)
-                assert isinstance(strategy, NetworkTopologyReplicationStrategy), \
-                    "Should have been already switched to NetworkStrategy"
-                strategy.replication_factors.update({new_dc_name: 1})
-                replication_strategy_setter(**{keyspace: strategy})
-            InfoEvent(message='execute rebuild on new datacenter').publish()
-            new_node.run_nodetool(sub_cmd=f"rebuild -- {datacenters[0]}")
-            InfoEvent(message='Running full cluster repair on each node').publish()
-            for node in self.cluster.nodes:
-                node.run_nodetool(sub_cmd="repair -pr", publish_event=True)
-            self._write_read_data_to_multi_dc_keyspace(datacenters)
-        self.cluster.decommission(new_node)
-        self.monitoring_set.reconfigure_scylla_monitoring()
         datacenters = list(self.tester.db_cluster.get_nodetool_status().keys())
-        assert not [dc for dc in datacenters if dc.endswith("_nemesis_dc")], "new datacenter was not unregistered"
-        self._verify_multi_dc_keyspace_data(consistency_level="QUORUM")
+        self.tester.create_keyspace("keyspace_new_dc", replication_factor={
+                                    datacenters[0]: min(3, len(self.cluster.nodes))})
+        node_added = False
+        try:
+            with temporary_replication_strategy_setter(node) as replication_strategy_setter:
+                new_node = self._add_new_node_in_new_dc()
+                node_added = True
+                status = self.tester.db_cluster.get_nodetool_status()
+                new_dc_list = [dc for dc in list(status.keys()) if dc.endswith("_nemesis_dc")]
+                assert new_dc_list, "new datacenter was not registered"
+                new_dc_name = new_dc_list[0]
+                for keyspace in system_keyspaces + ["keyspace_new_dc"]:
+                    strategy = ReplicationStrategy.get(node, keyspace)
+                    assert isinstance(strategy, NetworkTopologyReplicationStrategy), \
+                        "Should have been already switched to NetworkStrategy"
+                    strategy.replication_factors.update({new_dc_name: 1})
+                    replication_strategy_setter(**{keyspace: strategy})
+                InfoEvent(message='execute rebuild on new datacenter').publish()
+                new_node.run_nodetool(sub_cmd=f"rebuild -- {datacenters[0]}")
+                InfoEvent(message='Running full cluster repair on each node').publish()
+                for node in self.cluster.nodes:
+                    node.run_nodetool(sub_cmd="repair -pr", publish_event=True)
+                datacenters = list(self.tester.db_cluster.get_nodetool_status().keys())
+                self._write_read_data_to_multi_dc_keyspace(datacenters)
+            self.cluster.decommission(new_node)
+            node_added = False
+            datacenters = list(self.tester.db_cluster.get_nodetool_status().keys())
+            assert not [dc for dc in datacenters if dc.endswith("_nemesis_dc")], "new datacenter was not unregistered"
+            self._verify_multi_dc_keyspace_data(consistency_level="QUORUM")
+        finally:
+            with self.cluster.cql_connection_patient(node) as session:
+                session.execute('DROP KEYSPACE IF EXISTS keyspace_new_dc')
+            if node_added:
+                self.cluster.decommission(new_node)
 
 
 def disrupt_method_wrapper(method):  # pylint: disable=too-many-statements

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2028,7 +2028,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             If it's int, the default of replication_strategy will be 'SimpleStrategy'
             If it's dict, the default of replication_strategy will be 'NetworkTopologyStrategy'
 
-        In the case of NetworkTopologyStrategy, replication_strategy should be a dict that contains the name of
+        In the case of NetworkTopologyStrategy, replication_factor should be a dict that contains the name of
         every dc that the keyspace should be replicated to as keys, and the replication factor of each of those dc
         as values, like so:
         {"dc_name1": 4, "dc_name2": 6, "<dc_name>": <int>...}


### PR DESCRIPTION
After decommisioning node, multidc keyspace RF was not set to single-datacenter causing errors in other nemesis.

This commit removes decommissioned dc from this keyspace RF and removes keyspace after nemesis completes.

refs:
https://github.com/scylladb/scylla-cluster-tests/issues/5299 
https://github.com/scylladb/scylla-cluster-tests/issues/5236

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
