### PR TITLE
feature(log_collector): add scripts debug logs

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -817,7 +817,9 @@ class ScyllaLogCollector(LogCollector):
                     CommandLog(name='cassandra-rackdc.properties',
                                command=f'cat {SCYLLA_PROPERTIES_PATH}'),
                     CommandLog(name='scylla-manager-agent.yaml',
-                               command=f'cat {SCYLLA_MANAGER_AGENT_YAML_PATH}')
+                               command=f'cat {SCYLLA_MANAGER_AGENT_YAML_PATH}'),
+                    CommandLog(name='setup_scripts_errors.log',
+                               command='for i in /var/tmp/scylla/*.log;do echo [$i]; cat $i;done')
                     ]
     cluster_log_type = "db-cluster"
     cluster_dir_prefix = "db-cluster"


### PR DESCRIPTION
We recently added setup scripts debug log on
https://github.com/scylladb/scylladb/pull/10472,
which is generated at /var/tmp/scylla/{scriptname}-{pid}-debug.log. The file contains more detail of traceback with current value of variables, it helps to fix bugs which hard to reproduce.
Since it could be multiple files and should be deleted since we expect /var/tmp/scylla will be empty when we run next test, so we need to iterate on /var/tmp/scylla/*, collect log and then delete it.