### PR TITLE
feature(chaos-mesh): use chaos-mesh for memory stress in k8s clusters

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -91,8 +91,9 @@ from sdcm.utils.decorators import timeout as timeout_decor
 from sdcm.utils.docker_utils import ContainerManager
 from sdcm.utils.k8s import (
     convert_cpu_units_to_k8s_value,
-    convert_cpu_value_from_k8s_to_units,
+    convert_cpu_value_from_k8s_to_units, convert_memory_value_from_k8s_to_units,
 )
+from sdcm.utils.k8s.chaos_mesh import MemoryStressExperiment
 from sdcm.utils.ldap import SASLAUTHD_AUTHENTICATOR
 from sdcm.utils.replication_strategy_utils import temporary_replication_strategy_setter, \
     NetworkTopologyReplicationStrategy, ReplicationStrategy, SimpleReplicationStrategy
@@ -409,6 +410,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def _is_it_on_kubernetes(self) -> bool:
         return isinstance(getattr(self.tester, "db_cluster", None), PodCluster)
+
+    def _is_chaos_mesh_initialized(self) -> bool:
+        return self.tester.k8s_cluster.chaos_mesh.initialized
 
     # pylint: disable=too-many-arguments,unused-argument
     def get_list_of_methods_by_flags(
@@ -3532,12 +3536,38 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.disrupt_grow_shrink_cluster()
         InfoEvent(message="Finished grow_shrink disruption").publish()
 
+    def _k8s_disrupt_memory_stress(self):
+        """Uses chaos-mesh experiment based on https://github.com/chaos-mesh/memStress"""
+        if not self._is_chaos_mesh_initialized:
+            raise UnsupportedNemesis(
+                "Chaos Mesh is not installed. Set 'k8s_use_chaos_mesh' config option to 'true'")
+        memory_limit = self.tester.k8s_cluster.calculated_memory_limit
+        # If a container's memory usage increases too quickly the OOM killer is invoked
+        # so reduce ramp to ~2GB/s: time_to_reach = memory (in GB) /2
+        time_to_reach_secs = int(convert_memory_value_from_k8s_to_units(memory_limit)/2)
+        duration = 100 + time_to_reach_secs
+        self.log.info('Try to allocate 90% available memory')
+        experiment = MemoryStressExperiment(pod=self.target_node, duration=f"{duration}s",
+                                            workers=1, size="90%", time_to_reach=f"{time_to_reach_secs}s")
+        experiment.start()
+        experiment.wait_until_finished()
+
+        self.log.info('Try to allocate 100% total memory')
+        experiment = MemoryStressExperiment(pod=self.target_node, duration=f"{duration}s",
+                                            workers=1, size="100%", time_to_reach=f"{time_to_reach_secs}s")
+        experiment.start()
+        experiment.wait_until_finished()
+
     def disrupt_memory_stress(self):
         """
         Try to run stress-ng to preempt allocated memory of scylla process,
         we don't monitor swap usage in /proc/$scylla_pid/status, just make sure
         no coredump, serious db error occur during the heavy load of memory.
+
         """
+        if self._is_it_on_kubernetes():
+            self._k8s_disrupt_memory_stress()
+            return
         if self.target_node.distro.is_rhel_like:
             self.target_node.install_epel()
             self.target_node.remoter.sudo('yum install -y stress-ng')

--- a/sdcm/utils/k8s/chaos_mesh.py
+++ b/sdcm/utils/k8s/chaos_mesh.py
@@ -16,6 +16,7 @@ import json
 import logging
 from datetime import datetime
 from enum import Enum
+from json import JSONDecodeError
 from tempfile import NamedTemporaryFile
 import time
 
@@ -32,18 +33,19 @@ class ChaosMeshException(Exception):
     pass
 
 
-class PodChaosException(ChaosMeshException):
+class ChaosMeshExperimentException(ChaosMeshException):
 
-    def __init__(self, msg: str, k8s_cluster: "KubernetesCluster", podchaos_name: str, namespace: str):
+    # pylint: disable=too-many-arguments
+    def __init__(self, msg: str, experiment: "ChaosMeshExperiment"):
         super().__init__(msg)
-        self.message = msg
-        self.details = k8s_cluster.kubectl(f"describe podchaos {podchaos_name} -n {namespace}").stdout
+        self.message = f"{msg}. Search debug log about {experiment.name}"
+        LOGGER.debug(experiment.describe())
 
     def __str__(self):
-        return f"{self.message}. Details:\n" + self.details
+        return self.message
 
 
-class PodChaosTimeout(PodChaosException):
+class ChaosMeshTimeout(ChaosMeshExperimentException):
     pass
 
 
@@ -55,12 +57,14 @@ class ChaosMesh:  # pylint: disable=too-few-public-methods
         'dnsServer': {"create": True}
     }
 
