### PR TITLE
fix(logcollector): change order of collection

### DIFF
--- a/sdcm/logcollector.py
+++ b/sdcm/logcollector.py
@@ -1254,18 +1254,22 @@ class Collector:  # pylint: disable=too-many-instance-attributes,
         self.sct_set = []
         self.pt_report_set = []
         self.cluster_log_collectors = {
-            SSTablesCollector: self.db_cluster,
             ScyllaLogCollector: self.db_cluster,
-            MonitorLogCollector: self.monitor_set,
-            SirenManagerLogCollector: self.siren_manager_set,
-            LoaderLogCollector: self.loader_set,
             SCTLogCollector: self.sct_set,
-            JepsenLogCollector: self.loader_set,
-            ParallelTimelinesReportCollector: self.pt_report_set
+            MonitorLogCollector: self.monitor_set,
+            LoaderLogCollector: self.loader_set,
         }
         if self.backend.startswith("k8s"):
-            self.cluster_log_collectors[KubernetesLogCollector] = self.kubernetes_set
-            self.cluster_log_collectors[KubernetesAPIServerLogCollector] = self.kubernetes_set
+            self.cluster_log_collectors |= {
+                KubernetesLogCollector: self.kubernetes_set,
+                KubernetesAPIServerLogCollector: self.kubernetes_set,
+            }
+        self.cluster_log_collectors |= {
+            SirenManagerLogCollector: self.siren_manager_set,
+            SSTablesCollector: self.db_cluster,
+            JepsenLogCollector: self.loader_set,
+            ParallelTimelinesReportCollector: self.pt_report_set,
+        }
 
     @property
     def test_id(self):


### PR DESCRIPTION
since getting sct.log is more importent then
trying to collect melformed sstables, we should
first start with the must have collector, and then move to the less frequent used.

since in some cases we've seen the collection of sstables were stack, probably since it trying to read all of the events and it was a 3day job with lots of events.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
