### PR TITLE
fix(cluster_aws.py): Add logging for creating an on demand instance

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -143,9 +143,16 @@ class AWSCluster(cluster.BaseCluster):  # pylint: disable=too-many-instance-attr
         instance_profile = self.instance_profile_name
         if instance_profile:
             params['IamInstanceProfile'] = {'Name': instance_profile}
+        ec2 = ec2_client.EC2ClientWrapper(region_name=self.region_names[dc_idx])
+        subnet_info = ec2.get_subnet_info(self._ec2_subnet_id[dc_idx])
+        region_name_with_az = subnet_info['AvailabilityZone']
+        LOGGER.debug('Sending an On-Demand request with params: %s', params)
+        LOGGER.debug('Using EC2 service with DC-index: %s, (associated with region: %s)',
+                     dc_idx, self.region_names[dc_idx])
+        LOGGER.debug("Using Availability Zone of: %s", region_name_with_az)
+
         instances = self._ec2_services[dc_idx].create_instances(**params)
 
-        ec2 = ec2_client.EC2ClientWrapper(region_name=self.region_names[dc_idx])
         ec2.add_tags(instances, {'Name': 'on_demand'})
 
         self.log.debug("Created instances: %s." % instances)


### PR DESCRIPTION
	In order to verify correctness of the instance-create-request.
	
Refs:  [#5645](https://github.com/scylladb/scylla-cluster-tests/issues/5645)
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
