### PR TITLE
fix(hydra): fix tab completion

### DIFF
--- a/docker/env/version
+++ b/docker/env/version
@@ -1,1 +1,1 @@
-1.34-deepdiff
+1.35-fix_completion

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 PyYAML==5.4.1
-paramiko==2.10.1
-fabric==2.6.0
-invoke==1.6.0
+paramiko==3.0.0
+fabric==3.0.0
+invoke==2.0.0
 boto3==1.26.49
 boto3-stubs[s3,ec2,dynamodb,pricing]==1.26.49
 awscli==1.27.49
@@ -15,8 +15,7 @@ jinja2==3.0.2
 prometheus_client==0.11.0
 pre-commit==2.15.0
 anyconfig==0.12.0
-click==8.0.1
-click-completion==0.5.2
+click==8.1.3
 PTable==0.9.2
 pycryptodome==3.10.4
 pyzmq==22.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -123,9 +123,9 @@ botocore==1.29.49 \
     #   awscli
     #   boto3
     #   s3transfer
-botocore-stubs==1.29.60 \
-    --hash=sha256:a513557870bda27ba8a55714ae5d1ee6f3a25d85e36ea398cd96a0f635f38f31 \
-    --hash=sha256:ff61c1be334aeb6f20beb2d96ad6fab6c4401a9bf64a8a1adf965e37dd32d97b
+botocore-stubs==1.29.61 \
+    --hash=sha256:77f9138963ead27768527b23d4efe881845869367b76de7404f2971d82373509 \
+    --hash=sha256:80c1d4cf67feda2e44e0b778366300bae960adcab106ae3a078303cecec4aa53
     # via boto3-stubs
 cachetools==5.3.0 \
     --hash=sha256:13dfddc7b8df938c21a940dfa6557ce6e94a2f1cdfa58eb90c805721d58f2c14 \
@@ -219,17 +219,13 @@ charset-normalizer==2.1.1 \
     --hash=sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845 \
     --hash=sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f
     # via requests
-click==8.0.1 \
-    --hash=sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a \
-    --hash=sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6
+click==8.1.3 \
+    --hash=sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e \
+    --hash=sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48
     # via
     #   -r ../../requirements.in
-    #   click-completion
     #   geomet
     #   pip-tools
-click-completion==0.5.2 \
-    --hash=sha256:5bf816b81367e638a190b6e91b50779007d14301b3f9f3145d68e3cade7bce86
-    # via -r ../../requirements.in
 colorama==0.4.4 \
     --hash=sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b \
     --hash=sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2
@@ -292,9 +288,9 @@ elasticsearch==7.15.0 \
     --hash=sha256:6c47eb68f643f3d7d6a6d971e571448b900b9470dc481421c9af9d28a1303911 \
     --hash=sha256:bf1d210d82c78fbd3ae5cbedd756716d732433cc97184966688dcd1c75df4619
     # via -r ../../requirements.in
-fabric==2.6.0 \
-    --hash=sha256:47f184b070272796fd2f9f0436799e18f2ccba4ee8ee587796fca192acd46cd2 \
-    --hash=sha256:7a71714b8b8f28cf828eceb155196f43ebac1bd4c849b7161ed5993d1cbcaa40
+fabric==3.0.0 \
+    --hash=sha256:2a05508854ddef5a020a0be9aa7787e5397b528deb5936bbd2493c0b8eaaefa3 \
+    --hash=sha256:bfe960c1ae904e7624af9d40ad5b9b99581ed9c4fd09349c0d02b7486e1d0f89
     # via -r ../../requirements.in
 filelock==3.9.0 \
     --hash=sha256:7b319f24340b51f55a2bf7a12ac0755a9b03e718311dac567a0f4f7fabd2f5de \
@@ -504,10 +500,9 @@ iniconfig==2.0.0 \
     --hash=sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3 \
     --hash=sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374
     # via pytest
-invoke==1.6.0 \
-    --hash=sha256:374d1e2ecf78981da94bfaf95366216aaec27c2d6a7b7d5818d92da55aa258d3 \
-    --hash=sha256:769e90caeb1bd07d484821732f931f1ad8916a38e3f3e618644687fc09cb6317 \
-    --hash=sha256:e6c9917a1e3e73e7ea91fdf82d5f151ccfe85bf30cc65cdb892444c02dbb5f74
+invoke==2.0.0 \
+    --hash=sha256:7ab5dd9cd76b787d560a78b1a9810d252367ab595985c50612702be21d671dd7 \
+    --hash=sha256:a860582bcf7a4b336fe18ef53937f0f28cec1c0053ffa767c2fcf7ba0b850f59
     # via
     #   -r ../../requirements.in
     #   fabric
