### PR TITLE
fix(pylint): remove duplication for cluster_driver

### DIFF
--- a/sdcm/utils/cluster_utils.py
+++ b/sdcm/utils/cluster_utils.py
@@ -1,0 +1,13 @@
+from cassandra.cluster import Cluster  # pylint: disable=no-name-in-module
+from sdcm.utils.docker_utils import running_in_docker
+
+
+def get_cluster_driver(docker_scylla) -> Cluster:
+    if running_in_docker():
+        address = f"{docker_scylla.internal_ip_address}:9042"
+    else:
+        address = docker_scylla.get_port("9042")
+    node_ip, port = address.split(":")
+    port = int(port)
+
+    return Cluster([node_ip], port=port)

--- a/unit_tests/test_scylla_bench_thread.py
+++ b/unit_tests/test_scylla_bench_thread.py
@@ -12,10 +12,9 @@
 # Copyright (c) 2022 ScyllaDB
 
 import pytest
-from cassandra.cluster import Cluster  # pylint: disable=no-name-in-module
 
 from sdcm.scylla_bench_thread import ScyllaBenchThread
-from sdcm.utils.docker_utils import running_in_docker
+from sdcm.utils.cluster_utils import get_cluster_driver
 from unit_tests.dummy_remote import LocalLoaderSetDummy
 from test_lib.scylla_bench_tools import create_scylla_bench_table_query
 
@@ -27,14 +26,7 @@ pytestmark = [
 
 @pytest.fixture(scope="session")
 def create_cql_ks_and_table(docker_scylla):
-    if running_in_docker():
-        address = f"{docker_scylla.internal_ip_address}:9042"
-    else:
-        address = docker_scylla.get_port("9042")
-    node_ip, port = address.split(":")
-    port = int(port)
-
-    cluster_driver = Cluster([node_ip], port=port)
+    cluster_driver = get_cluster_driver(docker_scylla)
     create_table_query = create_scylla_bench_table_query(
         compaction_strategy="SizeTieredCompactionStrategy", seed=None
     )

--- a/unit_tests/test_ycsb_thread.py
+++ b/unit_tests/test_ycsb_thread.py
@@ -15,9 +15,9 @@ import re
 
 import pytest
 import requests
-from cassandra.cluster import Cluster  # pylint: disable=no-name-in-module
 
 from sdcm.utils import alternator
+from sdcm.utils.cluster_utils import get_cluster_driver
 from sdcm.utils.decorators import timeout
 from sdcm.utils.docker_utils import running_in_docker
 from sdcm.ycsb_thread import YcsbStressThread
@@ -48,14 +48,7 @@ def create_table(docker_scylla):
 
 @pytest.fixture(scope="session")
 def create_cql_ks_and_table(docker_scylla):
-    if running_in_docker():
-        address = f"{docker_scylla.internal_ip_address}:9042"
-    else:
-        address = docker_scylla.get_port("9042")
-    node_ip, port = address.split(":")
-    port = int(port)
-
-    cluster_driver = Cluster([node_ip], port=port)
+    cluster_driver = get_cluster_driver(docker_scylla)
     session = cluster_driver.connect()
     session.execute(
         """create keyspace ycsb WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor': 1 };"""


### PR DESCRIPTION
There's code duplication when getting cluster driver punishing us by pylint.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
