### PR TITLE
fix(docker artifacts): fix locale verification

### DIFF
--- a/artifacts_test.py
+++ b/artifacts_test.py
@@ -234,9 +234,9 @@ class ArtifactsTest(ClusterTester):  # pylint: disable=too-many-public-methods
     def verify_docker_locale_settings(self) -> None:
         run = self.node.remoter.run
         expected_locale_settings = {
-            "LC_ALL": "en_US.UTF-8",
-            "LANG": "en_US.UTF-8",
-            "LANGUAGE": "en_US:en",
+            "LC_ALL": ["en_US.UTF-8", "C.UTF-8"],
+            "LANG": ["en_US.UTF-8", "C.UTF-8"],
+            "LANGUAGE": ["en_US:en", ""],
         }
 
         locale_settings_raw = run("locale").stdout.split(sep="\n")
@@ -245,7 +245,7 @@ class ArtifactsTest(ClusterTester):  # pylint: disable=too-many-public-methods
 
         for setting_key, expected_value in expected_locale_settings.items():
             configured_value = locale_settings.get(setting_key)
-            self.assertEqual(configured_value, expected_value)
+            self.assertIn(configured_value, expected_value, f'value for key {setting_key} differs')
 
     def verify_docker_latest_match_release(self) -> None:
         for product in typing.get_args(ScyllaProduct):


### PR DESCRIPTION
introduced on commit scylladb/scylladb#12122,
we don't have `LANGUAGE`, and changed to the minimal Ubuntu image not having `en_US.UTF-8`.

Fixes: scylladb#5517
this is an alternative PR for #5518

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
