### PR TITLE
improvement(k8s-gke): use taint for Scylla K8S nodes

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -165,6 +165,7 @@ class CloudK8sNodePool(metaclass=abc.ABCMeta):  # pylint: disable=too-many-insta
             disk_size: int = None,
             disk_type: str = None,
             labels: dict = None,
+            taints: list = None,
             is_deployed: bool = False):
         self.k8s_cluster = k8s_cluster
         self.name = name
@@ -174,6 +175,7 @@ class CloudK8sNodePool(metaclass=abc.ABCMeta):  # pylint: disable=too-many-insta
         self.disk_type = disk_type
         self.image_type = image_type
         self.labels = labels
+        self.taints = taints
         self.is_deployed = is_deployed
 
     @property
@@ -823,6 +825,12 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
                 "key": "scylla/cluster", "operator": "In", "values": [cluster_name],
             }]}
         }]}
+        placement["tolerations"] = [{
+            "key": "role",
+            "value": "scylla-clusters",
+            "operator": "Equal",
+            "effect": "NoSchedule",
+        }]
         return HelmValues({
             'nameOverride': '',
             'fullnameOverride': cluster_name,

--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -55,6 +55,7 @@ class GkeNodePool(CloudK8sNodePool):
             disk_type: str = None,
             image_type: str = "UBUNTU_CONTAINERD",
             labels: dict = None,
+            taints: list = None,
             local_ssd_count: int = None,
             gce_project: str = None,
             is_deployed: bool = False
@@ -68,6 +69,7 @@ class GkeNodePool(CloudK8sNodePool):
             image_type=image_type,
             instance_type=instance_type,
             labels=labels,
+            taints=taints,
             is_deployed=is_deployed,
         )
         self.local_ssd_count = local_ssd_count
@@ -100,6 +102,8 @@ class GkeNodePool(CloudK8sNodePool):
             # Stable API: --local-ssd-count 3
             # Beta API  : --ephemeral-storage="local-ssd-count=3"
             cmd.append(f"--ephemeral-storage=\"local-ssd-count={self.local_ssd_count}\"")
+        if self.taints:
+            cmd.append(f"--node-taints {' '.join(self.taints)}")
         if self.tags:
             cmd.append(f"--metadata {','.join(f'{key}={value}' for key, value in self.tags.items())}")
         return ' '.join(cmd)

--- a/sdcm/k8s_configs/static-local-volume-provisioner.yaml
+++ b/sdcm/k8s_configs/static-local-volume-provisioner.yaml
@@ -89,6 +89,11 @@ spec:
       serviceAccountName: "static-local-volume-provisioner-sa"
       # NOTE: 'affinity' option will be updated in the code
       affinity: {}
+      tolerations:
+      - key: role
+        operator: Equal
+        value: scylla-clusters
+        effect: NoSchedule
       containers:
         - image: "quay.io/external_storage/local-volume-provisioner:v2.3.4"
           imagePullPolicy: IfNotPresent

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1388,6 +1388,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             disk_type=self.params.get("gce_root_disk_type_db"),
             instance_type=self.params.get("gce_instance_type_db"),
             num_nodes=self.params.get("n_db_nodes"),
+            taints=["role=scylla-clusters:NoSchedule"],
             k8s_cluster=self.k8s_cluster)
         self.k8s_cluster.deploy_node_pool(scylla_pool, wait_till_ready=False)
 


### PR DESCRIPTION
GKE deploys lots of redundant, for Scylla K8S nodes, pods. So, make it be scheduled elsewhere by setting a taint that will be tolerated by all the expected pods.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
