### PR TITLE
fix(cluster.py): Increase nodetool command timeout for gp3 disk

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -2567,7 +2567,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         :return: Remoter result object
         """
         cmd = self._gen_nodetool_cmd(sub_cmd, args, options)
-
+        if sub_cmd == 'flush' and self.parent_cluster.params.get("data_volume_disk_type") == 'gp3':
+            timeout = timeout * 10 if timeout else 3000
         with NodetoolEvent(nodetool_command=sub_cmd,
                            node=self.name,
                            options=options,


### PR DESCRIPTION
	nodetool commands like 'flush' fails for default 60 seconds
timeout with a gp3 disk.
Refs: https://github.com/scylladb/scylladb/issues/12674

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
