### PR TITLE
fix(azure): add retry to listing resources

### DIFF
--- a/sdcm/utils/azure_utils.py
+++ b/sdcm/utils/azure_utils.py
@@ -28,6 +28,7 @@ from azure.mgmt.resourcegraph import ResourceGraphClient
 from azure.mgmt.resourcegraph.models import QueryRequestOptions, QueryRequest
 
 from sdcm.keystore import KeyStore
+from sdcm.utils.decorators import retrying
 from sdcm.utils.metaclasses import Singleton
 
 if TYPE_CHECKING:
@@ -167,6 +168,7 @@ class AzureService(metaclass=Singleton):
 
     # Azure Resource Graph is a service with extremely powerful query language for the resource exploration.
     # See https://docs.microsoft.com/en-us/azure/governance/resource-graph/overview for more details.
+    @retrying(n=3)
     def resource_graph_query(self, query: str) -> Iterator:
         LOGGER.debug("query=%r", query)
         request = QueryRequest(


### PR DESCRIPTION
Sometimes azure api fails during querying resources with resource graph queries.

This commit adds retries for these queries so it is more stable.

refs: #5543

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
