### PR TITLE
fix(setup): stabilise docker installation

### DIFF
--- a/install-hydra.sh
+++ b/install-hydra.sh
@@ -2,7 +2,7 @@
 HYDRA_LINK_PATH=/usr/local/bin/hydra
 if ! docker --version ; then
     echo "Docker not installed!!!"
-    curl -fsSL get.docker.com -o get-docker.sh
+    curl -fsSL get.docker.com --retry 5 --retry-max-time 300  -o get-docker.sh
     sh get-docker.sh
     # Docker post install, adds ability to run Docker as current user
     groupadd docker || true

--- a/install-prereqs.sh
+++ b/install-prereqs.sh
@@ -47,7 +47,7 @@ install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
 # Install docker
 
-curl -fsSL get.docker.com -o get-docker.sh
+curl -fsSL get.docker.com --retry 5 --retry-max-time 300 -o get-docker.sh
 sh get-docker.sh
 groupadd docker || true
 usermod -aG docker $USER || true

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4748,7 +4748,7 @@ class BaseLoaderSet():
 
         # install docker
         docker_install = dedent("""
-            curl -fsSL get.docker.com -o get-docker.sh
+            curl -fsSL get.docker.com --retry 5 --retry-max-time 300 -o get-docker.sh
             sh get-docker.sh
             systemctl enable docker
             systemctl start docker
@@ -5077,7 +5077,7 @@ class BaseMonitorSet:  # pylint: disable=too-many-public-methods,too-many-instan
                 yum install -y python36-pip
                 python3 -m pip install --upgrade pip
                 python3 -m pip install pyyaml
-                curl -fsSL get.docker.com -o get-docker.sh
+                curl -fsSL get.docker.com --retry 5 --retry-max-time 300 -o get-docker.sh
                 sh get-docker.sh
                 systemctl start docker
             """)


### PR DESCRIPTION
Sometimes it happens docker cannot be downloaded due to:
```
+ curl -fsSL get.docker.com -o get-docker.sh curl: (56)
Recv failure: Connection reset by peer
```

This commit use retry mechanism of curl to fix it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
