### PR TITLE
fix(test): fix different seed for k8s large collections test

### DIFF
--- a/configurations/operator/large-collections-12h.yaml
+++ b/configurations/operator/large-collections-12h.yaml
@@ -3,3 +3,8 @@ nemesis_selector: ['kubernetes']
 
 n_db_nodes: 5
 k8s_n_scylla_pods_per_cluster: 4
+
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_seed: '256'
+nemesis_multiply_factor: 3
+nemesis_interval: 15


### PR DESCRIPTION
We face issue with 'nodetool_cleanup' nemesis, where it takes too long (https://github.com/scylladb/scylladb/issues/9917).

Commit switches SisyphusNemesis seed to different, so this disruption is not executed.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
