### PR TITLE
fix(manager-test): fix azure resources creation az

### DIFF
--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -254,7 +254,9 @@ def call(Map pipelineParams) {
                                             echo "need to choose one of SCT_AMI_ID_DB_SCYLLA | SCT_GCE_IMAGE_DB | SCT_SCYLLA_VERSION | SCT_SCYLLA_REPO | SCT_AZURE_IMAGE_DB"
                                             exit 1
                                         fi
-
+                                        if [[ -n "${params.availability_zone ? params.availability_zone : ''}" ]] ; then
+                                            export SCT_AVAILABILITY_ZONE="${params.availability_zone}"
+                                        fi
                                         export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"
                                         export SCT_POST_BEHAVIOR_LOADER_NODES="${params.post_behavior_loader_nodes}"
                                         export SCT_POST_BEHAVIOR_MONITOR_NODES="${params.post_behavior_monitor_nodes}"


### PR DESCRIPTION
Manager pipeline didn't create VM's in proper resource group due missing setting availability_zone variable properly (according to the pipeline settings). Failing that made SCT runner to not be able connect using SSH as created resources belonged to different network causing SSH timeout errors.

This fix makes `availability_zone` to be respected in SCT manager test, fixing proper Azure resources creation location (RG).

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
