### PR TITLE
feature(k8s): run dynamic loader pods in parallel for the static ones

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -161,8 +161,6 @@ k8s_deploy_monitoring: false
 k8s_minio_storage_size: '10Gi'
 k8s_n_scylla_pods_per_cluster: 3
 
-# NOTE: use dynamic while 'static' one is not compatible with K8S v1.24+ versions
-#       it must stop using docker.
 k8s_loader_run_type: 'dynamic'
 
 k8s_tenants_num: 1

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1685,10 +1685,12 @@ class BasePodContainer(cluster.BaseNode):  # pylint: disable=too-many-public-met
                 "NodeIndex": str(self.node_index), }
 
     def _init_remoter(self, ssh_login_info):
-        self.remoter = KubernetesCmdRunner(kluster=self.parent_cluster.k8s_cluster,
-                                           pod_name=self.name,
-                                           container=self.parent_cluster.container,
-                                           namespace=self.parent_cluster.namespace)
+        self.remoter = KubernetesCmdRunner(
+            kluster=self.parent_cluster.k8s_cluster,
+            pod_image=self.image,
+            pod_name=self.name,
+            container=self.parent_cluster.container,
+            namespace=self.parent_cluster.namespace)
 
     def _init_port_mapping(self):
         pass

--- a/unit_tests/test_remoter.py
+++ b/unit_tests/test_remoter.py
@@ -94,6 +94,7 @@ class TestRemoteCmdRunners(unittest.TestCase):
         else:
             remoter = KubernetesCmdRunner(
                 FakeKluster('http://127.0.0.1:8001'),
+                pod_image="fake-pod-image",
                 pod_name='sct-cluster-dc-1-kind-0', container="scylla", namespace="scylla")
         try:
             result = remoter.run(stmt, **kwargs)
@@ -115,6 +116,7 @@ class TestRemoteCmdRunners(unittest.TestCase):
         else:
             remoter = KubernetesCmdRunner(
                 FakeKluster('http://127.0.0.1:8001'),
+                pod_image="fake-pod-image",
                 pod_name='sct-cluster-dc-1-kind-0', container="scylla", namespace="scylla")
         try:
             result = remoter.run(stmt, **kwargs)
@@ -217,6 +219,7 @@ class TestRemoteCmdRunners(unittest.TestCase):
         else:
             remoter = KubernetesCmdRunner(
                 FakeKluster('http://127.0.0.1:8001'),
+                pod_image="fake-pod-image",
                 pod_name='sct-cluster-dc-1-kind-0', container="scylla", namespace="scylla")
         try:
             result = remoter.run(stmt, **kwargs)
@@ -283,6 +286,7 @@ class TestRemoteCmdRunners(unittest.TestCase):
         else:
             remoter = KubernetesCmdRunner(
                 FakeKluster('http://127.0.0.1:8001'),
+                pod_image="fake-pod-image",
                 pod_name='sct-cluster-dc-1-kind-0', container="scylla", namespace="scylla")
 
         libssh2_thread_results = []


### PR DESCRIPTION
After removal of the docker dependency for the static loader run type in K8S we are not able anymore to run utility loads of other types. So, add such possibility by detecting different load type in the static loader runner and reuse dynamic one in such cases.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
