### PR TITLE
improvement(Ldap): Added a new Nemesis - LdapRoleAddRemovePermission

### DIFF
--- a/configurations/ldap-authorization.yaml
+++ b/configurations/ldap-authorization.yaml
@@ -5,3 +5,5 @@ authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra
 authenticator_password: cassandra
 authorizer: 'CassandraAuthorizer'
+prepare_saslauthd: false
+use_ldap_authentication: false

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -35,7 +35,8 @@ from concurrent.futures import ThreadPoolExecutor
 from threading import Lock
 from types import MethodType  # pylint: disable=no-name-in-module
 
-from cassandra import ConsistencyLevel
+import pytest
+from cassandra import ConsistencyLevel, Unauthorized
 from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
 from invoke import UnexpectedExit
 from elasticsearch.exceptions import ConnectionTimeout as ElasticSearchConnectionTimeout
@@ -98,7 +99,7 @@ from sdcm.utils.k8s import (
     convert_cpu_value_from_k8s_to_units, convert_memory_value_from_k8s_to_units,
 )
 from sdcm.utils.k8s.chaos_mesh import MemoryStressExperiment, IOFaultChaosExperiment, DiskError
-from sdcm.utils.ldap import SASLAUTHD_AUTHENTICATOR
+from sdcm.utils.ldap import SASLAUTHD_AUTHENTICATOR, LDAP_USERS, LDAP_PASSWORD, LdapServerType
 from sdcm.utils.replication_strategy_utils import temporary_replication_strategy_setter, \
     NetworkTopologyReplicationStrategy, ReplicationStrategy, SimpleReplicationStrategy
 from sdcm.utils.sstable.load_utils import SstableLoadUtils
@@ -1117,6 +1118,79 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.log.info('Will now resume the LDAP container')
         ContainerManager.unpause_container(self.tester.localhost, 'ldap')
         self.log.info('finished with nemesis')
