### PR TITLE
feature(chaos-mesh): added installation of chaos-mesh

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -337,3 +337,5 @@
 | **<a href="#user-content-max_deviation" name="max_deviation">max_deviation</a>**  | Max relative difference between best and current throughput,<br>if current throughput larger then best on max_rel_diff, it become new best one | N/A | SCT_MAX_DEVIATION
 | **<a href="#user-content-n_stress_process" name="n_stress_process">n_stress_process</a>**  | Number of stress processes per loader | N/A | SCT_N_STRESS_PROCESS
 | **<a href="#user-content-stress_process_step" name="stress_process_step">stress_process_step</a>**  | add/remove num of process on each round | N/A | SCT_STRESS_PROCESS_STEP
+| **<a href="#user-content-use_hdr_cs_histogram" name="use_hdr_cs_histogram">use_hdr_cs_histogram</a>**  | Enable hdr histogram logging for cs | N/A | SCT_USE_HDR_CS_HISTOGRAM
+| **<a href="#user-content-k8s_use_chaos_mesh" name="k8s_use_chaos_mesh">k8s_use_chaos_mesh</a>**  | enables chaos-mesh for k8s testing | N/A | SCT_K8S_USE_CHAOS_MESH

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -84,6 +84,7 @@ from sdcm.utils.k8s import (
 )
 from sdcm.utils.decorators import log_run_info, retrying
 from sdcm.utils.decorators import timeout as timeout_wrapper
+from sdcm.utils.k8s.chaos_mesh import ChaosMesh
 from sdcm.utils.remote_logger import get_system_logging_thread, CertManagerLogger, ScyllaOperatorLogger, \
     KubectlClusterEventsLogger, ScyllaManagerLogger, KubernetesWrongSchedulingLogger
 from sdcm.utils.sstable.load_utils import SstableLoadUtils
@@ -319,6 +320,7 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
             ('scylla-operator.scylladb.com/node-config-job-type', 'Containers'),
         ]
         self._scylla_cluster_events_threads = {}
