### PR TITLE
test(limit): perf test for limit streaming

### DIFF
--- a/jenkins-pipelines/feature-limit-streaming-io.jenkinsfile
+++ b/jenkins-pipelines/feature-limit-streaming-io.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+perfRegressionParallelPipeline(
+    backend: "aws",
+    test_name: "performance_regression_test.PerformanceRegressionTest",
+    test_config: "test-cases/features/limit-streaming-io.yaml",
+    sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"],
+
+    timeout: [time: 1600, unit: "MINUTES"]
+)

--- a/sdcm/provision/scylla_yaml/scylla_yaml.py
+++ b/sdcm/provision/scylla_yaml/scylla_yaml.py
@@ -172,6 +172,7 @@ class ScyllaYaml(BaseModel):  # pylint: disable=too-few-public-methods
         'org.apache.cassandra.scheduler.NoScheduler',
         'org.apache.cassandra.scheduler.RoundRobinScheduler'
     ] = "org.apache.cassandra.scheduler.NoScheduler"
+    stream_io_throughput_mb_per_sec: int = 0
 
     # pylint: disable=no-self-argument,no-self-use
     @validator("request_scheduler", pre=True, always=True)

--- a/test-cases/features/limit-streaming-io.yaml
+++ b/test-cases/features/limit-streaming-io.yaml
@@ -1,0 +1,44 @@
+# test for https://github.com/scylladb/scylladb/commit/1f21c1ecc8e90d2bced38c019b1de0b3f651ddf1
+# based on perf-regression-latency-250gb-with-nemesis
+# For full result, compare latency and time of cluster operations with performance test results.
+# Latency drop during cluster operations should be lower when streaming limit is set but as a drawback these operations will
+# take longer to complete.
+# Results from previous runs documented in: https://docs.google.com/document/d/1tCyYgwGWww0qVfu-lf80ytesw0Q1uYpgikPz2kEhamQ/edit#
+test_duration: 880
+prepare_write_cmd: ["cassandra-stress write no-warmup cl=ALL n=62500000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=1..62500000",
+                    "cassandra-stress write no-warmup cl=ALL n=62500000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=62500001..125000000",
+                    "cassandra-stress write no-warmup cl=ALL n=62500000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=125000001..187500000",
+                    "cassandra-stress write no-warmup cl=ALL n=62500000 -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate threads=200 -col 'size=FIXED(128) n=FIXED(8)' -pop seq=187500001..250000000"]
+
+stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=800m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=50 throttle=5000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..250000000,125000000,12500000)' "
+stress_cmd_r: "cassandra-stress read no-warmup  cl=QUORUM duration=800m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=50 throttle=4000/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..250000000,125000000,12500000)' "
+stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=800m -schema 'replication(factor=3)' -port jmx=6868 -mode cql3 native -rate 'threads=50 throttle=3500/s' -col 'size=FIXED(128) n=FIXED(8)' -pop 'dist=gauss(1..250000000,125000000,12500000)' "
+
+n_db_nodes: 3
+nemesis_add_node_cnt: 3
+n_loaders: 4
+n_monitor_nodes: 1
+
+instance_type_loader: 'c5.2xlarge'
+instance_type_monitor: 't3.large'
+instance_type_db: 'i3.2xlarge'
+
+nemesis_class_name: 'NemesisSequence'
+nemesis_interval: 30
+nemesis_sequence_sleep_between_ops: 10
+
+user_prefix: 'limit-streaming'
+space_node_threshold: 644245094
+ami_id_db_scylla_desc: 'VERSION_DESC'
+
+round_robin: true
+append_scylla_args: '--blocked-reactor-notify-ms 5'
+backtrace_decoding: false
+print_kernel_callstack: true
+
+store_perf_results: false
+send_email: true
+email_recipients: ["qa@scylladb.com"]
+
+append_scylla_yaml: |
+  stream_io_throughput_mb_per_sec: 300

--- a/unit_tests/test_scylla_yaml.py
+++ b/unit_tests/test_scylla_yaml.py
@@ -392,6 +392,7 @@ class ScyllaYamlTest(unittest.TestCase):
                 'system_key_directory': None,
                 'system_info_encryption': None,
                 'kmip_hosts': None,
+                'stream_io_throughput_mb_per_sec': 0,
             }
         )
 


### PR DESCRIPTION
Added stream_io_throughput_mb_per_sec limit to 250gb perf test with nemesis to see the impact on latency and nemesis duration.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
