### PR TITLE
Fix pod watcher kills healthy execution

### DIFF
--- a/sdcm/remote/kubernetes_cmd_runner.py
+++ b/sdcm/remote/kubernetes_cmd_runner.py
@@ -342,8 +342,9 @@ class KubernetesPodWatcher(KubernetesRunner):
                 reread_bytes = 0
                 while self.current_read_bytes_num > reread_bytes:
                     time.sleep(0.01)
-                    self.process.read(self.read_chunk_size)
-                    reread_bytes += self.read_chunk_size
+                    read_chunk_size = min(self.read_chunk_size, self.current_read_bytes_num - reread_bytes)
+                    self.process.read(read_chunk_size)
+                    reread_bytes += read_chunk_size
                 LOGGER.debug(
                     "'runner._start()' method for the '%s' pod: "
                     "Successfully re-read '%s' num of bytes.",
@@ -430,7 +431,7 @@ class KubernetesPodWatcher(KubernetesRunner):
         # NOTE: 'pod logs reader driver' provides only combined output (stdout + stderr)
         with self._ws_lock:
             result = self._read_from_stream(num_bytes)
-            self.current_read_bytes_num += num_bytes
+            self.current_read_bytes_num += len(result)
             return result
 
     def read_proc_stderr(self, num_bytes: int) -> str:

--- a/sdcm/remote/kubernetes_cmd_runner.py
+++ b/sdcm/remote/kubernetes_cmd_runner.py
@@ -262,6 +262,9 @@ class KubernetesPodWatcher(KubernetesRunner):
         self.pod_counter_to_live = self.POD_COUNTER_TO_LIVE
         self.stream_connection_start_time = time.time()
 
+    def should_use_pty(self, pty: bool, fallback: bool) -> bool:
+        return True
+
     @retrying(n=20, sleep_time=3, allowed_exceptions=(ConnectionError, ))
     def _open_stream(self) -> None:
         try:


### PR DESCRIPTION
Fixing 3 issues related `KubernetesPodWatcher`: redundand stderr stream read, and premature killing long running loader commands, missing some log lines when drops connection. See commit messages for more details.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
