### PR TITLE
fix(multitanent): `stop_resources when` `setUp` fails

### DIFF
--- a/sdcm/utils/operator/multitenant_common.py
+++ b/sdcm/utils/operator/multitenant_common.py
@@ -18,7 +18,7 @@ import logging
 import time
 
 from sdcm.utils.common import ParallelObject
-
+from sdcm.tester import silence
 
 LOGGER = logging.getLogger(__name__)
 
@@ -130,12 +130,17 @@ def get_tenants(test_class_instance):  # pylint: disable=too-many-branches,too-m
 #       - save_email_data
 #       - _check_if_db_log_time_consistency_looks_good
 class MultiTenantTestMixin:
+    tenants = None
 
     def setUp(self):  # pylint: disable=invalid-name
         super().setUp()
         self.tenants = get_tenants(self)
 
+    @silence()
     def stop_resources(self):
+        if not self.tenants:
+            self.tenants = get_tenants(self)
+
         def _stop_resources(tenant):
             tenant.stop_resources()
 


### PR DESCRIPTION
if `setUp` is failing for some reason, stop resources was failing like the following:
```
Traceback (most recent call last):
   File ".../sdcm/utils/operator/multitenant_common.py", line 135, in setUp
     super().setUp()
   File ".../sdcm/tester.py", line 158, in wrapper
     args[0].tearDown()
   File ".../sdcm/tester.py", line 2680, in tearDown
     self.stop_resources()
   File ".../sdcm/utils/operator/multitenant_common.py", line 145, in stop_resources
     objects=[[tenant] for tenant in self.tenants],
AttributeError: 'LongevityOperatorMultiTenantTest' object has no attribute 'tenants'
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
