### PR TITLE
fix(perf*.yaml): add loaders ami to perf*.yamls

### DIFF
--- a/configurations/perf-loaders-non-shard-aware-config.yaml
+++ b/configurations/perf-loaders-non-shard-aware-config.yaml
@@ -1,0 +1,16 @@
+# manual on creating loader AMI's: see docs/new_loader_ami.md
+# AMIs from branch-perf-v8 with non-shardware driver
+use_prepared_loaders: true
+regions_data:
+    us-east-1:
+      security_group_ids: 'sg-c5e1f7a0'
+      subnet_id: 'subnet-ec4a72c4'
+      ami_id_loader: 'ami-01784b575d450e3b2' # Loader dedicated AMI v9 with golang 1.13
+    eu-west-1:
+      security_group_ids: 'sg-059a7f66a947d4b5c'
+      subnet_id: 'subnet-088fddaf520e4c7a8'
+      ami_id_loader: 'ami-0396fc0c3458abca9' # Loader dedicated AMI v9 with golang 1.13
+    us-west-2:
+      security_group_ids: 'sg-81703ae4'
+      subnet_id: 'subnet-5207ee37'
+      ami_id_loader: 'ami-0d2703a09ffa20a1e' # Loader dedicated AMI v9 with golang 1.13

--- a/configurations/perf-loaders-shard-aware-config.yaml
+++ b/configurations/perf-loaders-shard-aware-config.yaml
@@ -1,0 +1,15 @@
+# manual on creating loader AMI's: see docs/new_loader_ami.md
+use_prepared_loaders: true
+regions_data:
+  us-east-1: # US East (N. Virginia)
+    ami_id_loader: 'ami-00c1a16b5136fbb7c' # Loader dedicated AMI v19
+  us-west-2: # US West (Oregon)
+    ami_id_loader: 'ami-04d2eb44d523b3ccb' # Loader dedicated AMI v19
+  eu-west-1: # Europe (Ireland)
+    ami_id_loader: 'ami-042cf1bc21e30ce60' # Loader dedicated AMI v19
+  eu-west-2: # Europe (London)
+    ami_id_loader: 'ami-0370fbb289d8310d2' # Loader dedicated AMI v19
+  eu-north-1: # Europe (Stockholm)
+    ami_id_loader: 'ami-0226185e7d7951b6a' # Loader dedicated AMI v19
+  eu-central-1: # Europe (Frankfurt)
+    ami_id_loader: 'ami-0bc7811c417b0eb09' # Loader dedicated AMI v19

