### PR TITLE
fix(k8s-dynamic-loader): stop assuming src/dest filename is identical

### DIFF
--- a/sdcm/remote/kubernetes_cmd_runner.py
+++ b/sdcm/remote/kubernetes_cmd_runner.py
@@ -588,7 +588,7 @@ class KubernetesPodRunner(KubernetesCmdRunner):
 
             # Create configMap from the 'src' file
             self.kluster.kubectl(
-                f"create configmap {cm_name} --from-file={src}",
+                f"create configmap {cm_name} --from-file={filename}={src}",
                 namespace=self.namespace)
 
             # Create modifier function for the pod template


### PR DESCRIPTION
in cases like:
```
  cmd_runner.send_files('/somedir/fileA.xml', '/tmp/fileB.xml')
```

would be failing the mount, since we configmap was create with `fileA.xml` as key, and the mount would look for `fileB.xml` as the key in the configmap

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