+
+    def disrupt_ldap_role_add_remove_permission(self):
+        """
+        Scenario:
+        1. Create new user in Scylla
+        2. Create new role in Ldap containing the new user as a member.
+        3. Verify this new user is unauthorised on resources (create a keyspace).
+        4. Create a new super-user role in Scylla.
+        5. Create a new super-user role in Ldap, with the new user as a member.
+        6. Verify this new user is authorised on resources.
+        7. Modify Ldap role to remove membership of new user.
+        8. Verify the new user is unauthorised on resources (create a table).
+        9. Do clean-up: delete Ldap Role, Scylla roles and keyspace/tables.
+
+        """
+        if not self.target_node.is_enterprise:
+            raise UnsupportedNemesis('Cluster is not enterprise. LDAP is supported only for enterprise. Skipping')
+        if not self.cluster.params.get('use_ldap_authorization'):
+            raise UnsupportedNemesis('Cluster is not configured to run with LDAP authorization, hence skipping')
+        if not self.cluster.params.get('ldap_server_type') == LdapServerType.MS_AD:
+            raise UnsupportedNemesis('Cluster is not configured to run with open LDAP authorization, hence skipping')
+        node = self.cluster.nodes[0]
+        superuser_role = 'superuser_role'
+        new_test_user = 'new_test_user'
+        ldap_keyspace = 'customer_ldap'
+        self.log.debug("Create new user in Scylla")
+        self.tester.create_role_in_scylla(node=node, role_name=new_test_user, is_superuser=False,
+                                          is_login=True)
+        if self.cluster.params.get('prepare_saslauthd'):
+            self.tester.add_user_in_ldap(username=new_test_user)
+        with pytest.raises(Unauthorized, match="has no CREATE permission"):
+            with self.cluster.cql_connection_patient(node=node, user=new_test_user, password=LDAP_PASSWORD) as session:
+                session.execute(
+                    f""" CREATE KEYSPACE IF NOT EXISTS {ldap_keyspace} WITH replication = {{'class': 'SimpleStrategy',
+                    'replication_factor': 1}} """)
+
+        self.log.debug("Create a new super-user role in Scylla")
+        self.tester.create_role_in_scylla(node=node, role_name=superuser_role, is_superuser=True,
+                                          is_login=False)
+        self.cluster.wait_for_schema_agreement()
+        self.log.debug("Create a new super-user role in Ldap, associated with the new user")
+
+        self.tester.create_role_in_ldap(ldap_role_name=superuser_role, unique_members=[new_test_user, LDAP_USERS[1]])
+
+        self.tester.wait_for_user_roles_update(are_roles_expected=True, username=new_test_user)
+        self.log.debug("Create keyspace and table where authorized")
+        self.tester.wait_verify_user_permissions(username=new_test_user, keyspace=ldap_keyspace)
+
+        # Run a backgound stress while new user permissions are removed
+        write_cmd = f"cassandra-stress write no-warmup cl=QUORUM duration=10m -schema 'keyspace={ldap_keyspace} replication(factor=3)' " \
+                    f"-mode cql3 native user={new_test_user} password={LDAP_PASSWORD} -rate threads=2 -pop seq=1..1002003 -log interval=5"
+        write_thread = self.tester.run_stress_thread(stress_cmd=write_cmd, round_robin=True)
+        self.log.debug("Remove authorization and verify unauthorized user")
+        self.tester.modify_ldap_role_delete_member(ldap_role_name=superuser_role, member_name=new_test_user)
+        self.tester.wait_for_user_roles_update(are_roles_expected=False, username=new_test_user)
+        self.tester.wait_verify_user_no_permissions(username=new_test_user)
+        self.tester.verify_stress_thread(cs_thread_pool=write_thread)
+
+        # Clean-up resources
+        self.tester.delete_ldap_role(ldap_role_name=superuser_role)
+
+        with self.cluster.cql_connection_patient(node=node, user=LDAP_USERS[0], password=LDAP_PASSWORD) as session:
+
+            session.execute(f""" DROP TABLE IF EXISTS {ldap_keyspace}.info """)
+            session.execute(f""" DROP TABLE IF EXISTS {ldap_keyspace}.standard1 """)
+            session.execute(f""" DROP KEYSPACE IF EXISTS {ldap_keyspace} """)
+            session.execute(""" DROP KEYSPACE IF EXISTS test_no_permission """)
+            session.execute(""" DROP KEYSPACE IF EXISTS test_permission_ks """)
+            session.execute(f"DROP ROLE IF EXISTS {superuser_role}")
+            if self.cluster.params.get('prepare_saslauthd'):
+                self.tester.delete_ldap_user(ldap_user_name=new_test_user)
+                session.execute(f"ALTER ROLE {new_test_user} WITH login=false")
+            session.execute(f"DROP ROLE IF EXISTS {new_test_user}")
 
     def disrupt_disable_enable_ldap_authorization(self):
         if not self.cluster.params.get('use_ldap_authorization'):
@@ -4193,6 +4267,14 @@ class ToggleLdapConfiguration(Nemesis):
 
     def disrupt(self):
         self.disrupt_disable_enable_ldap_authorization()
+
+
+class LdapRoleAddRemovePermission(Nemesis):
+    disruptive = False
+    limited = True
+
+    def disrupt(self):
+        self.disrupt_ldap_role_add_remove_permission()
 
 
 class NoOpMonkey(Nemesis):

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -36,9 +36,9 @@ import yaml
 from invoke.exceptions import UnexpectedExit, Failure
 
 from cassandra.concurrent import execute_concurrent_with_args  # pylint: disable=no-name-in-module
-from cassandra import ConsistencyLevel
 from cassandra.cluster import Session  # pylint: disable=no-name-in-module
 from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
+from cassandra import ConsistencyLevel, Unauthorized
 
 from argus.db.db_types import TestStatus, PackageVersion
 from sdcm import nemesis, cluster_docker, cluster_k8s, cluster_baremetal, db_stats, wait
