### PR TITLE
Shell fixes

### DIFF
--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -12,7 +12,7 @@ SCT_DIR=$(dirname "${SCT_DIR}")
 VERSION=v$(cat "${DOCKER_ENV_DIR}/version")
 HOST_NAME=SCT-CONTAINER
 RUN_BY_USER=$(python3 "${SCT_DIR}/sdcm/utils/get_username.py")
-USER_ID=$(id -u "${USER}")
+USER_ID=$(id -u "${USER}"):$(id -g "${USER}")
 HOME_DIR=${HOME}
 
 CREATE_RUNNER_INSTANCE=""
@@ -355,7 +355,7 @@ if [[ -n "$RUNNER_IP" ]]; then
 
     SCT_DIR="/home/ubuntu/scylla-cluster-tests"
     HOST_NAME="ip-${RUNNER_IP//./-}"
-    USER_ID=1000
+    USER_ID=1000:1000
     RUNNER_CMD="ssh -o StrictHostKeyChecking=no ubuntu@${RUNNER_IP}"
     DOCKER_HOST="-H ssh://ubuntu@${RUNNER_IP}"
 fi

--- a/vars/cdcReplicationPipeline.groovy
+++ b/vars/cdcReplicationPipeline.groovy
@@ -7,8 +7,7 @@ def runSctTest(Map params, String region){
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)
     def cloud_provider = params.backend.trim().toLowerCase()
 
-    sh """
-    #!/bin/bash
+    sh """#!/bin/bash
     set -xe
     env
 

--- a/vars/cleanSctRunners.groovy
+++ b/vars/cleanSctRunners.groovy
@@ -6,8 +6,7 @@ def call(Map params, RunWrapper currentBuild){
     def cloud_provider = getCloudProviderFromBackend(params.backend)
     def test_status = currentBuild.currentResult
 
-    sh """
-    #!/bin/bash
+    sh """#!/bin/bash
 
     set -xe
     env

--- a/vars/copyLogsFromSctRunner.groovy
+++ b/vars/copyLogsFromSctRunner.groovy
@@ -3,9 +3,7 @@
 def call(String sct_latest_dir) {
     def sct_runner_ip =  sh(returnStdout: true, script:'cat sct_runner_ip||echo ""').trim()
 
-    sh """
-        #!/bin/bash
-
+    sh """#!/bin/bash
         set -xe
 
         eval \$(ssh-agent)

--- a/vars/createSctRunner.groovy
+++ b/vars/createSctRunner.groovy
@@ -25,8 +25,7 @@ def call(Map params, Integer test_duration, String region) {
     }
 
     println(params)
-    sh """
-    #!/bin/bash
+    sh """#!/bin/bash
     set -xe
     env
 

--- a/vars/createTestJobPipeline.groovy
+++ b/vars/createTestJobPipeline.groovy
@@ -63,8 +63,7 @@ def call() {
                                 script {
                                     wrap([$class: 'BuildUser']) {
                                         dir('scylla-cluster-tests') {
-                                            sh """
-                                                #!/bin/bash
+                                            sh """#!/bin/bash
                                                 set -xe
                                                 env
 

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -221,8 +221,7 @@ def call(Map pipelineParams) {
                                         def test_config = groovy.json.JsonOutput.toJson(params.test_config)
                                         def cloud_provider = params.backend.trim().toLowerCase()
 
-                                        sh """
-                                        #!/bin/bash
+                                        sh """#!/bin/bash
                                         set -xe
                                         env
                                         rm -fv ./latest

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -170,8 +170,7 @@ def call(Map pipelineParams) {
                                                     def test_config = groovy.json.JsonOutput.toJson(pipelineParams.test_config)
                                                     timeout(time: testRunTimeout, unit: 'MINUTES') { dir('scylla-cluster-tests') {
 
-                                                        sh """
-                                                        #!/bin/bash
+                                                        sh """#!/bin/bash
                                                         set -xe
                                                         env
 

--- a/vars/perfSearchBestConfigParallelPipeline.groovy
+++ b/vars/perfSearchBestConfigParallelPipeline.groovy
@@ -190,8 +190,7 @@ def call(Map pipelineParams) {
                                                     def test_config = groovy.json.JsonOutput.toJson(pipelineParams.test_config)
                                                     timeout(time: testRunTimeout, unit: 'MINUTES') { dir('scylla-cluster-tests') {
 
-                                                        sh """
-                                                        #!/bin/bash
+                                                        sh """#!/bin/bash
                                                         set -xe
                                                         env
 

--- a/vars/provisionResources.groovy
+++ b/vars/provisionResources.groovy
@@ -5,8 +5,7 @@ def call(Map params, String region){
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)
     def cloud_provider = getCloudProviderFromBackend(params.backend)
 
-    sh """
-    #!/bin/bash
+    sh """#!/bin/bash
 
     set -xe
     env

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -168,8 +168,7 @@ def call(Map pipelineParams) {
                                                         dir('scylla-cluster-tests') {
                                                             def test_config = groovy.json.JsonOutput.toJson(pipelineParams.test_config)
                                                             def cloud_provider = getCloudProviderFromBackend(params.backend)
-                                                            sh """
-                                                            #!/bin/bash
+                                                            sh """#!/bin/bash
                                                             set -xe
                                                             env
 

--- a/vars/runCleanupResource.groovy
+++ b/vars/runCleanupResource.groovy
@@ -9,8 +9,7 @@ def call(Map params, String region){
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)
     def cloud_provider = getCloudProviderFromBackend(params.backend)
 
-    sh """
-    #!/bin/bash
+    sh """#!/bin/bash
 
     set -xe
     env

--- a/vars/runCollectLogs.groovy
+++ b/vars/runCollectLogs.groovy
@@ -9,8 +9,7 @@ def call(Map params, String region){
     }
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)
     def cloud_provider = getCloudProviderFromBackend(params.backend)
-    sh """
-    #!/bin/bash
+    sh """#!/bin/bash
 
     set -xe
     env

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -17,8 +17,7 @@ def call(Map params, String region, functional_test = false, Map pipelineParams 
         test_cmd = "run-test"
     }
 
-    sh """
-    #!/bin/bash
+    sh """#!/bin/bash
     set -xe
     env
 

--- a/vars/runSendEmail.groovy
+++ b/vars/runSendEmail.groovy
@@ -15,8 +15,7 @@ def call(Map params, RunWrapper currentBuild){
     def email_recipients = groovy.json.JsonOutput.toJson(params.email_recipients)
     def cloud_provider = getCloudProviderFromBackend(params.backend)
 
-    sh """
-    #!/bin/bash
+    sh """#!/bin/bash
     set -xe
     env
     echo "Start send email ..."


### PR DESCRIPTION
Add group ID for Docker container user:

```shell
$ docker run --help
...
  -u, --user string                    Username or UID (format: <name|uid>[:<group|gid>])
...
```

This make it to set a proper group for files created by processes inside a container.

Also, to set the shell properly in sh step in Jenkinsfile, the shebang line must be exactly the first line of a script. Otherwise, system shell will be used (with -xe args.)

Despite we live with it from the very beginning it hits us sometimes.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
