### PR TITLE
fix(gemini_thread): Increase request and connect timeouts for gemini

### DIFF
--- a/sdcm/gemini_thread.py
+++ b/sdcm/gemini_thread.py
@@ -66,6 +66,8 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
         self.oracle_cluster = oracle_cluster
         self._gemini_result_file = None
         self.gemini_commands = []
+        self.gemini_request_timeout = 180
+        self.gemini_connect_timeout = 120
 
     @property
     def gemini_result_file(self):
@@ -81,10 +83,13 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
         test_nodes = ",".join(self.test_cluster.get_node_cql_ips())
         oracle_nodes = ",".join(self.oracle_cluster.get_node_cql_ips()) if self.oracle_cluster else None
 
-        cmd = "{} --test-cluster={} --outfile {} --seed {} ".format(self.stress_cmd.strip(),
-                                                                    test_nodes,
-                                                                    self.gemini_result_file,
-                                                                    seed)
+        cmd = "{} --test-cluster={} --outfile {} --seed {} --request-timeout {}s --connect-timeout {}s".format(
+            self.stress_cmd.strip(),
+            test_nodes,
+            self.gemini_result_file,
+            seed,
+            self.gemini_request_timeout,
+            self.gemini_connect_timeout)
         if oracle_nodes:
             cmd += "--oracle-cluster={} ".format(oracle_nodes)
         if table_options:


### PR DESCRIPTION
Sometimes default connect and request timeouts for gocql driver 10s could be not enough. While node was replaced, gemini query failed by timeout for si.
To avoid such errors, increasing request and connect timeouts

Job where issue happened:
https://jenkins.scylladb.com/job/enterprise-2022.1/job/gemini-/job/gemini-3h-with-nemesis-test/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
