### PR TITLE
fix(sct.py): make test-name param be optional for create-sct-runner cmd

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1466,7 +1466,7 @@ def create_runner_image(cloud_provider, region, availability_zone):
 @click.option("-i", "--instance-type", required=False, type=str, default="", help="Instance type")
 @click.option("-i", "--root-disk-size-gb", required=False, type=int, default=0, help="Root disk size in Gb")
 @click.option("-t", "--test-id", required=True, type=str, help="Test ID")
-@click.option("-tn", "--test-name", required=True, type=str, help="Test Name")
+@click.option("-tn", "--test-name", required=False, type=str, default="", help="Test Name")
 @click.option("-d", "--duration", required=True, type=int, help="Test duration in MINUTES")
 @click.option("-rm", "--restore-monitor", required=False, type=bool,
               help="Is the runner for restore monitor purpose or not")
@@ -1487,6 +1487,7 @@ def create_runner_instance(cloud_provider, region, availability_zone, instance_t
     sct_config = SCTConfiguration()
     instance_type = instance_type or sct_config.get('instance_type_runner')
     root_disk_size_gb = root_disk_size_gb or sct_config.get('root_disk_size_runner')
+    test_name = test_name or test_id
 
     instance = sct_runner.create_instance(
         instance_type=instance_type,


### PR DESCRIPTION
One of the recent changes (https://github.com/scylladb/scylla-cluster-tests/pull/5721) added new required parameter `test-name` to the `create-sct-runner` command of the `sct.py` module.

It broke backwards compatibility and made the `show-monitor` CI job fail.
So, fix it by making this new parameter be optional because it is not needed in case of the `show-monitor` CI job.

Fixes: https://github.com/scylladb/scylla-cluster-tests/issues/5727

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
