### PR TITLE
fix(k8s-perf): explicitly set the static loader run type

### DIFF
--- a/test-cases/performance/perf-regression-latency-500gb-30min.yaml
+++ b/test-cases/performance/perf-regression-latency-500gb-30min.yaml
@@ -8,6 +8,9 @@ stress_cmd_w: "cassandra-stress write no-warmup cl=QUORUM duration=30m -schema '
 stress_cmd_r: "cassandra-stress read no-warmup  cl=QUORUM duration=30m -schema 'replication(factor=3)' -mode cql3 native -rate 'threads=100 throttle=10000/s' -col 'size=FIXED(1024) n=FIXED(1)' -pop 'dist=gauss(1..500000000,250000000,25000000)' "
 stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=30m -schema 'replication(factor=3)' -mode cql3 native -rate 'threads=100 throttle=9000/s'  -col 'size=FIXED(1024) n=FIXED(1)' -pop 'dist=gauss(1..500000000,250000000,25000000)' "
 
+# NOTE: following is needed for the K8S case
+k8s_loader_run_type: 'static'
+
 n_db_nodes: 3
 n_loaders: 4
 n_monitor_nodes: 1

--- a/test-cases/performance/perf-regression-latency-k8s-multitenant.yaml
+++ b/test-cases/performance/perf-regression-latency-k8s-multitenant.yaml
@@ -10,6 +10,8 @@
 test_duration: 480
 user_prefix: 'k8s-perf-regression-latency'
 
+k8s_loader_run_type: 'static'
+
 # NOTE: we disable second type of monitoring - K8S based one. It is redundant while we use standalone ones.
 k8s_deploy_monitoring: false
 

--- a/test-cases/performance/perf-regression.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys.yaml
@@ -5,6 +5,9 @@ prepare_write_cmd: "cassandra-stress write no-warmup cl=QUORUM n=30000000 -schem
 stress_cmd_r: "cassandra-stress read no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -mode cql3 native -rate threads=100 -pop 'dist=gauss(1..30000000,15000000,1500000)' "
 stress_cmd_m: "cassandra-stress mixed no-warmup cl=QUORUM duration=50m -schema 'replication(factor=3)' -mode cql3 native -rate threads=100 -pop 'dist=gauss(1..30000000,15000000,1500000)' "
 
+# NOTE: following is needed for the K8S case
+k8s_loader_run_type: 'static'
+
 n_db_nodes: 3
 n_loaders: 4
 n_monitor_nodes: 1


### PR DESCRIPTION
Recently we changed the default loader run type on K8S from 'static' to 'dynamic'. But performance tests must use only static ones because they are more performant.
So, configure it explicitly.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
