### PR TITLE
fix(k8s-gke): fix cleanup to not leave env variaible behind

### DIFF
--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -14,7 +14,6 @@
 #pylint: disable=too-many-lines
 from __future__ import annotations
 
-import os
 import logging
 import string
 import tempfile
@@ -52,6 +51,8 @@ from sdcm.utils.gce_utils import get_gce_service, SUPPORTED_PROJECTS
 from sdcm.utils.azure_utils import AzureService, list_instances_azure
 from sdcm.utils.azure_region import AzureOsState, AzureRegion, region_name_to_location
 from sdcm.utils.get_username import get_username
+from sdcm.utils.context_managers import environment
+
 
 if TYPE_CHECKING:
     # pylint: disable=ungrouped-imports
@@ -795,8 +796,8 @@ class GceSctRunner(SctRunner):
         sct_runners = []
         instances = []
         for project in SUPPORTED_PROJECTS:
-            os.environ['SCT_GCE_PROJECT'] = project
-            instances += list_instances_gce(tags_dict={"NodeType": cls.NODE_TYPE}, verbose=True)
+            with environment(SCT_GCE_PROJECT=project):
+                instances += list_instances_gce(tags_dict={"NodeType": cls.NODE_TYPE}, verbose=True)
         for instance in instances:
             tags = gce_meta_to_dict(instance.extra["metadata"])
             region = instance.extra["zone"].name

--- a/sdcm/utils/cloud_monitor/resources/instances.py
+++ b/sdcm/utils/cloud_monitor/resources/instances.py
@@ -1,5 +1,3 @@
-import os
-
 from logging import getLogger
 from datetime import datetime, timezone
 
@@ -12,6 +10,7 @@ from sdcm.utils.cloud_monitor.resources import CloudInstance, CloudResources
 from sdcm.utils.common import aws_tags_to_dict, gce_meta_to_dict, list_instances_aws, list_instances_gce
 from sdcm.utils.pricing import AWSPricing, GCEPricing, AzurePricing
 from sdcm.utils.gce_utils import SUPPORTED_PROJECTS
+from sdcm.utils.context_managers import environment
 
 LOGGER = getLogger(__name__)
 
@@ -137,9 +136,9 @@ class CloudInstances(CloudResources):
     def get_gce_instances(self):
         self["gce"] = []
         for project in SUPPORTED_PROJECTS:
-            os.environ['SCT_GCE_PROJECT'] = project
-            gce_instances = list_instances_gce(verbose=True)
-            self["gce"] += [GCEInstance(instance) for instance in gce_instances]
+            with environment(SCT_GCE_PROJECT=project):
+                gce_instances = list_instances_gce(verbose=True)
+                self["gce"] += [GCEInstance(instance) for instance in gce_instances]
         self.all.extend(self["gce"])
 
     def get_azure_instances(self):

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -79,6 +79,7 @@ from sdcm.utils.gce_utils import GcloudContainerMixin
 from sdcm.remote import LocalCmdRunner
 from sdcm.remote import RemoteCmdRunnerBase
 from sdcm.utils.gce_utils import SUPPORTED_PROJECTS
+from sdcm.utils.context_managers import environment
 
 
 LOGGER = logging.getLogger('utils')
@@ -546,12 +547,14 @@ def clean_cloud_resources(tags_dict, dry_run=False):
     clean_elastic_ips_aws(tags_dict, dry_run=dry_run)
     clean_test_security_groups(tags_dict, dry_run=dry_run)
     clean_load_balancers_aws(tags_dict, dry_run=dry_run)
-    clean_clusters_gke(tags_dict, dry_run=dry_run)
-    clean_orphaned_gke_disks(dry_run=dry_run)
+    for project in SUPPORTED_PROJECTS:
+        with environment(SCT_GCE_PROJECT=project):
+            clean_clusters_gke(tags_dict, dry_run=dry_run)
+            clean_orphaned_gke_disks(dry_run=dry_run)
     clean_clusters_eks(tags_dict, dry_run=dry_run)
     for project in SUPPORTED_PROJECTS:
-        os.environ['SCT_GCE_PROJECT'] = project
-        clean_instances_gce(tags_dict, dry_run=dry_run)
+        with environment(SCT_GCE_PROJECT=project):
+            clean_instances_gce(tags_dict, dry_run=dry_run)
     clean_instances_azure(tags_dict, dry_run=dry_run)
     clean_resources_docker(tags_dict, dry_run=dry_run)
     return True

--- a/sdcm/utils/context_managers.py
+++ b/sdcm/utils/context_managers.py
@@ -1,0 +1,26 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2023 ScyllaDB
+
+import os
+from contextlib import contextmanager
+
+
+@contextmanager
+def environment(**kwargs):
+    original_environment = dict(os.environ)
+    os.environ.update(kwargs)
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(original_environment)


### PR DESCRIPTION
leave this enviremnt variables behind, cause us to miss cleaning up some of the GKE cluster, since the code was looking for them in the wrong project

Fixes: #5566

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
