### PR TITLE
fix(scylla.yaml): change default for compaction throughput limit

### DIFF
--- a/sdcm/provision/scylla_yaml/scylla_yaml.py
+++ b/sdcm/provision/scylla_yaml/scylla_yaml.py
@@ -58,7 +58,7 @@ class ScyllaYaml(BaseModel):  # pylint: disable=too-few-public-methods
     rpc_interface: str = "eth1"
     rpc_interface_prefer_ipv6: bool = False
     seed_provider: List[SeedProvider] = [SeedProvider(class_name='org.apache.cassandra.locator.SimpleSeedProvider')]
-    compaction_throughput_mb_per_sec: int = 16
+    compaction_throughput_mb_per_sec: int = 0
     compaction_large_partition_warning_threshold_mb: int = 1000
     compaction_large_row_warning_threshold_mb: int = 10
     compaction_large_cell_warning_threshold_mb: int = 1

--- a/unit_tests/test_scylla_yaml.py
+++ b/unit_tests/test_scylla_yaml.py
@@ -181,7 +181,7 @@ class ScyllaYamlTest(unittest.TestCase):
                         'parameters': [{'seeds': ['1.1.1.1', '2.2.2.2']}],
                     },
                 ],
-                'compaction_throughput_mb_per_sec': 16,
+                'compaction_throughput_mb_per_sec': 0,
                 'compaction_large_partition_warning_threshold_mb': 1000,
                 'compaction_large_row_warning_threshold_mb': 10,
                 'compaction_large_cell_warning_threshold_mb': 1,


### PR DESCRIPTION
`compaction_throughput_mb_per_sec` setting in scylla.yaml was activated by https://github.com/scylladb/scylladb/commit/bfc521ee9c2ba16fc4a15e68c21f68300658f530 Default value was also changed.

This commit reflects default value change for this scylla.yaml parameter.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
