### PR TITLE
fix(k8s): make the Scylla IP change watcher thread be more stable

### DIFF
--- a/functional_tests/scylla_operator/libs/helpers.py
+++ b/functional_tests/scylla_operator/libs/helpers.py
@@ -196,42 +196,37 @@ def verify_resharding_on_k8s(db_cluster: ScyllaPodCluster, cpus: Union[str, int,
     # Wait for the start of the resharding.
     # In K8S it starts from the last node of a rack and then goes to previous ones.
     # One resharding with 100Gb+ may take about 3-4 minutes. So, set 5 minutes timeout per node.
-    try:
-        for node, liveness_probe_failures, resharding_start, resharding_finish in nodes_data:
-            assert wait_for(
-                func=lambda: list(resharding_start),  # pylint: disable=cell-var-from-loop
-                step=1, timeout=600, throw_exc=False,
-                text=f"Waiting for the start of resharding on the '{node.name}' node.",
-            ), f"Start of resharding hasn't been detected on the '{node.name}' node."
-            resharding_started = time.time()
-            log.debug("Resharding has been started on the '%s' node.", node.name)
+    for node, liveness_probe_failures, resharding_start, resharding_finish in nodes_data:
+        assert wait_for(
+            func=lambda: list(resharding_start),  # pylint: disable=cell-var-from-loop
+            step=1, timeout=600, throw_exc=False,
+            text=f"Waiting for the start of resharding on the '{node.name}' node.",
+        ), f"Start of resharding hasn't been detected on the '{node.name}' node."
+        resharding_started = time.time()
+        log.debug("Resharding has been started on the '%s' node.", node.name)
 
-            # Wait for the end of resharding
-            assert wait_for(
-                func=lambda: list(resharding_finish),  # pylint: disable=cell-var-from-loop
-                step=3, timeout=600, throw_exc=False,
-                text=f"Waiting for the finish of resharding on the '{node.name}' node.",
-            ), f"Finish of the resharding hasn't been detected on the '{node.name}' node."
-            log.debug("Resharding has been finished successfully on the '%s' node.", node.name)
+        # Wait for the end of resharding
+        assert wait_for(
+            func=lambda: list(resharding_finish),  # pylint: disable=cell-var-from-loop
+            step=3, timeout=600, throw_exc=False,
+            text=f"Waiting for the finish of resharding on the '{node.name}' node.",
+        ), f"Finish of the resharding hasn't been detected on the '{node.name}' node."
+        log.debug("Resharding has been finished successfully on the '%s' node.", node.name)
 
-            # Calculate the time spent for resharding. We need to have it be bigger than 2minutes
-            # because it is the timeout of the liveness probe for Scylla pods.
-            resharding_time = time.time() - resharding_started
-            if resharding_time < 120:
-                log.warning(
-                    "Resharding was too fast - '%s's (<120s) on the '%s' node",
-                    resharding_time, node.name)
-            else:
-                log.info(
-                    "Resharding has taken '%s's on the '%s' node", resharding_time, node.name)
+        # Calculate the time spent for resharding. We need to have it be bigger than 2minutes
+        # because it is the timeout of the liveness probe for Scylla pods.
+        resharding_time = time.time() - resharding_started
+        if resharding_time < 120:
+            log.warning(
+                "Resharding was too fast - '%s's (<120s) on the '%s' node",
+                resharding_time, node.name)
+        else:
+            log.info(
+                "Resharding has taken '%s's on the '%s' node", resharding_time, node.name)
 
-            # Check that liveness probe didn't report any errors
-            # https://github.com/scylladb/scylla-operator/issues/894
-            liveness_probe_failures_list = list(liveness_probe_failures)
-            assert not liveness_probe_failures_list, (
-                f"liveness probe has failures: {liveness_probe_failures_list}")
-    finally:
-        # NOTE: refresh Scylla pods IP addresses because it may get changed at this step
-        for node in nodes_data:
-            node[0].refresh_ip_address()
+        # Check that liveness probe didn't report any errors
+        # https://github.com/scylladb/scylla-operator/issues/894
+        liveness_probe_failures_list = list(liveness_probe_failures)
+        assert not liveness_probe_failures_list, (
+            f"liveness probe has failures: {liveness_probe_failures_list}")
     log.info("Resharding has successfully ended on whole Scylla cluster.")

--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -219,7 +219,6 @@ def test_drain_and_replace_node_kubernetes(db_cluster):
     target_node.wait_till_k8s_pod_get_uid(ignore_uid=old_uid)
     target_node.wait_for_pod_readiness()
     db_cluster.wait_for_pods_readiness(pods_to_wait=1, total_pods=len(db_cluster.nodes))
-    target_node.refresh_ip_address()
 
 
 @pytest.mark.requires_node_termination_support('drain_k8s_node')
@@ -235,7 +234,6 @@ def test_drain_wait_and_replace_node_kubernetes(db_cluster):
     target_node.wait_till_k8s_pod_get_uid(ignore_uid=old_uid)
     target_node.wait_for_pod_readiness()
     db_cluster.wait_for_pods_readiness(pods_to_wait=1, total_pods=len(db_cluster.nodes))
-    target_node.refresh_ip_address()
 
 
 @pytest.mark.requires_node_termination_support('drain_k8s_node')

--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1583,12 +1583,6 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
             LOGGER.info("Wait for the '%s' pod to be ready", pod_object.name)
             pod_object.wait_for_pod_readiness(
                 pod_readiness_timeout_minutes=pod_readiness_timeout_minutes)
-            LOGGER.info("The '%s' pod is ready, refresh IP addresses", pod_object.name)
-            pod_object.refresh_ip_address()
-            # NOTE: update monitoring after each pod update
-            #       to minimize the loss of monitoring data
-            if monitors := self.test_config.tester_obj().monitors:
-                monitors.reconfigure_scylla_monitoring()
 
     @contextlib.contextmanager
     def scylla_config_map(self, namespace: str = SCYLLA_NAMESPACE) -> dict:
@@ -1892,7 +1886,6 @@ class BasePodContainer(cluster.BaseNode):  # pylint: disable=too-many-public-met
             timeout=self.pod_terminate_timeout * 60 + 10)
 
         self.wait_for_pod_readiness()
-        self.refresh_ip_address()
 
     def soft_reboot(self):
         # Kubernetes brings pods back to live right after it is deleted
@@ -1902,7 +1895,6 @@ class BasePodContainer(cluster.BaseNode):  # pylint: disable=too-many-public-met
             timeout=self.pod_terminate_timeout * 60 + 10)
 
         self.wait_for_pod_readiness()
