### PR TITLE
Update branch 2021.1 to use latest s-b by default

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -156,6 +156,6 @@ mgmt_docker_image: ''
 k8s_deploy_monitoring: false
 
 scylla_rsyslog_setup: false
-scylla_bench_version: v0.1.6
+scylla_bench_version: v0.1.14
 
 service_level_shares: [1000]

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -156,6 +156,6 @@ mgmt_docker_image: ''
 k8s_deploy_monitoring: false
 
 scylla_rsyslog_setup: false
-scylla_bench_version: v0.1.3
+scylla_bench_version: v0.1.6
 
 service_level_shares: [1000]

--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -585,15 +585,14 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             sb_version = f'heads/{sb_version}'
         self.remoter.sudo(shell_script_cmd(f"""\
             rm -rf /usr/local/go
-            curl -LO https://storage.googleapis.com/golang/go1.16.3.linux-amd64.tar.gz
-            tar -C /usr/local -xvzf go1.16.3.linux-amd64.tar.gz
-            echo 'export GOPATH=$HOME/go' >> $HOME/.bash_profile
-            echo 'export PATH=$PATH:/usr/local/go/bin' >> $HOME/.bash_profile
-            source $HOME/.bash_profile
-            
             rm -f /tmp/sb_install || true
             mkdir /tmp/sb_install
             cd /tmp/sb_install
+            curl -Lo go.tar.gz https://storage.googleapis.com/golang/go1.17.4.linux-amd64.tar.gz
+            tar -C /usr/local -xvzf go.tar.gz
+            echo 'export GOPATH=$HOME/go' >> $HOME/.bash_profile
+            echo 'export PATH=$PATH:/usr/local/go/bin' >> $HOME/.bash_profile
+            source $HOME/.bash_profile
             curl -Lo sb.zip https://github.com/scylladb/scylla-bench/archive/refs/{sb_version}.zip
             unzip sb.zip
             cd ./scylla-bench-*


### PR DESCRIPTION
we did update branch 2022.1 and 2022.2, and asymmetric test case was working on them
we want that case back and operational also on 2021.1 

## Testing 
- [ ] run the `asymmetric-cluster-3h` on this PR - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-large-partition-asymmetric-cluster-3h-test/17/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
