### PR TITLE
fix(workaround): reactor stall threshold increase

### DIFF
--- a/test-cases/performance/perf-regression-latency-1TB.yaml
+++ b/test-cases/performance/perf-regression-latency-1TB.yaml
@@ -21,7 +21,7 @@ user_prefix: 'perf-regression-latency'
 space_node_threshold: 644245094
 
 round_robin: true
-append_scylla_args: '--blocked-reactor-notify-ms 4'
+append_scylla_args: '--blocked-reactor-notify-ms 5'
 
 store_perf_results: true
 send_email: true

--- a/test-cases/performance/perf-regression-latency-500gb-30min.yaml
+++ b/test-cases/performance/perf-regression-latency-500gb-30min.yaml
@@ -23,7 +23,7 @@ backtrace_decoding: false
 print_kernel_callstack: true
 
 round_robin: true
-append_scylla_args: '--blocked-reactor-notify-ms 4'
+append_scylla_args: '--blocked-reactor-notify-ms 5'
 
 store_perf_results: true
 use_mgmt: false

--- a/test-cases/performance/perf-regression-user-profiles.yaml
+++ b/test-cases/performance/perf-regression-user-profiles.yaml
@@ -33,7 +33,7 @@ cs_user_profiles:
     - scylla-qa-internal/cust_s/case2.yaml
 
 store_perf_results: true
-append_scylla_args: '--blocked-reactor-notify-ms 4'
+append_scylla_args: '--blocked-reactor-notify-ms 5'
 
 backtrace_decoding: false
 print_kernel_callstack: true


### PR DESCRIPTION
because of https://github.com/scylladb/scylladb/issues/10981#issuecomment-1257045821 we are increasing the threshold of these reactor
stalls to 5 ms, to avoid this issue, until
it is fixed.
once it will be fixed, we will want to revert
this change.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