+        self.chaos_mesh = ChaosMesh(self)
 
     # NOTE: Following class attr(s) are defined for consumers of this class
     #       such as 'sdcm.utils.remote_logger.ScyllaOperatorLogger'.

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1414,7 +1414,9 @@ class SCTConfiguration(dict):
         dict(name="stress_process_step", env="SCT_STRESS_PROCESS_STEP", type=int,
              help="""add/remove num of process on each round"""),
         dict(name="use_hdr_cs_histogram", env="SCT_USE_HDR_CS_HISTOGRAM", type=boolean,
-             help="""Enable hdr histogram logging for cs""")
+             help="""Enable hdr histogram logging for cs"""),
+        dict(name="k8s_use_chaos_mesh", env="SCT_K8S_USE_CHAOS_MESH", type=boolean,
+             help="""enables chaos-mesh for k8s testing""")
     ]
 
     required_params = ['cluster_backend', 'test_duration', 'n_db_nodes', 'n_loaders', 'use_preinstalled_scylla',

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -26,7 +26,7 @@ from sdcm.loader import CassandraStressExporter, CassandraStressHDRExporter
 from sdcm.cluster import BaseLoaderSet  # , BaseNode
 from sdcm.prometheus import nemesis_metrics_obj
 from sdcm.sct_events import Severity
-from sdcm.utils.common import FileFollowerThread, get_profile_content, get_data_dir_path
+from sdcm.utils.common import FileFollowerThread, get_profile_content, get_data_dir_path, time_period_str_to_seconds
 from sdcm.sct_events.loaders import CassandraStressEvent, CS_ERROR_EVENTS_PATTERNS, CS_NORMAL_EVENTS_PATTERNS
 from sdcm.stress.base import DockerBasedStressThread, format_stress_cmd_error
 from sdcm.utils.docker_remote import RemoteDocker
@@ -359,14 +359,8 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
         return cs_summary, errors
 
 
-duration_pattern = re.compile(r'(?P<hours>[\d]*)h|(?P<minutes>[\d]*)m|(?P<seconds>[\d]*)s')
 stress_cmd_get_duration_pattern = re.compile(r' [-]{0,2}duration[\s=]+([\d]+[hms]+)')
 stress_cmd_get_warmup_pattern = re.compile(r' [-]{0,2}warmup[\s=]+([\d]+[hms]+)')
-
-
-def time_period_str_to_seconds(time_str: str) -> int:
-    """Transforms duration string into seconds int. e.g. 1h -> 3600, 1h22m->4920 or 10m->600"""
-    return sum([int(g[0] or 0) * 3600 + int(g[1] or 0) * 60 + int(g[2] or 0) for g in duration_pattern.findall(time_str)])
 
 
 def get_timeout_from_stress_cmd(stress_cmd: str) -> int | None:

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -738,6 +738,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
         self.init_resources()
 
+        if self.k8s_cluster and self.params.get("k8s_use_chaos_mesh"):
+            self.k8s_cluster.chaos_mesh.initialize()
+
         if self.db_cluster and not self.db_clusters_multitenant:
             self.db_clusters_multitenant = [self.db_cluster]
         for db_cluster in self.db_clusters_multitenant:

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -2808,3 +2808,11 @@ class RemoteTemporaryFolder:
     def __exit__(self, exit_type, value, _traceback):
         # remove the temporary folder as `sudo` to cover the case when the folder owner was changed during test
         self.node.remoter.sudo(f'rm -rf {self.folder_name}')
+
+
+duration_pattern = re.compile(r'(?P<hours>[\d]*)h|(?P<minutes>[\d]*)m|(?P<seconds>[\d]*)s')
+
+
+def time_period_str_to_seconds(time_str: str) -> int:
+    """Transforms duration string into seconds int. e.g. 1h -> 3600, 1h22m->4920 or 10m->600"""
+    return sum([int(g[0] or 0) * 3600 + int(g[1] or 0) * 60 + int(g[2] or 0) for g in duration_pattern.findall(time_str)])

--- a/sdcm/utils/k8s/__init__.py
+++ b/sdcm/utils/k8s/__init__.py
@@ -557,7 +557,9 @@ class HelmContainerMixin:
                                  use_devel: bool = False,
                                  debug: bool = True,
                                  values: 'HelmValues' = None,
-                                 namespace: Optional[str] = None) -> str:
+                                 namespace: Optional[str] = None,
+                                 atomic: bool = False,
+                                 timeout: Optional[str] = None) -> str:
         command = [operation_type, target_chart_name, source_chart_name]
         prepend_command = []
         if version:
@@ -566,7 +568,15 @@ class HelmContainerMixin:
             command.extend(("--devel",))
         if debug:
             command.extend(("--debug",))
-
+        if atomic:
+            # if set, the installation process deletes the installation on failure
+            # or upgrade process rolls back changes made in case of failed upgrade
+            # waits for operation completion - so should specify timeout.
+            command.extend(("--atomic",))
+            if timeout is None:
+                LOGGER.warning("No timeout provided for atomic operation, default of '5m' is used.")
+            else:
+                command.extend(("--timeout", timeout))
         return self.helm(
             kluster,
             *command,

--- a/sdcm/utils/k8s/chaos_mesh.py
+++ b/sdcm/utils/k8s/chaos_mesh.py
@@ -1,8 +1,50 @@
-import logging
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2022 ScyllaDB
 
+import ast
+import json
+import logging
+from datetime import datetime
+from enum import Enum
+from tempfile import NamedTemporaryFile
+import time
+
+import yaml
+from botocore.utils import deep_merge
+
+from sdcm.utils.common import time_period_str_to_seconds
 from sdcm.utils.k8s import HelmValues, get_helm_pool_affinity_values
 
 LOGGER = logging.getLogger(__name__)
+
+
+class ChaosMeshException(Exception):
+    pass
+
+
+class PodChaosException(ChaosMeshException):
+
+    def __init__(self, msg: str, k8s_cluster: "KubernetesCluster", podchaos_name: str, namespace: str):
+        super().__init__(msg)
+        self.message = msg
+        self.details = k8s_cluster.kubectl(f"describe podchaos {podchaos_name} -n {namespace}").stdout
+
+    def __str__(self):
+        return f"{self.message}. Details:\n" + self.details
+
+
+class PodChaosTimeout(PodChaosException):
+    pass
 
 
 class ChaosMesh:  # pylint: disable=too-few-public-methods
@@ -44,3 +86,114 @@ class ChaosMesh:  # pylint: disable=too-few-public-methods
             timeout="30m"
         )
         LOGGER.info("chaos-mesh installed successfully on %s k8s cluster.", self._k8s_cluster.k8s_scylla_cluster_name)
