### PR TITLE
fix(k8s-ingress): remove wrong configuration options

### DIFF
--- a/sdcm/k8s_configs/ingress-controller/10_haproxy-kubernetes-ingress.configmap.yaml
+++ b/sdcm/k8s_configs/ingress-controller/10_haproxy-kubernetes-ingress.configmap.yaml
@@ -3,39 +3,3 @@ kind: ConfigMap
 metadata:
   name: haproxy-kubernetes-ingress
   namespace: haproxy-controller
-data:
-  hard-stop-after: "60s"
-  maxconn: "38000"
-  scale-server-slots: "5"
-  rate-limit-period: "1s"
-  rate-limit-status-code: "429"
-  rate-limit-size: "1000000"
-  timeout-client: "55s"
-  timeout-connect: "7s"
-  timeout-http-request: "5m"
-  timeout-http-keep-alive: "65s"
-  timeout-queue: "8s"
-  timeout-server: "4s"
-  timeout-tunnel: "29m"
-  dontlognull: "true"
-  src-ip-header: "True-Client-IP"
-  forwarded-for: "true"
-  http-keep-alive: "true"
-  http-server-close: "false"
-  load-balance: "roundrobin"
-  logasap: "false"
-  syslog-server: "address:stdout, format: raw, facility:daemon, level: trace"
-  global-config-snippet: |
-    tune.bufsize 32768
-    tune.idletimer 0
-    tune.ssl.cachesize 200000
-    tune.ssl.lifetime 300000
-    tune.pipesize 10485760
-    maxpipes 400000
-  backend-config-snippet: |
-    option splice-auto
-    option splice-request
-    option splice-response
-    option tcplog
-  stats-config-snippet: |
-    option dontlog-normal


### PR DESCRIPTION
cleanup all the configuration options, since if some are wrong it would keep restarting the haproxy to update them

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