@@ -522,9 +517,7 @@ isort==5.12.0 \
 jinja2==3.0.2 \
     --hash=sha256:827a0e32839ab1600d4eb1c4c33ec5a8edfbc5cb42dafa13b81f182f97784b45 \
     --hash=sha256:8569982d3f0889eed11dd620c706d39b60c36d6d25843961f33f77fb6bc6b20c
-    # via
-    #   -r ../../requirements.in
-    #   click-completion
+    # via -r ../../requirements.in
 jmespath==1.0.1 \
     --hash=sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980 \
     --hash=sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe
@@ -646,9 +639,9 @@ mccabe==0.6.1 \
     --hash=sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42 \
     --hash=sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f
     # via pylint
-msal==1.20.0 \
-    --hash=sha256:78344cd4c91d6134a593b5e3e45541e666e37b747ff8a6316c3668dd1e6ab6b2 \
-    --hash=sha256:d2f1c26368ecdc28c8657d457352faa0b81b1845a7b889d8676787721ba86792
+msal==1.21.0 \
+    --hash=sha256:96b5c867830fd116e5f7d0ec8ef1b238b4cda4d1aea86d8fecf518260e136fbf \
+    --hash=sha256:e8444617c1eccdff7bb73f5d4f94036002accea4a2c05f8f39c9efb5bd2b0c6a
     # via
     #   azure-identity
     #   msal-extensions
@@ -677,9 +670,9 @@ mypy-boto3-dynamodb==1.26.24 \
     --hash=sha256:41fc3303eb9b7153e2726f948a952cf7a1344cad5e44e0c225e3c6c3decfe2a6 \
     --hash=sha256:94d059f692189fa3f1315df4e16f02b94018b09b61e3a54bd56c9715f5bfe418
     # via boto3-stubs
-mypy-boto3-ec2==1.26.60 \
-    --hash=sha256:53639912fd184870362d2f5b34725ae988329a5d0ebf37c1b39af791e0a18898 \
-    --hash=sha256:824949590dde4f3b33d11d611dc468f783e801644d0daea34bef6d9d59f95934
+mypy-boto3-ec2==1.26.61 \
+    --hash=sha256:1ae59f6d7c53055fa2e5367a13c80f8c3d9e4f9545abc1400f3ae0a7ad9657f0 \
+    --hash=sha256:33571399983d9174cc1a6466dd9c4399d2414f302cbe847eee4fa404bc1ee153
     # via boto3-stubs
 mypy-boto3-pricing==1.26.0.post1 \
     --hash=sha256:58ced4de43c5e74ff16fdc5bde751c53175fe234ee9382e896d9e7cc97169663 \
@@ -777,9 +770,9 @@ parameterized==0.8.1 \
     --hash=sha256:41bbff37d6186430f77f900d777e5bb6a24928a1c46fb1de692f8b52b8833b5c \
     --hash=sha256:9cbb0b69a03e8695d68b3399a8a5825200976536fe1cb79db60ed6a4c8c9efe9
     # via -r ../../requirements.in
-paramiko==2.10.1 \
-    --hash=sha256:443f4da23ec24e9a9c0ea54017829c282abdda1d57110bf229360775ccd27a31 \
-    --hash=sha256:f6cbd3e1204abfdbcd40b3ecbc9d32f04027cd3080fe666245e21e7540ccfc1b
+paramiko==3.0.0 \
+    --hash=sha256:6bef55b882c9d130f8015b9a26f4bd93f710e90fe7478b9dcc810304e79b3cd8 \
+    --hash=sha256:fedc9b1dd43bc1d45f67f1ceca10bc336605427a46dcdf8dec6bfea3edf57965
     # via
     #   -r ../../requirements.in
     #   fabric
@@ -791,10 +784,6 @@ path-py==12.5.0 \
     --hash=sha256:8d885e8b2497aed005703d94e0fd97943401f035e42a136810308bff034529a8 \
     --hash=sha256:a43e82eb2c344c3fd0b9d6352f6b856f40b8b7d3d65cc05978b42c3715668496
     # via tcconfig
