### PR TITLE
fix(cluster.py): use networkctl to start an interface if possible

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -746,6 +746,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
     def start_network_interface(self, interface_name="eth1"):
         if self.is_rhel_like():
             startup_interface_command = "/sbin/ifup {}"
+        elif self.distro.uses_systemd and \
+                self.remoter.run("systemctl is-active --quiet systemd-networkd.service", ignore_status=True).ok:
+            startup_interface_command = "networkctl reconfigure {}"
         else:
             startup_interface_command = "ip link set {} up"
         self.remoter.sudo(startup_interface_command.format(interface_name))


### PR DESCRIPTION
On systems which use systemd-networkd to manage networking interfaces use the provided tool to start an interface, e.g.:

   $ networkctl reconfigure eth1

This will fix the problem with stop/start interface network monkey.

Fixes: https://github.com/scylladb/scylladb/issues/11609

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
