### PR TITLE
fix(k8s-gke): make GKE cleanup work having more than 1 project

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -546,8 +546,10 @@ def clean_cloud_resources(tags_dict, dry_run=False):
     clean_elastic_ips_aws(tags_dict, dry_run=dry_run)
     clean_test_security_groups(tags_dict, dry_run=dry_run)
     clean_load_balancers_aws(tags_dict, dry_run=dry_run)
-    clean_clusters_gke(tags_dict, dry_run=dry_run)
-    clean_orphaned_gke_disks(dry_run=dry_run)
+    for project in SUPPORTED_PROJECTS:
+        os.environ['SCT_GCE_PROJECT'] = project
+        clean_clusters_gke(tags_dict, dry_run=dry_run)
+        clean_orphaned_gke_disks(dry_run=dry_run)
     clean_clusters_eks(tags_dict, dry_run=dry_run)
     for project in SUPPORTED_PROJECTS:
         os.environ['SCT_GCE_PROJECT'] = project


### PR DESCRIPTION
Merge one of the recent PRs (https://github.com/scylladb/scylla-cluster-tests/pull/5575) led to the bug where we get GKE clusters undeleted.
The root cause for it is pick up of the creds from the unexpected project.
So, fix it by covering each project we support which will make guaranteed GKE cluster cleanup.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/5566

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
