### PR TITLE
fix(scale-cluster): Setting backtrace_decoding to false for scale test

### DIFF
--- a/test-cases/scale/scale-cluster.yaml
+++ b/test-cases/scale/scale-cluster.yaml
@@ -23,3 +23,4 @@ nemesis_class_name: 'ChaosMonkey'
 cluster_health_check: false
 
 workaround_kernel_bug_for_iotune: true
+backtrace_decoding: false


### PR DESCRIPTION
In large clusters where we have many stalls and oversized_allocations, the log if filled up with backtrace decoding.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
