### PR TITLE
fix(get_nodes_status): print more information about exception

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2646,11 +2646,11 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                         if node_ip:
                             LOGGER.error("Get nodes statuses. Failed to find a node in cluster by IP: %s", node_ip)
 
-        except Exception as exc:  # pylint: disable=broad-except
+        except Exception as error:  # pylint: disable=broad-except
             ClusterHealthValidatorEvent.NodeStatus(
                 severity=Severity.WARNING,
                 node=self.name,
-                message=f"Unable to get nodetool status from `{self.name}': {exc}",
+                message=f"Unable to get nodetool status from `{self.name}': {error=}",
             ).publish()
         return nodes_status
 


### PR DESCRIPTION
When the exception does not have `.args`, the statement `f"{exc}"` returns nothing, and the reason why `nodetool status` failed is not printed in the log.
Changed printing to display the exception class name together with the `.args`.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] ~~I added the relevant `backport` labels~~
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
