### PR TITLE
fix(k8s-eks): make i4i instance types be supported for the Scylla nodes

### DIFF
--- a/sdcm/k8s_configs/eks/scylla-node-prepare.yaml
+++ b/sdcm/k8s_configs/eks/scylla-node-prepare.yaml
@@ -235,7 +235,7 @@ spec:
 
             # Create directories for each Scylla cluster on each K8S node which will host PVs
             while true; do
-              if [[ -z $(mount | grep  "/dev/md0") ]]; then
+              if [[ -z $(mount | grep -e "/dev/md0" -e "/dev/nvme") ]]; then
                 sleep 5;
                 continue
               fi


### PR DESCRIPTION
Using `i3` nodes we have local NVME disks be attached to the `/dev/md0` path, 
but in the `i4i` ones it is `/dev/nvme0n1p1`. 
So, make the `pv-setup` on EKS consider both cases.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
