### PR TITLE
fix(argus_test_run): Don't use argus for local runs with docker

### DIFF
--- a/sdcm/argus_test_run.py
+++ b/sdcm/argus_test_run.py
@@ -244,13 +244,13 @@ class ArgusTestRun:
         LOGGER.info("Preparing Test Details...")
         job_name = get_job_name()
         job_url = get_job_url()
-        if job_name == "local_run":
+        if not job_name or job_name == "local_run":
             raise ArgusTestRunError("Will not track a locally run job")
 
         config_files = sct_config.get("config_files")
         started_by = get_username()
 
-        details = TestDetails(scm_revision_id=get_git_commit_id(), started_by=started_by, build_job_url=job_url,
+        details = TestDetails(scm_revision_id=get_git_commit_id(), started_by=started_by, build_job_url=job_url,   # pylint: disable=no-value-for-parameter
                               yaml_test_duration=sct_config.get("test_duration"),
                               start_time=datetime.utcnow().replace(microsecond=0),
                               config_files=config_files, packages=[])
@@ -276,7 +276,7 @@ class ArgusTestRun:
 
         run_info = TestRunInfo(details=details, setup=setup_details, resources=resources, logs=logs, results=results)
         LOGGER.info("Initializing TestRun...")
-        cls.TESTRUN_INSTANCE = TestRunWithHeartbeat(test_id=test_id, build_id=job_name,
+        cls.TESTRUN_INSTANCE = TestRunWithHeartbeat(test_id=test_id, build_id=job_name,  # pylint: disable=unexpected-keyword-arg,no-value-for-parameter
                                                     assignee=None,
                                                     run_info=run_info,
                                                     config=cls.config())


### PR DESCRIPTION
if run sct locally with docker backend, argus error reported to cli output
  File "/usr/local/lib/python3.10/site-packages/argus/db/testrun.py",
 line 723, in _heartbeat_entry
    self.argus.session.execute(bound_statement)
  File "cassandra/cluster.py", line 2668, in cassandra.cluster.Session.execute
  File "cassandra/cluster.py", line 4953, in cassandra.cluster.ResponseFuture.result
cassandra.InvalidRequest: Error from server: code=2200
 [Invalid query] message="Key may not be empty"

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
