### PR TITLE
test(longevity): new test of MV synchronous updates

### DIFF
--- a/data_dir/mv_synchronous_updates.yaml
+++ b/data_dir/mv_synchronous_updates.yaml
@@ -1,0 +1,84 @@
+# LWT test: create and update data using LWT.
+### DML ###
+
+# Keyspace Name
+keyspace: mv_synchronous_ks
+
+# The CQL for creating a keyspace (optional if it already exists)
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS mv_synchronous_ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};
+
+# Table name
+table: mv_synchronous_cf
+
+# The CQL for creating a table you wish to stress (optional if it already exists)
+table_definition: |
+  CREATE TABLE IF NOT EXISTS mv_synchronous_cf (
+        domain int,
+        published_date int,
+        mv_pk int,
+        url text,
+        author text,
+        title text,
+        PRIMARY KEY(domain)
+  ) WITH comment='A table to hold blog posts'
+
+extra_definitions:
+  - create MATERIALIZED VIEW cf_update_2_columns_mv_pk as select mv_pk, author from mv_synchronous_cf where domain is not null and mv_pk > 1000000 and mv_pk <= 1150000 PRIMARY KEY(mv_pk, domain) WITH synchronous_updates = true;
+  - create MATERIALIZED VIEW cf_update_mv_pk as select * from mv_synchronous_cf where domain is not null and mv_pk > 1150000 and mv_pk < 300000000 PRIMARY KEY(mv_pk, domain) WITH synchronous_updates = true;
+  - create MATERIALIZED VIEW cf_update_asynch_test as select published_date, author from mv_synchronous_cf where domain is not null and published_date >= 10000000 and published_date < 19000000 PRIMARY KEY(published_date, domain);
+  - create MATERIALIZED VIEW cf_update_synch_test as select * from mv_synchronous_cf where domain is not null and published_date > 1000000 and published_date < 10000000 PRIMARY KEY(published_date, domain) WITH synchronous_updates = true;
+
+### Column Distribution Specifications ###
+
+columnspec:
+  - name: domain
+    population: seq(1..200000001)  #10M possible domains to pick from
+
+  - name: published_date
+    cluster: uniform(1..2000000)         #under each domain we will have max 1000 posts
+
+  - name: mv_pk
+    population: seq(1..2001000)
+
+  - name: url
+    size: uniform(30..30)
+
+  - name: title                  #titles shouldn't go beyond 200 chars
+    size: gaussian(10..20)
+
+  - name: author
+    size: uniform(5..20)         #author names should be short
+
+### Batch Ratio Distribution Specifications ###
+
+insert:
+  partitions: fixed(1)            # Our partition key is the domain so only insert one per batch
+
+  select:    fixed(1)/1000        # We have 1000 posts per domain so 1/1000 will allow 1 post per batch
+
+  batchtype: UNLOGGED             # Unlogged batches
+
+
+#
+# A list of queries you wish to run against the schema
+#
+queries:
+   select_base:
+      cql: select * from mv_synchronous_cf where domain = ? LIMIT 1
+      fields: samerow
+   select_mv:
+      cql: select * from cf_update_2_columns_mv_pk where domain = ? and mv_pk = ? LIMIT 1
+      fields: samerow
+   select_mv_2:
+      cql: select * from cf_update_mv_pk where domain = ? and mv_pk = ? LIMIT 1
+      fields: samerow
+   mv_pk_update_two_columns:
+      cql: update mv_synchronous_cf set mv_pk = ?, author = 'text' where domain = ?
+      fields: samerow
+   mv_pk_update_all_non_pk:
+      cql: update mv_synchronous_cf set author = ?, published_date = ?, url = ?, title = ?  where domain = ?
+      fields: samerow
+   mv_deletes:
+     cql: delete from mv_synchronous_cf where domain = ?
+     fields: samerow

