### PR TITLE
improvement(parse_version): align to expected version format 

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -29,11 +29,11 @@ from cassandra import InvalidRequest
 from cassandra.util import sortedset, SortedSet  # pylint: disable=no-name-in-module
 from cassandra import ConsistencyLevel
 from cassandra.protocol import ProtocolException  # pylint: disable=no-name-in-module
-from pkg_resources import parse_version
 
 from sdcm.tester import ClusterTester
 from sdcm.utils.decorators import retrying
 from sdcm.utils.cdc.options import CDC_LOGTABLE_SUFFIX
+from sdcm.utils.version_utils import parse_scylla_version
 
 
 LOGGER = logging.getLogger(__name__)
@@ -3141,7 +3141,7 @@ class FillDatabaseData(ClusterTester):
 
     @property
     def parsed_scylla_version(self):
-        return parse_version(self.db_cluster.nodes[0].scylla_version.replace('~', '-'))
+        return parse_scylla_version(self.db_cluster.nodes[0].scylla_version)
 
     @property
     def is_enterprise(self) -> bool:
@@ -3152,14 +3152,14 @@ class FillDatabaseData(ClusterTester):
             version_with_support = self.NULL_VALUES_SUPPORT_ENTERPRISE_MIN_VERSION
         else:
             version_with_support = self.NULL_VALUES_SUPPORT_OS_MIN_VERSION
-        return self.parsed_scylla_version >= parse_version(version_with_support)
+        return self.parsed_scylla_version >= parse_scylla_version(version_with_support)
 
     def version_new_sorting_order_with_secondary_indexes(self):
         if self.is_enterprise:
             version_with_support = self.NEW_SORTING_ORDER_WITH_SECONDARY_INDEXES_ENTERPRISE_MIN_VERSION
         else:
             version_with_support = self.NEW_SORTING_ORDER_WITH_SECONDARY_INDEXES_OS_MIN_VERSION
-        return self.parsed_scylla_version >= parse_version(version_with_support)
+        return self.parsed_scylla_version >= parse_scylla_version(version_with_support)
 
     def version_non_frozen_udt_support(self):
         """
@@ -3170,14 +3170,14 @@ class FillDatabaseData(ClusterTester):
             version_with_support = self.NON_FROZEN_SUPPORT_ENTERPRISE_MIN_VERSION
         else:
             version_with_support = self.NON_FROZEN_SUPPORT_OS_MIN_VERSION
-        return self.parsed_scylla_version >= parse_version(version_with_support)
+        return self.parsed_scylla_version >= parse_scylla_version(version_with_support)
 
     def version_cdc_support(self):
         if self.is_enterprise:
             version_with_support = self.CDC_SUPPORT_MIN_ENTERPRISE_VERSION
         else:
             version_with_support = self.CDC_SUPPORT_MIN_VERSION
-        return self.parsed_scylla_version >= parse_version(version_with_support)
+        return self.parsed_scylla_version >= parse_scylla_version(version_with_support)
 
     @retrying(n=3, sleep_time=20, allowed_exceptions=ProtocolException)
     def truncate_table(self, session, truncate):  # pylint: disable=no-self-use

--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -21,6 +21,7 @@ from collections import namedtuple
 from urllib.parse import urlparse
 from functools import lru_cache, wraps
 from itertools import count
+from pkg_resources import parse_version
 
 import yaml
 import boto3
@@ -115,6 +116,11 @@ FILE_REGEX_DICT = {
 # The variable "type" indices the type of URL (Debian or Yum)
 # The variable "urls" contains all urls using the Scylla pattern
 RepositoryDetails = namedtuple("RepositoryDetails", ["type", "urls"])
+
+
+def parse_scylla_version(version_to_parse: str) -> version.Version:
+    version_format = re.compile(r'(\d+\.\d)|(\.\d+)')
+    return parse_version(version_format.search(version_to_parse)[0])
 
 
 @lru_cache(maxsize=1024)

--- a/utils/get_supported_scylla_base_versions.py
+++ b/utils/get_supported_scylla_base_versions.py
@@ -4,9 +4,9 @@ import sys
 import re
 import os
 
-from pkg_resources import parse_version
 from sdcm.utils.version_utils import is_enterprise, get_all_versions
 from sdcm.utils.common import get_s3_scylla_repos_mapping
+from sdcm.utils.version_utils import parse_scylla_version
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
@@ -97,9 +97,10 @@ class UpgradeBaseVersion:  # pylint: disable=too-many-instance-attributes
                 else:
                     # Choose the last two releases as upgrade base
                     ent_base_version += ent_release_list[idx-1:][:2]
-            elif version == 'enterprise' or parse_version(version) > parse_version(ent_release_list[0]):
+            elif version == 'enterprise' or parse_scylla_version(version) > parse_scylla_version(ent_release_list[0]):
                 ent_base_version.append(ent_release_list[-1])
-            elif re.match(r'\d+.\d+', version) and parse_version(version) >= parse_version(ent_release_list[0]):
+            elif re.match(r'\d+.\d+', version) and parse_scylla_version(version) \
+                    >= parse_scylla_version(ent_release_list[0]):
                 oss_base_version.append(oss_release_list[-1])
                 ent_base_version += ent_release_list[-2:]
         elif product == 'scylla':
@@ -112,10 +113,12 @@ class UpgradeBaseVersion:  # pylint: disable=too-many-instance-attributes
                 else:
                     # Choose the last two releases as upgrade base
                     oss_base_version += oss_release_list[idx-1:][:2]
-            elif version == 'master' or parse_version(version) > parse_version(oss_release_list[0]):
+            elif version == 'master' or parse_scylla_version(version) > parse_scylla_version(oss_release_list[0]):
                 oss_base_version.append(oss_release_list[-1])
-            elif re.match(r'\d+.\d+', version) and parse_version(version) < parse_version(oss_release_list[0]):
-                # If dest version is smaller than the first supported opensource release, it might be an invalid dest version
+            elif re.match(r'\d+.\d+', version) and parse_scylla_version(version) \
+                    < parse_scylla_version(oss_release_list[0]):
+                # If dest version is smaller than the first supported opensource release,
+                # it might be an invalid dest version
                 oss_base_version.append(oss_release_list[-1])
         else:
             raise ValueError("Unsupported product %s" % product)
@@ -153,11 +156,11 @@ class UpgradeBaseVersion:  # pylint: disable=too-many-instance-attributes
                 continue
             # OSS: the major version is smaller than the start support version
             if self.oss_start_support_version and not is_enterprise(version_prefix) and \
-                    parse_version(version_prefix) < parse_version(self.oss_start_support_version):
+                    parse_scylla_version(version_prefix) < parse_scylla_version(self.oss_start_support_version):
                 continue
             # Enterprise: the major version is smaller than the start support version
             if self.ent_start_support_version and is_enterprise(version_prefix) and \
-                    parse_version(version_prefix) < parse_version(self.ent_start_support_version):
+                    parse_scylla_version(version_prefix) < parse_scylla_version(self.ent_start_support_version):
                 continue
             supported_versions.append(version_prefix)
         version_list = self.get_supported_scylla_base_versions(supported_versions)


### PR DESCRIPTION
the package complains about our Scylla versions
when we have the full version format including
commit hash and date (e.g. `5.2.0~rc0-0.20230119.34ab98e1be2e`)
with tilde or dash.
this change will give to the `parse_version` function
only `major.minor.micro` for the sake of comparisons,
as everything else is ignored anyway.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
