### PR TITLE
fix(k8s-eks): use 3 auxiliary nodes on EKS by default

### DIFF
--- a/defaults/k8s_eks_config.yaml
+++ b/defaults/k8s_eks_config.yaml
@@ -43,7 +43,7 @@ n_monitor_nodes: 1
 n_loaders: 1
 n_db_nodes: 4
 k8s_n_scylla_pods_per_cluster: 3
-k8s_n_auxiliary_nodes: 2
+k8s_n_auxiliary_nodes: 3
 
 # TODO: add '--abort-on-seastar-bad-alloc' arg to the 'append_scylla_args' option when
 #       following operator bug gets fixed: https://github.com/scylladb/scylla-operator/issues/991

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1566,9 +1566,9 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         self.k8s_cluster.deploy_node_pool(
             eks.EksNodePool(
                 name=self.k8s_cluster.AUXILIARY_POOL_NAME,
+                # NOTE: It should have at least 5 vCPU to be able to hold all the pods
                 num_nodes=self.params.get('k8s_n_auxiliary_nodes'),
                 instance_type="t3.large",
-                # It should have at least 3 vCPU to be able to hold all the pods
                 disk_size=40,
                 role_arn=self.k8s_cluster.nodegroup_role_arn,
                 k8s_cluster=self.k8s_cluster),


### PR DESCRIPTION
If turned out that existing `2 auxiliary nodes` is not enough when we enable `scylla-manager` and `serverless` features in addition to all other pods which get installed always.

So, make `EKS` use `3 auxiliary nodes` by default to avoid scheduling problems.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
