### PR TITLE
fix(perf-with-nemesis): Support ubuntu 22.04

### DIFF
--- a/defaults/manager_versions.yaml
+++ b/defaults/manager_versions.yaml
@@ -7,6 +7,7 @@ manager_repos_by_version:
     ubuntu16: 'http://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
     ubuntu18: 'http://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
     ubuntu20: 'http://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
+    ubuntu22: 'http://downloads.scylladb.com/manager/deb/unstable/unified-deb/master/latest/scylla-manager.list'
   "3.0":
     centos7: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-3.0.repo'
     centos8: 'http://downloads.scylladb.com.s3.amazonaws.com/rpm/centos/scylladb-manager-3.0.repo'
@@ -14,6 +15,7 @@ manager_repos_by_version:
     debian11: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/debian/scylladb-manager-3.0.list'
     ubuntu18: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.0-bionic.list'
     ubuntu20: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.0-focal.list'
+    ubuntu22: 'http://downloads.scylladb.com.s3.amazonaws.com/deb/ubuntu/scylladb-manager-3.0-focal.list'
   "2.6":
     centos7: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.6.repo'
     centos8: 'http://downloads.scylladb.com/rpm/centos/scylladb-manager-2.6.repo'

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -303,7 +303,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             instance_details = CloudInstanceDetails(public_ip=self.public_ip_address, region=self.region,
                                                     provider=self.parent_cluster.cluster_backend,
                                                     private_ip=self.ip_address, creation_time=int(time.time()))
-            resource = CloudResource(name=self.name, state=ResourceState.RUNNING,
+            resource = CloudResource(name=self.name, state=ResourceState.RUNNING,  # pylint: disable=no-value-for-parameter
                                      instance_info=instance_details)
             self.argus_resource = resource
             run.run_info.resources.attach_resource(resource)
@@ -4230,6 +4230,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                 self.log.info("Waiting for preinstalled Scylla")
                 self._wait_for_preinstalled_scylla(node)
                 self.log.info("Done waiting for preinstalled Scylla")
+                node.install_package("rsync")
                 if self.params.get('workaround_kernel_bug_for_iotune'):
                     self.copy_preconfigured_iotune_files(node)
             if node.is_nonroot_install:

--- a/sdcm/mgmt/common.py
+++ b/sdcm/mgmt/common.py
@@ -21,6 +21,7 @@ def get_distro_name(distro_object):
         Distro.UBUNTU16: "ubuntu16",
         Distro.UBUNTU18: "ubuntu18",
         Distro.UBUNTU20: "ubuntu20",
+        Distro.UBUNTU22: "ubuntu22",
         Distro.OEL7: "centos7",
         Distro.OEL8: "centos8"
     }

--- a/sdcm/provision/common/utils.py
+++ b/sdcm/provision/common/utils.py
@@ -58,6 +58,13 @@ def configure_sshd_script():
     sed -i 's/#MaxSessions \(.*\)$/MaxSessions 1000/' /etc/ssh/sshd_config
     sed -i 's/#MaxStartups \(.*\)$/MaxStartups 60/' /etc/ssh/sshd_config
     sed -i 's/#LoginGraceTime \(.*\)$/LoginGraceTime 15s/' /etc/ssh/sshd_config
+    SSH_VERSION=$(ssh -V 2>&1 | tr -d "[:alpha:][:blank:][:punct:]" | cut -c-2)
+    echo $SSH_VERSION
+    if [ ${SSH_VERSION} -gt 88 ]; then
+        sed -i "s/#PubkeyAuthentication \(.*\)$/PubkeyAuthentication yes/" /etc/ssh/sshd_config
+        sed -i -e "\$aPubkeyAcceptedAlgorithms +ssh-rsa" /etc/ssh/sshd_config
+        sed -i -e "\$aHostKeyAlgorithms +ssh-rsa" /etc/ssh/sshd_config
+    fi
     """)
 
 
@@ -66,4 +73,8 @@ def restart_sshd_service():
 
 
 def restart_rsyslog_service():
-    return "systemctl restart rsyslog\n"
+    return dedent("""
+        if command -v rsyslog >/dev/null 2>&1; then
+            systemctl restart rsyslog
+        fi
+    """)

--- a/sdcm/utils/distro.py
+++ b/sdcm/utils/distro.py
@@ -42,6 +42,7 @@ class Distro(enum.Enum):
     UBUNTU18 = ("ubuntu", "18.04")
     UBUNTU20 = ("ubuntu", "20.04")
     UBUNTU21 = ("ubuntu", "21.04")
+    UBUNTU22 = ("ubuntu", "22.04")
     SLES15 = ("sles", "15")
 
     @classmethod

--- a/test-cases/performance/perf-regression-latency-1TB.yaml
+++ b/test-cases/performance/perf-regression-latency-1TB.yaml
@@ -28,3 +28,4 @@ send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com']
 backtrace_decoding: false
 print_kernel_callstack: true
+logs_transport: "ssh"

--- a/test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml
+++ b/test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml
@@ -33,3 +33,4 @@ print_kernel_callstack: true
 store_perf_results: true
 send_email: true
 email_recipients: ["scylla-perf-results@scylladb.com"]
+logs_transport: "ssh"

--- a/test-cases/performance/perf-regression.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys.yaml
@@ -23,3 +23,4 @@ store_perf_results: true
 use_mgmt: false
 send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com']
+logs_transport: "ssh"


### PR DESCRIPTION
Ubuntu 22.04 have disabled ssh rsa and removed rsyslog by default Enable rsa and switch to use ssh logging

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
