### PR TITLE
fix(dynamic-loader): create new pods on `reuse_cluster`

### DIFF
--- a/sdcm/remote/kubernetes_cmd_runner.py
+++ b/sdcm/remote/kubernetes_cmd_runner.py
@@ -530,6 +530,12 @@ class KubernetesPodRunner(KubernetesCmdRunner):
         # NOTE: we increase counter here because each new usage of the "KubernetesPodWatcher" class
         #       instance is triggered by the need to created a new pod with a unique name.
         self._pod_counter += 1
+
+        if self.kluster.params.get('reuse_cluster'):
+            pod_names = self.kluster.kubectl("get pods -o name", namespace=self.namespace).stdout.split()
+            while f'pod/{self.pod_name}' in pod_names:
+                self._pod_counter += 1
+
         connection = KubernetesPodWatcher(Context(Config(overrides={
             "k8s_kluster": self.kluster,
             "k8s_template_path": self.template_path,


### PR DESCRIPTION
when `reuse-cluster` is being used, we might have old pod in complated state, we need to make sure we don't try to use them since they can be modified and would fail the test.

insted we keep incressing the counter until we find "unused" podname.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
