### PR TITLE
fix(longevity-twcs-48h): add timeout to s-b commands

### DIFF
--- a/test-cases/longevity/longevity-twcs-48h.yaml
+++ b/test-cases/longevity/longevity-twcs-48h.yaml
@@ -1,13 +1,13 @@
 test_duration: 3000
 bench_run: true
 
-stress_cmd: ["scylla-bench -workload=timeseries -mode=write -replication-factor=3 -partition-count=400 -clustering-row-count=10000000 -clustering-row-size=200 -concurrency=100 -rows-per-request=100 -start-timestamp=SET_WRITE_TIMESTAMP -connection-count 100 -max-rate 50000 --timeout 120s -duration=2880m"]
+stress_cmd: ["scylla-bench -workload=timeseries -mode=write -replication-factor=3 -partition-count=400 -clustering-row-count=10000000 -clustering-row-size=200 -concurrency=100 -rows-per-request=100 -start-timestamp=SET_WRITE_TIMESTAMP -connection-count 100 -max-rate 50000 -timeout=120s -retry-number=30 -retry-interval=80ms,1s -duration=2880m"]
 # write-rate with timeseries workload for read mode
 # calculated from timeseries workload for write mode by formula:
 # write-rate = -max-rate / -partition-count = 50000 / 400 = 125
 stress_read_cmd: [
-    "scylla-bench -workload=timeseries -mode=read -partition-count=20000 -concurrency=100 -replication-factor=3 -clustering-row-count=10000000 -clustering-row-size=200  -rows-per-request=100 -start-timestamp=GET_WRITE_TIMESTAMP -write-rate 125 -distribution hnormal --connection-count 100 -duration=2880m",
-    "scylla-bench -workload=timeseries -mode=read -partition-count=20000 -concurrency=100 -replication-factor=3 -clustering-row-count=10000000 -clustering-row-size=200  -rows-per-request=100 -start-timestamp=GET_WRITE_TIMESTAMP -write-rate 125 -distribution uniform --connection-count 100 -duration=2880m"
+    "scylla-bench -workload=timeseries -mode=read -partition-count=20000 -concurrency=100 -replication-factor=3 -clustering-row-count=10000000 -clustering-row-size=200  -rows-per-request=100 -start-timestamp=GET_WRITE_TIMESTAMP -write-rate 125 -distribution hnormal --connection-count 100 -duration=2880m -timeout=30s -retry-number=30 -retry-interval=80ms,1s",
+    "scylla-bench -workload=timeseries -mode=read -partition-count=20000 -concurrency=100 -replication-factor=3 -clustering-row-count=10000000 -clustering-row-size=200  -rows-per-request=100 -start-timestamp=GET_WRITE_TIMESTAMP -write-rate 125 -distribution uniform --connection-count 100 -duration=2880m -timeout=30s -retry-number=30 -retry-interval=80ms,1s"
     ]
 
 
@@ -28,7 +28,7 @@ user_prefix: 'longevity-twcs-48h'
 post_prepare_cql_cmds: "ALTER TABLE scylla_bench.test with gc_grace_seconds = 15000 and default_time_to_live = 21600 and compaction = {'class':'TimeWindowCompactionStrategy', 'compaction_window_size': 60, 'compaction_window_unit': 'MINUTES'};"
 
 # Temporarily downgrade scylla_bench to a stable version
-stress_image:
-  scylla-bench: 'scylladb/hydra-loaders:scylla-bench-v0.1.3'
+#stress_image:
+#  scylla-bench: 'scylladb/hydra-loaders:scylla-bench-v0.1.3'
 
 round_robin: true


### PR DESCRIPTION
there are 100s of failure like this:
```
Operation timed out for scylla_bench.test -
received only 1 responses from 2 CL=QUORUM.
```

and this test case was pinned to old s-b version
trying it with a newer version and with timeouts

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
