### PR TITLE
fix(upgrade): remove enable_authorization_after_upgrade parameter

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -131,11 +131,9 @@ new_scylla_repo: ''
 new_version: ''
 upgrade_node_packages: ''
 test_sst3: false
-authorization_in_upgrade: ''
 new_introduced_pkgs: ''
 recover_system_tables: false
 scylla_version: ''
-remove_authorization_in_rollback: false
 test_upgrade_from_installed_3_1_0: false
 target_upgrade_version: ''
 

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -258,8 +258,6 @@
 | **<a href="#user-content-upgrade_node_packages" name="upgrade_node_packages">upgrade_node_packages</a>**  |  | N/A | SCT_UPGRADE_NODE_PACKAGES
 | **<a href="#user-content-test_sst3" name="test_sst3">test_sst3</a>**  |  | N/A | SCT_TEST_SST3
 | **<a href="#user-content-test_upgrade_from_installed_3_1_0" name="test_upgrade_from_installed_3_1_0">test_upgrade_from_installed_3_1_0</a>**  | Enable an option for installed 3.1.0 for work around a scylla issue if it's true | N/A | SCT_TEST_UPGRADE_FROM_INSTALLED_3_1_0
-| **<a href="#user-content-authorization_in_upgrade" name="authorization_in_upgrade">authorization_in_upgrade</a>**  | Which Authorization to enable after upgrade | N/A | SCT_AUTHORIZATION_IN_UPGRADE
-| **<a href="#user-content-remove_authorization_in_rollback" name="remove_authorization_in_rollback">remove_authorization_in_rollback</a>**  | Disable Authorization after rollback to old Scylla | N/A | SCT_REMOVE_AUTHORIZATION_IN_ROLLBACK
 | **<a href="#user-content-new_introduced_pkgs" name="new_introduced_pkgs">new_introduced_pkgs</a>**  |  | N/A | SCT_NEW_INTRODUCED_PKGS
 | **<a href="#user-content-recover_system_tables" name="recover_system_tables">recover_system_tables</a>**  |  | N/A | SCT_RECOVER_SYSTEM_TABLES
 | **<a href="#user-content-stress_cmd_1" name="stress_cmd_1">stress_cmd_1</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_1

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1085,12 +1085,6 @@ class SCTConfiguration(dict):
         dict(name="test_upgrade_from_installed_3_1_0", env="SCT_TEST_UPGRADE_FROM_INSTALLED_3_1_0", type=boolean,
              help="Enable an option for installed 3.1.0 for work around a scylla issue if it's true"),
 
-        dict(name="authorization_in_upgrade", env="SCT_AUTHORIZATION_IN_UPGRADE", type=str,
-             help="Which Authorization to enable after upgrade"),
-
-        dict(name="remove_authorization_in_rollback", env="SCT_REMOVE_AUTHORIZATION_IN_ROLLBACK", type=boolean,
-             help="Disable Authorization after rollback to old Scylla"),
-
         dict(name="new_introduced_pkgs", env="SCT_NEW_INTRODUCED_PKGS", type=str,
              help=""),
 

--- a/test-cases/scylla-operator/kubernetes-scylla-upgrade.yaml
+++ b/test-cases/scylla-operator/kubernetes-scylla-upgrade.yaml
@@ -21,8 +21,6 @@ user_prefix: 'kubernetes-scylla-upgrade'
 #authenticator: 'PasswordAuthenticator'
 #authenticator_user: 'cassandra'
 #authenticator_password: 'cassandra'
-#authorization_in_upgrade: 'CassandraAuthorizer'
-#remove_authorization_in_rollback: true
 #recover_system_tables: true
 
 # Does not work due to the lack of support, could be anabled after - https://github.com/scylladb/scylla-cluster-tests/issues/2747

--- a/test-cases/upgrades/generic-rolling-upgrade.yaml
+++ b/test-cases/upgrades/generic-rolling-upgrade.yaml
@@ -19,8 +19,6 @@ authenticator: 'PasswordAuthenticator'
 authenticator_user: 'cassandra'
 authenticator_password: 'cassandra'
 
