### PR TITLE
fix(test_operator_managed_tls): add WhiteList when connecting to cluster

### DIFF
--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -22,7 +22,12 @@ import path
 
 import pytest
 import yaml
-from cassandra.cluster import Cluster  # pylint: disable=no-name-in-module
+from cassandra.cluster import (  # pylint: disable=no-name-in-module
+    Cluster,
+    ExecutionProfile,
+    EXEC_PROFILE_DEFAULT,
+)
+from cassandra.policies import WhiteListRoundRobinPolicy
 
 from sdcm.cluster_k8s import (
     ScyllaPodCluster,
@@ -775,8 +780,10 @@ def test_operator_managed_tls(db_cluster: ScyllaPodCluster, tmp_path: path.Path)
         log.debug(file)
         log.debug(file.read_text())
 
-    db_cluster.nodes[0].refresh_ip_address()
-    cluster = Cluster(contact_points=[db_cluster.nodes[0].cql_ip_address], port=db_cluster.nodes[0].CQL_SSL_PORT)
+    execution_profile = ExecutionProfile(load_balancing_policy=WhiteListRoundRobinPolicy([
+                                         db_cluster.nodes[0].cql_ip_address]))
+    cluster = Cluster(contact_points=[db_cluster.nodes[0].cql_ip_address], port=db_cluster.nodes[0].CQL_SSL_PORT,
+                      execution_profiles={EXEC_PROFILE_DEFAULT: execution_profile})
     ssl_context = ssl.SSLContext(protocol=ssl.PROTOCOL_SSLv23)
     ssl_context.verify_mode = ssl.VerifyMode.CERT_REQUIRED  # pylint: disable=no-member
 


### PR DESCRIPTION
since the address we connect to the cluster are diffrent then the addresses used by scylla to publish it's nodes.
we need to whitelist the extrenal addresses we use other wise the driver would remove all the connections, since they are not accessable, and we'll fail with connction refused.

## Testing
- [ ] https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/functional-eks/2/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
