### PR TITLE
fix(test_default): Switch oracle db version for gemini

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -114,7 +114,7 @@ authenticator_password: ''
 # gemini defaults
 n_test_oracle_db_nodes: 1
 gemini_seed: 0
-oracle_scylla_version: '4.4.7'
+oracle_scylla_version: '4.6.9'
 append_scylla_args_oracle: '--enable-cache false'
 
 # cassandra-stress defaults

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -426,7 +426,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         self.assertEqual(conf.get('gce_image_db'), resolved_image_link)
 
     def test_16_default_oracle_scylla_version_eu_west_1(self):
-        ami_4_4_7 = "ami-0cac6b91be579df80"
+        ami_4_6_9 = "ami-0daa3e4e3d314d2b3"
 
         os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-06f919eb'
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
@@ -437,7 +437,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         conf = sct_config.SCTConfiguration()
         conf.verify_configuration()
 
-        self.assertEqual(conf.get('ami_id_db_oracle'), ami_4_4_7)
+        self.assertEqual(conf.get('ami_id_db_oracle'), ami_4_6_9)
 
     def test_16_oracle_scylla_version_us_east_1(self):
         ami_4_5_2 = "ami-0e075abbcb95ac10a"

--- a/unit_tests/test_data/test_scylla_yaml_builders/PR-provision-test.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/PR-provision-test.yaml
@@ -22,7 +22,7 @@ instance_provision: 'spot'
 
 gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
 
-scylla_version: 4.4.7
+scylla_version: 4.6.9
 scylla_mgmt_repo: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.3.repo'
 
 workaround_kernel_bug_for_iotune: true

--- a/unit_tests/test_scylla_yaml_builders.py
+++ b/unit_tests/test_scylla_yaml_builders.py
@@ -499,8 +499,8 @@ class DummyNode(BaseNode):  # pylint: disable=abstract-method
 
 class IntegrationTests(unittest.TestCase):
     get_scylla_ami_version_output = ObjectDict(**{
-        'Architecture': 'x86_64', 'CreationDate': '2021-04-11T11:42:47.000Z',
-        'ImageId': 'ami-01717260ff878ed92', 'ImageLocation': '797456418907/ScyllaDB 4.4.7',
+        'Architecture': 'x86_64', 'CreationDate': '2022-10-13T11:10:59.000Z',
+        'ImageId': 'ami-0daa3e4e3d314d2b3', 'ImageLocation': '797456418907/ScyllaDB 4.6.9',
         'ImageType': 'machine', 'Public': True, 'OwnerId': '797456418907',
         'PlatformDetails': 'Linux/UNIX', 'UsageOperation': 'RunInstances',
         'State': 'available', 'BlockDeviceMappings': [
@@ -526,19 +526,19 @@ class IntegrationTests(unittest.TestCase):
              'VirtualName': 'ephemeral6'},
             {'DeviceName': '/dev/sdi',
              'VirtualName': 'ephemeral7'}],
-        'Description': 'ScyllaDB 4.4.7', 'EnaSupport': True, 'Hypervisor': 'xen',
-        'Name': 'ScyllaDB 4.4.7', 'RootDeviceName': '/dev/sda1', 'RootDeviceType': 'ebs',
+        'Description': 'ScyllaDB 4.6.9', 'EnaSupport': True, 'Hypervisor': 'xen',
+        'Name': 'ScyllaDB 4.6.9', 'RootDeviceName': '/dev/sda1', 'RootDeviceType': 'ebs',
         'Tags': [
-            {'Key': 'ScyllaMachineImageVersion', 'Value': '4.4.7-20210407.3e5b0f86c2'},
-            {'Key': 'ScyllaPython3Version', 'Value': '4.4.7-0.20210406.00da6b5e9'},
+            {'Key': 'ScyllaMachineImageVersion', 'Value': '4.6.9-20221009.a36534e106b-1'},
+            {'Key': 'ScyllaPython3Version', 'Value': '4.6.9-0.20221009.18e7a4603-1'},
             {'Key': 'user_data_format_version', 'Value': '2'},
-            {'Key': 'ScyllaToolsVersion', 'Value': '4.4.7-0.20210406.00da6b5e9'},
-            {'Key': 'ScyllaJMXVersion', 'Value': '4.4.7-0.20210406.00da6b5e9'},
-            {'Key': 'branch', 'Value': 'branch-4.4'},
-            {'Key': 'scylla-git-commit', 'Value': '1439d48e2a2b5a3841a87b47f1f52d6fb904a902'},
-            {'Key': 'build-tag', 'Value': 'jenkins-scylla-4.4-ami-52'},
-            {'Key': 'ScyllaVersion', 'Value': '4.4.7-0.20210406.00da6b5e9'},
-            {'Key': 'build-id', 'Value': '52'}
+            {'Key': 'ScyllaToolsVersion', 'Value': '4.6.9-0.20221009.18e7a4603-1'},
+            {'Key': 'ScyllaJMXVersion', 'Value': '4.6.9-0.20221009.18e7a4603-1'},
+            {'Key': 'branch', 'Value': 'branch-4.6'},
+            {'Key': 'scylla-git-commit', 'Value': '18e7a46038379e566619197eb11c1f650bfec2be'},
+            {'Key': 'build-tag', 'Value': 'jenkins-scylla-4.6-ami-63'},
+            {'Key': 'ScyllaVersion', 'Value': '4.6.9-0.20221009.18e7a4603-1'},
+            {'Key': 'build-id', 'Value': '94'}
         ], 'VirtualizationType': 'hvm'})
 
     @property


### PR DESCRIPTION
Change oracle db version for gemini tests

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
