### PR TITLE
New performance index

### DIFF
--- a/configurations/es_mapping/performance_index_mapping.json
+++ b/configurations/es_mapping/performance_index_mapping.json
@@ -1,0 +1,25 @@
+{
+		"properties": {
+				"test_details": {
+					"properties": {
+						"start_time": {
+							"type": "date",
+							"format": "yyyy-MM-dd HH:mm:ss||yyyy/MM/dd HH:mm:ss||epoch_millis||epoch_second||strict_date_optional_time"
+						}
+					}
+				},
+				"versions": {
+					"properties": {
+						"scylla-server":{
+							"properties": {
+								"date": {
+									"type": "date",
+									"format": "yyyyMMdd||yyyy-MM-dd HH:mm:ss||yyyy/MM/dd HH:mm:ss||epoch_millis||epoch_second||strict_date_optional_time"
+								}
+							}
+						}
+					}
+				}
+		}
+
+}

--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -217,3 +217,5 @@ service_level_shares: [1000]
 use_hdr_cs_histogram: false
 
 stop_on_hw_perf_failure: false
+
+custom_es_index: ''

--- a/docs/hydra-create-es-index.md
+++ b/docs/hydra-create-es-index.md
@@ -1,0 +1,36 @@
+# Create ES index
+
+ES index stores all documents. ES document could have fields with different data type. The mapping of document properties and field types described in es mapping settings. ES could detect the field type dynamically and generate mapping when first document is written to ES index. After mapping is added to index, it could be changed.
+
+Detected type for document properties is not always correct.
+
+Example, Performance tests use test_details.start_time field to store date when test was start executed. But data type was set in mapping as str/long for different indexes. This doesn't allow to build Kibana dashboards based on start_time.
+
+To avoid this issues, ES Index could be create with specified mappings schema before any document added to the index. Any addition settings and formants could be configured for certain field in future documents.
+
+Sct creates ES Index using the Class name of maing test,
+
+```python
+class PerformanceTest(ClusterTester):
+	pass
+
+class LongevityTest(ClusterTester):
+	pass
+```
+
+Once test is configured to store results and is run, SCT create new index, if it is not yet exists, with name `performancetest` or `longevitytest`, but field mapping will be done dynamically and by fields of first inserted document.
+
+To be sure that certain document property has required data type, index could be created with mapping settings provided in file with new sct commands
+
+# SCT commands
+
+1. Create file with mappings with any editor you prefer.
+2. Run sct to create new index in ES:
+```bash
+# hydra create-es-index --name <index_name> --doc-type <doc_type_in_index> --filepath <full_path_to_file_with_mapping>
+hydra create-es-index --name newtestindex --doc-type test_stats --filepath "configration/es_mappings/newmapping.json"
+
+```
+3. sct test automatically will write new document to new index if its class name will `NewTestIndex
+-or-
+4. you can use ES client to write document to index `newtestindex`

--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -50,6 +50,9 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
     @teardown_on_exception
     @log_run_info
     def setUp(self):
+        if es_index := self.params.get("custom_es_index"):
+            self._test_index = es_index
+
         super().setUp()
         if self.params.get("run_db_node_benchmarks"):
             self.log.info("Validate node benchmarks results")

--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -719,6 +719,16 @@ class TestStatsMixin(Stats):
         self._stats['results'].update(prometheus_stats)
         return prometheus_stats
 
+    def update_hdrhistograms(self, histogram_name, histogram_data):
+        if "histograms" not in self._stats['results']:
+            self._stats['results']['histograms'] = {}
+        if histogram_name not in self._stats['results']['histograms']:
+            self._stats['results']['histograms'][histogram_name] = [histogram_data]
+        else:
+            self._stats['results']['histograms'][histogram_name].extend(histogram_data)
+
+        self.update(dict(results=self._stats['results']))
+
     def update_stress_results(self, results, calculate_stats=True):
         if 'stats' not in self._stats['results']:
             self._stats['results']['stats'] = results

--- a/sdcm/db_stats.py
+++ b/sdcm/db_stats.py
@@ -619,7 +619,7 @@ class TestStatsMixin(Stats):
         test_details['job_url'] = get_job_url()
         test_details['start_host'] = platform.node()
         test_details['test_duration'] = self.params.get(key='test_duration')
-        test_details['start_time'] = time.time()
+        test_details['start_time'] = int(time.time())
         test_details['grafana_snapshots'] = []
         test_details['grafana_screenshots'] = []
         test_details['grafana_annotations'] = []

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1440,6 +1440,8 @@ class SCTConfiguration(dict):
                        after hw perf tests detect node with hw results not in margin with average
                     If stop_on_hw_perf_failure is False, then sct performance test will be run
                        even after hw perf tests detect node with hw results not in margin with average"""),
+        dict(name="custom_es_index", env="SCT_CUSTOM_ES_INDEX", type=str,
+             help="""Use custom ES index for storing test results"""),
 
     ]
 

--- a/sdcm/utils/es_index.py
+++ b/sdcm/utils/es_index.py
@@ -1,0 +1,29 @@
+import logging
+import json
+import sys
+import os
+
+from typing import Any
+from pathlib import Path
+
+from sdcm.es import ES
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def create_index(index_name: str, mappings: dict, **kwargs):
+    if not mappings:
+        raise Exception(f"Mappings configuration is empty {mappings}")
+    es_client = ES()
+    doc_type = kwargs.get("doc_type")
+    es_client.indices.create(index=index_name)
+    es_client.indices.put_mapping(index=index_name, doc_type=doc_type, body=mappings,  # pylint: disable=unexpected-keyword-arg
+                                  include_type_name=True)
+
+
+def get_mapping(mapping_filepath: str) -> Any:
+    file_content = Path(mapping_filepath).read_text(encoding="utf-8")
+    mapping = json.loads(file_content)
+    return mapping

--- a/test-cases/performance/perf-regression-latency-125gb.yaml
+++ b/test-cases/performance/perf-regression-latency-125gb.yaml
@@ -31,5 +31,4 @@ store_perf_results: true
 send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com']
 custom_es_index: 'performancestatsv2'
-
 use_hdr_cs_histogram: true

--- a/test-cases/performance/perf-regression-latency-125gb.yaml
+++ b/test-cases/performance/perf-regression-latency-125gb.yaml
@@ -30,3 +30,6 @@ use_mgmt: true
 store_perf_results: true
 send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com']
+custom_es_index: 'performancestatsv2'
+
+use_hdr_cs_histogram: true

--- a/test-cases/performance/perf-regression-latency-1TB.yaml
+++ b/test-cases/performance/perf-regression-latency-1TB.yaml
@@ -29,3 +29,4 @@ email_recipients: ['scylla-perf-results@scylladb.com']
 backtrace_decoding: false
 print_kernel_callstack: true
 custom_es_index: 'performancestatsv2'
+use_hdr_cs_histogram: true

--- a/test-cases/performance/perf-regression-latency-1TB.yaml
+++ b/test-cases/performance/perf-regression-latency-1TB.yaml
@@ -28,3 +28,4 @@ send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com']
 backtrace_decoding: false
 print_kernel_callstack: true
+custom_es_index: 'performancestatsv2'

--- a/test-cases/performance/perf-regression-throughput-125gb.yaml
+++ b/test-cases/performance/perf-regression-throughput-125gb.yaml
@@ -35,3 +35,5 @@ email_recipients: ['scylla-perf-results@scylladb.com']
 
 email_subject_postfix: 'disk and cache'
 custom_es_index: 'performancestatsv2'
+
+use_hdr_cs_histogram: true

--- a/test-cases/performance/perf-regression-throughput-125gb.yaml
+++ b/test-cases/performance/perf-regression-throughput-125gb.yaml
@@ -34,3 +34,4 @@ send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com']
 
 email_subject_postfix: 'disk and cache'
+custom_es_index: 'performancestatsv2'

--- a/test-cases/performance/perf-regression.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys.yaml
@@ -28,3 +28,4 @@ send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com']
 
 custom_es_index: 'performancestatsv2'
+use_hdr_cs_histogram: true

--- a/test-cases/performance/perf-regression.100threads.30M-keys.yaml
+++ b/test-cases/performance/perf-regression.100threads.30M-keys.yaml
@@ -26,3 +26,5 @@ store_perf_results: true
 use_mgmt: false
 send_email: true
 email_recipients: ['scylla-perf-results@scylladb.com']
+
+custom_es_index: 'performancestatsv2'


### PR DESCRIPTION
Performance tests require new branch based on latest master. such branch should become branch-perf-v14
For that there is a decision to create new index for performance which will store new results including the hdr histograms data 
and new performance results for latest version.

for that new index will be created using  new sct subcommand create-es-index which allow to set up appropriate mappings for field. "test_details.start_time" will now have date type and will allow to build valid dashboards in kibana

Also hdr histogram data will be stored in es documents.
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
