### PR TITLE
fix: set permissions to scylla-manager.repo on any distributions

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1696,8 +1696,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
         self.remoter.sudo(f"curl -o {repo_path} -L {scylla_repo}")
 
         # Prevent issue https://github.com/scylladb/scylla/issues/9683
-        if self.distro.is_oel8:
-            self.remoter.sudo(f"chmod 644 {repo_path}")
+        self.remoter.sudo(f"chmod 644 {repo_path}")
 
         if self.distro.is_debian_like:
             self.remoter.sudo("mkdir -p /etc/apt/keyrings")


### PR DESCRIPTION
We are trying to harden our machine image by applying CIS rules, and it's recommended to use strict umask setting (see scylladb/scylla-pkg#2953). However, it causes permission error on scylla-housekeeping again, just like we saw on OEL8 AMI (scylladb/scylladb#9683).

This is because the fix (79868771282b89664b6be64d2070331ada0f2afb) was only limited for OEL8, we should apply it on any distributions since we can set strict umask on any distributions.

Fixes scylladb/scylladb#12610