--- a/data_dir/mv_synchronous_updates_lwt.yaml
+++ b/data_dir/mv_synchronous_updates_lwt.yaml
@@ -1,0 +1,82 @@
+# LWT test: create and update data using LWT.
+### DML ###
+
+# Keyspace Name
+keyspace: mv_synchronous_lwt_ks
+
+# The CQL for creating a keyspace (optional if it already exists)
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS mv_synchronous_lwt_ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};
+
+# Table name
+table: mv_synchronous_lwt_cf
+
+# The CQL for creating a table you wish to stress (optional if it already exists)
+table_definition: |
+  CREATE TABLE IF NOT EXISTS mv_synchronous_lwt_cf (
+        domain int,
+        published_date int,
+        mv_pk int,
+        url text,
+        author text,
+        title text,
+        PRIMARY KEY(domain, mv_pk)
+  ) WITH comment='A table to hold data for MV synchronous updates test'
+
+extra_definitions:
+  - create MATERIALIZED VIEW mv_synchronous_lwt_publish_date as select published_date, author from mv_synchronous_lwt_cf where domain is not null and mv_pk is not null and published_date > 0 and published_date > 150000 PRIMARY KEY(published_date, domain, mv_pk) WITH synchronous_updates = true;
+  - create MATERIALIZED VIEW mv_synchronous_lwt_publish_date_after_update as select published_date, author from mv_synchronous_lwt_cf where domain is not null and mv_pk is not null and published_date = 300000000 PRIMARY KEY(published_date, domain, mv_pk) WITH synchronous_updates = true;
+  - create MATERIALIZED VIEW mv_synchronous_lwt_manual_test as select * from mv_synchronous_lwt_cf where domain is not null and mv_pk is not null and published_date > 1000000 and published_date < 5000000 PRIMARY KEY(published_date, domain, mv_pk);
+  - create MATERIALIZED VIEW mv_synchronous_lwt_deletions as select * from mv_synchronous_lwt_cf where domain is not null and mv_pk is not null and published_date > 150000 and published_date < 240000 PRIMARY KEY(published_date, domain, mv_pk);
+
+
+### Column Distribution Specifications ###
+
+columnspec:
+  - name: domain
+    population: seq(1..200000001)  #10M possible domains to pick from
+
+  - name: published_date
+    cluster: uniform(1..2000000)         #under each domain we will have max 1000 posts
+
+  - name: mv_pk
+    population: seq(1..2001000)
+
+  - name: url
+    size: uniform(30..30)
+
+  - name: title                  #titles shouldn't go beyond 200 chars
+    size: gaussian(10..20)
+
+  - name: author
+    size: uniform(5..20)         #author names should be short
+
+### Batch Ratio Distribution Specifications ###
+
+insert:
+  partitions: fixed(1)            # Our partition key is the domain so only insert one per batch
+
+  select:    fixed(1)/1000        # We have 1000 posts per domain so 1/1000 will allow 1 post per batch
+
+  batchtype: UNLOGGED             # Unlogged batches
+
+
+#
+# A list of queries you wish to run against the schema
+#
+queries:
+   select_base:
+      cql: select * from mv_synchronous_lwt_cf where domain = ? and mv_pk = ? LIMIT 1
+      fields: samerow
+   select_mv:
+      cql: select * from mv_synchronous_lwt_publish_date where domain = ? and published_date = ? and mv_pk = ? LIMIT 1
+      fields: samerow
+   select_mv_2:
+      cql: select * from mv_synchronous_lwt_publish_date_after_update where domain = ? and published_date = ? and mv_pk = ? LIMIT 1
+      fields: samerow
+   lwt_update_one_column:
+      cql: update mv_synchronous_lwt_cf set published_date = 30000000 where domain = ? and mv_pk = ? if published_date > 0 and published_date <= 150000
+      fields: samerow
+   lwt_deletes:
+     cql: delete from mv_synchronous_lwt_cf where domain = ? and mv_pk = ? if published_date > 150000 and published_date < 240000
+     fields: samerow

