### PR TITLE
fix(alternator-perf-yaml): switch to use syslog-ng logger

### DIFF
--- a/test-cases/performance/perf-regression-alternator-latency-500gb-30min.yaml
+++ b/test-cases/performance/perf-regression-alternator-latency-500gb-30min.yaml
@@ -51,8 +51,6 @@ append_scylla_args: '--blocked-reactor-notify-ms 50'
 backtrace_decoding: false
 print_kernel_callstack: true
 
-logs_transport: "ssh"
-
 store_perf_results: true
 send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com', 'alternator@scylladb.com']

--- a/test-cases/performance/perf-regression-alternator.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression-alternator.100threads.30M-keys.yaml
@@ -57,4 +57,3 @@ send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com', 'alternator@scylladb.com']
 
 print_kernel_callstack: true
-logs_transport: "ssh"


### PR DESCRIPTION
Switch to use syslog-ng default log transport

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
