### PR TITLE
fix(chaos-mesh): fix installation for gke

### DIFF
--- a/sdcm/utils/k8s/chaos_mesh.py
+++ b/sdcm/utils/k8s/chaos_mesh.py
@@ -81,7 +81,9 @@ class ChaosMesh:  # pylint: disable=too-few-public-methods
             "get nodes -o jsonpath='{.items[0].status.nodeInfo.containerRuntimeVersion}'").stdout
         runtime_settings = {
             "runtime": "containerd", "socketPath": "/run/containerd/containerd.sock"} if runtime.startswith("containerd") else {}
-        chaos_daemon_settings = scylla_node_pool_affinity | runtime_settings
+        tolerations = {'tolerations': [{'key': 'role', 'operator': 'Equal',
+                                        'value': 'scylla-clusters', 'effect': 'NoSchedule'}]}
+        chaos_daemon_settings = scylla_node_pool_affinity | runtime_settings | tolerations
         self._k8s_cluster.helm_install(
             target_chart_name="chaos-mesh",
             source_chart_name="chaos-mesh/chaos-mesh",


### PR DESCRIPTION
looks chaos-mesh does not work on GKE as
 chaos-daemons are not deployed.

Added `tolerations` settings for chaos-daemons to use scylla

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
