### PR TITLE
fix(docker-loader): fix ipv6 support

### DIFF
--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -239,6 +239,7 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
             cmd_runner = cleanup_context = RemoteDocker(loader, self.docker_image_name,
                                                         command_line="-c 'tail -f /dev/null'",
                                                         extra_docker_opts=f'{cpu_options} '
+                                                                          '--network=host '
                                                                           f'--label shell_marker={self.shell_marker}'
                                                                           f' --entrypoint /bin/bash'
                                                                           f' -v $HOME/{remote_hdr_file_name}:/{remote_hdr_file_name}')


### PR DESCRIPTION
ipv6 test cases were failing to connect to ipv6 addresses failing like:
```
java.net.SocketException: Protocol family unavailable
```

changing the docker loader to use the host network, fixes that problem

Fix: #5610

## Testing:

- [x] - https://jenkins.scylladb.com/job/manager-master/job/centos-sanity-ipv6-test/593/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
