### PR TITLE
fix(nemesis): remove exception prints from `execute_disrupt_method`

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1645,12 +1645,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.metrics_srv.event_start(disrupt_method_name)
         try:
             disrupt_method()
-        except Exception as exc:  # pylint: disable=broad-except
-            error_msg = "Exception in random_disrupt_method %s: %s", disrupt_method_name, exc
-            self.log.error(error_msg, exc_info=True)
-            self.error_list.append(error_msg)
-            raise
-        else:
             self.log.info("<<<<<<<<<<<<<Finished random_disrupt_method %s" % disrupt_method_name)
         finally:
             self.metrics_srv.event_stop(disrupt_method_name)


### PR DESCRIPTION
since now we raise the `UnsupportedNemesis`, there no need to print it again like this in error level, we have a warning for it

```
...
Traceback (most recent call last):
   File ".../sdcm/nemesis.py", line 1647, in execute_disrupt_method
     disrupt_method()
   File ".../sdcm/nemesis.py", line 3848, in wrapper
     result = method(*args[1:], **kwargs)
   File ".../sdcm/nemesis.py", line 2848, in disrupt_network_random_interruptions
     raise UnsupportedNemesis("for this nemesis to work,
                               you need to set `extra_network_interface: True`")
 sdcm.nemesis.UnsupportedNemesis: for this nemesis to work,
                                  you need to set `extra_network_interface: True`
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
