### PR TITLE
fix(aws-ami): skip arm AMI when listing AMIs

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1028,6 +1028,7 @@ def get_scylla_ami_versions(region):
         Owners=['797456418907'],  # ScyllaDB
         Filters=[
             {'Name': 'name', 'Values': ['ScyllaDB *']},
+            {'Name': 'architecture', 'Values': ['x86_64']}
         ],
     )
 
@@ -1352,6 +1353,7 @@ def get_branched_ami(ami_version, region_name):
     else:
         filters = [{'Name': 'tag:branch', 'Values': [branch]}, {'Name': 'tag:build-id', 'Values': [build_id]}]
 
+    filters += [{'Name': 'architecture', 'Values': ['x86_64']}]
     amis = list(ec2_resource.images.filter(Filters=filters))
 
     amis = sorted(amis, key=lambda x: x.creation_date, reverse=True)


### PR DESCRIPTION
Since SCT branch-2021.1 doesn't support ARM yet
we just skip it until it would be backported

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
