### PR TITLE
fix(pylint): make it not complain with 'R0801: Similar lines in 2 files'

### DIFF
--- a/functional_tests/scylla_operator/libs/helpers.py
+++ b/functional_tests/scylla_operator/libs/helpers.py
@@ -223,16 +223,15 @@ def verify_resharding_on_k8s(db_cluster: ScyllaPodCluster, cpus: Union[str, int,
                     resharding_time, node.name)
             else:
                 log.info(
-                    "Resharding took '%s's on the '%s' node",
-                    resharding_time, node.name)
+                    "Resharding has taken '%s's on the '%s' node", resharding_time, node.name)
 
             # Check that liveness probe didn't report any errors
             # https://github.com/scylladb/scylla-operator/issues/894
-            liveness_probe_failures = list(liveness_probe_failures)
-            assert not liveness_probe_failures, (
-                f"There are liveness probe failures: {liveness_probe_failures}")
+            liveness_probe_failures_list = list(liveness_probe_failures)
+            assert not liveness_probe_failures_list, (
+                f"liveness probe has failures: {liveness_probe_failures_list}")
     finally:
-        # NOTE: refresh scylla pods IP addresses because it may get changed here
+        # NOTE: refresh Scylla pods IP addresses because it may get changed at this step
         for node in nodes_data:
             node[0].refresh_ip_address()
     log.info("Resharding has successfully ended on whole Scylla cluster.")


### PR DESCRIPTION
`functional_tests/scylla_operator/libs/helpers.py` and `sdcm/nemesis.py` 
have one function ported from one place to another and it happens that we get following pylint error:

    R0801: Similar lines in 2 files
    ==functional_tests.scylla_operator.libs.helpers:[226:237]
    ==sdcm.nemesis:[1232:1243]

So, fix it by changing the code a bit in the `helpers.py` file to make the pylint be happy.

Closes: https://github.com/scylladb/scylla-cluster-tests/issues/5312

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
