### PR TITLE
feature(cassandra-stress): add option for enabling debug

### DIFF
--- a/data_dir/logback-tools-debug.xml
+++ b/data_dir/logback-tools-debug.xml
@@ -1,0 +1,34 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+
+<configuration>
+  <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+    <target>System.err</target>
+    <encoder>
+      <pattern>%-5level %date{"HH:mm:ss,SSS"} %msg%n</pattern>
+    </encoder>
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>DEBUG</level>
+    </filter>
+  </appender>
+
+  <root level="DEBUG">
+    <appender-ref ref="STDERR" />
+  </root>
+</configuration>

--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -245,6 +245,7 @@
 | **<a href="#user-content-stress_cmd_no_mv_profile" name="stress_cmd_no_mv_profile">stress_cmd_no_mv_profile</a>**  |  | N/A | SCT_STRESS_CMD_NO_MV_PROFILE
 | **<a href="#user-content-cs_user_profiles" name="cs_user_profiles">cs_user_profiles</a>**  |  | N/A | SCT_CS_USER_PROFILES
 | **<a href="#user-content-cs_duration" name="cs_duration">cs_duration</a>**  |  | 50m | SCT_CS_DURATION
+| **<a href="#user-content-cs_debug" name="cs_debug">cs_debug</a>**  | enable debug for cassandra-stress | N/A | SCT_CS_DEBUG
 | **<a href="#user-content-stress_cmd_mv" name="stress_cmd_mv">stress_cmd_mv</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_STRESS_CMD_MV
 | **<a href="#user-content-prepare_stress_cmd" name="prepare_stress_cmd">prepare_stress_cmd</a>**  | cassandra-stress commands.<br>You can specify everything but the -node parameter, which is going to<br>be provided by the test suite infrastructure.<br>multiple commands can passed as a list | N/A | SCT_PREPARE_STRESS_CMD
 | **<a href="#user-content-skip_download" name="skip_download">skip_download</a>**  |  | N/A | SCT_SKIP_DOWNLOAD

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1050,6 +1050,8 @@ class SCTConfiguration(dict):
              help=""),
         dict(name="cs_duration", env="SCT_CS_DURATION", type=str,
              help=""),
+        dict(name="cs_debug", env="SCT_CS_DEBUG", type=boolean,
+             help="enable debug for cassandra-stress"),
 
         dict(name="stress_cmd_mv", env="SCT_STRESS_CMD_MV", type=str_or_list,
              help="""cassandra-stress commands.

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -188,7 +188,9 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
                                                                           f' --entrypoint /bin/bash')
 
         stress_cmd = self.create_stress_cmd(cmd_runner, keyspace_idx)
-
+        if self.params.get('cs_debug'):
+            cmd_runner.send_files(get_data_dir_path('logback-tools-debug.xml'),
+                                  '/etc/scylla/cassandra/logback-tools.xml', delete_dst=True)
         if self.profile:
             with open(self.profile, encoding="utf-8") as profile_file:
                 LOGGER.info('Profile content:\n%s', profile_file.read())

--- a/unit_tests/test_cassandra_stress_thread.py
+++ b/unit_tests/test_cassandra_stress_thread.py
@@ -22,6 +22,8 @@ pytestmark = [
 
 
 def test_01_cassandra_stress(request, docker_scylla, params):
+    params['cs_debug'] = True
+
     loader_set = LocalLoaderSetDummy()
 
     cmd = (


### PR DESCRIPTION
add `cs_debug` option to SCT, to enable c-s debug when needed

Note: keep in mind, add it can hurt performence of some use-cases
      and running out of sct-runer disk space for some use-cases

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
