### PR TITLE
test(EaR KMS): Add configuration of EaR AWS KMS service

### DIFF
--- a/configurations/kms-ear.yaml
+++ b/configurations/kms-ear.yaml
@@ -1,0 +1,11 @@
+
+# scylla_encryption_options: "{ 'cipher_algorithm' : 'AES/ECB/PKCS5Padding', 'secret_key_strength' : 128, 'kms_host': 'kms_test'}"
+
+# config kms_hosts for AWS KMS service account
+append_scylla_yaml: |
+  kms_hosts:
+      kms_test:
+          aws_region: 'us-east-1'
+          master_key: 'alias/kms_encryption_test'
+#          aws_access_key_id: <your aws account id/name>
+#          aws_secret_access_key: <aws access key>

--- a/jenkins-pipelines/EaR-longevity-kms-200gb-6h.jenkinsfile
+++ b/jenkins-pipelines/EaR-longevity-kms-200gb-6h.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-encryption-at-rest-200GB-6h.yaml", "configurations/kms-ear.yaml"]'''
+
+)

--- a/sdcm/provision/scylla_yaml/scylla_yaml.py
+++ b/sdcm/provision/scylla_yaml/scylla_yaml.py
@@ -315,6 +315,7 @@ class ScyllaYaml(BaseModel):  # pylint: disable=too-few-public-methods
     system_key_directory: str = None
     system_info_encryption: dict = None
     kmip_hosts: dict = None
+    kms_hosts: dict = None
 
     def dict(  # pylint: disable=arguments-differ
         self,

--- a/unit_tests/test_scylla_yaml.py
+++ b/unit_tests/test_scylla_yaml.py
@@ -394,6 +394,7 @@ class ScyllaYamlTest(unittest.TestCase):
                 'system_info_encryption': None,
                 'kmip_hosts': None,
                 'stream_io_throughput_mb_per_sec': 0,
+                'kms_hosts': None,
             }
         )
 


### PR DESCRIPTION
	Scylla added a support for AWS KMS to be used with
	The enterprise feature of Encryption-at-Rest.
	Adding new configuration yaml for testing it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
