### PR TITLE
fix(k8s-gke): skip flush and reshard nemesis due to the bug

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1266,6 +1266,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         """Covers https://github.com/scylladb/scylla-operator/issues/894"""
         if not self._is_it_on_kubernetes():
             raise UnsupportedNemesis('It is supported only on kubernetes')
+        if self.cluster.params.get('cluster_backend') == "k8s-gke":
+            raise UnsupportedNemesis(
+                "Skipped due to the following bug: "
+                "https://github.com/scylladb/scylla-operator/issues/1077")
 
         def _check_pod_stats(node):
             # Pod info:


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
