### PR TITLE
feature(k8s-kind): upgrade kind version to v0.17.0

### DIFF
--- a/defaults/k8s_local_kind_config.yaml
+++ b/defaults/k8s_local_kind_config.yaml
@@ -1,5 +1,5 @@
 # Version of the kind to be used
-mini_k8s_version: '0.14.0'
+mini_k8s_version: '0.17.0'
 
 n_db_nodes: 4
 k8s_n_scylla_pods_per_cluster: 3


### PR DESCRIPTION
This version includes Kubernetes 1.25.3 as default and we want to test scylla-operator 1.8 with it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
