### PR TITLE
fix(scylla_start_server): move `verify_up_timeout` default into property

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2366,7 +2366,12 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
     def restart_service(self, service_name: str, timeout=500, ignore_status=False):
         self._service_cmd(service_name=service_name, cmd='restart', timeout=timeout, ignore_status=ignore_status)
 
-    def start_scylla_server(self, verify_up=True, verify_down=False, timeout=500, verify_up_timeout=300):
+    @property
+    def verify_up_timeout(self):
+        return 300
+
+    def start_scylla_server(self, verify_up=True, verify_down=False, timeout=500, verify_up_timeout=None):
+        verify_up_timeout = verify_up_timeout or self.verify_up_timeout
         if verify_down:
             self.wait_db_down(timeout=timeout)
         self.start_service(service_name='scylla-server', timeout=timeout)

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -115,7 +115,8 @@ class DockerNode(cluster.BaseNode, NodeContainerMixin):  # pylint: disable=abstr
         return self.remoter.sudo('sh -c "{0} || {0}.service"'.format(f"supervisorctl status {service_name}"),
                                  timeout=timeout, ignore_status=ignore_status)
 
-    def start_scylla_server(self, verify_up=True, verify_down=False, timeout=300, verify_up_timeout=300):
+    def start_scylla_server(self, verify_up=True, verify_down=False, timeout=300, verify_up_timeout=None):
+        verify_up_timeout = verify_up_timeout or self.verify_up_timeout
         if verify_down:
             self.wait_db_down(timeout=timeout)
         self.remoter.sudo('sh -c "{0} || {0}-server"'.format("supervisorctl start scylla"),


### PR DESCRIPTION
since there are cases they we in general need to have bigger timeouts for this call (i.e. when using EBS disks as one), we are moving this to a property that diffrent backends can apply logic before setting it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
