### PR TITLE
fix(azure): fix running without setting az

### DIFF
--- a/defaults/azure_config.yaml
+++ b/defaults/azure_config.yaml
@@ -13,7 +13,7 @@ azure_instance_type_monitor: 'Standard_D2_v5'
 azure_image_loader: 'Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202208100'
 azure_image_monitor: 'Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202208100'
 
-availability_zone: 'a'
+availability_zone: ''
 root_disk_size_monitor: 50  # GB, remove this field if default disk size should be used
 root_disk_size_db: 30  # GB, increase root disk for larger swap (maximum: 16G)
 root_disk_size_loader: 30  # GB, Increase loader disk in order to have extra space for a larger swap

--- a/vars/createSctRunner.groovy
+++ b/vars/createSctRunner.groovy
@@ -15,12 +15,15 @@ def call(Map params, Integer test_duration, String region) {
     // NOTE: EKS jobs have 'availability_zone' be defined as 'a,b'
     //       So, just pick up the first one for the SCT runner in such a case.
     def availability_zone = ""
+    def availability_zone_arg = ""
     if ( params.availability_zone.contains(',') ) {
         availability_zone = params.availability_zone[0]
     } else {
         availability_zone = params.availability_zone
     }
-
+    if ( availability_zone ) {
+        availability_zone_arg = "--availability-zone " + availability_zone
+    }
     println(params)
     sh """
     #!/bin/bash
@@ -32,7 +35,7 @@ def call(Map params, Integer test_duration, String region) {
         ./docker/env/hydra.sh create-runner-instance \
             --cloud-provider ${cloud_provider} \
             --region ${region} \
-            --availability-zone ${availability_zone} \
+            $availability_zone_arg \
             $instance_type_arg \
             $root_disk_size_gb_arg \
             --test-id \${SCT_TEST_ID} \

--- a/vars/provisionResources.groovy
+++ b/vars/provisionResources.groovy
@@ -138,7 +138,7 @@ def call(Map params, String region){
     if [[ -n "\${RUNNER_IP}" ]] ; then
         ./docker/env/hydra.sh --execute-on-runner \${RUNNER_IP} provision-resources -b "${params.backend}" -t "${params.test_name}"
     else
-        ./docker/env/hydra.sh provision-resources -b "${params.backend}" -t "${params.test_name}" --logdir "`pwd`"
+        ./docker/env/hydra.sh provision-resources -b "${params.backend}" -t "${params.test_name}"
     fi
     echo "Finished resource provision"
     """


### PR DESCRIPTION
When avaliability zone is not set, sct test on azure fails to create sct-runner instance due wrong command. Later there's a problem with incorrect log param when running without runner provision-resources step. And finally, when az is not set, default is taken from azure_config.yaml which breaks concept of running without az.

This commit fixes all these issues.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
