### PR TITLE
fix(k8s): make flush and reshard logic be more stable

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1310,23 +1310,6 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 "Skipped due to the following bug: "
                 "https://github.com/scylladb/scylla-operator/issues/1077")
 
-        def _check_pod_stats(node):
-            # Pod info:
-            # status:
-            #   containerStatuses:
-            #   - ready: false
-            #     restartCount: 0
-            #     started: true
-            #     ...
-            target_pod_stats = {}
-            for container in node._pod_status.container_statuses:  # pylint: disable=protected-access
-                if container.name == "scylla":
-                    target_pod_stats["started"] = container.started
-                    target_pod_stats["restart_count"] = container.restart_count
-                    target_pod_stats["ready"] = container.ready
-                    break
-            return target_pod_stats
-
         # Calculate new value for the CPU cores dedicated for Scylla pods
         current_cpus = convert_cpu_value_from_k8s_to_units(
             self.cluster.k8s_cluster.calculated_cpu_limit)
@@ -1336,33 +1319,16 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             new_cpus = current_cpus - 1
         new_cpus = convert_cpu_units_to_k8s_value(new_cpus)
 
-        # Calculate Scylla pod stats and make sure it is ok
-        origin_target_pod_stats = _check_pod_stats(self.target_node)
-        assert origin_target_pod_stats["started"] in (True, 'True', 'true')
-        assert origin_target_pod_stats["ready"] in (True, 'True', 'true')
-
         # Run 'nodetool flush' command
         self.target_node.run_nodetool("flush -- keyspace1")
 
-        # Change number of CPUs dedicated for Scylla pods
-        # and make sure that the resharding process begins and finishes
-        self._verify_resharding_on_k8s(new_cpus)
-
-        # Make sure that Scylla pods didn't get restarted
-        target_pod_stats = _check_pod_stats(self.target_node)
-
-        # Return the cpu count back and wait for the resharding begin and finish
-        self._verify_resharding_on_k8s(current_cpus)
-
-        # Make sure that pod was not restarted during the first resharding process
-        assert target_pod_stats
-        assert origin_target_pod_stats
-        assert target_pod_stats.get("restart_count") == origin_target_pod_stats.get("restart_count")
-
-        # Make sure that pod was not restarted during the second resharding process
-        final_target_pod_stats = _check_pod_stats(self.target_node)
-        assert final_target_pod_stats
-        assert final_target_pod_stats.get("restart_count") == origin_target_pod_stats.get("restart_count")
+        try:
+            # Change number of CPUs dedicated for Scylla pods
+            # and make sure that the resharding process begins and finishes
+            self._verify_resharding_on_k8s(new_cpus)
+        finally:
+            # Return the cpu count back and wait for the resharding begin and finish
+            self._verify_resharding_on_k8s(current_cpus)
 
     def disrupt_drain_kubernetes_node_then_replace_scylla_node(self):
         self._disrupt_kubernetes_then_replace_scylla_node('drain_k8s_node')


### PR DESCRIPTION
We have `flush and reshard` nemesis and functional K8S test. Both are identical in steps.
One of the steps it so check that all scylla containers didn't have additional restarts and are successful from a first attempt.

It is not correct assumption. We may get 1 or 2 restarts which do not influence a Scylla cluster workability.
From a user point of view he waits about the same time before a new Scylla member becomes up and running.

So, remove redundant logic for checking restart count which will make the logic be more stable.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