--- a/data_dir/mv_synchronous_updates_on_standard.yaml
+++ b/data_dir/mv_synchronous_updates_on_standard.yaml
@@ -1,0 +1,22 @@
+# LWT test: create and update data using LWT.
+### DML ###
+
+# Keyspace Name
+keyspace: keyspace1
+
+# Table name
+table: standard1
+
+#
+# A list of queries you wish to run against the schema
+#
+queries:
+   select:
+      cql: select * from main_mv_standard1 where key = ? LIMIT 1
+      fields: samerow
+   mv_pk_update_pk:
+      cql: update standard1 set "C0" = ? where key = ?
+      fields: samerow
+   mv_pk_update_non_pk:
+      cql: update standard1 set "C1" = ? where key = ?
+      fields: samerow

--- a/jenkins-pipelines/mv_synchronous_updates.jenkinsfile
+++ b/jenkins-pipelines/mv_synchronous_updates.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_mv_synchronous_test.MvSynchronousLongevityTest.test_mv_synch_longevity',
+    test_config: 'test-cases/longevity/longevity-mv-synchronous.yaml'
+
+)

--- a/longevity_mv_synchronous_test.py
+++ b/longevity_mv_synchronous_test.py
@@ -1,0 +1,161 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2020 ScyllaDB
+
+# This is stress longevity test that runs light weight transactions in parallel with different node operations:
+# disruptive and not disruptive
+#
+# After the test is finished will be performed the data validation.
+
+from unittest.mock import MagicMock
+
+from longevity_test import LongevityTest
+from sdcm.sct_events import Severity
+from sdcm.sct_events.database import DatabaseLogEvent
+from sdcm.sct_events.filters import DbEventsFilter
+from sdcm.sct_events.health import DataValidatorEvent
+from sdcm.sct_events.system import InfoEvent
+from sdcm.utils.common import keyspace_min_max_tokens, get_view_name_from_user_profile, get_keyspace_from_user_profile
+from sdcm.utils.data_validator import LongevityDataValidator
+from sdcm.sct_events.group_common_events import ignore_mutation_write_errors
+
+
+class MvSynchronousLongevityTest(LongevityTest):
+    BASE_TABLE_PARTITION_KEYS = ['domain', 'mv_pk']
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.data_validator = None
+        self.synchronous_updates_keyspace = get_keyspace_from_user_profile(params=self.params,
+                                                                           stress_cmds_part="prepare_write_cmd",
+                                                                           search_for_user_profile="_synchronous_updates.")
+        self.synch_view_name = get_view_name_from_user_profile(params=self.params,
+                                                               stress_cmds_part="prepare_write_cmd",
+                                                               search_for_user_profile="_synchronous_updates.",
+                                                               view_name_substr="_synch_test")
+        self.asynch_view_name = get_view_name_from_user_profile(params=self.params,
+                                                                stress_cmds_part="prepare_write_cmd",
+                                                                search_for_user_profile="_synchronous_updates.",
+                                                                view_name_substr="_asynch_test")
+
+    def wait_for_views_build_for_synch_mode_test(self):
+        if not (self.synch_view_name and self.asynch_view_name):
+            InfoEvent(message="One or both 'synch_view_name' and 'asynch_view_name' is not found. "
+                              "Validation of 'synchronous_updates' mode is not performed")
+            return
+
+        with self.db_cluster.cql_connection_patient(self.db_cluster.nodes[0]) as session:
+            for view_name in [self.synch_view_name, self.asynch_view_name]:
+                self.log.debug("Start waiting for %s view", view_name)
+                self._wait_for_view(scylla_cluster=self.db_cluster,
+                                    session=session,
+                                    key_space=self.synchronous_updates_keyspace,
+                                    view=view_name,
+                                    wait_attempts=3600)
+                self.log.debug("Finish waiting for %s view", view_name)
+
+    def wait_for_views_build_before_test_start(self):
+        """
+        Part of the views has to be built before test start. So we need to wait for build is completed.
+        We do need to do it in the parallel as these views build is running in the parallel.
+        So actually we need to wait for the biggest view. It is views for testing of 'synchronous_updates' mode
+        """
+
+        # Wait for views for testing of 'synchronous_updates' mode
+        self.wait_for_views_build_for_synch_mode_test()
+
+        # Wait for view build for update and delete tests
+        views = [view[0] for view in self.data_validator.list_of_view_names_for_update_test()]
+        self.log.info("views: %s", views)
+        self.log.info("views plus: %s", views + [self.data_validator.view_name_for_deletion_data])
+        with self.db_cluster.cql_connection_patient(self.db_cluster.nodes[0]) as session:
+            for view_name in views + [self.data_validator.view_name_for_deletion_data]:
+                self.log.debug("Start waiting for %s view", view_name)
+                self._wait_for_view(scylla_cluster=self.db_cluster,
+                                    session=session,
+                                    key_space=self.data_validator.keyspace_name,
+                                    view=view_name,
+                                    wait_attempts=3600)
+                self.log.debug("Finish waiting for %s view", view_name)
+
+    def run_prepare_write_cmd(self):
+        with ignore_mutation_write_errors():
+            super().run_prepare_write_cmd()
+
+        # Stop nemesis. Prefer all nodes will be run before collect data for validation
+        # Increase timeout to wait for nemesis finish
+        if self.db_cluster.nemesis_threads:
+            self.db_cluster.stop_nemesis(timeout=300)
+
+        self.create_main_mv()
+
+        if self.db_cluster.nemesis_count > 1:
+            self.data_validator = MagicMock()
+            DataValidatorEvent.DataValidator(severity=Severity.WARNING,
+                                             message="Test runs with parallel nemesis. Data validator is disabled."
+                                             ).publish()
+        else:
+            self.data_validator = LongevityDataValidator(longevity_self_object=self,
+                                                         user_profile_name='lwt',
+                                                         base_table_partition_keys=self.BASE_TABLE_PARTITION_KEYS,
+                                                         stress_cmds_part="stress_read_cmd")
+
+        self.wait_for_views_build_before_test_start()
+
+        self.data_validator.copy_immutable_expected_data()
+        self.data_validator.copy_updated_expected_data()
+        self.data_validator.save_count_rows_for_deletion()
+
+        # Run nemesis during stress as it was stopped before copy expected data
+        if self.params.get('nemesis_during_prepare'):
+            self.db_cluster.start_nemesis()
+
+    def test_mv_synch_longevity(self):
+        with DbEventsFilter(db_event=DatabaseLogEvent.WARNING, line="perf_event_open"):
+            self.test_custom_time()
+
+            # Stop nemesis. Prefer all nodes will be run before collect data for validation
+            # Increase timeout to wait for nemesis finish
+            if self.db_cluster.nemesis_threads:
+                self.db_cluster.stop_nemesis(timeout=300)
+            self.validate_data()
+
+    def validate_data(self):
+        node = self.db_cluster.nodes[0]
+        with self.db_cluster.cql_connection_patient(node, keyspace=self.data_validator.keyspace_name) as session:
+            self.data_validator.validate_range_not_expected_to_change(session=session)
+            self.data_validator.validate_range_expected_to_change(session=session)
+            self.data_validator.validate_deleted_rows(session=session)
+
+    def create_main_mv(self):
+        """
+        Create materialized view for keyspace1.standard1 base table
+        """
+        with self.db_cluster.cql_connection_patient(self.db_cluster.nodes[0]) as session:
+            min_token, max_token = keyspace_min_max_tokens(node=self.db_cluster.nodes[0], keyspace="keyspace1")
+            self.log.debug("Partition ranges. Min: %s, max: %s", min_token, max_token)
+            if min_token is not None and max_token is not None:
+                token_range = max_token - min_token
+                # Create MV for part of the base table data
+                view_token_min = int(min_token + (token_range / 4))
+                view_token_max = int(max_token - (token_range / 4))
+                where = f"WHERE token(key) > {view_token_min} and token(key) < {view_token_max}"
+            else:
+                where = "WHERE key is not NULL"
+
+            main_mv_query = (f"CREATE MATERIALIZED VIEW keyspace1.main_mv_standard1 AS "
+                             f"SELECT * FROM keyspace1.standard1 "
+                             f"{where} PRIMARY KEY (key) WITH synchronous_updates = true")
+            self.log.debug("Create mv_standard1 materialized view with query: %s", main_mv_query)
+            session.execute(main_mv_query)
+
+            # We do not need to wait for view build here. Let it run as it

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -84,7 +84,7 @@ from sdcm.utils.common import (
     normalize_ipv6_url,
     download_dir_from_cloud,
     generate_random_string,
-    prepare_and_start_saslauthd_service,
+    prepare_and_start_saslauthd_service
 )
 from sdcm.utils.ci_tools import get_test_name
 from sdcm.utils.distro import Distro

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2234,7 +2234,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         self.log.debug('MV create statement: {}'.format(query))
         session.execute(query)
 
