### PR TITLE
feature(gcp): adding local-ssd-latency project

### DIFF
--- a/docs/gcp_create_new_project.md
+++ b/docs/gcp_create_new_project.md
@@ -1,0 +1,39 @@
+# using a new GCP project
+
+```
+# create a key from the project service account
+# upload it to our credential store
+
+# upload public key into place
+https://console.cloud.google.com/compute/metadata?authuser=1&project=local-ssd-latency&tab=sshkeys
+
+# then you can use the project
+export SCT_GCE_PROJECT=gcp-local-ssd-latency
+
+# run a few times, and handle any service that need to be enable,
+# untail working/passing
+./sct.py prepare-regions -c gce -r us-east1
+
+# create `gcp-local-ssd-latency_service_accounts.json` with the
+# details of the backup service account
+# and upload to the credential store
+
+# create the runner image
+./sct.py create-runner-image --cloud-provider gce --region us-east1
+
+# create jenkins worker
+./sct.py create-runner-instance -c gce -r us-east1 -d 9999 --test-id 1234
+
+# rename worker
+gcloud beta compute instances stop sct-runner-1-5-instance-1234  --project=local-ssd-latency
+gcloud beta compute instances set-name sct-runner-1-5-instance-1234  --project=local-ssd-latency --new-name=gcp-local-ssd-latency-builder1-us-east1
+gcloud beta compute instances start gcp-local-ssd-latency-builder1-us-east1  --project=local-ssd-latency
+
+# set static ip
+https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address
+
+# configure it in jenkins under name `gcp-local-ssd-latency-builder1-us-east1`
+# with following labels
+# gcp-local-ssd-latency-builders-us-east1 gcp-local-ssd-latency-builders sct-local-ssd-latency-us-east1
+
+```

--- a/sdcm/utils/gce_utils.py
+++ b/sdcm/utils/gce_utils.py
@@ -43,7 +43,8 @@ SUPPORTED_REGIONS = {
     'us-west1': 'abc'}
 
 
-SUPPORTED_PROJECTS = {'gcp', 'gcp-sct-project-1'} | {os.environ.get('SCT_GCE_PROJECT', 'gcp-sct-project-1')}
+SUPPORTED_PROJECTS = {'gcp', 'gcp-sct-project-1',
+                      'gcp-local-ssd-latency'} | {os.environ.get('SCT_GCE_PROJECT', 'gcp-sct-project-1')}
 
 
 def append_zone(region: str) -> str:


### PR DESCRIPTION
* support for running with `local-ssd-latency`
* instructions on what's needed to be done to add new GCP project

## Testing
- [x] artifact test - https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2204-test/14
- [x] 3h longevity - https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-10gb-3h-gce-test/17

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
