### PR TITLE
fix(k8s-multitenancy): create proper number of loaders

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2756,7 +2756,7 @@ class LoaderPodCluster(cluster.BaseLoaderSet, PodCluster):
                 "K8S_NAMESPACE": self.namespace,
                 "K8S_LOADER_CLUSTER_NAME": self.loader_cluster_name,
                 "DOCKER_IMAGE_WITH_TAG": self._get_docker_image(),
-                "N_LOADERS": self.params.get("n_loaders"),
+                "N_LOADERS": count,
                 "POD_CPU_LIMIT": self.k8s_cluster.calculated_loader_cpu_limit,
                 "POD_MEMORY_LIMIT": self.k8s_cluster.calculated_loader_memory_limit,
             },


### PR DESCRIPTION
Recent merged change [1] introduced a bug where we try to create loaders pods using number of 'loader K8S nodes' instead of proper config option for pods number.
It makes no effect in case of single DB cluster setup, but fails on multitenant one by fact that we cannot create all the loader pods (the redundant ones) and fail due to it.

So, fix it by using proper variable.

[1] https://github.com/scylladb/scylla-cluster-tests/pull/5314

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
