### PR TITLE
feature(stress-thread): set timeout based on duration

### DIFF
--- a/unit_tests/test_stress_thread_functions.py
+++ b/unit_tests/test_stress_thread_functions.py
@@ -1,0 +1,38 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2022 ScyllaDB
+
+import pytest
+
+from sdcm.stress_thread import time_period_str_to_seconds, get_timeout_from_stress_cmd
+
+
+@pytest.mark.parametrize("duration,seconds", (
+    ("1h1m20s", 3680),
+    ("1m20s", 80),
+    ("1h20s", 3620),
+    ("25m", 1500),
+    ("10h", 36000),
+    ("25s", 25),
+))
+def test_duration_str_to_seconds_function(duration, seconds):
+    assert time_period_str_to_seconds(duration) == seconds
+
+
+@pytest.mark.parametrize("stress_cmd, timeout", (
+    ("cassandra-stress counter_write cl=QUORUM duration=20m -schema 'replication(factor=3)' no-warmup", 1200 + 600),
+    ("scylla-bench -workload=uniform -concurrency 64 -duration 1h -validate-data", 3600 + 600),
+    ("scylla-bench -partition-count=20000 -duration=250s", 250 + 600),
+    ("gemini -d --duration 10m --warmup 10s -c 5 -m write", 610 + 600)
+))
+def test_get_timeout_from_stress_cmd(stress_cmd, timeout):
+    assert get_timeout_from_stress_cmd(stress_cmd) == timeout


### PR DESCRIPTION
Sometimes we face freeze of c-s thread blocking the test flow.

This commit adds automatic timeout to stress threads (c-s, sb and gemini) when duration in stress cmd is specified.
Timeout is calculated as this:
warmup + duration + 600 (all in seconds).

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] ~~I added the relevant `backport` labels~~
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
