### PR TITLE
feature(sct-builders): move to use gcp launch template

### DIFF
--- a/sdcm/utils/aws_builder.py
+++ b/sdcm/utils/aws_builder.py
@@ -23,7 +23,6 @@ from mypy_boto3_ec2 import EC2ServiceResource
 
 from sdcm.utils.aws_region import AwsRegion
 from sdcm.sct_runner import AwsSctRunner
-from sdcm.utils.sct_cmd_helpers import CloudRegion, add_file_logger
 from sdcm.keystore import KeyStore
 
 LOGGER = logging.getLogger(__name__)
@@ -346,21 +345,3 @@ class AwsCiBuilder(AwsBuilder):
     @cached_property
     def jenkins_labels(self):
         return f"aws-sct-builders-{self.region.region_name}-v2-CI"
-
-
-configure_jenkins_builders: click.Command
-
-
-@click.command("configure-jenkins-builders", help="Configure all required jenkins builders for SCT")
-@click.option("-r", "--regions", type=CloudRegion(cloud_provider='aws'),
-              default=[], help="Cloud regions", multiple=True)
-def configure_jenkins_builders(regions):
-    add_file_logger()
-    logging.basicConfig(level=logging.INFO)
-
-    AwsCiBuilder(AwsRegion('eu-west-1')).configure_auto_scaling_group()
-    AwsBuilder.configure_in_all_region(regions=regions)
-
-
-if __name__ == '__main__':
-    configure_jenkins_builders()  # pylint: disable=no-value-for-parameter

