### PR TITLE
fix(events): add subcontext to LogEvent

### DIFF
--- a/sdcm/sct_events/base.py
+++ b/sdcm/sct_events/base.py
@@ -227,7 +227,9 @@ class SctEvent:
                 return
 
             for nemesis in running_disruption_events:
-                self.subcontext.append(nemesis)
+                # To prevent multiplying of subcontext for LogEvent
+                if nemesis not in self.subcontext:
+                    self.subcontext.append(nemesis)
 
     def publish(self, warn_not_ready: bool = True) -> None:
         # pylint: disable=import-outside-toplevel; to avoid cyclic imports
@@ -430,6 +432,7 @@ class LogEvent(Generic[T_log_event], InformationalEvent, abstract=True):
         self.line_number = 0
         self.backtrace = None
         self.raw_backtrace = None
+        self.subcontext = []
 
         self._ready_to_publish: bool = False  # set it to True in `.add_info()'
 
@@ -460,6 +463,8 @@ class LogEvent(Generic[T_log_event], InformationalEvent, abstract=True):
         self.node = str(node)
         self.line = line
         self.line_number = line_number
+
+        self.add_subcontext()
 
         self._ready_to_publish = True  # this property not included to the clones, so need to call `.add_info()' first.
 


### PR DESCRIPTION
Nemesis subcontext has been added by https://github.com/scylladb/scylla-cluster-tests/pull/5159. But it does not work for LogEvents.
This commit fixes this problem

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
