### PR TITLE
fix(5499): don't use assume `nemesis_seed` is always define

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -199,7 +199,7 @@ class ArtifactsTest(ClusterTester):  # pylint: disable=too-many-public-methods
         Verify that the snitch used in the cluster is appropriate for
         the backend used.
         """
-        if not self.params["use_preinstalled_scylla"]:
+        if not self.params.get("use_preinstalled_scylla"):
             self.log.info("Skipping verifying the snitch due to the 'use_preinstalled_scylla' being set to False")
             return
 
@@ -225,7 +225,7 @@ class ArtifactsTest(ClusterTester):  # pylint: disable=too-many-public-methods
                             )
 
     def verify_write_back_cache_param(self) -> None:
-        if self.params["cluster_backend"] in ("gce", "azure") and self.params["use_preinstalled_scylla"]:
+        if self.params.get("cluster_backend") in ("gce", "azure") and self.params.get("use_preinstalled_scylla"):
             expected_write_back_cache_param = 0
         else:
             expected_write_back_cache_param = None
@@ -298,7 +298,7 @@ class ArtifactsTest(ClusterTester):  # pylint: disable=too-many-public-methods
 
     # pylint: disable=too-many-statements,too-many-branches
     def test_scylla_service(self):
-        backend = self.params["cluster_backend"]
+        backend = self.params.get("cluster_backend")
 
         if backend == "aws":
             with self.subTest("check ENA support"):
@@ -320,7 +320,7 @@ class ArtifactsTest(ClusterTester):  # pylint: disable=too-many-public-methods
 
         expected_housekeeping_status_code = 'cr' if backend == "docker" else 'r'
 
-        if self.params["use_preinstalled_scylla"] and backend != "docker":
+        if self.params.get("use_preinstalled_scylla") and backend != "docker":
             with self.subTest("check the cluster name"):
                 self.check_cluster_name()
 

--- a/mgmt_upgrade_test.py
+++ b/mgmt_upgrade_test.py
@@ -69,7 +69,7 @@ class ManagerUpgradeTest(BackupFunctionsMixIn, ClusterTester):
         with manager_node.remote_manager_yaml() as scylla_manager_yaml:
             node_ip = scylla_manager_yaml["http"].split(":", maxsplit=1)[0]
             scylla_manager_yaml["http"] = f"{node_ip}:{new_manager_http_port}"
-            scylla_manager_yaml["prometheus"] = f"{node_ip}:{self.params['manager_prometheus_port']}"
+            scylla_manager_yaml["prometheus"] = f"{node_ip}:{self.params.get('manager_prometheus_port')}"
             LOGGER.info("The new Scylla Manager is:\n{}".format(scylla_manager_yaml))
         manager_node.restart_manager_server(port=new_manager_http_port)
         manager_tool = get_scylla_manager_tool(manager_node=manager_node)

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -228,8 +228,7 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
             # If self.instance_provision == "spot_low_price"
             instances_provision_fallbacks = [self.instance_provision]
 
-        if 'instance_provision_fallback_on_demand' in self.params \
-                and self.params['instance_provision_fallback_on_demand']:
+        if self.params.get('instance_provision_fallback_on_demand'):
             instances_provision_fallbacks.append(INSTANCE_PROVISION_ON_DEMAND)
 
         self.log.debug(f"Instances provision fallbacks : {instances_provision_fallbacks}")

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -925,7 +925,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
 
     def create_scylla_manager_agent_config(self, namespace=SCYLLA_NAMESPACE):
         data = {}
-        if self.params['use_mgmt']:
+        if self.params.get('use_mgmt'):
             data["s3"] = {
                 'provider': 'Minio',
                 'endpoint': self.s3_provider_endpoint,

--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1291,7 +1291,7 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
         except ImportError:
             LOGGER.error("Couldn't collect Siren manager logs, cluster_cloud module isn't installed")
         else:
-            cloud_cluster_id = self.params["cloud_cluster_id"] if "cloud_cluster_id" in self.params else None
+            cloud_cluster_id = self.params.get("cloud_cluster_id")
             if not cloud_cluster_id:
                 LOGGER.error("Cloud cluster id is not found. Probably the cluster has not been created")
                 return
@@ -1307,7 +1307,7 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
             LOGGER.info("Manager instance: %s", instance)
             ssh_login_info = {"hostname": instance["publicip"],
                               "user": "support",
-                              "key_file": self.params["cloud_credentials_path"]}
+                              "key_file": self.params.get("cloud_credentials_path")}
             LOGGER.info("Manager instance ssh_login_info: %s", ssh_login_info)
             self.siren_manager_set.append(CollectingNode(name=instance["externalid"],
                                                          ssh_login_info=ssh_login_info,
@@ -1326,8 +1326,8 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
             self.db_cluster.append(CollectingNode(name=name[0],
                                                   ssh_login_info={
                                                       "hostname": self.get_aws_ip_address(instance),
-                                                      "user": self.params['ami_db_scylla_user'],
-                                                      "key_file": self.params['user_credentials_path']},
+                                                      "user": self.params.get('ami_db_scylla_user'),
+                                                      "key_file": self.params.get('user_credentials_path')},
                                                   instance=instance,
                                                   global_ip=self.get_aws_ip_address(instance),
                                                   tags={**self.tags, "NodeType": "scylla-db", }))
@@ -1337,12 +1337,12 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
             self.monitor_set.append(CollectingNode(name=name[0],
                                                    ssh_login_info={
                                                        "hostname": self.get_aws_ip_address(instance),
-                                                       "user": self.params['ami_monitor_user'],
-                                                       "key_file": self.params['user_credentials_path']},
+                                                       "user": self.params.get('ami_monitor_user'),
+                                                       "key_file": self.params.get('user_credentials_path')},
                                                    instance=instance,
                                                    global_ip=self.get_aws_ip_address(instance),
                                                    tags={**self.tags, "NodeType": "monitor", }))
-        if self.params["use_cloud_manager"]:
+        if self.params.get("use_cloud_manager"):
             self.find_and_append_cloud_manager_instance_to_collecting_nodes()
 
         for instance in filtered_instances['loader_nodes']:
@@ -1351,8 +1351,8 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
             self.loader_set.append(CollectingNode(name=name[0],
                                                   ssh_login_info={
                                                       "hostname": self.get_aws_ip_address(instance),
-                                                      "user": self.params['ami_loader_user'],
-                                                      "key_file": self.params['user_credentials_path']},
+                                                      "user": self.params.get('ami_loader_user'),
+                                                      "key_file": self.params.get('user_credentials_path')},
                                                   instance=instance,
                                                   global_ip=self.get_aws_ip_address(instance),
                                                   tags={**self.tags, "NodeType": "loader", }))
@@ -1362,8 +1362,8 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
             self.kubernetes_set.append(CollectingNode(name=name[0],
                                                       ssh_login_info={
                 "hostname": self.get_aws_ip_address(instance),
-                "user": self.params['ami_loader_user'],
-                "key_file": self.params['user_credentials_path']},
+                "user": self.params.get('ami_loader_user'),
+                "key_file": self.params.get('user_credentials_path')},
                 instance=instance,
                 global_ip=self.get_aws_ip_address(instance),
                 tags={**self.tags, "NodeType": "loader", }))
@@ -1375,8 +1375,8 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
             self.db_cluster.append(CollectingNode(name=instance.name,
                                                   ssh_login_info={
                                                       "hostname": instance.public_ips[0],
-                                                      "user": self.params['gce_image_username'],
-                                                      "key_file": self.params['user_credentials_path']},
+                                                      "user": self.params.get('gce_image_username'),
+                                                      "key_file": self.params.get('user_credentials_path')},
                                                   instance=instance,
                                                   global_ip=instance.public_ips[0],
                                                   tags={**self.tags, "NodeType": "scylla-db", }))
@@ -1384,8 +1384,8 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
             self.monitor_set.append(CollectingNode(name=instance.name,
                                                    ssh_login_info={
                                                        "hostname": instance.public_ips[0],
-                                                       "user": self.params['gce_image_username'],
-                                                       "key_file": self.params['user_credentials_path']},
+                                                       "user": self.params.get('gce_image_username'),
+                                                       "key_file": self.params.get('user_credentials_path')},
                                                    instance=instance,
                                                    global_ip=instance.public_ips[0],
                                                    tags={**self.tags, "NodeType": "monitor", }))
@@ -1393,8 +1393,8 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
             self.loader_set.append(CollectingNode(name=instance.name,
                                                   ssh_login_info={
                                                       "hostname": instance.public_ips[0],
-                                                      "user": self.params['gce_image_username'],
-                                                      "key_file": self.params['user_credentials_path']},
+                                                      "user": self.params.get('gce_image_username'),
+                                                      "key_file": self.params.get('user_credentials_path')},
                                                   instance=instance,
                                                   global_ip=instance.public_ips[0],
                                                   tags={**self.tags, "NodeType": "loader", }))
@@ -1402,12 +1402,12 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
             self.kubernetes_set.append(CollectingNode(name=instance.name,
                                                       ssh_login_info={
                                                           "hostname": instance.public_ips[0],
-                                                          "user": self.params['gce_image_username'],
-                                                          "key_file": self.params['user_credentials_path']},
+                                                          "user": self.params.get('gce_image_username'),
+                                                          "key_file": self.params.get('user_credentials_path')},
                                                       instance=instance,
                                                       global_ip=instance.public_ips[0],
                                                       tags={**self.tags, "NodeType": "loader", }))
-        if self.params["use_cloud_manager"]:
+        if self.params.get("use_cloud_manager"):
             self.find_and_append_cloud_manager_instance_to_collecting_nodes()
 
     def create_collecting_nodes(self):
@@ -1430,7 +1430,7 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
                         self.monitor_set.append(c_node)
                     case "loader":
                         self.loader_set.append(c_node)
-            if self.params["use_cloud_manager"]:
+            if self.params.get("use_cloud_manager"):
                 self.find_and_append_cloud_manager_instance_to_collecting_nodes()
         except ProvisionerError:
             LOGGER.debug("get_running_cluster_sets: unknown backend type: %s", self.backend)
@@ -1443,7 +1443,7 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
                                                   ssh_login_info={
                                                       "hostname": instance.public_ips[0],
                                                       "user": 'scylla-test',
-                                                      "key_file": self.params['user_credentials_path']},
+                                                      "key_file": self.params.get('user_credentials_path')},
                                                   instance=instance,
                                                   global_ip=instance.public_ips[0],
                                                   tags={**self.tags, "NodeType": "scylla-db", }))
@@ -1456,7 +1456,7 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
                                                   ssh_login_info={
                                                       "hostname": instance.public_ips[0],
                                                       "user": 'scylla-test',
-                                                      "key_file": self.params['user_credentials_path']},
+                                                      "key_file": self.params.get('user_credentials_path')},
                                                   instance=instance,
                                                   global_ip=instance.public_ips[0],
                                                   tags={**self.tags, "NodeType": "loader", }))

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -260,7 +260,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         return func  # returning func means func can still be used normally
 
     def use_nemesis_seed(self):
-        if nemesis_seed := self.tester.params["nemesis_seed"]:
+        if nemesis_seed := self.tester.params.get("nemesis_seed"):
             random.seed(nemesis_seed)
 
     def update_stats(self, disrupt, status=True, data=None):

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -753,7 +753,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
         # cs_db_cluster is created in case MIXED_CLUSTER. For example, gemini test
         if self.cs_db_cluster:
-            init_value = self.params["use_mgmt"]
+            init_value = self.params.get("use_mgmt")
             self.params["use_mgmt"] = False
             self.init_nodes(db_cluster=self.cs_db_cluster)
             self.params["use_mgmt"] = init_value
@@ -3365,7 +3365,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         alive_node = self._get_live_node() or None
 
         start_time = format_timestamp(self.start_time)
-        config_file_name = ";".join(os.path.splitext(os.path.basename(cfg))[0] for cfg in self.params["config_files"])
+        config_file_name = ";".join(os.path.splitext(os.path.basename(cfg))[
+                                    0] for cfg in self.params.get("config_files"))
         test_status = self.get_test_status()
         backend = self.params.get("cluster_backend")
         region_name = self.params.get('region_name') or self.params.get('gce_datacenter')


### PR DESCRIPTION
this wrong assumption, failed the provision tests and any other test that doesn't use SisyphusMonkey

```
if nemesis_seed := self.tester.params["nemesis_seed"]:
KeyError: 'nemesis_seed'
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
