### PR TITLE
test(upgrade): run upgrade test with SLA

### DIFF
--- a/configurations/rolling-upgrade-with-sla.yaml
+++ b/configurations/rolling-upgrade-with-sla.yaml
@@ -1,0 +1,14 @@
+# workloads
+stress_before_upgrade: "cassandra-stress write cl=QUORUM n=60000000 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=1000 -pop seq=1..60000000 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
+stress_during_entire_upgrade: [ "cassandra-stress read cl=QUORUM duration=30m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native <sla credentials 0> -rate threads=200 -pop seq=1..30000000 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+                                "cassandra-stress read  cl=QUORUM duration=30m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native <sla credentials 1> -rate threads=200 -pop seq=30000001..60000000 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
+]
+stress_after_cluster_upgrade: [ "cassandra-stress read cl=QUORUM duration=10m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native <sla credentials 0> -rate threads=200 -pop seq=1..30000000 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+                                "cassandra-stress read  cl=QUORUM duration=10m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native <sla credentials 1> -rate threads=200 -pop seq=30000001..60000000 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
+]
+
+upgrade_sstables: false
+n_loaders: 2
+round_robin: true
+
+service_level_shares: [200, 800]

--- a/jenkins-pipelines/rolling-upgrade-with-sla.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-with-sla.jenkinsfile
@@ -1,0 +1,14 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+rollingUpgradePipeline(
+    backend: 'gce',
+    base_versions: '',  // auto mode
+    linux_distro: 'centos-8',
+    gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-stream-8',
+
+    test_name: 'upgrade_test.UpgradeTest.test_generic_cluster_upgrade',
+    test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-with-sla.yaml"]'''
+)

--- a/longevity_sla_test.py
+++ b/longevity_sla_test.py
@@ -12,20 +12,12 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2022 ScyllaDB
-import re
-
 from longevity_test import LongevityTest
-from sdcm.sct_events import Severity
-from sdcm.sct_events.system import TestFrameworkEvent
-from test_lib.sla import Role, ServiceLevel
+from sdcm.utils import loader_utils
+from test_lib.sla import create_sla_auth
 
 
-class LongevitySlaTest(LongevityTest):
-    DEFAULT_USER = "cassandra"
-    DEFAULT_USER_PASSWORD = "cassandra"
-    STRESS_ROLE_NAME_TEMPLATE = 'role%d_%d'
-    STRESS_ROLE_PASSWORD_TEMPLATE = 'rolep%d'
-    SERVICE_LEVEL_NAME_TEMPLATE = 'sl%d_%d'
+class LongevitySlaTest(LongevityTest, loader_utils.LoaderUtilsMixin):
     FULLSCAN_SERVICE_LEVEL_SHARES = 600
 
     def __init__(self, *args):
@@ -35,72 +27,19 @@ class LongevitySlaTest(LongevityTest):
         self.roles = []
 
     def test_custom_time(self):
-        with self.db_cluster.cql_connection_patient(node=self.db_cluster.nodes[0], user=self.DEFAULT_USER,
-                                                    password=self.DEFAULT_USER_PASSWORD) as session:
+        with self.db_cluster.cql_connection_patient(node=self.db_cluster.nodes[0], user=loader_utils.DEFAULT_USER,
+                                                    password=loader_utils.DEFAULT_USER_PASSWORD) as session:
             # Add index (shares position in the self.service_level_shares list) to role and service level names to do
             # it unique and prevent failure when try to create role/SL with same name
             for index, shares in enumerate(self.service_level_shares):
-                self.roles.append(self.create_sla_auth(session=session, shares=shares, index=index))
+                self.roles.append(create_sla_auth(session=session, shares=shares, index=index))
 
             if self.params.get("run_fullscan"):
-                self.fullscan_role = self.create_sla_auth(session=session, shares=self.FULLSCAN_SERVICE_LEVEL_SHARES,
-                                                          index=0)
+                self.fullscan_role = create_sla_auth(session=session, shares=self.FULLSCAN_SERVICE_LEVEL_SHARES,
+                                                     index=0)
 
-        self.add_sla_credentials_to_stress_cmds()
+        self.add_sla_credentials_to_stress_cmds(workload_names=['prepare_write_cmd', 'stress_cmd', 'stress_read_cmd'],
+                                                roles=self.roles, params=self.params,
+                                                parent_class_name=self.__class__.__name__)
+
         super().test_custom_time()
