### PR TITLE
feature(monitor): move to newer images

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -8,7 +8,7 @@ instance_type_loader: 'c5.xlarge'
 instance_type_monitor: 't3.large'
 # manual on creating loader AMI's: see docs/new_loader_ami.md
 ami_id_loader: 'scylla-qa-loader-ami-v19'
-ami_id_monitor: 'ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221206' # ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221206 Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2022-12-06
+ami_id_monitor: 'scylla-monitor-4.2'
 
 availability_zone: 'a'
 root_disk_size_monitor: 50  # GB, remove this field if default disk size should be used

--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -5,7 +5,7 @@ gce_project: '' # empty mean default one, can be overwritten to use different on
 
 gce_image_db: '' # so we can use `scylla_version` as needed
 gce_image_loader: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
-gce_image_monitor: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-7'
+gce_image_monitor: 'https://www.googleapis.com/compute/alpha/projects/skilled-adapter-452/global/images/scylla-monitoring-cloud-ubuntu-4-0-2-2022-09-19t14-39-35z'
 gce_image_username: 'scylla-test'
 
 gce_instance_type_loader: 'e2-standard-2'

--- a/test-cases/longevity/longevity-10gb-3h.yaml
+++ b/test-cases/longevity/longevity-10gb-3h.yaml
@@ -21,4 +21,5 @@ space_node_threshold: 64424
 
 gce_n_local_ssd_disk_db: 2
 use_preinstalled_scylla: true
-run_db_node_benchmarks: true
+# TESING
+# run_db_node_benchmarks: true

--- a/utils/copy_ami_to_all_regions.sh
+++ b/utils/copy_ami_to_all_regions.sh
@@ -1,10 +1,10 @@
-AMI_ID=ami-00c1a16b5136fbb7c
-AMI_NAME='scylla-qa-loader-ami-v19'
+AMI_ID=ami-03bcb976479f42c61
+AMI_NAME='scylla_monitoring_2023-01-16T11-43-28Z'
 SOURCE_REGION=us-east-1
 TARGET_REGIONS='us-west-2 eu-west-1 eu-west-2 eu-north-1 eu-central-1'
 
 for target_region in $TARGET_REGIONS
 do
 	echo "copy AMI to $target_region"
-	aws ec2 copy-image --region $target_region  --name "$AMI_NAME" --source-region $SOURCE_REGION --source-image-id $AMI_ID
+	aws ec2 copy-image --region $target_region  --name "$AMI_NAME" --source-region $SOURCE_REGION --source-image-id $AMI_ID --copy-image-tags
 done


### PR DESCRIPTION
move to formal monitoring images, and skip installation of docker
and such if such images are identifed.
(also mean that now by default we will be using an ubuntu image)

Testing:
- [ ] AWS - https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity/job/longevity-10gb-3h/85/
- [ ] GCE - https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-10gb-3h-gce-test/24/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