@@ -73,7 +73,7 @@ from sdcm.utils.common import format_timestamp, wait_ami_available, update_certi
 from sdcm.utils.get_username import get_username
 from sdcm.utils.decorators import log_run_info, retrying
 from sdcm.utils.ldap import LDAP_USERS, LDAP_PASSWORD, LDAP_ROLE, LDAP_BASE_OBJECT, \
-    LdapConfigurationError, LdapServerType
+    LdapConfigurationError, LdapServerType, LDAP_PORT, LDAP_SSH_TUNNEL_LOCAL_PORT
 from sdcm.utils.log import configure_logging, handle_exception
 from sdcm.db_stats import PrometheusDBStats
 from sdcm.results_analyze import PerformanceResultsAnalyzer, SpecifiedStatsPerformanceAnalyzer, \
@@ -515,6 +515,17 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     def _init_ldap_openldap(self):
         self.configure_ldap(node=self.localhost, use_ssl=False)
 
+    def create_role_in_scylla(self, node: BaseNode, role_name: str, is_superuser: bool = True,
+                              is_login: bool = True):
+        self.log.debug("Configuring an LDAP Role %s in Scylla DB", role_name)
+        create_role_cmd = f'CREATE ROLE IF NOT EXISTS \'{role_name}\''
+        superuser_argument = ' WITH SUPERUSER=true' if is_superuser else ' WITH SUPERUSER=false'
+        login_argument = ' AND login=true' if is_login else ' AND login=false'
+        create_role_cmd += superuser_argument + login_argument
+        if not self.params.get('prepare_saslauthd'):
+            create_role_cmd += f' AND password=\'{LDAP_PASSWORD}\''
+        node.run_cqlsh(create_role_cmd)
+
     def _setup_ldap_roles(self, db_cluster: BaseScyllaCluster):
         self.log.debug("Configuring LDAP Roles.")
         node = db_cluster.nodes[0]
@@ -523,6 +534,167 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             node.run_cqlsh(f'CREATE ROLE \'{user}\' WITH login=true')
         node.run_cqlsh(f'ALTER ROLE \'{LDAP_USERS[0]}\' with SUPERUSER=true and password=\'{LDAP_PASSWORD}\'')
         self.params['are_ldap_users_on_scylla'] = True
