### PR TITLE
fix(nemesis.py): fail nemesis if non-empty table not found

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -984,13 +984,20 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 'Non-system keyspace and table are not found. CorruptThenRepair nemesis can\'t be run')
 
         tables = []
+        errors = []
         with self.cluster.cql_connection_patient(self.target_node) as session:
             for table in ks_cfs:
-                has_data = self.cluster.is_table_has_data(session=session, table_name=table)
+                has_data, error = self.cluster.is_table_has_data(session=session, table_name=table)
                 if has_data:
                     tables.append(table)
+                if error:
+                    errors.append(error)
                 if len(tables) > 20:
                     break
+
+        if not tables and errors:
+            raise ValueError(
+                f'A non-empty user table is not found. Nemesis can\'t run. Got errors of: {errors}')
 
         # Stop scylla service before deleting sstables to avoid partial deletion of files that are under compaction
         self.target_node.stop_scylla_server(verify_up=False, verify_down=True)


### PR DESCRIPTION
  fix(nemesis.py): fail nemesis if non-empty table not found
  
          If failed to find non-empty user tables, cannot run any
          data deletion operation and should fail nemesis due to table query issues.
          Fixes: #5538

https://github.com/scylladb/scylla-cluster-tests/issues/5538

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
