### PR TITLE
fix(install_bench_tool): Install git on db instances

### DIFF
--- a/sdcm/utils/benchmarks.py
+++ b/sdcm/utils/benchmarks.py
@@ -238,6 +238,7 @@ class ScyllaNodeBenchmarkRunner:
         return self._benchmark_results
 
     def install_benchmark_tools(self):
+        self._node.install_package("git")
         clone_repo(self._remoter, "https://github.com/akopytov/sysbench.git")
         # upstream repo: https://github.com/ibspoof/cassandra-fio
         clone_repo(self._remoter, "https://github.com/KnifeyMoloko/cassandra-fio.git")


### PR DESCRIPTION
Git command was removed from db instances. to run hw bench tools repos from git have to be cloned. Install git to db instance

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
