### PR TITLE
fix(loader): typo in java-8 installation

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4715,8 +4715,8 @@ class BaseLoaderSet():
         if node.is_rhel_like():
             node.remoter.run('sudo yum install -y {}-tools'.format(node.scylla_pkg()))
             node.remoter.sudo('yum install -y java-1.8.0-openjdk-devel', verbose=True, ignore_status=True)
-            node.remote.sudo("ln -sf /usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/bin/java* /etc/alternatives/java",
-                             verbose=True, ignore_status=True)
+            node.remoter.sudo("ln -sf /usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/bin/java* /etc/alternatives/java",
+                              verbose=True, ignore_status=True)
         else:
             node.remoter.run('sudo apt-get update')
             node.remoter.run('sudo apt-get install -y '


### PR DESCRIPTION
c5591e26de2c596af35326c3821620017cdc05ed introduced new code that was failing like:

```
File ".../sdcm/cluster.py", line 4718, in node_setup
    node.remote.sudo("ln -sf /usr/lib/jvm/java-1.8.0-openjdk-
                      amd64/jre/bin/java* /etc/alternatives/java",
AttributeError: 'GCENode' object has no attribute 'remote'
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
