### PR TITLE
ci(k8s-gke): use dynamic loader run type for the longevity-3h job

### DIFF
--- a/configurations/operator/loader-run-type-dynamic.yaml
+++ b/configurations/operator/loader-run-type-dynamic.yaml
@@ -1,0 +1,1 @@
+k8s_loader_run_type: 'dynamic'

--- a/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke.jenkinsfile
+++ b/jenkins-pipelines/operator/gke/longevity-scylla-operator-3h-gke.jenkinsfile
@@ -5,7 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 longevityPipeline(
     backend: 'k8s-gke',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/scylla-operator/longevity-scylla-operator-3h.yaml',
+    test_config: '''["test-cases/scylla-operator/longevity-scylla-operator-3h.yaml", "configurations/operator/loader-run-type-dynamic.yaml"]''',
     email_recipients: 'qa@scylladb.com,scylla-operator@scylladb.com',
     post_behavior_db_nodes: 'destroy',
     post_behavior_loader_nodes: 'destroy',


### PR DESCRIPTION
This job will be weekly triggered.
So, enable dynamic loader run type for this job to test it in addition to the GKE backend itself.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