-        self.refresh_ip_address()
 
     # On kubernetes there is no stop/start, closest analog of node restart would be soft_restart
     restart = soft_reboot

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -787,11 +787,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                            line="Can't find a column family with UUID", node=self.target_node):
             self.target_node.restart()
 
-        # pods can change their ip address during the process,
-        # so we update the monitor at this point
-        if self._is_it_on_kubernetes():
-            self.refresh_nodes_ip_and_reconfigure_monitor(nodes=[self.target_node])
-
         self.log.info('Waiting scylla services to start after node restart')
         self.target_node.wait_db_up(timeout=28800)  # 8 hours
         self.log.info('Waiting JMX services to start after node restart')
@@ -883,9 +878,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     @decorate_with_context(ignore_ycsb_connection_refused)
     def disrupt_rolling_restart_cluster(self, random_order=False):
         self.cluster.restart_scylla(random_order=random_order)
-
-        if self._is_it_on_kubernetes():
-            self.refresh_nodes_ip_and_reconfigure_monitor()
 
     def disrupt_switch_between_password_authenticator_and_saslauthd_authenticator_and_back(self):
         """
@@ -1269,47 +1261,41 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         # Wait for the start of the resharding.
         # In K8S it starts from the last node of a rack and then goes to previous ones.
         # One resharding with 100Gb+ may take about 3-4 minutes. So, set 5 minutes timeout per node.
-        try:
-            for node, liveness_probe_failures, resharding_start, resharding_finish in nodes_data:
-                assert wait.wait_for(
-                    func=lambda: list(resharding_start),  # pylint: disable=cell-var-from-loop
-                    step=1, timeout=300, throw_exc=False,
-                    text=f"Waiting for the start of resharding on the '{node.name}' node.",
-                ), f"Start of resharding hasn't been detected on the '{node.name}' node."
-                resharding_started = time.time()
-                self.log.debug("Resharding has been started on the '%s' node.", node.name)
+        for node, liveness_probe_failures, resharding_start, resharding_finish in nodes_data:
+            assert wait.wait_for(
+                func=lambda: list(resharding_start),  # pylint: disable=cell-var-from-loop
+                step=1, timeout=300, throw_exc=False,
+                text=f"Waiting for the start of resharding on the '{node.name}' node.",
+            ), f"Start of resharding hasn't been detected on the '{node.name}' node."
+            resharding_started = time.time()
+            self.log.debug("Resharding has been started on the '%s' node.", node.name)
 
-                # Wait for the end of resharding
-                assert wait.wait_for(
-                    func=lambda: list(resharding_finish),  # pylint: disable=cell-var-from-loop
-                    step=3, timeout=1800, throw_exc=False,
-                    text=f"Waiting for the finish of resharding on the '{node.name}' node.",
-                ), f"Finish of the resharding hasn't been detected on the '{node.name}' node."
-                self.log.debug("Resharding has been finished successfully on the '%s' node.", node.name)
+            # Wait for the end of resharding
+            assert wait.wait_for(
+                func=lambda: list(resharding_finish),  # pylint: disable=cell-var-from-loop
+                step=3, timeout=1800, throw_exc=False,
+                text=f"Waiting for the finish of resharding on the '{node.name}' node.",
+            ), f"Finish of the resharding hasn't been detected on the '{node.name}' node."
+            self.log.debug("Resharding has been finished successfully on the '%s' node.", node.name)
 
-                # Calculate the time spent for resharding. We need to have it be bigger than 2minutes
-                # because it is the timeout of the liveness probe for Scylla pods.
-                resharding_time = time.time() - resharding_started
-                if resharding_time < 120:
-                    self.log.warning(
-                        "Resharding was too fast - '%s's (<120s) on the '%s' node. "
-                        "So, nemesis didn't cover the case.",
-                        resharding_time, node.name)
-                else:
-                    self.log.info(
-                        "Resharding took '%s's on the '%s' node. It is enough to cover the case.",
-                        resharding_time, node.name)
+            # Calculate the time spent for resharding. We need to have it be bigger than 2minutes
+            # because it is the timeout of the liveness probe for Scylla pods.
+            resharding_time = time.time() - resharding_started
+            if resharding_time < 120:
+                self.log.warning(
+                    "Resharding was too fast - '%s's (<120s) on the '%s' node. "
+                    "So, nemesis didn't cover the case.",
+                    resharding_time, node.name)
+            else:
+                self.log.info(
+                    "Resharding took '%s's on the '%s' node. It is enough to cover the case.",
+                    resharding_time, node.name)
 
-                # Check that liveness probe didn't report any errors
-                # https://github.com/scylladb/scylla-operator/issues/894
-                liveness_probe_failures = list(liveness_probe_failures)
-                assert not liveness_probe_failures, (
-                    f"There are liveness probe failures: {liveness_probe_failures}")
-        finally:
-            # NOTE: refresh scylla pods IP addresses because it may get changed here
-            for node in nodes_data:
-                node[0].refresh_ip_address()
-            self.monitoring_set.reconfigure_scylla_monitoring()
+            # Check that liveness probe didn't report any errors
+            # https://github.com/scylladb/scylla-operator/issues/894
+            liveness_probe_failures = list(liveness_probe_failures)
+            assert not liveness_probe_failures, (
+                f"There are liveness probe failures: {liveness_probe_failures}")
 
         self.log.info("Resharding has successfully ended on whole Scylla cluster.")
 
@@ -1433,8 +1419,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         node.wait_till_k8s_pod_get_uid(ignore_uid=old_uid)
         self.log.info('Wait till %s is ready', node)
         node.wait_for_pod_readiness()
-        self.log.info(f'{node} is ready, updating ip address and monitoring')
-        self.refresh_nodes_ip_and_reconfigure_monitor(nodes=[node])
 
     def disrupt_terminate_and_replace_node(self):  # pylint: disable=invalid-name
 
@@ -1604,9 +1588,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 finally:
                     clean_enospc_on_node(target_node=node, sleep_time=sleep_time)
 
-        if self._is_it_on_kubernetes():
-            self.refresh_nodes_ip_and_reconfigure_monitor(nodes=nodes)
-
     def disrupt_remove_service_level_while_load(self):
         if not getattr(self.tester, "roles", None):
             raise UnsupportedNemesis('This nemesis is supported for SLA test only')
@@ -1629,27 +1610,11 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                                      removed_shares, random.randint(0, 10)),
                                  shares=removed_shares).create())
 
-    def refresh_nodes_ip_and_reconfigure_monitor(self, nodes: list = None):
-        # relevant for kubernetes
-        # pods can change their ip address during the process,
-        # so we update the monitor at this point and get updated IPs
-        if not nodes:
-            nodes = self.cluster.nodes
-
-        for node in nodes:
-            node.refresh_ip_address()
-
-        self.monitoring_set.reconfigure_scylla_monitoring()
-
     def _deprecated_disrupt_stop_start(self):
         # TODO: We don't support fully stopping the AMI instance anymore
         # TODO: This nemesis has to be rewritten to just stop/start scylla server
         self.log.info('StopStart %s', self.target_node)
         self.target_node.restart()
-        # pods can change their ip address during the process,
-        # so we update the monitor at this point
-        if self._is_it_on_kubernetes():
-            self.refresh_nodes_ip_and_reconfigure_monitor(nodes=[self.target_node])
 
     def call_random_disrupt_method(self, disrupt_methods=None, predefined_sequence=False):
         # pylint: disable=too-many-branches
@@ -3227,10 +3192,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         target_node.reboot(hard=hard, verify_ssh=verify_ssh)
         if self.tester.params.get('print_kernel_callstack'):
             save_kallsyms_map(node=target_node)
-        # pods can change their ip address during the process,
-        # so we update the monitor at this point
-        if self._is_it_on_kubernetes():
-            self.refresh_nodes_ip_and_reconfigure_monitor(nodes=[target_node])
 
     def disrupt_network_start_stop_interface(self):  # pylint: disable=invalid-name
         if not self.cluster.extra_network_interface:

--- a/sdcm/utils/k8s/__init__.py
+++ b/sdcm/utils/k8s/__init__.py
@@ -676,7 +676,9 @@ class ScyllaPodsIPChangeTrackerThread(threading.Thread):
 
     SCYLLA_PODS_SELECTOR = "app.kubernetes.io/name=scylla"
     SCYLLA_PODS_EXPECTED_LABEL_KEYS = ("scylla/datacenter", "scylla/rack")
-    READ_REQUEST_TIMEOUT = 10800  # 3h
+    # NOTE: Knowing that in common case a Scylla pod gets up in 3-4 minutes,
+    #       make the timeout be about it.
+    READ_REQUEST_TIMEOUT = 180
 
     def __init__(self, k8s_kluster, mapper_dict):
         self._termination_event = threading.Event()

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -1058,10 +1058,6 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         upgrade_version, scylla_pool = self.k8s_cluster.upgrade_kubernetes_platform(
             pod_objects=self.db_cluster.nodes,
             use_additional_scylla_nodepool=True)
-        # NOTE: refresh IP addresses of the Scylla nodes because they get changed in current case
-        for db_node in self.db_cluster.nodes:
-            db_node.refresh_ip_address()
-        self.monitors.reconfigure_scylla_monitoring()
 
         InfoEvent(message="Step4 - Validate K8S versions after the upgrade").publish()
         data_plane_versions = self.k8s_cluster.kubectl(


### PR DESCRIPTION
In the `ScyllaPodsIPChangeTrackerThread` thread we set `read` timeout be equal to `3h`.
And it means that if a stream read hangs for any reason then we get next bunch of info out of it only in 3 hours.
And hanging of this kind of stream happens much faster than 3 hours on GKE backend.
    
Knowing that in a common case a Scylla pod gets up in 3-4 minutes, make the timeout be about it - 3m.
    
Mostly, it will lead to the redundant reconnections having alive stream,
but 1 redundant API call in 3 minutes is much better than unpredictable errors caused by the wrong IP mapping.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
