### PR TITLE
fix(drain): fix timeout for nodetool drain command

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1015,7 +1015,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.repair_nodetool_rebuild()
 
     def disrupt_nodetool_drain(self):
-        result = self.target_node.run_nodetool("drain", timeout=3600, coredump_on_timeout=True)
+        result = self.target_node.run_nodetool("drain", timeout=15*60, coredump_on_timeout=True)
         self.target_node.run_nodetool("status", ignore_status=True, verbose=True,
                                       warning_event_on_exception=(Exception,))
 
@@ -4215,7 +4215,7 @@ class RollbackNemesis(Nemesis):
         node.remoter.run(
             'sudo yum downgrade scylla scylla-server scylla-jmx scylla-tools scylla-conf scylla-kernel-conf scylla-debuginfo -y')
         # flush all memtables to SSTables
-        node.run_nodetool("drain", timeout=3600, coredump_on_timeout=True)
+        node.run_nodetool("drain", timeout=15*60, coredump_on_timeout=True)
         node.remoter.run('sudo cp {0}-backup {0}'.format(SCYLLA_YAML_PATH))
         node.remoter.run('sudo systemctl restart scylla-server.service')
         node.wait_db_up(verbose=True)

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -173,7 +173,7 @@ class UpgradeTest(FillDatabaseData):
             # replace the packages
             node.remoter.run(r'rpm -qa scylla\*')
             # flush all memtables to SSTables
-            node.run_nodetool("drain", timeout=3600, coredump_on_timeout=True)
+            node.run_nodetool("drain", timeout=15*60, coredump_on_timeout=True)
             node.run_nodetool("snapshot")
             node.stop_scylla_server()
             # update *development* packages
@@ -192,7 +192,7 @@ class UpgradeTest(FillDatabaseData):
             assert new_scylla_repo.startswith('http')
             node.download_scylla_repo(new_scylla_repo)
             # flush all memtables to SSTables
-            node.run_nodetool("drain", timeout=3600, coredump_on_timeout=True)
+            node.run_nodetool("drain", timeout=15*60, coredump_on_timeout=True)
             node.run_nodetool("snapshot")
             node.stop_scylla_server(verify_down=False)
 
@@ -265,7 +265,7 @@ class UpgradeTest(FillDatabaseData):
         result = node.remoter.run('scylla --version')
         orig_ver = result.stdout
         # flush all memtables to SSTables
-        node.run_nodetool("drain", timeout=3600, coredump_on_timeout=True)
+        node.run_nodetool("drain", timeout=15*60, coredump_on_timeout=True)
         # backup the data
         node.run_nodetool("snapshot")
         node.stop_scylla_server(verify_down=False)


### PR DESCRIPTION
In https://github.com/scylladb/scylla-cluster-tests/pull/1912 timeout was introduced to `nodetool drain` command. Timeout value was not discussed in PR and it seems to be too big (1h).

This commit sets `nodetool drain` timeout to 15 minutes. After that time coredump should be created for analysis.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
