### PR TITLE
improvement(k8s-local): cache docker images only on fresh setups

### DIFF
--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -576,10 +576,11 @@ class LocalKindCluster(LocalMinimalClusterBase):
         for image_repo in ('kube-controllers', 'cni', 'node'):
             images_to_cache.append(f"calico/{image_repo}:{CNI_CALICO_VERSION}")
 
-        for image in images_to_cache:
-            self.docker_pull(image)
-            self.host_node.remoter.run(
-                f"/var/tmp/kind load docker-image {image}", ignore_status=True)
+        if not self.params.get('reuse_cluster'):
+            for image in images_to_cache:
+                self.docker_pull(image)
+                self.host_node.remoter.run(
+                    f"/var/tmp/kind load docker-image {image}", ignore_status=True)
         if new_scylla_image_tag:
             self.params['scylla_version'] = new_scylla_image_tag
         for src_image, dst_image in images_to_retag.items():


### PR DESCRIPTION
For the moment we cache docker images all the time
even running on an already existing cluster having `reuse_cluster=1` option set.

So, skip `docker images caching` operations for reused clusters to reduce time we spend for init test.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