+
+
+class ExperimentStatus(Enum):
+    STARTING = 0
+    RUNNING = 1
+    PAUSED = 2
+    FINISHED = 3
+    ERROR = 4
+    UNKNOWN = 5
+
+
+class PodChaosExperiment:
+    """Base class for all PodChaos experiments."""
+    API_VERSION = "chaos-mesh.org/v1alpha1"
+
+    def __init__(self, pod: "BasePodContainer", name: str, timeout: int = 0):
+        self._k8s_cluster = pod.parent_cluster.k8s_cluster
+        self._name = name
+        self._namespace = pod.parent_cluster.namespace
+        self._experiment = {
+            "apiVersion": self.API_VERSION,
+            "metadata": {
+                "name": self._name,
+                "namespace": self._namespace
+            },
+            "spec": {
+                "mode": "one",
+                "selector": {
+                    "labelSelectors": {
+                        "statefulset.kubernetes.io/pod-name": pod.name
+                    }
+                }
+            }
+        }
+        self._timeout: int = timeout
+        self._end_time: int = 0
+
+    def start(self):
+        """Starts experiment. Does not wait for finish."""
+        LOGGER.debug("Starting a pod-failure experiment %s", self._name)
+        assert self._k8s_cluster, "K8s cluster hasn't been configured for this experiment."
+        with NamedTemporaryFile(suffix=".yaml", mode="w") as experiment_config_file:
+            yaml.dump(self._experiment, experiment_config_file)
+            experiment_config_file.flush()
+            self._k8s_cluster.apply_file(experiment_config_file.name)
+        LOGGER.info("pod-failure experiment '%s' has started", self._name)
+        self._end_time = time.time() + self._timeout
+
+    def get_status(self) -> ExperimentStatus:
+        """Gets status of podchaos experiment."""
+        result = self._k8s_cluster.kubectl(
+            f"get podchaos {self._name}  -n {self._namespace} -o jsonpath='{{.status.conditions}}'", verbose=False)
+        condition = {cond["type"]: ast.literal_eval(cond["status"]) for cond in json.loads(result.stdout)}
+        if not condition["Selected"] and condition["Paused"]:
+            return ExperimentStatus.ERROR
+        if not condition["Selected"] and not condition["Paused"] and not condition["AllRecovered"] and not condition["AllInjected"]:
+            return ExperimentStatus.STARTING
+        if condition["Selected"] and not condition["Paused"] and not condition["AllRecovered"] and condition["AllInjected"]:
+            return ExperimentStatus.RUNNING
+        if condition["AllRecovered"] and condition["Paused"]:
+            return ExperimentStatus.PAUSED
+        if condition["AllRecovered"] and not condition["Paused"]:
+            return ExperimentStatus.FINISHED
+        LOGGER.warning("Unknown experiment status: %s", condition)
+        return ExperimentStatus.UNKNOWN
+
+    def wait_until_finished(self):
+        """Waits given timeout seconds for experiment to finish.
+
+        In case of experiment status being an error or timeout occurred, raises an exception."""
+        LOGGER.debug("waiting until '%s' experiment ends...", self._name)
+        assert self._end_time, "Experiment was not started. Use 'start()' method before waiting."
+        while time.time() < self._end_time:
+            status = self.get_status()
+            if status == ExperimentStatus.FINISHED:
+                LOGGER.debug("'%s' experiment ended.", self._name)
+                return
+            elif status == ExperimentStatus.ERROR:
+                raise PodChaosException(msg="Experiment status error",
+                                        k8s_cluster=self._k8s_cluster,
+                                        podchaos_name=self._name,
+                                        namespace=self._namespace)
+            time.sleep(2)
+        raise PodChaosTimeout(msg="Timeout when waiting for ChaosMesh experiment to complete.",
+                              k8s_cluster=self._k8s_cluster,
+                              podchaos_name=self._name,
+                              namespace=self._namespace)
+
+
+class PodFailureExperiment(PodChaosExperiment):
+    """
+    This experiment works by replacing container image with dummy image.
+    Then it waits for specified duration and rolls back image config.
+    """
+
+    def __init__(self, pod: "BasePodContainer", duration: str):
+        """Injects fault into a specified Pod to make the Pod unavailable for a period of time.
+
+        'duration' is str type in k8s notation. E.g. 10s, 5m
+        """
+        # timeout based on duration + 10 seconds margin
+        timeout = time_period_str_to_seconds(duration) + 10
+        super().__init__(
+            pod=pod, name=f"pod-failure-{pod.name}-{datetime.now().strftime('%d-%H.%M.%S')}", timeout=timeout)
+        deep_merge(self._experiment, {
+            "kind": "PodChaos",
+            "spec": {
+                "action": "pod-failure",
+                "duration": duration,
+            }
+        })

