### PR TITLE
fix(get_any_ks_cf_list): wrong usage of parameter 'session'

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -3469,9 +3469,9 @@ class BaseCluster:  # pylint: disable=too-many-instance-attributes,too-many-publ
             else:
                 raise ValueError(f"The following value '{entity_type}' not supported")
 
-            session.default_fetch_size = 1000
-            session.default_consistency_level = ConsistencyLevel.ONE
-            execute_result = session.execute_async(cmd)
+            cql_session.default_fetch_size = 1000
+            cql_session.default_consistency_level = ConsistencyLevel.ONE
+            execute_result = cql_session.execute_async(cmd)
             fetcher = PageFetcher(execute_result).request_all(timeout=120)
             current_rows = fetcher.all_data()
 


### PR DESCRIPTION
	the correct parameter to use in execute_cmd() should be: 'cql_session'.


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
