### PR TITLE
improvement(config param): support None for service_level_shares

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1711,6 +1711,14 @@ class SCTConfiguration(dict):
                 raise ValueError("For PasswordAuthenticator authenticator authenticator_user and authenticator_password"
                                  " have to be provided")
 
+        # 14) convert service_level_shares 'None' to pythonic None
+        if self.get('service_level_shares'):
+            service_level_shares = []
+            for shares in self.get('service_level_shares'):
+                service_level_shares.append(None if shares == "None" else shares)
+
+            self["service_level_shares"] = service_level_shares
+
     def log_config(self):
         self.log.info(self.dump_config())
 

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -634,6 +634,12 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
 
         self.assertEqual(conf.get('stress_read_cmd'), ['cassandra_stress', 'cassandra_stress'])
 
+    def test_22_convert_none_shares(self):
+        os.environ['SCT_CLUSTER_BACKEND'] = 'docker'
+        os.environ['SCT_CONFIG_FILES'] = 'unit_tests/test_data/service_level_shares_none.yaml'
+        conf = sct_config.SCTConfiguration()
+        self.assertEqual(conf["service_level_shares"], [None, None])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/unit_tests/test_data/service_level_shares_none.yaml
+++ b/unit_tests/test_data/service_level_shares_none.yaml
@@ -1,0 +1,1 @@
+service_level_shares: [None, None]


### PR DESCRIPTION
This commit must for https://github.com/scylladb/scylla-cluster-tests/pull/5451. 
OSS does not support 'shares' attribute for Service Level. But it's possible to create Service Level without 'shares'. 
Add option to define shares as None and ignore this attribute in time SL creation. 
'service_level_shares' config parameter define how many roles should be created for load running

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
