### PR TITLE
fix(k8s_local): ingress maxconn value is too high

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -1036,17 +1036,22 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
                 memory_limit = convert_memory_units_to_k8s_value(memory_limit)
                 cpu_request = convert_cpu_units_to_k8s_value(cpu_request)
                 memory_request = convert_memory_units_to_k8s_value(memory_request)
+                haproxy_maxconn = 70000
             else:
-                cpu_limit = '100m'
-                memory_limit = '50M'
+                # TODO: measure these values in performance testing and update if needed.
+                cpu_limit = '400m'
+                memory_limit = '200M'
                 cpu_request = '100m'
                 memory_request = '50M'
+                # that's the default, and trigger haproxy auto calculation of it.
+                haproxy_maxconn = 0
 
             environ = {
                 "POD_CPU_LIMIT": cpu_limit,
                 "POD_MEMORY_LIMIT": memory_limit,
                 "POD_CPU_REQUEST": cpu_request,
                 "POD_MEMORY_REQUEST": memory_request,
+                "HAPROXY_MAXCONN": haproxy_maxconn,
                 "TAGS": comma_separated_tags,
             }
             self.apply_file(

--- a/sdcm/k8s_configs/ingress-controller/10_haproxy-kubernetes-ingress.configmap.yaml
+++ b/sdcm/k8s_configs/ingress-controller/10_haproxy-kubernetes-ingress.configmap.yaml
@@ -5,6 +5,6 @@ metadata:
   namespace: haproxy-controller
 data:
   load-balance: "roundrobin"
-  maxconn: "70000"
+  maxconn: "$HAPROXY_MAXCONN"
   src-ip-header: "True-Client-IP"
   http-keep-alive: "true"


### PR DESCRIPTION
Since we added some of the producation configuration to the ingress haproxy, the values for `maxconn` is too high for the local kind setup and fails with the following error:

```
[ALERT]    (286) : config : Cannot compute the automatic maxsslconn because
 global.maxconn is already too high for the global.memmax value (31 MB).
 The absolute maximum possible value without SSL is 780, but 70000 was found
 and SSL is in use.
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
