### PR TITLE
fix(k8s): make CSHDRFileLogger context manager be compatible with K8S

### DIFF
--- a/sdcm/utils/remote_logger.py
+++ b/sdcm/utils/remote_logger.py
@@ -94,7 +94,13 @@ class SSHLoggerBase(NodeLoggerBase):
 
     @raise_event_on_failure
     def _journal_thread(self):
-        self._remoter = RemoteCmdRunnerBase.create_remoter(**self._remoter_params)
+        # NOTE: K8S and docker backends use separate non-SSH remoters
+        #       where each new call is separate process.
+        #       So, reuse the remoter class we already have defined in the node.
+        if self.node.is_docker():
+            self._remoter = self.node.remoter
+        else:
+            self._remoter = RemoteCmdRunnerBase.create_remoter(**self._remoter_params)
         read_from_timestamp = None
         while not self._termination_event.is_set():
             self._wait_ssh_up(verbose=False)


### PR DESCRIPTION
Recently merged PR https://github.com/scylladb/scylla-cluster-tests/pull/5348 added 2 more context manager objects in the `CassandraStressThread` class.
But the problem is that one of these new objects uses explicitly only SSH-based remoter not allowing to use K8S-based ones. 
So, detect that we use K8S and enable proper remoter for that context manager.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/5590

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
