### PR TITLE
fix(sct_runner): upgrade runner image to Ubuntu 22.04

### DIFF
--- a/defaults/azure_config.yaml
+++ b/defaults/azure_config.yaml
@@ -2,8 +2,8 @@
 instance_provision: 'spot'
 spot_max_price: 0.60
 instance_provision_fallback_on_demand: false
-region_name:
-  - westeurope
+azure_region_name:
+  - eastus
 user_credentials_path: '~/.ssh/scylla-qa-ec2'
 
 azure_instance_type_db: 'Standard_L8s_v2'

--- a/docker/env/Dockerfile
+++ b/docker/env/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_IMAGE_TAG=3.10.0-slim-buster
+ARG PYTHON_IMAGE_TAG=3.10.0-slim-bullseye
 
 FROM python:$PYTHON_IMAGE_TAG as apt_base
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/env/version
+++ b/docker/env/version
@@ -1,1 +1,1 @@
-1.32-update-aws-libs
+1.33

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -119,7 +119,7 @@ class SctRunnerInfo:  # pylint: disable=too-many-instance-attributes
 
 class SctRunner(ABC):
     """Provision and configure the SCT runner."""
-    VERSION = "1.5"  # Version of the Image
+    VERSION = "1.6"  # Version of the Image
     NODE_TYPE = "sct-runner"
     RUNNER_NAME = "SCT-Runner"
     LOGIN_USER = "ubuntu"
@@ -420,7 +420,7 @@ class SctRunner(ABC):
 class AwsSctRunner(SctRunner):
     """Provision and configure the SCT Runner on AWS."""
     CLOUD_PROVIDER = "aws"
-    BASE_IMAGE = "ami-0c4a211d2b7c38400"  # ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210907
+    BASE_IMAGE = "ami-07c2ae35d31367b3e"  # Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2022-12-01
     SOURCE_IMAGE_REGION = "eu-west-2"  # where the source Runner image will be created and copied to other regions
     IMAGE_BUILDER_INSTANCE_TYPE = "t2.small"
     REGULAR_TEST_INSTANCE_TYPE = "t3.large"  # 2 vcpus, 8G, 36 CPU credits/hour
@@ -645,7 +645,7 @@ class GceSctRunner(SctRunner):
     """Provision and configure the SCT runner on GCE."""
 
     CLOUD_PROVIDER = "gce"
-    BASE_IMAGE = "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2004-lts"
+    BASE_IMAGE = "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts"
     SOURCE_IMAGE_REGION = "us-east1"  # where the source Runner image will be created and copied to other regions
     IMAGE_BUILDER_INSTANCE_TYPE = "e2-standard-2"
     REGULAR_TEST_INSTANCE_TYPE = "e2-standard-2"  # 2 vcpus, 8G
@@ -840,8 +840,8 @@ class AzureSctRunner(SctRunner):
     GALLERY_IMAGE_VERSION = f"{SctRunner.VERSION}.0"  # Azure requires to have it in `X.Y.Z' format
     BASE_IMAGE = {
         "publisher": "canonical",
-        "offer": "0001-com-ubuntu-server-focal",
-        "sku": "20_04-lts-gen2",
+        "offer": "0001-com-ubuntu-server-jammy",
+        "sku": "22_04-lts-gen2",
         "version": "latest",
     }
     SOURCE_IMAGE_REGION = AzureRegion.SCT_GALLERY_REGION


### PR DESCRIPTION
Modern Scylla images built on top of Ubuntu 22.04 and in result we have compatibility problems when try to run Scylla' Docker image on SCT Runner.

For example:

```
$ docker run --entrypoint java scylladb/scylla-nightly -version [0.003s][warning][os,thread] Failed to start thread "GC Thread#0" - pt... 
#
# There is insufficient memory for the Java Runtime Environment to continue. 
# Cannot create worker GC thread. Out of system resources. 
# An error report file with more information is saved as: 
# //hs_err_pid1.log
```
This particular problem w/ Java makes it impossible to run c-s on SCT Runner using Scylla' Docker image.

See https://stackoverflow.com/a/72841934

Also, we need to upgrade base image for SCT because of too old sudo package.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
