### PR TITLE
feature(k8s): select loader based on `stress_image.cassandra-stress`

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2820,9 +2820,12 @@ class LoaderPodCluster(cluster.BaseLoaderSet, PodCluster):
         # TODO: detect the stress type and apply appropriate docker image
         #       `scylla-bench` stress commands will fail when c-s gets switched
         #       to the docker approach.
-        docker_image = self.params.get('docker_image')
-        scylla_version = self.params.get('scylla_version')
-        return f"{docker_image}:{scylla_version}"
+        if loader_image := self.params.get('stress_image.cassandra-stress'):
+            return loader_image
+        else:
+            docker_image = self.params.get('docker_image')
+            scylla_version = self.params.get('scylla_version')
+            return f"{docker_image}:{scylla_version}"
 
     def add_nodes(self,
                   count: int,


### PR DESCRIPTION
Since we have cases we want to be able to run with newer loader image and not the exact version we are testing, we should enable it for k8s as we do for VMs.

example use case, when we need to run c-s with fixes to be able to connect to all nodes, when we run ontop of older releases.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
