### PR TITLE
test(5000-tables): change seed for 5000 tables test

### DIFF
--- a/test-cases/scale/longevity-5000-tables.yaml
+++ b/test-cases/scale/longevity-5000-tables.yaml
@@ -41,7 +41,7 @@ user_prefix: 'longevity-5000-tables'
 cluster_health_check: false
 
 nemesis_class_name: 'SisyphusMonkey'
-nemesis_seed: '004'
+nemesis_seed: '404'
 nemesis_interval: 60
 
 


### PR DESCRIPTION
We ran into problematic nemesis for 5000 tables test: https://github.com/scylladb/scylla-manager/issues/3237

This commit switch nemesis seed to make this test with different nemesis set.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
