### PR TITLE
fix(start_and_interrupt_rebuild_streaming): Increased timeout to 400

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3150,7 +3150,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         trigger = partial(
             self.target_node.run_nodetool, sub_cmd="rebuild", warning_event_on_exception=(Exception,), retry=0,
         )
-        timeout = 1800 if self._is_it_on_kubernetes() else 300
+        timeout = 1800 if self._is_it_on_kubernetes() else 400
 
         watcher = partial(
             self._call_disrupt_func_after_expression_logged,


### PR DESCRIPTION
The previous timeout of 300 seconds was insufficient for the reboot function, so I lengthened it to 400 seconds.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
