### PR TITLE
feature(k8s-eks): update k8s to verison 1.24

### DIFF
--- a/defaults/k8s_eks_config.yaml
+++ b/defaults/k8s_eks_config.yaml
@@ -9,12 +9,12 @@ availability_zone: 'a,b'
 instance_provision: 'on_demand'
 instance_type_db: 'i3.4xlarge'
 
-eks_cluster_version: '1.22'
+eks_cluster_version: '1.24'
 eks_role_arn: 'arn:aws:iam::797456418907:role/eksServicePolicy'
 eks_service_ipv4_cidr: '172.20.0.0/16'
 eks_nodegroup_role_arn: 'arn:aws:iam::797456418907:role/helm-test-worker-nodes-NodeInstanceRole-6ACHDYEKNN3I'
 # NOTE: https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
-eks_vpc_cni_version: 'v1.11.3-eksbuild.1'
+eks_vpc_cni_version: 'v1.12.0-eksbuild.1'
 
 scylla_version: '4.5.3'
 scylla_mgmt_agent_version: '3.0.0'
@@ -53,3 +53,6 @@ mgmt_docker_image: 'scylladb/scylla-manager:3.0.0'
 
 backup_bucket_backend: 's3'
 backup_bucket_location: 'minio-bucket'
+
+# since we can't install minio in since k8s v1.23 (not without ebs-csi-driver setup)
+use_mgmt: false

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -160,7 +160,11 @@ k8s_log_api_calls: false
 k8s_deploy_monitoring: false
 k8s_minio_storage_size: '10Gi'
 k8s_n_scylla_pods_per_cluster: 3
-k8s_loader_run_type: 'static'
+
+# NOTE: use dynamic while 'static' one is not compatible with K8S v1.24+ versions
+#       it must stop using docker.
+k8s_loader_run_type: 'dynamic'
+
 k8s_tenants_num: 1
 
 # NOTE: 'k8s_enable_performance_tuning' is alpha feature in operator-1.6 , so it is disabled by default

--- a/test-cases/scylla-operator/functional.yaml
+++ b/test-cases/scylla-operator/functional.yaml
@@ -10,8 +10,6 @@ k8s_loader_cluster_name: 'sct-loaders'
 
 n_monitor_nodes: 0
 
-use_mgmt: true
-
 mgmt_docker_image: 'scylladb/scylla-manager:3.0.0'
 scylla_mgmt_agent_version: '3.0.0'
 scylla_version: '4.6.3'


### PR DESCRIPTION
Since we want to test operator 1.8 with latest versions of k8s, we are switch to use 1.24 which is the latest available in EKS

## Testing
- [x] functional - https://jenkins.scylladb.com/job/scylla-operator/job/operator-1.8/job/upgrade/job/upgrade-platform-k8s-eks/4/
- [x] longevity - https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-scylla-operator-3h-eks/25/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)

