### PR TITLE
fix(severity.yaml): change nosqlbench severity

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -69,7 +69,7 @@ KclStressEvent.failure: ERROR
 KclStressEvent.start: NORMAL
 KclStressEvent.finish: NORMAL
 NoSQLBenchStressEvent: CRITICAL
-NoSQLBenchStressLogEvents.ProgressIndicatorRunningEvent: DEBUG
+NoSQLBenchStressLogEvents.ProgressIndicatorRunningEvent: NORMAL
 NoSQLBenchStressLogEvents.ProgressIndicatorFinishedEvent: NORMAL
 NoSQLBenchStressLogEvents.ProgressIndicatorStoppedEvent: CRITICAL
 CassandraStressLogEvent.IOException: ERROR


### PR DESCRIPTION
NoSQLBenchStressLogEvents.ProgressIndicatorRunningEvent added on PR #4015 used severity DEBUG, but it is meant for some specific use, hence moving it to be normal events instead.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
