### PR TITLE
refactor(fullscan): randomized fullscan thread

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -14,6 +14,7 @@ ScyllaHelpErrorEvent.filtered: WARNING
 FullScanEvent: ERROR
 FullPartitionScanReversedOrderEvent: ERROR
 FullPartitionScanEvent: ERROR
+FullScanAggregateEvent: ERROR
 DatabaseLogEvent.WARNING: WARNING
 DatabaseLogEvent.NO_SPACE_ERROR: ERROR
 DatabaseLogEvent.UNKNOWN_VERB: WARNING

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -33,12 +33,10 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
 
     default_params = {'timeout': 650000}
 
-    def _get_scan_operation_params(self, scan_operation: str) -> dict:
-        params = {}
-        if scan_operation_params := self.params.get(scan_operation):
-            params = json.loads(scan_operation_params)
-            self.log.info('Scan operation %s params are: %s', scan_operation, params)
-        return params
+    def _get_scan_operation_params(self) -> dict:
+        params = self.params.get("run_fullscan") if self.params.get("run_fullscan") else {}
+        self.log.debug('Scan operation params are: %s', params)
+        return json.loads(params)
 
     def run_pre_create_schema(self):
         pre_create_schema = self.params.get('pre_create_schema')
@@ -70,11 +68,8 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
         self.run_pre_create_keyspace()
         self.run_pre_create_schema()
 
-        if fullscan_params := self._get_scan_operation_params(scan_operation='run_fullscan'):
-            self.run_fullscan_thread(ks_cf=fullscan_params['ks_cf'], interval=fullscan_params['interval'])
-
-        if full_partition_scan_params := self._get_scan_operation_params(scan_operation='run_full_partition_scan'):
-            self.run_full_partition_scan_thread(**full_partition_scan_params)
+        if scan_operation_params := self._get_scan_operation_params():
+            self.run_fullscan_thread(scan_operation_params)
 
         self.run_prepare_write_cmd()
 

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -43,7 +43,7 @@ from tenacity import RetryError
 from invoke.exceptions import UnexpectedExit, Failure, CommandTimedOut
 from cassandra import ConsistencyLevel
 from cassandra.auth import PlainTextAuthProvider
-from cassandra.cluster import Cluster as ClusterDriver  # pylint: disable=no-name-in-module
+from cassandra.cluster import Cluster as ClusterDriver, Session  # pylint: disable=no-name-in-module
 from cassandra.cluster import NoHostAvailable  # pylint: disable=no-name-in-module
 from cassandra.policies import RetryPolicy
 from cassandra.policies import WhiteListRoundRobinPolicy
@@ -3308,7 +3308,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
                                # pylint: disable=too-many-arguments,unused-argument
                                user=None, password=None,
                                compression=True, protocol_version=None,
