### PR TITLE
feature(k8s-tls): control `k8s_enable_tls` via pipeline parameters

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,6 +28,7 @@ def createRunConfiguration(String backend) {
             configuration.scylla_version = 'latest'
             configuration.k8s_scylla_operator_helm_repo = 'https://storage.googleapis.com/scylla-operator-charts/latest'
             configuration.k8s_scylla_operator_chart_version = 'latest'
+            configuration.k8s_enable_tls = 'true'
         }
         configuration.test_config = "test-cases/scylla-operator/functional.yaml"
         configuration.test_name = "functional_tests/scylla_operator"

--- a/test-cases/scylla-operator/functional.yaml
+++ b/test-cases/scylla-operator/functional.yaml
@@ -28,7 +28,4 @@ k8s_scylla_operator_docker_image: ''
 k8s_deploy_monitoring: false
 k8s_functional_test_dataset: MULTI_COLUMNS_DATA
 
-# enable by default
-k8s_enable_tls: true
-
 k8s_use_chaos_mesh: true

--- a/vars/byoOperatorPipeline.groovy
+++ b/vars/byoOperatorPipeline.groovy
@@ -32,6 +32,9 @@ def call(Map pipelineParams) {
             string(defaultValue: '2.0.2',
                    description: '',
                    name: 'scylla_mgmt_agent_version')
+            string(defaultValue: "${pipelineParams.get('k8s_enable_tls', '')}",
+                   description: 'if true, enable operator tls, and install haproxy ingress controller',
+                   name: 'k8s_enable_tls')
             string(defaultValue: "${pipelineParams.get('test_name', 'longevity_test.LongevityTest.test_custom_time')}",
                    description: '',
                    name: 'test_name')
@@ -96,6 +99,9 @@ def call(Map pipelineParams) {
 
                             if [[ -n "${params.k8s_scylla_operator_helm_repo ? params.k8s_scylla_operator_helm_repo : ''}" ]] ; then
                                 export SCT_K8S_SCYLLA_OPERATOR_HELM_REPO=${params.k8s_scylla_operator_helm_repo}
+                            fi
+                            if [[ -n "${params.k8s_scylla_operator_docker_image ? params.k8s_scylla_operator_docker_image : ''}" ]] ; then
+                                export SCT_K8S_SCYLLA_OPERATOR_DOCKER_IMAGE=${params.k8s_scylla_operator_docker_image}
                             fi
 
                             if [[ -n "${params.k8s_scylla_operator_chart_version}" ]]; then

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -124,6 +124,10 @@ def call(Map pipelineParams) {
                    description: 'Scylla docker image repo',
                    name: 'docker_image')
 
+            string(defaultValue: "${pipelineParams.get('k8s_enable_tls', '')}",
+                   description: 'if true, enable operator tls, and install haproxy ingress controller',
+                   name: 'k8s_enable_tls')
+
             string(defaultValue: "${pipelineParams.get('gce_project', '')}",
                description: 'Gce project to use',
                name: 'gce_project')

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -70,6 +70,9 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('k8s_scylla_operator_docker_image', '')}",
                    description: 'Scylla Operator docker image',
                    name: 'k8s_scylla_operator_docker_image')
+            string(defaultValue: "${pipelineParams.get('k8s_enable_tls', '')}",
+                   description: 'if true, enable operator tls, and install haproxy ingress controller',
+                   name: 'k8s_enable_tls')
         }
         options {
             timestamps()
@@ -230,6 +233,9 @@ def call(Map pipelineParams) {
                                                         fi
                                                         if [[ -n "${pipelineParams.k8s_scylla_utils_docker_image ? pipelineParams.k8s_scylla_utils_docker_image : ''}" ]] ; then
                                                             export SCT_K8S_SCYLLA_UTILS_DOCKER_IMAGE=${pipelineParams.k8s_scylla_utils_docker_image}
+                                                        fi
+                                                        if [[ -n "${params.k8s_enable_tls ? params.k8s_enable_tls : ''}" ]] ; then
+                                                            export SCT_K8S_ENABLE_TLS=${params.k8s_enable_tls}
                                                         fi
 
                                                         echo "start test ......."

--- a/vars/rollingOperatorUpgradePipeline.groovy
+++ b/vars/rollingOperatorUpgradePipeline.groovy
@@ -46,6 +46,9 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('k8s_scylla_operator_upgrade_docker_image', '')}",
                    description: 'Example: scylladb/scylla-operator:latest or scylladb/scylla-operator:1.3.0',
                    name: 'k8s_scylla_operator_upgrade_docker_image')
+            string(defaultValue: "${pipelineParams.get('k8s_enable_tls', '')}",
+                   description: 'if true, enable operator tls, and install haproxy ingress controller',
+                   name: 'k8s_enable_tls')
             string(defaultValue: "${pipelineParams.get('provision_type', 'spot_low_price')}",
                    description: 'spot_low_price|on_demand|spot_fleet|spot_low_price|spot_duration',
                    name: 'provision_type')

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -71,6 +71,9 @@ def call(Map params, String region, functional_test = false, Map pipelineParams 
     if [[ -n "${pipelineParams.k8s_log_api_calls ? pipelineParams.k8s_log_api_calls : ''}" ]] ; then
         export SCT_K8S_LOG_API_CALLS=${pipelineParams.k8s_log_api_calls}
     fi
+    if [[ -n "${params.k8s_enable_tls ? params.k8s_enable_tls : ''}" ]] ; then
+        export SCT_K8S_ENABLE_TLS=${params.k8s_enable_tls}
+    fi
 
     if [[ -n "${params.docker_image ? params.docker_image : ''}" ]] ; then
         export SCT_DOCKER_IMAGE=${params.docker_image}


### PR DESCRIPTION
Since we still have old version and operator release we would want to test with enabling the sni_proxy setup by default we now can enable it when needed via the pipeline

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
