### PR TITLE
improvement(k8s): allow more reconnections to a dynamic loader pod

### DIFF
--- a/sdcm/remote/kubernetes_cmd_runner.py
+++ b/sdcm/remote/kubernetes_cmd_runner.py
@@ -219,7 +219,7 @@ class KubernetesPodWatcher(KubernetesRunner):
     """
 
     READ_REQUEST_TIMEOUT = 30
-    POD_COUNTER_TO_LIVE = 300
+    POD_COUNTER_TO_LIVE = 600
     STREAM_CONNECTION_TTL = 7200
 
     def __init__(self, context: Context) -> None:


### PR DESCRIPTION
For the moment, we allow `300` reconnections to an alive `dynamic loader pod` before we consider the test run failed.
In case of `GKE` may be not enough running `12 hours` because connections there may live just couple of minutes.
So, increase to `600` to cover the `12 hours` jobs.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
