### PR TITLE
fix(gce_datacenter): set its type to str_or_list_or_eval

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -694,7 +694,7 @@ class SCTConfiguration(dict):
         dict(name="gce_project", env="SCT_GCE_PROJECT", type=str,
              help="gcp project name to use"),
 
-        dict(name="gce_datacenter", env="SCT_GCE_DATACENTER", type=str_or_list,
+        dict(name="gce_datacenter", env="SCT_GCE_DATACENTER", type=str_or_list_or_eval,
              help="Supported: us-east1 - means that the zone will be selected automatically or "
                   "you can mention the zone explicitly, for example: us-east1-b"),
 


### PR DESCRIPTION
Since gce_datacenter can be a python list (multi region), I changed its type to str_or_list_or_eval

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