-                               port=None, ssl_opts=None, connect_timeout=100, verbose=True):
+                               port=None, ssl_opts=None, connect_timeout=100, verbose=True) -> Session:
         """
         Returns a connection after it stops throwing NoHostAvailables.
 

--- a/sdcm/scan_operation_thread.py
+++ b/sdcm/scan_operation_thread.py
@@ -1,66 +1,259 @@
+from __future__ import annotations
+
 import json
 import logging
 import random
+import re
 import tempfile
 import threading
 import time
 from abc import abstractmethod
-from typing import Optional
+from dataclasses import dataclass, field, fields
+from string import Template
+from typing import Optional, NamedTuple, Type
 
 from cassandra import ConsistencyLevel
-from cassandra.cluster import ResponseFuture  # pylint: disable=no-name-in-module
+from cassandra.cluster import ResponseFuture, ResultSet  # pylint: disable=no-name-in-module
 from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
+from prettytable import PrettyTable
 
 from sdcm import wait
-from sdcm.cluster import BaseScyllaCluster, BaseCluster
+from sdcm.cluster import BaseScyllaCluster, BaseCluster, BaseNode
 from sdcm.remote import LocalCmdRunner
-from sdcm.utils.common import get_partition_keys, get_table_clustering_order
 from sdcm.sct_events import Severity
-from sdcm.sct_events.database import FullScanEvent, FullPartitionScanReversedOrderEvent, FullPartitionScanEvent
+from sdcm.sct_events.database import FullScanEvent, FullPartitionScanReversedOrderEvent, FullPartitionScanEvent, \
+    FullScanAggregateEvent
+from sdcm.utils.common import get_partition_keys, get_table_clustering_order
 
 ERROR_SUBSTRINGS = ("timed out", "unpack requires", "timeout")
 LOCAL_CMD_RUNNER = LocalCmdRunner()
 
 
 # pylint: disable=too-many-instance-attributes
-class ScanOperationThread:
-    bypass_cache = ' bypass cache'
-    basic_query = 'select * from {}'
+@dataclass
+class FullScanParams:
+    mode: str
+    db_cluster: [BaseScyllaCluster, BaseCluster] = None
+    ks_cf: str = random
+    duration: int = None
+    interval: int = 1
+    page_size: int = 10000
+    fullscan_user: str = None
+    fullscan_user_password: str = None
+    pk_name: str = None
+    ck_name: str = None
+    data_column_name: str = None
+    validate_data: bool = None
+    include_data_column: bool = None
 
-    # pylint: disable=too-many-arguments,unused-argument
-    def __init__(self, db_cluster: [BaseScyllaCluster, BaseCluster], duration: int, interval: int,
-                 termination_event: threading.Event, ks_cf: str,
-                 scan_event: [FullScanEvent, FullPartitionScanReversedOrderEvent], page_size: int = 10000, **kwargs):
-        self.ks_cf = ks_cf
-        self.db_cluster = db_cluster
-        self.page_size = page_size
-        self.duration = duration
-        self.interval = interval
-        self.number_of_rows_read = 0
-        self.db_node = None
-        self.read_pages = 0
-        self.scans_counter = 0
-        self.time_elapsed = 0
-        self.total_scan_time = 0
-        self.scan_event = scan_event
-        self.termination_event = termination_event
+
+@dataclass
+class FullScanStats:
+    number_of_rows_read: int = 0
+    read_pages: int = 0
+    scans_counter: int = 0
+    time_elapsed: int = 0
+    total_scan_time: int = 0
+    stats: list[FullScanOperationStat] = field(default_factory=list)
+
+    def get_stats_pretty_table(self) -> PrettyTable | None:
+        if not self.stats:
+            return None
+
+        pretty_table = PrettyTable(field_names=[field.name for field in fields(self.stats[0])])
+        for stat in self.stats:
+            pretty_table.add_row([stat.op_type, stat.duration, stat.exceptions, stat.nemesis_at_start,
+                                  stat.nemesis_at_end, stat.success, stat.cmd])
+
+        return pretty_table
+
+
+@dataclass
+class FullScanOperationStat:
+    op_type: str = None
+    duration: float = None
+    exceptions: list = None
+    nemesis_at_start: str = None
+    nemesis_at_end: str = None
+    success: bool = None
+    cmd: str = None
+
+
+class FullscanException(Exception):
+    """ Exception during running a fullscan"""
+    ...
+
+
+# pylint: disable=too-many-instance-attributes
+class ScanOperationThread:
+    def __init__(self, fullscan_params: FullScanParams):
+        self.fullscan_params = fullscan_params
+        self.fullscan_stats = FullScanStats()
+        self.current_scan_event = None
         self.log = logging.getLogger(self.__class__.__name__)
-        self.user = kwargs.get("user", None)
-        self.password = kwargs.get("password", None)
         self._thread = threading.Thread(daemon=True, name=self.__class__.__name__, target=self.run)
 
-    def wait_until_user_table_exists(self, db_node, table_name: str = 'random', timeout_min: int = 20):
-        text = f'Waiting until {table_name} user table exists'
-        if table_name.lower() == 'random':
-            wait.wait_for(func=lambda: len(self.db_cluster.get_non_system_ks_cf_list(db_node)) > 0, step=60,
-                          text=text, timeout=60 * timeout_min, throw_exc=True)
-        else:
-            wait.wait_for(func=lambda: table_name in (self.db_cluster.get_non_system_ks_cf_list(db_node)), step=60,
-                          text=text, timeout=60 * timeout_min, throw_exc=True)
+    def _get_random_node(self) -> BaseNode:
+        return random.choice(self.fullscan_params.db_cluster.nodes)
 
-    def randomly_bypass_cache(self, cmd: str) -> str:
+    def _get_scan_operation_instance(self, **kwargs) -> FullScanOperation | FullPartitionScanOperation \
+            | FullScanAggregatesOperation | None:
+        match self.fullscan_params.mode:
+            case "random":
+                scan_op_type = random.choice(
+                    [FullScanOperation, FullPartitionScanOperation, FullScanAggregatesOperation])
+                return scan_op_type(**kwargs)
+            case "select":
+                return FullScanOperation(**kwargs)
+            case "partition":
+                return FullPartitionScanOperation(**kwargs)
+            case "aggregate":
+                return FullScanAggregatesOperation(**kwargs)
+            case _:
+                return None
+
+    def run_next_scan_operation(self):
+        try:
+            scan_op = self._get_scan_operation_instance(
+                fullscan_params=self.fullscan_params,
+                fullscan_stats=self.fullscan_stats,
+            )
+            self.log.info("Going to run fullscan operation %s", scan_op.__class__.__name__)
+            scan_op.run_scan_operation()
+            self.log.info("Fullscan stats:\n%s", self.fullscan_stats.get_stats_pretty_table())
+
+            # for stat in self.fullscan_stats.stats:
+            #     self.log.info(stat)
+
+        except Exception as exc:  # pylint: disable=broad-except
+            self.log.warning("Encountered exception while performing a fullscan operation:\n%s", exc)
+
+    def run(self):
+        end_time = time.time() + self.fullscan_params.duration
+        while time.time() < end_time and not self.fullscan_params.db_cluster.nemesis_termination_event.is_set():
+            self.fullscan_stats.read_pages = random.choice([100, 1000, 0])
+            self.run_next_scan_operation()
+            time.sleep(self.fullscan_params.interval)
+
+    def start(self):
+        self._thread.start()
+
+    def join(self, timeout=None):
+        return self._thread.join(timeout)
+
+
+class ScanOperation:
+    def __init__(self, fullscan_params: FullScanParams, fullscan_stats: FullScanStats,
+                 scan_event: Type[FullScanEvent] | Type[FullPartitionScanEvent]
+                 | Type[FullPartitionScanReversedOrderEvent] | Type[FullScanAggregateEvent]):
+        self.log = logging.getLogger(self.__class__.__name__)
+        self.fullscan_params = fullscan_params
+        self.fullscan_stats = fullscan_stats
+        self.scan_event = scan_event
+        self.termination_event = self.fullscan_params.db_cluster.nemesis_termination_event
+        self.db_node = self._get_random_node()
+
+    def _get_random_node(self) -> BaseNode:
+        return random.choice(self.fullscan_params.db_cluster.nodes)
+
+    def _set_test_ks_cf(self) -> None:
+        if self.fullscan_params.ks_cf.lower() == "random":
+            self.fullscan_params.ks_cf = random.choice(
+                self.fullscan_params.db_cluster.get_non_system_ks_cf_list(self.db_node))
+
+    def wait_until_user_table_exists(self, ks_cf: str = 'random', timeout_min: int = 20):
+        text = f'Waiting until {ks_cf} user table exists'
+        if ks_cf.lower() == 'random':
+            wait.wait_for(func=lambda: len(self.fullscan_params.db_cluster.get_non_system_ks_cf_list(self.db_node)) > 0,
+                          step=60, text=text, timeout=60 * timeout_min, throw_exc=True)
+        else:
+            wait.wait_for(func=lambda: ks_cf in (
+                self.fullscan_params.db_cluster.get_non_system_ks_cf_list(self.db_node)
+            ), step=60, text=text, timeout=60 * timeout_min, throw_exc=True)
+
+    @abstractmethod
+    def randomly_form_cql_statement(self):
+        ...
+
+    def update_stats(self):
+        self.fullscan_stats.scans_counter += 1
+        self.fullscan_stats.total_scan_time += self.fullscan_stats.time_elapsed
+        self.log.info('Average scan duration of %s scans is: %s', self.fullscan_stats.scans_counter,
+                      (self.fullscan_stats.total_scan_time / self.fullscan_stats.scans_counter))
+
+    def execute_query(self, session, cmd: str) -> ResultSet:
+        self.log.info('Will run command "%s"', cmd)
+        return session.execute(SimpleStatement(
+            cmd,
+            fetch_size=self.fullscan_params.page_size,
+            consistency_level=ConsistencyLevel.ONE))
+
+    def run_scan_event(self, cmd: str,
+                       scan_event: Type[FullScanEvent | FullPartitionScanEvent
+                                        | FullPartitionScanReversedOrderEvent] = None) -> FullScanOperationStat:
+        scan_event = scan_event or self.scan_event
+
+        with scan_event(node=self.db_node.name, ks_cf=self.fullscan_params.ks_cf, message="",
+                        user=self.fullscan_params.fullscan_user,
+                        password=self.fullscan_params.fullscan_user_password) as scan_op_event:
+            cmd = cmd or self.randomly_form_cql_statement()
+
+            op_stat = FullScanOperationStat(
+                op_type=scan_op_event.__class__.__name__,
+                nemesis_at_start=self.db_node.running_nemesis,
+                cmd=cmd
+            )
+
+            with self.fullscan_params.db_cluster.cql_connection_patient(
+                    node=self.db_node,
+                    connect_timeout=300,
+                    user=self.fullscan_params.fullscan_user,
+                    password=self.fullscan_params.fullscan_user_password) as session:
+                if self.termination_event.is_set():
+                    op_stat.exceptions.append(FullscanException("Aborted fullcan operation due to test "
+                                                                "termination event."))
+                    op_stat.success = False
+                    op_stat.nemesis_at_end = self.db_node.running_nemesis
+                    return op_stat
+
+                try:
+                    start_time = time.time()
+                    result = self.execute_query(session=session, cmd=cmd)
+                    self.fetch_result_pages(result=result, read_pages=self.fullscan_stats.read_pages)
+                    scan_op_event.message = f"{type(self).__name__} operation ended successfully"
+                except Exception as exc:  # pylint: disable=broad-except
+                    op_stat.exceptions.append(exc)
+                    msg = str(exc)
+                    msg = f"{msg} while running " \
+                          f"Nemesis: {self.db_node.running_nemesis}" if self.db_node.running_nemesis else msg
+                    scan_op_event.message = msg
+
+                    if self.db_node.running_nemesis or any(s in msg.lower() for s in ERROR_SUBSTRINGS):
+                        scan_op_event.severity = Severity.WARNING
+                    else:
+                        scan_op_event.severity = Severity.ERROR
+                finally:
+                    duration = time.time() - start_time
+                    self.fullscan_stats.time_elapsed += duration
+                    self.fullscan_stats.scans_counter += 1
+                    self.update_stats()
+                    op_stat.nemesis_at_end = self.db_node.running_nemesis
+                    op_stat.duration = duration
+                    op_stat.success = not bool(op_stat.exceptions)  # success is True if there were no exceptions
+                    self.fullscan_stats.stats.append(op_stat)
+                    return op_stat  # pylint: disable=lost-exception
+
+    def run_scan_operation(self, cmd: str = None):
+        self.log.info("Running fullscan operation: %s", self.__class__.__name__)
+        self._set_test_ks_cf()
+        self.wait_until_user_table_exists(ks_cf=self.fullscan_params.ks_cf)
+
+        self.run_scan_event(cmd=cmd or self.randomly_form_cql_statement(), scan_event=self.scan_event)
+
+    @staticmethod
+    def randomly_bypass_cache(cmd: str) -> str:
         if random.choice([True] + [False]):
-            cmd += self.bypass_cache
+            cmd += ' BYPASS CACHE'
         return cmd
 
     @staticmethod
@@ -71,17 +264,6 @@ class ScanOperationThread:
             cmd += cql_timeout_param
         return cmd
 
-    @abstractmethod
-    def randomly_form_cql_statement(self) -> Optional[str]:
-        ...
-
-    def execute_query(self, session, cmd: str):
-        self.log.info('Will run command "%s"', cmd)
-        return session.execute(SimpleStatement(
-            cmd,
-            fetch_size=self.page_size,
-            consistency_level=ConsistencyLevel.ONE))
-
     def fetch_result_pages(self, result, read_pages):
         self.log.debug('Will fetch up to %s result pages.."', read_pages)
         pages = 0
@@ -90,74 +272,25 @@ class ScanOperationThread:
             if read_pages > 0:
                 pages += 1
 
-    def update_stats(self):
-        self.scans_counter += 1
-        self.total_scan_time += self.time_elapsed
-        self.log.info('Average scan duration of %s scans is: %s', self.scans_counter,
-                      (self.total_scan_time / self.scans_counter))
 
-    def run_scan_operation(self, cmd: str = None, update_stats: bool = True):  # pylint: disable=too-many-locals
-        db_node = self.db_node
-        self.wait_until_user_table_exists(db_node=db_node, table_name=self.ks_cf)
-        if self.ks_cf.lower() == 'random':
-            self.ks_cf = random.choice(self.db_cluster.get_non_system_ks_cf_list(db_node))
-        with self.scan_event(node=db_node.name, ks_cf=self.ks_cf, message="",
-                             user=self.user, password=self.password) as operation_event:
-            cmd = cmd or self.randomly_form_cql_statement()
-            if not cmd:
-                return
-            with self.db_cluster.cql_connection_patient(node=db_node, connect_timeout=300,
-                                                        user=self.user, password=self.password) as session:
-
-                if self.termination_event.is_set():
-                    return
-
-                try:
-                    start_time = time.time()
-                    result = self.execute_query(session=session, cmd=cmd)
-                    self.fetch_result_pages(result=result, read_pages=self.read_pages)
-                    self.time_elapsed = time.time() - start_time
-                    self.update_stats()
-                    self.log.debug('[%s] last scan duration of %s rows is: %s', {type(self).__name__},
-                                   self.number_of_rows_read, self.time_elapsed)
-                    operation_event.message = f"{type(self).__name__} operation ended successfully"
-                except Exception as exc:  # pylint: disable=broad-except
-                    msg = str(exc)
-                    msg = f"{msg} while running Nemesis: {db_node.running_nemesis}" if db_node.running_nemesis else msg
-                    operation_event.message = msg
-
-                    if db_node.running_nemesis or any(s in msg.lower() for s in ERROR_SUBSTRINGS):
-                        operation_event.severity = Severity.WARNING
-                    else:
-                        operation_event.severity = Severity.ERROR
-
-    def run(self):
-        end_time = time.time() + self.duration
-        while time.time() < end_time and not self.termination_event.is_set():
-            self.db_node = random.choice(self.db_cluster.nodes)
-            self.read_pages = random.choice([100, 1000, 0])
-            self.run_scan_operation()
-            self.log.debug('Executed %s number: %s', self.scan_event.__name__, self.scans_counter)
-            time.sleep(self.interval)
-
-    def start(self):
-        self._thread.start()
-
-    def join(self, timeout=None):
-        return self._thread.join(timeout)
-
-
-class FullScanThread(ScanOperationThread):
-
+class FullScanOperation(ScanOperation):
     def __init__(self, **kwargs):
         super().__init__(scan_event=FullScanEvent, **kwargs)
 
     def randomly_form_cql_statement(self) -> Optional[str]:
-        cmd = self.randomly_bypass_cache(cmd=self.basic_query).format(self.ks_cf)
+        base_query = FullScanAggregateCommands.SELECT_ALL.base_query
+        cmd = self.randomly_bypass_cache(cmd=base_query.substitute(ks_cf=self.fullscan_params.ks_cf))
         return self.randomly_add_timeout(cmd)
 
+    def execute_query(self, session, cmd: str) -> ResultSet:
+        self.log.info('Will run command "%s"', cmd)
+        return session.execute(SimpleStatement(
+            cmd,
+            fetch_size=self.fullscan_params.page_size,
+            consistency_level=ConsistencyLevel.ONE))
 
-class FullPartitionScanThread(ScanOperationThread):
+
+class FullPartitionScanOperation(ScanOperation):
     """
     Run a full scan of a partition, assuming it has a clustering key and multiple rows.
     It runs a reversed query of a partition, then optionally runs a normal partition scan in order
