### PR TITLE
Fix fullscan queries

### DIFF
--- a/sdcm/scan_operation_thread.py
+++ b/sdcm/scan_operation_thread.py
@@ -94,7 +94,7 @@ class FullScanCommand(NamedTuple):
 
 class FullScanAggregateCommands(NamedTuple):
     SELECT_ALL = FullScanCommand("SELECT_ALL", Template("SELECT * from $ks_cf$bypass_cache$timeout"))
-    AGG_COUNT_ALL = FullScanCommand("AGG_COUNT_ALL", Template("SELECT count(*) FROM $ks_cf$timeout$bypass_cache"))
+    AGG_COUNT_ALL = FullScanCommand("AGG_COUNT_ALL", Template("SELECT count(*) FROM $ks_cf$bypass_cache$timeout"))
 
 
 class FullscanException(Exception):
@@ -552,7 +552,7 @@ class FullScanAggregatesOperation(FullscanOperationBase):
         bypass_cache = self.generator.choice(BYPASS_CACHE_VALUES)
         cmd = FullScanAggregateCommands.AGG_COUNT_ALL.base_query.substitute(
             ks_cf=self.fullscan_params.ks_cf,
-            timeout=f" {timeout}s",
+            timeout=f" USING TIMEOUT {timeout}s" if timeout else "",
             bypass_cache=bypass_cache
         )
         return cmd


### PR DESCRIPTION
fixes: https://github.com/scylladb/scylla-cluster-tests/issues/5474
    
    Aggregate fullscan operations create their own random cql queries.
    Changes introduced with https://github.com/scylladb/scylla-cluster-tests/pull/5355
    missed the USING TIMEOUT part of a query with timeout which led to
    CQL errors. This commit adds the missing part of the query.

Staging run with fullscans (1 thread with mixed commands): https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/maciej/job/mc-longevity/job/mc-large-partitions-3h/72/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
