### PR TITLE
fix(argus_test_run.py): Add random seconds to the run start_time

### DIFF
--- a/sdcm/argus_test_run.py
+++ b/sdcm/argus_test_run.py
@@ -14,7 +14,8 @@
 import logging
 import unittest.mock
 from uuid import UUID
-from datetime import datetime
+from datetime import datetime, timedelta
+from random import randint
 
 from argus.db.db_types import TestStatus
 from argus.db.testrun import TestRunWithHeartbeat, TestRunInfo, TestDetails, TestResources, TestLogs, TestResults, \
@@ -235,9 +236,12 @@ class ArgusTestRun:
         config_files = sct_config.get("config_files")
         started_by = get_username()
 
+        # start time is a part of primary key and getting same start time will cause an overwrite
+        safe_start_time = datetime.utcnow().replace(microsecond=0) + timedelta(seconds=(randint(10, 60)))
+
         details = TestDetails(scm_revision_id=get_git_commit_id(), started_by=started_by, build_job_url=job_url,   # pylint: disable=no-value-for-parameter
                               yaml_test_duration=sct_config.get("test_duration"),
-                              start_time=datetime.utcnow().replace(microsecond=0),
+                              start_time=safe_start_time,
                               config_files=config_files, packages=[])
 
         LOGGER.info("Preparing Resource Setup...")


### PR DESCRIPTION
The reasoning for this fix is that since the primary key for sct reports is (build_id, start_time), two runs running in parallel could potentially start on the same second, as that's the level of precision we're currently using. This should fix missing rolling upgrade runs in the future.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
