### PR TITLE
fix(argus): print backtrace correctly on `stop_nemesis`

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4264,10 +4264,10 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                 self.log.debug("Marking nemesis \"%s\" as terminated in argus...", nemesis.name)
                 nemesis.complete(f"Nemesis termination at the end of the test\n{stack_trace}")
                 nemesis.nemesis_status = NemesisStatus.TERMINATED
-            run.save()
+            if running_nemeses:
+                run.save()
         except Exception:  # pylint: disable=broad-except
-            self.log.warning("Error recording nemesis termination information in Argus")
-            self.log.debug(exc_info=True)
+            self.log.warning("Error recording nemesis termination information in Argus", exc_info=True)
 
     def scylla_configure_non_root_installation(self, node, devname, verbose, timeout):
         node.stop_scylla_server(verify_down=False)


### PR DESCRIPTION
for a while now this failure is happening on tests (mostly artifacts)
```
2023-01-12 18:26:57.006: (TestFrameworkEvent Severity.ERROR) period_type=one-time
  event_id=36c76719-0d23-45ba-ba48-29dd497fb3ab, source=ArtifactsTest.stop_nemesis()
  message=stop_nemesis (silenced) failed with:
exception=LoggerAdapter.debug() missing 1 required positional argument: 'msg'
```

this is fixing the failure to the test, not the root casue of loosing connection to argus (which #5482 might address)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
