### PR TITLE
fix(unittests): switch away from delete old AMIs

### DIFF
--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -174,13 +174,13 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
     def test_12_scylla_version_ami(self):
         os.environ.pop('SCT_AMI_ID_DB_SCYLLA', None)
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
-        os.environ['SCT_SCYLLA_VERSION'] = '3.0.3'
+        os.environ['SCT_SCYLLA_VERSION'] = '4.6.3'
 
         os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/multi_region_dc_test_case.yaml'
         conf = sct_config.SCTConfiguration()
         conf.verify_configuration()
 
-        self.assertEqual(conf.get('ami_id_db_scylla'), 'ami-05f62259c7715e1a6 ami-027c1337dcb46da50')
+        self.assertEqual(conf.get('ami_id_db_scylla'), 'ami-03d8b6dcd63bd4e24 ami-09c658571b2d46d18')
 
     @staticmethod
     def test_12_scylla_version_ami_case1():  # pylint: disable=invalid-name
@@ -440,10 +440,10 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         self.assertEqual(conf.get('ami_id_db_oracle'), ami_4_6_9)
 
     def test_16_oracle_scylla_version_us_east_1(self):
-        ami_4_5_2 = "ami-0e075abbcb95ac10a"
+        ami_4_6_3 = "ami-09c658571b2d46d18"
 
         os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
-        os.environ['SCT_ORACLE_SCYLLA_VERSION'] = "4.5.2"
+        os.environ['SCT_ORACLE_SCYLLA_VERSION'] = "4.6.3"
         os.environ['SCT_REGION_NAME'] = 'us-east-1'
         os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-eae4f795'
         os.environ['SCT_CONFIG_FILES'] = 'internal_test_data/minimal_test_case.yaml'
@@ -452,7 +452,7 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
         conf = sct_config.SCTConfiguration()
         conf.verify_configuration()
 
-        self.assertEqual(conf.get('ami_id_db_oracle'), ami_4_5_2)
+        self.assertEqual(conf.get('ami_id_db_oracle'), ami_4_6_3)
 
     def test_16_oracle_scylla_version_eu_west_1(self):
         ami_4_5_2 = "ami-057f1cfd8877782b2"


### PR DESCRIPTION
seems like recently 3.0.3 and 4.5.2 images from us-east-1 have been deleted, switching to test with newer versions

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
