### PR TITLE
fix(ignore_stream_mutation_fragments): filter mutation write error

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -208,6 +208,12 @@ def ignore_stream_mutation_fragments_errors():
             regex=r".*Failed to handle STREAM_MUTATION_FRAGMENTS.*",
             extra_time_to_expiration=30
         ))
+        stack.enter_context(EventsSeverityChangerFilter(
+            new_severity=Severity.WARNING,
+            event_class=DatabaseLogEvent,
+            regex=r"storage_proxy \- exception during mutation write.*gate_closed_exception",
+            extra_time_to_expiration=30
+        ))
         yield
 
 


### PR DESCRIPTION
During node power off upon decommission, scylla report next error to log !ERR | scylla[7945]:  [shard  0] storage_proxy - exception during mutation write to 10.12.0.200:
 utils::internal::nested_exception<std::runtime_error>
 (Could not write mutation cdc_test:test_table_postimage
 (pk{00072b127a257d676c}) to commitlog): seastar::gate_closed_exception (gate closed)

Adding filter to change the severity from error to warning

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
