### PR TITLE
test(nemesis): added FreeTierSetMonkey

### DIFF
--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-multitenant.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-multitenant.yaml
@@ -24,7 +24,7 @@ n_monitor_nodes: 1
 n_loaders: 4
 k8s_n_loader_pods_per_cluster: 2
 
-nemesis_class_name: ['SisyphusMonkey', 'SisyphusMonkey']
+nemesis_class_name: ['FreeTierSetMonkey', 'FreeTierSetMonkey']
 nemesis_interval: [5, 6]
 nemesis_seed: ['385', '543']
 space_node_threshold: [64424, 64423]


### PR DESCRIPTION
For free tier cloud we want to limit disruptions to ones that may actually happen. So we want to skip disruptions for mgmt, topology changes (except ones that may happen due failures) or any other that are unlikely to happen on Scylla Cloud's free tier.

New Monkey `FreeTierSetMonkey` has been created which behaves similar to SisyphusMonkey but on limited set. Disruptions eliglible for free tier are marked with new flag `free_tier_set` in `Nemesis` class so when new nemesis are added it's easier to remember to update `FreeTierSetMonkey`.

refs: https://github.com/scylladb/qa-tasks/issues/910

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