@@ -183,7 +316,7 @@ class FullPartitionScanThread(ScanOperationThread):
         self.ck_name = self.full_partition_scan_params.get('ck_name', 'ck')
         self.data_column_name = self.full_partition_scan_params.get('data_column_name', 'v')
         self.rows_count = self.full_partition_scan_params.get('rows_count', 5000)
-        self.table_clustering_order = self.get_table_clustering_order()
+        self.table_clustering_order = ""
         self.reversed_order = 'desc' if self.table_clustering_order.lower() == 'asc' else 'asc'
         self.reversed_query_filter_ck_stats = {'lt': {'count': 0, 'total_scan_duration': 0},
                                                'gt': {'count': 0, 'total_scan_duration': 0},
@@ -197,15 +330,17 @@ class FullPartitionScanThread(ScanOperationThread):
                                                                encoding='utf-8')
 
     def get_table_clustering_order(self) -> str:
-        for node in self.db_cluster.nodes:
-            try:
-                with self.db_cluster.cql_connection_patient(node=node, connect_timeout=300) as session:
-                    # Using CL ONE. No need for a quorum since querying a constant fixed attribute of a table.
-                    session.default_consistency_level = ConsistencyLevel.ONE
-                    return get_table_clustering_order(ks_cf=self.ks_cf, ck_name=self.ck_name, session=session)
-            except Exception as error:  # pylint: disable=broad-except
-                self.log.error('Failed getting table %s clustering order through node %s : %s', self.ks_cf, node.name,
-                               error)
+        node = self._get_random_node()
+        try:
+            with self.fullscan_params.db_cluster.cql_connection_patient(node=node, connect_timeout=300) as session:
+                # Using CL ONE. No need for a quorum since querying a constant fixed attribute of a table.
+                session.default_consistency_level = ConsistencyLevel.ONE
+                return get_table_clustering_order(ks_cf=self.fullscan_params.fullscan_user,
+                                                  ck_name=self.ck_name, session=session)
+        except Exception as error:  # pylint: disable=broad-except
+            self.log.error('Failed getting table %s clustering order through node %s : %s',
+                           self.fullscan_params.ks_cf, node.name,
+                           error)
         raise Exception('Failed getting table clustering order from all db nodes')
 
     def randomly_form_cql_statement(self) -> Optional[tuple[str, str]]:  # pylint: disable=too-many-branches
