### PR TITLE
fix(k8s-eks-pv-setup): find right local store device name

### DIFF
--- a/sdcm/k8s_configs/eks/scylla-node-prepare.yaml
+++ b/sdcm/k8s_configs/eks/scylla-node-prepare.yaml
@@ -233,9 +233,13 @@ spec:
             kubectl config set-context scylla --cluster=scylla --user=qa@scylladb.com
             kubectl config use-context scylla
 
+            # TODO: only for debugging, remove later
+            DEVICES=`curl -s http://169.254.169.254/latest/meta-data/block-device-mapping`
+
+            EPHEMERAL_DEV_NAME=`curl -s http://169.254.169.254/latest/meta-data/block-device-mapping/ephemeral0`
             # Create directories for each Scylla cluster on each K8S node which will host PVs
             while true; do
-              if [[ -z $(mount | grep -e "/dev/md0" -e "/dev/nvme") ]]; then
+              if [[ -z $(mount | grep -e "/dev/md0" -e "/dev/$EPHEMERAL_DEV_NAME") ]]; then
                 sleep 5;
                 continue
               fi


### PR DESCRIPTION
code was assuming all device name staring with nvme are local store and on some instances (i3en family) also the root device can be nvme. insted we should be asking the instance metadate api for the correct information

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
