### PR TITLE
fix(k8s_loader): make docker base loader work

### DIFF
--- a/sdcm/k8s_configs/loaders/sts.yaml
+++ b/sdcm/k8s_configs/loaders/sts.yaml
@@ -31,4 +31,20 @@ spec:
             requests:
               cpu: ${POD_CPU_LIMIT}
               memory: ${POD_MEMORY_LIMIT}
+          # TODO: those mounts/securityContext should be remove once we'll stop using bare docker for loaders
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /usr/bin/docker
+              name: docker-binary
+            - mountPath: /var/run/docker.sock
+              name: docker-socket
+      volumes:
+        - name: docker-binary
+          hostPath:
+            path: /usr/bin/docker
+            type: File
+        - name: docker-socket
+          hostPath:
+            type: Socket
       hostNetwork: false


### PR DESCRIPTION
60735f3fc4f5d0b70ec7bd616341bb9826d4fa44 splited the loader configuration into 2 files, but dropped the docker mount which is still needed, until we refactor the code to use the dynamic loaders approch.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
