### PR TITLE
improvement(latency with ops): adjust to follow acceptance criteria

### DIFF
--- a/jenkins-pipelines/perf-regression-latency-650gb-with-nemesis.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-650gb-with-nemesis.jenkinsfile
@@ -1,0 +1,11 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    test_name: "performance_regression_test.PerformanceRegressionTest",
+    test_config: """["test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml"]""",
+    sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"]
+)

--- a/sdcm/results_analyze/__init__.py
+++ b/sdcm/results_analyze/__init__.py
@@ -18,6 +18,7 @@ import math
 import pprint
 import logging
 import collections
+import re
 
 from datetime import datetime
 from sortedcontainers import SortedDict
@@ -313,7 +314,10 @@ class LatencyDuringOperationsPerformanceAnalyzer(BaseResultsAnalyzer):
         kernel_callstack_events = self.get_kernel_callstack_events()
         kernel_callstack_events_summary = {Severity.DEBUG.name: len(kernel_callstack_events)}
 
-        subject = f'Performance Regression Compare Results (latency during operations) -' \
+        config_files = ' '.join(doc["_source"]["setup_details"]["config_files"])
+        dataset_size = re.search(r'(\d{3}gb)', config_files).group() or 'unknown size'
+
+        subject = f'Performance Regression Compare Results (latency during operations {dataset_size}) -' \
                   f' {test_name} - {test_version} - {str(test_start_time)}'
         # best_results_per_nemesis = self._get_best_per_nemesis_for_each_version(doc, is_gce)
 

--- a/test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml
+++ b/test-cases/performance/perf-regression-latency-650gb-with-nemesis.yaml
@@ -1,0 +1,37 @@
+test_duration: 1200
+prepare_write_cmd: ["cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..162500000",
+                    "cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=162500000..325000000",
+                    "cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=325000000..487500000",
+                    "cassandra-stress write no-warmup cl=ALL n=162500000 -schema 'replication(factor=3)' -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=487500000..650000000"]
+
+stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=800m -schema 'replication(factor=3)' -mode cql3 native -rate 'threads=250 fixed=20332/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,9750000)' "
+stress_cmd_r: "cassandra-stress read no-warmup  cl=QUORUM duration=800m -schema 'replication(factor=3)' -mode cql3 native -rate 'threads=250 fixed=10310/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,9750000)' "
+stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=800m -schema 'replication(factor=3)' -mode cql3 native -rate 'threads=250 fixed=8750/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..650000000,325000000,6500000)' "
+
+n_db_nodes: 3
+nemesis_add_node_cnt: 3
+n_loaders: 4
+n_monitor_nodes: 1
+
+instance_type_loader: 'c5.2xlarge'
+instance_type_monitor: 't3.large'
+instance_type_db: 'i3en.2xlarge'
+
+nemesis_class_name: 'NemesisSequence'
+nemesis_interval: 60
+nemesis_sequence_sleep_between_ops: 10
+
+user_prefix: 'perf-latency-nemesis'
+space_node_threshold: 644245094
+ami_id_db_scylla_desc: 'VERSION_DESC'
+
+round_robin: true
+append_scylla_args: '--blocked-reactor-notify-ms 5'
+backtrace_decoding: false
+print_kernel_callstack: true
+
+store_perf_results: true
+send_email: true
+email_recipients: ["scylla-perf-results@scylladb.com"]
+use_prepared_loaders: true
+use_hdr_cs_histogram: true


### PR DESCRIPTION
following definition of acceptance criteria for this
test, these changes are moving in the direction
to adjust existing test to follow the required
througput, instance type, gaussian STDEV and other
to be able to run the acceptance criteria as defined 
in a document (https://docs.google.com/document/d/1i4Scus4OW4DMfVJGyBSN7dJF0Mb1XPRkXkBzsde4_40/edit?usp=sharing).

the changes were basically:
* changed instance type to i3en as we consider i3 deprecated
* dataset should be 10 * max memory in the cluster, so:
* * 10 * 64GB (as we write with RF=3) = ~650GB
* moved from throttle to fixed, to force get 50% of max throughput
* changed c-s gaussian distribution from `12500000` to `1200000` to
  to get ~70% cache hit ratio (previously had ~20%) 
* increased stress and test durations, to fit new dataset size

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
