### PR TITLE
fix(longevity): descrease stress duration in longevity-lwt-500G-3d-test

### DIFF
--- a/test-cases/longevity/longevity-lwt-500G-3d.yaml
+++ b/test-cases/longevity/longevity-lwt-500G-3d.yaml
@@ -6,13 +6,13 @@ prepare_write_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml n=
                     "cassandra-stress user profile=/tmp/lwt_builtin_functions.yaml n=33333333 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=50 -pop seq=33333334..66666666",
                     "cassandra-stress user profile=/tmp/lwt_builtin_functions.yaml n=33333333 ops'(insert_query=1)' cl=QUORUM -mode native cql3 -rate threads=50 -pop seq=66666667..100000000",
                    ]
-stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1,lwt_deletes=1)' cl=QUORUM duration=3600m -mode native cql3 -rate threads=10" ,
-             "cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1,lwt_deletes=1)' cl=QUORUM duration=3600m -mode native cql3 -rate threads=10",
-             "cassandra-stress user profile=/tmp/lwt_builtin_functions.yaml ops'(lwt_update_by_pk=1,lwt_update_by_ck=1)' cl=QUORUM duration=3600m -mode native cql3 -rate threads=10 -pop seq=1..33333333",
-             "cassandra-stress user profile=/tmp/lwt_builtin_functions.yaml ops'(lwt_update_by_pk=1,lwt_update_by_ck=1)' cl=QUORUM duration=3600m -mode native cql3 -rate threads=10 -pop seq=33333334..66666666",
-             "cassandra-stress user profile=/tmp/lwt_builtin_functions.yaml ops'(lwt_update_by_pk=1,lwt_update_by_ck=1)' cl=QUORUM duration=3600m -mode native cql3 -rate threads=10 -pop seq=66666667..100000000"
+stress_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1,lwt_deletes=1)' cl=QUORUM duration=3420m -mode native cql3 -rate threads=10" ,
+             "cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml ops'(lwt_update_one_column=1,lwt_update_two_columns=1,lwt_deletes=1)' cl=QUORUM duration=3420m -mode native cql3 -rate threads=10",
+             "cassandra-stress user profile=/tmp/lwt_builtin_functions.yaml ops'(lwt_update_by_pk=1,lwt_update_by_ck=1)' cl=QUORUM duration=3420m -mode native cql3 -rate threads=10 -pop seq=1..33333333",
+             "cassandra-stress user profile=/tmp/lwt_builtin_functions.yaml ops'(lwt_update_by_pk=1,lwt_update_by_ck=1)' cl=QUORUM duration=3420m -mode native cql3 -rate threads=10 -pop seq=33333334..66666666",
+             "cassandra-stress user profile=/tmp/lwt_builtin_functions.yaml ops'(lwt_update_by_pk=1,lwt_update_by_ck=1)' cl=QUORUM duration=3420m -mode native cql3 -rate threads=10 -pop seq=66666667..100000000"
             ]
-stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml ops'(select=1)' cl=SERIAL duration=3600m -mode native cql3 -rate threads=10" ]
+stress_read_cmd: ["cassandra-stress user profile=/tmp/c-s_lwt_big_data.yaml ops'(select=1)' cl=SERIAL duration=3420m -mode native cql3 -rate threads=10" ]
 
 n_db_nodes: 4
 n_loaders: 3


### PR DESCRIPTION
Now the stress duration is defined as '3600m'. It cause to test timeout. Test duration is 74h but real test duration when stress runs 3600m is more then 76h. Decrease it to 3420m (57h instead of 60h)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
