### PR TITLE
test(rolling-upgrade): set yaml entries in upgade procedure for raft

### DIFF
--- a/defaults/severities.yaml
+++ b/defaults/severities.yaml
@@ -11,6 +11,7 @@ DataValidatorEvent.UpdatedRowsValidator: CRITICAL
 DataValidatorEvent.DeletedRowsValidator: ERROR
 ScyllaHelpErrorEvent.duplicate: WARNING
 ScyllaHelpErrorEvent.filtered: WARNING
+ScyllaYamlUpdateEvent: NORMAL
 FullScanEvent: ERROR
 FullPartitionScanReversedOrderEvent: ERROR
 FullPartitionScanEvent: ERROR

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -103,7 +103,7 @@ from sdcm.sct_events.base import LogEvent
 from sdcm.sct_events.health import ClusterHealthValidatorEvent
 from sdcm.sct_events.system import TestFrameworkEvent, INSTANCE_STATUS_EVENTS_PATTERNS, InfoEvent, SoftTimeoutEvent
 from sdcm.sct_events.grafana import set_grafana_url
-from sdcm.sct_events.database import SYSTEM_ERROR_EVENTS_PATTERNS, ScyllaHelpErrorEvent
+from sdcm.sct_events.database import SYSTEM_ERROR_EVENTS_PATTERNS, ScyllaHelpErrorEvent, ScyllaYamlUpdateEvent
 from sdcm.sct_events.nodetool import NodetoolEvent
 from sdcm.sct_events.decorators import raise_event_on_failure
 from sdcm.utils.auto_ssh import AutoSshContainerMixin
@@ -1540,7 +1540,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             yield new_scylla_yaml
             diff = old_scylla_yaml.diff(new_scylla_yaml)
             if not diff:
-                LOGGER.debug("%s: scylla.yaml hasn't been changed", self)
+                ScyllaYamlUpdateEvent(node_name=self.name,
+                                      message=f"ScyllaYaml has not been changed on node: {self.name}")
                 return
             scylla_yaml.clear()
             scylla_yaml.update(
@@ -1551,7 +1552,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                     explicit=['partitioner', 'commitlog_sync', 'commitlog_sync_period_in_ms', 'endpoint_snitch']
                 )
             )
-            LOGGER.debug("%s: scylla.yaml will be updated to:\n%s", self, scylla_yaml)
+            ScyllaYamlUpdateEvent(node_name=self.name, message=f"ScyllaYaml has been changed on node: {self.name}. "
+                                                               f"Diff: {diff}")
 
     def remote_manager_yaml(self):
         return self._remote_yaml(path=SCYLLA_MANAGER_YAML_PATH)

--- a/sdcm/provision/scylla_yaml/scylla_yaml.py
+++ b/sdcm/provision/scylla_yaml/scylla_yaml.py
@@ -58,6 +58,7 @@ class ScyllaYaml(BaseModel):  # pylint: disable=too-few-public-methods
     rpc_interface: str = "eth1"
     rpc_interface_prefer_ipv6: bool = False
     seed_provider: List[SeedProvider] = [SeedProvider(class_name='org.apache.cassandra.locator.SimpleSeedProvider')]
+    consistent_cluster_management: bool = False
     compaction_throughput_mb_per_sec: int = 0
     compaction_large_partition_warning_threshold_mb: int = 1000
     compaction_large_row_warning_threshold_mb: int = 10

--- a/sdcm/sct_events/database.py
+++ b/sdcm/sct_events/database.py
@@ -381,6 +381,13 @@ class ScyllaSysconfigSetupEvent(ScyllaDatabaseContinuousEvent):
         super().__init__(node=node, severity=severity, publish_event=True)
 
 
+class ScyllaYamlUpdateEvent(InformationalEvent):
+    def __init__(self, node_name: str, message: Optional[str] = None, diff: dict | None = None,
+                 severity=Severity.NORMAL, **__):
+        super().__init__(severity=severity)
+        self.message = message or f"Updating scylla.yaml contents on node: {node_name}. Diff: {diff}"
+
+
 SCYLLA_DATABASE_CONTINUOUS_EVENTS = [
     ScyllaServerStatusEvent,
     BootstrapEvent,

--- a/unit_tests/test_scylla_yaml.py
+++ b/unit_tests/test_scylla_yaml.py
@@ -189,6 +189,7 @@ class ScyllaYamlTest(unittest.TestCase):
                 'memtable_total_space_in_mb': 0,
                 'concurrent_reads': 32,
                 'concurrent_writes': 32,
+                'consistent_cluster_management': False,
                 'concurrent_counter_writes': 32,
                 'incremental_backups': False,
                 'snapshot_before_compaction': False,


### PR DESCRIPTION
Adds a new flag, `consistent_cluster_management` to the upgraded nodes' scylla.yaml and tidies up the way in which we change scylla.yaml contents in rolling_upgrades. It also removes the legacy `enable_3_1_0_compatibility_mode` flag setting. A new continuous event is added to allow for easier debugging of the scylla.yaml updates.

Staging job with test runs: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/maciej/job/rolling-upgrade-raft/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
