### PR TITLE
test(upgrade): run upgrade test with SLA [branch 2022.2]

### DIFF
--- a/configurations/rolling-upgrade-with-sla.yaml
+++ b/configurations/rolling-upgrade-with-sla.yaml
@@ -1,0 +1,14 @@
+# workloads
+stress_before_upgrade: "cassandra-stress write cl=QUORUM n=60000000 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=1000 -pop seq=1..60000000 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
+stress_during_entire_upgrade: [ "cassandra-stress read cl=QUORUM duration=70m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native <sla credentials 0> -rate threads=200 -pop seq=1..30000000 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+                                "cassandra-stress read  cl=QUORUM duration=70m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native <sla credentials 1> -rate threads=200 -pop seq=30000001..60000000 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
+]
+stress_after_cluster_upgrade: [ "cassandra-stress read cl=QUORUM duration=10m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native <sla credentials 0> -rate threads=200 -pop seq=1..30000000 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+                                "cassandra-stress read  cl=QUORUM duration=10m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native <sla credentials 1> -rate threads=200 -pop seq=30000001..60000000 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
+]
+
+upgrade_sstables: false
+n_loaders: 2
+round_robin: true
+
+service_level_shares: [200, 800]

--- a/jenkins-pipelines/rolling-upgrade-with-sla.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-with-sla.jenkinsfile
@@ -1,0 +1,14 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+rollingUpgradePipeline(
+    backend: 'gce',
+    base_versions: '',  // auto mode
+    linux_distro: 'centos-8',
+    gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-stream-8',
+
+    test_name: 'upgrade_test.UpgradeTest.test_generic_cluster_upgrade',
+    test_config: '''["test-cases/upgrades/generic-rolling-upgrade.yaml", "configurations/rolling-upgrade-with-sla.yaml"]'''
+)

--- a/longevity_sla_test.py
+++ b/longevity_sla_test.py
@@ -12,20 +12,11 @@
 # See LICENSE for more details.
 #
 # Copyright (c) 2022 ScyllaDB
-import re
-
 from longevity_test import LongevityTest
-from sdcm.sct_events import Severity
-from sdcm.sct_events.system import TestFrameworkEvent
-from test_lib.sla import Role, ServiceLevel
+from test_lib.sla import create_sla_auth, add_sla_credentials_to_stress_cmds, DEFAULT_USER, DEFAULT_USER_PASSWORD
 
 
 class LongevitySlaTest(LongevityTest):
-    DEFAULT_USER = "cassandra"
-    DEFAULT_USER_PASSWORD = "cassandra"
-    STRESS_ROLE_NAME_TEMPLATE = 'role%d_%d'
-    STRESS_ROLE_PASSWORD_TEMPLATE = 'rolep%d'
-    SERVICE_LEVEL_NAME_TEMPLATE = 'sl%d_%d'
     FULLSCAN_SERVICE_LEVEL_SHARES = 600
 
     def __init__(self, *args):
@@ -35,72 +26,19 @@ class LongevitySlaTest(LongevityTest):
         self.roles = []
 
     def test_custom_time(self):
-        with self.db_cluster.cql_connection_patient(node=self.db_cluster.nodes[0], user=self.DEFAULT_USER,
-                                                    password=self.DEFAULT_USER_PASSWORD) as session:
+        with self.db_cluster.cql_connection_patient(node=self.db_cluster.nodes[0], user=DEFAULT_USER,
+                                                    password=DEFAULT_USER_PASSWORD) as session:
             # Add index (shares position in the self.service_level_shares list) to role and service level names to do
             # it unique and prevent failure when try to create role/SL with same name
             for index, shares in enumerate(self.service_level_shares):
-                self.roles.append(self.create_sla_auth(session=session, shares=shares, index=index))
+                self.roles.append(create_sla_auth(session=session, shares=shares, index=index))
 
             if self.params.get("run_fullscan"):
