### PR TITLE
feature(check_hw_perf): Validate hw performance for performance test

### DIFF
--- a/configurations/run_db_node_benchmarks.yaml
+++ b/configurations/run_db_node_benchmarks.yaml
@@ -1,0 +1,2 @@
+run_db_node_benchmarks: true
+stop_on_hw_perf_failure: false

--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -127,3 +127,4 @@ WorkloadPrioritisationEvent.EmptyPrometheusData: ERROR
 ScyllaSysconfigSetupEvent: NORMAL
 TestStepEvent: ERROR
 CpuNotHighEnoughEvent: ERROR
+HWPerforanceEvent: CRITICAL

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -218,3 +218,5 @@ stress_image:
 service_level_shares: [1000]
 
 use_hdr_cs_histogram: false
+
+stop_on_hw_perf_failure: false

--- a/jenkins-pipelines/perf-regression-latency-non-shard-aware-125gb.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-non-shard-aware-125gb.jenkinsfile
@@ -7,7 +7,7 @@ perfRegressionParallelPipeline(
     backend: "aws",
     region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: '''["test-cases/performance/perf-regression-latency-125gb.yaml","configurations/perf-loaders-non-shard-aware-config.yaml"]''',
+    test_config: '''["test-cases/performance/perf-regression-latency-125gb.yaml","configurations/perf-loaders-non-shard-aware-config.yaml", "configurations/run_db_node_benchmarks.yaml"]''',
     sub_tests: ["test_latency"],
 
     timeout: [time: 680, unit: "MINUTES"]

--- a/jenkins-pipelines/perf-regression-latency-non-shard-aware-1TB.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-non-shard-aware-1TB.jenkinsfile
@@ -7,7 +7,7 @@ perfRegressionParallelPipeline(
     backend: "aws",
     region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: '''["test-cases/performance/perf-regression-latency-1TB.yaml", "configurations/perf-loaders-non-shard-aware-config.yaml"]''',
+    test_config: '''["test-cases/performance/perf-regression-latency-1TB.yaml", "configurations/perf-loaders-non-shard-aware-config.yaml", "configurations/run_db_node_benchmarks.yaml"]''',
     sub_tests: ["test_latency"],
 
     timeout: [time: 500, unit: "MINUTES"]

--- a/jenkins-pipelines/perf-regression-latency-non-shard-aware-250gb-with-nemesis.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-non-shard-aware-250gb-with-nemesis.jenkinsfile
@@ -6,6 +6,6 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 perfRegressionParallelPipeline(
     backend: "aws",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: '''["test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml", "configurations/perf-loaders-non-shard-aware-config.yaml"]''',
+    test_config: '''["test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml", "configurations/perf-loaders-non-shard-aware-config.yaml", "configurations/run_db_node_benchmarks.yaml"]''',
     sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"]
 )

--- a/jenkins-pipelines/perf-regression-latency-shard-aware-1TB.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-shard-aware-1TB.jenkinsfile
@@ -7,7 +7,7 @@ perfRegressionParallelPipeline(
     backend: "aws",
     region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: '''["test-cases/performance/perf-regression-latency-1TB.yaml", "configurations/perf-loaders-non-shard-aware-config.yaml"]''',
+    test_config: '''["test-cases/performance/perf-regression-latency-1TB.yaml", "configurations/perf-loaders-non-shard-aware-config.yaml", "configurations/run_db_node_benchmarks.yaml"]''',
     sub_tests: ["test_latency"],
 
     timeout: [time: 500, unit: "MINUTES"]

--- a/jenkins-pipelines/perf-regression-latency-shard-aware-250gb-with-nemesis.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-shard-aware-250gb-with-nemesis.jenkinsfile
@@ -6,6 +6,6 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 perfRegressionParallelPipeline(
     backend: "aws",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: '''["test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml", "configurations/perf-loaders-shard-aware-config.yaml"]''',
+    test_config: '''["test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml", "configurations/perf-loaders-shard-aware-config.yaml", "configurations/run_db_node_benchmarks.yaml"]''',
     sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"]
 )

--- a/jenkins-pipelines/perf-regression-throughput-non-shard-aware-125gb.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-throughput-non-shard-aware-125gb.jenkinsfile
@@ -7,7 +7,7 @@ perfRegressionParallelPipeline(
     backend: "aws",
     region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: '''["test-cases/performance/perf-regression-throughput-125gb.yaml", "configurations/perf-loaders-non-shard-aware-config.yaml"]''',
+    test_config: '''["test-cases/performance/perf-regression-throughput-125gb.yaml", "configurations/perf-loaders-non-shard-aware-config.yaml", "configurations/run_db_node_benchmarks.yaml"]''',
     sub_tests: ["test_write", "test_read", "test_mixed"],
 
     timeout: [time: 600, unit: "MINUTES"]

--- a/jenkins-pipelines/perf-regression-throughput-non-shard-aware-30min.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-throughput-non-shard-aware-30min.jenkinsfile
@@ -7,7 +7,7 @@ perfRegressionParallelPipeline(
     backend: "aws",
     region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: '''["test-cases/performance/perf-regression.100threads.30M-keys.yaml","configurations/perf-loaders-non-shard-aware-config.yaml"]''',
+    test_config: '''["test-cases/performance/perf-regression.100threads.30M-keys.yaml","configurations/perf-loaders-non-shard-aware-config.yaml", "configurations/run_db_node_benchmarks.yaml"]''',
     sub_tests: ["test_write", "test_read", "test_mixed"],
 
     timeout: [time: 350, unit: "MINUTES"]

--- a/jenkins-pipelines/perf-regression-throughput-shard-aware-30min.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-throughput-shard-aware-30min.jenkinsfile
@@ -7,7 +7,7 @@ perfRegressionParallelPipeline(
     backend: "aws",
     region: "us-east-1",
     test_name: "performance_regression_test.PerformanceRegressionTest",
-    test_config: '''["test-cases/performance/perf-regression.100threads.30M-keys.yaml","configurations/perf-loaders-shard-aware-config.yaml"]''',
+    test_config: '''["test-cases/performance/perf-regression.100threads.30M-keys.yaml","configurations/perf-loaders-shard-aware-config.yaml", "configurations/run_db_node_benchmarks.yaml"]''',
     sub_tests: ["test_write", "test_read", "test_mixed"],
 
     timeout: [time: 350, unit: "MINUTES"]

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3584,11 +3584,12 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
     def run_node_benchmarks(self):
         if not self.params.get("run_db_node_benchmarks") or not self.nodes:
             return
+        if "db-cluster" not in self.name:
+            return
 
         self.node_benchmark_manager.add_nodes(self.nodes)
         self.node_benchmark_manager.install_benchmark_tools()
         self.node_benchmark_manager.run_benchmarks()
-        self.get_node_benchmarks_results()
 
     def get_node_benchmarks_results(self):
         if not self.params.get("run_db_node_benchmarks") or not self.nodes:

--- a/sdcm/report_templates/results_latency_during_ops_short.html
+++ b/sdcm/report_templates/results_latency_during_ops_short.html
@@ -131,4 +131,43 @@
                 {% endif %}
             {% endfor %}
         </div>
+    {% if node_benchmarks %}
+        <h4>Node benchmarks</h4>
+        <div>
+            <table class='nodes_info_table'>
+                <tr>
+                    <th>Node Name</th>
+                    {% for item in node_benchmarks|dictsort|first|last|sort %}
+                    <th>{{ item }}</th>
+                    {% endfor %}
+                </tr>
+                {% for item in node_benchmarks|dictsort %}
+                <tr>
+                    <td>{{ item|first }}</td>
+                    {% for name in node_benchmarks|dictsort|first|last|sort %}
+                    <td>
+                        <table class="'">
+                            {% for key, value in (item|last)[name].items() %}
+                            <tr>
+                                <td style="font-weight: bold">{{ key }}</td>
+                                {% if value is boolean() %}
+                                    {% if value is true() %}
+                                        <td style="color: green">{{ value }}</td>
+                                    {% else %}
+                                        <td style="color: red">{{ value }}</td>
+                                    {% endif %}
+                                {% else %}
+                                    <td>{{ "%.2f"|format(value) }}</td>
+                                {% endif %}
+                            </tr>
+                            {% endfor %}
+                        </table>
+                    </td>
+                    {% endfor %}
+                </tr>
+                {% endfor %}
+            </table>
+        </div>
+    {% endif %}
+
 {% endblock %}

--- a/sdcm/report_templates/results_performance.html
+++ b/sdcm/report_templates/results_performance.html
@@ -137,4 +137,42 @@
         {% endfor %}
     </table>
     {% endfor %}
+    {% if node_benchmarks %}
+        <h4>Node benchmarks</h4>
+        <div>
+            <table class='nodes_info_table'>
+                <tr>
+                    <th>Node Name</th>
+                    {% for item in node_benchmarks|dictsort|first|last|sort %}
+                    <th>{{ item }}</th>
+                    {% endfor %}
+                </tr>
+                {% for item in node_benchmarks|dictsort %}
+                <tr>
+                    <td>{{ item|first }}</td>
+                    {% for name in node_benchmarks|dictsort|first|last|sort %}
+                    <td>
+                        <table class="'">
+                            {% for key, value in (item|last)[name].items() %}
+                            <tr>
+                                <td style="font-weight: bold">{{ key }}</td>
+                                {% if value is boolean() %}
+                                    {% if value is true() %}
+                                        <td style="color: green">{{ value }}</td>
+                                    {% else %}
+                                        <td style="color: red">{{ value }}</td>
+                                    {% endif %}
+                                {% else %}
+                                    <td>{{ "%.2f"|format(value) }}</td>
+                                {% endif %}
+                            </tr>
+                            {% endfor %}
+                        </table>
+                    </td>
+                    {% endfor %}
+                </tr>
+                {% endfor %}
+            </table>
+        </div>
+    {% endif %}
 {% endblock %}

--- a/sdcm/results_analyze/__init__.py
+++ b/sdcm/results_analyze/__init__.py
@@ -286,7 +286,7 @@ class LatencyDuringOperationsPerformanceAnalyzer(BaseResultsAnalyzer):
 
         return best_results
 
-    def check_regression(self, test_id, data, is_gce=False):  # pylint: disable=too-many-locals, too-many-branches, too-many-statements
+    def check_regression(self, test_id, data, is_gce=False, node_benchmarks=None):  # pylint: disable=too-many-locals, too-many-branches, too-many-statements
         doc = self.get_test_by_id(test_id)
         full_test_name = doc["_source"]["test_details"]["test_name"]
         test_name = full_test_name.split('.')[-1]  # Example: longevity_test.LongevityTest.test_custom_time
@@ -335,7 +335,7 @@ class LatencyDuringOperationsPerformanceAnalyzer(BaseResultsAnalyzer):
             grafana_snapshots=self._get_grafana_snapshot(doc),
             grafana_screenshots=self._get_grafana_screenshot(doc),
             job_url=doc['_source']['test_details'].get('job_url', ""),
-            # best_stat_per_version=best_results_per_nemesis,
+            node_benchmarks=node_benchmarks,
         )
         attachment_file = [
             self.save_html_to_file(results,
@@ -571,7 +571,9 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
         return cmp_res
 
     # pylint: disable=too-many-arguments
-    def check_regression(self, test_id, is_gce=False, email_subject_postfix=None, use_wide_query=False, lastyear=False):
+    def check_regression(self, test_id, is_gce=False, email_subject_postfix=None,
+                         use_wide_query=False, lastyear=False,
+                         node_benchmarks=None):
         """
         Get test results by id, filter similar results and calculate max values for each version,
         then compare with max in the test version and all the found versions.
@@ -717,6 +719,7 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
             "kibana_url": self.gen_kibana_dashboard_url(dashboard_path),
             "events_summary": events_summary,
             "last_events": last_events,
+            "node_benchmarks": node_benchmarks,
         }
         self.log.debug('Regression analysis:')
         self.log.debug(PP.pformat(results))

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1426,6 +1426,21 @@ class SCTConfiguration(dict):
              help="""add/remove num of process on each round"""),
         dict(name="use_hdr_cs_histogram", env="SCT_USE_HDR_CS_HISTOGRAM", type=boolean,
              help="""Enable hdr histogram logging for cs"""),
+
+        dict(name="stop_on_hw_perf_failure", env="SCT_STOP_ON_HW_PERF_FAILURE", type=boolean,
+             help="""Stop sct performance test if hardware performance test failed
+
+                    Hardware performance tests runs on each node with sysbench and cassandra-fio tools.
+                    Results stored in ES. HW perf tests run during cluster setups and not affect
+                    SCT Performance tests. Results calculated as average among all results for certain
+                    instance type or among all nodes during single run.
+                    if results for a single node is not in margin 0.01 of
+                    average result for all nodes, hw test considered as Failed.
+                    If stop_on_hw_perf_failure is True, then sct performance test will be terminated
+                       after hw perf tests detect node with hw results not in margin with average
+                    If stop_on_hw_perf_failure is False, then sct performance test will be run
+                       even after hw perf tests detect node with hw results not in margin with average"""),
+
     ]
 
     required_params = ['cluster_backend', 'test_duration', 'n_db_nodes', 'n_loaders', 'use_preinstalled_scylla',

--- a/sdcm/sct_events/system.py
+++ b/sdcm/sct_events/system.py
@@ -40,6 +40,16 @@ class TestTimeoutEvent(SctEvent):
         return f"{super().msgfmt}, Test started at {start_time}, reached it's timeout ({self.duration} minute)"
 
 
+class HWPerforanceEvent(SctEvent):
+    def __init__(self, message: str, severity: Severity = Severity.NORMAL):
+        super().__init__(severity)
+        self.message = message
+
+    @property
+    def msgfmt(self) -> str:
+        return super().msgfmt + ": message={0.message}"
+
+
 class TestFrameworkEvent(InformationalEvent):  # pylint: disable=too-many-instance-attributes
     __test__ = False  # Mark this class to be not collected by pytest.
 

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -52,6 +52,9 @@ def call(Map pipelineParams) {
             string(defaultValue: "${groovy.json.JsonOutput.toJson(pipelineParams.get('sub_tests'))}",
                    description: 'subtests in format ["sub_test1", "sub_test2"] or empty',
                    name: 'sub_tests')
+            string(defaultValue: "false",
+                   description: 'Stop test if perf hardware test values exceed the set limits',
+                   name: 'stop_on_hw_perf_failure')
 
             string(defaultValue: "${pipelineParams.get('email_recipients', 'scylla-perf-results@scylladb.com')}",
                    description: 'email recipients of email report',
@@ -194,6 +197,10 @@ def call(Map pipelineParams) {
                                                         fi
 
                                                         export SCT_EMAIL_RECIPIENTS="${email_recipients}"
+
+                                                        if [[ "${params.stop_on_hw_perf_failure}" == "true" ]] ; then
+                                                            export SCT_STOP_ON_HW_PERF_FAILURE="true"
+                                                        fi
                                                         if [[ ! -z "${params.scylla_ami_id}" ]] ; then
                                                             export SCT_AMI_ID_DB_SCYLLA=${params.scylla_ami_id}
                                                         elif [[ ! -z "${params.scylla_version}" ]] ; then


### PR DESCRIPTION
Run and check results of hw performance test before usual performance
test, to be sure that all db nodes have similar performance on hardware

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
