### PR TITLE
fix(rolling_upgrade): fix node naming issues in rolling-upgrade-ami

### DIFF
--- a/jenkins-pipelines/rolling-upgrade-ami.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-ami.jenkinsfile
@@ -6,6 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 rollingUpgradePipeline(
     backend: 'aws',
     base_versions: '',  // auto mode
+    linux_distro: 'ubuntu-focal',
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
     test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
     workaround_kernel_bug_for_iotune: false,

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -221,8 +221,12 @@ def call(Map pipelineParams) {
                                                                 export SCT_GCE_IMAGE_DB=${pipelineParams.gce_image_db}
                                                             fi
                                                             export SCT_SCYLLA_LINUX_DISTRO=${pipelineParams.linux_distro}
-                                                            export SCT_AMI_ID_DB_SCYLLA_DESC="\$SCT_AMI_ID_DB_SCYLLA_DESC-\$SCT_SCYLLA_LINUX_DISTRO"
 
+                                                            if [[ -n \$SCT_AMI_ID_DB_SCYLLA_DESC  ]]; then
+                                                                export SCT_AMI_ID_DB_SCYLLA_DESC="\$SCT_AMI_ID_DB_SCYLLA_DESC-\$SCT_SCYLLA_LINUX_DISTRO"
+                                                            else
+                                                                export SCT_AMI_ID_DB_SCYLLA_DESC="\$SCT_SCYLLA_LINUX_DISTRO"
+                                                            fi
                                                             export SCT_WORKAROUND_KERNEL_BUG_FOR_IOTUNE=${pipelineParams.workaround_kernel_bug_for_iotune}
                                                             if [[ ${pipelineParams.internode_compression} != null ]] ; then
                                                                 export SCT_INTERNODE_COMPRESSION=${pipelineParams.internode_compression}


### PR DESCRIPTION
This commit fixes an issue which made node names in `rolling-upgrade-ami` jobs include `--null`. This happens when no `linux_distro` param is provided. In the rolling-upgrade pipeline we assume the `GIT_BRANCH` environment variable to be present as well as the `linux_distro` pipeline param. If both are missing, the nodes get `--null` in their name.

Staging job with the changes: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/maciej/job/ru-ami/50/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
