### PR TITLE
improvement(k8s): split K8S node diruptive nemesis to separate methods

### DIFF
--- a/data_dir/nemesis.yml
+++ b/data_dir/nemesis.yml
@@ -41,6 +41,12 @@
 - disrupt_disable_enable_ldap_authorization:
   - disruptive = True
   - limited = True
+- disrupt_drain_kubernetes_node_then_decommission_and_add_scylla_node:
+  - disruptive = True
+  - kubernetes = True
+- disrupt_drain_kubernetes_node_then_replace_scylla_node:
+  - disruptive = True
+  - kubernetes = True
 - disrupt_grow_shrink_cluster:
   - disruptive = True
   - kubernetes = True
@@ -165,7 +171,7 @@
   - disruptive = True
 - disrupt_repair_streaming_err:
   - disruptive = True
-- disrupt_replace_node_kubernetes:
+- disrupt_replace_scylla_node_on_kubernetes:
   - disruptive = True
   - kubernetes = True
   - free_tier_set = True
@@ -244,10 +250,10 @@
   - disruptive = True
   - kubernetes = False
   - topology_changes = True
-- disrupt_terminate_and_replace_node_kubernetes:
+- disrupt_terminate_kubernetes_host_then_decommission_and_add_scylla_node:
   - disruptive = True
   - kubernetes = True
-- disrupt_terminate_decommission_add_node_kubernetes:
+- disrupt_terminate_kubernetes_host_then_replace_scylla_node:
   - disruptive = True
   - kubernetes = True
 - disrupt_toggle_cdc_feature_properties_on_table:

--- a/data_dir/nemesis_classes.yml
+++ b/data_dir/nemesis_classes.yml
@@ -15,6 +15,8 @@
 - DeleteByPartitionsMonkey
 - DeleteByRowsRangeMonkey
 - DeleteOverlappingRowRangesMonkey
+- DrainKubernetesNodeThenDecommissionAndAddScyllaNode
+- DrainKubernetesNodeThenReplaceScyllaNode
 - DrainerMonkey
 - EnospcAllNodesMonkey
 - EnospcMonkey
@@ -34,8 +36,6 @@
 - NodeTerminateAndReplace
 - NodeToolCleanupMonkey
 - OperatorNodeReplace
-- OperatorNodeTerminateAndReplace
-- OperatorNodeTerminateDecommissionAdd
 - OperatorNodetoolFlushAndReshard
 - PauseLdapNemesis
 - RandomInterruptionNetworkMonkey
@@ -67,6 +67,8 @@
 - StopWaitStartMonkey
 - SwitchBetweenPasswordAuthAndSaslauthdAuth
 - TerminateAndRemoveNodeMonkey
+- TerminateKubernetesHostThenDecommissionAndAddScyllaNode
+- TerminateKubernetesHostThenReplaceScyllaNode
 - ToggleCDCMonkey
 - ToggleGcModeMonkey
 - ToggleLdapConfiguration

--- a/functional_tests/scylla_operator/conftest.py
+++ b/functional_tests/scylla_operator/conftest.py
@@ -89,17 +89,6 @@ def change_test_dir(request):
 
 
 @pytest.fixture(autouse=True)
-def skip_if_node_termination_method_not_supported(request, db_cluster: ScyllaPodCluster) -> None:
-    marker = request.node.get_closest_marker('requires_node_termination_support')
-    if marker and marker.args:
-        supported_methods = getattr(db_cluster, 'node_terminate_methods', [])
-        for terminate_method in marker.args:
-            if terminate_method not in supported_methods:
-                pytest.skip(f'cluster {type(db_cluster).__name__} does not support {terminate_method} '
-                            'node termination method')
-
-
-@pytest.fixture(autouse=True)
 def skip_if_scylla_manager_required_and_absent(request, tester: ScyllaOperatorFunctionalClusterTester) -> None:
     if request.node.get_closest_marker('requires_mgmt') and not tester.params.get('use_mgmt'):
         pytest.skip('test requires scylla manager to exist')

--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -209,11 +209,10 @@ def test_mgmt_backup(db_cluster, manager_version):
     assert TaskStatus.DONE == status
 
 