-pathlib2==2.3.7.post1 \
-    --hash=sha256:5266a0fd000452f1b3467d782f079a4343c63aaa119221fbdc4e39577489ca5b \
-    --hash=sha256:9fe0edad898b83c0c3e199c842b27ed216645d2e177757b2dd67384d4113c641
-    # via fabric
 pathvalidate==2.5.2 \
     --hash=sha256:5ff57d0fabe5ecb7a4f1e4957bfeb5ad8ab5ab4c0fa71f79c6bbc24bd9b7d14d \
     --hash=sha256:e39a4dfacdba70e3a96d3e4c6ff617a39e991cf242e6e1f2017f1f67c3408d33
@@ -1181,10 +1170,6 @@ selenium==3.141.0 \
     --hash=sha256:2d7131d7bc5a5b99a2d9b04aaf2612c411b03b8ca1b1ee8d3de5845a9be2cb3c \
     --hash=sha256:deaf32b60ad91a4611b98d8002757f29e6f2c2d5fcaf202e1c9ad06d6772300d
     # via -r ../../requirements.in
-shellingham==1.5.0.post1 \
-    --hash=sha256:368bf8c00754fd4f55afb7bbb86e272df77e4dc76ac29dbcbb81a59e9fc15744 \
-    --hash=sha256:823bc5fb5c34d60f285b624e7264f4dda254bc803a3774a147bf99c0e3004a28
-    # via click-completion
 simplesqlite==1.3.0 \
     --hash=sha256:6fdfecbc0c6e34a2dc08ae8ba484a7f2b2495597c28114e0c7f0612e8de4555d \
     --hash=sha256:f7e862bec5982059e665cc73b6fdb4c8340a1f565ba3497387c3c48f10d43bf8
@@ -1195,15 +1180,12 @@ six==1.16.0 \
     # via
     #   azure-core
     #   azure-identity
-    #   click-completion
     #   docker
     #   geomet
     #   google-auth
     #   google-auth-httplib2
     #   isodate
     #   kubernetes
-    #   paramiko
-    #   pathlib2
     #   python-dateutil
     #   python-jenkins
     #   repodataparser

--- a/sct.py
+++ b/sct.py
@@ -33,7 +33,6 @@ from uuid import UUID
 
 import pytest
 import click
-import click_completion
 import yaml
 from prettytable import PrettyTable
 
@@ -108,8 +107,6 @@ SCT_RUNNER_HOST = get_sct_runner_ip()
 
 LOGGER = setup_stdout_logger()
 
-click_completion.init()
-
 
 def sct_option(name, sct_name, **kwargs):
     sct_opt = SCTConfiguration.get_config_option(sct_name)
@@ -121,7 +118,8 @@ def sct_option(name, sct_name, **kwargs):
 def install_callback(ctx, _, value):
     if not value or ctx.resilient_parsing:
         return value
-    shell, path = click_completion.core.install()
+    shell, path = "bash", Path.home() / '.bash_completion'
+    path.write_text((Path(__file__).parent / 'utils' / '.bash_completion').read_text())
     click.echo('%s completion installed in %s' % (shell, path))
     return sys.exit(0)
 
@@ -1603,4 +1601,4 @@ cli.add_command(sct_ssh.attach_test_sg_cmd)
 cli.add_command(sct_ssh.ssh_cmd)
 
 if __name__ == '__main__':
-    cli()
+    cli.main(prog_name="hydra")

--- a/utils/.bash_completion
+++ b/utils/.bash_completion
@@ -1,0 +1,34 @@
+_hydra_completion() {
+    local IFS=$'\n'
+    local response
+
+    response=$(env COMP_WORDS="${COMP_WORDS[*]}" COMP_CWORD=$COMP_CWORD _HYDRA_COMPLETE=bash_complete $1)
+
+    for completion in $response; do
+        IFS=',' read type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            COMPREPLY+=($value)
+        fi
+    done
+
+    return 0
+}
+
+_hydra_completion_setup() {
+    complete -o nosort -F _hydra_completion hydra
+
+}
+_hydra_completion_setup;
+
+_sct_completion_setup() {
+    complete -o nosort -F _hydra_completion ./sct.py
+
+}
+_sct_completion_setup;


### PR DESCRIPTION
for some time the tab completion we were using wasn't working removed the package that we were using, and switch to using click core tab completion support.

also upgrade fabric/paramiko to get rid of the annying warning, which was part of the breakage of completion as well:
```
CryptographyDeprecationWarning: Blowfish has been deprecated
```

currently we only support bash (even that click supports also zsh and fish, and one can manual setup them if needed)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
