### PR TITLE
fix(50gb-3days-ebs-gp3): don't use multi line in test_config

### DIFF
--- a/jenkins-pipelines/longevity-50gb-3days-ebs-gp3.jenkinsfile
+++ b/jenkins-pipelines/longevity-50gb-3days-ebs-gp3.jenkinsfile
@@ -7,7 +7,5 @@ longevityPipeline(
     backend: 'aws',
     region: 'eu-west-1',
     test_name: 'longevity_test.LongevityTest.test_custom_time',
-    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml","configurations/ebs/ebs-gp3-2v-4tb-16k-iops.yaml",
-                     "configurations/ebs/longevity-50GB-3days-authorization-and-tls-ssl-stress.yaml"]'''
-
+    test_config: '''["test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml","configurations/ebs/ebs-gp3-2v-4tb-16k-iops.yaml", "configurations/ebs/longevity-50GB-3days-authorization-and-tls-ssl-stress.yaml"]'''
 )


### PR DESCRIPTION
seem like our groovy pipeline are not handling correctly `test_config` if it has multiple lines

and that's breaks the test like the following:

```
anyconfig.common.errors.UnknownFileTypeError: No parser found for file: file extension=yaml"]
```

## Testing
- [x] https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-50gb-3days-ebs-gp3-test/6/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