-    def __init__(self, k8s_cluster: "KubernetesCluster"):
+    def __init__(self, k8s_cluster: "sdcm.cluster_k8s.KubernetesCluster"):
         self._k8s_cluster = k8s_cluster
+        self.initialized = False
 
     def initialize(self) -> None:
         """Installs chaos-mesh on k8s cluster and prepares for future k8s chaos testing."""
         if self._k8s_cluster.kubectl(f"get ns {self.NAMESPACE}", ignore_status=True).ok:
+            self.initialized = True
             LOGGER.info("Chaos Mesh is already installed. Skipping installation.")
             return
         LOGGER.info("Installing chaos-mesh on %s k8s cluster...", self._k8s_cluster.k8s_scylla_cluster_name)
@@ -71,8 +75,11 @@ class ChaosMesh:  # pylint: disable=too-few-public-methods
             self._k8s_cluster.POOL_LABEL_NAME, self._k8s_cluster.AUXILIARY_POOL_NAME)
         scylla_node_pool_affinity = get_helm_pool_affinity_values(
             self._k8s_cluster.POOL_LABEL_NAME, self._k8s_cluster.SCYLLA_POOL_NAME)
-        chaos_daemon_settings = scylla_node_pool_affinity | {
-            "runtime": "containerd", "socketPath": "/run/containerd/containerd.sock"}
+        runtime = self._k8s_cluster.kubectl(
+            "get nodes -o jsonpath='{.items[0].status.nodeInfo.containerRuntimeVersion}'").stdout
+        runtime_settings = {
+            "runtime": "containerd", "socketPath": "/run/containerd/containerd.sock"} if runtime.startswith("containerd") else {}
+        chaos_daemon_settings = scylla_node_pool_affinity | runtime_settings
         self._k8s_cluster.helm_install(
             target_chart_name="chaos-mesh",
             source_chart_name="chaos-mesh/chaos-mesh",
@@ -88,6 +95,7 @@ class ChaosMesh:  # pylint: disable=too-few-public-methods
             timeout="30m"
         )
         LOGGER.info("chaos-mesh installed successfully on %s k8s cluster.", self._k8s_cluster.k8s_scylla_cluster_name)
+        self.initialized = True
 
 
 class ExperimentStatus(Enum):
@@ -99,16 +107,18 @@ class ExperimentStatus(Enum):
     UNKNOWN = 5
 
 
-class PodChaosExperiment:
-    """Base class for all PodChaos experiments."""
+class ChaosMeshExperiment:
+    """Base class for all chaos-mesh experiments."""
     API_VERSION = "chaos-mesh.org/v1alpha1"
+    CHAOS_KIND = ""  # need to override it in child classes
 
