### PR TITLE
fix(perf-regression-report): broken casue of cdc stress check

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -802,8 +802,7 @@ def update_conf_docs():
 @cli.command("perf-regression-report", help="Generate and send performance regression report")
 @click.option("-i", "--es-id", required=True, type=str, help="Id of the run in Elastic Search")
 @click.option("-e", "--emails", required=True, type=str, help="Comma separated list of emails. Example a@b.com,c@d.com")
-@click.option("-l", "--logdir", required=True, type=str, help="Dir configured to store SCT logs")
-def perf_regression_report(es_id, emails, logdir):
+def perf_regression_report(es_id, emails):
     add_file_logger()
     emails = emails.split(',')
     if not emails:
@@ -812,7 +811,9 @@ def perf_regression_report(es_id, emails, logdir):
     results_analyzer = PerformanceResultsAnalyzer(es_index="performanceregressiontest", es_doc_type="test_stats",
                                                   email_recipients=emails, logger=LOGGER)
     results_analyzer.check_regression(es_id)
-    email_results_file = "email_data.json"
+
+    logdir = Path(get_test_config().logdir())
+    email_results_file = logdir / "email_data.json"
     test_results = read_email_data_from_file(email_results_file)
     if not test_results:
         LOGGER.error("Test Results file not found")

--- a/sdcm/results_analyze/__init__.py
+++ b/sdcm/results_analyze/__init__.py
@@ -523,7 +523,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
             return PerformanceFilterScyllaBench(test_doc, is_gce, use_wide_query, lastyear)()
         elif test_doc['_source']['test_details'].get('ycsb'):
             return PerformanceFilterYCSB(test_doc, is_gce, use_wide_query, lastyear)()
-        elif "cdc" in test_doc['_source']['test_details'].get('sub_type'):
+        elif "cdc" in test_doc['_source']['test_details'].get('sub_type', ''):
             return CDCQueryFilterCS(test_doc, is_gce, use_wide_query, lastyear)()
         else:
             return PerformanceFilterCS(test_doc, is_gce, use_wide_query, lastyear)()


### PR DESCRIPTION
* fallback to None was breaking the code:
```
 Traceback (most recent call last):
   File ".../sdcm/tester.py", line 2946, in check_regression
     results_analyzer.check_regression(self._test_id, is_gce,
   File ".../sdcm/results_analyze/__init__.py", line 588, in check_regression
     query = self._query_filter(doc, is_gce, use_wide_query, lastyear)
   File ".../sdcm/results_analyze/__init__.py", line 526, in _query_filter
     elif "cdc" in test_doc['_source']['test_details'].get('sub_type'):
 TypeError: argument of type 'NoneType' is not iterable
```

* fix the email_results_file location, it's now inside the logdir and not at SCT root folder

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
