### PR TITLE
fix(sct_config): make .get(None) work

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1800,12 +1800,12 @@ class SCTConfiguration(dict):
 
         return environment_vars
 
-    def get(self, key: str):
+    def get(self, key: str | None):
         """
         get the value of test configuration parameter by the name
         """
 
-        if '.' in key:
+        if key and '.' in key:
             if ret_val := self._dotted_get(key):
                 return ret_val
         ret_val = super().get(key)

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -668,6 +668,17 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
 
         self.assertEqual(conf.get('stress_read_cmd'), ['cassandra_stress', 'cassandra_stress'])
 
+    @staticmethod
+    def test_22_get_none():
+        os.environ['SCT_CLUSTER_BACKEND'] = 'aws'
+        os.environ['SCT_CONFIG_FILES'] = "internal_test_data/minimal_test_case.yaml"
+        os.environ['SCT_AMI_ID_DB_SCYLLA'] = 'ami-1234'
+        conf = sct_config.SCTConfiguration()
+        conf.verify_configuration()
+
+        val = conf.get(None)
+        assert val is None
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Since a recent change in instance profiles, we are doing calls of `params.get(None)`, assuming it would work like a regular dict and would return None, but it was failing like this:

```
File ".../instance_parameters_builder.py", line 74, in IamInstanceProfile
   if profile := self.params.get(self._INSTANCE_PROFILE_PARAM_NAME):
File ".../sdcm/sct_config.py", line 1808, in get
   if '.' in key:
TypeError: argument of type 'NoneType' is not iterable
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