--- a/sdcm/utils/gce_builder.py
+++ b/sdcm/utils/gce_builder.py
@@ -1,0 +1,239 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2023 ScyllaDB
+import sys
+import logging
+from typing import Any
+from functools import cached_property
+
+import click
+import requests
+from google.oauth2 import service_account
+from google.cloud import compute_v1
+from google.api_core.extended_operation import ExtendedOperation
+import google.api_core.exceptions
+
+from sdcm.utils.gce_region import GceRegion
+from sdcm.utils.gce_utils import SUPPORTED_PROJECTS, SUPPORTED_REGIONS
+from sdcm.utils.context_managers import environment
+from sdcm.sct_runner import GceSctRunner
+from sdcm.keystore import KeyStore
+
+LOGGER = logging.getLogger(__name__)
+
+JENKINS_CONFIG_FORMAT = """
+// just modify this config other code just logic
+config = [
+    name: "{name}",
+    region: "{region_name}",
+    projectId: "{project_id}",
+    credentialsId: "{project_id}",
+    instanceCapStr: "{max_instances}",
+    labels: "{jenkins_labels}",
+]
+
+import com.google.jenkins.plugins.computeengine.ComputeEngineCloud
+import com.google.jenkins.plugins.computeengine.InstanceConfiguration
+import com.google.jenkins.plugins.computeengine.SshConfiguration
+import hudson.plugins.sshslaves.SSHConnector
+import hudson.plugins.sshslaves.verifiers.NonVerifyingKeyVerificationStrategy
+import hudson.model.*
+import jenkins.model.Jenkins
+
+ComputeEngineCloud gcpCloud = new ComputeEngineCloud(config.name, config.projectId, config.credentialsId, config.instanceCapStr)
+gcpCloud.setNoDelayProvisioning(true)
+
+InstanceConfiguration instanceConfiguration = new InstanceConfiguration()
+instanceConfiguration.setNumExecutorsStr("4")
+instanceConfiguration.setOneShot(false)
+instanceConfiguration.setNamePrefix("builders")
+instanceConfiguration.setDescription("SCT Jenkins builders")
+instanceConfiguration.setRegion("https://www.googleapis.com/compute/v1/projects/{project_id}/regions/{region_name}")
+instanceConfiguration.setZone("https://www.googleapis.com/compute/v1/projects/{project_id}/zones/{region_name}-b")
+instanceConfiguration.setLabelString(config.labels)
+instanceConfiguration.setMode(Node.Mode.NORMAL)
+instanceConfiguration.setTemplate("https://www.googleapis.com/compute/v1/projects/{project_id}/global/instanceTemplates/{name}")
+instanceConfiguration.setRetentionTimeMinutesStr("6")
+instanceConfiguration.setLaunchTimeoutSecondsStr("300")
+instanceConfiguration.setRunAsUser("jenkins")
+instanceConfiguration.setSshConfiguration(SshConfiguration.builder().customPrivateKeyCredentialsId("6e17c350-0a47-4a59-b0b9-7e64f1c35a65").build())
+
+gcpCloud.addConfiguration(instanceConfiguration)
+
+// get Jenkins instance
+Jenkins jenkins = Jenkins.get()
+
+// clear old configuration
+jenkins.clouds.removeAll {{ it.name == "gce-${{config.name}}" }}
+
+res = jenkins.clouds.add(gcpCloud)
+
+// save current Jenkins state to disk
+jenkins.save()
+"""
+
+
+class GceBuilder:
+    """
+    This class is for configuration our Jenkins setup for GCE
+
+    It creates a launch template based on sct-runner image, and adds configuration needed in Jenkins to use it
+    """
+
+    def __init__(self, region: GceRegion, number=1):
+        self.region = region
+        self.number = number
+        self.jenkins_info = KeyStore().get_json("jenkins.json")
+        self.runner = GceSctRunner(region_name=self.region.region_name,
+                                   availability_zone="a")
+
+        info = KeyStore().get_gcp_credentials()
+        self.credentials = service_account.Credentials.from_service_account_info(info)
+
+    @cached_property
+    def name(self):
+        # example: gce-sct-project-1-us-east1-qa-builder
+        return f"gce-{self.region.project}-{self.region.region_name}-qa-builder"
+
+    @cached_property
+    def jenkins_labels(self):
+        return f"gcp-{self.region.project}-builders-{self.region.region_name}-template"
+
+    def _add_cloud_configuration_to_jenkins(self):
+        click.echo(f"{self.region.project}: {self.region.region_name}: add_cloud_configuration_to_jenkins")
+        res = requests.post(url=f"{self.jenkins_info['url']}/scriptText",
+                            auth=(self.jenkins_info['username'], self.jenkins_info['password']),
+                            params=dict(script=JENKINS_CONFIG_FORMAT.format(name=self.name,
+                                                                            project_id=self.region.project,
+                                                                            region_name=self.region.region_name,
+                                                                            max_instances=20,
+                                                                            jenkins_labels=self.jenkins_labels)))
+        res.raise_for_status()
+        logging.info(res.text)
+        assert not res.text
+
+    @staticmethod
+    def _wait_for_extended_operation(
+            operation: ExtendedOperation, verbose_name: str = "operation", timeout: int = 300
+    ) -> Any:
+        """
+        This method will wait for the extended (long-running) operation to
+        complete. If the operation is successful, it will return its result.
+        If the operation ends with an error, an exception will be raised.
+        If there were any warnings during the execution of the operation
+        they will be printed to sys.stderr.
+
+        Args:
+            operation: a long-running operation you want to wait on.
+            verbose_name: (optional) a more verbose name of the operation,
+                used only during error and warning reporting.
+            timeout: how long (in seconds) to wait for operation to finish.
+                If None, wait indefinitely.
+
+        Returns:
+            Whatever the operation.result() returns.
+
+        Raises:
+            This method will raise the exception received from `operation.exception()`
+            or RuntimeError if there is no exception set, but there is an `error_code`
+            set for the `operation`.
+
+            In case of an operation taking longer than `timeout` seconds to complete,
+            a `concurrent.futures.TimeoutError` will be raised.
+        """
+        result = operation.result(timeout=timeout)
+
+        if operation.error_code:
+            click.echo(
+                f"Error during {verbose_name}: [Code: {operation.error_code}]: {operation.error_message}",
+                file=sys.stderr,
+            )
+            click.echo(f"Operation ID: {operation.name}", file=sys.stderr)
+            raise operation.exception() or RuntimeError(operation.error_message)
+
+        if operation.warnings:
+            click.echo(f"Warnings during {verbose_name}:\n", file=sys.stderr)
+            for warning in operation.warnings:
+                click.echo(f" - {warning.code}: {warning.message}", file=sys.stderr)
+
+        return result
+
+    def _create_launch_template(self) -> compute_v1.InstanceTemplate:
+        """
+        Create a new instance template with the provided name and a specific
+        instance configuration.
+
+        Returns:
+            InstanceTemplate object that represents the new instance template.
+        """
+        # The template describes the size and source image of the boot disk
+        # to attach to the instance.
+        disk = compute_v1.AttachedDisk()
+        initialize_params = compute_v1.AttachedDiskInitializeParams()
+        initialize_params.source_image = (
+            self.runner.image.extra.get('selfLink')
+        )
+        initialize_params.disk_type = 'pd-standard'
+        initialize_params.disk_size_gb = 80
+        disk.initialize_params = initialize_params
+        disk.auto_delete = True
+        disk.boot = True
+
+        # The template connects the instance to the `default` network,
+        # without specifying a subnetwork.
+        network_interface = compute_v1.NetworkInterface()
+        network_interface.network = self.region.network.self_link
+
+        # The template lets the instance use an external IP address.
+        access_config = compute_v1.AccessConfig()
+        access_config.name = "External NAT"
+        access_config.type_ = "ONE_TO_ONE_NAT"
+        access_config.network_tier = "PREMIUM"
+        network_interface.access_configs = [access_config]
+
+        template = compute_v1.InstanceTemplate()
+        template.name = self.name
+        template.properties.disks = [disk]
+        template.properties.machine_type = "e2-medium"
+        template.properties.network_interfaces = [network_interface]
+
+        metadata = compute_v1.Metadata()
+        metadata.items += [{"key": "RunByUser", "value": "QA"}]
+        metadata.items += [{"key": "NodeType", "value": "builder"}]
+        metadata.items += [{"key": "keep", "value": "alive"}]
+
+        template.properties.metadata = metadata
+        template_client = compute_v1.InstanceTemplatesClient(credentials=self.credentials)
+        try:
+            operation = template_client.insert(
+                project=self.region.project, instance_template_resource=template
+            )
+
+            self._wait_for_extended_operation(operation, "instance template creation")
+        except google.api_core.exceptions.Conflict:
+            click.echo(f'template: {template.name} already exists. '
+                       'if change affecting were made, delete it and run this again')
+
+        return template_client.get(project=self.region.project, instance_template=self.name)
+
+    def configure(self):
+        self._create_launch_template()
+        self._add_cloud_configuration_to_jenkins()
+
+    @classmethod
+    def configure_in_all_region(cls, regions=None):
+        for project in SUPPORTED_PROJECTS:
+            with environment(SCT_GCE_PROJECT=project):
+                regions = regions or SUPPORTED_REGIONS.keys()
+                for region_name in regions:
+                    gce_builder = cls(GceRegion(region_name))
+                    gce_builder.configure()

