### PR TITLE
improvement(mv-si longevity): explicitly set STCS

### DIFF
--- a/data_dir/c-s_profile_3si_5queries.yaml
+++ b/data_dir/c-s_profile_3si_5queries.yaml
@@ -19,7 +19,7 @@ table_definition: |
     userdata blob,
     last_access timeuuid,
     PRIMARY KEY(userid)
-  );
+  ) WITH compaction = {'class': 'SizeTieredCompactionStrategy'};
 
 extra_definitions:
   - CREATE INDEX IF NOT EXISTS  users_last_name_ind ON sec_index.users (last_name)

--- a/data_dir/c-s_profile_4mv_5queries.yaml
+++ b/data_dir/c-s_profile_4mv_5queries.yaml
@@ -19,7 +19,7 @@ table_definition: |
     userdata blob,
     last_access timeuuid,
     PRIMARY KEY(userid)
-  );
+  ) WITH compaction = {'class': 'SizeTieredCompactionStrategy'};
 
 extra_definitions:
   - CREATE MATERIALIZED VIEW mview.users_by_first_name AS SELECT userid, first_name, email FROM mview.users WHERE first_name IS NOT NULL and userid IS NOT NULL PRIMARY KEY (first_name, userid);


### PR DESCRIPTION
for OSS it shouldn't change anything, as STCS is the default, but for enterprise ones, now the default is ICS, hence to have both being tested, this one will be explicitly set to use STCS, while the ICS job does use explicitly ICS in it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
