### PR TITLE
feature(raft jobs): Add raft pipelines to list of groups created

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1315,6 +1315,7 @@ def create_test_release_jobs(branch, username, password, sct_branch, sct_repo):
         ('repair-based-operation', "SCT RBO Tests"),
         ('scale', 'SCT Scale Tests'),
         ('operator', 'SCT Operator Tests'),
+        ('raft', 'SCT Raft Experimental'),
     ]:
         server.create_directory(name=group_name, display_name=group_desc)
 
@@ -1328,6 +1329,9 @@ def create_test_release_jobs(branch, username, password, sct_branch, sct_repo):
                 server.create_pipeline_job(jenkins_file, group_name)
         if group_name == 'operator':
             for jenkins_file in glob.glob(f'{base_path}/operator/functional/*aws*.jenkinsfile'):
+                server.create_pipeline_job(jenkins_file, group_name)
+        if group_name == 'raft':
+            for jenkins_file in glob.glob(f'{base_path}/raft/*'):
                 server.create_pipeline_job(jenkins_file, group_name)
 
     server.create_directory(


### PR DESCRIPTION
Adding raft pipelines folder to the list of groups created automatically in Jenkins.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
