### PR TITLE
fix(get_docker_image_by_version): make it more roubst to errors

### DIFF
--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -349,14 +349,17 @@ def get_docker_image_by_version(scylla_version: str):
         scylla_version = short_scylla_version
 
     for page_number in count(start=1):
-        all_tags = requests.get(url=f'https://hub.docker.com/v2/repositories/{docker_repo}/'
-                                    f'tags?page_size=50&page={page_number}').json()
-        for image in all_tags['results']:
-            if scylla_version == image['name']:
-                return f"{docker_repo}:{image['name']}"
+        try:
+            all_tags = requests.get(url=f'https://hub.docker.com/v2/repositories/{docker_repo}/'
+                                        f'tags?page_size=50&page={page_number}').json()
+        except requests.RequestException:
+            break
+        for image in all_tags.get('results', []):
+            image_name = image.get('name')
+            if image_name and scylla_version == image_name:
+                return f"{docker_repo}:{image_name}"
         if not all_tags.get('next'):
             break
-
     # if image wasn't found, default to the latest releases
     return default_image
 


### PR DESCRIPTION
In some runs that are using AMIs which doesn't have corresponding docker images, we've seen this failures, when c-s stress command is running:

```
File "../sdcm/stress_thread.py", line 173, in _run_cs_stress
    cassandra_stress = get_docker_image_by_version(
        self.node_list[0].get_scylla_binary_version())
  File "../sdcm/utils/version_utils.py", line 354, in get_docker_image_by_version
    for image in all_tags['results']:
KeyError: 'results'
```

improved `get_docker_image_by_version` to be more robust on handling errors, and melformed responses.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
