### PR TITLE
fix(perfsearch): new pipeline parameter cs commands

### DIFF
--- a/vars/perfSearchBestConfigParallelPipeline.groovy
+++ b/vars/perfSearchBestConfigParallelPipeline.groovy
@@ -76,7 +76,10 @@ def call(Map pipelineParams) {
 
             string(defaultValue: '', description: 'Relative difference between current and best to choose new best result', name: 'max_deviation')
 
-
+            string(defaultValue: '', description: 'Prepare Cassandra Stress command to run', name: 'prepare_write_cmd')
+            string(defaultValue: '', description: 'Write Cassandra Stress command to run', name: 'stress_cmd_w')
+            string(defaultValue: '', description: 'Read Cassandra Stress command to run', name: 'stress_cmd_r')
+            string(defaultValue: '', description: 'Mixed Cassandra Stress command to run', name: 'stress_cmd_m')
 
             string(defaultValue: "${pipelineParams.get('k8s_scylla_operator_helm_repo', 'https://storage.googleapis.com/scylla-operator-charts/latest')}",
                    description: 'Scylla Operator helm repo',
@@ -236,6 +239,21 @@ def call(Map pipelineParams) {
                                                         if [[ ! -z "${params.loader_ami_id}" ]] ; then
                                                             export SCT_AMI_ID_LOADER=${params.loader_ami_id}
                                                         fi
+
+
+                                                        if [[ ! -z "${params.prepare_write_cmd}" ]] ; then
+                                                            export SCT_PREPARE_WRITE_CMD="${params.prepare_write_cmd}"
+                                                        fi
+                                                        if [[ ! -z "${params.stress_cmd_w}" ]] ; then
+                                                            export SCT_STRESS_CMD_W="${params.stress_cmd_w}"
+                                                        fi
+                                                        if [[ ! -z "${params.stress_cmd_r}" ]] ; then
+                                                            export SCT_STRESS_CMD_R="${params.stress_cmd_r}"
+                                                        fi
+                                                        if [[ ! -z "${params.stress_cmd_m}" ]] ; then
+                                                            export SCT_STRESS_CMD_M="${params.stress_cmd_m}"
+                                                        fi
+
 
                                                         export SCT_AVAILABILITY_ZONE="${params.availability_zone}"
 


### PR DESCRIPTION
Added new pipeline paremter which set running cs commands


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
