### PR TITLE
feature(azure): add azure to cloud report

### DIFF
--- a/sdcm/provision/azure/provisioner.py
+++ b/sdcm/provision/azure/provisioner.py
@@ -13,7 +13,7 @@
 
 import logging
 import string
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, List
 
 from azure.mgmt.compute.models import VirtualMachine, VirtualMachinePriorityTypes
@@ -188,7 +188,8 @@ class AzureProvisioner(Provisioner):  # pylint: disable=too-many-instance-attrib
         tags = v_m.tags.copy()
         ssh_user = tags.pop("ssh_user", "")
         ssh_key = tags.pop("ssh_key", "")
-        creation_time = datetime.fromisoformat(tags.pop("creation_time")) if 'creation_time' in tags else None
+        creation_time = datetime.fromisoformat(tags.pop("creation_time")).replace(
+            tzinfo=timezone.utc) if 'creation_time' in tags else None
         image = str(v_m.storage_profile.image_reference)
         pricing_model = self._get_pricing_model(v_m)
 

--- a/sdcm/provision/azure/resource_group_provider.py
+++ b/sdcm/provision/azure/resource_group_provider.py
@@ -52,7 +52,7 @@ class ResourceGroupProvider:
             resource_group_name=self._name,
             parameters={
                 "location": self._region,
-                "tags": {"creation_time": datetime.now().isoformat(sep=" ", timespec="seconds"), "_az": self._az}
+                "tags": {"creation_time": datetime.utcnow().isoformat(sep=" ", timespec="seconds"), "_az": self._az}
             },
         )
         LOGGER.info("Provisioned resource group %s in the %s region", resource_group.name, resource_group.location)

--- a/sdcm/provision/azure/virtual_machine_provider.py
+++ b/sdcm/provision/azure/virtual_machine_provider.py
@@ -64,7 +64,7 @@ class VirtualMachineProvider:
                 "location": self._region,
                 "zones": [self._az] if self._az else [],
                 "tags": definition.tags | {"ssh_user": definition.user_name, "ssh_key": definition.ssh_key.name,
-                                           "creation_time": datetime.now().isoformat(sep=" ", timespec="seconds")},
+                                           "creation_time": datetime.utcnow().isoformat(sep=" ", timespec="seconds")},
                 "hardware_profile": {
                     "vm_size": definition.type,
                 },

--- a/sdcm/utils/cloud_monitor/report.py
+++ b/sdcm/utils/cloud_monitor/report.py
@@ -152,19 +152,22 @@ class InstancesTimeDistributionReport(BaseReport, metaclass=abc.ABCMeta):
     def __init__(self, cloud_instances: CloudInstances, user=None):
         super().__init__(cloud_instances, static_ips=None, html_template="per_qa_user.html")
         self.user = user
-        self.report = {7: defaultdict(list), 5: defaultdict(list), 3: defaultdict(list)}
+        self.report = {"unknown": defaultdict(list), "7": defaultdict(
+            list), "5": defaultdict(list), "3": defaultdict(list)}
         self.qa_users = KeyStore().get_qa_users()
 
     def to_html(self):
         for instance in self.cloud_instances.all:
             if self._is_user_be_skipped(instance) or self._is_instance_be_skipped(instance):
                 continue
-            if self._is_older_than_3days(instance.create_time):
-                self.report[3][instance.owner].append(instance)
+            if not instance.create_time:
+                self.report["unknown"][instance.owner].append(instance)
+            elif self._is_older_than_3days(instance.create_time):
+                self.report["3"][instance.owner].append(instance)
             elif self._is_older_than_5days(instance.create_time):
-                self.report[5][instance.owner].append(instance)
+                self.report["5"][instance.owner].append(instance)
             elif self._is_older_than_7days(instance.create_time):
-                self.report[7][instance.owner].append(instance)
+                self.report["7"][instance.owner].append(instance)
             else:
                 continue
         if self.user:

--- a/sdcm/utils/cloud_monitor/resources/__init__.py
+++ b/sdcm/utils/cloud_monitor/resources/__init__.py
@@ -27,7 +27,7 @@ class CloudInstance:  # pylint: disable=too-few-public-methods,too-many-instance
         raise NotImplementedError
 
     def hours_running(self):
-        if self.state == "running":
+        if self.state == "running" and self.create_time:
             dt_since_created = datetime.now(self.create_time.tzinfo) - self.create_time
             return ceil(dt_since_created.total_seconds() / 3600)
         return 0

--- a/sdcm/utils/cloud_monitor/resources/__init__.py
+++ b/sdcm/utils/cloud_monitor/resources/__init__.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from math import ceil
 
