### PR TITLE
improvement(sct_config): Refer to AMI images by name instead of AMI ID

### DIFF
--- a/configurations/perf-loaders-non-shard-aware-config.yaml
+++ b/configurations/perf-loaders-non-shard-aware-config.yaml
@@ -1,16 +1,14 @@
 # manual on creating loader AMI's: see docs/new_loader_ami.md
 # AMIs from branch-perf-v8 with non-shardware driver
 use_prepared_loaders: true
+ami_id_loader: 'scylla-qa-loader-ami-v9'
 regions_data:
     us-east-1:
       security_group_ids: 'sg-c5e1f7a0'
       subnet_id: 'subnet-ec4a72c4'
-      ami_id_loader: 'ami-01784b575d450e3b2' # Loader dedicated AMI v9 with golang 1.13
     eu-west-1:
       security_group_ids: 'sg-059a7f66a947d4b5c'
       subnet_id: 'subnet-088fddaf520e4c7a8'
-      ami_id_loader: 'ami-0396fc0c3458abca9' # Loader dedicated AMI v9 with golang 1.13
     us-west-2:
       security_group_ids: 'sg-81703ae4'
       subnet_id: 'subnet-5207ee37'
-      ami_id_loader: 'ami-0d2703a09ffa20a1e' # Loader dedicated AMI v9 with golang 1.13

--- a/configurations/perf-loaders-shard-aware-config.yaml
+++ b/configurations/perf-loaders-shard-aware-config.yaml
@@ -1,15 +1,3 @@
 # manual on creating loader AMI's: see docs/new_loader_ami.md
 use_prepared_loaders: true
-regions_data:
-  us-east-1: # US East (N. Virginia)
-    ami_id_loader: 'ami-00c1a16b5136fbb7c' # Loader dedicated AMI v19
-  us-west-2: # US West (Oregon)
-    ami_id_loader: 'ami-04d2eb44d523b3ccb' # Loader dedicated AMI v19
-  eu-west-1: # Europe (Ireland)
-    ami_id_loader: 'ami-042cf1bc21e30ce60' # Loader dedicated AMI v19
-  eu-west-2: # Europe (London)
-    ami_id_loader: 'ami-0370fbb289d8310d2' # Loader dedicated AMI v19
-  eu-north-1: # Europe (Stockholm)
-    ami_id_loader: 'ami-0226185e7d7951b6a' # Loader dedicated AMI v19
-  eu-central-1: # Europe (Frankfurt)
-    ami_id_loader: 'ami-0bc7811c417b0eb09' # Loader dedicated AMI v19
+ami_id_loader: 'scylla-qa-loader-ami-v19'

--- a/defaults/aws_config.yaml
+++ b/defaults/aws_config.yaml
@@ -7,25 +7,8 @@ user_credentials_path: '~/.ssh/scylla-qa-ec2'
 instance_type_loader: 'c5.xlarge'
 instance_type_monitor: 't3.large'
 # manual on creating loader AMI's: see docs/new_loader_ami.md
-regions_data:
-  us-east-1: # US East (N. Virginia)
-    ami_id_loader: 'ami-00c1a16b5136fbb7c' # Loader dedicated AMI scylla-qa-loader-ami-v19
-    ami_id_monitor: 'ami-06878d265978313ca' # ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221206 Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2022-12-06
-  us-west-2: # US West (Oregon)
-    ami_id_loader: 'ami-09808043b7fcdb244' # Loader dedicated AMI scylla-qa-loader-ami-v19
-    ami_id_monitor: 'ami-03f8756d29f0b5f21' # ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221206 Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2022-12-06
-  eu-west-1: # EU (Ireland)
-    ami_id_loader: 'ami-042cf1bc21e30ce60' # Loader dedicated AMI scylla-qa-loader-ami-v19
-    ami_id_monitor: 'ami-026e72e4e468afa7b' # ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221206 Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2022-12-06
-  eu-west-2: # Europe (London)
-    ami_id_loader: 'ami-0370fbb289d8310d2' # Loader dedicated AMI scylla-qa-loader-ami-v19
-    ami_id_monitor: 'ami-01b8d743224353ffe' # ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221206 Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2022-12-06
-  eu-north-1: # Europe (Stockholm)
-    ami_id_loader: 'ami-0226185e7d7951b6a' # Loader dedicated AMI scylla-qa-loader-ami-v19
-    ami_id_monitor: 'ami-03df6dea56f8aa618' # ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221206 Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2022-12-06
-  eu-central-1: # EU (Frankfurt)
-    ami_id_loader: 'ami-0bc7811c417b0eb09' # Loader dedicated AMI scylla-qa-loader-ami-v19
-    ami_id_monitor: 'ami-0039da1f3917fa8e3' # ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221206 Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2022-12-06
+ami_id_loader: 'scylla-qa-loader-ami-v19'
+ami_id_monitor: 'ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221206' # ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20221206 Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2022-12-06
 
 availability_zone: 'a'
 root_disk_size_monitor: 50  # GB, remove this field if default disk size should be used

