### PR TITLE
improvement(k8s): add possibility to mount files to dynamic loader pods

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2095,7 +2095,8 @@ class LoaderPodContainer(BasePodContainer):
         self.remoter = KubernetesPodRunner(
             kluster=self.parent_cluster.k8s_cluster,
             template_path=self.TEMPLATE_PATH,
-            template_modifiers=self.parent_cluster.k8s_cluster.calculated_loader_affinity_modifiers,
+            template_modifiers=list(
+                self.parent_cluster.k8s_cluster.calculated_loader_affinity_modifiers),
             pod_name_template=self.loader_pod_name_template,
             namespace=self.parent_cluster.namespace,
             environ=environ,


### PR DESCRIPTION
Make it possible to upload files to 'dynamic' loaders. Use cases:
- Running tests which use 'profile' files
- Running tests against serverless K8S clusters which require bundle file.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
