### PR TITLE
fix(longevity-4h): optimized test stability and cost

### DIFF
--- a/jenkins-pipelines/longevity-100gb-4h.jenkinsfile
+++ b/jenkins-pipelines/longevity-100gb-4h.jenkinsfile
@@ -7,6 +7,6 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: 'test-cases/longevity/longevity-100gb-4h.yaml'
-
+    test_config: 'test-cases/longevity/longevity-100gb-4h.yaml',
+    instance_provision_fallback_on_demand: true
 )

--- a/test-cases/longevity/longevity-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-100gb-4h.yaml
@@ -1,4 +1,4 @@
-test_duration: 360
+test_duration: 330
 
 prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=20971520 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
 


### PR DESCRIPTION
Recently longevity 4h job is failing due to lack of spot machines.

This commit adds fallback to `on_demand` for this test. Also to make spot machines probability to last till the end of the test, shorten `test_duration` so it fits into `MAX_SPOT_DURATION_TIME` (which is 360 and spot duration is calulated this way: `test_duration // 60 * 60 + 60`)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
