### PR TITLE
fix(scylla-bench): fix s-b delay for first run

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -212,5 +212,6 @@ stress_image:
   alternator-dns: 'scylladb/hydra-loaders:alternator-dns-0.1'
   cdc-stresser: 'scylladb/hydra-loaders:cdc-stresser-20210630'
   kcl: 'scylladb/hydra-loaders:kcl-jdk8-20210526-ShardSyncStrategyType-PERIODIC'
+  harry: 'scylladb/hydra-loaders:cassandra-harry-jdk11-20220816'
 
 service_level_shares: [1000]

--- a/sdcm/cassandra_harry_thread.py
+++ b/sdcm/cassandra_harry_thread.py
@@ -51,6 +51,9 @@ class CassandraHarryStressEventsPublisher(FileFollowerThread):
 
 #  pylint: disable=too-many-instance-attributes
 class CassandraHarryThread(DockerBasedStressThread):
+
+    DOCKER_IMAGE_PARAM_NAME = "stress_image.harry"
+
     #  pylint: disable=too-many-arguments
     def __init__(self, *args, **kwargs):
         credentials = kwargs.pop('credentials', None)
@@ -76,7 +79,7 @@ class CassandraHarryThread(DockerBasedStressThread):
         else:
             node_cmd = self.stress_cmd
 
