### PR TITLE
fix(tester): removed wait_for_nodes_up_and_normal from run_stress_thread

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -41,7 +41,7 @@ from cassandra import ConsistencyLevel
 from argus.db.db_types import TestStatus, PackageVersion
 from sdcm import nemesis, cluster_docker, cluster_k8s, cluster_baremetal, db_stats, wait
 from sdcm.cluster import NoMonitorSet, SCYLLA_DIR, TestConfig, UserRemoteCredentials, BaseLoaderSet, BaseMonitorSet, \
-    BaseScyllaCluster, BaseNode, MAX_TIME_WAIT_FOR_ALL_NODES_UP
+    BaseScyllaCluster, BaseNode
 from sdcm.argus_test_run import ArgusTestRun
 from sdcm.cluster_azure import ScyllaAzureCluster, LoaderSetAzure, MonitorSetAzure
 from sdcm.cluster_gce import ScyllaGCECluster
@@ -1735,9 +1735,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                           round_robin=False, stats_aggregate_cmds=True, keyspace_name=None, compaction_strategy='',
                           use_single_loader=False,
                           stop_test_on_failure=True):
-        # We want to prevent situation when stress command starts on not ready cluster (no all nodes are UP).
-        # It may cause to stress failure and as result the test will be stopped and failed
-        self.db_cluster.wait_for_nodes_up_and_normal(iterations=0, timeout=MAX_TIME_WAIT_FOR_ALL_NODES_UP)
 
         params = dict(stress_cmd=stress_cmd, duration=duration, stress_num=stress_num, keyspace_num=keyspace_num,
                       keyspace_name=keyspace_name, profile=profile, prefix=prefix, round_robin=round_robin,


### PR DESCRIPTION
Removed wait_for_nodes_up_and_normal from def run_stress_thread

Since the issue we had with the c-s selecting a random node to connect with been fixed in c-s

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
