### PR TITLE
fix(run_nodetool): fix coredump on timeout

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -64,7 +64,7 @@ from sdcm.provision.scylla_yaml.certificate_builder import ScyllaYamlCertificate
 from sdcm.provision.scylla_yaml.cluster_builder import ScyllaYamlClusterAttrBuilder
 from sdcm.provision.scylla_yaml.scylla_yaml import ScyllaYaml
 from sdcm.provision.helpers.certificate import install_client_certificate, install_encryption_at_rest_files
-from sdcm.remote import RemoteCmdRunnerBase, LOCALRUNNER, NETWORK_EXCEPTIONS, shell_script_cmd
+from sdcm.remote import RemoteCmdRunnerBase, LOCALRUNNER, NETWORK_EXCEPTIONS, shell_script_cmd, RetryableNetworkException
 from sdcm.remote.remote_file import remote_file, yaml_file_to_dict, dict_to_yaml_file
 from sdcm import wait, mgmt
 from sdcm.sct_config import SCTConfiguration
@@ -2537,7 +2537,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 nodetool_event.duration = result.duration
                 return result
             except Exception as details:  # pylint: disable=broad-except
-                if coredump_on_timeout and isinstance(details, CommandTimedOut):
+                if isinstance(details, RetryableNetworkException):
+                    details = details.original
+                if details.__class__.__name__.endswith("CommandTimedOut"):
                     self.generate_coredump_file()
 
                 nodetool_event.add_error([f"{error_message}{str(details)}"])

--- a/sdcm/remote/libssh2_client/__init__.py
+++ b/sdcm/remote/libssh2_client/__init__.py
@@ -94,10 +94,10 @@ class SSHReaderThread(Thread):  # pylint: disable=too-many-instance-attributes
         eof_result = stdout_size = stderr_size = 1
         while eof_result == LIBSSH2_ERROR_EAGAIN or stdout_size == LIBSSH2_ERROR_EAGAIN or \
                 stdout_size > 0 or stderr_size == LIBSSH2_ERROR_EAGAIN or stderr_size > 0:  # pylint: disable=consider-using-in
-            if not self._can_run.is_set():
-                break
             if perf_counter() > end_time:
                 self.timeout_reached = True
+                break
+            if not self._can_run.is_set():
                 break
             with session.lock:
                 if stdout_size == LIBSSH2_ERROR_EAGAIN and stderr_size == LIBSSH2_ERROR_EAGAIN:  # pylint: disable=consider-using-in


### PR DESCRIPTION
There are 2 reasons of coredump not creating on timeout error when running nodetool (e.g. in upgrade test when we run: `node.run_nodetool("drain", timeout=3600, coredump_on_timeout=True)`:
1. kind of race condition when `SSHReaderThread` got end event (due timeout) but reader didn't acknowledge that it occured yet. This even lead to sometimes freeze of whole ssh command until CriticalError killed ssh connection.
2. wrong exception handling when running nodetool

This commit fixes both problems.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
