### PR TITLE
ci(k8s): use K8sSetMonkey nemesis for 2clients setup

### DIFF
--- a/test-cases/scylla-operator/longevity-scylla-operator-3h-multitenant.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-3h-multitenant.yaml
@@ -26,12 +26,17 @@ k8s_n_loader_pods_per_cluster: 2
 
 k8s_n_auxiliary_nodes: 3
 
-nemesis_class_name: ['FreeTierSetMonkey', 'FreeTierSetMonkey']
+nemesis_class_name: ['FreeTierSetMonkey', 'K8sSetMonkey']
 nemesis_interval: [5, 6]
 nemesis_seed: ['385', '543']
 space_node_threshold: [64424, 64423]
 
 user_prefix: 'longevity-scylla-operator-3h-multitenant'
-cluster_health_check: true
+
+# NOTE: enable 'cluster_health_check' back only when SCT becomes smart enough
+#       to detect multiple pod disruptions in multi-tenant setups
+#       using exclusive nemesis disruptions.
+#       See: https://github.com/scylladb/scylla-cluster-tests/issues/5745
+cluster_health_check: false
 
 k8s_enable_tls: true


### PR DESCRIPTION
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
