### PR TITLE
fix(azure): fix clean resources for user

### DIFF
--- a/sdcm/provision/azure/provisioner.py
+++ b/sdcm/provision/azure/provisioner.py
@@ -92,7 +92,7 @@ class AzureProvisioner(Provisioner):  # pylint: disable=too-many-instance-attrib
         else:
             # extract test_id from rg names where rg.name format is: SCT-<test_id>-<region>-<az>
             provisioner_params = [(test_id, rg.location, cls._get_az_from_name(rg), azure_service) for rg in all_resource_groups
-                                  if (test_id := rg.name.split("SCT-")[-1][:36])]
+                                  if (test_id := rg.name.split("SCT-")[-1][:36]) and len(test_id) == 36]
         return [cls(*params) for params in provisioner_params]
 
     def get_or_create_instance(self, definition: InstanceDefinition,


### PR DESCRIPTION
When running clean-resources for specific user, resources group list also invalid RG's (with no test_id).

This fix enforces proper discovery of test_id's from RG's names, fixing cleanup for specific user.

refs: https://github.com/scylladb/scylla-cluster-tests/issues/5373

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
