### PR TITLE
fix(disrupt_nodetool_refresh): download tar to the runner in cloud runs

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1532,7 +1532,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             # Executing rolling refresh one by one
             shards_num = self.cluster.nodes[0].scylla_shards
             for node in self.cluster.nodes:
-                SstableLoadUtils.upload_sstables(node, test_data=test_data[0])
+                SstableLoadUtils.upload_sstables(node, test_data=test_data[0],
+                                                 is_cloud_cluster=self.cluster.params.get("db_type") == 'cloud_scylla')
                 system_log_follower = SstableLoadUtils.run_refresh(node, test_data=test_data[0])
                 # NOTE: resharding happens only if we have more than 1 core.
                 #       We may have 1 core in a K8S multitenant setup.


### PR DESCRIPTION
In some cloud runs, the nodes have no public IP, and as such cannot download files from s3, like the sstable tarball that is downloaded in the disrupt_nodetool_refresh nemesis. To amend that, I changed SstableLoadUtils.upload_sstables as such that in cloud runs, the tarball would be first downloaded to the sct runner, and then moved to the node.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
