### PR TITLE
fix(k8s-functional): use --cloudconf on cqlsh only from scylla 5.2.0

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2748,7 +2748,9 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                       auth_params=auth_params, use_keyspace=use_keyspace, timeout=timeout,
                       connect_timeout=connect_timeout, ssl_params=ssl_params)
 
-        if self.parent_cluster.connection_bundle_file:
+        if self.parent_cluster.connection_bundle_file and (
+                packaging.version.LegacyVersion(self.scylla_version) >= packaging.version.LegacyVersion('5.2.0~dev')):
+
             connection_bundle_file = self.parent_cluster.connection_bundle_file
             target_connection_bundle_file = str(Path('/tmp/') / connection_bundle_file.name)
             self.remoter.send_files(str(connection_bundle_file), target_connection_bundle_file)


### PR DESCRIPTION
Since we enabled by default the `k8s_enable_tls` the code using the cloud bundle for cqlsh wrongly assumes it's available, and that's not true for released version, since it's just merged to master a week or two ago.

Fixes: #5577

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