@@ -219,22 +354,22 @@ class FullPartitionScanThread(ScanOperationThread):
         3) Add a random CK filter with random row values.
         :return: a CQL reversed-query
         """
-        with self.db_cluster.cql_connection_patient(node=self.db_node, connect_timeout=300) as session:
-            ck_name = self.ck_name
-            rows_count = self.rows_count
-            ck_random_min_value = random.randint(a=1, b=rows_count)
-            ck_random_max_value = random.randint(a=ck_random_min_value, b=rows_count)
+        db_node = self._get_random_node()
+        with self.fullscan_params.db_cluster.cql_connection_patient(
+                node=db_node, connect_timeout=300) as session:
+            ck_random_min_value = random.randint(a=1, b=self.rows_count)
+            ck_random_max_value = random.randint(a=ck_random_min_value, b=self.rows_count)
             self.ck_filter = ck_filter = random.choice(list(self.reversed_query_filter_ck_by.keys()))
             pk_name = self.pk_name
-            if pks := get_partition_keys(ks_cf=self.ks_cf, session=session, pk_name=pk_name):
+            if pks := get_partition_keys(ks_cf=self.fullscan_params.ks_cf, session=session, pk_name=pk_name):
                 partition_key = random.choice(pks)
                 # Form a random query out of all options, like:
                 # select * from scylla_bench.test where pk = 1234 and ck < 4721 and ck > 2549 order by ck desc
                 # limit 3467 bypass cache
-                selected_columns = [pk_name, ck_name]
+                selected_columns = [pk_name, self.ck_name]
                 if self.full_partition_scan_params.get('include_data_column'):
                     selected_columns.append(self.data_column_name)
-                reversed_query = f'select {",".join(selected_columns)} from {self.ks_cf}' + \
+                reversed_query = f'select {",".join(selected_columns)} from {self.fullscan_params.ks_cf}' + \
                     f' where {pk_name} = {partition_key}'
                 query_suffix = self.limit = ''
 
@@ -248,9 +383,9 @@ class FullPartitionScanThread(ScanOperationThread):
                 match ck_filter:
                     case 'lt_and_gt':
                         # Example: select * from scylla_bench.test where pk = 1 and ck > 10 and ck < 15 order by ck desc
-                        reversed_query += self.reversed_query_filter_ck_by[ck_filter].format(ck_name,
+                        reversed_query += self.reversed_query_filter_ck_by[ck_filter].format(self.ck_name,
                                                                                              ck_random_max_value,
-                                                                                             ck_name,
+                                                                                             self.ck_name,
                                                                                              ck_random_min_value)
 
                     case 'gt':
@@ -258,7 +393,7 @@ class FullPartitionScanThread(ScanOperationThread):
                         # reversed query is: select * from scylla_bench.test where pk = 1 and ck > 10
                         # order by ck desc limit 5
                         # normal query should be: select * from scylla_bench.test where pk = 1 and ck > 15 limit 5
-                        reversed_query += self.reversed_query_filter_ck_by[ck_filter].format(ck_name,
+                        reversed_query += self.reversed_query_filter_ck_by[ck_filter].format(self.ck_name,
                                                                                              ck_random_min_value)
 
                     case 'lt':
@@ -266,35 +401,37 @@ class FullPartitionScanThread(ScanOperationThread):
                         # reversed query is: select * from scylla_bench.test where pk = 1 and ck < 10
                         # order by ck desc limit 5
                         # normal query should be: select * from scylla_bench.test where pk = 1 and ck >= 5 limit 5
-                        reversed_query += self.reversed_query_filter_ck_by[ck_filter].format(ck_name,
+                        reversed_query += self.reversed_query_filter_ck_by[ck_filter].format(self.ck_name,
                                                                                              ck_random_min_value)
                 query_suffix = self.randomly_bypass_cache(cmd=query_suffix)
                 normal_query = reversed_query + query_suffix
                 if random.choice([False] + [True]):  # Randomly add a LIMIT
-                    self.limit = random.randint(a=1, b=rows_count)
+                    self.limit = random.randint(a=1, b=self.rows_count)
                     query_suffix = f' limit {self.limit}' + query_suffix
-                reversed_query += f' order by {ck_name} {self.reversed_order}' + query_suffix
+                reversed_query += f' order by {self.ck_name} {self.reversed_order}' + query_suffix
                 self.log.debug('Randomly formed normal query is: %s', normal_query)
-                self.log.debug('[scan: %s, type: %s] Randomly formed reversed query is: %s', self.scans_counter,
+                self.log.debug('[scan: %s, type: %s] Randomly formed reversed query is: %s',
+                               self.fullscan_stats.scans_counter,
                                ck_filter, reversed_query)
             else:
-                self.log.debug('No partition keys found for table: %s! A reversed query cannot be executed!', self.ks_cf)
+                self.log.debug('No partition keys found for table: %s! A reversed query cannot be executed!',
+                               self.fullscan_params.ks_cf)
                 return None
         return normal_query, reversed_query
 
     def fetch_result_pages(self, result: ResponseFuture, read_pages):
         self.log.debug('Will fetch up to %s result pages.."', read_pages)
-        self.number_of_rows_read = 0
-        handler = PagedResultHandler(future=result, scan_operation_thread=self)
+        self.fullscan_stats.number_of_rows_read = 0
+        handler = PagedResultHandler(future=result, scan_operation=self)
         handler.finished_event.wait()
         if handler.error:
             self.log.warning("Got a Page Handler error: %s", handler.error)
             raise handler.error
         self.log.debug('Fetched a total of %s pages', handler.current_read_pages)
 
-    def execute_query(self, session, cmd: str):
+    def execute_query(self, session, cmd: str) -> ResponseFuture:
         self.log.debug('Will run command "%s"', cmd)
-        session.default_fetch_size = self.page_size
+        session.default_fetch_size = self.fullscan_params.page_size
         session.default_consistency_level = ConsistencyLevel.ONE
         return session.execute_async(cmd)
 
@@ -306,9 +443,10 @@ class FullPartitionScanThread(ScanOperationThread):
         self.normal_query_output = tempfile.NamedTemporaryFile(mode='w+', delete=False,  # pylint: disable=consider-using-with
                                                                encoding='utf-8')
 
-    def _compare_output_files(self):
+    def _compare_output_files(self) -> bool:
         self.normal_query_output.flush()
         self.reversed_query_output.flush()
+        result = False
 
         with tempfile.NamedTemporaryFile(mode='w+', delete=True, encoding='utf-8') as reorder_normal_query_output:
             cmd = f'tac {self.normal_query_output.name}'
@@ -328,6 +466,7 @@ class FullPartitionScanThread(ScanOperationThread):
         if not result.stderr:
             if not result.stdout:
                 self.log.info("Compared output of normal and reversed queries is identical!")
+                result = True
             else:
                 self.log.warning("Normal and reversed queries output differs: \n%s", result.stdout.strip())
                 ls_cmd = f"ls -alh {file_names}"
@@ -338,62 +477,116 @@ class FullPartitionScanThread(ScanOperationThread):
                         stdout = result.stdout.strip()
                         self.log.info("%s command output is: \n%s", cmd, stdout)
         self.reset_output_files()
+        return result
 
-    def run_scan_operation(self, cmd: str = None, update_stats: bool = True):  # pylint: disable=too-many-locals
+    def run_scan_operation(self, cmd: str = None):  # pylint: disable=too-many-locals
         queries = self.randomly_form_cql_statement()
+        self.wait_until_user_table_exists(self.fullscan_params.ks_cf)
+        self.table_clustering_order = self.get_table_clustering_order()
+
         if not queries:
             return
+
         normal_query, reversed_query = queries
-        self.scan_event = FullPartitionScanReversedOrderEvent
-        super().run_scan_operation(cmd=reversed_query)
+
+        full_partition_op_stat = FullScanOperationStat(
+            op_type=self.scan_event.__class__.__name__,
+            nemesis_at_start=self.db_node.running_nemesis,
+            cmd=str(queries)
+        )
+
+        reversed_op_stat = self.run_scan_event(cmd=reversed_query, scan_event=FullPartitionScanReversedOrderEvent)
         self.reversed_query_filter_ck_stats[self.ck_filter]['count'] += 1
-        self.reversed_query_filter_ck_stats[self.ck_filter]['total_scan_duration'] += self.time_elapsed
+        self.reversed_query_filter_ck_stats[self.ck_filter]['total_scan_duration'] += self.fullscan_stats.time_elapsed
         count = self.reversed_query_filter_ck_stats[self.ck_filter]['count']
         average = self.reversed_query_filter_ck_stats[self.ck_filter]['total_scan_duration'] / count
         self.log.debug('Average %s scans duration of %s executions is: %s', self.ck_filter, count, average)
+        self.update_stats()
+
         if self.full_partition_scan_params.get('validate_data'):
             self.log.debug('Executing the normal query: %s', normal_query)
-            self.scan_event = FullPartitionScanEvent
-            super().run_scan_operation(cmd=normal_query)
-            self._compare_output_files()
+            regular_op_stat = self.run_scan_event(cmd=normal_query, scan_event=FullPartitionScanEvent)
+            comparison_result = self._compare_output_files()
+            full_partition_op_stat.nemesis_at_end = self.db_node.running_nemesis
+            full_partition_op_stat.exceptions = reversed_op_stat.exceptions + regular_op_stat.exceptions
+            if comparison_result and not full_partition_op_stat.exceptions:
+                full_partition_op_stat.success = True
+            else:
+                full_partition_op_stat.success = False
 
     def update_stats(self):
         if self.scan_event == FullPartitionScanReversedOrderEvent:
             super().update_stats()
 
 
+class FullScanAggregatesOperation(ScanOperation):
+    def __init__(self, **kwargs):
+        super().__init__(scan_event=FullScanAggregateEvent, **kwargs)
+
+    def randomly_form_cql_statement(self) -> Optional[str]:
+        cmd = FullScanAggregateCommands.AGG_COUNT_ALL.base_query.substitute(ks_cf=self.fullscan_params.ks_cf)
+        return self.randomly_add_timeout(cmd)
+
+    def execute_query(self, session, cmd: str) -> ResultSet:
+        cmd_result: ResultSet = session.execute(query=cmd, trace=True)
+        if self._validate_fullscan_result(cmd_result):
+            self.scan_event.message = f"{type(self).__name__} operation ended successfully"
+        else:
+            self.scan_event.severity = Severity.WARNING
+            self.scan_event.message = f"{type(self).__name__} operation failed."
+        return cmd_result
+
+    def _validate_fullscan_result(self, cmd_result: ResultSet):
+        regex_found = False
+        dispatch_forward_statement_regex_pattern = re.compile(r"Dispatching forward_request to \d* endpoints")
+
+        result = cmd_result.all()
+
+        if not result:
+            self.log.warning("Fullscan failed - got empty result.")
+            return False
+
+        for trace_event in cmd_result.get_query_trace().events:
+            if dispatch_forward_statement_regex_pattern.search(str(trace_event)):
+                regex_found = True
+
+        self.log.debug("Fullscan aggregation result: %s", result[0])
+
+        return int(result[0].count) > 0 and regex_found
+
+
 class PagedResultHandler:
 
-    def __init__(self, future: ResponseFuture, scan_operation_thread: FullPartitionScanThread):
+    def __init__(self, future: ResponseFuture, scan_operation: FullPartitionScanOperation):
         self.error = None
         self.finished_event = threading.Event()
         self.future = future
-        self.max_read_pages = scan_operation_thread.read_pages
+        self.max_read_pages = scan_operation.fullscan_stats.read_pages
         self.current_read_pages = 0
         self.log = logging.getLogger(self.__class__.__name__)
-        self.scan_operation_thread = scan_operation_thread
+        self.scan_operation = scan_operation
         self.future.add_callbacks(
             callback=self.handle_page,
             errback=self.handle_error)
 
     def _row_to_string(self, row, include_data_column: bool = False) -> str:
-        row_string = str(getattr(row, self.scan_operation_thread.pk_name))
-        row_string += str(getattr(row, self.scan_operation_thread.ck_name))
+        row_string = str(getattr(row, self.scan_operation.fullscan_params.pk_name))
+        row_string += str(getattr(row, self.scan_operation.fullscan_params.ck_name))
         if include_data_column:
-            row_string += str(getattr(row, self.scan_operation_thread.data_column_name))
+            row_string += str(getattr(row, self.scan_operation.fullscan_params.data_column_name))
         return f'{row_string}\n'
 
     def handle_page(self, rows):
-        include_data_column = self.scan_operation_thread.full_partition_scan_params.get('include_data_column')
-        if self.scan_operation_thread.scan_event == FullPartitionScanEvent:
+        include_data_column = self.scan_operation.fullscan_params.include_data_column
+        if self.scan_operation.scan_event == FullPartitionScanEvent:
             for row in rows:
-                self.scan_operation_thread.normal_query_output.write(
+                self.scan_operation.normal_query_output.write(
                     self._row_to_string(row=row, include_data_column=include_data_column))
-        elif self.scan_operation_thread.scan_event == FullPartitionScanReversedOrderEvent:
-            self.scan_operation_thread.number_of_rows_read += len(rows)
-            if self.scan_operation_thread.full_partition_scan_params['validate_data']:
+        elif self.scan_operation.scan_event == FullPartitionScanReversedOrderEvent:
+            self.scan_operation.fullscan_stats.number_of_rows_read += len(rows)
+            if self.scan_operation.fullscan_params.validate_data:
                 for row in rows:
-                    self.scan_operation_thread.reversed_query_output.write(
+                    self.scan_operation.reversed_query_output.write(
                         self._row_to_string(row=row, include_data_column=include_data_column))
 
         if self.future.has_more_pages and self.current_read_pages <= self.max_read_pages:
@@ -407,3 +600,15 @@ class PagedResultHandler:
     def handle_error(self, exc):
         self.error = exc
         self.finished_event.set()
+
+
+class FullScanCommand(NamedTuple):
+    name: str
+    base_query: Template
+
+
+class FullScanAggregateCommands(NamedTuple):
+    SELECT_ALL = FullScanCommand("SELECT_ALL", Template("SELECT * from $ks_cf"))
+    AGG_COUNT_ALL = FullScanCommand(
+        "AGG_COUNT_ALL", Template("SELECT count(*) FROM $ks_cf")
+    )

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -326,6 +326,20 @@ class FullPartitionScanEvent(ScyllaDatabaseContinuousEvent):
         return fmt
 
 
+class FullScanAggregateEvent(ScyllaDatabaseContinuousEvent):
+    def __init__(self, node: str, ks_cf: str, message: str | None = None, severity=Severity.NORMAL, **__):
+        super().__init__(node=node, severity=severity)
+        self.ks_cf = ks_cf
+        self.message = message
+
+    @property
+    def msgfmt(self):
+        fmt = super().msgfmt + "select_from={0.ks_cf}"
+        if self.message:
+            fmt += " message={0.message}"
+        return fmt
+
+
 class RepairEvent(ScyllaDatabaseContinuousEvent):
     begin_pattern = r'Repair 1 out of \d+ ranges, id=\[id=\d+, uuid=(?P<uuid>[\d\w-]{36})\w*\], shard=(?P<shard>\d+)'
     end_pattern = r'repair id \[id=\d+, uuid=(?P<uuid>[\d\w-]{36})\w*\] on shard (?P<shard>\d+) completed'

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -53,7 +53,7 @@ from sdcm.cluster_k8s import mini_k8s, gke, eks
 from sdcm.cluster_k8s.eks import MonitorSetEKS
 from sdcm.provision.azure.provisioner import AzureProvisioner
 from sdcm.provision.provisioner import provisioner_factory
-from sdcm.scan_operation_thread import FullScanThread, FullPartitionScanThread
+from sdcm.scan_operation_thread import FullScanParams, ScanOperationThread
 from sdcm.nosql_thread import NoSQLBenchStressThread
 from sdcm.scylla_bench_thread import ScyllaBenchThread
 from sdcm.cassandra_harry_thread import CassandraHarryThread
@@ -1974,7 +1974,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                          'errors': stats['errors']})
         return stats
 
-    def run_fullscan_thread(self, ks_cf='random', interval=1, duration=None):
+    def run_fullscan_thread(self, fullscan_params: dict):
         """Run thread of cql command select *
 
         Calculate test duration and timeout interval between