--- a/jenkins-pipelines/perf-regression-latency-125gb.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-125gb.jenkinsfile
@@ -7,7 +7,7 @@ perfRegressionParallelPipeline(
     backend: "aws",
     region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: "test-cases/performance/perf-regression-latency-125gb.yaml",
+    test_config: """["test-cases/performance/perf-regression-latency-125gb.yaml"]""",
     sub_tests: ["test_latency"],
 
     timeout: [time: 680, unit: "MINUTES"]

--- a/jenkins-pipelines/perf-regression-latency-1TB.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-1TB.jenkinsfile
@@ -7,7 +7,7 @@ perfRegressionParallelPipeline(
     backend: "aws",
     region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: "test-cases/performance/perf-regression-latency-1TB.yaml",
+    test_config: """["test-cases/performance/perf-regression-latency-1TB.yaml"]""",
     sub_tests: ["test_latency"],
 
     timeout: [time: 500, unit: "MINUTES"]

--- a/jenkins-pipelines/perf-regression-latency-250gb-with-nemesis.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-250gb-with-nemesis.jenkinsfile
@@ -6,6 +6,6 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 perfRegressionParallelPipeline(
     backend: "aws",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: "test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml",
+    test_config: """["test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml"]""",
     sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"]
 )

--- a/jenkins-pipelines/perf-regression-latency-non-shard-aware-125gb.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-non-shard-aware-125gb.jenkinsfile
@@ -7,8 +7,8 @@ perfRegressionParallelPipeline(
     backend: "aws",
     region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: """["test-cases/performance/perf-regression.100threads.30M-keys.yaml"]""",
-    sub_tests: ["test_write", "test_read", "test_mixed"],
+    test_config: '''["test-cases/performance/perf-regression-latency-125gb.yaml","configurations/perf-loaders-non-shard-aware-config.yaml"]''',
+    sub_tests: ["test_latency"],
 
-    timeout: [time: 350, unit: "MINUTES"]
+    timeout: [time: 680, unit: "MINUTES"]
 )

--- a/jenkins-pipelines/perf-regression-latency-non-shard-aware-1TB.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-non-shard-aware-1TB.jenkinsfile
@@ -7,8 +7,8 @@ perfRegressionParallelPipeline(
     backend: "aws",
     region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: """["test-cases/performance/perf-regression.100threads.30M-keys.yaml"]""",
-    sub_tests: ["test_write", "test_read", "test_mixed"],
+    test_config: '''["test-cases/performance/perf-regression-latency-1TB.yaml", "configurations/perf-loaders-non-shard-aware-config.yaml"]''',
+    sub_tests: ["test_latency"],
 
-    timeout: [time: 350, unit: "MINUTES"]
+    timeout: [time: 500, unit: "MINUTES"]
 )

--- a/jenkins-pipelines/perf-regression-latency-non-shard-aware-250gb-with-nemesis.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-non-shard-aware-250gb-with-nemesis.jenkinsfile
@@ -5,10 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: """["test-cases/performance/perf-regression.100threads.30M-keys.yaml"]""",
-    sub_tests: ["test_write", "test_read", "test_mixed"],
-
-    timeout: [time: 350, unit: "MINUTES"]
+    test_config: '''["test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml", "configurations/perf-loaders-non-shard-aware-config.yaml"]''',
+    sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"]
 )

--- a/jenkins-pipelines/perf-regression-latency-shard-aware-125gb.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-shard-aware-125gb.jenkinsfile
@@ -7,8 +7,8 @@ perfRegressionParallelPipeline(
     backend: "aws",
     region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: """["test-cases/performance/perf-regression.100threads.30M-keys.yaml"]""",
-    sub_tests: ["test_write", "test_read", "test_mixed"],
+    test_config: '''["test-cases/performance/perf-regression-latency-125gb.yaml","configurations/perf-loaders-shard-aware-config.yaml"]''',
+    sub_tests: ["test_latency"],
 
-    timeout: [time: 350, unit: "MINUTES"]
+    timeout: [time: 680, unit: "MINUTES"]
 )

--- a/jenkins-pipelines/perf-regression-latency-shard-aware-1TB.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-shard-aware-1TB.jenkinsfile
@@ -7,8 +7,8 @@ perfRegressionParallelPipeline(
     backend: "aws",
     region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: """["test-cases/performance/perf-regression.100threads.30M-keys.yaml"]""",
-    sub_tests: ["test_write", "test_read", "test_mixed"],
+    test_config: '''["test-cases/performance/perf-regression-latency-1TB.yaml", "configurations/perf-loaders-non-shard-aware-config.yaml"]''',
+    sub_tests: ["test_latency"],
 
-    timeout: [time: 350, unit: "MINUTES"]
+    timeout: [time: 500, unit: "MINUTES"]
 )

--- a/jenkins-pipelines/perf-regression-latency-shard-aware-250gb-with-nemesis.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-shard-aware-250gb-with-nemesis.jenkinsfile
@@ -5,10 +5,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 perfRegressionParallelPipeline(
     backend: "aws",
-    region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: """["test-cases/performance/perf-regression.100threads.30M-keys.yaml"]""",
-    sub_tests: ["test_write", "test_read", "test_mixed"],
-
-    timeout: [time: 350, unit: "MINUTES"]
+    test_config: '''["test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml", "configurations/perf-loaders-shard-aware-config.yaml"]''',
+    sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"]
 )

--- a/jenkins-pipelines/perf-regression-throughput-125gb.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-throughput-125gb.jenkinsfile
@@ -7,7 +7,7 @@ perfRegressionParallelPipeline(
     backend: "aws",
     region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: "test-cases/performance/perf-regression-throughput-125gb.yaml",
+    test_config: """["test-cases/performance/perf-regression-throughput-125gb.yaml"]""",
     sub_tests: ["test_write", "test_read", "test_mixed"],
 
     timeout: [time: 600, unit: "MINUTES"]

--- a/jenkins-pipelines/perf-regression-throughput-non-shard-aware-125gb.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-throughput-non-shard-aware-125gb.jenkinsfile
@@ -7,8 +7,8 @@ perfRegressionParallelPipeline(
     backend: "aws",
     region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: """["test-cases/performance/perf-regression.100threads.30M-keys.yaml"]""",
+    test_config: '''["test-cases/performance/perf-regression-throughput-125gb.yaml", "configurations/perf-loaders-non-shard-aware-config.yaml"]''',
     sub_tests: ["test_write", "test_read", "test_mixed"],
 
-    timeout: [time: 350, unit: "MINUTES"]
+    timeout: [time: 600, unit: "MINUTES"]
 )

--- a/jenkins-pipelines/perf-regression-throughput-non-shard-aware-30min.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-throughput-non-shard-aware-30min.jenkinsfile
@@ -7,7 +7,7 @@ perfRegressionParallelPipeline(
     backend: "aws",
     region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: """["test-cases/performance/perf-regression.100threads.30M-keys.yaml"]""",
+    test_config: '''["test-cases/performance/perf-regression.100threads.30M-keys.yaml","configurations/perf-loaders-non-shard-aware-config.yaml"]''',
     sub_tests: ["test_write", "test_read", "test_mixed"],
 
     timeout: [time: 350, unit: "MINUTES"]

--- a/jenkins-pipelines/perf-regression-throughput-shard-aware-125gb.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-throughput-shard-aware-125gb.jenkinsfile
@@ -7,8 +7,8 @@ perfRegressionParallelPipeline(
     backend: "aws",
     region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: """["test-cases/performance/perf-regression.100threads.30M-keys.yaml"]""",
+    test_config: '''["test-cases/performance/perf-regression-throughput-125gb.yaml","configurations/perf-loaders-shard-aware-config.yaml"]''',
     sub_tests: ["test_write", "test_read", "test_mixed"],
 
-    timeout: [time: 350, unit: "MINUTES"]
+    timeout: [time: 600, unit: "MINUTES"]
 )

--- a/jenkins-pipelines/perf-regression-throughput-shard-aware-30min.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-throughput-shard-aware-30min.jenkinsfile
@@ -7,7 +7,7 @@ perfRegressionParallelPipeline(
     backend: "aws",
     region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: """["test-cases/performance/perf-regression.100threads.30M-keys.yaml"]""",
+    test_config: '''["test-cases/performance/perf-regression.100threads.30M-keys.yaml","configurations/perf-loaders-shard-aware-config.yaml"]''',
     sub_tests: ["test_write", "test_read", "test_mixed"],
 
     timeout: [time: 350, unit: "MINUTES"]


### PR DESCRIPTION
Add explicitly loaders ami to performance yamls

qa-task: https://github.com/scylladb/qa-tasks/issues/848

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
