### PR TITLE
fix(data validator): list of unique view names with same elements order

### DIFF
--- a/sdcm/utils/data_validator.py
+++ b/sdcm/utils/data_validator.py
@@ -277,7 +277,7 @@ class LongevityDataValidator:
     def get_profile_content(self, cs_profile=None):
         if not cs_profile:
             stress_cmd = self.longevity_self_object.params.get(self.stress_cmds_part) or []
-            cs_profile = list(set(cmd for cmd in stress_cmd if self.user_profile_name in cmd))
+            cs_profile = [cmd for cmd in stress_cmd if self.user_profile_name in cmd]
 
         if not cs_profile:
             return []
@@ -309,7 +309,7 @@ class LongevityDataValidator:
                     if not all_entries:
                         break
 
-        return mv_names
+        return list(dict.fromkeys(mv_names))  # list of unique view names and keep the elements order
 
     @staticmethod
     def get_view_cmd_from_profile(profile_content, name_substr, all_entries=False):


### PR DESCRIPTION
longevity-lwt-500G-3d-test failed with error:
```
AlreadyExists: Table 'cqlstress_lwt_example.blogposts_update_one_column_lwt_indicator_expect' already exists
```

It happened because of test-cases/longevity/longevity-lwt-500G-3d.yaml runs the same user profile a few times, so list of view names is not unique, like:
```
['blogposts_update_one_column_lwt_indicator', 'blogposts_update_2_columns_lwt_indicator', 'blogposts_update_one_column_lwt_indicator', 'blogposts_update_2_columns_lwt_indicator', 'blogposts_update_one_column_lwt_indicator', 'blogposts_update_2_columns_lwt_indicator']
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
