### PR TITLE
fix(rolling-upgrade): add missing linux_distro param

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -34,6 +34,7 @@ from uuid import UUID
 import pytest
 import click
 import click_completion
+import yaml
 from prettytable import PrettyTable
 
 import sct_ssh
@@ -618,8 +619,7 @@ def list_repos(dist_type, dist_version):
               help='Scylla version, eg: 4.5, 2021.1')
 @click.option('-r', '--scylla-repo', type=str,
               help='Scylla repo')
-@click.option('-d', '--linux-distro', type=str,
-              default='centos', help='Linux Distribution type')
+@click.option('-d', '--linux-distro', type=str, help='Linux Distribution type')
 @click.option('-o', '--only-print-versions', type=bool, default=False, required=False, help='')
 def get_scylla_base_versions(scylla_version, scylla_repo, linux_distro, only_print_versions):  # pylint: disable=too-many-locals
     """
@@ -628,6 +628,12 @@ def get_scylla_base_versions(scylla_version, scylla_repo, linux_distro, only_pri
     the base version for each branch.
     """
     add_file_logger()
+
+    with Path("defaults/test_default.yaml").open(mode="r", encoding="utf-8") as test_defaults_yaml:
+        test_defaults = yaml.safe_load(test_defaults_yaml)
+
+    if not linux_distro or linux_distro == "null":
+        linux_distro = test_defaults.get("scylla_linux_distro")
 
     version_detector = UpgradeBaseVersion(scylla_repo, linux_distro, scylla_version)
 


### PR DESCRIPTION
Recent rolling-upgrade-ami jobs have been failing due to the `linux_distro` pipeline param missing. This PR reintroduces it to the jenkinsfile.

Failing master jobs: https://jenkins.scylladb.com/view/master/job/scylla-master/job/rolling-upgrade/job/rolling-upgrade-ami-test/
Staging job with the fix: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/maciej/job/ru-ami/
Staging job using CentOS (provided as the pipelineParam): https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/maciej/job/ru-5.0-centos-8/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
