### PR TITLE
fix(unit-tests): fix CI checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,3 +44,4 @@ repos:
   hooks:
       - id: commitlint
         stages: [commit-msg]
+        language_version: 16.15.1

--- a/sct.py
+++ b/sct.py
@@ -82,9 +82,9 @@ from sdcm.utils.get_username import get_username
 from sdcm.send_email import get_running_instances_for_email_report, read_email_data_from_file, build_reporter, \
     send_perf_email
 from sdcm.parallel_timeline_report.generate_pt_report import ParallelTimelinesReportGenerator
-from utils.build_system.create_test_release_jobs import JenkinsPipelines  # pylint: disable=no-name-in-module
-from utils.get_supported_scylla_base_versions import UpgradeBaseVersion  # pylint: disable=no-name-in-module
-from utils.mocks.aws_mock import AwsMock  # pylint: disable=no-name-in-module
+from utils.build_system.create_test_release_jobs import JenkinsPipelines  # pylint: disable=no-name-in-module,import-error
+from utils.get_supported_scylla_base_versions import UpgradeBaseVersion  # pylint: disable=no-name-in-module,import-error
+from utils.mocks.aws_mock import AwsMock  # pylint: disable=no-name-in-module,import-error
 
 
 SUPPORTED_CLOUDS = ("aws", "gce", "azure",)

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -35,9 +35,9 @@ import botocore.exceptions
 import yaml
 import tenacity
 from mypy_boto3_ec2 import EC2Client
-from sdcm.ec2_client import CreateSpotInstancesError
 from pkg_resources import parse_version
 
+from sdcm.ec2_client import CreateSpotInstancesError
 from sdcm import ec2_client, cluster, wait
 from sdcm.wait import exponential_retry
 from sdcm.provision.aws.utils import configure_eth1_script, network_config_ipv6_workaround_script, \

--- a/sdcm/cluster_gce.py
+++ b/sdcm/cluster_gce.py
@@ -65,14 +65,14 @@ class GCENode(cluster.BaseNode):
         self._gce_logging_client = GceLoggingClient(name, self._instance.extra["zone"].name)
         self._last_logs_fetch_time = 0.0
         ssh_login_info = {'hostname': None,
-                          'user': gce_image_username,
                           'key_file': credentials.key_file,
+                          'user': gce_image_username,
                           'extra_ssh_options': '-tt'}
         super().__init__(name=name,
                          parent_cluster=parent_cluster,
-                         ssh_login_info=ssh_login_info,
                          base_logdir=base_logdir,
                          node_prefix=node_prefix,
+                         ssh_login_info=ssh_login_info,
                          dc_idx=dc_idx)
 
     @staticmethod

--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -16,7 +16,6 @@ from functools import wraps
 from typing import ContextManager, Callable, Sequence
 
 from sdcm.sct_events import Severity
-from sdcm.sct_events.base import LogEvent
 from sdcm.sct_events.filters import DbEventsFilter, EventsSeverityChangerFilter, EventsFilter
 from sdcm.sct_events.loaders import YcsbStressEvent
 from sdcm.sct_events.database import DatabaseLogEvent

--- a/unit_tests/test_base_version.py
+++ b/unit_tests/test_base_version.py
@@ -33,7 +33,7 @@ class TestBaseVersion(unittest.TestCase):
         scylla_repo = self.url_base + 'unstable/scylla/master/rpm/centos/2021-08-29T00:58:58Z/scylla.repo'
         linux_distro = 'centos'
         version_list = general_test(scylla_repo, linux_distro)
-        self.assertEqual(version_list, ['5.0'])
+        self.assertEqual(version_list, ['5.1'])
 
     def test_4_5_with_centos8(self):
         scylla_repo = self.url_base + 'unstable/scylla/branch-4.5/rpm/centos/2021-08-29T00:58:58Z/scylla.repo'

