### PR TITLE
test(k8s-functional): skip `deploy_helm_with_default_values` for EKS

### DIFF
--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -509,6 +509,9 @@ def test_readiness_probe_exists_in_mgmt_pods(db_cluster: ScyllaPodCluster):
     assert not pods, f"readinessProbe is not found in the following pods: {pods}"
 
 
+# Since we moved in EKS to k8s version 1.24, the default EBS based storage isn't working
+# should be resolved in https://github.com/scylladb/qa-tasks/issues/952
+@pytest.mark.requires_backend(['k8s-local-kind-aws', 'k8s-local-kind-gce', 'k8s-gke', 'k8s-local-kind'])
 def test_deploy_helm_with_default_values(db_cluster: ScyllaPodCluster):
     """
     https://github.com/scylladb/scylla-operator/issues/501


### PR DESCRIPTION
Since we moved in EKS to k8s version 1.24, the default EBS based storage isn't working should be resolved in https://github.com/scylladb/qa-tasks/issues/952

meanwhile we'll skip this test for EKS

Fixes: #5641

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