--- a/sdcm/utils/k8s/chaos_mesh.py
+++ b/sdcm/utils/k8s/chaos_mesh.py
@@ -1,0 +1,46 @@
+import logging
+
+from sdcm.utils.k8s import HelmValues, get_helm_pool_affinity_values
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ChaosMesh:  # pylint: disable=too-few-public-methods
+    NAMESPACE = "chaos-mesh"
+    VERSION = "2.5.0"
+    HELM_SETTINGS = {
+        'dashboard.create': True,
+        'dnsServer.create': True
+    }
+
+    def __init__(self, k8s_cluster: "KubernetesCluster"):
+        self._k8s_cluster = k8s_cluster
+
+    def initialize(self) -> None:
+        """Installs chaos-mesh on k8s cluster and prepares for future k8s chaos testing."""
+        if self._k8s_cluster.kubectl(f"get ns {self.NAMESPACE}", ignore_status=True).ok:
+            LOGGER.info("Chaos Mesh is already installed. Skipping installation.")
+            return
+        LOGGER.info("Installing chaos-mesh on %s k8s cluster...", self._k8s_cluster.k8s_scylla_cluster_name)
+        self._k8s_cluster.helm("repo add chaos-mesh https://charts.chaos-mesh.org")
+        self._k8s_cluster.helm('repo update')
+        self._k8s_cluster.kubectl(f"create namespace {self.NAMESPACE}")
+        aux_node_pool_affinity = get_helm_pool_affinity_values(
+            self._k8s_cluster.POOL_LABEL_NAME, self._k8s_cluster.AUXILIARY_POOL_NAME)
+        scylla_node_pool_affinity = get_helm_pool_affinity_values(
+            self._k8s_cluster.POOL_LABEL_NAME, self._k8s_cluster.SCYLLA_POOL_NAME)
+        self._k8s_cluster.helm_install(
+            target_chart_name="chaos-mesh",
+            source_chart_name="chaos-mesh/chaos-mesh",
+            version=self.VERSION,
+            use_devel=False,
+            namespace=self.NAMESPACE,
+            values=HelmValues(self.HELM_SETTINGS | {
+                "chaosDaemon": scylla_node_pool_affinity,
+                "controllerManager": aux_node_pool_affinity,
+                "dnsServer": aux_node_pool_affinity
+            }),
+            atomic=True,
+            timeout="30m"
+        )
+        LOGGER.info("chaos-mesh installed successfully on %s k8s cluster.", self._k8s_cluster.k8s_scylla_cluster_name)

