### PR TITLE
fix(distro): added linux Mint distro support

### DIFF
--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -94,7 +94,7 @@ class MinimalK8SNodePool(CloudK8sNodePool):
 class MinimalK8SOps:
     @classmethod
     def setup_prerequisites(cls, node: cluster.BaseNode) -> None:
-        if node.distro.is_ubuntu or node.distro.is_debian:
+        if node.distro.is_debian_like:
             cls.setup_prerequisites_ubuntu(node)
         else:
             raise ValueError(f"{node.distro} is not supported")

--- a/sdcm/mgmt/common.py
+++ b/sdcm/mgmt/common.py
@@ -28,6 +28,7 @@ def get_distro_name(distro_object):
         Distro.FEDORA34: "centos8",
         Distro.FEDORA35: "centos8",
         Distro.FEDORA36: "centos8",
+        Distro.MINT20: "mint20",
     }
     distro_name = known_distro_dict.get(distro_object, None)
     assert distro_name, f"Unfamiliar distribution: {distro_object}"

--- a/sdcm/utils/distro.py
+++ b/sdcm/utils/distro.py
@@ -41,6 +41,8 @@ KNOWN_OS = (
     ("UBUNTU", "ubuntu", ["14.04", "16.04", "18.04", "20.04", "21.04", "21.10", "22.04"], DistroBase.DEBIAN),
     ("SLES", "sles", ["15"], DistroBase.UNKNOWN),
     ("FEDORA", "fedora", ["34", "35", "36"], DistroBase.RHEL),
+    ("MINT", "linuxmint", ["20"], DistroBase.DEBIAN),
+
 )
 
 


### PR DESCRIPTION
On workstations where linux Mint is installed it's not possible to run tests locally due unsupported distro.

Added linux Mint to supported versions.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
