### PR TITLE
feature(decommission): add timeout to cluster.decommission

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -92,6 +92,7 @@ ScyllaOperatorLogEvent.WRONG_SCHEDULED_PODS: WARNING
 StartupTestEvent: NORMAL
 TestTimeoutEvent: CRITICAL
 TestFrameworkEvent: CRITICAL
+SoftTimeoutEvent: ERROR
 ElasticsearchEvent: ERROR
 SpotTerminationEvent: CRITICAL
 ScyllaRepoEvent: WARNING

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2610,7 +2610,7 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
             self.nodes.remove(node)
         node.destroy()
 
-    def decommission(self, node):
+    def decommission(self, node: BaseScyllaPodContainer, timeout: int | float = None, soft_timeout: int | float = None):
         rack = node.rack
         rack_nodes = self.get_rack_nodes(rack)
         assert rack_nodes[-1] == node, "Can withdraw the last node only"
@@ -2621,10 +2621,13 @@ class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disabl
         # node deletion using "terminate_node" command.
         scylla_shards = node.scylla_shards
 
+        # NOTE: on k8s we treat soft_timeout as the "hard" timeout,
+        # at least until we'll have case with bigger data sets in it
+        timeout = timeout or soft_timeout or (node.pod_terminate_timeout * 60)
         self.replace_scylla_cluster_value(f"/spec/datacenter/racks/{rack}/members", current_members - 1)
-        self.k8s_cluster.kubectl(f"wait --timeout={node.pod_terminate_timeout}m --for=delete pod {node.name}",
+        self.k8s_cluster.kubectl(f"wait --timeout={timeout}s --for=delete pod {node.name}",
                                  namespace=self.namespace,
-                                 timeout=node.pod_terminate_timeout * 60 + 10)
+                                 timeout=timeout + 10)
         self.terminate_node(node, scylla_shards=scylla_shards)
         if current_members == 1:
             self._delete_k8s_rack(rack)

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -50,6 +50,7 @@ from sdcm.cluster import (
     DB_LOG_PATTERN_RESHARDING_START,
     DB_LOG_PATTERN_RESHARDING_FINISH,
     MAX_TIME_WAIT_FOR_NEW_NODE_UP,
+    MAX_TIME_WAIT_FOR_DECOMMISSION,
     NodeSetupFailed,
     NodeSetupTimeout,
     NodeStayInClusterAfterDecommission,
@@ -1154,7 +1155,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if self._is_it_on_kubernetes() and disruption_name is None:
             self.set_target_node(allow_only_last_node_in_rack=True)
         target_is_seed = self.target_node.is_seed
-        self.cluster.decommission(self.target_node)
+        self.cluster.decommission(self.target_node, soft_timeout=MAX_TIME_WAIT_FOR_DECOMMISSION)
         new_node = None
         if add_node:
             # When adding node after decommission the node is declared as up only after it completed bootstrapping,
@@ -1369,7 +1370,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         node_terminate_method = getattr(node, node_terminate_method_name)
         node_terminate_method()
         self.log.info('Decommission %s', node)
-        self.cluster.decommission(node)
+        self.cluster.decommission(node, soft_timeout=MAX_TIME_WAIT_FOR_DECOMMISSION)
         new_node = self.add_new_node(rack=node.rack)
         self.unset_current_running_nemesis(new_node)
 
@@ -3394,7 +3395,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     @latency_calculator_decorator(legend="Decommission node: remove node from cluster")
     def decommission_node(self, node):
-        self.cluster.decommission(node)
+        self.cluster.decommission(node, soft_timeout=MAX_TIME_WAIT_FOR_DECOMMISSION)
 
     def decommission_nodes(self, add_nodes_number, rack, is_seed: Optional[Union[bool, DefaultValue]] = DefaultValue,
                            dc_idx: Optional[int] = None):
@@ -3746,7 +3747,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                     cluster_node.run_nodetool(sub_cmd="repair -pr", publish_event=True)
                 datacenters = list(self.tester.db_cluster.get_nodetool_status().keys())
                 self._write_read_data_to_multi_dc_keyspace(datacenters)
-            self.cluster.decommission(new_node)
+            self.cluster.decommission(new_node, soft_timeout=MAX_TIME_WAIT_FOR_DECOMMISSION)
             node_added = False
             datacenters = list(self.tester.db_cluster.get_nodetool_status().keys())
             assert not [dc for dc in datacenters if dc.endswith("_nemesis_dc")], "new datacenter was not unregistered"
@@ -3755,7 +3756,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             with self.cluster.cql_connection_patient(node) as session:
                 session.execute('DROP KEYSPACE IF EXISTS keyspace_new_dc')
             if node_added:
-                self.cluster.decommission(new_node)
+                self.cluster.decommission(new_node, soft_timeout=MAX_TIME_WAIT_FOR_DECOMMISSION)
 
 
 def disrupt_method_wrapper(method, is_exclusive=False):  # pylint: disable=too-many-statements


### PR DESCRIPTION
since in some cases decomission might take as long as adding
a new node to cluster (big data set / slow disks)

until now we didn't timeout on VMs, and had a 30min timeout on k8s
this should align both to wait the same time

for VMs we are going to set it soft_timeout, i.e. we would
only raise error event if it took longer then expected, and
would put a hard timeout.

For k8s we will use the soft_timeout as hard timeout, since
we are not directly calling `nodetool decommission` by
just waiting for that operation by polling.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
