### PR TITLE
fix(hydra): use properly built image with actual requirements

### DIFF
--- a/docker/env/version
+++ b/docker/env/version
@@ -1,1 +1,1 @@
-1.28
+1.28-fixed-kubectl-version-v2

--- a/requirements.in
+++ b/requirements.in
@@ -36,6 +36,7 @@ parameterized==0.8.1
 pylint==2.11.1  # Needed for pre-commit hooks
 autopep8==1.5.7  # Needed for pre-commit hooks
 kubernetes==18.20.0
+packaging==21.3
 ldap3==2.9.1
 google-api-python-client==2.24.0
 google-cloud-storage==2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,9 +24,9 @@ astroid==2.8.6 \
     --hash=sha256:5f6f75e45f15290e73b56f9dfde95b4bf96382284cde406ef4203e928335a495 \
     --hash=sha256:cd8326b424c971e7d87678609cf6275d22028afd37d6ac59c16d47f1245882f6
     # via pylint
-attrs==22.1.0 \
-    --hash=sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6 \
-    --hash=sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c
+attrs==22.2.0 \
+    --hash=sha256:29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836 \
+    --hash=sha256:c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99
     # via pytest
 autopep8==1.5.7 \
     --hash=sha256:276ced7e9e3cb22e5d7c14748384a5cf5d9002257c0ed50c0e075b68011bb6d0 \
@@ -123,17 +123,17 @@ botocore==1.21.55 \
     #   awscli
     #   boto3
     #   s3transfer
-botocore-stubs==1.29.24 \
-    --hash=sha256:19bfab87e7aec0cf8eb8b82fe64ecaec04971bf950a0bc34fdd03ed2d5ab7c75 \
-    --hash=sha256:77af297c8f6491517a2759355943f77657f7767ebb2fc562ae23a9c6ab227ace
+botocore-stubs==1.29.35 \
+    --hash=sha256:0c89e23c964e131430f637741328b3d83cfec840a45634c76f485f92cde6a1d9 \
+    --hash=sha256:6f58863c82dd1d6a7286972598a48ecdec2340a9a3bf912e3de9dffec819fe93
     # via boto3-stubs
 cachetools==5.2.0 \
     --hash=sha256:6a94c6402995a99c3970cc7e4884bb60b4a8639938157eeed436098bf9831757 \
     --hash=sha256:f9f17d2aec496a9aa6b76f53e3b614c965223c061982d434d160f930c698a9db
     # via google-auth
-certifi==2022.9.24 \
-    --hash=sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14 \
-    --hash=sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382
+certifi==2022.12.7 \
+    --hash=sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3 \
+    --hash=sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18
     # via
     #   elasticsearch
     #   kubernetes
@@ -492,9 +492,9 @@ humanreadable==0.1.0 \
     --hash=sha256:80f10a1575ebb140d9345a347f981dc6faa70d090885490d77f63361290b4ff7 \
     --hash=sha256:c925e8d805d7a29ff089d11be92a5b80f4545e9e44b20e01d23a65b278a9b573
     # via tcconfig
-identify==2.5.9 \
-    --hash=sha256:906036344ca769539610436e40a684e170c3648b552194980bb7b617a8daeb9f \
-    --hash=sha256:a390fb696e164dbddb047a0db26e57972ae52fbd037ae68797e5ae2f4492485d
+identify==2.5.11 \
+    --hash=sha256:14b7076b29c99b1b0b8b08e96d448c7b877a9b07683cd8cfda2ea06af85ffa1c \
+    --hash=sha256:e7db36b772b188099616aaf2accbee122949d1c6a1bac4f38196720d6f9f06db
     # via pre-commit
 idna==3.4 \
     --hash=sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4 \
@@ -515,9 +515,9 @@ isodate==0.6.1 \
     --hash=sha256:0751eece944162659049d35f4f549ed815792b38793f07cf73381c1c87cbed96 \
     --hash=sha256:48c5881de7e8b0a0d648cb024c8062dc84e7b840ed81e864c7614fd3c127bde9
     # via msrest
