### PR TITLE
fix(nemesis): wait for db_up in start_and_interrupt_rebuild_streaming()

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3161,6 +3161,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             delay=1
         )
         ParallelObject(objects=[trigger, watcher], timeout=timeout + 60).call_objects()
+        self.target_node.wait_db_up(timeout=300)
         self.target_node.run_nodetool("rebuild")
 
     def disrupt_decommission_streaming_err(self):


### PR DESCRIPTION
fixes: https://github.com/scylladb/scylla-cluster-tests/issues/5285

The method start_and_interrupt_rebuild_streaming() is used to hard reboot a node during the rebuild operation. After the reboot we attempt to rebuild. We waited on ssh_up on the target machine, but that can be true before Scylla finishes it's own restart. This commit introduces a wait for db_up to avoid asking the db for a rebuild before it's up.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
