### PR TITLE
test(k8s): skip flush and reshard test due to operator's bug

### DIFF
--- a/functional_tests/scylla_operator/conftest.py
+++ b/functional_tests/scylla_operator/conftest.py
@@ -193,6 +193,15 @@ def fixture_scylla_yaml(db_cluster: ScyllaPodCluster):
     return db_cluster.remote_scylla_yaml
 
 
+@pytest.fixture(autouse=True)
+def skip_if_not_supported_backend(request: pytest.FixtureRequest,
+                                  tester: ScyllaOperatorFunctionalClusterTester):
+    if requires_backend := request.node.get_closest_marker('requires_backend'):
+        backend_name = tester.params.get("cluster_backend")
+        if backend_name not in requires_backend.args:
+            pytest.skip(f"'{backend_name}' backend is not supported.")
+
+
 # NOTE: Reason: https://github.com/scylladb/scylla/issues/9543
 @pytest.fixture(autouse=True)
 def skip_if_scylla_not_semver(request, tester: ScyllaOperatorFunctionalClusterTester) -> None:

--- a/functional_tests/scylla_operator/pytest.ini
+++ b/functional_tests/scylla_operator/pytest.ini
@@ -2,5 +2,6 @@
 markers =
     requires_node_termination_support: test gets skipped if backend doesn't support specified K8S node termination method
     requires_mgmt: test requires scylla manager to exist, set "use_mgmt: true" to enable it
+    requires_backend: used for the specification of supported backends and making a test be skipped if there is not match
     readonly: test that does not make any changes to cluster, only reads. Useful for running fast subset of tests
     restart_is_used: used for skipping tests which suffer from https://github.com/scylladb/scylla/issues/9543

--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -693,6 +693,9 @@ def test_default_dns_policy(db_cluster: ScyllaPodCluster):
         f"Pods: {yaml.safe_dump(pods_with_wrong_dns_policy, indent=2)}")
 
 
+# NOTE: non-fast K8S backends such as 'k8s-gke' and 'k8s-local-kind' are affected by following bug:
+#       https://github.com/scylladb/scylla-operator/issues/1077
+@pytest.mark.requires_backend("k8s-eks")
 def test_nodetool_flush_and_reshard(db_cluster: ScyllaPodCluster):
     target_node = db_cluster.nodes[0]
 


### PR DESCRIPTION
The 'test_nodetool_flush_and_reshard' test fails due to the following bug: 
https://github.com/scylladb/scylla-operator/issues/1077 
So, skip it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
