### PR TITLE
improvement(k8s): use C-S image with serverless feature support

### DIFF
--- a/defaults/k8s_eks_config.yaml
+++ b/defaults/k8s_eks_config.yaml
@@ -54,3 +54,9 @@ mgmt_docker_image: 'scylladb/scylla-manager:3.0.0'
 
 backup_bucket_backend: 's3'
 backup_bucket_location: 'minio-bucket'
+
+# NOTE: Define a separate image for the 'cassandra stress' that supports 'serverless' feature.
+#       It will allow to test 'serverless' feature against any stable Scylla release
+#       with old 'cassandra-stress' binary.
+stress_image:
+  cassandra-stress: 'scylladb/scylla-nightly:5.2.0-rc0-0.20230119.34ab98e1be2e'

--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -64,3 +64,9 @@ append_scylla_args: '--abort-on-lsa-bad-alloc 1 --abort-on-internal-error 1 --ab
 docker_image: ''
 backup_bucket_backend: 's3'
 backup_bucket_location: 'minio-bucket'
+
+# NOTE: Define a separate image for the 'cassandra stress' that supports 'serverless' feature.
+#       It will allow to test 'serverless' feature against any stable Scylla release
+#       with old 'cassandra-stress' binary.
+stress_image:
+  cassandra-stress: 'scylladb/scylla-nightly:5.2.0-rc0-0.20230119.34ab98e1be2e'

--- a/defaults/k8s_local_kind_config.yaml
+++ b/defaults/k8s_local_kind_config.yaml
@@ -36,3 +36,9 @@ backtrace_decoding: false
 append_scylla_args: '--abort-on-lsa-bad-alloc 1 --abort-on-internal-error 1 --abort-on-ebadf 1 --enable-sstable-key-validation 1'
 docker_image: ''
 backup_bucket_location: 'minio-bucket'
+
+# NOTE: Define a separate image for the 'cassandra stress' that supports 'serverless' feature.
+#       It will allow to test 'serverless' feature against any stable Scylla release
+#       with old 'cassandra-stress' binary.
+stress_image:
+  cassandra-stress: 'scylladb/scylla-nightly:5.2.0-rc0-0.20230119.34ab98e1be2e'


### PR DESCRIPTION
Specifying a new enough Scylla image that supports the 'serverless' feature for the 'cassandra-stress' loaders will allow us to test the feature against any Scylla version.

With this configuration we will only need to set 'true' value for the 'k8s_enable_tls' option when we want
to test the 'serverless' feature.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
