### PR TITLE
fix(k8s-eks): make i4i instances work great again

### DIFF
--- a/sdcm/k8s_configs/eks/scylla-node-prepare.yaml
+++ b/sdcm/k8s_configs/eks/scylla-node-prepare.yaml
@@ -235,7 +235,8 @@ spec:
 
             # Create directories for each Scylla cluster on each K8S node which will host PVs
             while true; do
-              if [[ -z $(mount | grep -e "/dev/md0" -e "/dev/nvme") ]]; then
+              DEVICE_PATH=$(mount | grep "raid-disks/disk0 " | awk '{print $1;}')
+              if [[ -z $DEVICE_PATH ]]; then
                 sleep 5;
                 continue
               fi
@@ -244,7 +245,7 @@ spec:
                   mkdir "/mnt/hostfs/mnt/raid-disks/disk0/${i}"
                 fi
                 ( mount | grep "/mnt/hostfs/mnt/raid-disks/disk0/${i} " 2>/dev/null 1>&2 ) || \
-                mount --bind "/mnt/hostfs/mnt/raid-disks/disk0/${i}"{,}
+                mount -t xfs $DEVICE_PATH "/mnt/hostfs/mnt/raid-disks/disk0/${i}"
               done
               sleep 10
             done


### PR DESCRIPTION
Recently the i4i instance types started having 2 nvme disks and the unexpected one started being picked up by the mount command all the time in the `pv-setup` container.
So, fix it by specifying the needed device explicitly when we use mount command.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
