### PR TITLE
fix(k8s): make static loaders work on K8S v1.24+

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4789,8 +4789,7 @@ class BaseLoaderSet():
         return next(self._loader_cycle)
 
     def kill_stress_thread(self):
-        if self.nodes and self.nodes[0].is_kubernetes() and self.params.get(
-                'k8s_loader_run_type') != 'static':
+        if self.nodes and self.nodes[0].is_kubernetes():
             for node in self.nodes:
                 node.remoter.stop()
         else:

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1686,7 +1686,7 @@ class BasePodContainer(cluster.BaseNode):  # pylint: disable=too-many-public-met
 
     def _init_remoter(self, ssh_login_info):
         self.remoter = KubernetesCmdRunner(kluster=self.parent_cluster.k8s_cluster,
-                                           pod=self.name,
+                                           pod_name=self.name,
                                            container=self.parent_cluster.container,
                                            namespace=self.parent_cluster.namespace)
 

--- a/sdcm/k8s_configs/loaders/sts.yaml
+++ b/sdcm/k8s_configs/loaders/sts.yaml
@@ -31,21 +31,4 @@ spec:
             requests:
               cpu: ${POD_CPU_LIMIT}
               memory: ${POD_MEMORY_LIMIT}
-          # TODO: those mounts/securityContext should be remove once we'll stop using bare docker for loaders
-          securityContext:
-            privileged: true
-          volumeMounts:
-            - mountPath: /usr/bin/docker
-              name: docker-binary
-            - mountPath: /var/run/docker.sock
-              name: docker-socket
-      volumes:
-        - name: docker-binary
-          hostPath:
-            path: /usr/bin/docker
-            type: File
-        - name: docker-socket
-          hostPath:
-            path: /var/run/docker.sock
-            type: Socket
       hostNetwork: false

--- a/sdcm/scylla_bench_thread.py
+++ b/sdcm/scylla_bench_thread.py
@@ -158,8 +158,7 @@ class ScyllaBenchThread(DockerBasedStressThread):  # pylint: disable=too-many-in
 
     def _run_stress(self, loader, loader_idx, cpu_idx):  # pylint: disable=too-many-locals
         cmd_runner = None
-        if "k8s" in self.params.get("cluster_backend") and self.params.get(
-                "k8s_loader_run_type") == 'dynamic':
+        if "k8s" in self.params.get("cluster_backend"):
             cmd_runner = loader.remoter
             cmd_runner_name = loader.remoter.pod_name
             cleanup_context = contextlib.nullcontext()

--- a/sdcm/stress/base.py
+++ b/sdcm/stress/base.py
@@ -99,8 +99,7 @@ class DockerBasedStressThread:  # pylint: disable=too-many-instance-attributes
         return results, errors
 
     def kill(self):
-        if self.loaders and self.loaders[0].is_kubernetes() and self.params.get(
-                'k8s_loader_run_type') != 'static':
+        if self.loaders and self.loaders[0].is_kubernetes():
             for loader in self.loaders:
                 loader.remoter.stop()
         else:

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -221,10 +221,7 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
 
         if "k8s" in self.params.get("cluster_backend"):
             cmd_runner = loader.remoter
-            if self.params.get("k8s_loader_run_type") == 'dynamic':
-                cmd_runner_name = loader.remoter.pod_name
-            else:
-                cmd_runner_name = loader.ip_address
+            cmd_runner_name = loader.remoter.pod_name
         elif self.params.get("use_prepared_loaders"):
             cmd_runner = loader.remoter
             cmd_runner_name = loader.ip_address

--- a/unit_tests/test_remoter.py
+++ b/unit_tests/test_remoter.py
@@ -94,7 +94,7 @@ class TestRemoteCmdRunners(unittest.TestCase):
         else:
             remoter = KubernetesCmdRunner(
                 FakeKluster('http://127.0.0.1:8001'),
-                pod='sct-cluster-dc-1-kind-0', container="scylla", namespace="scylla")
+                pod_name='sct-cluster-dc-1-kind-0', container="scylla", namespace="scylla")
         try:
             result = remoter.run(stmt, **kwargs)
         except Exception as exc:  # pylint: disable=broad-except
@@ -115,7 +115,7 @@ class TestRemoteCmdRunners(unittest.TestCase):
         else:
             remoter = KubernetesCmdRunner(
                 FakeKluster('http://127.0.0.1:8001'),
-                pod='sct-cluster-dc-1-kind-0', container="scylla", namespace="scylla")
+                pod_name='sct-cluster-dc-1-kind-0', container="scylla", namespace="scylla")
         try:
             result = remoter.run(stmt, **kwargs)
         except Exception as exc:  # pylint: disable=broad-except
@@ -217,7 +217,7 @@ class TestRemoteCmdRunners(unittest.TestCase):
         else:
             remoter = KubernetesCmdRunner(
                 FakeKluster('http://127.0.0.1:8001'),
-                pod='sct-cluster-dc-1-kind-0', container="scylla", namespace="scylla")
+                pod_name='sct-cluster-dc-1-kind-0', container="scylla", namespace="scylla")
         try:
             result = remoter.run(stmt, **kwargs)
         except Exception as exc:  # pylint: disable=broad-except
@@ -283,7 +283,7 @@ class TestRemoteCmdRunners(unittest.TestCase):
         else:
             remoter = KubernetesCmdRunner(
                 FakeKluster('http://127.0.0.1:8001'),
-                pod='sct-cluster-dc-1-kind-0', container="scylla", namespace="scylla")
+                pod_name='sct-cluster-dc-1-kind-0', container="scylla", namespace="scylla")
 
         libssh2_thread_results = []
 


### PR DESCRIPTION
Starting with K8S `v1.24` the docker-shim support was removed. 
So, stop using docker for our static loaders because we are going to switch to new K8S versions.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/5636

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
