### PR TITLE
improvement(k8s): make K8S events print timestamps

### DIFF
--- a/sdcm/utils/remote_logger.py
+++ b/sdcm/utils/remote_logger.py
@@ -311,7 +311,13 @@ class KubectlClusterEventsLogger(CommandClusterLoggerBase):
 
     @property
     def _logger_cmd(self) -> str:
-        cmd = self._cluster.kubectl_cmd("get events -w", namespace=self.namespace)
+        cmd = (
+            "get events -w -o custom-columns="
+            "FirstSeen:.firstTimestamp,LastSeen:.lastTimestamp,"
+            "Count:.count,From:.source.component,Type:.type,"
+            "Reason:.reason,Message:.message"
+        )
+        cmd = self._cluster.kubectl_cmd(cmd, namespace=self.namespace)
         return f"{cmd} >> {self._target_log_file} 2>&1"
 
 


### PR DESCRIPTION
We run a python thread that watches for the K8S events objects updates in the Scylla namespace.
For the moment it doesn't print timestamps which would be very useful for debugging because timing matters.

So, fix it by changing the expected output structure in the API call we use for watching updates.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
