### PR TITLE
fix(events-subcontext): subcontext was missing when log events cloned

### DIFF
--- a/sdcm/sct_events/base.py
+++ b/sdcm/sct_events/base.py
@@ -302,6 +302,8 @@ class SctEvent:
         if subcontext := getattr(self, "subcontext"):
             attrs["subcontext"] = [self.attribute_with_value_for_json(attributes_list=event.subcontext_fields,
                                                                       event=event) for event in subcontext]
+        else:
+            attrs["subcontext"] = []
         return attrs
 
     def __str__(self):

--- a/unit_tests/test_sct_events_base.py
+++ b/unit_tests/test_sct_events_base.py
@@ -156,7 +156,8 @@ class TestSctEvent(SctEventTestCase):
             y.to_json(),
             f'{{"base": "Y", "type": null, "subtype": null, "event_timestamp": {y.event_timestamp}, '
             f'"source_timestamp": null, '
-            f'"severity": "UNKNOWN", "event_id": "fa4a84a2-968b-474c-b188-b3bac4be8527", "log_level": 30}}'
+            f'"severity": "UNKNOWN", "event_id": "fa4a84a2-968b-474c-b188-b3bac4be8527", "log_level": 30, '
+            f'"subcontext": []}}'
         )
 
     def test_publish(self):

--- a/unit_tests/test_sct_events_continuous_events_registry.py
+++ b/unit_tests/test_sct_events_continuous_events_registry.py
@@ -9,7 +9,7 @@ import pytest
 from sdcm.sct_events import Severity
 from sdcm.sct_events.continuous_event import ContinuousEventsRegistry, ContinuousEventRegistryException
 from sdcm.sct_events.database import get_pattern_to_event_to_func_mapping, CompactionEvent, \
-    IndexSpecialColumnErrorEvent, ScyllaServerStatusEvent
+    IndexSpecialColumnErrorEvent, ScyllaServerStatusEvent, DatabaseLogEvent
 from sdcm.sct_events.loaders import GeminiStressEvent
 from sdcm.sct_events.nemesis import DisruptionEvent
 from sdcm.sct_events.nodetool import NodetoolEvent
@@ -103,6 +103,29 @@ class TestContinuousEventsRegistry:
 
         assert event.msgfmt == ('({0.base} {0.severity}) period_type={0.period_type} event_id={0.event_id} '
                                 'during_nemesis=test0,test1: message={0.message}')
+
+        # Validate that the event subcontext is serialized
+        assert event.to_json()
+
+    def test_add_nemesis_sub_context_to_db_log_event(self):
+        event = DatabaseLogEvent.ABORTING_ON_SHARD()
+        # event not during nemesis
+        assert event.subcontext == []
+
+        # cloned events should have empty subcontext as well
+        cloned_event = event.clone()
+        assert cloned_event.subcontext == []
+
+        number_of_insertions = 2
+        for i in range(number_of_insertions):
+            DisruptionEvent(node=uuid.uuid1(), nemesis_name=f"test{i}", publish_event=False).begin_event()
+            GeminiStressEvent(node=uuid.uuid1(), cmd="gemini hello", publish_event=False).begin_event()
+
+        event = DatabaseLogEvent.ABORTING_ON_SHARD().clone()
+        event.add_info(node="n1", line="kernel: Linux version", line_number=0)
+        assert event.msgfmt == ('({0.base} {0.severity}) period_type={0.period_type} event_id={0.event_id} '
+                                'during_nemesis=test0,test1: type={0.type} regex={0.regex} '
+                                'line_number={0.line_number} node={0.node}\n{0.line}')
 
         # Validate that the event subcontext is serialized
         assert event.to_json()


### PR DESCRIPTION
since the `clone` uses pickle that uses the object `__getstate__` we missed adding the subcontext there if empty, and object would be created with it set to None.


Fixes: #5544 

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
