### PR TITLE
fix(disrupt_nodetool_enospc): re-enable enospc nemesis

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1529,9 +1529,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             assert '(1 rows)' in result.stdout, f'The key {key} is not loaded by `nodetool refresh`'
 
     def disrupt_nodetool_enospc(self, sleep_time=30, all_nodes=False):
-        raise UnsupportedNemesis('disabling ENOSPC nemesis until #11245 will be fixed')
-
-        # pylint: disable=unreachable
         if isinstance(self.cluster, LocalKindCluster):
             # Kind cluster has shared file system, it is shared not only among cluster nodes, but
             # also among kubernetes services which make kubernetes inoperational once enospc is reached.


### PR DESCRIPTION
Since Scylla issue #11245 is now considered as fixed, we would like to enable this nemesis so we can continue testing it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
