### PR TITLE
fix(gce): strip image url

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -892,12 +892,12 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         user_credentials = self.params.get('user_credentials_path')
         self.credentials.append(UserRemoteCredentials(key_file=user_credentials))
 
-        gce_image_db = self.params.get('gce_image_db')
+        gce_image_db = self.params.get('gce_image_db').strip()
         if not gce_image_db:
-            gce_image_db = self.params.get('gce_image')
-        gce_image_monitor = self.params.get('gce_image_monitor')
+            gce_image_db = self.params.get('gce_image').strip()
+        gce_image_monitor = self.params.get('gce_image_monitor').strip()
         if not gce_image_monitor:
-            gce_image_monitor = self.params.get('gce_image')
+            gce_image_monitor = self.params.get('gce_image').strip()
         cluster_additional_disks = {'pd-ssd': self.params.get('gce_pd_ssd_disk_size_db'),
                                     'pd-standard': self.params.get('gce_pd_standard_disk_size_db')}
 
@@ -987,7 +987,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 loader_info['n_nodes'] = [int(n) for n in n_loader_nodes.split()]
             else:
                 self.fail('Unsupported parameter type: {}'.format(type(n_loader_nodes)))
-        azure_image = self.params.get("azure_image_db")
+        azure_image = self.params.get("azure_image_db").strip()
         user_prefix = self.params.get('user_prefix')
         self.credentials.append(UserRemoteCredentials(key_file="~/.ssh/scylla-test"))
 


### PR DESCRIPTION
When gce_image_db contains trailing spaces it fails the test. It's easy to copy/paste image url with additional space at the end.

This commit removes trailing spaces from gce image url when used.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
