### PR TITLE
refactor(manager): use sctool info to get tasks' parameters and history

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -2508,7 +2508,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             #  │ --dc 'AWS_US_EAST_1' -L AWS_US_EAST_1:s3:scylla-cloud-backup-9952-10120-4q4w4d --retention 14
             #  --rate-limit AWS_US_EAST_1:100 --snapshot-parallel '<nil>' --upload-parallel '<nil>'
             #  │ 06 Jun 21 18:10:05 UTC (+1d)  │ NEW
-            location = auto_backup_task.arguments.split('-L')[1].split()[0]
+            location = auto_backup_task.get_task_info_dict()["location"]
         else:
             if not self.cluster.params.get('backup_bucket_location'):
                 raise UnsupportedNemesis('backup bucket location configuration is not defined!')

--- a/unit_tests/test_sdcm_mgmt_cli.py
+++ b/unit_tests/test_sdcm_mgmt_cli.py
@@ -1,0 +1,42 @@
+from textwrap import dedent
+from unittest import mock
+
+from sdcm.mgmt.cli import ManagerTask
+
+
+def test_01_get_task_info_dict():
+    manager_node_mock = mock.MagicMock()
+    remoter_result = mock.MagicMock()
+    stdout = mock.PropertyMock(return_value=dedent("""Name:      healthcheck/cql
+        Cron:     @every 15s
+        Tz:       UTC
+
+        Properties:
+        - mode: cql
+
+        ╭──────────────────────────────────────┬────────────────────────┬──────────┬────────╮
+        │ ID                                   │ Start time             │ Duration │ Status │
+        ├──────────────────────────────────────┼────────────────────────┼──────────┼────────┤
+        │ 13814000-1dd2-11b2-a009-02c33d089f9b │ 07 Jan 23 23:08:59 UTC │ 0s       │ DONE   │
+        ╰──────────────────────────────────────┴────────────────────────┴──────────┴────────╯"""))
+    stderr = mock.PropertyMock = None
+    exited = mock.PropertyMock = 0
+    type(remoter_result).stdout = stdout
+    type(remoter_result).stderr = stderr
+    type(remoter_result).exited = exited
+    manager_node_mock.remoter.sudo.return_value = remoter_result
+    task = ManagerTask(task_id='13814000-1dd2-11b2-a009-02c33d089f9b',
+                       cluster_id='8c20f334-cf37-4528-9219-862d75b84c99',
+                       manager_node=manager_node_mock)
+
+    assert task.get_task_info_dict() == {
+        'Name': 'healthcheck/cql',
+        'Cron': '@every 15s',
+        'Tz': 'UTC',
+        'Properties': '',
+        'mode': 'cql',
+        'history': [
+            ['', 'ID', 'Start time', 'Duration', 'Status'],
+            ['', '13814000-1dd2-11b2-a009-02c33d089f9b', '07 Jan 23 23:08:59 UTC', '0s', 'DONE']
+        ]
+    }


### PR DESCRIPTION
Since manager 3.0.1, a task's params are no longer printed in the output of 'sctool progress', but instead in the output of 'sctool info'. I replaced the use of 'sctool progress' in the Nemesis._mgmt_backup

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
