### PR TITLE
fix(nemesis.py): Shadowing of a node variable

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3613,8 +3613,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 InfoEvent(message='execute rebuild on new datacenter').publish()
                 new_node.run_nodetool(sub_cmd=f"rebuild -- {datacenters[0]}")
                 InfoEvent(message='Running full cluster repair on each node').publish()
-                for node in self.cluster.nodes:
-                    node.run_nodetool(sub_cmd="repair -pr", publish_event=True)
+                for cluster_node in self.cluster.nodes:
+                    cluster_node.run_nodetool(sub_cmd="repair -pr", publish_event=True)
                 datacenters = list(self.tester.db_cluster.get_nodetool_status().keys())
                 self._write_read_data_to_multi_dc_keyspace(datacenters)
             self.cluster.decommission(new_node)


### PR DESCRIPTION
While not a show-stopper right now, this shadowing could bring potential issues later as `finally:` block will try to operate on a decomissioned node and not on the intended first node of the cluster

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
