### PR TITLE
fix(get_any_ks_cf_list): skip broken tables when filter_empty_tables

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3475,13 +3475,13 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
                 if filter_out_cdc_log_tables and getattr(row, column_names[1]).endswith(cdc.options.CDC_LOGTABLE_SUFFIX):
                     continue
 
-                if table_name in ["system_schema.dropped_columns", "system.truncated"]:
-                    # skipping those cause of some scylla issues on system tables
-                    # https://github.com/scylladb/scylladb/issues/7186
-                    # https://github.com/scylladb/scylladb/issues/12239
-                    continue
-
                 if is_column_type and filter_empty_tables:
+                    if table_name in ["system_schema.dropped_columns", "system.truncated"]:
+                        # skipping those cause of some scylla issues on system tables
+                        # https://github.com/scylladb/scylladb/issues/7186
+                        # https://github.com/scylladb/scylladb/issues/12239
+                        continue
+
                     has_data = False
                     try:
                         stmt = SimpleStatement(f"SELECT * FROM {table_name}", fetch_size=10)

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -605,6 +605,29 @@ def test_get_any_ks_cf_list(docker_scylla, params):
                                 'system_distributed.view_build_status', 'system.built_views',
                                 'mview.users_by_first_name', 'mview.users_by_last_name', 'mview.users'}
 
+    table_names = cluster.get_any_ks_cf_list(docker_scylla, filter_empty_tables=False)
+    assert set(table_names) == {'system.runtime_info', 'system_distributed.cdc_generation_timestamps',
+                                'system.config', 'system.local', 'system.token_ring', 'system.clients',
+                                'system_schema.tables', 'system_schema.columns', 'system.compaction_history',
+                                'system.cdc_local', 'system.versions', 'system_distributed_everywhere.cdc_generation_descriptions_v2',
+                                'system.scylla_local', 'system.cluster_status', 'system.protocol_servers',
+                                'system_distributed.cdc_streams_descriptions_v2', 'system_schema.keyspaces',
+                                'system.size_estimates', 'system_schema.scylla_tables', 'system_auth.roles',
+                                'system.scylla_table_schema_history', 'system_schema.views',
+                                'system_distributed.view_build_status', 'system.built_views',
+                                'mview.users_by_first_name', 'mview.users_by_last_name', 'mview.users',
+                                'system.IndexInfo', 'system.batchlog', 'system.compactions_in_progress',
+                                'system.hints', 'system.large_cells', 'system.large_partitions', 'system.large_rows',
+                                'system.paxos', 'system.peer_events', 'system.peers', 'system.range_xfers', 'system.repair_history',
+                                'system.scylla_views_builds_in_progress', 'system.snapshots', 'system.sstable_activity',
+                                'system.truncated', 'system.views_builds_in_progress', 'system_auth.role_attributes',
+                                'system_auth.role_members', 'system_distributed.service_levels', 'system_schema.aggregates',
+                                'system_schema.computed_columns', 'system_schema.dropped_columns', 'system_schema.functions',
+                                'system_schema.indexes', 'system_schema.scylla_aggregates', 'system_schema.scylla_keyspaces',
+                                'system_schema.triggers', 'system_schema.types', 'system_schema.view_virtual_columns',
+                                'system_traces.events', 'system_traces.node_slow_log', 'system_traces.node_slow_log_time_idx',
+                                'system_traces.sessions', 'system_traces.sessions_time_idx'}
+
     table_names = cluster.get_non_system_ks_cf_list(docker_scylla, filter_empty_tables=False, filter_out_mv=True)
     assert set(table_names) == {'mview.users'}
 


### PR DESCRIPTION
Since on cases we want all of the tables (i.e. for comparing with snapshots) we also need to include those system tables, and not skip them.

Fixes: #5618

Ref: https://github.com/scylladb/scylladb/issues/7186
Ref: https://github.com/scylladb/scylladb/issues/12239

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
