### PR TITLE
fix(cluster.py): Generate a scylla core dump according to boolean flag

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -95,7 +95,7 @@ TestFrameworkEvent: CRITICAL
 ElasticsearchEvent: ERROR
 SpotTerminationEvent: CRITICAL
 ScyllaRepoEvent: WARNING
-InfoEvent: NORMAL
+InfoEvent: ERROR
 ThreadFailedEvent: ERROR
 CoreDumpEvent: ERROR
 TestResultEvent: ERROR

--- a/sdcm/sct_events/system.py
+++ b/sdcm/sct_events/system.py
@@ -122,8 +122,8 @@ class ScyllaRepoEvent(InformationalEvent):
 
 
 class InfoEvent(SctEvent):
-    def __init__(self, message: str):
-        super().__init__(severity=Severity.NORMAL)
+    def __init__(self, message: str, severity=Severity.NORMAL):
+        super().__init__(severity=severity)
 
         self.message = message
 


### PR DESCRIPTION
	When run_nodetool command gets an exception it ignored coredump_on_timeout parameter.
	This is fixed and also added an event before the actual node kill starts.
	Refs: #5418

Fix: #5418 

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
