### PR TITLE
fix(ignore_stream_mutation): match regexp in full string

### DIFF
--- a/sdcm/sct_events/group_common_events.py
+++ b/sdcm/sct_events/group_common_events.py
@@ -211,7 +211,7 @@ def ignore_stream_mutation_fragments_errors():
         stack.enter_context(EventsSeverityChangerFilter(
             new_severity=Severity.WARNING,
             event_class=DatabaseLogEvent,
-            regex=r"storage_proxy \- exception during mutation write.*gate_closed_exception",
+            regex=r".*storage_proxy \- exception during mutation write.*gate_closed_exception",
             extra_time_to_expiration=30
         ))
         yield


### PR DESCRIPTION
eval_filter use re.match, this method start matching from the begining of the string.
Added .* to the begining of regexp to search in any place of string

During job with cdc feature, for DecommissionStreamingError upon decommission interruption , 
next log message happened with error:
```
2023-01-12 21:25:34.108 <2023-01-12 21:25:28.000>: (DatabaseLogEvent Severity.ERROR) period_type=one-time event_id=0f33a6d7-ee60-4acb-9582-8ed1af825767: type=RUNTIME_ERROR regex=std::runtime_error line_number=54745 node=longevity-cdc-100gb-4h-2022-2-db-node-08d07ba6-5
2023-01-12T21:25:28+00:00 longevity-cdc-100gb-4h-2022-2-db-node-08d07ba6-5      !ERR | scylla[7993]:  [shard 10] storage_proxy - exception during mutation write to 10.12.0.234: utils::internal::nested_exception<std::runtime_error> (Could not write mutation cdc_test:test_table_preimage (pk{00062d594c341814}) to commitlog): seastar::gate_closed_exception (gate closed)
```
and attempt to set new severity in EventsSeverityChangerFilter failed, because of regexp was not found

Job:
https://argus.scylladb.com/test/94c121cb-357b-45e9-b044-27e1e34b2dff/runs?additionalRuns[]=08d07ba6-1037-4c54-80d0-019ff9f64c63

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