-
-    def create_sla_auth(self, session, shares: int, index: int) -> Role:
-        role = Role(session=session, name=self.STRESS_ROLE_NAME_TEMPLATE % (shares, index),
-                    password=self.STRESS_ROLE_PASSWORD_TEMPLATE % shares, login=True).create()
-        role.attach_service_level(ServiceLevel(session=session, name=self.SERVICE_LEVEL_NAME_TEMPLATE % (shares, index),
-                                               shares=shares).create())
-
-        return role
-
-    def add_sla_credentials_to_stress_cmds(self):
-        def _set_credentials_to_cmd(cmd):
-            if self.roles and "<sla credentials " in cmd:
-                if 'user=' in cmd:
-                    # if stress command is not defined as expected, stop the tests and fix it. Then re-run
-                    TestFrameworkEvent(
-                        source=self.__class__.__name__,
-                        message="Stress command is defined wrong. Credentials already applied. Remove unnecessary "
-                                f"and re-run the test. Command: {cmd}",
-                        severity=Severity.CRITICAL
-                    ).publish()
-
-                index = re.search(r"<sla credentials (\d+)>", cmd)
-                role_index = int(index.groups(0)[0]) if index else None
-                if role_index is None:
-                    # if stress command is not defined as expected, stop the tests and fix it. Then re-run
-                    TestFrameworkEvent(
-                        source=self.__class__.__name__,
-                        message="Stress command is defined wrong. Expected pattern '<credentials \\d>' was not found. "
-                                f"Fix the command and re-run the test. Command: {cmd}",
-                        severity=Severity.CRITICAL
-                    ).publish()
-                sla_role_name = self.roles[role_index].name.replace('"', '')
-                sla_role_password = self.roles[role_index].password
-                return re.sub(r'<sla credentials \d+>', f'user={sla_role_name} password={sla_role_password}', cmd)
-            return cmd
-
-        for stress_op in ['prepare_write_cmd', 'stress_cmd', 'stress_read_cmd']:
-            stress_cmds = []
-            stress_params = self.params.get(stress_op)
-            if isinstance(stress_params, str):
-                stress_params = [stress_params]
-
-            if not stress_params:
-                continue
-
-            for stress_cmd in stress_params:
-                # cover multitenant test
-                if isinstance(stress_cmd, list):
-                    cmds = []
-                    for current_cmd in stress_cmd:
-                        cmds.append(_set_credentials_to_cmd(cmd=current_cmd))
-                    stress_cmds.append(cmds)
-                else:
-                    stress_cmds.append(_set_credentials_to_cmd(cmd=stress_cmd))
-
-            self.params[stress_op] = stress_cmds

--- a/test_lib/sla.py
+++ b/test_lib/sla.py
@@ -5,6 +5,9 @@ import logging
 from dataclasses import dataclass, field, fields
 
 from sdcm.utils.decorators import retrying
+from sdcm.utils.loader_utils import (STRESS_ROLE_NAME_TEMPLATE,
+                                     STRESS_ROLE_PASSWORD_TEMPLATE,
+                                     SERVICE_LEVEL_NAME_TEMPLATE)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -341,3 +344,12 @@ class User(UserRoleBase):
         self.session.execute(query)
         LOGGER.debug('User %s has been created', self.name)
         return self
+
+
+def create_sla_auth(session, shares: int, index: int) -> Role:
+    role = Role(session=session, name=STRESS_ROLE_NAME_TEMPLATE % (shares, index),
+                password=STRESS_ROLE_PASSWORD_TEMPLATE % shares, login=True).create()
+    role.attach_service_level(ServiceLevel(session=session, name=SERVICE_LEVEL_NAME_TEMPLATE % (shares, index),
+                                           shares=shares).create())
+
+    return role


### PR DESCRIPTION
Add new basic rolling upgrade test with SLA authentication defined and running load with SLA connection while upgrade

Generic rolling upgrade for 2022.2: https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/rolling-upgrade-with-sla/10/

Longevity SLA test succeeded to create roles with SL and run load with it: https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/staging-sla-100gb-4h/58/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
