### PR TITLE
improvement(nemesis.py): refactor nodetool_cleanup to run in parallel

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -34,7 +34,6 @@ from functools import wraps, partial
 
 from collections import defaultdict, Counter, namedtuple
 from concurrent.futures import ThreadPoolExecutor
-from concurrent.futures import wait as wait_for_futures
 from threading import Lock
 from types import MethodType  # pylint: disable=no-name-in-module
 
@@ -1841,19 +1840,15 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.target_node.run_nodetool('rebuild', retry=0)
 
     def disrupt_nodetool_cleanup(self):
-        # This fix important when just user profile is run in the test and "keyspace1" doesn't exist.
-        # test_keyspaces = self.cluster.get_test_keyspaces()
-
         # Inner disrupt function for ParallelObject
-        def _dis_nodetool_cleanup(node):
+        def _nodetool_cleanup(node):
             InfoEvent('NodetoolCleanupMonkey %s' % node).publish()
             with adaptive_timeout(Operations.CLEANUP, node, timeout=HOUR_IN_SEC * 48):
-                # for keyspace in test_keyspaces:
                 node.run_nodetool(sub_cmd="cleanup")
 
-        threads = ParallelObject(self.cluster.nodes, num_workers=min(32, len(self.cluster.nodes)))
-        thread_results = threads.run(_dis_nodetool_cleanup, unpack_objects=True)
-        wait_for_futures(thread_results)
+        parallel_objects = ParallelObject(self.cluster.nodes, num_workers=min(
+            32, len(self.cluster.nodes)), timeout=HOUR_IN_SEC * 48)
+        parallel_objects.run(_nodetool_cleanup)
 
     def _prepare_test_table(self, ks='keyspace1', table=None):
         ks_cfs = self.cluster.get_non_system_ks_cf_list(db_node=self.target_node)


### PR DESCRIPTION
Based on task: https://github.com/scylladb/qa-tasks/issues/884 Refactoring nodetool_cleanup to be called by threadPoolExecutor (parallel).

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