-                self.fullscan_role = self.create_sla_auth(session=session, shares=self.FULLSCAN_SERVICE_LEVEL_SHARES,
-                                                          index=0)
+                self.fullscan_role = create_sla_auth(session=session, shares=self.FULLSCAN_SERVICE_LEVEL_SHARES,
+                                                     index=0)
 
-        self.add_sla_credentials_to_stress_cmds()
+        add_sla_credentials_to_stress_cmds(workload_names=['prepare_write_cmd', 'stress_cmd', 'stress_read_cmd'],
+                                           roles=self.roles, params=self.params,
+                                           parent_class_name=self.__class__.__name__)
+
         super().test_custom_time()
-
-    def create_sla_auth(self, session, shares: int, index: int) -> Role:
-        role = Role(session=session, name=self.STRESS_ROLE_NAME_TEMPLATE % (shares, index),
-                    password=self.STRESS_ROLE_PASSWORD_TEMPLATE % shares, login=True).create()
-        role.attach_service_level(ServiceLevel(session=session, name=self.SERVICE_LEVEL_NAME_TEMPLATE % (shares, index),
-                                               shares=shares).create())
-
-        return role
-
-    def add_sla_credentials_to_stress_cmds(self):
-        def _set_credentials_to_cmd(cmd):
-            if self.roles and "<sla credentials " in cmd:
-                if 'user=' in cmd:
-                    # if stress command is not defined as expected, stop the tests and fix it. Then re-run
-                    TestFrameworkEvent(
-                        source=self.__class__.__name__,
-                        message="Stress command is defined wrong. Credentials already applied. Remove unnecessary "
-                                f"and re-run the test. Command: {cmd}",
-                        severity=Severity.CRITICAL
-                    ).publish()
-
-                index = re.search(r"<sla credentials (\d+)>", cmd)
-                role_index = int(index.groups(0)[0]) if index else None
-                if role_index is None:
-                    # if stress command is not defined as expected, stop the tests and fix it. Then re-run
-                    TestFrameworkEvent(
-                        source=self.__class__.__name__,
-                        message="Stress command is defined wrong. Expected pattern '<credentials \\d>' was not found. "
-                                f"Fix the command and re-run the test. Command: {cmd}",
-                        severity=Severity.CRITICAL
-                    ).publish()
-                sla_role_name = self.roles[role_index].name.replace('"', '')
-                sla_role_password = self.roles[role_index].password
-                return re.sub(r'<sla credentials \d+>', f'user={sla_role_name} password={sla_role_password}', cmd)
-            return cmd
-
-        for stress_op in ['prepare_write_cmd', 'stress_cmd', 'stress_read_cmd']:
-            stress_cmds = []
-            stress_params = self.params.get(stress_op)
-            if isinstance(stress_params, str):
-                stress_params = [stress_params]
-
-            if not stress_params:
-                continue
-
-            for stress_cmd in stress_params:
-                # cover multitenant test
-                if isinstance(stress_cmd, list):
-                    cmds = []
-                    for current_cmd in stress_cmd:
-                        cmds.append(_set_credentials_to_cmd(cmd=current_cmd))
-                    stress_cmds.append(cmds)
-                else:
-                    stress_cmds.append(_set_credentials_to_cmd(cmd=stress_cmd))
-
-            self.params[stress_op] = stress_cmds

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -35,6 +35,7 @@ from sdcm.sct_events.system import InfoEvent
 from sdcm.sct_events.database import IndexSpecialColumnErrorEvent
 from sdcm.sct_events.group_common_events import ignore_upgrade_schema_errors, ignore_ycsb_connection_refused, \
     ignore_abort_requested_errors, decorate_with_context
+from test_lib.sla import create_sla_auth, add_sla_credentials_to_stress_cmds, DEFAULT_USER, DEFAULT_USER_PASSWORD
 
 
 def truncate_entries(func):
@@ -785,20 +786,47 @@ class UpgradeTest(FillDatabaseData):
         InfoEvent(message='Rollback Node %s ended' % node).publish()
         node.check_node_health()
 
