### PR TITLE
fix(nemesis): ignore reactor stalls in MemoryStress

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -75,7 +75,8 @@ from sdcm.sct_events.filters import DbEventsFilter, EventsSeverityChangerFilter
 from sdcm.sct_events.group_common_events import (ignore_alternator_client_errors, ignore_no_space_errors,
                                                  ignore_scrub_invalid_errors, ignore_view_error_gate_closed_exception,
                                                  ignore_stream_mutation_fragments_errors,
-                                                 ignore_ycsb_connection_refused, decorate_with_context)
+                                                 ignore_ycsb_connection_refused, decorate_with_context,
+                                                 ignore_reactor_stall_errors)
 from sdcm.sct_events.loaders import CassandraStressLogEvent
 from sdcm.sct_events.nemesis import DisruptionEvent
 from sdcm.sct_events.system import InfoEvent
@@ -3575,6 +3576,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         experiment.start()
         experiment.wait_until_finished()
 
+    @decorate_with_context(ignore_reactor_stall_errors)
     def disrupt_memory_stress(self):
         """
         Try to run stress-ng to preempt allocated memory of scylla process,

--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -158,6 +158,13 @@ def ignore_mutation_write_errors():
 
 
 @contextmanager
+def ignore_reactor_stall_errors():
+    with EventsSeverityChangerFilter(new_severity=Severity.WARNING, event_class=DatabaseLogEvent,
+                                     regex=r".*Reactor stalled for"):
+        yield
+
+
+@contextmanager
 def ignore_ycsb_connection_refused():
     with EventsFilter(event_class=YcsbStressEvent, regex='.*Unable to execute HTTP request: .*Connection refused'):
         yield


### PR DESCRIPTION
As mentioned in https://github.com/scylladb/scylladb/issues/11972 when we run MemoryStress we tend to expect very high reactor stall times. As this is not deemed unexpected, this commit lowers the severity for such events to WARNING.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
