### PR TITLE
fix(page-size & query timeout): Decrease page size from 10k to 1k

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3510,8 +3510,9 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
         Checking if a result page with any data is received.
         """
         try:
-            result = session.execute(SimpleStatement(f"SELECT * FROM {table_name}", fetch_size=10))
-            return bool(len(result.one())), None
+            result = session.execute(SimpleStatement(f"SELECT * FROM {table_name} USING TIMEOUT 300s", fetch_size=10),
+                                     timeout=300)
+            return bool(result.one()), None
 
         except Exception as exc:  # pylint: disable=broad-except
             self.log.warning(f'Failed to get rows from {table_name} table. Error: {exc}')

--- a/sdcm/scan_operation_thread.py
+++ b/sdcm/scan_operation_thread.py
@@ -30,7 +30,7 @@ class ScanOperationThread:
     # pylint: disable=too-many-arguments,unused-argument
     def __init__(self, db_cluster: [BaseScyllaCluster, BaseCluster], duration: int, interval: int,
                  termination_event: threading.Event, ks_cf: str,
-                 scan_event: [FullScanEvent, FullPartitionScanReversedOrderEvent], page_size: int = 10000, **kwargs):
+                 scan_event: [FullScanEvent, FullPartitionScanReversedOrderEvent], page_size: int = 1000, **kwargs):
         self.ks_cf = ks_cf
         self.db_cluster = db_cluster
         self.page_size = page_size
@@ -135,7 +135,7 @@ class ScanOperationThread:
         end_time = time.time() + self.duration
         while time.time() < end_time and not self.termination_event.is_set():
             self.db_node = random.choice(self.db_cluster.nodes)
-            self.read_pages = random.choice([100, 1000, 0])
+            self.read_pages = random.choice([100, 1000, 10000, 0])
             self.run_scan_operation()
             self.log.debug('Executed %s number: %s', self.scan_event.__name__, self.scans_counter)
             time.sleep(self.interval)


### PR DESCRIPTION
	In order not to fail for timeouts of for:
	'Tombstones processed by unpaged query exceeds limit of 10000',
	page size of scan threads is decreased to 1k.
	In addition, set timeout of searching non-empty-tables to 5 minutes.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
