### PR TITLE
fix(upgrade): increase load time during upgrade/rollback

### DIFF
--- a/configurations/rolling-upgrade-with-sla.yaml
+++ b/configurations/rolling-upgrade-with-sla.yaml
@@ -1,7 +1,7 @@
 # workloads
 stress_before_upgrade: "cassandra-stress write cl=QUORUM n=60000000 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=1000 -pop seq=1..60000000 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
-stress_during_entire_upgrade: [ "cassandra-stress read cl=QUORUM duration=30m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native <sla credentials 0> -rate threads=200 -pop seq=1..30000000 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
-                                "cassandra-stress read  cl=QUORUM duration=30m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native <sla credentials 1> -rate threads=200 -pop seq=30000001..60000000 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
+stress_during_entire_upgrade: [ "cassandra-stress read cl=QUORUM duration=70m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native <sla credentials 0> -rate threads=200 -pop seq=1..30000000 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+                                "cassandra-stress read  cl=QUORUM duration=70m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native <sla credentials 1> -rate threads=200 -pop seq=30000001..60000000 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
 ]
 stress_after_cluster_upgrade: [ "cassandra-stress read cl=QUORUM duration=10m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native <sla credentials 0> -rate threads=200 -pop seq=1..30000000 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
                                 "cassandra-stress read  cl=QUORUM duration=10m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native <sla credentials 1> -rate threads=200 -pop seq=30000001..60000000 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
@@ -10,5 +10,7 @@ stress_after_cluster_upgrade: [ "cassandra-stress read cl=QUORUM duration=10m -s
 upgrade_sstables: false
 n_loaders: 2
 round_robin: true
+
+user_prefix: 'rolling-upgrade-sla'
 
 service_level_shares: [200, 800]


### PR DESCRIPTION
Increase load time during upgrade/rollback for rolling upgrade SLA test

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