+
+    @property
+    def ldap_server_ip(self) -> str:
+        if self.params.get('ldap_server_type') == LdapServerType.MS_AD:
+            ldap_ms_ad_credentials = KeyStore().get_ldap_ms_ad_credentials()
+            return ldap_ms_ad_credentials["server_address"]
+        ldap_server_ip = '127.0.0.1' if self.test_config.IP_SSH_CONNECTIONS == 'public' \
+            else self.test_config.LDAP_ADDRESS[0]
+        return ldap_server_ip
+
+    @property
+    def ldap_port(self) -> str:
+        if self.params.get('ldap_server_type') == LdapServerType.MS_AD:
+            return LDAP_PORT
+        ldap_port = LDAP_SSH_TUNNEL_LOCAL_PORT if self.test_config.IP_SSH_CONNECTIONS == 'public' \
+            else self.test_config.LDAP_ADDRESS[1]
+        return ldap_port
+
+    def _add_ldap_entry(self, ldap_entry: list):
+        self.log.debug("Adding an Ldap entry of: %s", ldap_entry)
+        username = f'cn=admin,{LDAP_BASE_OBJECT}'
+        self.localhost.add_ldap_entry(ip=self.ldap_server_ip, ldap_port=self.ldap_port,
+                                      user=username, password=LDAP_PASSWORD, ldap_entry=ldap_entry)
+
+    def create_role_in_ldap(self, ldap_role_name: str, unique_members: list):
+        unique_members_list = [f'uid={user},ou=Person,{LDAP_BASE_OBJECT}' for user in unique_members]
+        role_entry = [
+            f'cn={ldap_role_name},{LDAP_BASE_OBJECT}',
+            ['groupOfUniqueNames', 'simpleSecurityObject', 'top'],
+            {
+                'uniqueMember': unique_members_list,
+                'userPassword': LDAP_PASSWORD
+            }
+        ]
+        self._add_ldap_entry(ldap_entry=role_entry)
+
+    def search_ldap_role(self, ldap_role_name: str, raise_error: bool = True) -> str:
+        ldap_entry = f'(cn={ldap_role_name})'
+        self.log.debug("Searching for Ldap entry: %s, %s", LDAP_BASE_OBJECT, ldap_entry)
+        res = self.localhost.search_ldap_entry(LDAP_BASE_OBJECT, ldap_entry)
+        self.log.debug("Ldap entry Search result: %s", res)
+        if not res and raise_error:
+            raise Exception(f'Failed to find {ldap_role_name} in Ldap.')
+        distinguished_name = str(res).split()[1]
+        return distinguished_name
+
+    def search_ldap_user(self, ldap_user_name: str, raise_error: bool = True) -> str:
+        ldap_entry = f'(uid={ldap_user_name})'
+        self.log.debug("Searching for Ldap user: %s, %s", LDAP_BASE_OBJECT, ldap_entry)
+        res = self.localhost.search_ldap_entry(search_base=LDAP_BASE_OBJECT, search_filter=ldap_entry)
+        self.log.debug("Ldap user search result: %s", res)
+        if not res and raise_error:
+            raise Exception(f'Failed to find {ldap_user_name} in Ldap.')
+        distinguished_name = str(res).split()[1]
+        return distinguished_name
+
+    def modify_ldap_role_delete_member(self, ldap_role_name: str, member_name: str, raise_error: bool = True):
+        distinguished_name = self.search_ldap_role(ldap_role_name=ldap_role_name, raise_error=raise_error)
+        self.log.debug("Deleting member %s from Ldap entry: %s", member_name, distinguished_name)
+        unique_member_update = {'uniqueMember': [
+            ('MODIFY_DELETE', [f'uid={member_name},ou=Person,{LDAP_BASE_OBJECT}'])]}
+        res = self.localhost.modify_ldap_entry(distinguished_name, unique_member_update)
+        if not res and raise_error:
+            raise Exception(f'Failed to delete entry {distinguished_name} from Ldap role {ldap_role_name}')
+
+    def delete_ldap_role(self, ldap_role_name: str, raise_error: bool = True):
+        distinguished_name = self.search_ldap_role(ldap_role_name=ldap_role_name, raise_error=raise_error)
+        self.log.debug("Deleting Ldap entry: %s", distinguished_name)
+        res = self.localhost.delete_ldap_entry(distinguished_name)
+        if not res and raise_error:
+            raise Exception(f'Failed to delete entry {distinguished_name} from Ldap.')
+
+    def delete_ldap_user(self, ldap_user_name: str, raise_error: bool = True):
+        distinguished_name = self.search_ldap_user(ldap_user_name=ldap_user_name, raise_error=raise_error)
+        self.log.debug("Deleting Ldap user entry: %s", distinguished_name)
+        res = self.localhost.delete_ldap_entry(distinguished_name)
+        if not res and raise_error:
+            raise Exception(f'Failed to delete entry {distinguished_name} from Ldap.')
+
+    @retrying(n=10, sleep_time=30, message='Waiting for no user permissions verification', allowed_exceptions=(ValueError,))
+    def wait_verify_user_no_permissions(self, username: str):
+        """
+        Checks for unauthorized user permission following roles update.
+        Creating a keyspace by the user and verify it fails as expected.
+        """
+        self.log.debug("Verifying user %s roles permission change in Scylla DB (following an LDAP Role update) ", username)
+
+        try:
+            with self.db_cluster.cql_connection_patient(node=self.db_cluster.nodes[0], user=username,
+                                                        password=LDAP_PASSWORD) as session:
+                session.execute(
+                    """ CREATE KEYSPACE IF NOT EXISTS test_no_permission WITH replication = {'class': 'SimpleStrategy',
+                    'replication_factor': 1} """)
+                session.execute(""" DROP KEYSPACE IF EXISTS test_no_permission """)
+            raise ValueError('DID NOT RAISE')
+        except Unauthorized:
+            return
+
+    @retrying(n=10, sleep_time=30, message='Waiting for user permissions update', allowed_exceptions=Unauthorized)
+    def wait_verify_user_permissions(self, username: str, keyspace: str = 'customer_ldap'):
+        """
+        Checks for authorized user permission following roles update.
+        Creating a keyspace by the user and verify it doesn't fail.
+        """
+        self.log.debug("Verifying user %s roles permission change in Scylla DB (following an LDAP Role update) ", username)
+
+        with self.db_cluster.cql_connection_patient(node=self.db_cluster.nodes[0], user=username,
+                                                    password=LDAP_PASSWORD) as session:
+            session.execute(
+                """ CREATE KEYSPACE IF NOT EXISTS test_permission_ks WITH replication = {'class': 'SimpleStrategy',
+                'replication_factor': 1} """)
+            session.execute(""" DROP KEYSPACE IF EXISTS test_permission_ks """)
+
+            session.execute(
+                f""" CREATE KEYSPACE IF NOT EXISTS {keyspace} WITH replication = {{'class': 'SimpleStrategy',
+                'replication_factor': 3}} """)
+            session.execute(
+                f""" CREATE TABLE IF NOT EXISTS {keyspace}.info (key varchar, c varchar, v varchar, PRIMARY KEY(key, c)) """)
+            session.execute('INSERT INTO customer_ldap.info (key, c, v) VALUES (\'key1\', \'c1\', \'v1\')')
+            session.execute("SELECT * from customer_ldap.info LIMIT 1")
+
+    @retrying(n=10, sleep_time=30, message='Waiting for user permissions update', allowed_exceptions=(AssertionError,))
+    def wait_for_user_roles_update(self, username: str, are_roles_expected: bool):
+        """
+        Checks for updated output of user roles.
+        Example command: LIST ROLES OF new_user;
+        Example output:
+
+        LIST ROLES OF new_user;
+        ╭─────────┬─────────┬──────────────────────┬────────────╮
+        │role     │ super   │ login                │ options    │
+        ├─────────┼─────────┼──────────────────────┼────────────┤
+        │customer │ False   │ False                │ {}         │
+        ├─────────┼─────────┼──────────────────────┼────────────┤
+        │trainer  │ False   │ False                │ {}         │
+        ├─────────┼─────────┼──────────────────────┼────────────┤
+        │new_user │ False   │ True                 │ {}         │
+        ╰─────────┴─────────┴──────────────────────┴────────────╯
+        """
+        self.log.debug("Waiting user %s roles change in Scylla DB (following an LDAP Role update) ", username)
+        with self.db_cluster.cql_connection_patient(node=self.db_cluster.nodes[0]) as session:
+            query = f"LIST ROLES OF '{username}';"
+            result = session.execute(query)
+            output = result.all()
+            self.log.debug("LIST ROLES OF %s: %s", username, output)
+            if are_roles_expected:
+                assert len(output) > 1
+            else:
+                assert len(output) == 1
+
+    def add_user_in_ldap(self, username: str):
+        user_entry = [
+            f'uid={username},ou=Person,{LDAP_BASE_OBJECT}',
+            ['uidObject', 'organizationalPerson', 'top'],
+            {
+                'userPassword': LDAP_PASSWORD,
+                'sn': 'PersonSn',
+                'cn': 'PersonCn'
+            }
+        ]
+        self._add_ldap_entry(ldap_entry=user_entry)
 
     def configure_ldap(self, node, use_ssl=False):
         self.test_config.configure_ldap(node=node, use_ssl=use_ssl)