-CLOUD_PROVIDERS = ("aws", "gce")
+CLOUD_PROVIDERS = ("aws", "gce", "azure")
 
 
 class CloudInstance:  # pylint: disable=too-few-public-methods,too-many-instance-attributes

--- a/sdcm/utils/cloud_monitor/resources/instances.py
+++ b/sdcm/utils/cloud_monitor/resources/instances.py
@@ -105,6 +105,9 @@ class AzureInstance(CloudInstance):
 
     def __init__(self, instance: VirtualMachine, resource_group: str):
         tags = instance.tags or {}
+        creation_time = tags.get("creation_time", None)
+        if creation_time:
+            creation_time = datetime.fromisoformat(creation_time).replace(tzinfo=timezone.utc)
         super().__init__(
             cloud="azure",
             name=instance.name,
@@ -114,9 +117,7 @@ class AzureInstance(CloudInstance):
             lifecycle=InstanceLifecycle.SPOT if instance.priority == "Spot" else InstanceLifecycle.ON_DEMAND,
             instance_type=instance.hardware_profile.vm_size,
             owner=tags.get("RunByUser", NA),
-            # azure is not providing vm creation time - for machines that don't have creation_time, set default in the past
-            create_time=datetime.fromisoformat(
-                tags.get("creation_time", "2022-12-20T12:00:00")).replace(tzinfo=timezone.utc),
+            create_time=creation_time,
             keep=tags.get("keep", ""),
             project=resource_group
         )

--- a/sdcm/utils/cloud_monitor/resources/static_ips.py
+++ b/sdcm/utils/cloud_monitor/resources/static_ips.py
@@ -99,7 +99,7 @@ class StaticIPs(CloudResources):
         self.all.extend(self["gce"])
 
     def get_azure_static_ips(self):
-        # all azure ip's are external resources and we pay for it
+        # all azure public ip's are external resources and we pay for it
         query_bits = ["Resources", "where type =~ 'Microsoft.Network/publicIPAddresses'",
                       "project id, resourceGroup, name, location, properties"]
         res = AzureService().resource_graph_query(query=' | '.join(query_bits))

--- a/unit_tests/lib/fake_provisioner.py
+++ b/unit_tests/lib/fake_provisioner.py
@@ -45,7 +45,7 @@ class FakeProvisioner(Provisioner):
                          private_ip_address='10.10.10.10', tags=definition.tags,
                          pricing_model=pricing_model,
                          image=definition.image_id,
-                         creation_time=datetime.datetime.now(),
+                         creation_time=datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc),
                          _provisioner=self)
         self._instances[definition.name] = v_m
         return v_m

--- a/unit_tests/provisioner/conftest.py
+++ b/unit_tests/provisioner/conftest.py
@@ -51,7 +51,7 @@ def params():
                             "SCT_AZURE_IMAGE_DB", "SCT_N_LOADERS", "SCT_N_MONITORS_NODES", "SCT_AVAILABILITY_ZONE"])
     env_config = EnvConfig(
         SCT_CLUSTER_BACKEND="azure",
-        SCT_TEST_ID=f"unit-test-{str(uuid.uuid4())}",
+        SCT_TEST_ID=f"{str(uuid.uuid4())}",
         SCT_CONFIG_FILES=f'["{Path(__file__).parent.absolute()}/azure_default_config.yaml"]',
         SCT_AZURE_REGION_NAME="['eastus', 'easteu']",
         SCT_N_DB_NODES="3 1",

--- a/unit_tests/provisioner/test_provisioner.py
+++ b/unit_tests/provisioner/test_provisioner.py
@@ -12,7 +12,7 @@
 # Copyright (c) 2022 ScyllaDB
 # pylint: disable=redefined-outer-name
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -89,7 +89,7 @@ def provisioner(backend, provisioner_params):
 
 
 def test_can_provision_scylla_vm(region, definition, provisioner, backend, provisioner_params):
-    creation_time = datetime.now().replace(microsecond=0)
+    creation_time = datetime.utcnow().replace(microsecond=0).replace(tzinfo=timezone.utc)
     v_m = provisioner.get_or_create_instances(definitions=[definition])[0]
     assert v_m.name == definition.name
     assert v_m.region == region


### PR DESCRIPTION
Currently we don't monitor Azure cloud resources usage. This leads to not needed VM's running without notice and generating costs.

This commit adds Azure backend to cloud usage report.

refs: 
- https://github.com/scylladb/qa-tasks/issues/919
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
