### PR TITLE
fix(duplicate): remove unused `create_cql_ks_and_table`

### DIFF
--- a/unit_tests/test_scylla_bench_thread.py
+++ b/unit_tests/test_scylla_bench_thread.py
@@ -12,41 +12,14 @@
 # Copyright (c) 2022 ScyllaDB
 
 import pytest
-from cassandra.cluster import Cluster  # pylint: disable=no-name-in-module
 
 from sdcm.scylla_bench_thread import ScyllaBenchThread
-from sdcm.utils.docker_utils import running_in_docker
 from unit_tests.dummy_remote import LocalLoaderSetDummy
-from test_lib.scylla_bench_tools import create_scylla_bench_table_query
 
 pytestmark = [
     pytest.mark.usefixtures("events",),
     pytest.mark.skip(reason="those are integration tests only"),
 ]
-
-
-@pytest.fixture(scope="session")
-def create_cql_ks_and_table(docker_scylla):
-    if running_in_docker():
-        address = f"{docker_scylla.internal_ip_address}:9042"
-    else:
-        address = docker_scylla.get_port("9042")
-    node_ip, port = address.split(":")
-    port = int(port)
-
-    cluster_driver = Cluster([node_ip], port=port)
-    create_table_query = create_scylla_bench_table_query(
-        compaction_strategy="SizeTieredCompactionStrategy", seed=None
-    )
-
-    with cluster_driver.connect() as session:
-        # pylint: disable=no-member
-        session.execute(
-            """
-                CREATE KEYSPACE IF NOT EXISTS scylla_bench WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}
-        """
-        )
-        session.execute(create_table_query)
 
 
 @pytest.mark.parametrize("extra_cmd", argvalues=[


### PR DESCRIPTION
remove duplicate code from unittests

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