-@pytest.mark.requires_node_termination_support('drain_k8s_node')
-def test_drain_and_replace_node_kubernetes(db_cluster):
+def test_drain_kubernetes_node_then_replace_scylla_node(db_cluster):
     target_node = random.choice(db_cluster.non_seed_nodes)
     old_uid = target_node.k8s_pod_uid
-    log.info('TerminateNode %s (uid=%s)', target_node, old_uid)
+    log.info("Drain K8S node that hosts '%s' scylla node (uid=%s)", target_node, old_uid)
     target_node.drain_k8s_node()
     target_node.mark_to_be_replaced()
     target_node.wait_till_k8s_pod_get_uid(ignore_uid=old_uid)
@@ -221,11 +220,10 @@ def test_drain_and_replace_node_kubernetes(db_cluster):
     db_cluster.wait_for_pods_readiness(pods_to_wait=1, total_pods=len(db_cluster.nodes))
 
 
-@pytest.mark.requires_node_termination_support('drain_k8s_node')
-def test_drain_wait_and_replace_node_kubernetes(db_cluster):
+def test_drain_kubernetes_node_then_wait_and_replace_scylla_node(db_cluster):
     target_node = random.choice(db_cluster.non_seed_nodes)
     old_uid = target_node.k8s_pod_uid
-    log.info('TerminateNode %s (uid=%s)', target_node, old_uid)
+    log.info("Drain K8S node that hosts '%s' scylla node (uid=%s)", target_node, old_uid)
     target_node.drain_k8s_node()
     target_node.wait_till_k8s_pod_get_uid(ignore_uid=old_uid)
     old_uid = target_node.k8s_pod_uid
@@ -236,11 +234,10 @@ def test_drain_wait_and_replace_node_kubernetes(db_cluster):
     db_cluster.wait_for_pods_readiness(pods_to_wait=1, total_pods=len(db_cluster.nodes))
 
 
-@pytest.mark.requires_node_termination_support('drain_k8s_node')
-@pytest.mark.skip("Disabled due to the https://github.com/scylladb/scylla-operator/issues/982")
-def test_drain_terminate_decommission_add_node_kubernetes(db_cluster):
+def test_drain_kubernetes_node_then_decommission_and_add_scylla_node(db_cluster):
     target_rack = random.choice([*db_cluster.racks])
     target_node = db_cluster.get_rack_nodes(target_rack)[-1]
+    log.info("Drain K8S node that hosts '%s' scylla node not waiting for pod absence", target_node)
     target_node.drain_k8s_node()
     db_cluster.decommission(target_node)
     db_cluster.add_nodes(count=1, dc_idx=0, enable_auto_bootstrap=True, rack=0)

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2338,7 +2338,6 @@ class PodCluster(cluster.BaseCluster):
 
 class ScyllaPodCluster(cluster.BaseScyllaCluster, PodCluster):  # pylint: disable=too-many-public-methods
     node_setup_requires_scylla_restart = False