@@ -543,30 +715,31 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         self.localhost.add_ldap_entry(ip=ldap_address[0], ldap_port=ldap_address[1],
                                       user=ldap_username, password=LDAP_PASSWORD, ldap_entry=role_entry)
 
-        organizational_unit_entry = [
-            f'ou=Person,{LDAP_BASE_OBJECT}',
-            ['organizationalUnit', 'top'],
-            {
-                'ou': 'Person'
-            }
-        ]
-        self.localhost.add_ldap_entry(ip=ldap_address[0], ldap_port=ldap_address[1],
-                                      user=ldap_username, password=LDAP_PASSWORD, ldap_entry=organizational_unit_entry)
-
-        # Built-in user also need to be added in ldap server, otherwise it can't log in to create LDAP_USERS
-        for user in [self.params.get('authenticator_user')] + LDAP_USERS:
-            password = LDAP_PASSWORD if user in LDAP_USERS else self.params.get("authenticator_password")
-            user_entry = [
-                f'uid={user},ou=Person,{LDAP_BASE_OBJECT}',
-                ['uidObject', 'organizationalPerson', 'top'],
+        if self.params.get('prepare_saslauthd'):
+            organizational_unit_entry = [
+                f'ou=Person,{LDAP_BASE_OBJECT}',
+                ['organizationalUnit', 'top'],
                 {
-                    'userPassword': password,
-                    'sn': 'PersonSn',
-                    'cn': 'PersonCn'
+                    'ou': 'Person'
                 }
             ]
             self.localhost.add_ldap_entry(ip=ldap_address[0], ldap_port=ldap_address[1],
-                                          user=ldap_username, password=LDAP_PASSWORD, ldap_entry=user_entry)
+                                          user=ldap_username, password=LDAP_PASSWORD, ldap_entry=organizational_unit_entry)
+
+            # Built-in user also need to be added in ldap server, otherwise it can't log in to create LDAP_USERS
+            for user in [self.params.get('authenticator_user')] + LDAP_USERS:
+                password = LDAP_PASSWORD if user in LDAP_USERS else self.params.get("authenticator_password")
+                user_entry = [
+                    f'uid={user},ou=Person,{LDAP_BASE_OBJECT}',
+                    ['uidObject', 'organizationalPerson', 'top'],
+                    {
+                        'userPassword': password,
+                        'sn': 'PersonSn',
+                        'cn': 'PersonCn'
+                    }
+                ]
+                self.localhost.add_ldap_entry(ip=ldap_address[0], ldap_port=ldap_address[1],
+                                              user=ldap_username, password=LDAP_PASSWORD, ldap_entry=user_entry)
 
     def _init_test_timeout_thread(self) -> threading.Timer:
         start_time = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(self.start_time))

