### PR TITLE
fix(OperatorNodetoolFlushAndReshard): prolong resharding timeout

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1261,7 +1261,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             # Wait for the end of resharding
             assert wait.wait_for(
                 func=lambda: list(resharding_finish),  # pylint: disable=cell-var-from-loop
-                step=3, timeout=600, throw_exc=False,
+                step=3, timeout=1800, throw_exc=False,
                 text=f"Waiting for the finish of resharding on the '{node.name}' node.",
             ), f"Finish of the resharding hasn't been detected on the '{node.name}' node."
             self.log.debug("Resharding has been finished successfully on the '%s' node.", node.name)


### PR DESCRIPTION
Tests with bigger set of data need more time for resharding.

This commit prolongs timeout for resharding from 10m to 30m.
refs: #5652

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
