### PR TITLE
fix(sct-cleanup): add CreatedBy tag to security groups

### DIFF
--- a/sdcm/utils/aws_region.py
+++ b/sdcm/utils/aws_region.py
@@ -279,6 +279,7 @@ class AwsRegion:
             security_group.create_tags(Tags=[{"Key": "Name",
                                               "Value": name},
                                              {"Key": "RunByUser", "Value": get_username()},
+                                             {"Key": "CreatedBy", "Value": "SCT"},
                                              {"Key": "TestId", "Value": test_id}])
             LOGGER.debug("'%s' with id '%s' created. ", name, self.sct_security_group.group_id)
             LOGGER.debug("Creating common ingress rules...")


### PR DESCRIPTION
Since we start adding CreateBy tag for VMs, to limit the user from cleaning up only resources created by SCT (when using hydra commandline) a user couldn't cleanup his own security groups, that we left over from a job, or manually created by `hydra attach-test-sg` command

this adds the tag to the test_id based security group

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
