### PR TITLE
fix(azure): switch instance types

### DIFF
--- a/configurations/azure/azure_rolling_upgrade.yaml
+++ b/configurations/azure/azure_rolling_upgrade.yaml
@@ -1,5 +1,5 @@
 azure_region_name: 'eastus'
-azure_instance_type_db: 'Standard_L8s_v2'
+azure_instance_type_db: 'Standard_L8s_v3'
 azure_image_db: ''
 workaround_kernel_bug_for_iotune: false
 internode_compression: 'all'

--- a/defaults/azure_config.yaml
+++ b/defaults/azure_config.yaml
@@ -1,14 +1,14 @@
 # TODO: Go over it and fix detauls
 instance_provision: 'spot'
 spot_max_price: 0.60
-instance_provision_fallback_on_demand: false
+instance_provision_fallback_on_demand: true
 azure_region_name:
   - eastus
 user_credentials_path: '~/.ssh/scylla-qa-ec2'
 
-azure_instance_type_db: 'Standard_L8s_v2'
+azure_instance_type_db: 'Standard_L8s_v3'
 azure_instance_type_loader: 'Standard_F4s_v2'
-azure_instance_type_monitor: 'Standard_D2_v5'
+azure_instance_type_monitor: 'Standard_D2_v4'
 # get images urn's by running: `az vm image list --output table --all --offer CentOS --publisher OpenLogic`
 azure_image_loader: 'Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202208100'
 azure_image_monitor: 'Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202208100'

--- a/sdcm/cluster_azure.py
+++ b/sdcm/cluster_azure.py
@@ -156,7 +156,7 @@ class AzureNode(cluster.BaseNode):
 class AzureCluster(cluster.BaseCluster):   # pylint: disable=too-many-instance-attributes
     def __init__(self, image_id, root_disk_size,  # pylint: disable=too-many-arguments, too-many-locals
                  provisioners: List[AzureProvisioner], credentials,
-                 cluster_uuid=None, instance_type='Standard_L8s_v2', region_names=None,
+                 cluster_uuid=None, instance_type='Standard_L8s_v3', region_names=None,
                  user_name='root', cluster_prefix='cluster',
                  node_prefix='node', n_nodes=3, params=None, node_type=None):
         self.provisioners: List[AzureProvisioner] = provisioners
@@ -239,7 +239,7 @@ class ScyllaAzureCluster(cluster.BaseScyllaCluster, AzureCluster):
 
     def __init__(self, image_id, root_disk_size,  # pylint: disable=too-many-arguments
                  provisioners: List[AzureProvisioner], credentials,
-                 instance_type='Standard_L8s_v2',
+                 instance_type='Standard_L8s_v3',
                  user_name='ubuntu',
                  user_prefix=None, n_nodes=3, params=None, region_names=None):
         # pylint: disable=too-many-locals

--- a/test-cases/artifacts/azure-image.yaml
+++ b/test-cases/artifacts/azure-image.yaml
@@ -3,7 +3,7 @@ azure_region_name: "eastus"
 use_preinstalled_scylla: true
 backtrace_decoding: false
 azure_image_db: ''
-azure_instance_type_db: 'Standard_L8s_v2'
+azure_instance_type_db: 'Standard_L8s_v3'
 #azure_root_disk_type_db: 'pd-ssd'  # todo: need more research if needed
 #root_disk_size_db: 50
 #azure_n_local_ssd_disk_db: 1

--- a/unit_tests/provisioner/azure_default_config.yaml
+++ b/unit_tests/provisioner/azure_default_config.yaml
@@ -3,9 +3,9 @@ user_prefix: unit-test
 instance_provision: 'spot'
 instance_provision_fallback_on_demand: false
 
-azure_instance_type_db: 'Standard_L8s_v2'
+azure_instance_type_db: 'Standard_L8s_v3'
 azure_instance_type_loader: 'Standard_F4s_v2'
-azure_instance_type_monitor: 'Standard_D2_v5'
+azure_instance_type_monitor: 'Standard_D2_v4'
 # get images urn's by running: `az vm image list --output table --all --offer CentOS --publisher OpenLogic`
 azure_image_loader: 'OpenLogic:CentOS:7_9:latest'
 azure_image_monitor: 'OpenLogic:CentOS:7_9:latest'

--- a/unit_tests/provisioner/test_azure_region_definition_builder.py
+++ b/unit_tests/provisioner/test_azure_region_definition_builder.py
@@ -51,7 +51,7 @@ def test_can_create_basic_scylla_instance_definition_from_sct_config():
     region_definitions = builder.build_all_region_definitions()
 
     instance_definition = InstanceDefinition(name=f"{prefix}-db-node-eastus-1", image_id=env_config.SCT_AZURE_IMAGE_DB,
-                                             type="Standard_L8s_v2", user_name="scyllaadm", root_disk_size=30,
+                                             type="Standard_L8s_v3", user_name="scyllaadm", root_disk_size=30,
                                              tags=tags | {"NodeType": "scylla-db", "keep_action": "", 'NodeIndex': '1'},
                                              ssh_key=ssh_key)
     assert len(region_definitions) == 2


### PR DESCRIPTION
Due available quotas we switch instance types for Azure tests.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