-isort==5.10.1 \
-    --hash=sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7 \
-    --hash=sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951
+isort==5.11.4 \
+    --hash=sha256:6db30c5ded9815d813932c04c2f85a360bcdd35fed496f4d8f35495ef0a261b6 \
+    --hash=sha256:c033fd0edb91000a7f09527fe5c75321878f98322a77ddcc81adbd83724afb7b
     # via pylint
 jinja2==3.0.2 \
     --hash=sha256:827a0e32839ab1600d4eb1c4c33ec5a8edfbc5cb42dafa13b81f182f97784b45 \
@@ -650,9 +650,9 @@ mypy-boto3-dynamodb==1.26.24 \
     --hash=sha256:41fc3303eb9b7153e2726f948a952cf7a1344cad5e44e0c225e3c6c3decfe2a6 \
     --hash=sha256:94d059f692189fa3f1315df4e16f02b94018b09b61e3a54bd56c9715f5bfe418
     # via boto3-stubs
-mypy-boto3-ec2==1.26.23 \
-    --hash=sha256:1d56015301cd8160e803fcf7947cc13cec5fd12fc8bc6ca8f9528d150528557c \
-    --hash=sha256:cdc4d46e26f12828afa92f1e42a616a7cf3c97600e2367f3eb481ae02853daaf
+mypy-boto3-ec2==1.26.34 \
+    --hash=sha256:7d477de32e854eed36aacc0a305914cfba92364cb3d54583a7eac34dcc37f559 \
+    --hash=sha256:c6bda0c4e56871c57dd4ed319717b2c843afe7709af976be2bd314106af43dd4
     # via boto3-stubs
 mypy-boto3-pricing==1.26.0.post1 \
     --hash=sha256:58ced4de43c5e74ff16fdc5bde751c53175fe234ee9382e896d9e7cc97169663 \
@@ -693,6 +693,7 @@ packaging==21.3 \
     --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \
     --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
     # via
+    #   -r ../../requirements.in
     #   pytest
     #   typepy
 parameterized==0.8.1 \
@@ -766,21 +767,21 @@ proto-plus==1.22.1 \
     --hash=sha256:6c7dfd122dfef8019ff654746be4f5b1d9c80bba787fe9611b508dd88be3a2fa \
     --hash=sha256:ea8982669a23c379f74495bc48e3dcb47c822c484ce8ee1d1d7beb339d4e34c5
     # via google-cloud-compute
