### PR TITLE
fix(k8s): allow to use custom cassandra-stress image in dynamic loaders

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -2843,9 +2843,6 @@ class LoaderPodCluster(cluster.BaseLoaderSet, PodCluster):
             node.config_client_encrypt()
 
     def _get_docker_image(self):
-        # TODO: detect the stress type and apply appropriate docker image
-        #       `scylla-bench` stress commands will fail when c-s gets switched
-        #       to the docker approach.
         if loader_image := self.params.get('stress_image.cassandra-stress'):
             return loader_image
         else:

--- a/sdcm/remote/kubernetes_cmd_runner.py
+++ b/sdcm/remote/kubernetes_cmd_runner.py
@@ -361,6 +361,8 @@ class KubernetesPodWatcher(KubernetesRunner):
         params = self.context.config.k8s_kluster.params
         if is_scylla_bench_command(command):
             return params.get('stress_image.scylla-bench')
+        if loader_image := params.get('stress_image.cassandra-stress'):
+            return loader_image
         return f"{params.get('docker_image')}:{params.get('scylla_version')}"
 
     def _get_pod_status(self) -> dict:


### PR DESCRIPTION
For the moment, using `dynamic` loader run type on K8S, we allow to use only the same Scylla image as the test target Scylla one when our stress tool is set to be `cassandra-stress`.

This limitation disallows us to test latest stable Scylla versions with the serverless feature of the `scylla-operator`.

So, fix it by considering the `stress_image.cassandra-stress` option first and only if it is not set then use the test target Scylla version.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
