### PR TITLE
improvement(k8s-functional): support a test skip based on Scylla version

### DIFF
--- a/functional_tests/scylla_operator/conftest.py
+++ b/functional_tests/scylla_operator/conftest.py
@@ -203,6 +203,19 @@ def skip_if_scylla_not_semver(request, tester: ScyllaOperatorFunctionalClusterTe
 
 
 @pytest.fixture(autouse=True)
+def skip_if_not_supported_scylla_version(request: pytest.FixtureRequest,
+                                         tester: ScyllaOperatorFunctionalClusterTester):
+    requires_scylla_versions = request.node.get_closest_marker('requires_scylla_versions')
+    if not requires_scylla_versions:
+        return
+    requires_scylla_versions = requires_scylla_versions.args
+    try:
+        version_utils.scylla_versions(*requires_scylla_versions)(lambda c: None)(tester.db_cluster)
+    except version_utils.MethodVersionNotFound as exc:
+        pytest.skip(str(exc))
+
+
+@pytest.fixture(autouse=True)
 def skip_based_on_operator_version(request: pytest.FixtureRequest, tester: ScyllaOperatorFunctionalClusterTester):
     # pylint: disable=protected-access
     if required_operator := request.node.get_closest_marker('required_operator'):


### PR DESCRIPTION
Example of the usage:
```
        @pytest.mark.requires_scylla_versions(("4.4.4", "4.5"), ("5.1.0", None))
        def test_foo(db_cluster):
            ...
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
