### PR TITLE
fix(cordump_thread): get coredumpctl output in json format

### DIFF
--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -11,6 +11,12 @@ from repodataParser.RepoParser import Parser
 #   - 2019.1.4-0.20191217.b59e92dbd
 SCYLLA_VERSION_RE = re.compile(r"\d+(\.\d+)?\.[\d\w]+([.~][\d\w]+)?")
 
+# Example of output for `systemctl --version' command:
+#   $ systemctl --version
+#   systemd 237
+#   +PAM ... default-hierarchy=hybrid
+SYSTEMD_VERSION_RE = re.compile(r"^systemd (?P<version>\d+)")
+
 
 def get_branch_version(url):
     try:
@@ -71,3 +77,12 @@ def is_enterprise(version):
     :return: True if this version string passed is a scylla enterprise version
     """
     return parse_version(version) > parse_version('2000')
+
+
+def get_systemd_version(output: str) -> int:
+    if match := SYSTEMD_VERSION_RE.match(output):
+        try:
+            return int(match.group("version"))
+        except ValueError:
+            pass
+    return 0


### PR DESCRIPTION
Switch to used json format when available, to avoid
parsing the outout of coredumpctl which keep of changing

Implementation of #5492 

(cherry picked from commit 5a3b46bad5f9fcdd07fb6a496360b835a8031e4c)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
