### PR TITLE
improvement(kernel traces): Enable print_kernel_callstack by default

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -58,7 +58,7 @@ use_cloud_manager: false
 cloud_prom_bearer_token: ''
 
 backtrace_decoding: true
-print_kernel_callstack: false
+print_kernel_callstack: true
 
 update_db_packages: ''
 


### PR DESCRIPTION
	The Reactor-Stall trace might be less accurate than in kernel traces.
	It would be helpfull to analyse reactor-stall issues if these traces
	are enabled for all tests by default.

Refs: https://github.com/scylladb/scylladb/issues/12623

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
