### PR TITLE
fix(schema-agreement): print proper error messages. v2

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2622,21 +2622,35 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
     @retrying(n=5, sleep_time=5, raise_on_exceeded=False)
     def get_peers_info(self):
-        cql_result = self.run_cqlsh('select peer, data_center, host_id, rack, release_version, '
-                                    'rpc_address, schema_version, supported_features from system.peers',
-                                    split=True, verbose=False)
+        columns = (
+            'peer', 'data_center', 'host_id', 'rack', 'release_version',
+            'rpc_address', 'schema_version', 'supported_features',
+        )
+        columns_len = len(columns)
+        cql_result = self.run_cqlsh(
+            f"select {', '.join(columns)} from system.peers", split=True, verbose=False)
         # peer | data_center | host_id | rack | release_version | rpc_address | schema_version | supported_features
         # ------+-------------+---------+------+-----------------+-------------+----------------+--------------------
 
         peers_details = {}
+        err = ''
         for line in cql_result:
+            if '|' not in line or all(column in line for column in columns):
+                # NOTE: skip non-rows and header lines
+                continue
             line_splitted = line.split('|')
-            if len(line_splitted) < 8:
+            if len(line_splitted) != columns_len:
+                current_err = f"Failed to parse the cqlsh command output line: \n{line}\n"
+                LOGGER.warning(current_err)
+                err += current_err
                 continue
             peer = line_splitted[0].strip()
             try:
                 ipaddress.ip_address(peer)
-            except ValueError:
+            except ValueError as exc:
+                current_err = f"Peer '{peer}' is not an IP address, err: {exc}\n"
+                LOGGER.warning(current_err)
+                err += current_err
                 continue
 
             if node := self.parent_cluster.find_node_by_ip(peer):
@@ -2650,9 +2664,14 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                     'supported_features': line_splitted[7].strip(),
                 }
             else:
-                if peer:
-                    LOGGER.error("Get peers info. Failed to find a node in the cluster by IP: %s", peer)
+                current_err = f"'get_peers_info' failed to find a node by IP: {peer}\n"
+                LOGGER.error(current_err)
+                err += current_err
 
+        if not (peers_details or err):
+            LOGGER.error(
+                "No data, no errors. Check the output from the cqlsh for the correctness:\n%s",
+                cql_result)
         return peers_details
 
     @retrying(n=5, sleep_time=10, raise_on_exceeded=False)
@@ -3903,7 +3922,8 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
     def wait_for_schema_agreement(self):
 
         for node in self.nodes:
-            assert check_schema_agreement_in_gossip_and_peers(node), 'Schema agreement is not reached'
+            err = check_schema_agreement_in_gossip_and_peers(node)
+            assert not err, err
         self.log.debug('Schema agreement is reached')
         return True
 

--- a/sdcm/utils/health_checker.py
+++ b/sdcm/utils/health_checker.py
@@ -221,35 +221,44 @@ def check_schema_version(gossip_info, peers_details, nodes_status, current_node)
         )
 
 
-def check_schema_agreement_in_gossip_and_peers(node, retries: int = CHECK_NODE_HEALTH_RETRIES) -> bool:
+def check_schema_agreement_in_gossip_and_peers(node, retries: int = CHECK_NODE_HEALTH_RETRIES) -> str:
+    err = ''
     for retry_n in range(retries):
         if retry_n:
+            err = ''
             time.sleep(CHECK_NODE_HEALTH_RETRY_DELAY)
         message_pref = f'Check for schema agreement on the node {node.name} ({node}) [attempt #{retry_n}].'
         gossip_info = node.get_gossip_info()
-        peers_info = node.get_peers_info()
         LOGGER.debug("%s Gossip info: %s", message_pref, gossip_info)
-        LOGGER.debug("%s Peers info: %s", message_pref, peers_info)
-
-        if gossip_info is None or peers_info is None:
-            LOGGER.warning("%s Unable to get gossip or peers information", message_pref)
+        if not gossip_info:
+            err = f"{message_pref} Unable to get the gossip info"
+            LOGGER.warning(err)
             continue
 
-        gossip_schema = {data["schema"] for data in gossip_info.values() if data['status'] == "NORMAL"}
+        peers_info = node.get_peers_info()
+        LOGGER.debug("%s Peers info: %s", message_pref, peers_info)
+        if not peers_info:
+            err = f"{message_pref} Unable to get the peers info"
+            LOGGER.warning(err)
+            continue
+
+        gossip_schema = {data["schema"] for data in gossip_info.values()
+                         if data['status'] == "NORMAL"}
         if len(gossip_schema) > 1:
-            LOGGER.warning("%s Schema version is not same on nodes in the gossip", message_pref)
+            err = f"{message_pref} Schema version is not same on nodes in the gossip"
+            LOGGER.warning(err)
             continue
 
         for current_node, data in gossip_info.items():
-            if data['status'] == "NORMAL" and current_node in peers_info:
-                if data["schema"] != peers_info[current_node]['schema_version']:
-                    LOGGER.warning("%s Schema version is not same in the gossip and peers for %s",
-                                   message_pref, current_node)
-                    continue
-
+            if not (data['status'] == "NORMAL" and current_node in peers_info):
+                continue
+            if data["schema"] != peers_info[current_node]['schema_version']:
+                current_err = (f"{message_pref} Schema version is not same in "
+                               f"the gossip and peers for {current_node}")
+                LOGGER.warning(current_err)
+                err += f"{current_err}\n"
+                continue
         break  # Everything is OK, break the cycle.
-    else:
-        return False  # Something was wrong even on the last cycle.
-
-    LOGGER.debug('Schema agreement has been completed on all nodes')
-    return True
+    if not err:
+        LOGGER.debug('Schema agreement has been completed on all nodes')
+    return err


### PR DESCRIPTION
For the moment, if we fail to get the peers info for some reason, then we get 'Schema agreement is not reached' error running the 'ToggleTableIcs' nemesis.
So, detect specific problems and report correct messages not hiding valueable info.

Closes: https://github.com/scylladb/scylla-cluster-tests/issues/5265

P.S.
First version of this change was merged with 2 bugs in the [1]. And then reverted in the [2].

The problem with v1 was lots of redundant 'gossip' and 'peers' API calls with huge waiting intervals '2m14s' instead of '7s' for each of the DB nodes.

It was caused by the absence of the 'break' statement for the retry loop in case of success and reporting of a failure from previous iterations on the last succeeded, which caused the rerun of the function again.

The side effect of this redundancy is increase of spent time for a DB table creation in the 'upgrade_test.py' from '30s' to '537s'. 
Diff is 18 times in this case.
Multiplying it to the huge number of DB tables (90+) we were getting job timeouts.

So, fix 2 mentioned bugs and cover both cases in the unit tests.

[1] https://github.com/scylladb/scylla-cluster-tests/pull/5272 
[2] https://github.com/scylladb/scylla-cluster-tests/pull/5294

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