-    def __init__(self, pod: "BasePodContainer", name: str, timeout: int = 0):
+    def __init__(self, pod: "sdcm.cluster_k8s.BasePodContainer", name: str, timeout: int = 0):
         self._k8s_cluster = pod.parent_cluster.k8s_cluster
         self._name = name
         self._namespace = pod.parent_cluster.namespace
         self._experiment = {
             "apiVersion": self.API_VERSION,
+            "kind": self.CHAOS_KIND,
             "metadata": {
                 "name": self._name,
                 "namespace": self._namespace
@@ -125,6 +135,10 @@ class PodChaosExperiment:
         self._timeout: int = timeout
         self._end_time: int = 0
 
+    @property
+    def name(self):
+        return self._name
+
     def start(self):
         """Starts experiment. Does not wait for finish."""
         LOGGER.debug("Starting a pod-failure experiment %s", self._name)
@@ -133,23 +147,30 @@ class PodChaosExperiment:
             yaml.dump(self._experiment, experiment_config_file)
             experiment_config_file.flush()
             self._k8s_cluster.apply_file(experiment_config_file.name)
-        LOGGER.info("pod-failure experiment '%s' has started", self._name)
+        LOGGER.info("'%s' experiment '%s' has started", self.CHAOS_KIND, self._name)
         self._end_time = time.time() + self._timeout
 
+    # pylint: disable=too-many-return-statements
     def get_status(self) -> ExperimentStatus:
-        """Gets status of podchaos experiment."""
+        """Gets status of chaos-mesh experiment."""
         result = self._k8s_cluster.kubectl(
-            f"get podchaos {self._name}  -n {self._namespace} -o jsonpath='{{.status.conditions}}'", verbose=False)
-        condition = {cond["type"]: ast.literal_eval(cond["status"]) for cond in json.loads(result.stdout)}
+            f"get {self.CHAOS_KIND} {self._name} -n {self._namespace} -o jsonpath='{{.status.conditions}}'", verbose=False)
+        try:
+            condition = {cond["type"]: ast.literal_eval(cond["status"]) for cond in json.loads(result.stdout)}
+        except JSONDecodeError:
+            # it may happen shortly after startup when command returns empty result
+            return ExperimentStatus.UNKNOWN
         if not condition["Selected"] and condition["Paused"]:
             return ExperimentStatus.ERROR
-        if not condition["Selected"] and not condition["Paused"] and not condition["AllRecovered"] and not condition["AllInjected"]:
+        if not condition["Selected"] and not condition["Paused"] and condition["AllRecovered"] and not condition["AllInjected"]:
+            return ExperimentStatus.ERROR
+        if not condition["Selected"] and not condition["Paused"]:
             return ExperimentStatus.STARTING
         if condition["Selected"] and not condition["Paused"] and not condition["AllRecovered"] and condition["AllInjected"]:
             return ExperimentStatus.RUNNING
         if condition["AllRecovered"] and condition["Paused"]:
             return ExperimentStatus.PAUSED
-        if condition["AllRecovered"] and not condition["Paused"]:
+        if condition["AllRecovered"] and not condition["Paused"] and condition["Selected"]:
             return ExperimentStatus.FINISHED
         LOGGER.warning("Unknown experiment status: %s", condition)
         return ExperimentStatus.UNKNOWN
@@ -166,36 +187,71 @@ class PodChaosExperiment:
                 LOGGER.debug("'%s' experiment ended.", self._name)
                 return
             elif status == ExperimentStatus.ERROR:
-                raise PodChaosException(msg="Experiment status error",
-                                        k8s_cluster=self._k8s_cluster,
-                                        podchaos_name=self._name,
-                                        namespace=self._namespace)
+                raise ChaosMeshExperimentException(msg="Experiment status error", experiment=self)
             time.sleep(2)
-        raise PodChaosTimeout(msg="Timeout when waiting for ChaosMesh experiment to complete.",
-                              k8s_cluster=self._k8s_cluster,
-                              podchaos_name=self._name,
-                              namespace=self._namespace)
+        raise ChaosMeshTimeout(msg="Timeout when waiting for ChaosMesh experiment to complete.", experiment=self)
+
+    def describe(self):
+        """Runs kubectl describe experiment resource"""
+        return self._k8s_cluster.kubectl(f"describe {self.CHAOS_KIND} {self._name} -n {self._namespace}").stdout
 
 
-class PodFailureExperiment(PodChaosExperiment):
+class PodFailureExperiment(ChaosMeshExperiment):
     """
     This experiment works by replacing container image with dummy image.
     Then it waits for specified duration and rolls back image config.
     """
+    CHAOS_KIND = "PodChaos"
 
-    def __init__(self, pod: "BasePodContainer", duration: str):
+    def __init__(self, pod: "sdcm.cluster_k8s.BasePodContainer", duration: str):
         """Injects fault into a specified Pod to make the Pod unavailable for a period of time.
 
-        'duration' is str type in k8s notation. E.g. 10s, 5m
+            :param sdcm.cluster_k8s.BasePodContainer pod: affected scylla pod
+            :param str duration: how long pod will be unavailable. str type in k8s notation. E.g. 10s, 5m
         """
         # timeout based on duration + 10 seconds margin
         timeout = time_period_str_to_seconds(duration) + 10
         super().__init__(
             pod=pod, name=f"pod-failure-{pod.name}-{datetime.now().strftime('%d-%H.%M.%S')}", timeout=timeout)
         deep_merge(self._experiment, {
-            "kind": "PodChaos",
             "spec": {
                 "action": "pod-failure",
                 "duration": duration,
             }
         })
+
+
+class MemoryStressExperiment(ChaosMeshExperiment):
+    """
+    This experiment uses memStress https://github.com/chaos-mesh/memStress for stressing memory in provided scylla pod.
+    """
+    CHAOS_KIND = "StressChaos"
+
+    # pylint: disable=too-many-arguments
+    def __init__(self, pod: "sdcm.cluster_k8s.BasePodContainer", duration: str, workers: int, size: str, time_to_reach: str | None = None):
+        """Stresses memory on scylla pod using https://github.com/chaos-mesh/memStress
+
+            :param sdcm.cluster_k8s.BasePodContainer pod: affected scylla pod
+            :param str duration: how long stress will be applied. str type in k8s notation. E.g. 10s, 5m
+            :param int workers: Specifies the number of threads that apply memory stress E.g. 4
+            :param str size: Specifies the memory size to be occupied or a percentage of the total memory size per worker. E.g.: 256MB / 25%
+            :param str time_to_reach: time to reach the size of allocated memory (default "0s")
+        """
+        # timeout based on duration + 30 seconds margin
+        timeout = time_period_str_to_seconds(duration) + 30
+        super().__init__(
+            pod=pod, name=f"memory-stress-{pod.name}-{datetime.now().strftime('%d-%H.%M.%S')}", timeout=timeout)
+        deep_merge(self._experiment, {
+            "spec": {
+                "duration": duration,
+                "containerNames": ["scylla"],
+                "stressors": {
+                    "memory": {
+                        "workers": workers,
+                        "size": size,
+                    }
+                }
+            }
+        })
+        if time_to_reach:
+            self._experiment["spec"]["stressors"]["memory"]["options"] = ["-time", time_to_reach]

--- a/unit_tests/test_chaos_mesh.py
+++ b/unit_tests/test_chaos_mesh.py
@@ -21,7 +21,8 @@ import yaml
 from invoke import Result
 import pytest
 
-from sdcm.utils.k8s.chaos_mesh import PodFailureExperiment, ExperimentStatus, PodChaosTimeout, PodChaosException
+from sdcm.utils.k8s.chaos_mesh import PodFailureExperiment, ExperimentStatus, ChaosMeshTimeout, ChaosMeshExperimentException, \
+    MemoryStressExperiment
 
 
 @dataclass
@@ -55,7 +56,7 @@ class DummyPod:
     name: str
 
 
-def test_experiment_configuration_is_valid(capsys):
+def test_podchaos_experiment_configuration_is_valid(capsys):
     k8s_cluster = DummyK8sCluster()
     pod = DummyPod(DummyPodCluster(k8s_cluster), name="dummy-pod-1")
     experiment = PodFailureExperiment(pod=pod, duration="10s")
@@ -79,7 +80,34 @@ def test_experiment_configuration_is_valid(capsys):
     assert actual_config == expected_config
 
 
-finished_conditions = '[{"status":"False","type":"AllInjected"},' \
+def test_memorystress_experiment_configuration_is_valid(capsys):
+    k8s_cluster = DummyK8sCluster()
+    pod = DummyPod(DummyPodCluster(k8s_cluster), name="dummy-pod-1")
+    experiment = MemoryStressExperiment(pod=pod, duration="10s", workers=4, size="512MB", time_to_reach="10s")
+    experiment.start()
+    captured = capsys.readouterr()
+    expected_config = {'apiVersion': 'chaos-mesh.org/v1alpha1',
+                       'kind': 'StressChaos',
+                       'metadata': {'name': 'memory-stress-dummy-pod-', 'namespace': 'scylla'},
+                       'spec': {'containerNames': ['scylla'],
+                                'duration': '10s',
+                                'mode': 'one',
+                                'selector': {'labelSelectors': {'statefulset.kubernetes.io/pod-name': 'dummy-pod-1'}},
+                                'stressors':
+                                    {'memory':
+                                     {'options': ['-time', '10s'],
+                                      'size': '512MB',
+                                      'workers': 4}
+                                     }
+                                }
+                       }
+    actual_config = eval(captured.out)
+    # strip the time from name
+    actual_config["metadata"]["name"] = actual_config["metadata"]["name"][:-13]
+    assert actual_config == expected_config
+
+
+finished_conditions = '[{"status":"True","type":"AllInjected"},' \
                       '{"status":"True","type":"AllRecovered"},' \
                       '{"status":"False","type":"Paused"},' \
                       '{"status":"True","type":"Selected"}]'
@@ -99,6 +127,11 @@ error_conditions = '[{"status":"True","type":"AllInjected"},' \
                    '{"status":"False","type":"AllRecovered"},' \
                    '{"status":"True","type":"Paused"},' \
                    '{"status":"False","type":"Selected"}]'
+error_conditions_2 = '[{"status":"False","type":"AllInjected"},' \
+    '{"status":"True","type":"AllRecovered"},' \
+    '{"status":"False","type":"Paused"},' \
+    '{"status":"False","type":"Selected"}]'
+unknown_conditions = ''
 
 
 @pytest.mark.parametrize("conditions, status", (
@@ -106,11 +139,13 @@ error_conditions = '[{"status":"True","type":"AllInjected"},' \
     (running_conditions, ExperimentStatus.RUNNING),
     (starting_conditions, ExperimentStatus.STARTING),
     (paused_conditions, ExperimentStatus.PAUSED),
-    (error_conditions, ExperimentStatus.ERROR)
+    (error_conditions, ExperimentStatus.ERROR),
+    (error_conditions_2, ExperimentStatus.ERROR),
+    (unknown_conditions, ExperimentStatus.UNKNOWN)
 ))
 def test_experiment_statuses_for_podchaos_condidtions(conditions, status):
     k8s_cluster = DummyK8sCluster()
-    k8s_cluster.register_kubectl_result("get podchaos", Result(stdout=conditions))
+    k8s_cluster.register_kubectl_result("get PodChaos", Result(stdout=conditions))
     pod = DummyPod(DummyPodCluster(k8s_cluster), name="dummy-pod-1")
 
     experiment = PodFailureExperiment(pod=pod, duration="10s")
@@ -119,7 +154,7 @@ def test_experiment_statuses_for_podchaos_condidtions(conditions, status):
 
 def test_wait_for_finished_returns_when_status_is_finished():
     k8s_cluster = DummyK8sCluster()
-    k8s_cluster.register_kubectl_result("get podchaos", Result(stdout=finished_conditions))
+    k8s_cluster.register_kubectl_result("get PodChaos", Result(stdout=finished_conditions))
     pod = DummyPod(DummyPodCluster(k8s_cluster), name="dummy-pod-1")
 
     experiment = PodFailureExperiment(pod=pod, duration="1s")
@@ -130,26 +165,26 @@ def test_wait_for_finished_returns_when_status_is_finished():
 
 def test_wait_for_finished_raises_exception_when_status_is_error():
     k8s_cluster = DummyK8sCluster()
-    k8s_cluster.register_kubectl_result("get podchaos", Result(error_conditions))
-    k8s_cluster.register_kubectl_result("describe podchaos ", Result(stdout="pod description got from k8s"))
+    k8s_cluster.register_kubectl_result("get PodChaos", Result(error_conditions))
+    k8s_cluster.register_kubectl_result("describe PodChaos ", Result(stdout="pod description got from k8s"))
     pod = DummyPod(DummyPodCluster(k8s_cluster), name="dummy-pod-1")
 
     experiment = PodFailureExperiment(pod=pod, duration="1s")
     experiment.start()
 
-    with pytest.raises(PodChaosException):
+    with pytest.raises(ChaosMeshExperimentException):
         experiment.wait_until_finished()
 
 
 def test_wait_for_finished_raises_exception_when_timeout_occurs():
     k8s_cluster = DummyK8sCluster()
-    k8s_cluster.register_kubectl_result("get podchaos", Result(running_conditions))
-    k8s_cluster.register_kubectl_result("describe podchaos ", Result(stdout="pod description got from k8s"))
+    k8s_cluster.register_kubectl_result("get PodChaos", Result(running_conditions))
+    k8s_cluster.register_kubectl_result("describe PodChaos ", Result(stdout="pod description got from k8s"))
     pod = DummyPod(DummyPodCluster(k8s_cluster), name="dummy-pod-1")
 
     experiment = PodFailureExperiment(pod=pod, duration="1s")
     experiment._timeout = 0
     experiment.start()
 
-    with pytest.raises(PodChaosTimeout):
+    with pytest.raises(ChaosMeshTimeout):
         experiment.wait_until_finished()


### PR DESCRIPTION
Memory stress nemesis does not work on k8s:
- #5455

This commit adds support for chaos-mesh's memory stress experiment.
Also made some bug fixing: additional experiment failure detection.
Code unification to ease adding new experiments.


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
