### PR TITLE
feature(sct-runner): new test configuration for instance/disk

### DIFF
--- a/defaults/k8s_local_kind_aws_config.yaml
+++ b/defaults/k8s_local_kind_aws_config.yaml
@@ -1,0 +1,2 @@
+instance_type_runner: c5.2xlarge
+root_disk_size_runner: 120

--- a/defaults/k8s_local_kind_gce_config.yaml
+++ b/defaults/k8s_local_kind_gce_config.yaml
@@ -1,0 +1,2 @@
+instance_type_runner: e2-standard-8
+root_disk_size_runner: 120

--- a/sct.py
+++ b/sct.py
@@ -1404,12 +1404,20 @@ def create_runner_image(cloud_provider, region, availability_zone):
               help="Test ID of the test that the runner is created for restore monitor")
 def create_runner_instance(cloud_provider, region, availability_zone, instance_type, root_disk_size_gb,
                            test_id, duration, restore_monitor=False, restored_test_id=""):
+    # pylint: disable=too-many-locals
+
     if cloud_provider == "aws":
         assert len(availability_zone) == 1, f"Invalid AZ: {availability_zone}, availability-zone is one-letter a-z."
     add_file_logger()
     sct_runner_ip_path = Path("sct_runner_ip")
     sct_runner_ip_path.unlink(missing_ok=True)
     sct_runner = get_sct_runner(cloud_provider=cloud_provider, region_name=region, availability_zone=availability_zone)
+
+    os.environ.setdefault('SCT_CLUSTER_BACKEND', cloud_provider)
+    sct_config = SCTConfiguration()
+    instance_type = instance_type or sct_config.get('instance_type_runner')
+    root_disk_size_gb = root_disk_size_gb or sct_config.get('root_disk_size_runner')
+
     instance = sct_runner.create_instance(
         instance_type=instance_type,
         root_disk_size_gb=root_disk_size_gb,

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -605,6 +605,9 @@ class SCTConfiguration(dict):
         dict(name="instance_type_db_oracle", env="SCT_INSTANCE_TYPE_DB_ORACLE", type=str,
              help="AWS image type of the oracle node"),
 
+        dict(name="instance_type_runner", env="SCT_INSTANCE_TYPE_RUNNER", type=str,
+             help="instance type of the sct-runner node"),
+
         dict(name="region_name", env="SCT_REGION_NAME", type=str_or_list_or_eval,
              help="AWS regions to use"),
 
@@ -637,6 +640,9 @@ class SCTConfiguration(dict):
 
         dict(name="root_disk_size_loader", env="SCT_ROOT_DISK_SIZE_LOADER", type=int,
              help=""),
+
+        dict(name="root_disk_size_runner", env="SCT_ROOT_DISK_SIZE_RUNNER", type=int,
+             help="root disk size in Gb for sct-runner"),
 
         dict(name="ami_db_scylla_user", env="SCT_AMI_DB_SCYLLA_USER", type=str,
              help=""),
@@ -1477,8 +1483,12 @@ class SCTConfiguration(dict):
         "gce-siren": [sct_abs_path('defaults/gce_config.yaml')],
         "k8s-local-kind": [sct_abs_path('defaults/k8s_local_kind_config.yaml')],
         "k8s-local-kind-aws": [
-            sct_abs_path('defaults/aws_config.yaml'), sct_abs_path('defaults/k8s_local_kind_config.yaml')],
-        "k8s-local-kind-gce": [sct_abs_path('defaults/k8s_local_kind_config.yaml')],
+            sct_abs_path('defaults/aws_config.yaml'),
+            sct_abs_path('defaults/k8s_local_kind_aws_config.yaml'),
+            sct_abs_path('defaults/k8s_local_kind_config.yaml')],
+        "k8s-local-kind-gce": [
+            sct_abs_path('defaults/k8s_local_kind_gce_config.yaml'),
+            sct_abs_path('defaults/k8s_local_kind_config.yaml')],
         "k8s-gke": [sct_abs_path('defaults/k8s_gke_config.yaml')],
         "k8s-eks": [sct_abs_path('defaults/aws_config.yaml'), sct_abs_path('defaults/k8s_eks_config.yaml')],
     }

--- a/test-cases/longevity/longevity-multi-keyspaces.yaml
+++ b/test-cases/longevity/longevity-multi-keyspaces.yaml
@@ -24,6 +24,7 @@ instance_type_db: 'i3.8xlarge'
 root_disk_size_db: 60 # twice as as default, cause each keyspace generate lots of logs
 instance_type_loader: 'c5.4xlarge'
 root_disk_size_monitor: 100
+root_disk_size_runner: 120
 
 user_prefix: 'longevity-1000-keyspaces'
 


### PR DESCRIPTION
Since we have more and more cases that we found that need specific configuration for sct-runner machine, like stronger machines or bigger disks we are introducing two new test configuration options, that can be configured like that:

```yaml
instance_type_runner: c5.2xlarge
root_disk_size_runner: 120
```

Fix: #5428

- [x] testing it on k8s functional test: https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/functional-k8s-local-kind-aws-test/17/


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