@@ -1983,42 +1983,57 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         random choosen from current configuration'
 
         Keyword Arguments:
-            interval {number} -- interval between requests in min (default: {1})
-            duration {int} -- duration of running thread in min (default: {None})
+            fullscan_params: dict with params relevant for starting
+            the ScanOperationThread
         """
+        # TODO: wrap into fullscan section in the yaml
         sla_role_name, sla_role_password = None, None
         if fullscan_role := getattr(self, "fullscan_role", None):
             sla_role_name = fullscan_role.name
             sla_role_password = fullscan_role.password
 
-        FullScanThread(
-            db_cluster=self.db_cluster,
-            ks_cf=ks_cf,
-            duration=self.get_duration(duration),
-            interval=interval * 60,
-            termination_event=self.db_cluster.nemesis_termination_event,
-            user=sla_role_name,
-            password=sla_role_password,
+        ScanOperationThread(
+            fullscan_params=(
+                FullScanParams(
+                    db_cluster=self.db_cluster,
+                    fullscan_user=sla_role_name,
+                    fullscan_user_password=sla_role_password,
+                    duration=self.get_duration(fullscan_params.get("duration")),
+                    **fullscan_params
+                )
+            )
         ).start()
 
-    def run_full_partition_scan_thread(self, duration=None, interval=1, **kwargs):
-        """Run thread of cql command select with a clustering key reversed query.
+    # def run_full_partition_scan_thread(self, duration=None, interval=1, **kwargs):
+    #     """Run thread of cql command select with a clustering key reversed query.
+    #
+    #     Calculate test duration and timeout interval between
+    #     requests and execute the thread with cqlsh command to
+    #     db node: select * from ks.cf where pk = ? order by ck desc'
+    #
+    #     Keyword Arguments:
+    #         interval {number} -- interval between requests in seconds (default: {1})
+    #         duration {int} -- duration of running thread in min (default: {None})
+    #     """
+    #     FullPartitionScanOperation(
+    #         db_cluster=self.db_cluster,
+    #         termination_event=self.db_cluster.nemesis_termination_event,
+    #         duration=self.get_duration(duration),
+    #         interval=interval,
+    #         **kwargs
+    #     ).start()
 
