### PR TITLE
fix(disrupt_no_corrupt_repair): wait for schema agreement

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1442,6 +1442,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         for i in range(10):
             self.log.debug('Prepare test tables if they do not exist')
             self._prepare_test_table(ks=f'drop_table_during_repair_ks_{i}', table='standard1')
+            self.cluster.wait_for_schema_agreement()
 
         self.log.debug("Start repair target_node in background")
         with ThreadPoolExecutor(max_workers=1, thread_name_prefix='NodeToolRepairThread') as thread_pool:


### PR DESCRIPTION
C-S thread creating keyspaces triggered in `_prepare_test_table` may fail to write data and freeze if the nodes do not get to schema agreement quickly enough (due to Scylla's problem with schema management).
To avoid it we will wait for schema agreement each time after calling `_prepare_test_table`.

This workaround should fix https://github.com/scylladb/scylla-cluster-tests/issues/5413

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
