### PR TITLE
fix(get_relocatable_pkg_url): skip get reloc_pkg if version is none

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -20,6 +20,7 @@ import os
 import re
 import stat
 import time
+import traceback
 import unittest
 import unittest.mock
 from typing import NamedTuple, Optional, Union, List, Dict, Any
@@ -3260,7 +3261,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self._argus_add_relocatable_pkg(email_data)
             self.argus_collect_screenshots(email_data)
         except Exception as exc:  # pylint: disable=broad-except
-            self.log.error("Error while saving email data. Error: %s", exc)
+            self.log.error("Error while saving email data. Error: %s\nTraceback: %s", exc, traceback.format_exc())
 
         json_file_path = os.path.join(self.logdir, "email_data.json")
 

--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -558,7 +558,7 @@ class scylla_versions:  # pylint: disable=invalid-name,too-few-public-methods
 
 def get_relocatable_pkg_url(scylla_version: str) -> str:
     relocatable_pkg = ""
-    if "build-id" in scylla_version:
+    if scylla_version and "build-id" in scylla_version:
         try:
             scylla_build_id = scylla_version.split('build-id')[-1].split()[0]
             get_pkgs_cmd = f'curl -s -X POST http://backtrace.scylladb.com/index.html -d "build_id={scylla_build_id}&backtrace="'


### PR DESCRIPTION
During job Artifacts-ubuntu-2204, _get_common_email_data failed, because scylla version could not be get from scylla, and attempt to get relocatable packages failed with error and cause failing the the save email data and the send email

```
16:40:44  < t:2022-11-15 09:40:44,170 f:cluster.py      l:2114 c:sdcm.cluster_gce     p:WARNING > Node artifacts-ubuntu2204-jenkins-db-node-1c68b572-0-1 [34.74.229.149 | 10.142.0.37] (seed: True): All attempts to get ScyllaDB version failed. Looks like there is no ScyllaDB installed.
16:40:44  < t:2022-11-15 09:40:44,172 f:tester.py       l:3262 c:ArtifactsTest        p:ERROR > Error while saving email data. Error: argument of type 'NoneType' is not iterable
16:40:44  < t:2022-11-15 09:40:44,172 f:tester.py       l:3262 c:ArtifactsTest        p:ERROR > Traceback: Traceback (most recent call last):
16:40:44  < t:2022-11-15 09:40:44,172 f:tester.py       l:3262 c:ArtifactsTest        p:ERROR >   File "/home/jenkins/slave/workspace/scylla-5.0/artifacts-offline-install/artifacts-ubuntu2204-nonroot-test/scylla-cluster-tests/sdcm/tester.py", line 3260, in save_email_data
16:40:44  < t:2022-11-15 09:40:44,172 f:tester.py       l:3262 c:ArtifactsTest        p:ERROR >     email_data = self.get_email_data()
16:40:44  < t:2022-11-15 09:40:44,172 f:tester.py       l:3262 c:ArtifactsTest        p:ERROR >   File "/home/jenkins/slave/workspace/scylla-5.0/artifacts-offline-install/artifacts-ubuntu2204-nonroot-test/scylla-cluster-tests/artifacts_test.py", line 433, in get_email_data
16:40:44  < t:2022-11-15 09:40:44,172 f:tester.py       l:3262 c:ArtifactsTest        p:ERROR >     email_data = self._get_common_email_data()
16:40:44  < t:2022-11-15 09:40:44,172 f:tester.py       l:3262 c:ArtifactsTest        p:ERROR >   File "/home/jenkins/slave/workspace/scylla-5.0/artifacts-offline-install/artifacts-ubuntu2204-nonroot-test/scylla-cluster-tests/sdcm/tester.py", line 3414, in _get_common_email_data
16:40:44  < t:2022-11-15 09:40:44,172 f:tester.py       l:3262 c:ArtifactsTest        p:ERROR >     "relocatable_pkg": get_relocatable_pkg_url(scylla_version)}
16:40:44  < t:2022-11-15 09:40:44,172 f:tester.py       l:3262 c:ArtifactsTest        p:ERROR >   File "/home/jenkins/slave/workspace/scylla-5.0/artifacts-offline-install/artifacts-ubuntu2204-nonroot-test/scylla-cluster-tests/sdcm/utils/version_utils.py", line 561, in get_relocatable_pkg_url
16:40:44  < t:2022-11-15 09:40:44,172 f:tester.py       l:3262 c:ArtifactsTest        p:ERROR >     if "build-id" in scylla_version:
16:40:44  < t:2022-11-15 09:40:44,172 f:tester.py       l:3262 c:ArtifactsTest        p:ERROR > TypeError: argument of type 'NoneType' is not iterable
16:40:44  < t:2022-11-15 09:40:44,522 f:tester.py       l:3325 c:ArtifactsTest        p:WARNING > Email is not configured: False or no email data: None
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
