### PR TITLE
refactor(get_peers_info): switch to use python-driver

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2669,27 +2669,15 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             'peer', 'data_center', 'host_id', 'rack', 'release_version',
             'rpc_address', 'schema_version', 'supported_features',
         )
-        columns_len = len(columns)
-        cql_result = self.run_cqlsh(
-            f"select {', '.join(columns)} from system.peers", split=True, verbose=False)
-        # peer | data_center | host_id | rack | release_version | rpc_address | schema_version | supported_features
-        # ------+-------------+---------+------+-----------------+-------------+----------------+--------------------
-
         peers_details = {}
+        with self.parent_cluster.cql_connection_patient_exclusive(self) as session:
+            result = session.execute(f"select {', '.join(columns)} from system.peers")
+            cql_results = result.all()
         err = ''
-        for line in cql_result:
-            if '|' not in line or all(column in line for column in columns):
-                # NOTE: skip non-rows and header lines
-                continue
-            line_splitted = line.split('|')
-            if len(line_splitted) != columns_len:
-                current_err = f"Failed to parse the cqlsh command output line: \n{line}\n"
-                LOGGER.warning(current_err)
-                err += current_err
-                continue
-            peer = line_splitted[0].strip()
+        for row in cql_results:
+            peer = row.peer
             try:
-                ipaddress.ip_address(peer)
+                ipaddress.ip_address(row.peer)
             except ValueError as exc:
                 current_err = f"Peer '{peer}' is not an IP address, err: {exc}\n"
                 LOGGER.warning(current_err)
@@ -2697,15 +2685,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 continue
 
             if node := self.parent_cluster.find_node_by_ip(peer):
-                peers_details[node] = {
-                    'data_center': line_splitted[1].strip(),
-                    'host_id': line_splitted[2].strip(),
-                    'rack': line_splitted[3].strip(),
-                    'release_version': line_splitted[4].strip(),
-                    'rpc_address': line_splitted[5].strip(),
-                    'schema_version': line_splitted[6].strip(),
-                    'supported_features': line_splitted[7].strip(),
-                }
+                peers_details[node] = row._asdict()
             else:
                 current_err = f"'get_peers_info' failed to find a node by IP: {peer}\n"
                 LOGGER.error(current_err)
@@ -2713,8 +2693,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
         if not (peers_details or err):
             LOGGER.error(
-                "No data, no errors. Check the output from the cqlsh for the correctness:\n%s",
-                cql_result)
+                "No data, no errors. Check the output from the cql command for the correctness:\n%s",
+                cql_results)
         return peers_details
 
     @retrying(n=5, sleep_time=10, raise_on_exceeded=False)

--- a/unit_tests/test_utils_health_checker.py
+++ b/unit_tests/test_utils_health_checker.py
@@ -13,6 +13,8 @@
 
 
 import unittest
+from unittest.mock import MagicMock
+from uuid import UUID
 
 from sdcm.sct_events import Severity
 from sdcm.utils.health_checker import (
@@ -31,6 +33,7 @@ class Node:
         self.ip_address = ip_address
         self.name = name
         self.running_nemesis = None
+        self.parent_cluster = MagicMock()
 
     @staticmethod
     def print_node_running_nemesis(_):
@@ -93,19 +96,19 @@ NODES_STATUS = {
 PEERS_INFO = {
     node2: {
         'data_center': 'datacenter1',
-        'host_id': 'b231fe54-8093-4d5c-9a35-b5e34dc81500',
+        'host_id': UUID('b231fe54-8093-4d5c-9a35-b5e34dc81500'),
         'rack': 'rack1',
         'release_version': '3.0.8',
         'rpc_address': '127.0.0.2',
-        'schema_version': 'cbe15453-33f3-3387-aaf1-4120548f41e8',
+        'schema_version': UUID('cbe15453-33f3-3387-aaf1-4120548f41e8'),
     },
     node3: {
         'data_center': 'datacenter1',
-        'host_id': 'e11cb4ea-a129-48aa-a9e9-7815dcd2828c',
+        'host_id': UUID('e11cb4ea-a129-48aa-a9e9-7815dcd2828c'),
         'rack': 'rack1',
         'release_version': '3.0.8',
         'rpc_address': '127.0.0.3',
-        'schema_version': 'cbe15453-33f3-3387-aaf1-4120548f41e8',
+        'schema_version': UUID('cbe15453-33f3-3387-aaf1-4120548f41e8'),
     },
 }
 


### PR DESCRIPTION
since when using cqlsh with cloud bundle, we don't have a guarantee anymore that we'll uses only a specific node, since we are connecting to all of them.

thing like reading `system.peers` should be done now with the python-driver `cql_connection_patient_exclusive` helper function.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