--- a/sct.py
+++ b/sct.py
@@ -108,7 +108,6 @@ SCT_RUNNER_HOST = get_sct_runner_ip()
 
 LOGGER = setup_stdout_logger()
 
-
 click_completion.init()
 
 
@@ -580,10 +579,12 @@ def list_resources(ctx, user, test_id, get_all, get_all_running, verbose):
               help="architecture of the AMI (default: x86_64)")
 def list_images(cloud_provider: str, branch: str, version: str, region: str, arch: AwsArchType):
     add_file_logger()
-    branch_fields = ["Backend", "Name", "ImageId", "CreationDate", "BuildId", "Arch", "ScyllaVersion"]
-    #  TODO: align branch and version fields once scylla-pkg#2995 is resolved
     version_fields = ["Backend", "Name", "ImageId", "CreationDate"]
-
+    version_fields_with_tag_name = version_fields + ["NameTag"]
+    #  TODO: align branch and version fields once scylla-pkg#2995 is resolved
+    branch_specific_fields = ["BuildId", "Arch", "ScyllaVersion"]
+    branch_fields = version_fields + branch_specific_fields
+    branch_fields_with_tag_name = version_fields_with_tag_name + branch_specific_fields
     if version and branch:
         click.echo("Use --version or --branch, not both.")
         return
