### PR TITLE
fix(es_queries): Use explicit job name instead of wc

### DIFF
--- a/sdcm/utils/es_queries.py
+++ b/sdcm/utils/es_queries.py
@@ -117,10 +117,10 @@ class PerformanceQueryFilter(QueryFilter):
             if job_name[0] and job_name[0] in job_item['job_folder']:
                 base_job_name = job_name[1]
                 if self.use_wide_query:
-                    filter_query = rf'test_details.job_name.keyword: {job_name[0]}\/{base_job_name}*'
+                    filter_query = rf'test_details.job_name.keyword: {job_name[0]}\/{base_job_name}'
                 else:
-                    filter_query = rf'(test_details.job_name.keyword: {job_name[0]}\/{base_job_name}* OR \
-                                       test_details.job_name.keyword: {base_job_name}*) '
+                    filter_query = rf'(test_details.job_name.keyword: {job_name[0]}\/{base_job_name} OR \
+                                       test_details.job_name.keyword: {base_job_name}) '
             return filter_query
 
         def get_query_filter_by_job_prefix(job_item):
@@ -130,10 +130,10 @@ class PerformanceQueryFilter(QueryFilter):
                     continue
                 base_job_name = job_name[0]
                 if self.use_wide_query:
-                    filter_query = rf'test_details.job_name.keyword: {job_item["job_folder"]}\/{base_job_name}*'
+                    filter_query = rf'test_details.job_name.keyword: {job_item["job_folder"]}\/{base_job_name}'
                 else:
-                    filter_query = rf'(test_details.job_name.keyword: {job_item["job_folder"]}\/{base_job_name}* OR \
-                                       test_details.job_name.keyword: {base_job_name}*) '
+                    filter_query = rf'(test_details.job_name.keyword: {job_item["job_folder"]}\/{base_job_name} OR \
+                                       test_details.job_name.keyword: {base_job_name}) '
                 break
             return filter_query
 


### PR DESCRIPTION
Latest performance results using wide query filters documents from ES also from another jobs which are have similar name but have suffix related to another instance type ex. Performance_throughput and Performance_throughput_i4i

this happened because filter query uses wc:
job_name.keyword: performance_throughput*

use explicit job name,ex:
ob_name.keyword: performance_throughput

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
