### PR TITLE
fix(longevity-50GB-3days-authorization-and-tls-ssl): remove `use_mgmt`

### DIFF
--- a/test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml
+++ b/test-cases/longevity/longevity-50GB-3days-authorization-and-tls-ssl.yaml
@@ -30,5 +30,3 @@ authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra
 authenticator_password: cassandra
 authorizer: 'CassandraAuthorizer'
-
-use_mgmt: true


### PR DESCRIPTION
use_mgmt is default True for a long time now

in ee6ff8a6d1cc71f160b8026aa1376cb8a688da1e we disabled manager for EKS since we can't install minio in since k8s v1.23 (not without ebs-csi-driver setup)

this flag on the test was mask our configuration for EKS to disable manager, and prevented us form running this test case.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
