### PR TITLE
fix(MemoryStress): fix k8_cluster reference for multitenant

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -418,7 +418,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         return isinstance(getattr(self.tester, "db_cluster", None), PodCluster)
 
     def _is_chaos_mesh_initialized(self) -> bool:
-        return self.tester.k8s_cluster.chaos_mesh.initialized
+        return self.cluster.k8s_cluster.chaos_mesh.initialized
 
     # pylint: disable=too-many-arguments,unused-argument
     def get_list_of_methods_by_flags(
@@ -3551,7 +3551,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if not self._is_chaos_mesh_initialized:
             raise UnsupportedNemesis(
                 "Chaos Mesh is not installed. Set 'k8s_use_chaos_mesh' config option to 'true'")
-        memory_limit = self.tester.k8s_cluster.calculated_memory_limit
+        memory_limit = self.cluster.k8s_cluster.calculated_memory_limit
         # If a container's memory usage increases too quickly the OOM killer is invoked
         # so reduce ramp to ~2GB/s: time_to_reach = memory (in GB) /2
         time_to_reach_secs = int(convert_memory_value_from_k8s_to_units(memory_limit)/2)


### PR DESCRIPTION
When running memory stress disruption in k8s multitenant setup, tester object has no reference to k8s_cluster causing this nemesis to fail.

Fix is about setting proper parent object (db_cluster) for k8s_cluster instance.

fixes: #5716

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