-    def _wait_for_view(self, scylla_cluster, session, key_space, view):
+    def _wait_for_view(self, scylla_cluster, session, key_space, view, wait_attempts=20):
         self.log.debug("Waiting for view {}.{} to finish building...".format(key_space, view))
 
         def _view_build_finished(live_nodes_amount):
@@ -2244,11 +2244,11 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self.log.debug('View build status result: {}'.format(result))
             return len([status for status in result if status[0] == 'SUCCESS']) >= live_nodes_amount
 
-        attempts = 20
+        attempts = wait_attempts
         nodes_status = scylla_cluster.get_nodetool_status()
         live_nodes_amount = 0
-        for dc in nodes_status.itervalues():
-            for ip in dc.itervalues():
+        for dc in nodes_status.values():
+            for ip in dc.values():
                 if ip['state'] == 'UN':
                     live_nodes_amount += 1
 

--- a/test-cases/longevity/longevity-mv-synchronous.yaml
+++ b/test-cases/longevity/longevity-mv-synchronous.yaml
@@ -1,0 +1,30 @@
+test_duration: 1500
+prepare_write_cmd: ["cassandra-stress write cl=QUORUM n=200200300  -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=1000 -col 'size=FIXED(1024) n=FIXED(5)' -pop seq=1..200200300 -log interval=15",
+                    "cassandra-stress user profile=/tmp/mv_synchronous_updates.yaml ops'(insert=25)' cl=QUORUM n=100000000 -mode cql3 native -rate threads=100",
+                    "cassandra-stress user profile=/tmp/mv_synchronous_updates_lwt.yaml ops'(insert=25)' cl=QUORUM n=10000000 -mode cql3 native -rate threads=100"
+                   ]
+stress_read_cmd: ["cassandra-stress mixed cl=QUORUM duration=1200m  -schema 'replication(factor=3) compaction(strategy=LeveledCompactionStrategy)' -mode cql3 native -rate threads=1000 -col 'size=FIXED(1024) n=FIXED(1)' -pop seq=1..200200300 -log interval=15",
+                  "cassandra-stress user profile=/tmp/mv_synchronous_updates.yaml ops'(select_base=3,select_mv=3,select_mv_2=3,mv_pk_update_two_columns=1)' cl=QUORUM duration=1200m -mode cql3 native -rate threads=50",
+                  "cassandra-stress user profile=/tmp/mv_synchronous_updates.yaml ops'(select_base=3,select_mv=3,select_mv_2=3,mv_deletes=1)' cl=QUORUM duration=1200m -mode cql3 native -rate threads=50",
+                  "cassandra-stress user profile=/tmp/mv_synchronous_updates.yaml ops'(select_base=3,select_mv=3,select_mv_2=3,mv_pk_update_all_non_pk=1)' cl=QUORUM duration=1200m -mode cql3 native -rate threads=50",
+                  "cassandra-stress user profile=/tmp/mv_synchronous_updates_lwt.yaml ops'(lwt_deletes=10)' cl=SERIAL duration=1200m -mode cql3 native -rate threads=50",
+                  "cassandra-stress user profile=/tmp/mv_synchronous_updates_lwt.yaml ops'(lwt_update_one_column=10)' cl=SERIAL duration=1200m -mode cql3 native -rate threads=50",
+                  "cassandra-stress user profile=/tmp/mv_synchronous_updates_on_standard.yaml ops'(select=6, mv_pk_update_pk=2, mv_pk_update_non_pk=2)' cl=QUORUM  duration=1200m -pop seq=0..200200300 -mode cql3 native -rate threads=50",
+                  "cassandra-stress user profile=/tmp/mv_synchronous_updates_on_standard.yaml ops'(select=6, mv_pk_update_pk=2, mv_pk_update_non_pk=2)' cl=QUORUM  duration=1200m -pop seq=0..200200300 -mode cql3 native -rate threads=50",
+                 ]
+run_fullscan: '{"ks_cf": "random", "interval": 15}' # 'ks.cf|random, interval(min)'
+
+n_db_nodes: 5
+n_loaders: 2
+n_monitor_nodes: 1
+round_robin: true
+
+instance_type_db: 'i3.4xlarge'
+
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_seed: '023'
+nemesis_interval: 5
+
+user_prefix: 'longevity-mv-synch'
+
+space_node_threshold: 644245

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -35,6 +35,7 @@ from sdcm.sct_events.database import SYSTEM_ERROR_EVENTS_PATTERNS
 from sdcm.sct_events.group_common_events import ignore_upgrade_schema_errors
 from sdcm.sct_events.filters import DbEventsFilter
 from sdcm.sct_events.system import InstanceStatusEvent
