### PR TITLE
improvement(k8s): tune K8S performance only running on EKS backend

### DIFF
--- a/defaults/k8s_eks_config.yaml
+++ b/defaults/k8s_eks_config.yaml
@@ -21,9 +21,9 @@ scylla_mgmt_agent_version: '3.0.0'
 k8s_cert_manager_version: '1.8.0'
 
 k8s_deploy_monitoring: false
+k8s_enable_performance_tuning: true
 
 k8s_loader_cluster_name: 'sct-loaders'
-
 k8s_scylla_cluster_name: 'sct-cluster'
 k8s_scylla_datacenter: 'us-east1-b'
 k8s_scylla_disk_gi: 500

--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -27,6 +27,7 @@ k8s_scylla_operator_helm_repo: 'https://storage.googleapis.com/scylla-operator-c
 k8s_scylla_operator_chart_version: 'latest'
 k8s_cert_manager_version: '1.8.0'
 k8s_deploy_monitoring: false
+k8s_enable_performance_tuning: false
 
 # NOTE: GKE requires 'k8s_scylla_utils_docker_image' be defined to enterprise Scylla version 2021+
 #       to have more performant configuration of disks.

--- a/defaults/k8s_local_kind_config.yaml
+++ b/defaults/k8s_local_kind_config.yaml
@@ -21,6 +21,7 @@ k8s_scylla_cluster_name: 'sct-cluster'
 k8s_scylla_disk_gi: 5
 k8s_scylla_disk_class: 'local-raid-disks'
 k8s_minio_storage_size: '20Gi'
+k8s_enable_performance_tuning: false
 
 # NOTE: if we do not specify 'k8s_n_loader_pods_per_cluster' then value of the 'n_loaders' is used
 n_loaders: 1

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -165,9 +165,6 @@ k8s_loader_run_type: 'dynamic'
 
 k8s_tenants_num: 1
 
-# NOTE: 'k8s_enable_performance_tuning' is alpha feature in operator-1.6 , so it is disabled by default
-k8s_enable_performance_tuning: false
-
 # NOTE: if 'k8s_scylla_utils_docker_image' is not specified then default values from operator-1.6+ will be used
 k8s_scylla_utils_docker_image: ''
 


### PR DESCRIPTION
Update default config files for all K8S backends according to the following statements:

- We should use perf tuning on EKS.
- We can/should not use perf tuning on local K8S.
- We do not plan to test and fix perf issues on GKE in nearest future.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
