### PR TITLE
fix(remotewebbrowser): fix typo in a message

### DIFF
--- a/sdcm/utils/remotewebbrowser.py
+++ b/sdcm/utils/remotewebbrowser.py
@@ -99,7 +99,7 @@ class RemoteBrowser:
         return Remote(command_executor=f"http://{host}:{port}/wd/hub", options=ChromeOptions())
 
     def open(self, url, resolution="1920px*1280px"):
-        LOGGER.info("Set resoltion %s", resolution)
+        LOGGER.info("Set resolution %s", resolution)
         self.browser.set_window_size(*resolution.replace("px", "").split("*", 1))
         LOGGER.info("Get url %s", url)
         self.browser.get(url)


### PR DESCRIPTION
Fix typo in a message in the remotewebbrowser.py

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