@@ -595,7 +596,7 @@ def list_images(cloud_provider: str, branch: str, version: str, region: str, arc
             case "aws":
                 rows = get_ami_images_versioned(region_name=region, arch=arch, version=version)
                 click.echo(
-                    create_pretty_table(rows=rows, field_names=version_fields).get_string(
+                    create_pretty_table(rows=rows, field_names=version_fields_with_tag_name).get_string(
                         title=f"AWS Machine Images by Version in region {region}")
                 )
             case "gce":
@@ -620,7 +621,7 @@ def list_images(cloud_provider: str, branch: str, version: str, region: str, arc
                 region = region or "eu-west-1"
                 ami_images = get_ami_images(branch=branch, region=region, arch=arch)
                 click.echo(
-                    create_pretty_table(rows=ami_images, field_names=branch_fields).get_string(
+                    create_pretty_table(rows=ami_images, field_names=branch_fields_with_tag_name).get_string(
                         title=f"AMI Machine Images for {branch} in region {region}"
                     )
                 )

--- a/test-cases/performance/perf-regression-latency-lwt-big.yaml
+++ b/test-cases/performance/perf-regression-latency-lwt-big.yaml
@@ -48,13 +48,7 @@ instance_type_db: 'i3.xlarge'
 
 user_prefix: 'perf-regression-latency-lwt-big'
 ami_id_db_scylla_desc: 'VERSION_DESC'
-regions_data:
-  us-east-1:
-    ami_id_loader: 'ami-0b94f0e897d884b1b'
-  eu-west-1:
-    ami_id_loader: 'ami-0ea704a8c9ec08e57'
-  us-west-2:
-    ami_id_loader: 'ami-063a97bde47353690'
+ami_id_loader: 'scylla-qa-loader-ami-lwt-v5'
 
 append_scylla_args: '--blocked-reactor-notify-ms 400 --memory 4G --experimental 1 --experimental-features=lwt'
 

--- a/test-cases/performance/perf-regression-latency-lwt-small.yaml
+++ b/test-cases/performance/perf-regression-latency-lwt-small.yaml
@@ -49,13 +49,7 @@ instance_type_db: 'i3.xlarge'
 
 user_prefix: 'perf-regression-latency-lwt-small'
 ami_id_db_scylla_desc: 'VERSION_DESC'
-regions_data:
-  us-east-1:
-    ami_id_loader: 'ami-0b94f0e897d884b1b'
-  eu-west-1:
-    ami_id_loader: 'ami-0ea704a8c9ec08e57'
-  us-west-2:
-    ami_id_loader: 'ami-063a97bde47353690'
+ami_id_loader: 'scylla-qa-loader-ami-lwt-v5'
 
 append_scylla_args: '--blocked-reactor-notify-ms 400 --memory 4G --experimental 1 --experimental-features=lwt'
 

--- a/test-cases/performance/perf-regression-throughput-lwt-big.yaml
+++ b/test-cases/performance/perf-regression-throughput-lwt-big.yaml
@@ -51,13 +51,7 @@ instance_type_db: 'i3.xlarge'
 
 user_prefix: 'perf-regression-throughput-lwt-big'
 ami_id_db_scylla_desc: 'VERSION_DESC'
-regions_data:
-  us-east-1:
-    ami_id_loader: 'ami-0b94f0e897d884b1b'
-  eu-west-1:
-    ami_id_loader: 'ami-0ea704a8c9ec08e57'
-  us-west-2:
-    ami_id_loader: 'ami-063a97bde47353690'
+ami_id_loader: 'scylla-qa-loader-ami-lwt-v5'
 
 append_scylla_args: '--blocked-reactor-notify-ms 1000 --memory 4G --experimental 1 --experimental-features=lwt'
 

--- a/test-cases/performance/perf-regression-throughput-lwt-small.yaml
+++ b/test-cases/performance/perf-regression-throughput-lwt-small.yaml
@@ -50,13 +50,7 @@ instance_type_db: 'i3.xlarge'
 
 user_prefix: 'perf-regression-throughput-lwt-small'
 ami_id_db_scylla_desc: 'VERSION_DESC'
-regions_data:
-  us-east-1:
-    ami_id_loader: 'ami-0b94f0e897d884b1b'
-  eu-west-1:
-    ami_id_loader: 'ami-0ea704a8c9ec08e57'
-  us-west-2:
-    ami_id_loader: 'ami-063a97bde47353690'
+ami_id_loader: 'scylla-qa-loader-ami-lwt-v5'
 
 append_scylla_args: '--blocked-reactor-notify-ms 1000 --memory 4G --experimental 1 --experimental-features=lwt'
 

--- a/test-cases/performance/perf-search-best-throughput-config.yaml
+++ b/test-cases/performance/perf-search-best-throughput-config.yaml
@@ -30,18 +30,5 @@ send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com']
 
 store_perf_results: false
-
 # tests are running on aws. The loader uses the shard-aware driver
-regions_data:
-  us-east-1: # US East (N. Virginia)
-    ami_id_loader: 'ami-00c1a16b5136fbb7c' # Loader dedicated AMI v19
-  us-west-2: # US West (Oregon)
-    ami_id_loader: 'ami-04d2eb44d523b3ccb' # Loader dedicated AMI v19
-  eu-west-1: # Europe (Ireland)
-    ami_id_loader: 'ami-042cf1bc21e30ce60' # Loader dedicated AMI v19
-  eu-west-2: # Europe (London)
-    ami_id_loader: 'ami-0370fbb289d8310d2' # Loader dedicated AMI v19
-  eu-north-1: # Europe (Stockholm)
-    ami_id_loader: 'ami-0226185e7d7951b6a' # Loader dedicated AMI v19
-  eu-central-1: # Europe (Frankfurt)
-    ami_id_loader: 'ami-0bc7811c417b0eb09' # Loader dedicated AMI v19
+ami_id_loader: 'scylla-qa-loader-ami-v19'


### PR DESCRIPTION
task: https://github.com/scylladb/qa-tasks/issues/268

added functionality to automaticaly convert image name  to ami_ids per region
added unit tests or converting logic
remove unused logic "assume multi dc by n_db_nodes set size" becuse when run it, "_check_multi_region_params" is fail

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
