### PR TITLE
Revert "improvement(k8s): remove redundant explicit Scylla IP mapping refreshes"

### DIFF
--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -219,6 +219,7 @@ def test_drain_and_replace_node_kubernetes(db_cluster):
     target_node.wait_till_k8s_pod_get_uid(ignore_uid=old_uid)
     target_node.wait_for_pod_readiness()
     db_cluster.wait_for_pods_readiness(pods_to_wait=1, total_pods=len(db_cluster.nodes))
+    target_node.refresh_ip_address()
 
 
 @pytest.mark.requires_node_termination_support('drain_k8s_node')
@@ -234,6 +235,7 @@ def test_drain_wait_and_replace_node_kubernetes(db_cluster):
     target_node.wait_till_k8s_pod_get_uid(ignore_uid=old_uid)
     target_node.wait_for_pod_readiness()
     db_cluster.wait_for_pods_readiness(pods_to_wait=1, total_pods=len(db_cluster.nodes))
+    target_node.refresh_ip_address()
 
 
 @pytest.mark.requires_node_termination_support('drain_k8s_node')

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1583,6 +1583,12 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
             LOGGER.info("Wait for the '%s' pod to be ready", pod_object.name)
             pod_object.wait_for_pod_readiness(
                 pod_readiness_timeout_minutes=pod_readiness_timeout_minutes)
+            LOGGER.info("The '%s' pod is ready, refresh IP addresses", pod_object.name)
+            pod_object.refresh_ip_address()
+            # NOTE: update monitoring after each pod update
+            #       to minimize the loss of monitoring data
+            if monitors := self.test_config.tester_obj().monitors:
+                monitors.reconfigure_scylla_monitoring()
 
     @contextlib.contextmanager
     def scylla_config_map(self, namespace: str = SCYLLA_NAMESPACE) -> dict:
@@ -1886,6 +1892,7 @@ class BasePodContainer(cluster.BaseNode):  # pylint: disable=too-many-public-met
             timeout=self.pod_terminate_timeout * 60 + 10)
 
         self.wait_for_pod_readiness()
+        self.refresh_ip_address()
 
     def soft_reboot(self):
         # Kubernetes brings pods back to live right after it is deleted
@@ -1895,6 +1902,7 @@ class BasePodContainer(cluster.BaseNode):  # pylint: disable=too-many-public-met
             timeout=self.pod_terminate_timeout * 60 + 10)
 
         self.wait_for_pod_readiness()
+        self.refresh_ip_address()
 
     # On kubernetes there is no stop/start, closest analog of node restart would be soft_restart
     restart = soft_reboot

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -1058,6 +1058,10 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         upgrade_version, scylla_pool = self.k8s_cluster.upgrade_kubernetes_platform(
             pod_objects=self.db_cluster.nodes,
             use_additional_scylla_nodepool=True)
+        # NOTE: refresh IP addresses of the Scylla nodes because they get changed in current case
+        for db_node in self.db_cluster.nodes:
+            db_node.refresh_ip_address()
+        self.monitors.reconfigure_scylla_monitoring()
 
         InfoEvent(message="Step4 - Validate K8S versions after the upgrade").publish()
         data_plane_versions = self.k8s_cluster.kubectl(


### PR DESCRIPTION
This reverts commit bf001fc97afc03aa6b0aaba7fe6d7575c7f5b436.

The reason is that GKE cluster may work about hour after pod IPs change not providing any update to the 'endpoint' resources which we listen to. So, return back the manual IP refreshes due to the GKE's slowliness.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
