### PR TITLE
feature(k8s-gke): update to run with k8s v1.24

### DIFF
--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -3,7 +3,7 @@ gce_datacenter: 'us-east1-b'
 gce_network: 'qa-vpc'
 gce_image_username: 'scylla-test'
 
-gke_cluster_version: '1.22'
+gke_cluster_version: '1.24'
 gke_k8s_release_channel: ''
 
 gce_instance_type_db: 'n1-standard-8'

--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -250,7 +250,7 @@ class GkeCluster(KubernetesCluster):
                        f" --network {self.gce_network}"
                        f" --num-nodes {self.n_nodes}"
                        f" --machine-type {self.gce_instance_type}"
-                       f" --image-type UBUNTU"
+                       f" --image-type ubuntu_containerd"
                        f" --disk-type {self.gce_disk_type}"
                        f" --disk-size {self.gce_disk_size}"
                        f" --logging=SYSTEM,WORKLOAD --monitoring=SYSTEM"


### PR DESCRIPTION
As part of testing scylla-operator 1.8, we should be move to k8s version v1.25

Ref: https://cloud.google.com/kubernetes-engine/docs/deprecations/docker-containerd

## Testing
- [x] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-scylla-operator-3h-gke/8/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
