### PR TITLE
fix(events): subcontext is not initialized

### DIFF
--- a/sdcm/sct_events/base.py
+++ b/sdcm/sct_events/base.py
@@ -220,6 +220,12 @@ class SctEvent:
         if self.severity.value < 3:
             return
 
+        # Issue https://github.com/scylladb/scylla-cluster-tests/issues/5544
+        # Print out event content for understanding which event does not initialize self.subcontext
+        if self.subcontext is None:
+            self.subcontext = []
+            LOGGER.error("'self.subcontext' was not initialized. Event: %s", self)
+
         # Add nemesis info if event happened during nemesis
         if self.base != "DisruptionEvent":
             running_disruption_events = ContinuousEventsRegistry().find_running_disruption_events()


### PR DESCRIPTION
Issue https://github.com/scylladb/scylla-cluster-tests/issues/5544 
Add print out for recognize which event is not initialized. 
Prevent event failure

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
