### PR TITLE
fix(_prepare_test_table): execute single c-s thread

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1692,7 +1692,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             stress_cmd = "cassandra-stress write n=400000 cl=QUORUM -mode native cql3 " \
                          f"-schema 'replication(factor={self.tester.reliable_replication_factor})' -log interval=5"
             cs_thread = self.tester.run_stress_thread(
-                stress_cmd=stress_cmd, keyspace_name=ks, stop_test_on_failure=False)
+                stress_cmd=stress_cmd, keyspace_name=ks, stop_test_on_failure=False, round_robin=True)
             cs_thread.verify_results()
 
     def disrupt_truncate(self):


### PR DESCRIPTION
If standard c-s schema is not created, the method execute c-s to create it, but run from all nodes which could bring to c-s stack. Set round robin to 1, for running single command

The problem appears in job:
https://jenkins.scylladb.com/job/enterprise-2022.2/job/longevity/job/longevity-cdc-3d-400gb-test/


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
