### PR TITLE
fix(performance): run perf test on Ubuntu22

### DIFF
--- a/test-cases/performance/perf-regression-latency-500gb-30min.yaml
+++ b/test-cases/performance/perf-regression-latency-500gb-30min.yaml
@@ -22,6 +22,8 @@ ami_id_db_scylla_desc: 'VERSION_DESC'
 backtrace_decoding: false
 print_kernel_callstack: true
 
+logs_transport: "ssh"
+
 round_robin: true
 append_scylla_args: '--blocked-reactor-notify-ms 5'
 


### PR DESCRIPTION
PR #5477 missed changing this job's configuration
to use SSH as `log_transport`.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
