### PR TITLE
fix(docker): fix `reuse_cluster` to find instance

### DIFF
--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -251,7 +251,7 @@ class DockerCluster(cluster.BaseCluster):  # pylint: disable=abstract-method
 
     def _get_nodes(self):
         containers = ContainerManager.get_containers_by_prefix(self.node_prefix)
-        for node_index, container in sorted((int(c.labels["NodeIndex"]), c) for c in containers):
+        for node_index, container in sorted(((int(c.labels["NodeIndex"]), c) for c in containers), key=lambda x: x[0]):
             LOGGER.debug("Found container %s with name `%s' and index=%d", container, container.name, node_index)
             node = self._create_node(node_index, container)
             self.nodes.append(node)

--- a/sdcm/utils/docker_utils.py
+++ b/sdcm/utils/docker_utils.py
@@ -406,7 +406,7 @@ class ContainerManager:  # pylint: disable=too-many-public-methods)
     @classmethod
     def get_containers_by_prefix(cls, prefix: str, docker_client: DockerClient = None) -> List[Container]:
         docker_client = docker_client or cls.default_docker_client
-        return docker_client.containers.list(all=True, filters={"name": prefix})
+        return docker_client.containers.list(all=True, filters={"name": f'{prefix}*'})
 
     @classmethod
     def get_container_name_by_id(cls, c_id: str, docker_client: DockerClient = None) -> str:

--- a/unit_tests/test_utils_docker.py
+++ b/unit_tests/test_utils_docker.py
@@ -314,7 +314,7 @@ class TestContainerManager(unittest.TestCase):
 
     def test_get_containers_by_prefix(self):
         self.assertEqual(ContainerManager.get_containers_by_prefix("blah"),
-                         ((), {"all": True, "filters": {"name": "blah"}, }, ))
+                         ((), {"all": True, "filters": {"name": "blah*"}, }, ))
 
     def test_get_container_name_by_id(self):
         with self.subTest("Try to get name of non-existent container"):


### PR DESCRIPTION
code was looking for docker instance by prefix, but the api need to have `*` at the end for it to actully find any instances

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
