### PR TITLE
fix(k8s): don't check packages repos in sct_config module running on K8S

### DIFF
--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1702,7 +1702,7 @@ class SCTConfiguration(dict):
 
         # 7) support lookup of repos for upgrade test
         new_scylla_version = self.get('new_version')
-        if new_scylla_version:
+        if new_scylla_version and not 'k8s' in cluster_backend:
             if not self.get('ami_id_db_scylla') and cluster_backend == 'aws':  # pylint: disable=no-else-raise
                 raise ValueError("'new_version' isn't supported for AWS AMIs")
 


### PR DESCRIPTION
For the moment, when we specify `new_version` option value
the `sct_config` module assumes we use common VMs approach and performs checks for it.
But, at first, it is not needed in case of K8S.
And, in second, it fails when we set there too new docker image whose version is not yet covered by AMIs or Scylla repos.

So, add check for `K8S` to avoid following error:

    >   File "%path%/sdcm/tester.py", line 610, in _init_params
    >     self.params = init_and_verify_sct_config()
    >   File "%path%/sdcm/sct_config.py", line 2233, in init_and_verify_sct_config
    >     sct_config = SCTConfiguration()
    >   File "%path%/sdcm/sct_config.py", line 1710, in __init__
    >     self['new_scylla_repo'] = find_scylla_repo(new_scylla_version, dist_type, dist_version)
    >   File "%path%/sdcm/utils/common.py", line 1619, in find_scylla_repo
    >     raise ValueError(f"repo for scylla version {scylla_version} wasn't found")
    > ValueError: repo for scylla version 5.1.2 wasn't found

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
