### PR TITLE
fix(user-data): add support to Ubuntu22

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -61,7 +61,7 @@ print_kernel_callstack: false
 
 update_db_packages: ''
 
-logs_transport: "rsyslog"
+logs_transport: "ssh"
 rsyslog_imjournal_rate_limit_interval: 60  # max. 65535 till rsyslog v8.34
 rsyslog_imjournal_rate_limit_burst: 50000  # max. 65535 till rsyslog v8.34
 

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -40,7 +40,7 @@ from sdcm import ec2_client, cluster, wait
 from sdcm.provision.aws.utils import configure_eth1_script, network_config_ipv6_workaround_script, \
     configure_set_preserve_hostname_script
 from sdcm.provision.common.utils import configure_rsyslog_set_hostname_script, configure_hosts_set_hostname_script, \
-    restart_rsyslog_service
+    restart_rsyslog_service, install_rsyslog
 from sdcm.provision.scylla_yaml import SeedProvider
 from sdcm.remote import LocalCmdRunner, shell_script_cmd, NETWORK_EXCEPTIONS
 from sdcm.ec2_client import CreateSpotInstancesError
@@ -505,7 +505,8 @@ class AWSNode(cluster.BaseNode):
         # FIXME: workaround to avoid host rename generating errors on other commands
         if self.is_debian():
             return
-        script = configure_rsyslog_set_hostname_script(self.name)
+        script = install_rsyslog()
+        script += configure_rsyslog_set_hostname_script(self.name)
         script += self.test_config.get_rsyslog_configuration_script()
         script += restart_rsyslog_service()
         if wait.wait_for(func=self._set_hostname, step=10, text='Retrying set hostname on the node', timeout=300):

--- a/sdcm/provision/aws/utils.py
+++ b/sdcm/provision/aws/utils.py
@@ -356,5 +356,14 @@ def configure_eth1_script():
 
 
 def configure_set_preserve_hostname_script():
-    return 'grep "preserve_hostname: true" /etc/cloud/cloud.cfg 1>/dev/null 2>&1 ' \
-           '|| echo "preserve_hostname: true" >> /etc/cloud/cloud.cfg\n'
+    return dedent(r"""
+    if ! grep -q "preserve_hostname: true" /etc/cloud/cloud.cfg; then
+        echo "preserve_hostname: true" >> /etc/cloud/cloud.cfg
+    fi\n
+    if command -v rsyslog >/dev/null 2>&1; then
+        if ! grep "\\$LocalHostname {self.name}" /etc/rsyslog.conf; then
+            echo "" >> /etc/rsyslog.conf
+            echo "\\$LocalHostname {self.name}" >> /etc/rsyslog.conf
+        fi
+    fi\n
+    """)

--- a/sdcm/provision/common/configuration_script.py
+++ b/sdcm/provision/common/configuration_script.py
@@ -16,7 +16,7 @@ from typing import Tuple
 
 from sdcm.provision.common.builders import AttrBuilder
 from sdcm.provision.common.utils import (
-    configure_rsyslog_target_script, configure_sshd_script, restart_sshd_service, restart_rsyslog_service)
+    configure_rsyslog_target_script, configure_sshd_script, restart_sshd_service, restart_rsyslog_service, install_rsyslog)
 
 
 class ConfigurationScriptBuilder(AttrBuilder, metaclass=abc.ABCMeta):
@@ -27,6 +27,7 @@ class ConfigurationScriptBuilder(AttrBuilder, metaclass=abc.ABCMeta):
         script += configure_sshd_script()
         script += restart_sshd_service()
         if self.rsyslog_host_port:
+            script += install_rsyslog()
             script += configure_rsyslog_target_script(host=self.rsyslog_host_port[0], port=self.rsyslog_host_port[1])
             script += restart_rsyslog_service()
         return script

--- a/sdcm/test_config.py
+++ b/sdcm/test_config.py
@@ -8,7 +8,7 @@ import requests
 
 from sdcm.keystore import KeyStore
 from sdcm.provision.common.utils import configure_sshd_script, configure_rsyslog_rate_limits_script, \
-    configure_rsyslog_target_script, restart_sshd_service, restart_rsyslog_service
+    configure_rsyslog_target_script, restart_sshd_service, restart_rsyslog_service, install_rsyslog
 from sdcm.utils.net import get_my_ip
 from sdcm.utils.decorators import retrying
 from sdcm.utils.docker_utils import ContainerManager
@@ -221,6 +221,7 @@ class TestConfig(metaclass=Singleton):  # pylint: disable=too-many-public-method
         script = "#!/bin/bash\n"
         script += configure_sshd_script()
         script += restart_sshd_service()
+        script += install_rsyslog()
         script += cls.get_rsyslog_configuration_script()
         script += restart_rsyslog_service()
         return script

--- a/sdcm/utils/distro.py
+++ b/sdcm/utils/distro.py
@@ -42,6 +42,7 @@ class Distro(enum.Enum):
     UBUNTU18 = ("ubuntu", "18.04")
     UBUNTU20 = ("ubuntu", "20.04")
     UBUNTU21 = ("ubuntu", "21.04")
+    UBUNTU22 = ("ubuntu", "22.04")
     SLES15 = ("sles", "15")
 
     @classmethod
@@ -143,6 +144,10 @@ class Distro(enum.Enum):
     @property
     def is_ubuntu20(self):
         return self == self.UBUNTU20
+
+    @property
+    def is_ubuntu22(self):
+        return self == self.UBUNTU22
 
     @property
     def is_ubuntu(self):


### PR DESCRIPTION
this old branch didn't have proper support to
Ubuntu22, and it is now the OS in the image created by Scylla, hence we are patching it (based on much more modern code in master branch) to have minimal support to run perf tests.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