--- a/test-cases/scylla-operator/functional.yaml
+++ b/test-cases/scylla-operator/functional.yaml
@@ -30,3 +30,5 @@ k8s_functional_test_dataset: MULTI_COLUMNS_DATA
 
 # enable by default
 k8s_enable_tls: true
+
+k8s_use_chaos_mesh: true

--- a/unit_tests/test_chaos_mesh.py
+++ b/unit_tests/test_chaos_mesh.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2021 ScyllaDB
+# pylint: skip-file
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+import yaml
+from invoke import Result
+import pytest
+
+from sdcm.utils.k8s.chaos_mesh import PodFailureExperiment, ExperimentStatus, PodChaosTimeout, PodChaosException
+
+
+@dataclass
+class DummyK8sCluster:
+    _commands: Dict[str, Result] = field(default_factory=dict)
+
+    def apply_file(self, config_path: str):
+        """Parses file content to yaml and prints it."""
+        with open(config_path, "r", encoding="utf-8") as config_file:
+            print(yaml.safe_load(config_file))
+
+    def kubectl(self, command, *args, **kwargs):
+        result = [result for cmd, result in self._commands.items() if cmd in command]
+        assert result, f"given command: {command} was not registered, failing test." \
+                       f" Please register result with 'register_kubectl_result"
+        return result[0]
+
+    def register_kubectl_result(self, command: str, command_result: Result):
+        self._commands[command] = command_result
+
+
+@dataclass
+class DummyPodCluster:
+    k8s_cluster: DummyK8sCluster
+    namespace: str = "scylla"
+
+
+@dataclass
+class DummyPod:
+    parent_cluster: DummyPodCluster
+    name: str
+
+
+def test_experiment_configuration_is_valid(capsys):
+    k8s_cluster = DummyK8sCluster()
+    pod = DummyPod(DummyPodCluster(k8s_cluster), name="dummy-pod-1")
+    experiment = PodFailureExperiment(pod=pod, duration="10s")
+    experiment.start()
+    captured = capsys.readouterr()
+    expected_config = {'apiVersion': 'chaos-mesh.org/v1alpha1',
+                       'kind': 'PodChaos',
+                       'metadata': {'name': 'pod-failure-dummy-pod-',
+                                    'namespace': 'scylla'},
+                       'spec': {'action': 'pod-failure',
+                                'duration': '10s',
+                                'mode': 'one',
+                                'selector': {'labelSelectors':
+                                             {'statefulset.kubernetes.io/pod-name': 'dummy-pod-1'}
+                                             }
+                                }
+                       }
+    actual_config = eval(captured.out)
+    # strip the time from name
+    actual_config["metadata"]["name"] = actual_config["metadata"]["name"][:-13]
+    assert actual_config == expected_config
+
+
+finished_conditions = '[{"status":"False","type":"AllInjected"},' \
+                      '{"status":"True","type":"AllRecovered"},' \
+                      '{"status":"False","type":"Paused"},' \
+                      '{"status":"True","type":"Selected"}]'
+running_conditions = '[{"status":"True","type":"AllInjected"},' \
+                     '{"status":"False","type":"AllRecovered"},' \
+                     '{"status":"False","type":"Paused"},' \
+                     '{"status":"True","type":"Selected"}]'
+starting_conditions = '[{"status":"False","type":"AllInjected"},' \
+                      '{"status":"False","type":"AllRecovered"},' \
+                      '{"status":"False","type":"Paused"},' \
+                      '{"status":"False","type":"Selected"}]'
+paused_conditions = '[{"status":"True","type":"AllInjected"},' \
+                    '{"status":"True","type":"AllRecovered"},' \
+                    '{"status":"True","type":"Paused"},' \
+                    '{"status":"True","type":"Selected"}]'
+error_conditions = '[{"status":"True","type":"AllInjected"},' \
+                   '{"status":"False","type":"AllRecovered"},' \
+                   '{"status":"True","type":"Paused"},' \
+                   '{"status":"False","type":"Selected"}]'
+
+
+@pytest.mark.parametrize("conditions, status", (
+    (finished_conditions, ExperimentStatus.FINISHED),
+    (running_conditions, ExperimentStatus.RUNNING),
+    (starting_conditions, ExperimentStatus.STARTING),
+    (paused_conditions, ExperimentStatus.PAUSED),
+    (error_conditions, ExperimentStatus.ERROR)
+))
+def test_experiment_statuses_for_podchaos_condidtions(conditions, status):
+    k8s_cluster = DummyK8sCluster()
+    k8s_cluster.register_kubectl_result("get podchaos", Result(stdout=conditions))
+    pod = DummyPod(DummyPodCluster(k8s_cluster), name="dummy-pod-1")
+
+    experiment = PodFailureExperiment(pod=pod, duration="10s")
+    assert experiment.get_status() == status
+
+
+def test_wait_for_finished_returns_when_status_is_finished():
+    k8s_cluster = DummyK8sCluster()
+    k8s_cluster.register_kubectl_result("get podchaos", Result(stdout=finished_conditions))
+    pod = DummyPod(DummyPodCluster(k8s_cluster), name="dummy-pod-1")
+
+    experiment = PodFailureExperiment(pod=pod, duration="1s")
+    experiment.start()
+
+    experiment.wait_until_finished()
+
+
+def test_wait_for_finished_raises_exception_when_status_is_error():
+    k8s_cluster = DummyK8sCluster()
+    k8s_cluster.register_kubectl_result("get podchaos", Result(error_conditions))
+    k8s_cluster.register_kubectl_result("describe podchaos ", Result(stdout="pod description got from k8s"))
+    pod = DummyPod(DummyPodCluster(k8s_cluster), name="dummy-pod-1")
+
+    experiment = PodFailureExperiment(pod=pod, duration="1s")
+    experiment.start()
+
+    with pytest.raises(PodChaosException):
+        experiment.wait_until_finished()
+
+
+def test_wait_for_finished_raises_exception_when_timeout_occurs():
+    k8s_cluster = DummyK8sCluster()
+    k8s_cluster.register_kubectl_result("get podchaos", Result(running_conditions))
+    k8s_cluster.register_kubectl_result("describe podchaos ", Result(stdout="pod description got from k8s"))
+    pod = DummyPod(DummyPodCluster(k8s_cluster), name="dummy-pod-1")
+
+    experiment = PodFailureExperiment(pod=pod, duration="1s")
+    experiment._timeout = 0
+    experiment.start()
+
+    with pytest.raises(PodChaosTimeout):
+        experiment.wait_until_finished()

--- a/unit_tests/test_stress_thread_functions.py
+++ b/unit_tests/test_stress_thread_functions.py
@@ -13,7 +13,8 @@
 
 import pytest
 
-from sdcm.stress_thread import time_period_str_to_seconds, get_timeout_from_stress_cmd
+from sdcm.stress_thread import get_timeout_from_stress_cmd
+from sdcm.utils.common import time_period_str_to_seconds
 
 
 @pytest.mark.parametrize("duration,seconds", (


### PR DESCRIPTION
We want to use chaos-mesh for chaos testing k8s clusters.

This PR adds:
* installation of chaos-mesh in k8s cluster for future use.
* example experiment (pod failure) and functional test using it



## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
