### PR TITLE
feature(integration-tests): enable the longer integration tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -142,6 +142,26 @@ pipeline {
                 }
             }
         }
+        stage("integration tests") {
+            when {
+                expression {
+                    return pullRequestContainsLabels("test-integration") && currentBuild.result == null
+                }
+            }
+            options {
+                timeout(time: 30, unit: 'MINUTES')
+            }
+            steps {
+                script {
+                    try {
+                        sh './docker/env/hydra.sh integration-tests'
+                        pullRequestSetResult('success', 'jenkins/integration-tests', 'All integration tests are passed')
+                    } catch(Exception ex) {
+                        pullRequestSetResult('failure', 'jenkins/integration-tests', 'Some integration tests failed')
+                    }
+                }
+            }
+        }
         stage("provision test") {
             when {
                 expression {

--- a/sct.py
+++ b/sct.py
@@ -957,7 +957,14 @@ cli.add_command(investigate)
 @click.option("-t", "--test", required=False, default="",
               help="Run specific test file from unit-tests directory")
 def unit_tests(test):
-    sys.exit(pytest.main(['-v', '-p', 'no:warnings', 'unit_tests/{}'.format(test)]))
+    sys.exit(pytest.main(['-v', '-p', 'no:warnings', '-m', 'not integration', 'unit_tests/{}'.format(test)]))
+
+
+@cli.command('integration-tests', help="Run all the SCT internal integration-tests")
+@click.option("-t", "--test", required=False, default="",
+              help="Run specific test file from unit-tests directory")
+def integration_tests(test):
+    sys.exit(pytest.main(['-v', '-p', 'no:warnings', '-m', 'integration', 'unit_tests/{}'.format(test)]))
 
 
 @cli.command('pre-commit', help="Run pre-commit checkers")

--- a/sdcm/cassandra_harry_thread.py
+++ b/sdcm/cassandra_harry_thread.py
@@ -86,7 +86,7 @@ class CassandraHarryThread(DockerBasedStressThread):
 
         CassandraHarryEvent.start(node=loader, stress_cmd=self.stress_cmd).publish()
 
-        with CassandraHarryStressExporter(instance_name=loader.cql_ip_address,
+        with CassandraHarryStressExporter(instance_name=loader.ip_address,
                                           metrics=nemesis_metrics_obj(),
                                           stress_operation='write',
                                           stress_log_filename=log_file_name,

--- a/unit_tests/test_alternator_streams_kcl.py
+++ b/unit_tests/test_alternator_streams_kcl.py
@@ -22,7 +22,7 @@ from unit_tests.lib.alternator_utils import TEST_PARAMS
 
 pytestmark = [
     pytest.mark.usefixtures("events"),
-    pytest.mark.skipif(True, reason="those are integration tests only"),
+    pytest.mark.integration,
 ]
 
 

--- a/unit_tests/test_alternator_streams_kcl.py
+++ b/unit_tests/test_alternator_streams_kcl.py
@@ -26,6 +26,7 @@ pytestmark = [
 ]
 
 
+@pytest.mark.skip("test isn't yet fully working")
 def test_01_kcl_with_ycsb(
     request, docker_scylla, events, params
 ):  # pylint: disable=too-many-locals

--- a/unit_tests/test_cassandra_harry.py
+++ b/unit_tests/test_cassandra_harry.py
@@ -18,7 +18,7 @@ from unit_tests.dummy_remote import LocalLoaderSetDummy
 
 pytestmark = [
     pytest.mark.usefixtures("events"),
-    pytest.mark.skip(reason="those are integration tests only"),
+    pytest.mark.integration,
 ]
 
 

--- a/unit_tests/test_cassandra_stress_thread.py
+++ b/unit_tests/test_cassandra_stress_thread.py
@@ -17,7 +17,7 @@ from unit_tests.dummy_remote import LocalLoaderSetDummy
 
 pytestmark = [
     pytest.mark.usefixtures("events"),
-    pytest.mark.skip(reason="those are integration tests only"),
+    pytest.mark.integration,
 ]
 
 

--- a/unit_tests/test_gemini_thread.py
+++ b/unit_tests/test_gemini_thread.py
@@ -18,7 +18,7 @@ from unit_tests.dummy_remote import LocalLoaderSetDummy
 
 pytestmark = [
     pytest.mark.usefixtures("events"),
-    pytest.mark.skip(reason="those are integration tests only"),
+    pytest.mark.integration,
 ]
 
 

--- a/unit_tests/test_ndbench_thread.py
+++ b/unit_tests/test_ndbench_thread.py
@@ -7,7 +7,7 @@ from unit_tests.dummy_remote import LocalLoaderSetDummy
 
 pytestmark = [
     pytest.mark.usefixtures("events"),
-    pytest.mark.skip(reason="those are integration tests only"),
+    pytest.mark.integration,
 ]
 
 

--- a/unit_tests/test_scylla_bench_thread.py
+++ b/unit_tests/test_scylla_bench_thread.py
@@ -17,11 +17,11 @@ from sdcm.scylla_bench_thread import ScyllaBenchThread
 from unit_tests.dummy_remote import LocalLoaderSetDummy
 
 pytestmark = [
-    pytest.mark.usefixtures("events",),
+    pytest.mark.usefixtures("events", ),
 ]
 
 
-@pytest.mark.skip(reason="those are integration tests only")
+@pytest.mark.integration
 @pytest.mark.parametrize("extra_cmd", argvalues=[
     pytest.param('', id="regular"),
     pytest.param('-tls', id="tls", marks=[pytest.mark.docker_scylla_args(ssl=True)])])
@@ -30,8 +30,8 @@ def test_01_scylla_bench(request, docker_scylla, params, extra_cmd):
 
     cmd = (
         f"scylla-bench -workload=sequential {extra_cmd} -mode=write -replication-factor=1 -partition-count=10 "
-        + "-clustering-row-count=5555 -clustering-row-size=uniform:10..20 -concurrency=10 "
-        + "-connection-count=10 -consistency-level=one -rows-per-request=10 -timeout=60s -duration=1m"
+        "-clustering-row-count=5555 -clustering-row-size=uniform:10..20 -concurrency=10 "
+        "-connection-count=10 -consistency-level=one -rows-per-request=10 -timeout=60s -duration=1m"
     )
     bench_thread = ScyllaBenchThread(
         loader_set=loader_set,

--- a/unit_tests/test_version_utils.py
+++ b/unit_tests/test_version_utils.py
@@ -397,7 +397,7 @@ def test_scylla_version_grouped_regexp(full_version, version, date, commit_id):
 @pytest.mark.parametrize("version, expected", (
     ("4.6.rc2-20220102.e8a1cfb6f", "scylladb/scylla:4.6.rc2"),
     ("5.0.1-0.20220719.b177dacd3", "scylladb/scylla:5.0.1"),
-    ("5.1", "scylladb/scylla:5.1"),
+    ("5.1", "scylladb/scylla:latest"),
     ("5.1.0~rc1", "scylladb/scylla:5.1.0-rc1"),
     ("5.0.1", "scylladb/scylla:5.0.1"),
     ("5.2.0~dev-0.20220824.6ce5e9079c1e", "scylladb/scylla-nightly:5.2.0-dev-0.20220824.6ce5e9079c1e"),

--- a/unit_tests/test_version_utils.py
+++ b/unit_tests/test_version_utils.py
@@ -370,9 +370,8 @@ def test_scylla_versions_decorator_negative_latest_scylla_no_attr():
             assert False, f"Versioned method must have been not found for the '{scylla_version}' scylla version"
 
 
-@pytest.mark.integration
 @pytest.mark.need_network
-@pytest.mark.skip(reason="those are integration tests only")
+@pytest.mark.integration
 @pytest.mark.parametrize('docker_repo', ['scylladb/scylla-nightly', 'scylladb/scylla-enterprise-nightly'])
 def test_get_specific_tag_of_docker_image(docker_repo):
     assert get_specific_tag_of_docker_image(docker_repo=docker_repo) != 'latest'
@@ -395,7 +394,6 @@ def test_scylla_version_grouped_regexp(full_version, version, date, commit_id):
 
 @pytest.mark.integration
 @pytest.mark.need_network
-@pytest.mark.skip(reason="those are integration tests only")
 @pytest.mark.parametrize("version, expected", (
     ("4.6.rc2-20220102.e8a1cfb6f", "scylladb/scylla:4.6.rc2"),
     ("5.0.1-0.20220719.b177dacd3", "scylladb/scylla:5.0.1"),


### PR DESCRIPTION
since we are not running those tests regulary, they tend to get broken, and also we might miss breakage espesily in our loader docker tests.

for now it's would be enable by using a label on the PR `test-integration`

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
