### PR TITLE
feature(sct-builders): move builder to auto scaling group

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,7 +67,7 @@ def runRestoreMonitoringStack(){
 pipeline {
     agent {
         label {
-            label "sct-builders"
+            label "aws-sct-builders-eu-west-1-v2-CI"
         }
     }
     parameters {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@
 def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 
 def target_backends = ['aws', 'gce', 'docker', 'k8s-local-kind-aws', 'k8s-eks', 'azure']
-def sct_runner_backends = ['aws', 'gce', 'k8s-local-kind-aws', 'k8s-eks', 'azure']
+def sct_runner_backends = ['aws', 'gce', 'docker', 'k8s-local-kind-aws', 'k8s-eks', 'azure']
 
 def createRunConfiguration(String backend) {
 
@@ -155,13 +155,33 @@ pipeline {
                 }
             }
             options {
-                timeout(time: 30, unit: 'MINUTES')
+                timeout(time: 40, unit: 'MINUTES')
             }
             steps {
                 script {
+                    def curr_params = createRunConfiguration('docker')
+                    def builder = getJenkinsLabels(curr_params.backend, curr_params.region, curr_params.gce_datacenter, curr_params.azure_region_name)
                     try {
-                        sh './docker/env/hydra.sh integration-tests'
-                        pullRequestSetResult('success', 'jenkins/integration-tests', 'All integration tests are passed')
+                        withEnv(["SCT_TEST_ID=${UUID.randomUUID().toString()}",]) {
+                            dir('scylla-cluster-tests') {
+                                checkout scm
+
+                                wrap([$class: 'BuildUser']) {
+                                    echo "calling createSctRunner"
+                                    timeout(time: 5, unit: 'MINUTES') {
+                                        createSctRunner(curr_params, 50 , builder.region)
+                                    }
+                                }
+                                sh """#!/bin/bash
+                                    set -xe
+                                    echo "start integration-tests ..."
+                                    RUNNER_IP=\$(cat sct_runner_ip||echo "")
+                                    ./docker/env/hydra.sh --execute-on-runner \${RUNNER_IP} integration-tests
+                                    echo "end  integration-tests ..."
+                                """
+                            }
+                            pullRequestSetResult('success', 'jenkins/integration-tests', 'All integration tests are passed')
+                        }
                     } catch(Exception ex) {
                         pullRequestSetResult('failure', 'jenkins/integration-tests', 'Some integration tests failed')
                     }
@@ -186,35 +206,19 @@ pipeline {
                             sctParallelTests["provision test on ${backend}"] = {
                                 def curr_params = createRunConfiguration(backend)
                                 def builder = getJenkinsLabels(curr_params.backend, curr_params.region, curr_params.gce_datacenter, curr_params.azure_region_name)
-                                node(builder.label) {
-                                    withEnv(["SCT_TEST_ID=${UUID.randomUUID().toString()}",]) {
-                                        script {
-                                            def result = null
+                                withEnv(["SCT_TEST_ID=${UUID.randomUUID().toString()}",]) {
+                                    script {
+                                        def result = null
 
-                                            dir('scylla-cluster-tests') {
-                                                checkout scm
-                                            }
-                                            if (sct_runner_backends.contains(backend)){
-                                                try {
-                                                    wrap([$class: 'BuildUser']) {
-                                                        dir('scylla-cluster-tests') {
-                                                            echo "calling createSctRunner"
-                                                            createSctRunner(curr_params, 90 , builder.region)
-                                                        }
-                                                    }
-                                                } catch(Exception err) {
-                                                    echo "${err}"
-                                                    result = 'FAILURE'
-                                                    pullRequestSetResult('failure', "jenkins/provision_${backend}", 'Some test cases are failed')
-                                                }
-                                            }
+                                        dir('scylla-cluster-tests') {
+                                            checkout scm
+                                        }
+                                        if (sct_runner_backends.contains(backend)){
                                             try {
                                                 wrap([$class: 'BuildUser']) {
-                                                    env.BUILD_USER_ID=env.CHANGE_AUTHOR
                                                     dir('scylla-cluster-tests') {
-                                                        runSctTest(curr_params, builder.region, curr_params.get('functional_tests', false))
-                                                        result = 'SUCCESS'
-                                                        pullRequestSetResult('success', "jenkins/provision_${backend}", 'All test cases are passed')
+                                                        echo "calling createSctRunner"
+                                                        createSctRunner(curr_params, 90 , builder.region)
                                                     }
                                                 }
                                             } catch(Exception err) {
@@ -222,40 +226,54 @@ pipeline {
                                                 result = 'FAILURE'
                                                 pullRequestSetResult('failure', "jenkins/provision_${backend}", 'Some test cases are failed')
                                             }
+                                        }
+                                        try {
+                                            wrap([$class: 'BuildUser']) {
+                                                env.BUILD_USER_ID=env.CHANGE_AUTHOR
+                                                dir('scylla-cluster-tests') {
+                                                    runSctTest(curr_params, builder.region, curr_params.get('functional_tests', false))
+                                                    result = 'SUCCESS'
+                                                    pullRequestSetResult('success', "jenkins/provision_${backend}", 'All test cases are passed')
+                                                }
+                                            }
+                                        } catch(Exception err) {
+                                            echo "${err}"
+                                            result = 'FAILURE'
+                                            pullRequestSetResult('failure', "jenkins/provision_${backend}", 'Some test cases are failed')
+                                        }
+                                        try {
+                                            wrap([$class: 'BuildUser']) {
+                                                dir('scylla-cluster-tests') {
+                                                    runCollectLogs(curr_params, builder.region)
+                                                }
+                                            }
+                                        } catch(Exception err) {
+                                            echo "${err}"
+                                        }
+                                        try {
+                                            wrap([$class: 'BuildUser']) {
+                                                dir('scylla-cluster-tests') {
+                                                    runCleanupResource(curr_params, builder.region)
+                                                }
+                                            }
+                                        } catch(Exception err) {
+                                            echo "${err}"
+                                        }
+                                        if (!(backend in ['k8s-local-kind-aws', 'k8s-eks'])) {
                                             try {
                                                 wrap([$class: 'BuildUser']) {
                                                     dir('scylla-cluster-tests') {
-                                                        runCollectLogs(curr_params, builder.region)
+                                                        runRestoreMonitoringStack()
                                                     }
                                                 }
                                             } catch(Exception err) {
                                                 echo "${err}"
-                                            }
-                                            try {
-                                                wrap([$class: 'BuildUser']) {
-                                                    dir('scylla-cluster-tests') {
-                                                        runCleanupResource(curr_params, builder.region)
-                                                    }
-                                                }
-                                            } catch(Exception err) {
-                                                echo "${err}"
-                                            }
-                                            if (!(backend in ['k8s-local-kind-aws', 'k8s-eks'])) {
-                                                try {
-                                                    wrap([$class: 'BuildUser']) {
-                                                        dir('scylla-cluster-tests') {
-                                                            runRestoreMonitoringStack()
-                                                        }
-                                                    }
-                                                } catch(Exception err) {
-                                                    echo "${err}"
-                                                    currentBuild.result = 'FAILURE'
-                                                }
-                                            }
-                                            if (result == 'FAILURE'){
                                                 currentBuild.result = 'FAILURE'
-                                                sh "exit 1"
                                             }
+                                        }
+                                        if (result == 'FAILURE'){
+                                            currentBuild.result = 'FAILURE'
+                                            sh "exit 1"
                                         }
                                     }
                                 }

--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -9,23 +9,23 @@ instance_type_monitor: 't3.large'
 # manual on creating loader AMI's: see docs/new_loader_ami.md
 regions_data:
   us-east-1: # US East (N. Virginia)
-    ami_id_loader: 'ami-00c1a16b5136fbb7c' # Loader dedicated AMI v19
-    ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
+    ami_id_loader: 'ami-00c1a16b5136fbb7c' # Loader dedicated AMI scylla-qa-loader-ami-v19
+    ami_id_monitor: 'ami-06878d265978313ca' # ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221206 Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2022-12-06
   us-west-2: # US West (Oregon)
-    ami_id_loader: 'ami-04d2eb44d523b3ccb' # Loader dedicated AMI v19
-    ami_id_monitor: 'ami-01ed306a12b7d1c96' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
-  eu-west-1: # Europe (Ireland)
-    ami_id_loader: 'ami-042cf1bc21e30ce60' # Loader dedicated AMI v19
-    ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
+    ami_id_loader: 'ami-09808043b7fcdb244' # Loader dedicated AMI scylla-qa-loader-ami-v19
+    ami_id_monitor: 'ami-03f8756d29f0b5f21' # ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221206 Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2022-12-06
+  eu-west-1: # EU (Ireland)
+    ami_id_loader: 'ami-042cf1bc21e30ce60' # Loader dedicated AMI scylla-qa-loader-ami-v19
+    ami_id_monitor: 'ami-026e72e4e468afa7b' # ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221206 Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2022-12-06
   eu-west-2: # Europe (London)
-    ami_id_loader: 'ami-0370fbb289d8310d2' # Loader dedicated AMI v19
-    ami_id_monitor: 'ami-0eab3a90fc693af19' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
+    ami_id_loader: 'ami-0370fbb289d8310d2' # Loader dedicated AMI scylla-qa-loader-ami-v19
+    ami_id_monitor: 'ami-01b8d743224353ffe' # ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221206 Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2022-12-06
   eu-north-1: # Europe (Stockholm)
-    ami_id_loader: 'ami-0226185e7d7951b6a' # Loader dedicated AMI v19
-    ami_id_monitor: 'ami-5ee66f20' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
-  eu-central-1: # Europe (Frankfurt)
-    ami_id_loader: 'ami-0bc7811c417b0eb09' # Loader dedicated AMI v19
-    ami_id_monitor: 'ami-04cf43aca3e6f3de3' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
+    ami_id_loader: 'ami-0226185e7d7951b6a' # Loader dedicated AMI scylla-qa-loader-ami-v19
+    ami_id_monitor: 'ami-03df6dea56f8aa618' # ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221206 Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2022-12-06
+  eu-central-1: # EU (Frankfurt)
+    ami_id_loader: 'ami-0bc7811c417b0eb09' # Loader dedicated AMI scylla-qa-loader-ami-v19
+    ami_id_monitor: 'ami-0039da1f3917fa8e3' # ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221206 Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2022-12-06
 
 availability_zone: 'a'
 root_disk_size_monitor: 50  # GB, remove this field if default disk size should be used
@@ -35,8 +35,8 @@ loader_swap_size: 10240  #10GB SWAP space
 ami_db_scylla_user: 'scyllaadm'
 # used prepared centos7 AMI for loader
 ami_loader_user: 'centos'
-# centos7 is used for monitor
-ami_monitor_user: 'centos'
+# ubuntu is used for monitor
+ami_monitor_user: 'ubuntu'
 aws_instance_profile_name_db: 'qa-scylla-manager-backup-instance-profile'
 
 ami_id_db_scylla: ''

--- a/jenkins-pipelines/hydra-clean-runner-instances.jenkinsfile
+++ b/jenkins-pipelines/hydra-clean-runner-instances.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 pipeline {
     agent {
         label {
-            label 'sct-builders'
+            label "aws-sct-builders-eu-west-1-v2-CI"
         }
     }
     environment {

--- a/jenkins-pipelines/hydra-show-jepsen-results.jenkinsfile
+++ b/jenkins-pipelines/hydra-show-jepsen-results.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 pipeline {
     agent {
         label {
-            label 'sct-builders'
+            label "aws-sct-builders-eu-west-1-v2-CI"
         }
     }
     environment {

--- a/jenkins-pipelines/hydra-show-monitor.jenkinsfile
+++ b/jenkins-pipelines/hydra-show-monitor.jenkinsfile
@@ -6,7 +6,7 @@ def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
 pipeline {
     agent {
         label {
-            label 'sct-builders'
+            label "aws-sct-builders-eu-west-1-v2-CI"
         }
     }
     environment {

--- a/sct.py
+++ b/sct.py
@@ -96,10 +96,10 @@ from sdcm.parallel_timeline_report.generate_pt_report import ParallelTimelinesRe
 from sdcm.utils.aws_utils import AwsArchType
 from sdcm.utils.gce_utils import SUPPORTED_PROJECTS
 from sdcm.utils.context_managers import environment
+from sdcm.cluster_k8s import mini_k8s
 from utils.build_system.create_test_release_jobs import JenkinsPipelines  # pylint: disable=no-name-in-module,import-error
 from utils.get_supported_scylla_base_versions import UpgradeBaseVersion  # pylint: disable=no-name-in-module,import-error
 from utils.mocks.aws_mock import AwsMock  # pylint: disable=no-name-in-module,import-error
-
 
 SUPPORTED_CLOUDS = ("aws", "gce", "azure",)
 DEFAULT_CLOUD = SUPPORTED_CLOUDS[0]
@@ -1009,6 +1009,19 @@ def unit_tests(test):
 @click.option("-t", "--test", required=False, default="",
               help="Run specific test file from unit-tests directory")
 def integration_tests(test):
+    get_test_config().logdir()
+    add_file_logger()
+
+    # setup prerequisites for the integration test is identical
+    # to the kind local functional tests
+    # TODO: to refactor setup_prerequisites out of LocalKindCluster
+    local_cluster = mini_k8s.LocalKindCluster(
+        software_version="",
+        user_prefix="",
+        params={},
+    )
+    local_cluster.setup_prerequisites()
+
     sys.exit(pytest.main(['-v', '-p', 'no:warnings', '-m', 'integration', 'unit_tests/{}'.format(test)]))
 
 

--- a/sct_ssh.py
+++ b/sct_ssh.py
@@ -33,7 +33,7 @@ def get_tags(instance: dict) -> dict:
 
 def find_bastion_for_instance(instance: dict) -> dict:
     region = get_region(instance)
-    tags = {'RunByUser': 'QA', 'bastion': 'true'}
+    tags = {'bastion': 'true'}
     bastions = list_instances_aws(tags, running=True, region_name=region)
     assert bastions, f"No bastion found for region: {region}"
     return bastions[0]

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -1139,7 +1139,7 @@ def clean_sct_runners(test_status: str,
         # trying to lookup on AWS instance from GCP/Azure
         if sct_runner_info.cloud_provider == "aws":
             ssh_run_cmd_result = ssh_run_cmd(command=cmd, test_id=sct_runner_info.test_id,
-                                             node_name=sct_runner_name)
+                                             node_name=sct_runner_name, force_use_public_ip=True)
 
             timeout_flag = bool(ssh_run_cmd_result.stdout) if ssh_run_cmd_result else False
 

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -388,6 +388,7 @@ class SctRunner(ABC):
             "keep": str(ceil(test_duration / 60) + 6),  # keep SCT Runner for 6h more than test_duration
             "keep_action": "terminate",
             "UserName": self.LOGIN_USER,
+            "bastion": "true",
         }
         if restore_monitor and restored_test_id:
             tags.update({"RestoredTestId": restored_test_id})

--- a/sdcm/utils/aws_builder.py
+++ b/sdcm/utils/aws_builder.py
@@ -336,7 +336,7 @@ class AwsBuilder:
 
 
 class AwsCiBuilder(AwsBuilder):
-    NUM_CPUS = 4
+    NUM_CPUS = 2
 
     @cached_property
     def name(self):

--- a/test-cases/PR-provision-test-docker.yaml
+++ b/test-cases/PR-provision-test-docker.yaml
@@ -7,6 +7,8 @@ n_loaders: 1
 n_monitor_nodes: 1
 n_db_nodes: 1
 
+instance_type_runner: c5.2xlarge
+
 nemesis_class_name: NonDisruptiveMonkey
 nemesis_interval: 1
 nemesis_filter_seeds: false

--- a/test-cases/manager/manager-regression-multiDC-set-distro.yaml
+++ b/test-cases/manager/manager-regression-multiDC-set-distro.yaml
@@ -18,3 +18,6 @@ user_prefix: manager-regression
 space_node_threshold: 6442
 
 aws_instance_profile_name_db: 'qa-scylla-manager-backup-instance-profile'
+
+ami_monitor_user: 'centos'
+ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01

--- a/test-cases/performance/perf-search-best-throughput-config.yaml
+++ b/test-cases/performance/perf-search-best-throughput-config.yaml
@@ -35,19 +35,13 @@ store_perf_results: false
 regions_data:
   us-east-1: # US East (N. Virginia)
     ami_id_loader: 'ami-00c1a16b5136fbb7c' # Loader dedicated AMI v19
-    ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
   us-west-2: # US West (Oregon)
     ami_id_loader: 'ami-04d2eb44d523b3ccb' # Loader dedicated AMI v19
-    ami_id_monitor: 'ami-01ed306a12b7d1c96' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
   eu-west-1: # Europe (Ireland)
     ami_id_loader: 'ami-042cf1bc21e30ce60' # Loader dedicated AMI v19
-    ami_id_monitor: 'ami-0ff760d16d9497662' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
   eu-west-2: # Europe (London)
     ami_id_loader: 'ami-0370fbb289d8310d2' # Loader dedicated AMI v19
-    ami_id_monitor: 'ami-0eab3a90fc693af19' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
   eu-north-1: # Europe (Stockholm)
     ami_id_loader: 'ami-0226185e7d7951b6a' # Loader dedicated AMI v19
-    ami_id_monitor: 'ami-5ee66f20' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01
   eu-central-1: # Europe (Frankfurt)
     ami_id_loader: 'ami-0bc7811c417b0eb09' # Loader dedicated AMI v19
-    ami_id_monitor: 'ami-04cf43aca3e6f3de3' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01

--- a/utils/copy_ami_to_all_regions.sh
+++ b/utils/copy_ami_to_all_regions.sh
@@ -1,0 +1,10 @@
+AMI_ID=ami-00c1a16b5136fbb7c
+AMI_NAME='scylla-qa-loader-ami-v19'
+SOURCE_REGION=us-east-1
+TARGET_REGIONS='us-west-2 eu-west-1 eu-west-2 eu-north-1 eu-central-1'
+
+for target_region in $TARGET_REGIONS
+do
+	echo "copy AMI to $target_region"
+	aws ec2 copy-image --region $target_region  --name "$AMI_NAME" --source-region $SOURCE_REGION --source-image-id $AMI_ID
+done

--- a/utils/create_aws_region_data.py
+++ b/utils/create_aws_region_data.py
@@ -1,0 +1,60 @@
+from textwrap import dedent
+
+import boto3
+
+region_names = {
+    'us-east-1': 'US East (N. Virginia)',
+    'us-east-2': 'US East (Ohio)',
+    'us-west-1': 'US West (N. California)',
+    'us-west-2': 'US West (Oregon)',
+    'af-south-1': 'Africa (Cape Town)',
+    'ap-east-1': 'Asia Pacific (Hong Kong)',
+    'ap-south-1': 'Asia Pacific (Mumbai)',
+    'ap-northeast-3': 'Asia Pacific (Osaka)',
+    'ap-northeast-2': 'Asia Pacific (Seoul)',
+    'ap-southeast-1': 'Asia Pacific (Singapore)',
+    'ap-southeast-2': 'Asia Pacific (Sydney)',
+    'ap-northeast-1': 'Asia Pacific (Tokyo)',
+    'ca-central-1': 'Canada (Central)',
+    'eu-central-1': 'EU (Frankfurt)',
+    'eu-west-1': 'EU (Ireland)',
+    'eu-west-2': 'Europe (London)',
+    'eu-south-1': 'Europe (Milan)',
+    'eu-west-3': 'Europe (Paris)',
+    'eu-north-1': 'Europe (Stockholm)',
+    'me-south-1': 'Middle East (Bahrain)',
+    'sa-east-1': 'South America (São Paulo)',
+}
+
+
+def main():
+
+    for region in ['us-east-1', 'us-west-2', 'eu-west-1', 'eu-west-2', 'eu-north-1', 'eu-central-1']:
+        # Create an EC2 client
+        ec2 = boto3.client('ec2', region_name=region)
+
+        # Set the name and owner for the AMI that we want to find
+        name = 'ubuntu/images/hvm-ssd/ubuntu-*-22.04-amd64-server-*'
+        owners = ['099720109477']  # Canonical's account ID
+
+        # Use the describe_images method to retrieve a list of AMIs that match the specified criteria
+        response = ec2.describe_images(Owners=owners, Filters=[{'Name': 'name', 'Values': [name]}])
+
+        # Get a list of the AMIs
+        amis = response['Images']
+        amis.sort(key=lambda x: x['CreationDate'])
+        loader_image_name = '*scylla-qa-loader-ami-v19'
+        owners = ['self']
+        response = ec2.describe_images(Owners=owners, Filters=[{'Name': 'name', 'Values': [loader_image_name]}])
+        loader_ami = response['Images'][-1]
+
+        # Print the AMI IDs
+        print(dedent(f"""
+            {region}: # {region_names[region]}
+              ami_id_loader: '{loader_ami['ImageId']}' # Loader dedicated AMI {loader_image_name[1:]}
+              ami_id_monitor: '{amis[-1]['ImageId']}' # {amis[-1]['Name']} {amis[-1]['Description']}
+        """).strip())
+
+
+if __name__ == '__main__':
+    main()

--- a/vars/byoLongevityPipeline.groovy
+++ b/vars/byoLongevityPipeline.groovy
@@ -39,7 +39,7 @@ def call() {
                description: 'aws|gce',
                name: 'backend')
             string(defaultValue: "eu-west-1",
-               description: 'Supported: us-east-1|eu-west-1|eu-west-2|eu-north-1|random (randomly select region)',
+               description: 'Supported: us-east-1 | eu-west-1 | eu-west-2 | eu-north-1 | eu-central-1 | us-west-2 | random (randomly select region)',
                name: 'region')
             string(defaultValue: "us-east1",
                    description: 'GCE datacenter supported: us-east1',

--- a/vars/cdcReplicationPipeline.groovy
+++ b/vars/cdcReplicationPipeline.groovy
@@ -89,7 +89,7 @@ def call(Map pipelineParams) {
                name: 'backend')
 
             string(defaultValue: "${pipelineParams.get('region', 'eu-west-1')}",
-               description: 'Supported: us-east-1|eu-west-1|eu-west-2|eu-north-1|random (randomly select region)',
+               description: 'Supported: us-east-1 | eu-west-1 | eu-west-2 | eu-north-1 | eu-central-1 | us-west-2 | random (randomly select region)',
                name: 'region')
             string(defaultValue: "${pipelineParams.get('gce_datacenter', 'us-east1')}",
                    description: 'GCE datacenter',

--- a/vars/getCloudProviderFromBackend.groovy
+++ b/vars/getCloudProviderFromBackend.groovy
@@ -7,7 +7,8 @@ def call(String backend) {
         'k8s-local-kind-gce': 'gce',
         'aws-siren': 'aws',
         'gce-siren': 'gce',
-        'azure': 'azure'
+        'azure': 'azure',
+        'docker': 'aws'
         ]
     if (!backend) {
         return backend

--- a/vars/getJenkinsLabels.groovy
+++ b/vars/getJenkinsLabels.groovy
@@ -18,11 +18,12 @@ def call(String backend, String region=null, String datacenter=null, String loca
     def gcp_project = params.gce_project?.trim() ?: 'gcp-sct-project-1'
     gcp_project = gcp_project == 'gcp' ? 'gce-sct' : gcp_project
 
-    def jenkins_labels = ['aws-eu-west-1': 'aws-sct-builders-eu-west-1-v2',
-                          'aws-eu-west-2': 'aws-sct-builders-eu-west-2-v2',
-                          'aws-eu-north-1': 'aws-sct-builders-eu-north-1-v2',
-                          'aws-eu-central-1': 'aws-sct-builders-eu-central-1-v2',
-                          'aws-us-east-1' : 'aws-sct-builders-us-east-1-v2',
+    def jenkins_labels = ['aws-eu-west-1': 'aws-sct-builders-eu-west-1-v2-asg',
+                          'aws-eu-west-2': 'aws-sct-builders-eu-west-2-v2-asg',
+                          'aws-eu-north-1': 'aws-sct-builders-eu-north-1-v2-asg',
+                          'aws-eu-central-1': 'aws-sct-builders-eu-central-1-v2-asg',
+                          'aws-us-east-1' : 'aws-sct-builders-us-east-1-v2-asg',
+                          'aws-us-west-2' : 'aws-sct-builders-us-west-2-v2-asg',
                           'gce-us-east1': "${gcp_project}-builders-us-east1",
                           'gce-us-west1': "${gcp_project}-builders-us-west1",
                           'gce': "${gcp_project}-builders",
@@ -35,7 +36,7 @@ def call(String backend, String region=null, String datacenter=null, String loca
         def supported_regions = []
 
         if (cloud_provider == 'aws') {
-            supported_regions = ["eu-west-2", "eu-north-1", "eu-central-1"]
+            supported_regions = ["eu-west-2", "eu-north-1", "eu-central-1", "us-west-2"]
         } else if (cloud_provider == 'gce') {
             supported_regions = ["us-east1", "us-west1"]
             region = datacenter

--- a/vars/getJenkinsLabels.groovy
+++ b/vars/getJenkinsLabels.groovy
@@ -27,7 +27,7 @@ def call(String backend, String region=null, String datacenter=null, String loca
                           'gce-us-east1': "${gcp_project}-builders-us-east1",
                           'gce-us-west1': "${gcp_project}-builders-us-west1",
                           'gce': "${gcp_project}-builders",
-                          'docker': 'sct-builders',
+                          'aws': 'aws-sct-builders-eu-west-1-v2-asg',
                           'azure-eastus': 'azure-sct-builders']
 
     def cloud_provider = getCloudProviderFromBackend(backend)

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -26,7 +26,7 @@ def call(Map pipelineParams) {
                name: 'backend')
 
             string(defaultValue: "${pipelineParams.get('region', 'eu-west-1')}",
-               description: 'Supported: us-east-1|eu-west-1|eu-west-2|eu-north-1|random (randomly select region)',
+               description: 'Supported: us-east-1 | eu-west-1 | eu-west-2 | eu-north-1 | eu-central-1 | us-west-2 | random (randomly select region)',
                name: 'region')
             string(defaultValue: "${pipelineParams.get('gce_datacenter', 'us-east1')}",
                    description: 'GCE datacenter',

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -58,7 +58,7 @@ def call(Map pipelineParams) {
                description: 'aws|gce',
                name: 'backend')
             string(defaultValue: "${pipelineParams.get('region', 'eu-west-1')}",
-               description: 'Supported: us-east-1|eu-west-1|eu-west-2|eu-north-1|random (randomly select region)',
+               description: 'Supported: us-east-1 | eu-west-1 | eu-west-2 | eu-north-1 | eu-central-1 | us-west-2 | random (randomly select region)',
                name: 'region')
             string(defaultValue: "${pipelineParams.get('gce_datacenter', 'us-east1')}",
                    description: 'GCE datacenter',

--- a/vars/rollingOperatorUpgradePipeline.groovy
+++ b/vars/rollingOperatorUpgradePipeline.groovy
@@ -17,7 +17,7 @@ def call(Map pipelineParams) {
             choice(choices: ["${pipelineParams.get('backend', 'k8s-gke')}", 'k8s-eks', 'k8s-gke'],
                    name: 'backend')
             string(defaultValue: "${pipelineParams.get('region', '')}",
-               description: 'Supported: us-east-1|eu-west-1|eu-west-2|eu-north-1|random (randomly select region)',
+               description: 'Supported: us-east-1 | eu-west-1 | eu-west-2 | eu-north-1 | eu-central-1 | us-west-2 | random (randomly select region)',
                name: 'region')
             string(defaultValue: "a",
                description: 'Availability zone',

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -26,7 +26,7 @@ def call(Map pipelineParams) {
                name: 'backend')
 
             string(defaultValue: "${pipelineParams.get('region', 'eu-west-1')}",
-               description: 'Supported: us-east-1|eu-west-1|eu-west-2|eu-north-1|random (randomly select region)',
+               description: 'Supported: us-east-1 | eu-west-1 | eu-west-2 | eu-north-1 | eu-central-1 | us-west-2 | random (randomly select region)',
                name: 'region')
             string(defaultValue: "${pipelineParams.get('gce_datacenter', 'us-east1')}",
                    description: 'GCE datacenter',


### PR DESCRIPTION
Since we are not using those builder all the time, we are starting to create them as each time we start a job.

* very small machine that are only use to spin off the test
* in some cases it should be able to run the test (artifact test or SCT CI)
* this is creating the ASGs and launch templates in all regions we operate
* configure those ASGs in jenkins
* switch all monitors to ubuntu jammy, since the old centos images
  we use aren't available anymore across all regions

Testing:
- [x] CI - both integration test / docker backend
- [x] longevity - https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/3/
- [x] longevity - run on new region `ca-central-1` - https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-100gb-4h-test/10/
- [x] test artifact test - docker - https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-docker-test/17/
- [x] show monitor job - test and switch to same as CI
- [x] cloud report - 
- [ ] azure -
- [ ] azure artifact test -

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
