### PR TITLE
fix(nodetool_status): assert rack is specified

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -4057,6 +4057,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
                             node_ip = node.ip_address
                 node_info["load"] = node_info["load"].replace(" ", "")
                 status[dc_name][node_ip] = node_info
+                assert node_info["rack"], "Rack is not defined for node {}".format(node_info)
         return status
 
     @staticmethod

--- a/unit_tests/test_cluster.py
+++ b/unit_tests/test_cluster.py
@@ -501,28 +501,9 @@ class TestNodetoolStatus(unittest.TestCase):
         node = NodetoolDummyNode(resp=resp)
         db_cluster = DummyScyllaCluster([node])
 
-        status = db_cluster.get_nodetool_status()
-
-        assert status == {'eastus': {'10.0.0.4': {'host_id': 'ed6af9a0-8c22-4813-ac9b-6fbeb462b687',
-                                                  'load': '431KB',
-                                                  'owns': '?',
-                                                  'rack': '',
-                                                  'state': 'UN',
-                                                  'tokens': '256'},
-                                     '10.0.0.5': {'host_id': 'caa15869-cfb4-4229-85d7-0f4832986237',
-                                                  'load': '612KB',
-                                                  'owns': '?',
-                                                  'rack': '1',
-                                                  'state': 'UN',
-                                                  'tokens': '256'},
-                                     '10.0.0.6': {'host_id': '3046ded9-ce17-4a3a-ac44-a3ada6916972',
-                                                  'load': '806KB',
-                                                  'owns': '?',
-                                                  'rack': '',
-                                                  'state': 'UN',
-                                                  'tokens': '256'}
-                                     }
-                          }
+        with pytest.raises(AssertionError) as excinfo:
+            db_cluster.get_nodetool_status()
+            assert "Rack is not defined" in str(excinfo.value)
 
 
 @pytest.mark.parametrize("grep_results,expected_core_number", (


### PR DESCRIPTION
In case rack is not specified, drivers cannot work properly and show warnings. In azure when we don't specify availability zone, then it's not provided by metadata api. Recently support was provided to return region (location) as rack when AZ is not specified.

This fix forces `get_nodetool_status` to guard rack is always provided by `nodetool status` revealing issue of not specified rack.
refs: https://github.com/scylladb/scylladb/issues/12185

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
