### PR TITLE
improvement(k8s-functional): increase resharding wait time to 10m

### DIFF
--- a/functional_tests/scylla_operator/libs/helpers.py
+++ b/functional_tests/scylla_operator/libs/helpers.py
@@ -200,7 +200,7 @@ def verify_resharding_on_k8s(db_cluster: ScyllaPodCluster, cpus: Union[str, int,
         for node, liveness_probe_failures, resharding_start, resharding_finish in nodes_data:
             assert wait_for(
                 func=lambda: list(resharding_start),  # pylint: disable=cell-var-from-loop
-                step=1, timeout=300, throw_exc=False,
+                step=1, timeout=600, throw_exc=False,
                 text=f"Waiting for the start of resharding on the '{node.name}' node.",
             ), f"Start of resharding hasn't been detected on the '{node.name}' node."
             resharding_started = time.time()


### PR DESCRIPTION
It happens that the recreation of a Scylla pod may take more than our current wait timeout.
So, increase the timeout value to be 10 minutes to cover the reality for sure.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
