### PR TITLE
improvement(k8s): increase load in K8S jobs

### DIFF
--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-add-remove-rack.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-add-remove-rack.yaml
@@ -1,5 +1,5 @@
 test_duration: 300
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=100 throttle=5000/s -pop seq=1..10000000 -log interval=5"
              ]
 n_db_nodes: 4
 k8s_n_scylla_pods_per_cluster: 3

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-backup.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-backup.yaml
@@ -1,5 +1,5 @@
 test_duration: 300
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=100 throttle=5000/s -pop seq=1..10000000 -log interval=5"
              ]
 n_db_nodes: 3
 k8s_n_scylla_pods_per_cluster: 3

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-cluster-rolling.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-cluster-rolling.yaml
@@ -1,5 +1,5 @@
 test_duration: 300
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=100 throttle=5000/s -pop seq=1..10000000 -log interval=5"
              ]
 n_db_nodes: 3
 k8s_n_scylla_pods_per_cluster: 3

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-grow-shrink.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-grow-shrink.yaml
@@ -1,5 +1,5 @@
 test_duration: 300
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=100 throttle=5000/s -pop seq=1..10000000 -log interval=5"
              ]
 n_db_nodes: 4
 k8s_n_scylla_pods_per_cluster: 3

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-repair.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-repair.yaml
@@ -1,5 +1,5 @@
 test_duration: 300
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=100 throttle=5000/s -pop seq=1..10000000 -log interval=5"
              ]
 n_db_nodes: 3
 k8s_n_scylla_pods_per_cluster: 3

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-replace.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-replace.yaml
@@ -1,5 +1,5 @@
 test_duration: 300
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=100 throttle=5000/s -pop seq=1..10000000 -log interval=5"
              ]
 n_db_nodes: 3
 k8s_n_scylla_pods_per_cluster: 3

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-stop-start.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-stop-start.yaml
@@ -1,5 +1,5 @@
 test_duration: 300
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=100 throttle=5000/s -pop seq=1..10000000 -log interval=5"
              ]
 n_db_nodes: 3
 k8s_n_scylla_pods_per_cluster: 3

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-terminate-decommission-add.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-terminate-decommission-add.yaml
@@ -1,5 +1,5 @@
 test_duration: 300
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=100 throttle=5000/s -pop seq=1..10000000 -log interval=5"
              ]
 n_db_nodes: 3
 k8s_n_scylla_pods_per_cluster: 3

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-terminate-replace.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-terminate-replace.yaml
@@ -1,5 +1,5 @@
 test_duration: 300
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=100 throttle=5000/s -pop seq=1..10000000 -log interval=5"
              ]
 n_db_nodes: 3
 k8s_n_scylla_pods_per_cluster: 3

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h.yaml
@@ -1,5 +1,5 @@
 test_duration: 300
-stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=100 throttle=1000/s -pop seq=1..10000000 -log interval=5"
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=180m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=100 throttle=5000/s -pop seq=1..10000000 -log interval=5"
              ]
 n_db_nodes: 4
 k8s_n_scylla_pods_per_cluster: 3


### PR DESCRIPTION
Having load 2k op/s (2 laoders * 1k op/s) for 3 nodes with i3.4xlarge nodes is too small.
So, increase it to be 5k op/s per loader.
On GKE nodes are slower than on EKS, but must be able to handle 10k op/s too.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
