### PR TITLE
test(scale-k8s): add many-clients test to k8s

### DIFF
--- a/jenkins-pipelines/operator/scale/operator-scale-many-clients-4h.jenkinsfile
+++ b/jenkins-pipelines/operator/scale/operator-scale-many-clients-4h.jenkinsfile
@@ -1,0 +1,16 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'k8s-eks',
+    aws_region: 'eu-north-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/scylla-operator/longevity-scylla-operator-many-clients-4h.yaml',
+    availability_zone: 'a,b',
+    post_behavior_db_nodes: 'destroy',
+    post_behavior_loader_nodes: 'destroy',
+    post_behavior_monitor_nodes: 'destroy',
+    post_behavior_k8s_cluster: 'destroy',
+)

--- a/test-cases/scylla-operator/longevity-scylla-operator-many-clients-4h.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-many-clients-4h.yaml
@@ -1,0 +1,33 @@
+test_duration: 360
+
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=20971520 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=20 -pop seq=1..20971520 -col 'n=FIXED(2) size=FIXED(256)' -log interval=5"
+
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=240m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=4 -pop seq=1..20971520 -col 'n=FIXED(2) size=FIXED(256)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=240m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=4 -pop seq=1..20971520 -col 'n=FIXED(2) size=FIXED(256)' -log interval=5"
+             ]
+
+n_db_nodes: 5
+k8s_n_scylla_pods_per_cluster: 4
+n_loaders: 50
+n_monitor_nodes: 1
+
+instance_type_db: 'i3.metal'
+instance_type_loader: 'c5.large'
+instance_type_monitor: 'm5.2xlarge'
+instance_type_runner: 'r5.large'
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_seed: '031'
+nemesis_multiply_factor: 1
+nemesis_interval: 5
+nemesis_filter_seeds: false
+seeds_num: 3
+round_robin: true
+keyspace_num: 50
+use_mgmt: false
+k8s_deploy_monitoring: false
+k8s_enable_performance_tuning: true
+k8s_loader_run_type: 'static'
+k8s_enable_tls: true
+
+user_prefix: 'operator-many-clients-4h'
+space_node_threshold: 64424


### PR DESCRIPTION
We want to test how scylla on k8s is working with many clients.

This commit adds k8s test based on many-clients test.

Test works, but SNI Proxy limits throughput to ~17kops and needs further scaling up.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
