### PR TITLE
feature(enospc): fake enospc error on k8s with chaos-mesh

### DIFF
--- a/defaults/k8s_eks_config.yaml
+++ b/defaults/k8s_eks_config.yaml
@@ -34,6 +34,7 @@ k8s_scylla_disk_class: 'local-raid-disks'
 k8s_scylla_operator_docker_image: ''
 k8s_scylla_operator_helm_repo: 'https://storage.googleapis.com/scylla-operator-charts/latest'
 k8s_scylla_operator_chart_version: 'latest'
+k8s_use_chaos_mesh: true
 
 k8s_scylla_rack: 'us-east1'
 k8s_minio_storage_size: '60Gi'

--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -38,6 +38,7 @@ k8s_scylla_rack: 'us-east1'
 k8s_scylla_cluster_name: 'sct-cluster'
 k8s_scylla_disk_gi: 500
 k8s_scylla_disk_class: 'local-raid-disks'
+k8s_use_chaos_mesh: true
 
 k8s_minio_storage_size: '60Gi'
 k8s_loader_cluster_name: 'sct-loaders'

--- a/defaults/k8s_local_kind_config.yaml
+++ b/defaults/k8s_local_kind_config.yaml
@@ -22,6 +22,7 @@ k8s_scylla_disk_gi: 5
 k8s_scylla_disk_class: 'local-raid-disks'
 k8s_minio_storage_size: '20Gi'
 k8s_enable_performance_tuning: false
+k8s_use_chaos_mesh: true
 
 # NOTE: if we do not specify 'k8s_n_loader_pods_per_cluster' then value of the 'n_loaders' is used
 n_loaders: 1

--- a/test-cases/scylla-operator/functional.yaml
+++ b/test-cases/scylla-operator/functional.yaml
@@ -25,5 +25,3 @@ k8s_scylla_operator_chart_version: 'v1.7.2'
 k8s_scylla_operator_docker_image: ''
 k8s_deploy_monitoring: false
 k8s_functional_test_dataset: MULTI_COLUMNS_DATA
-
-k8s_use_chaos_mesh: true


### PR DESCRIPTION
On k8s we can make filesystem respond with errors artificially. E.g. instead of filling up disk we can make filesystem respond with ENOSPC error.

This commit adds support for IOChaos from chaos-mesh (https://chaos-mesh.org/docs/simulate-io-chaos-on-kubernetes/). Replaces enospc nemesis logic for k8s - so we don't fill up disks.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