-    def _run_stress_workload(self, workload_name: str, wait_for_finish: bool = False) -> CassandraStressThread:
+    def _run_stress_workload(self, workload_name: str, wait_for_finish: bool = False) -> [CassandraStressThread]:
         """Runs workload from param name specified in test-case yaml"""
         InfoEvent(message=f"Starting {workload_name}").publish()
-        stress_before_upgrade = self.params.get(workload_name)
-        workload_thread_pool = self.run_stress_thread(stress_cmd=stress_before_upgrade)
+        stress_commands = self.params.get(workload_name)
+        workload_thread_pools = []
+        if isinstance(stress_commands, str):
+            stress_commands = [stress_commands]
+
+        for stress_command in stress_commands:
+            workload_thread_pools.append(self.run_stress_thread(stress_cmd=stress_command))
+
         if self.params.get('alternator_port'):
             self.pre_create_alternator_tables()
         if wait_for_finish is True:
             InfoEvent(message=f"Waiting for {workload_name} to finish").publish()
-            self.verify_stress_thread(workload_thread_pool)
+            for thread_pool in workload_thread_pools:
+                self.verify_stress_thread(thread_pool)
         else:
             InfoEvent(message='Sleeping for 60s to let cassandra-stress start before the next steps...').publish()
             time.sleep(60)
-        return workload_thread_pool
+        return workload_thread_pools
+
+    def _add_sla_credentials_to_stress_commands(self, workloads_with_sla: list):
+        if not workloads_with_sla:
+            self.log.debug("No workloads supplied")
+            return
+
+        stress_during_entire_upgrade = self.params.get(workloads_with_sla[0])
+        if not [cmd for cmd in stress_during_entire_upgrade if "<sla credentials " in cmd]:
+            self.log.debug("No need to set SLA credentials for stress command: %s", stress_during_entire_upgrade)
+            return
+
+        roles = []
+        service_level_shares = self.params.get("service_level_shares")
+        with self.db_cluster.cql_connection_patient(node=self.db_cluster.nodes[0], user=DEFAULT_USER,
+                                                    password=DEFAULT_USER_PASSWORD) as session:
+            for index, shares in enumerate(service_level_shares):
+                roles.append(create_sla_auth(session=session, shares=shares, index=index))
+
+        add_sla_credentials_to_stress_cmds(workload_names=workloads_with_sla, roles=roles,
+                                           params=self.params, parent_class_name=self.__class__.__name__)
 
     def test_generic_cluster_upgrade(self):
         """
@@ -809,9 +837,11 @@ class UpgradeTest(FillDatabaseData):
 
         For multi-dc upgrades, alternates upgraded nodes between dc's.
         """
+        self._add_sla_credentials_to_stress_commands(workloads_with_sla=['stress_during_entire_upgrade',
+                                                                         'stress_after_cluster_upgrade'])
         step = itertools_count(start=1)
         self._run_stress_workload("stress_before_upgrade", wait_for_finish=True)
-        stress_thread_pool = self._run_stress_workload("stress_during_entire_upgrade", wait_for_finish=False)
+        stress_thread_pools = self._run_stress_workload("stress_during_entire_upgrade", wait_for_finish=False)
 
         # generate random order to upgrade
         nodes_to_upgrade = self.shuffle_nodes_and_alternate_dcs(list(self.db_cluster.nodes))
@@ -835,7 +865,8 @@ class UpgradeTest(FillDatabaseData):
         InfoEvent(message="All nodes were upgraded successfully").publish()
 
         InfoEvent(message="Waiting for stress_during_entire_upgrade to finish").publish()
-        self.verify_stress_thread(stress_thread_pool)
+        for stress_thread_pool in stress_thread_pools:
+            self.verify_stress_thread(stress_thread_pool)
 
         self._run_stress_workload("stress_after_cluster_upgrade", wait_for_finish=True)
 


### PR DESCRIPTION
This test was added by https://github.com/scylladb/scylla-cluster-tests/pull/5421 But it's not compatible with branch-2022.2.
Create separate commit

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