-protobuf==4.21.10 \
-    --hash=sha256:0413addc126c40a5440ee59be098de1007183d68e9f5f20ed5fbc44848f417ca \
-    --hash=sha256:05cbcb9a25cd781fd949f93f6f98a911883868c0360c6d2264fc99a903c8f0d7 \
-    --hash=sha256:0c968753028cb14b1d24cc839723f7e9505b305fc588a37a9e0f7d270cb59d89 \
-    --hash=sha256:2a172741b5b041a896b621cef4277077afd571e0d3a6e524e7171f1c70e33200 \
-    --hash=sha256:3f08f04b4f101dd469efbcc1731fbf48068eccd8a42f4e2ea530aa012a5f56f8 \
-    --hash=sha256:4d97c16c0d11155b3714a29245461f0eb60cace294455077f3a3b8a629afa383 \
-    --hash=sha256:5096b3922b45e4b7a04d3d3cb855d13bb5ccd4d5e44b129e706232ebf0ffb870 \
-    --hash=sha256:5efa8a8162ada7e10847140308fbf84fdc5b89dc21655d12ec04aed87284fe07 \
-    --hash=sha256:6b809f20923b6ef49dc1755cb50bdb21be179b4a3c7ffcab1fe5d3f139b58a51 \
-    --hash=sha256:81b233a06c62387ea5c9be2cd9aedd2ba09940e91da53b920e9ff5bd98e48e7f \
-    --hash=sha256:a5e89eabaa0ca72ce1b7c8104a740d44cdb67942cbbed00c69a4c0541de17107 \
-    --hash=sha256:b78d7c2c36b51c0041b9bf000be4adb09f4112bfc40bc7a9d48ac0b0dfad139e \
-    --hash=sha256:e53165dd14d19abc7f50733f365de431e51d1d262db40c0ee22e271a074fac59 \
-    --hash=sha256:e92768d17473657c87e98b79a4c7724b0ddfa23211b05ce137bfdc55e734e36f
+protobuf==4.21.12 \
+    --hash=sha256:1f22ac0ca65bb70a876060d96d914dae09ac98d114294f77584b0d2644fa9c30 \
+    --hash=sha256:237216c3326d46808a9f7c26fd1bd4b20015fb6867dc5d263a493ef9a539293b \
+    --hash=sha256:27f4d15021da6d2b706ddc3860fac0a5ddaba34ab679dc182b60a8bb4e1121cc \
+    --hash=sha256:299ea899484ee6f44604deb71f424234f654606b983cb496ea2a53e3c63ab791 \
+    --hash=sha256:3d164928ff0727d97022957c2b849250ca0e64777ee31efd7d6de2e07c494717 \
+    --hash=sha256:6ab80df09e3208f742c98443b6166bcb70d65f52cfeb67357d52032ea1ae9bec \
+    --hash=sha256:78a28c9fa223998472886c77042e9b9afb6fe4242bd2a2a5aced88e3f4422aa7 \
+    --hash=sha256:7cd532c4566d0e6feafecc1059d04c7915aec8e182d1cf7adee8b24ef1e2e6ab \
+    --hash=sha256:89f9149e4a0169cddfc44c74f230d7743002e3aa0b9472d8c28f0388102fc4c2 \
+    --hash=sha256:a53fd3f03e578553623272dc46ac2f189de23862e68565e83dde203d41b76fc5 \
+    --hash=sha256:b135410244ebe777db80298297a97fbb4c862c881b4403b71bac9d4107d61fd1 \
+    --hash=sha256:b98d0148f84e3a3c569e19f52103ca1feacdac0d2df8d6533cf983d1fda28462 \
+    --hash=sha256:d1736130bce8cf131ac7957fa26880ca19227d4ad68b4888b3be0dea1f95df97 \
+    --hash=sha256:f45460f9ee70a0ec1b6694c6e4e348ad2019275680bd68a1d9314b8c7e01e574
     # via
     #   google-api-core
     #   google-cloud-compute
@@ -924,9 +925,9 @@ python-jenkins==1.7.0 \
     --hash=sha256:c49c6e8770966906c0be1fe21d5e2ba08e08c93f315632929b20b3c2f2c3004c \
     --hash=sha256:deed8fa79d32769a615984a5dde5e01eda04914d3f4091bd9a23d30474695106
     # via -r ../../requirements.in
-pytz==2022.6 \
-    --hash=sha256:222439474e9c98fced559f1709d89e6c9cbf8d79c794ff3eb9f8800064291427 \
-    --hash=sha256:e89512406b793ca39f5971bc999cc538ce125c0e51c27941bef4568b460095e2
+pytz==2022.7 \
+    --hash=sha256:7ccfae7b4b2c067464a6733c6261673fdb8fd1be905460396b97a073e9fa683a \
+    --hash=sha256:93007def75ae22f7cd991c84e02d434876818661f8df9ad5df9e950ff4e52cfd
     # via typepy
 pyyaml==5.4.1 \
     --hash=sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf \
@@ -1213,9 +1214,9 @@ typepy[datetime]==1.3.0 \
     #   sqliteschema
     #   tabledata
     #   tcconfig
-types-awscrt==0.16.0 \
-    --hash=sha256:243986ded138639c019cd29030b33f104993aa85d8b227a7d1d0a3c9edc1717c \
-    --hash=sha256:66600ed56e330414a390cded71c364dff7dadeb06285aef00009ebf06d93bc79
+types-awscrt==0.16.1 \
+    --hash=sha256:4e9d8fa79d0b540ccf780a46aa5bb08a30acd5fb6b6aac6491eaee41d69c560b \
+    --hash=sha256:8dce0e6b35bb41ed3824b2db82e15408766b3d5f7113a684441ec3ae10a867f7
     # via botocore-stubs
 typing-extensions==4.4.0 \
     --hash=sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa \


### PR DESCRIPTION
Latest, for now, hydra image `v1.28` was built without regards to the changes made as part of the `v1.26` version. 
So, use fixed version of it called `v1.28-fixed-kubectl-version`.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/5586

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
