### PR TITLE
improvement(reversed queries): Added select-order-by to scylla-bench

### DIFF
--- a/jenkins-pipelines/longevity-large-partition-2days-reversed-queries.jenkinsfile
+++ b/jenkins-pipelines/longevity-large-partition-2days-reversed-queries.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
+    test_config: '''["test-cases/longevity/longevity-large-partition-2days.yaml"]'''
+
+)

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -72,7 +72,7 @@ from sdcm.utils.ci_tools import get_job_name, get_job_url
 from sdcm.utils.common import format_timestamp, wait_ami_available, update_certificates, \
     download_dir_from_cloud, get_post_behavior_actions, get_testrun_status, download_encrypt_keys, PageFetcher, \
     rows_to_list, make_threads_be_daemonic_by_default, ParallelObject, clear_out_all_exit_hooks, \
-    change_default_password
+    change_default_password, get_partition_keys
 from sdcm.utils.get_username import get_username
 from sdcm.utils.decorators import log_run_info, retrying
 from sdcm.utils.git import get_git_commit_id
@@ -2545,16 +2545,14 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self.log.warning('Can\'t collect partitions data. Missed "table name" or "primary key column" info')
             return {}
 
-        get_distinct_partition_keys_cmd = 'select distinct {pk} from {table}'.format(pk=primary_key_column,
-                                                                                     table=table_name)
         try:
-            out = self.db_cluster.nodes[0].run_cqlsh(cmd=get_distinct_partition_keys_cmd, timeout=600, split=True,
-                                                     num_retry_on_failure=5)
+            with self.db_cluster.cql_connection_patient(node=self.db_cluster.nodes[0],
+                                                        connect_timeout=600) as session:
+                session.default_consistency_level = ConsistencyLevel.QUORUM
+                pk_list = get_partition_keys(ks_cf=table_name, session=session, pk_name=primary_key_column)
         except Exception as exc:  # pylint: disable=broad-except
             self.log.error("Failed to collect partition info. Error details: %s", str(exc))
             return None
-
-        pk_list = sorted([int(pk) for pk in out[3:-3]])
 
         # Collect data about partitions' rows amount.
         partitions = {}
@@ -2562,16 +2560,20 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         with open(partitions_stats_file, 'a', encoding="utf-8") as stats_file:
             for i in pk_list:
                 self.log.debug("Next PK: {}".format(i))
-                count_partition_keys_cmd = f'select count(*) from {table_name} where {primary_key_column} = {i}'
+                count_pk_rows_cmd = f'select count(*) from {table_name} where {primary_key_column} = {i}' \
+                                    ' using timeout 5m'
                 try:
-                    out = self.db_cluster.nodes[0].run_cqlsh(cmd=count_partition_keys_cmd, timeout=600, split=True,
-                                                             num_retry_on_failure=5)
+                    with self.db_cluster.cql_connection_patient(node=self.db_cluster.nodes[0],
+                                                                connect_timeout=600) as session:
+                        session.default_consistency_level = ConsistencyLevel.QUORUM
+                        result = session.execute(count_pk_rows_cmd)
+                        pk_rows_num_result = result.current_rows[0].count
                 except Exception as exc:  # pylint: disable=broad-except
                     self.log.error("Failed to collect partition info. Error details: %s", str(exc))
                     return None
 
-                self.log.debug('Count result: {}'.format(out))
-                partitions[i] = out[3] if len(out) > 3 else None
+                self.log.debug('Count result: %s', pk_rows_num_result)
+                partitions[i] = pk_rows_num_result
                 stats_file.write('{i}:{rows}, '.format(i=i, rows=partitions[i]))
         self.log.info('File with partitions row data: {}'.format(partitions_stats_file))
 

--- a/test-cases/longevity/longevity-large-partition-2days.yaml
+++ b/test-cases/longevity/longevity-large-partition-2days.yaml
@@ -1,0 +1,42 @@
+test_duration: 3000
+
+bench_run: true
+
+prepare_write_cmd:  ["scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=100 -clustering-row-count=50000 -clustering-row-size=uniform:100..5120 -concurrency=250 -rows-per-request=2000 -timeout=180s -connection-count 150",
+                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=100 -clustering-row-count=50000 -partition-offset=101 -clustering-row-size=uniform:100..5120 -concurrency=250 -rows-per-request=2000 -timeout=180s -connection-count 150",
+                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=100 -clustering-row-count=50000 -partition-offset=201 -clustering-row-size=uniform:100..5120 -concurrency=250 -rows-per-request=2000 -timeout=180s -connection-count 150",
+                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=100 -clustering-row-count=50000 -partition-offset=301 -clustering-row-size=uniform:100..5120 -concurrency=250 -rows-per-request=2000 -timeout=180s -connection-count 150",
+                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=100 -clustering-row-count=50000 -partition-offset=401 -clustering-row-size=uniform:100..5120 -concurrency=250 -rows-per-request=2000 -timeout=180s -connection-count 150",
+                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=100 -clustering-row-count=50000 -partition-offset=501 -clustering-row-size=uniform:100..5120 -concurrency=250 -rows-per-request=2000 -timeout=180s -connection-count 150",
+                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=100 -clustering-row-count=50000 -partition-offset=601 -clustering-row-size=uniform:100..5120 -concurrency=250 -rows-per-request=2000 -timeout=180s -connection-count 150",
+                     "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=100 -clustering-row-count=50000 -partition-offset=701 -clustering-row-size=uniform:100..5120 -concurrency=250 -rows-per-request=2000 -timeout=180s -connection-count 150"
+]
+stress_cmd: ["scylla-bench -workload=uniform -mode=read -select-order-by=desc -replication-factor=3 -partition-count=800 -clustering-row-count=50000 -clustering-row-size=uniform:100..5120 -rows-per-request=2000 -timeout=240s -retry-number=10 -concurrency=400 -duration=44h -connection-count 400",
+             "scylla-bench -workload=sequential -mode=write -replication-factor=3 -partition-count=200 -clustering-row-count=50000 -partition-offset=801 -clustering-row-size=uniform:100..5120 -concurrency=250 -rows-per-request=2000 -timeout=180s -connection-count 150"
+]
+
+n_db_nodes: 3
+n_loaders: 2
+n_monitor_nodes: 1
+
+instance_type_db: 'i4i.4xlarge'
+
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_seed: '156'
+# Set cql_schema_seed in order to get: "CLUSTERING ORDER BY (ck ASC)"
+cql_schema_seed: '930'
+instance_type_loader: 'c5n.4xlarge'
+round_robin: true
+nemesis_interval: 30
+nemesis_during_prepare: false
+
+user_prefix: 'longevity-large-partitions-2d-order-by-desc'
+
+# To validate rows in partitions: collect data about partitions and their rows amount
+# before and after running nemesis and compare it
+validate_partitions: true
+table_name: "scylla_bench.test"
+primary_key_column: "pk"
+
+
+run_fullscan: ['{"mode": "random", "ks_cf": "scylla_bench.test", "interval": 3600, "pk_name":"pk", "rows_count": 50000, "validate_data": true}']


### PR DESCRIPTION
            The new s-b parameter of select-order-by is added to v0.1.8
            So the new reversed-queries implementation of 5.0 can be tested this way.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
