### PR TITLE
fix(longevityPipeline): Add gemini seed to longevityPipeline

### DIFF
--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -99,6 +99,9 @@ def call(Map pipelineParams) {
                    description: 'Name of the test to run',
                    name: 'test_name')
 
+            string(defaultValue: '', description: 'run gemini job with specific gemini seed number',
+                   name: "gemini_seed")
+
             string(defaultValue: "${pipelineParams.get('pytest_addopts', '')}",
                    description: (
                         '"pytest_addopts" is used by "run_pytest" hydra command. \n' +
@@ -175,7 +178,7 @@ def call(Map pipelineParams) {
             stage('Get test duration') {
                 steps {
                     catchError(stageResult: 'FAILURE') {
-                        timeout(time: 2, unit: 'MINUTES') {
+                        timeout(time: 20, unit: 'MINUTES') {
                             script {
                                 wrap([$class: 'BuildUser']) {
                                     dir('scylla-cluster-tests') {

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -108,7 +108,7 @@ def call(Map params, String region, functional_test = false, Map pipelineParams 
         export SCT_ORACLE_SCYLLA_VERSION="${params.oracle_scylla_version}"
     fi
 
-    if [[ -n "${params.gemini_seed ? params.genini_seed : ''}" ]] ; then
+    if [[ -n "${params.gemini_seed ? params.gemini_seed : ''}" ]] ; then
         export SCT_GEMINI_SEED="${params.gemini_seed}"
     fi
 


### PR DESCRIPTION
To run gemini jobs with specified gemini seed also for reproducing issues longevigyPipeline was updated with new pipeline parameter gemini_seed

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