-        docker = RemoteDocker(loader, 'scylladb/hydra-loaders:cassandra-harry-jdk11-20220816',
+        docker = RemoteDocker(loader, self.docker_image_name,
                               extra_docker_opts=f' --label shell_marker={self.shell_marker}')
 
         node_cmd = f'STRESS_TEST_MARKER={self.shell_marker}; {node_cmd}'

--- a/sdcm/cdclog_reader_thread.py
+++ b/sdcm/cdclog_reader_thread.py
@@ -29,6 +29,7 @@ PP = pprint.PrettyPrinter(indent=2)
 
 
 class CDCLogReaderThread(DockerBasedStressThread):
+    DOCKER_IMAGE_PARAM_NAME = "stress_image.cdc-stresser"
 
     def __init__(self, *args, **kwargs):
 
@@ -57,7 +58,7 @@ class CDCLogReaderThread(DockerBasedStressThread):
         self.build_stress_command(worker_id, worker_count)
 
         LOGGER.info(self.stress_cmd)
-        docker = RemoteDocker(loader, self.params.get('stress_image.cdc-stresser'),
+        docker = RemoteDocker(loader, self.docker_image_name,
                               extra_docker_opts=f'--network=host --label shell_marker={self.shell_marker}')
 
         node_cmd = f'STRESS_TEST_MARKER={self.shell_marker}; {self.stress_cmd}'

--- a/sdcm/gemini_thread.py
+++ b/sdcm/gemini_thread.py
@@ -60,6 +60,8 @@ class GeminiEventsPublisher(FileFollowerThread):
 
 class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-instance-attributes
 
+    DOCKER_IMAGE_PARAM_NAME = "stress_image.gemini"
+
     def __init__(self, test_cluster, oracle_cluster, loaders, stress_cmd, timeout=None, params=None):  # pylint: disable=too-many-arguments
         super().__init__(loader_set=loaders, stress_cmd=stress_cmd, timeout=timeout, params=params)
         self.test_cluster = test_cluster
@@ -98,7 +100,7 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
         if self.stress_num > 1:
             cpu_options = f'--cpuset-cpus="{cpu_idx}"'
 
-        docker = RemoteDocker(loader, self.params.get("stress_image.gemini"),
+        docker = RemoteDocker(loader, self.docker_image_name,
                               extra_docker_opts=f'{cpu_options} --label shell_marker={self.shell_marker} --network=host')
 
         if not os.path.exists(loader.logdir):

--- a/sdcm/kcl_thread.py
+++ b/sdcm/kcl_thread.py
@@ -33,6 +33,8 @@ LOGGER = logging.getLogger(__name__)
 
 class KclStressThread(DockerBasedStressThread):  # pylint: disable=too-many-instance-attributes
 
+    DOCKER_IMAGE_PARAM_NAME = "stress_image.kcl"
+
     def run(self):
         _self = super().run()
         # wait for the KCL thread to create the tables, so the YCSB thread beat this one, and start failing
@@ -49,7 +51,7 @@ class KclStressThread(DockerBasedStressThread):  # pylint: disable=too-many-inst
         return stress_cmd
 
     def _run_stress(self, loader, loader_idx, cpu_idx):
-        docker = RemoteDocker(loader, self.params.get('stress_image.kcl'),
+        docker = RemoteDocker(loader, self.docker_image_name,
                               extra_docker_opts=f'--label shell_marker={self.shell_marker}')
         stress_cmd = self.build_stress_cmd()
 

--- a/sdcm/ndbench_thread.py
+++ b/sdcm/ndbench_thread.py
@@ -112,6 +112,8 @@ class NdBenchStatsPublisher(FileFollowerThread):
 
 class NdBenchStressThread(DockerBasedStressThread):  # pylint: disable=too-many-instance-attributes
 
+    DOCKER_IMAGE_PARAM_NAME = "stress_image.ndbench"
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # remove the ndbench command, and parse the rest of the ; separated values
@@ -134,7 +136,7 @@ class NdBenchStressThread(DockerBasedStressThread):  # pylint: disable=too-many-
         else:
             node_cmd = self.stress_cmd
 
-        docker = RemoteDocker(loader, self.params.get('stress_image.ndbench'),
+        docker = RemoteDocker(loader, self.docker_image_name,
                               extra_docker_opts=f'--network=host --label shell_marker={self.shell_marker}')
 
         node_cmd = f'STRESS_TEST_MARKER={self.shell_marker}; {node_cmd}'

--- a/sdcm/nosql_thread.py
+++ b/sdcm/nosql_thread.py
@@ -54,6 +54,7 @@ class NoSQLBenchStressThread(DockerBasedStressThread):  # pylint: disable=too-ma
       https://github.com/scylladb/scylla-cluster-tests/blob/master/docs/sct-events.md
     """
 
+    DOCKER_IMAGE_PARAM_NAME = "stress_image.nosqlbench"
     GRAPHITE_EXPORTER_CONFIG_SRC_PATH = "docker/graphite-exporter/graphite_mapping.conf"
     GRAPHITE_EXPORTER_CONFIG_DST_PATH = "/tmp/"
 
@@ -61,7 +62,6 @@ class NoSQLBenchStressThread(DockerBasedStressThread):  # pylint: disable=too-ma
         super().__init__(*args, **kwargs)
         self._per_loader_count = {}
         self._per_loader_count_lock = threading.Semaphore()
-        self._nosqlbench_image = self.loader_set.params.get('stress_image.nosqlbench')
 
     def build_stress_cmd(self, loader_idx: int):
         if hasattr(self.node_list[0], 'parent_cluster'):
@@ -109,7 +109,7 @@ class NoSQLBenchStressThread(DockerBasedStressThread):  # pylint: disable=too-ma
                 return loader.remoter.run(cmd=f'docker run '
                                               '--name=nb '
                                               '--network=nosql '
-                                              f'{self._nosqlbench_image} '
+                                              f'{self.docker_image_name} '
                                               f'{stress_cmd} --report-graphite-to graphite-exporter:9109',
                                           timeout=self.timeout + self.shutdown_timeout, log_file=log_file_name)
             except Exception as exc:  # pylint: disable=broad-except

--- a/sdcm/scylla_bench_thread.py
+++ b/sdcm/scylla_bench_thread.py
@@ -73,6 +73,8 @@ class ScyllaBenchStressEventsPublisher(FileFollowerThread):
 
 
 class ScyllaBenchThread(DockerBasedStressThread):  # pylint: disable=too-many-instance-attributes
+
+    DOCKER_IMAGE_PARAM_NAME = "stress_image.scylla-bench"
     _SB_STATS_MAPPING = {
         # Mapping for scylla-bench statistic and configuration keys to db stats keys
         'Mode': 'Mode',
@@ -116,6 +118,8 @@ class ScyllaBenchThread(DockerBasedStressThread):  # pylint: disable=too-many-in
         self.sb_mode: ScyllaBenchModes = ScyllaBenchModes(re.search(r"-mode=(.+?) ", stress_cmd).group(1))
         self.sb_workload: ScyllaBenchWorkloads = ScyllaBenchWorkloads(
             re.search(r"-workload=(.+?) ", stress_cmd).group(1))
+        for loader in self.loader_set.nodes:
+            RemoteDocker.pull_image(loader, self.params.get('stress_image.scylla-bench'))
 
     def verify_results(self):
         sb_summary = []

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -27,7 +27,7 @@ from sdcm.prometheus import nemesis_metrics_obj
 from sdcm.sct_events import Severity
 from sdcm.utils.common import FileFollowerThread, generate_random_string, get_profile_content
 from sdcm.sct_events.loaders import CassandraStressEvent, CS_ERROR_EVENTS_PATTERNS, CS_NORMAL_EVENTS_PATTERNS
-
+from sdcm.utils.docker_remote import RemoteDocker
 
 LOGGER = logging.getLogger(__name__)
 
@@ -299,6 +299,8 @@ class CassandraStressThread:  # pylint: disable=too-many-instance-attributes
 
 class DockerBasedStressThread:
     # pylint: disable=too-many-instance-attributes
+    DOCKER_IMAGE_PARAM_NAME = ""  # test yaml param that stores image
+
     def __init__(self, loader_set, stress_cmd, timeout, stress_num=1, node_list=None,  # pylint: disable=too-many-arguments
                  round_robin=False, params=None, stop_test_on_failure=True):
         self.loader_set: BaseLoaderSet = loader_set
@@ -316,6 +318,9 @@ class DockerBasedStressThread:
         self.shell_marker = generate_random_string(20)
         self.shutdown_timeout = 180  # extra 3 minutes
         self.stop_test_on_failure = stop_test_on_failure
+        self.docker_image_name = self.params.get(self.DOCKER_IMAGE_PARAM_NAME)
+        for loader in self.loader_set.nodes:
+            RemoteDocker.pull_image(loader, self.docker_image_name)
 
     def run(self):
         if self.round_robin:

--- a/sdcm/utils/docker_remote.py
+++ b/sdcm/utils/docker_remote.py
@@ -1,6 +1,6 @@
 import logging
 import shlex
-from functools import cached_property
+from functools import cached_property, cache
 
 from sdcm.cluster import BaseNode
 
@@ -103,3 +103,10 @@ class RemoteDocker(BaseNode):
 
     def __str__(self):
         return f'RemoteDocker [{self.image_name}] on [{self.node}]'
+
+    @staticmethod
+    @cache
+    def pull_image(node, image):
+        prefix = "sudo" if node.is_docker else ""
+        node.remoter.run(
+            f'{prefix} docker pull {image}', verbose=True)

--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -114,6 +114,8 @@ class YcsbStatsPublisher(FileFollowerThread):
 
 class YcsbStressThread(DockerBasedStressThread):  # pylint: disable=too-many-instance-attributes
 
+    DOCKER_IMAGE_PARAM_NAME = "stress_image.ycsb"
+
     def copy_template(self, docker):
         if self.params.get('alternator_use_dns_routing'):
             target_address = 'alternator'
@@ -229,7 +231,7 @@ class YcsbStressThread(DockerBasedStressThread):  # pylint: disable=too-many-ins
         if self.stress_num > 1:
             cpu_options = f'--cpuset-cpus="{cpu_idx}"'
 
-        docker = RemoteDocker(loader, self.params.get('stress_image.ycsb'),
+        docker = RemoteDocker(loader, self.docker_image_name,
                               extra_docker_opts=f'{dns_options} {cpu_options} --label shell_marker={self.shell_marker}')
         self.copy_template(docker)
         stress_cmd = self.build_stress_cmd()

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -697,7 +697,8 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
                           'nosqlbench': 'scylladb/hydra-loaders:nosqlbench-A',
                           'scylla-bench': 'scylladb/something',
                           'ycsb': 'scylladb/something_else',
-                          'kcl': 'scylladb/hydra-loaders:kcl-jdk8-20210526-ShardSyncStrategyType-PERIODIC'})
+                          'kcl': 'scylladb/hydra-loaders:kcl-jdk8-20210526-ShardSyncStrategyType-PERIODIC',
+                          'harry': 'scylladb/hydra-loaders:cassandra-harry-jdk11-20220816'})
 
         self.assertEqual(conf.get('stress_image.gemini'), 'scylladb/hydra-loaders:gemini-1.7.7')
         self.assertEqual(conf.get('stress_image.non-exist'), None)


### PR DESCRIPTION
When running scylla-bench for the first time on loader, there's around 3 minutes delay when it's executed for the first time. This is a result of docker image getting pulled. This delay may lead
to errors in tests. E.g. starting s-b in upgrade test happens when node gets drained and returning error.

This commit enforce pulling scylla-bench docker image before returning `ScyllaBenchThread` so test will wait for s-b being downloaded to loaders.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