--- a/unit_tests/test_base_version.py
+++ b/unit_tests/test_base_version.py
@@ -57,7 +57,7 @@ class TestBaseVersion(unittest.TestCase):
         scylla_repo = self.url_base + 'unstable/scylla-enterprise/enterprise/rpm/centos/2021-08-29T00:58:58Z/scylla.repo'
         linux_distro = 'centos'
         version_list = general_test(scylla_repo, linux_distro)
-        self.assertEqual(version_list, ['2022.1'])
+        self.assertEqual(version_list, ['2022.2'])
 
     def test_2021_1(self):
         scylla_repo = self.url_base + 'unstable/scylla-enterprise/branch-2021.1/rpm/centos/2021-08-29T00:58:58Z/scylla.repo'

--- a/unit_tests/test_base_version.py
+++ b/unit_tests/test_base_version.py
@@ -76,7 +76,7 @@ class TestBaseVersion(unittest.TestCase):
             'unstable/scylla-enterprise/enterprise-2022.1/deb/unified/2022-06-03T00:22:55Z/scylladb-2022.1/scylla.list'
         linux_distro = 'centos-8'
         version_list = general_test(scylla_repo, linux_distro)
-        self.assertEqual(['5.0', '2021.1'], version_list)
+        self.assertEqual(['5.0', '2021.1', '2022.1'], version_list)
 
 
 if __name__ == "__main__":

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -247,7 +247,6 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         os.environ['SCT_CLUSTER_BACKEND'] = 'k8s-local-kind'
         os.environ['SCT_SCYLLA_LINUX_DISTRO'] = 'ubuntu-xenial'
         os.environ['SCT_SCYLLA_LINUX_DISTRO_LOADER'] = 'centos'
-        os.environ['SCT_SCYLLA_VERSION'] = 'latest'
         conf = sct_config.SCTConfiguration()
         conf.verify_configuration()
 

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -163,7 +163,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         conf = sct_config.SCTConfiguration()
         conf.verify_configuration()
 
-        self.assertEqual(conf.get('ami_id_db_scylla'), 'ami-0f1aa8afb878fed2b ami-027c1337dcb46da50')
+        self.assertEqual(conf.get('ami_id_db_scylla'), 'ami-05f62259c7715e1a6 ami-027c1337dcb46da50')
 
     @staticmethod
     def test_12_scylla_version_ami_case1():  # pylint: disable=invalid-name
@@ -257,12 +257,12 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
 
     def test_13_scylla_version_ami_branch(self):  # pylint: disable=invalid-name
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
-        os.environ['SCT_SCYLLA_VERSION'] = 'branch-4.2:100'
+        os.environ['SCT_SCYLLA_VERSION'] = 'branch-5.0:32'
         os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/multi_region_dc_test_case.yaml'
         conf = sct_config.SCTConfiguration()
         conf.verify_configuration()
 
-        self.assertEqual(conf.get('ami_id_db_scylla'), 'ami-07d3138defbd9a2cf ami-0f703fdc8e06723f0')
+        self.assertEqual(conf.get('ami_id_db_scylla'), 'ami-076a213c791dc19cd ami-0625f2d18e05bf206')
 
     def test_13_scylla_version_ami_branch_latest(self):  # pylint: disable=invalid-name
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'

--- a/unit_tests/test_utils_common.py
+++ b/unit_tests/test_utils_common.py
@@ -30,7 +30,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 class TestUtils(unittest.TestCase):
     def test_tag_ami_01(self):  # pylint: disable=no-self-use
-        tag_ami(ami_id='ami-0876bfff890e17a06',
+        tag_ami(ami_id='ami-076a213c791dc19cd',
                 tags_dict={'JOB_longevity-multi-keyspaces-60h': 'PASSED'}, region_name='eu-west-1')
 
     def test_scylla_bench_metrics_conversion(self):  # pylint: disable=no-self-use


### PR DESCRIPTION
This PR includes a few commits cherry-picked from master and a small fix to imports in order to fix the CI checks on branch-2022.1.

Part of the effort in: https://github.com/scylladb/qa-tasks/issues/813

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
