### PR TITLE
fix(loaders): disable retry on main loader run commands

### DIFF
--- a/sdcm/cassandra_harry_thread.py
+++ b/sdcm/cassandra_harry_thread.py
@@ -98,7 +98,9 @@ class CassandraHarryThread(DockerBasedStressThread):
                 docker_run_result = docker.run(cmd=f"{node_cmd} -node {ip}",
                                                timeout=self.timeout + self.shutdown_timeout,
                                                log_file=log_file_name,
-                                               verbose=True)
+                                               verbose=True,
+                                               retry=0,
+                                               )
                 result = self._parse_harry_summary(docker_run_result.stdout.splitlines())
             except Exception as exc:  # pylint: disable=broad-except
                 errors_str = format_stress_cmd_error(exc)

--- a/sdcm/cdclog_reader_thread.py
+++ b/sdcm/cdclog_reader_thread.py
@@ -71,7 +71,9 @@ class CDCLogReaderThread(DockerBasedStressThread):
                                     timeout=self.timeout + self.shutdown_timeout,
                                     ignore_status=True,
                                     log_file=log_file_name,
-                                    verbose=True)
+                                    verbose=True,
+                                    retry=0
+                                    )
                 if not result.ok:
                     CDCReaderStressEvent.error(node=loader,
                                                stress_cmd=self.stress_cmd,

--- a/sdcm/gemini_thread.py
+++ b/sdcm/gemini_thread.py
@@ -124,7 +124,9 @@ class GeminiStressThread(DockerBasedStressThread):  # pylint: disable=too-many-i
                 result = docker.run(cmd=gemini_cmd,
                                     timeout=self.timeout,
                                     ignore_status=False,
-                                    log_file=log_file_name)
+                                    log_file=log_file_name,
+                                    retry=0,
+                                    )
                 # sleep to gather all latest log messages
                 time.sleep(5)
             except Exception as details:  # pylint: disable=broad-except

--- a/sdcm/kcl_thread.py
+++ b/sdcm/kcl_thread.py
@@ -77,6 +77,7 @@ class KclStressThread(DockerBasedStressThread):  # pylint: disable=too-many-inst
                 result = docker.run(cmd=node_cmd,
                                     timeout=self.timeout + self.shutdown_timeout,
                                     log_file=log_file_name,
+                                    retry=0,
                                     )
 
                 return result

--- a/sdcm/ndbench_thread.py
+++ b/sdcm/ndbench_thread.py
@@ -151,7 +151,9 @@ class NdBenchStressThread(DockerBasedStressThread):  # pylint: disable=too-many-
                                                timeout=self.timeout + self.shutdown_timeout,
                                                ignore_status=True,
                                                log_file=log_file_name,
-                                               verbose=True)
+                                               verbose=True,
+                                               retry=0,
+                                               )
                 return docker_run_result
             except Exception as exc:  # pylint: disable=broad-except
                 NdBenchStressEvent.failure(node=str(loader),

--- a/sdcm/scylla_bench_thread.py
+++ b/sdcm/scylla_bench_thread.py
@@ -215,7 +215,9 @@ class ScyllaBenchThread(DockerBasedStressThread):  # pylint: disable=too-many-in
                 result = cmd_runner.run(
                     cmd=stress_cmd,
                     timeout=self.timeout,
-                    log_file=log_file_name)
+                    log_file=log_file_name,
+                    retry=0,
+                )
             except Exception as exc:  # pylint: disable=broad-except
                 errors_str = format_stress_cmd_error(exc)
                 if "truncate: seastar::rpc::timeout_error" in errors_str:

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -237,7 +237,7 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
                                      log_file_name=log_file_name) as cs_stress_event:
             publisher.event_id = cs_stress_event.event_id
             try:
-                result = cmd_runner.run(cmd=node_cmd, timeout=self.timeout, log_file=log_file_name)
+                result = cmd_runner.run(cmd=node_cmd, timeout=self.timeout, log_file=log_file_name, retry=0)
             except Exception as exc:  # pylint: disable=broad-except
                 cs_stress_event.severity = Severity.CRITICAL if self.stop_test_on_failure else Severity.ERROR
                 cs_stress_event.add_error(errors=[format_stress_cmd_error(exc)])

--- a/sdcm/ycsb_thread.py
+++ b/sdcm/ycsb_thread.py
@@ -264,7 +264,8 @@ class YcsbStressThread(DockerBasedStressThread):  # pylint: disable=too-many-ins
                             callback=raise_event_callback,
                             raise_exception=False
                         )
-                    ]
+                    ],
+                    retry=0,
                 )
                 return self.parse_final_output(result)
 


### PR DESCRIPTION
we never want to retry a stress comamnd, regardless what
the exception was, if we retry midst the stress command
we would start it from begining (which is an outcome we never want)

list of exception we retry is defined in `CommandRunner._is_error_retryable`

Fixes: #5278

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
