### PR TITLE
fix(cassandra-stress): make sure docker image is pull upfront

### DIFF
--- a/sdcm/stress/base.py
+++ b/sdcm/stress/base.py
@@ -15,6 +15,7 @@ import logging
 import random
 import concurrent.futures
 from pathlib import Path
+from functools import cached_property
 
 from sdcm.cluster import BaseLoaderSet
 from sdcm.utils.common import generate_random_string
@@ -44,10 +45,13 @@ class DockerBasedStressThread:  # pylint: disable=too-many-instance-attributes
         self.shutdown_timeout = 180  # extra 3 minutes
         self.stop_test_on_failure = stop_test_on_failure
 
-        self.docker_image_name = self.params.get(self.DOCKER_IMAGE_PARAM_NAME)
         if "k8s" not in self.params.get("cluster_backend") and self.docker_image_name:
             for loader in self.loader_set.nodes:
                 RemoteDocker.pull_image(loader, self.docker_image_name)
+
+    @cached_property
+    def docker_image_name(self):
+        return self.params.get(self.DOCKER_IMAGE_PARAM_NAME)
 
     def configure_executer(self):
 

--- a/sdcm/utils/docker_remote.py
+++ b/sdcm/utils/docker_remote.py
@@ -15,7 +15,8 @@ class RemoteDocker(BaseNode):
         self.log = LOGGER
         ports = " ".join([f'-p {port}:{port}' for port in ports]) if ports else ""
         res = self.node.remoter.run(
-            f'{self.sudo_needed} docker run {extra_docker_opts} -d {ports} {image_name} {command_line}', verbose=True)
+            f'{self.sudo_needed} docker run {extra_docker_opts} -d {ports} {image_name} {command_line}',
+            verbose=True, retry=3)
         self.docker_id = res.stdout.strip()
         self.image_name = image_name
         super().__init__(name=image_name, parent_cluster=node.parent_cluster)
@@ -112,7 +113,7 @@ class RemoteDocker(BaseNode):
     def pull_image(node, image):
         prefix = "sudo" if node.is_docker else ""
         node.remoter.run(
-            f'{prefix} docker pull {image}', verbose=True)
+            f'{prefix} docker pull {image}', verbose=True, retry=3)
 
     def __enter__(self):
         return self


### PR DESCRIPTION
* align cassandra stress thread to pull the image before it's starts it's threads (same as all the other loaders)

* add retries for the image pulling, and the initial creation of the docker instance

if we don't have those, we could something see those failure when trying to pull images on creation, like this:
```
docker: Error response from daemon: Get "https://registry-1.docker.io/v2/":
net/http: request canceled while waiting for connection
(Client.Timeout exceeded while awaiting headers).
```

Fixes: #5464

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
