### PR TITLE
fix(list_loadbalancers): ignore exception upon list balancers

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -943,7 +943,7 @@ def list_load_balancers_aws(tags_dict=None, region_name=None, group_as_region=Fa
         if verbose:
             LOGGER.info("%s: done [%s/%s]", region, len(list(load_balancers.keys())), len(aws_regions))
 
-    ParallelObject(aws_regions, timeout=100).run(get_load_balancers, ignore_exceptions=False)
+    ParallelObject(aws_regions, timeout=100).run(get_load_balancers, ignore_exceptions=True)
 
     if not group_as_region:
         load_balancers = list(itertools.chain(*list(load_balancers.values())))  # flatten the list of lists


### PR DESCRIPTION
If user doesn't have permission to api for
list aws load-balancers, sct list-resources failed with error :
 botocore.exceptions.ClientError: An error occurred (AccessDeniedException)
  when calling the GetResources operation:
  User: arn:aws:iam::797456418907:user/alex.bykov is not authorized to perform:
  tag:GetResources because no identity-based policy allows the tag:GetResources action
  and don't show all resources.

Set ignore exception for list-loadbalancers

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
