### PR TITLE
fix(page-fetcher): extand the wait time calling `request_all`

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3460,7 +3460,7 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
             session.default_fetch_size = 1000
             session.default_consistency_level = ConsistencyLevel.ONE
             execute_result = session.execute_async(cmd)
-            fetcher = PageFetcher(execute_result).request_all()
+            fetcher = PageFetcher(execute_result).request_all(timeout=120)
             current_rows = fetcher.all_data()
 
             for row in current_rows:

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1541,6 +1541,7 @@ class ScyllaCQLSession:
 
     def __enter__(self):
         execute_orig = self.session.execute
+        execute_async_orig = self.session.execute_async
 
         def execute_verbose(*args, **kwargs):
             if args:
@@ -1550,8 +1551,17 @@ class ScyllaCQLSession:
             LOGGER.debug("Executing CQL '%s' ...", query)
             return execute_orig(*args, **kwargs)
 
+        def execute_async_verbose(*args, **kwargs):
+            if args:
+                query = args[0]
+            else:
+                query = kwargs.get("query")
+            LOGGER.debug("Executing CQL '%s' ...", query)
+            return execute_async_orig(*args, **kwargs)
+
         if self.verbose:
             self.session.execute = execute_verbose
+            self.session.execute_async = execute_async_verbose
         return self.session
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -2353,9 +2363,10 @@ class PageFetcher:
 
     def handle_error(self, exc):
         self.error = exc
+        LOGGER.error(self.error)
         raise exc
 
-    def request_one(self):
+    def request_one(self, timeout=10):
         """
         Requests the next page if there is one.
 
@@ -2364,11 +2375,11 @@ class PageFetcher:
         if self.future.has_more_pages:
             self.future.start_fetching_next_page()
             self.requested_pages += 1
-            self.wait()
+            self.wait(seconds=timeout)
 
         return self
 
-    def request_all(self):
+    def request_all(self, timeout=10):
         """
         Requests any remaining pages.
 
@@ -2377,7 +2388,7 @@ class PageFetcher:
         while self.future.has_more_pages:
             self.future.start_fetching_next_page()
             self.requested_pages += 1
-            self.wait()
+            self.wait(seconds=timeout)
 
         return self
 


### PR DESCRIPTION
* put a 120s wait time on the `request_all` call

* add debug information - trying to help with invesigating of scylladb/scylladb#12301 we are adding print for execute_async and for it's error callback

Ref: https://github.com/scylladb/scylladb/issues/12301

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
