### PR TITLE
fix(k8s-gke): skip 'disrupt_nodetool_enospc' due to bug

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1556,6 +1556,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             # Moreover, it will cause host system's /var hosting disk go out of free space too
             # which may cause unpredictable failures.
             raise UnsupportedNemesis('disrupt_nodetool_enospc is not supported on local K8S clusters')
+        if self.cluster.params.get('cluster_backend') == 'k8s-gke':
+            raise UnsupportedNemesis(
+                'disrupt_nodetool_enospc is skipped due to this: '
+                'https://github.com/scylladb/scylla-cluster-tests/issues/5671')
 
         if all_nodes:
             nodes = self.cluster.nodes


### PR DESCRIPTION
The `disrupt_nodetool_enospc` nemesis doesn't work on the `GKE` backend due to the following bug: https://github.com/scylladb/scylla-cluster-tests/issues/5671

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
