### PR TITLE
fix(select queries): use paged queries

### DIFF
--- a/add_new_dc_test.py
+++ b/add_new_dc_test.py
@@ -104,6 +104,7 @@ class TestAddNewDc(LongevityTest):
         self.log.info("Verifying if querying new node with RF=0 returns no data and does not crash the node. #8354")
         with self.db_cluster.cql_connection_exclusive(new_node) as session:
             statement = SimpleStatement(
-                "select * from keyspace1.standard1 limit 1;", consistency_level=ConsistencyLevel.LOCAL_QUORUM)
+                "select * from keyspace1.standard1 limit 1;", consistency_level=ConsistencyLevel.LOCAL_QUORUM,
+                fetch_size=10)
             data = session.execute(statement).one()
             assert not data, f"no data should be returned when querying with CL=LOCAL_QUORUM and RF=0. {data}"

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -36,6 +36,7 @@ from threading import Lock
 from types import MethodType  # pylint: disable=no-name-in-module
 
 from cassandra import ConsistencyLevel
+from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
 from invoke import UnexpectedExit
 from elasticsearch.exceptions import ConnectionTimeout as ElasticSearchConnectionTimeout
 from argus.db.db_types import NemesisStatus, NemesisRunInfo, NodeDescription
@@ -1967,7 +1968,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 # Get the max cl value in the partition.
                 cmd = f"select ck from {ks_cf} where pk={partition_key} order by ck desc limit 1"
                 try:
-                    result = session.execute(cmd, timeout=300)
+                    result = session.execute(SimpleStatement(cmd, fetch_size=1), timeout=300)
                 except Exception as exc:  # pylint: disable=broad-except
                     self.log.error(str(exc))
                     continue


### PR DESCRIPTION
	In certain cases a non-paged query can fail when not paged.
	Like where too many tombstones or large rows exist.
	Using a paged-query will eliminate such failures and runs faster.
	Refs: https://github.com/scylladb/scylladb/issues/12268

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