--- a/sdcm/utils/ldap.py
+++ b/sdcm/utils/ldap.py
@@ -91,3 +91,7 @@ class LdapContainerMixin:  # pylint: disable=too-few-public-methods
     @staticmethod
     def modify_ldap_entry(*args, **kwargs):
         return LdapContainerMixin.ldap_conn.modify(*args, **kwargs)
+
+    @staticmethod
+    def delete_ldap_entry(*args, **kwargs):
+        return LdapContainerMixin.ldap_conn.delete(*args, **kwargs)

--- a/unit_tests/test_nemesis_sisyphus.py
+++ b/unit_tests/test_nemesis_sisyphus.py
@@ -71,7 +71,7 @@ def test_list_all_available_nemesis(generate_file=True):
     disruption_list, disruptions_dict, disruption_classes = sisyphus.get_list_of_disrupt_methods(
         subclasses_list=subclasses, export_properties=True)
 
-    assert len(disruption_list) == 75
+    assert len(disruption_list) == 76
 
     if generate_file:
         with open('data_dir/nemesis.yml', 'w', encoding="utf-8") as outfile1:


### PR DESCRIPTION
	In order to test Ldap user permissions control
	during a real-world longevity test.

Task: https://github.com/scylladb/qa-tasks/issues/360

Contains fixes of:

- configurations/ldap-authorization.yaml => fix missing parameters.
- prepare_saslauthd => fix the conditions for this to be used in Ldap.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
