### PR TITLE
fix(gce manager backup): updated the bucket name

### DIFF
--- a/defaults/gce_config.yaml
+++ b/defaults/gce_config.yaml
@@ -29,4 +29,5 @@ gce_pd_ssd_disk_size_monitor: 0
 
 user_credentials_path: '~/.ssh/scylla-test'
 
+backup_bucket_location: 'manager-backup-tests-sct-project-1-us-east1'
 backup_bucket_backend: 'gcs'

--- a/test-cases/manager/manager-backup-1TB-gce.yaml
+++ b/test-cases/manager/manager-backup-1TB-gce.yaml
@@ -23,7 +23,6 @@ gce_instance_type_db: 'n1-highmem-16'
 gce_n_local_ssd_disk_db: 8
 gce_instance_type_loader: 'e2-standard-16'
 
-backup_bucket_location: 'manager-backup-tests-us-east1'
 nemesis_class_name: 'MgmtBackup'
 nemesis_interval: 30
 nemesis_filter_seeds: false

--- a/test-cases/manager/manager-regression-multiDC-gce.yaml
+++ b/test-cases/manager/manager-regression-multiDC-gce.yaml
@@ -14,5 +14,3 @@ use_preinstalled_scylla: true
 endpoint_snitch: 'GoogleCloudSnitch'
 user_prefix: manager-regression
 space_node_threshold: 6442
-
-backup_bucket_location: 'manager-backup-tests-us-east1'


### PR DESCRIPTION
Since we moved to a new gce project, 'sct-project-1', we can't use the bucket from the old project. As such, I switched the bucket name to the one that exists in the new project.

Also, removed the backup_bucket_location setting from test-cases/manager/manager-backup-1TB-gce.yaml and test-cases/manager/manager-regression-multiDC-gce.yaml since they were redundant. Setting it in defaults/gce_config.yaml is enough.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
