### PR TITLE
refactor(mgmt_upgrade_test): replace interval param 

### DIFF
--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -529,7 +529,7 @@ class ManagerCluster(ScyllaManagerBase):
         # even though it's deprecated in 3.0
         # TODO: remove start-date and interval once 2.6 is no longer supported
         if cron is not None:
-            cmd += " --cron {} ".format(" ".join(cron))
+            cmd += " --cron '{}' ".format(" ".join(cron))
         if upload_parallel_list is not None:
             upload_parallel_string = ','.join(upload_parallel_list)
             cmd += " --upload-parallel {} ".format(upload_parallel_string)
@@ -573,7 +573,7 @@ class ManagerCluster(ScyllaManagerBase):
         # deprecated in 3.0
         # TODO: remove start-date once 2.6 is no longer supported
         if cron is not None:
-            cmd += " --cron {} ".format(" ".join(cron))
+            cmd += " --cron '{}' ".format(" ".join(cron))
 
         res = self.sctool.run(cmd=cmd, parse_table_res=False)
         if not res:

--- a/sdcm/mgmt/common.py
+++ b/sdcm/mgmt/common.py
@@ -51,6 +51,12 @@ def duration_to_timedelta(duration_string):
     return datetime.timedelta(seconds=total_seconds)
 
 
+def create_cron_list_from_timedelta(minutes=0, hours=0):
+    destined_time = datetime.datetime.now() + datetime.timedelta(hours=hours, minutes=minutes)
+    cron_list = [str(destined_time.minute), str(destined_time.hour), "*", "*", "*"]
+    return cron_list
+
+
 def get_manager_repo_from_defaults(manager_version_name, distro):
     with open("defaults/manager_versions.yaml", encoding="utf-8") as mgmt_config:
         manager_repos_by_version_dict = yaml.safe_load(mgmt_config)["manager_repos_by_version"]


### PR DESCRIPTION
Since the interval parameter is no longer officially supported for manager 3.0 and later versions,
I replaced its use in the upgrade test with the cron parameter.
Also enclosed the cron value with apostrophes.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