-    node_terminate_methods: List[str] = None
 
     def __init__(self,
                  k8s_cluster: KubernetesCluster,

--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -626,13 +626,6 @@ class EksScyllaPodContainer(BaseScyllaPodContainer):
 
 
 class EksScyllaPodCluster(ScyllaPodCluster):
-    node_terminate_methods = [
-        'drain_k8s_node',
-        # NOTE: uncomment below when following scylla-operator bug is fixed:
-        #       https://github.com/scylladb/scylla-operator/issues/643
-        # 'terminate_k8s_host',
-        # 'terminate_k8s_node',
-    ]
     k8s_cluster: 'EksCluster'
     PodContainerClass = EksScyllaPodContainer
     nodes: List[EksScyllaPodContainer]

--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -451,15 +451,6 @@ class GkeScyllaPodContainer(BaseScyllaPodContainer):
 
 
 class GkeScyllaPodCluster(ScyllaPodCluster):
-    node_terminate_methods = [
-        'drain_k8s_node',
-        # NOTE: uncomment below when following scylla-operator bug is fixed:
-        #       https://github.com/scylladb/scylla-operator/issues/643
-        #       Also, need to add check that there are no PV duplicates
-        # 'terminate_k8s_host',
-        # 'terminate_k8s_node',
-    ]
-
     k8s_cluster: 'GkeCluster'
     node_pool: 'GkeNodePool'
     PodContainerClass = GkeScyllaPodContainer

--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -14,7 +14,7 @@ import abc
 import getpass
 import logging
 import os
-from typing import Tuple, Optional, List, Callable
+from typing import Tuple, Optional, Callable
 from textwrap import dedent
 from functools import cached_property
 import yaml
@@ -670,6 +670,9 @@ class LocalMinimalScyllaPodContainer(BaseScyllaPodContainer):
     def node_type(self) -> 'str':
         return 'db'
 
+    def terminate_k8s_node(self):
+        raise NotImplementedError("Not supported on local K8S backends")
+
     def terminate_k8s_host(self):
         raise NotImplementedError("Not supported on local K8S backends")
 
@@ -689,14 +692,6 @@ class LocalMinimalScyllaPodCluster(ScyllaPodCluster):
     """Represents scylla cluster hosted on locally running minimal k8s clusters such as k3d, minikube or kind"""
     k8s_cluster: MinimalClusterBase
     PodContainerClass = LocalMinimalScyllaPodContainer
-
-    @cached_property
-    def node_terminate_methods(self) -> List[str]:
-        if isinstance(self.k8s_cluster, LocalKindCluster):
-            # NOTE: local K8S installation supports only 'drain_k8s_node' method.
-            #       'terminate_k8s_host' and 'terminate_k8s_node' are not applicable to it.
-            return ['drain_k8s_node']
-        return []
 
     def wait_for_nodes_up_and_normal(self, nodes=None, verification_node=None, iterations=20, sleep_time=60, timeout=0):  # pylint: disable=too-many-arguments
         @retrying(n=iterations, sleep_time=sleep_time,

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-terminate-decommission-add.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-terminate-decommission-add.yaml
@@ -7,7 +7,7 @@ k8s_n_scylla_pods_per_cluster: 3
 n_loaders: 2
 n_monitor_nodes: 1
 
-nemesis_class_name: 'OperatorNodeTerminateDecommissionAdd'
+nemesis_class_name: 'DisruptKubernetesNodeThenDecommissionAndAddScyllaNode'
 nemesis_interval: 5
 
 user_prefix: 'longevity-scylla-operator-3h'

--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-terminate-replace.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-terminate-replace.yaml
@@ -7,7 +7,7 @@ k8s_n_scylla_pods_per_cluster: 3
 n_loaders: 2
 n_monitor_nodes: 1
 
-nemesis_class_name: 'OperatorNodeTerminateAndReplace'
+nemesis_class_name: 'DisruptKubernetesNodeThenReplaceScyllaNode'
 nemesis_interval: 5
 
 user_prefix: 'longevity-scylla-operator-3h'

--- a/unit_tests/test_nemesis_sisyphus.py
+++ b/unit_tests/test_nemesis_sisyphus.py
@@ -71,7 +71,7 @@ def test_list_all_available_nemesis(generate_file=True):
     disruption_list, disruptions_dict, disruption_classes = sisyphus.get_list_of_disrupt_methods(
         subclasses_list=subclasses, export_properties=True)
 
-    assert len(disruption_list) == 73
+    assert len(disruption_list) == 75
 
     if generate_file:
         with open('data_dir/nemesis.yml', 'w', encoding="utf-8") as outfile1:


### PR DESCRIPTION
Changes:
- Split `disrupt_terminate_and_replace_node_kubernetes` into following:
  - `disrupt_drain_kubernetes_node_then_replace_scylla_node`
  - `disrupt_terminate_kubernetes_host_then_replace_scylla_node`
- Split `disrupt_terminate_decommission_add_node_kubernetes` into following:
  - `disrupt_drain_kubernetes_node_then_decommission_and_add_scylla_node`
  - `disrupt_terminate_kubernetes_host_then_decommission_and_add_scylla_node`
- Rename `disrupt_replace_node_kubernetes` method -> `disrupt_replace_scylla_node_on_kubernetes`.
- Rename `OperatorNodeTerminateAndReplace` class -> `DisruptKubernetesNodeThenReplaceScyllaNode`.
- Rename `OperatorNodeTerminateDecommissionAdd` class -> `DisruptKubernetesNodeThenDecommissionAndAddScyllaNode`.

Reason:
Above is done because we were using 3 different disruption methods as one. It is not correct, we should treat them as separate ones.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