-authorization_in_upgrade: 'CassandraAuthorizer'
-remove_authorization_in_rollback: true
 recover_system_tables: true
 
 append_scylla_args: '--blocked-reactor-notify-ms 500 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1'

--- a/test-cases/upgrades/multi-dc-rolling-upgrade.yaml
+++ b/test-cases/upgrades/multi-dc-rolling-upgrade.yaml
@@ -20,8 +20,6 @@ authenticator: 'PasswordAuthenticator'
 authenticator_user: 'cassandra'
 authenticator_password: 'cassandra'
 
-authorization_in_upgrade: 'CassandraAuthorizer'
-remove_authorization_in_rollback: true
 recover_system_tables: true
 
 internode_compression: 'all'

--- a/test-cases/upgrades/rolling-upgrade.yaml
+++ b/test-cases/upgrades/rolling-upgrade.yaml
@@ -29,8 +29,6 @@ authenticator: 'PasswordAuthenticator'
 authenticator_user: 'cassandra'
 authenticator_password: 'cassandra'
 
-authorization_in_upgrade: 'CassandraAuthorizer'
-remove_authorization_in_rollback: true
 recover_system_tables: true
 
 append_scylla_args: '--blocked-reactor-notify-ms 500 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1'

--- a/unit_tests/test_data/test_scylla_yaml_builders/rolling-upgrade.yaml
+++ b/unit_tests/test_data/test_scylla_yaml_builders/rolling-upgrade.yaml
@@ -29,8 +29,6 @@ authenticator: 'PasswordAuthenticator'
 authenticator_user: 'cassandra'
 authenticator_password: 'cassandra'
 
-authorization_in_upgrade: 'CassandraAuthorizer'
-remove_authorization_in_rollback: true
 recover_system_tables: true
 
 append_scylla_args: '--blocked-reactor-notify-ms 500 --abort-on-lsa-bad-alloc 1 --abort-on-seastar-bad-alloc --abort-on-internal-error 1'

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -240,10 +240,6 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
             node.remoter.run("echo 'enable_sstables_mc_format: true' |sudo tee --append /etc/scylla/scylla.yaml")
         if self.params.get('test_upgrade_from_installed_3_1_0'):
             node.remoter.run("echo 'enable_3_1_0_compatibility_mode: true' |sudo tee --append /etc/scylla/scylla.yaml")
-        authorization_in_upgrade = self.params.get('authorization_in_upgrade')
-        if authorization_in_upgrade:
-            node.remoter.run("echo 'authorizer: \"%s\"' |sudo tee --append /etc/scylla/scylla.yaml" %
-                             authorization_in_upgrade)
         check_reload_systemd_config(node)
         # Current default 300s aren't enough for upgrade test of Debian 9.
         # Related issue: https://github.com/scylladb/scylla-cluster-tests/issues/1726
@@ -330,8 +326,6 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         if self.params.get('test_upgrade_from_installed_3_1_0'):
             node.remoter.run(
                 r'sudo sed -i -e "s/enable_3_1_0_compatibility_mode:/#enable_3_1_0_compatibility_mode:/g" /etc/scylla/scylla.yaml')
-        if self.params.get('remove_authorization_in_rollback'):
-            node.remoter.run('sudo sed -i -e "s/authorizer:/#authorizer:/g" /etc/scylla/scylla.yaml')
         # Current default 300s aren't enough for upgrade test of Debian 9.
         # Related issue: https://github.com/scylladb/scylla-cluster-tests/issues/1726
         node.run_scylla_sysconfig_setup()


### PR DESCRIPTION
Commit https://github.com/scylladb/scylla-cluster-tests/pull/981/commits/a5e0d1eaea98c2c197b7685b6f8c2ad99a131330 introduced enable_authorization_after_upgrade parameter for upgrade_test. It was added because old Scylla doesn't support Authorization, so we can't use to enable Authorization before & after upgrade. This change was added in 2019.1. Since all our releases supports authorizer option now, remove it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
