### PR TITLE
fix(k8s): do not call `docker pull` command in stress thread class

### DIFF
--- a/sdcm/scylla_bench_thread.py
+++ b/sdcm/scylla_bench_thread.py
@@ -118,8 +118,6 @@ class ScyllaBenchThread(DockerBasedStressThread):  # pylint: disable=too-many-in
         self.sb_mode: ScyllaBenchModes = ScyllaBenchModes(re.search(r"-mode=(.+?) ", stress_cmd).group(1))
         self.sb_workload: ScyllaBenchWorkloads = ScyllaBenchWorkloads(
             re.search(r"-workload=(.+?) ", stress_cmd).group(1))
-        for loader in self.loader_set.nodes:
-            RemoteDocker.pull_image(loader, self.params.get('stress_image.scylla-bench'))
 
     def verify_results(self):
         sb_summary = []

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -323,8 +323,9 @@ class DockerBasedStressThread:
         self.shutdown_timeout = 180  # extra 3 minutes
         self.stop_test_on_failure = stop_test_on_failure
         self.docker_image_name = self.params.get(self.DOCKER_IMAGE_PARAM_NAME)
-        for loader in self.loader_set.nodes:
-            RemoteDocker.pull_image(loader, self.docker_image_name)
+        if "k8s" not in self.params.get("cluster_backend"):
+            for loader in self.loader_set.nodes:
+                RemoteDocker.pull_image(loader, self.docker_image_name)
 
     def run(self):
         if self.round_robin:


### PR DESCRIPTION
K8S backends do not require preliminary pulling of docker images. 
Then, we get failure using `dynamic` loader run type. 
So, stop calling `docker pull` command in stress thread classes when we run on K8S backends.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