--- a/sdcm/utils/gce_region.py
+++ b/sdcm/utils/gce_region.py
@@ -40,7 +40,7 @@ class GceRegion:
 
         credentials = service_account.Credentials.from_service_account_info(info)
 
-        self.iam = build('iam', 'v1', credentials=credentials)
+        self.iam = build('iam', 'v1', credentials=credentials, cache_discovery=False)
 
         self.network_client = compute_v1.NetworksClient(credentials=credentials)
         self.firewall_client = compute_v1.FirewallsClient(credentials=credentials)

--- a/vars/getJenkinsLabels.groovy
+++ b/vars/getJenkinsLabels.groovy
@@ -16,7 +16,7 @@ def call(String backend, String region=null, String datacenter=null, String loca
     }
 
     def gcp_project = params.gce_project?.trim() ?: 'gcp-sct-project-1'
-    gcp_project = gcp_project == 'gcp' ? 'gce-sct' : gcp_project
+    gcp_project = gcp_project == 'gcp' ? 'gcp-skilled-adapter-452' : gcp_project
 
     def jenkins_labels = ['aws-eu-west-1': 'aws-sct-builders-eu-west-1-v2-asg',
                           'aws-eu-west-2': 'aws-sct-builders-eu-west-2-v2-asg',
@@ -24,9 +24,9 @@ def call(String backend, String region=null, String datacenter=null, String loca
                           'aws-eu-central-1': 'aws-sct-builders-eu-central-1-v2-asg',
                           'aws-us-east-1' : 'aws-sct-builders-us-east-1-v2-asg',
                           'aws-us-west-2' : 'aws-sct-builders-us-west-2-v2-asg',
-                          'gce-us-east1': "${gcp_project}-builders-us-east1",
-                          'gce-us-west1': "${gcp_project}-builders-us-west1",
-                          'gce': "${gcp_project}-builders",
+                          'gce-us-east1': "${gcp_project}-builders-us-east1-template",
+                          'gce-us-west1': "${gcp_project}-builders-us-west1-template",
+                          'gce': "${gcp_project}-builders-us-east1-template",
                           'aws': 'aws-sct-builders-eu-west-1-v2-asg',
                           'azure-eastus': 'azure-sct-builders']
 


### PR DESCRIPTION
* added `GceBuilder` to create templates and configure them in jenkins

* move the default labels for GCE backend to use those templates

## Testing

- [x] longevity -https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-10gb-3h-gce-test/22
- [x] artifact - https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/artifacts-ubuntu2204-test/27/
- [ ] ~~artifact docker~~ docker would run on AWS
- [x] test multiple artifacts runs sharing the same builder (4 as we did in AWS)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