+from sdcm.utils.common import get_keyspace_partition_ranges, keyspace_min_max_tokens
 from sdcm.utils.distro import Distro
 
 from unit_tests.dummy_remote import DummyRemote
@@ -436,6 +437,32 @@ class DummyScyllaCluster(BaseScyllaCluster, BaseCluster):  # pylint: disable=abs
     def __init__(self, params):  # pylint: disable=super-init-not-called
         self.nodes = params
         self.name = 'dummy_cluster'
+
+
+class TestNodetool(unittest.TestCase):
+    def test_describering_parsing(self):  # pylint: disable=no-self-use
+        """ Test "nodetool describering" output parsing """
+        resp = "\n".join(["Schema Version:00703362-03ed-3b41-afcb-ed34c1d1586c TokenRange:",
+                          "TokenRange(start_token:-9193109213506951143, end_token:9202125676696964746, "
+                          "endpoints:[127.0.49.3], rpc_endpoints:[127.0.49.3], "
+                          "endpoint_details:[EndpointDetails(host:127.0.49.3, datacenter:datacenter1, rack:rack1)])",
+                          "TokenRange(start_token:9154793403047166459, end_token:9156354786201613199, "
+                          "endpoints:[127.0.49.3], rpc_endpoints:[127.0.49.3], "
+                          "endpoint_details:[EndpointDetails(host:127.0.49.3, datacenter:datacenter1, rack:rack1)])",
+                          ]
+                         )
+        node = NodetoolDummyNode(resp=resp)
+        ranges = get_keyspace_partition_ranges(node=node, keyspace="")
+        assert ranges == [{'start_token': -9193109213506951143,
+                           'details': [{'host': '127.0.49.3', 'datacenter': 'datacenter1', 'rack': 'rack1'}],
+                           'end_token': 9202125676696964746, 'endpoints': '127.0.49.3', 'rpc_endpoints': '127.0.49.3'},
+                          {'start_token': 9154793403047166459,
+                           'details': [{'host': '127.0.49.3', 'datacenter': 'datacenter1', 'rack': 'rack1'}],
+                           'end_token': 9156354786201613199, 'endpoints': '127.0.49.3', 'rpc_endpoints': '127.0.49.3'}]
+
+        min_token, max_token = keyspace_min_max_tokens(node=node, keyspace="")
+        assert min_token == -9193109213506951143
+        assert max_token == 9202125676696964746
 
 
 class TestNodetoolStatus(unittest.TestCase):


### PR DESCRIPTION
Add new longevity test of MV synchronous updates feature

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
