### PR TITLE
fix(setup): stabilise download repo file

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1659,21 +1659,21 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             return
         if self.is_rhel_like():
             repo_path = '/etc/yum.repos.d/scylla.repo'
-            self.remoter.sudo('curl -o %s -L %s' % (repo_path, scylla_repo))
+            self.remoter.sudo('curl --retry 5 --retry-max-time 300 -o %s -L %s' % (repo_path, scylla_repo))
             self.remoter.sudo('chown root:root %s' % repo_path)
             self.remoter.sudo('chmod 644 %s' % repo_path)
             result = self.remoter.run('cat %s' % repo_path, verbose=True)
             verify_scylla_repo_file(result.stdout, is_rhel_like=True)
         elif self.distro.is_sles:
             repo_path = '/etc/zypp/repos.d/scylla.repo'
-            self.remoter.sudo('curl -o %s -L %s' % (repo_path, scylla_repo))
+            self.remoter.sudo('curl --retry 5 --retry-max-time 300 -o %s -L %s' % (repo_path, scylla_repo))
             self.remoter.sudo('chown root:root %s' % repo_path)
             self.remoter.sudo('chmod 644 %s' % repo_path)
             result = self.remoter.run('cat %s' % repo_path, verbose=True)
             verify_scylla_repo_file(result.stdout, is_rhel_like=True)
         else:
             repo_path = '/etc/apt/sources.list.d/scylla.list'
-            self.remoter.sudo('curl -o %s -L %s' % (repo_path, scylla_repo))
+            self.remoter.sudo('curl --retry 5 --retry-max-time 300 -o %s -L %s' % (repo_path, scylla_repo))
             result = self.remoter.run('cat %s' % repo_path, verbose=True)
             verify_scylla_repo_file(result.stdout, is_rhel_like=False)
             self.remoter.sudo("mkdir -p /etc/apt/keyrings")


### PR DESCRIPTION
Sometimes it may happen that curl fails to fetch repo file.

This commit adds curl retry on such cases.
Refs.: https://github.com/scylladb/scylla-cluster-tests/issues/5580

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
