### PR TITLE
fix(k8s-eks-pv-setup): revert wrong mount command

### DIFF
--- a/sdcm/k8s_configs/eks/scylla-node-prepare.yaml
+++ b/sdcm/k8s_configs/eks/scylla-node-prepare.yaml
@@ -245,7 +245,7 @@ spec:
                   mkdir "/mnt/hostfs/mnt/raid-disks/disk0/${i}"
                 fi
                 ( mount | grep "/mnt/hostfs/mnt/raid-disks/disk0/${i} " 2>/dev/null 1>&2 ) || \
-                mount -t xfs $DEVICE_PATH "/mnt/hostfs/mnt/raid-disks/disk0/${i}"
+                mount --bind "/mnt/hostfs/mnt/raid-disks/disk0/${i}"{,}
               done
               sleep 10
             done


### PR DESCRIPTION
partialy revert c62c8c70cd7ebe05804401868754ec10ab9dab8e, in that change we mounted the same device into multiple paths causing a loop that in turn failed the recycling of PVs and caused failure to almost any case changing topoloy

provisioner.log:
```
Cleanup for pv local-pv-1a671d64 failed. Restarting cleanup
Deleting PV file volume "local-pv-1a671d64" contents at hostpath
    "/mnt/raid-disks/disk0/pv-01", mountpath "/mnt/raid-disks/disk0/pv-01"
remove /mnt/raid-disks/disk0/pv-01/pv-01: device or resource busy
Cleanup for pv local-pv-1a671d64 failed. Restarting cleanup
```

## Testing:
- [x] https://jenkins.scylladb.com/job/scylla-operator/job/operator-1.8/job/eks/job/longevity-scylla-operator-50gb-3days/10/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