-        Calculate test duration and timeout interval between
-        requests and execute the thread with cqlsh command to
-        db node: select * from ks.cf where pk = ? order by ck desc'
-
-        Keyword Arguments:
-            interval {number} -- interval between requests in seconds (default: {1})
-            duration {int} -- duration of running thread in min (default: {None})
-        """
-        FullPartitionScanThread(
-            db_cluster=self.db_cluster,
-            termination_event=self.db_cluster.nemesis_termination_event,
-            duration=self.get_duration(duration),
-            interval=interval,
-            **kwargs
-        ).start()
+    # def run_aggregates_thread(self, interval: int, ks_cf: str, duration: int = None):
+    #     """
+    #     Run aggregatees thread.
+    #     """
+    #     FullScanAggregatesOperation(
+    #         db_cluster=self.db_cluster,
+    #         ks_cf=ks_cf,
+    #         duration=self.get_duration(duration),
+    #         interval=interval * 60,
+    #         termination_event=self.db_cluster.nemesis_termination_event,
+    #     ).start()
 
     @staticmethod
     def is_keyspace_in_cluster(session, keyspace_name):
@@ -2233,7 +2248,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         Copy data from <src_keyspace>.<src_view> to <dest_keyspace>.<dest_table> if copy_data is True
         """
         result = True
-        create_statement = "SELECT * FROM system_schema.table where table_name = '%s' " \
+        create_statement = "SELECT * FROM system_schema.table where ks_cf = '%s' " \
                            "and keyspace_name = '%s'" % (src_table, src_keyspace)
         if not self.create_table_as(node, src_keyspace, src_table, dest_keyspace,
                                     dest_table, create_statement, columns_list):
@@ -2309,7 +2324,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
                 for column in columns_list or result.column_names:
                     column_kind = session.execute("select kind from system_schema.columns where keyspace_name='{ks}' "
-                                                  "and table_name='{name}' and column_name='{column}'".format(
+                                                  "and ks_cf='{name}' and column_name='{column}'".format(
                                                       ks=src_keyspace,
                                                       name=src_table,
                                                       column=column))
@@ -2464,7 +2479,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         return table_id[0]
 
     def get_tables_name_of_keyspace(self, session, keyspace_name):
-        query = "SELECT table_name FROM system_schema.tables WHERE keyspace_name='{}' ".format(keyspace_name)
+        query = "SELECT ks_cf FROM system_schema.tables WHERE keyspace_name='{}' ".format(keyspace_name)
         table_id = self.rows_to_list(session.execute(query))
         return table_id[0]
 

--- a/test-cases/longevity/longevity-10gb-3h.yaml
+++ b/test-cases/longevity/longevity-10gb-3h.yaml
@@ -10,7 +10,7 @@ instance_type_db: 'i4i.2xlarge'
 gce_instance_type_db: 'n1-highmem-16'
 gce_instance_type_loader: 'e2-standard-4'
 azure_instance_type_db: 'Standard_L8s_v3'
-run_fullscan: '{"ks_cf": "keyspace1.standard1", "interval": 5}' # 'ks.cf|random, interval(min)'
+run_fullscan: '{"mode": "random", "ks_cf": "keyspace1.standard1", "interval": 5}' # 'ks.cf|random, interval(min)'
 nemesis_class_name: 'SisyphusMonkey'
 nemesis_seed: '111'
 nemesis_interval: 2


### PR DESCRIPTION
This commit introduces a refactor of the scan_operation_thread.py module, with the goal of allowing the user to run different types of fullscan operations on the fullscan thread at random. As a secondary goal an aggregation fullscan operaiton is added for count(*) queries.

With the refactor what previously were separate fullscan thread classes are now ScanOperations and the ScanOperationThread runs the different operations sequentially, collecting some stats from the runs, similarly to how we do with Nemesis operaitons.

Helper dataclasses are introduced to keep track of the stats for indiividual fullscan operations and present them in the log.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
