### PR TITLE
fix(test): pin scylla-bench to fix multidc counter test

### DIFF
--- a/test-cases/longevity/longevity-counters-multidc.yaml
+++ b/test-cases/longevity/longevity-counters-multidc.yaml
@@ -22,3 +22,7 @@ server_encrypt: true
 internode_encryption: 'dc'
 
 use_legacy_cluster_init: false
+
+# pin s-b version to mitigate https://github.com/scylladb/scylla-bench/issues/114
+stress_image:
+  scylla-bench: 'scylladb/hydra-loaders:scylla-bench-v0.1.3'


### PR DESCRIPTION
We face the issue with disconnecting from cluster after simple table modifications in scylla-bench (counters multidc test): https://github.com/scylladb/scylla-bench/issues/114

It was proven it behaves correctly when s-b is in version 0.1.3. This commit pins s-b for couters multidc test.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
