### PR TITLE
test(nemesis): remove service level while load

### DIFF
--- a/longevity_sla_test.py
+++ b/longevity_sla_test.py
@@ -49,7 +49,7 @@ class LongevitySlaTest(LongevityTest):
         self.add_sla_credentials_to_stress_cmds()
         super().test_custom_time()
 
-    def create_sla_auth(self, session, shares: int, index: int):
+    def create_sla_auth(self, session, shares: int, index: int) -> Role:
         role = Role(session=session, name=self.STRESS_ROLE_NAME_TEMPLATE % (shares, index),
                     password=self.STRESS_ROLE_PASSWORD_TEMPLATE % shares, login=True).create()
         role.attach_service_level(ServiceLevel(session=session, name=self.SERVICE_LEVEL_NAME_TEMPLATE % (shares, index),

--- a/test-cases/longevity/longevity-sla-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-sla-100gb-4h.yaml
@@ -1,11 +1,11 @@
 test_duration: 360
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=20971520 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=41943040 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=600 -pop seq=1..41943040 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
 
 # option <sla credentials 0> - where "0" is first element of "service_level_shares" test parameter. This option will be replaced with user and password of the role name that assigned to service level with shares=service_level_shares[0]
 # option <sla credentials 1> - where "1" is second element of "service_level_shares" test parameter. This option will be replaced with user and password of the role name that assigned to service level with shares=service_level_shares[1]
-stress_cmd: ["cassandra-stress read cl=QUORUM duration=240m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native <sla credentials 0> -rate threads=40 -pop seq=1..10485760 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=240m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native <sla credentials 1> -rate threads=40 -pop seq=10485761..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
+stress_cmd: ["cassandra-stress read cl=QUORUM duration=240m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native <sla credentials 0> -rate threads=600 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=240m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native <sla credentials 1> -rate threads=600 -pop seq=20971521..41943040 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
              ]
 
 n_db_nodes: 6

--- a/test_lib/sla.py
+++ b/test_lib/sla.py
@@ -96,7 +96,7 @@ class ServiceLevel:
 
     @property
     def created(self) -> bool:
-        return self.created
+        return self._created
 
     @created.setter
     def created(self, created: bool):


### PR DESCRIPTION
Add new nemesis that remove service level while load running connected with this SL

Refs: https://github.com/scylladb/qa-tasks/issues/805

Issue https://github.com/scylladb/scylla-enterprise/issues/2438 was reproduced. Example of run:
https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/staging-sla-100gb-4h/50/

```
2022-10-12T07:42:08+00:00 longevity-sla-100gb-4h-test-add-db-node-efcc62e5-4     !INFO | scylla[9871]:  [shard 0] workload prioritization - service level "sl200_0" was deleted.
2022-10-12T07:42:08+00:00 longevity-sla-100gb-4h-test-add-db-node-efcc62e5-4     !INFO | scylla[9871]: Segmentation fault on shard 6.
2022-10-12T07:42:08+00:00 longevity-sla-100gb-4h-test-add-db-node-efcc62e5-4     !INFO | scylla[9871]: Backtrace:
2022-10-12T07:42:08+00:00 longevity-sla-100gb-4h-test-add-db-node-efcc62e5-4     !INFO | scylla[9871]:   0x0000000002ec8bd2
2022-10-12T07:42:08+00:00 longevity-sla-100gb-4h-test-add-db-node-efcc62e5-4     !INFO | scylla[9871]:   0x0000000002ec9265
2022-10-12T07:42:08+00:00 longevity-sla-100gb-4h-test-add-db-node-efcc62e5-4     !INFO | scylla[9871]:   0x0000000002ec9515
2022-10-12T07:42:08+00:00 longevity-sla-100gb-4h-test-add-db-node-efcc62e5-4     !INFO | scylla[9871]:   0x0000000002ec95b0
2022-10-12T07:42:08+00:00 longevity-sla-100gb-4h-test-add-db-node-efcc62e5-4     !INFO | scylla[9871]:   0x00007f5b252a3a1f
2022-10-12T07:42:08+00:00 longevity-sla-100gb-4h-test-add-db-node-efcc62e5-4     !INFO | scylla[9871]:   0x000000000282e441
2022-10-12T07:42:08+00:00 longevity-sla-100gb-4h-test-add-db-node-efcc62e5-4     !INFO | scylla[9871]:   0x000000000282e7f1
2022-10-12T07:42:08+00:00 longevity-sla-100gb-4h-test-add-db-node-efcc62e5-4     !INFO | scylla[9871]:   0x000000000282f0d4
2022-10-12T07:42:08+00:00 longevity-sla-100gb-4h-test-add-db-node-efcc62e5-4     !INFO | scylla[9871]:   0x0000000002ec6fe7
2022-10-12T07:42:08+00:00 longevity-sla-100gb-4h-test-add-db-node-efcc62e5-4     !INFO | scylla[9871]:   0x0000000002ec729e
2022-10-12T07:42:08+00:00 longevity-sla-100gb-4h-test-add-db-node-efcc62e5-4     !INFO | scylla[9871]:   0x0000000002f07d35
2022-10-12T07:42:08+00:00 longevity-sla-100gb-4h-test-add-db-node-efcc62e5-4     !INFO | scylla[9871]:   0x0000000002f1a98a
2022-10-12T07:42:08+00:00 longevity-sla-100gb-4h-test-add-db-node-efcc62e5-4     !INFO | scylla[9871]:   0x0000000002e8fddd
2022-10-12T07:42:08+00:00 longevity-sla-100gb-4h-test-add-db-node-efcc62e5-4     !INFO | scylla[9871]:   /opt/scylladb/libreloc/libpthread.so.0+0x0000000000009298
2022-10-12T07:42:08+00:00 longevity-sla-100gb-4h-test-add-db-node-efcc62e5-4     !INFO | scylla[9871]:   /opt/scylladb/libreloc/libc.so.6+0x0000000000100352
2022-10-12T07:42:08+00:00 longevity-sla-100gb-4h-test-add-db-node-efcc62e5-4     !INFO | kernel: reactor-6[9877]: segfault at 6408 ip 000000000282e442 sp 00007f5b201d3c90 error 4
2022-10-12T07:42:08+00:00 longevity-sla-100gb-4h-test-add-db-node-efcc62e5-4     !INFO | kernel: reactor-8[9879]: segfault at 10 ip 000000000282e2c3 sp 00007f5b1f5d3c90 error 6

```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
