### PR TITLE
fix(aws_instance_profile): split profiles per node type

### DIFF
--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -37,7 +37,7 @@ ami_db_scylla_user: 'scyllaadm'
 ami_loader_user: 'centos'
 # centos7 is used for monitor
 ami_monitor_user: 'centos'
-aws_instance_profile_name: 'qa-scylla-manager-backup-instance-profile'
+aws_instance_profile_name_db: 'qa-scylla-manager-backup-instance-profile'
 
 ami_id_db_scylla: ''
 ami_id_db_oracle: ''

--- a/defaults/azure_config.yaml
+++ b/defaults/azure_config.yaml
@@ -24,7 +24,6 @@ ami_loader_user: 'ubuntu'
 scylla_repo_loader: 'https://s3.amazonaws.com/downloads.scylladb.com/deb/debian/scylla-4.6-buster.list'
 # centos7 is used for monitor
 ami_monitor_user: 'ubuntu'
-aws_instance_profile_name: 'qa-scylla-manager-backup-instance-profile'
 
 ami_id_db_scylla: ''
 ami_id_db_oracle: ''

--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -121,6 +121,14 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
     def calculate_spot_duration_for_test(self):
         return floor(self.test_config.TEST_DURATION / 60) * 60 + 60
 
+    @property
+    def instance_profile_name(self) -> str | None:
+        if self.node_type == "scylla-db":
+            return self.params.get('aws_instance_profile_name_db')
+        if self.node_type == "loader":
+            return self.params.get('aws_instance_profile_name_loader')
+        return None
+
     def _create_on_demand_instances(self, count, interfaces, ec2_user_data, dc_idx=0):  # pylint: disable=too-many-arguments
         ami_id = self._ec2_ami_id[dc_idx]
         self.log.debug(f"Creating {count} on-demand instances using AMI id '{ami_id}'... ")
@@ -132,7 +140,7 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
                       BlockDeviceMappings=self._ec2_block_device_mappings,
                       NetworkInterfaces=interfaces,
                       InstanceType=self._ec2_instance_type)
-        instance_profile = self.params.get('aws_instance_profile_name')
+        instance_profile = self.instance_profile_name
         if instance_profile:
             params['IamInstanceProfile'] = {'Name': instance_profile}
         instances = self._ec2_services[dc_idx].create_instances(**params)
@@ -156,7 +164,7 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
                            user_data=ec2_user_data,
                            count=count,
                            block_device_mappings=self._ec2_block_device_mappings,
-                           aws_instance_profile=self.params.get('aws_instance_profile_name'))
+                           aws_instance_profile=self.instance_profile_name)
         if self.instance_provision == INSTANCE_PROVISION_SPOT_DURATION:
             # duration value must be a multiple of 60
             spot_params.update({'duration': self.calculate_spot_duration_for_test()})

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -672,8 +672,11 @@ class SCTConfiguration(dict):
         dict(name="extra_network_interface", env="SCT_EXTRA_NETWORK_INTERFACE", type=boolean,
              help="if true, create extra network interface on each node"),
 
-        dict(name="aws_instance_profile_name", env="SCT_AWS_INSTANCE_PROFILE_NAME", type=str,
-             help="This is the name of the instance profile to set on all instances"),
+        dict(name="aws_instance_profile_name_db", env="SCT_AWS_INSTANCE_PROFILE_NAME_DB", type=str,
+             help="This is the name of the instance profile to set on all db instances"),
+
+        dict(name="aws_instance_profile_name_loader", env="SCT_AWS_INSTANCE_PROFILE_NAME_LOADER", type=str,
+             help="This is the name of the instance profile to set on all loader instances"),
 
         dict(name="backup_bucket_backend", env="SCT_BACKUP_BUCKET_BACKEND", type=str,
              help="the backend to be used for backup (e.g., 's3', 'gcs' or 'azure')"),

--- a/sdcm/sct_provision/aws/instance_parameters_builder.py
+++ b/sdcm/sct_provision/aws/instance_parameters_builder.py
@@ -33,6 +33,7 @@ class AWSInstanceParamsBuilder(AWSInstanceParamsBuilderBase, metaclass=abc.ABCMe
     _INSTANCE_TYPE_PARAM_NAME: str = None
     _IMAGE_ID_PARAM_NAME: str = None
     _ROOT_DISK_SIZE_PARAM_NAME: str = None
+    _INSTANCE_PROFILE_PARAM_NAME: str = None
 
     @property
     def BlockDeviceMappings(self) -> List[AWSDiskMapping]:  # pylint: disable=invalid-name
@@ -70,7 +71,7 @@ class AWSInstanceParamsBuilder(AWSInstanceParamsBuilderBase, metaclass=abc.ABCMe
 
     @property
     def IamInstanceProfile(self):  # pylint: disable=invalid-name
-        if profile := self.params.get('aws_instance_profile_name'):
+        if profile := self.params.get(self._INSTANCE_PROFILE_PARAM_NAME):
             return {'Name': profile}
         return None
 
@@ -148,6 +149,7 @@ class ScyllaInstanceParamsBuilder(AWSInstanceParamsBuilder):
     _INSTANCE_TYPE_PARAM_NAME = 'instance_type_db'
     _IMAGE_ID_PARAM_NAME = 'ami_id_db_scylla'
     _ROOT_DISK_SIZE_PARAM_NAME = 'root_disk_size_db'
+    _INSTANCE_PROFILE_PARAM_NAME = 'aws_instance_profile_name_db'
 
     @property
     def BlockDeviceMappings(self) -> List[AWSDiskMapping]:
@@ -183,6 +185,7 @@ class LoaderInstanceParamsBuilder(AWSInstanceParamsBuilder):
     _INSTANCE_TYPE_PARAM_NAME = 'instance_type_loader'
     _IMAGE_ID_PARAM_NAME = 'ami_id_loader'
     _ROOT_DISK_SIZE_PARAM_NAME = 'root_disk_size_loader'
+    _INSTANCE_PROFILE_PARAM_NAME = 'aws_instance_profile_name_loader'
 
 
 class MonitorInstanceParamsBuilder(AWSInstanceParamsBuilder):

--- a/test-cases/manager/manager-regression-ipv6.yaml
+++ b/test-cases/manager/manager-regression-ipv6.yaml
@@ -18,4 +18,4 @@ user_prefix: manager-regression
 space_node_threshold: 6442
 ip_ssh_connections: 'ipv6'
 
-aws_instance_profile_name: 'qa-scylla-manager-backup-instance-profile'
+aws_instance_profile_name_db: 'qa-scylla-manager-backup-instance-profile'

--- a/test-cases/manager/manager-regression-multiDC-set-distro.yaml
+++ b/test-cases/manager/manager-regression-multiDC-set-distro.yaml
@@ -17,4 +17,4 @@ post_behavior_monitor_nodes: "destroy"
 user_prefix: manager-regression
 space_node_threshold: 6442
 
-aws_instance_profile_name: 'qa-scylla-manager-backup-instance-profile'
+aws_instance_profile_name_db: 'qa-scylla-manager-backup-instance-profile'

--- a/test-cases/upgrades/manager-upgrade.yaml
+++ b/test-cases/upgrades/manager-upgrade.yaml
@@ -20,4 +20,4 @@ ip_ssh_connections: 'private'
 
 manager_prometheus_port: 10091
 
-aws_instance_profile_name: 'qa-scylla-manager-backup-instance-profile'
+aws_instance_profile_name_db: 'qa-scylla-manager-backup-instance-profile'


### PR DESCRIPTION
Split the configuration, so we can select specific profile for each type of node, and not use the same one for all of the nodes.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
