### PR TITLE
Rolling upgrade azure

### DIFF
--- a/configurations/azure/azure_rolling_upgrade.yaml
+++ b/configurations/azure/azure_rolling_upgrade.yaml
@@ -1,0 +1,5 @@
+azure_region_name: 'eastus'
+azure_instance_type_db: 'Standard_L8s_v2'
+azure_image_db: ''
+workaround_kernel_bug_for_iotune: false
+internode_compression: 'all'

--- a/jenkins-pipelines/rolling-upgrade-azure-image.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-azure-image.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+rollingUpgradePipeline(
+    backend: 'azure',
+    base_versions: '',  // auto mode,
+    linux_distro: 'ubuntu-focal',
+    test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
+    test_config: '''["test-cases/upgrades/rolling-upgrade.yaml", "configurations/azure/azure_rolling_upgrade.yaml"]'''
+)

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1559,7 +1559,12 @@ class SCTConfiguration(dict):
                 self["gce_image_db"] = gce_image.extra["selfLink"]
             elif not self.get("azure_image_db") and self.get("cluster_backend") == "azure":
                 scylla_azure_images = []
-                for region in self.get('azure_region_name'):
+                if isinstance(self.get('azure_region_name'), list):
+                    azure_region_names = self.get('azure_region_name')
+                else:
+                    azure_region_names = [self.get('azure_region_name')]
+
+                for region in azure_region_names:
                     azure_image = azure_utils.get_scylla_images(scylla_version, region)[0]
                     self.log.debug("Found AMI %s for scylla_version='%s' in %s",
                                    azure_image.name, scylla_version, region)

--- a/vars/createSctRunner.groovy
+++ b/vars/createSctRunner.groovy
@@ -21,9 +21,17 @@ def call(Map params, Integer test_duration, String region) {
     } else {
         availability_zone = params.availability_zone
     }
+
     if ( availability_zone ) {
         availability_zone_arg = "--availability-zone " + availability_zone
     }
+
+    if ( params.backend.equals("azure") ) {
+        region_zone_arg = "--region " + params.azure_region_name
+    } else {
+        region_zone_arg = "--region " + region
+    }
+
     println(params)
     sh """
     #!/bin/bash
@@ -34,7 +42,7 @@ def call(Map params, Integer test_duration, String region) {
         rm -fv sct_runner_ip
         ./docker/env/hydra.sh create-runner-instance \
             --cloud-provider ${cloud_provider} \
-            --region ${region} \
+            $region_zone_arg \
             $availability_zone_arg \
             $instance_type_arg \
             $root_disk_size_gb_arg \

--- a/vars/getCloudProviderFromBackend.groovy
+++ b/vars/getCloudProviderFromBackend.groovy
@@ -7,6 +7,7 @@ def call(String backend) {
         'k8s-local-kind-gce': 'gce',
         'aws-siren': 'aws',
         'gce-siren': 'gce',
+        'azure': 'azure'
         ]
     if (!backend) {
         return backend

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -15,6 +15,12 @@ def call(Map pipelineParams) {
             SCT_GCE_PROJECT = "${params.gce_project}"
         }
         parameters {
+            string(defaultValue: '',
+                   description: 'a Azure Image to run against',
+                   name: 'azure_image_db')
+            string(defaultValue: "${pipelineParams.get('azure_region_name', 'eastus')}",
+                   description: 'Azure location',
+                   name: 'azure_region_name')
             string(defaultValue: "${pipelineParams.get('backend', 'gce')}",
                description: 'aws|gce',
                name: 'backend')
@@ -179,6 +185,17 @@ def call(Map pipelineParams) {
                                                             export SCT_CONFIG_FILES=${test_config}
                                                             export SCT_SCYLLA_VERSION=${base_version}
                                                             export SCT_NEW_SCYLLA_REPO=${params.new_scylla_repo}
+
+                                                            if [[ ! -z "${params.azure_image_db}" ]]; then
+                                                                export SCT_AZURE_IMAGE_DB="${params.azure_image_db}"
+                                                            fi
+                                                            if [[ -n "${params.azure_region_name ? params.azure_region_name : ''}" ]] ; then
+                                                                export SCT_AZURE_REGION_NAME=${params.azure_region_name}
+                                                            fi
+
+                                                            if [[ -n "${params.availability_zone ? params.availability_zone : ''}" ]] ; then
+                                                                export SCT_AVAILABILITY_ZONE="${params.availability_zone}"
+                                                            fi
 
                                                             if [[ -n "${params.post_behavior_db_nodes ? params.post_behavior_db_nodes : ''}" ]] ; then
                                                                 export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -100,22 +100,24 @@ def call(Map pipelineParams) {
                     }
                 }
                 steps {
-                    timeout(time: 10, unit: 'MINUTES') {
-                        script {
-                            wrap([$class: 'BuildUser']) {
-                                dir('scylla-cluster-tests') {
-                                    checkout scm
-                                    ArrayList base_versions_list = params.base_versions.contains('.') ? params.base_versions.split('\\,') : []
-                                    supportedVersions = supportedUpgradeFromVersions(
-                                        base_versions_list,
-                                        pipelineParams.linux_distro,
-                                        params.new_scylla_repo
-                                    )
-                                    (testDuration,
-                                     testRunTimeout,
-                                     runnerTimeout,
-                                     collectLogsTimeout,
-                                     resourceCleanupTimeout) = getJobTimeouts(params, builder.region)
+                    catchError(stageResult: "FAILURE") {
+                        timeout(time: 10, unit: 'MINUTES') {
+                            script {
+                                wrap([$class: 'BuildUser']) {
+                                    dir('scylla-cluster-tests') {
+                                        checkout scm
+                                        ArrayList base_versions_list = params.base_versions.contains('.') ? params.base_versions.split('\\,') : []
+                                        supportedVersions = supportedUpgradeFromVersions(
+                                            base_versions_list,
+                                            pipelineParams.linux_distro,
+                                            params.new_scylla_repo
+                                        )
+                                        (testDuration,
+                                         testRunTimeout,
+                                         runnerTimeout,
+                                         collectLogsTimeout,
+                                         resourceCleanupTimeout) = getJobTimeouts(params, builder.region)
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
This PR introduces commits related to adding a rolling upgrade job for the Azure backend, i.e. running the rolling upgrade job on Azure, using the Azure machine images. 
An additional commit was added with a small refactor change for the `rollingUpgradePipeline.groovy` script file.

Git task: https://github.com/scylladb/qa-tasks/issues/336
Staging job for testing: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/maciej/job/ru-azure

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
