### PR TITLE
refactor(manager): Changed the triggers to match the new folder order

### DIFF
--- a/jenkins-pipelines/manager/centos-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/centos-manager-sanity.jenkinsfile
@@ -14,5 +14,5 @@ managerPipeline(
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
 
-    downstream_jobs_to_run: 'centos-upgrade-test, centos-sanity-ipv6-test, sct-feature-test-backup, sct-feature-test-backup-azure, sct-feature-test-backup-gce'
+    downstream_jobs_to_run: '../upgrade-tests/centos-upgrade-test, centos-sanity-ipv6-test, ../feature-tests/sct-feature-test-backup, ../feature-tests/sct-feature-test-backup-azure, ../feature-tests/sct-feature-test-backup-gce'
 )

--- a/jenkins-pipelines/manager/debian10-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/debian10-manager-sanity.jenkinsfile
@@ -13,5 +13,5 @@ managerPipeline(
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
 
-    downstream_jobs_to_run: 'debian10-upgrade-test'
+    downstream_jobs_to_run: '../upgrade-tests/debian10-upgrade-test'
 )

--- a/jenkins-pipelines/manager/debian11-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/debian11-manager-sanity.jenkinsfile
@@ -13,5 +13,5 @@ managerPipeline(
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
 
-    downstream_jobs_to_run: 'debian11-upgrade-test'
+    downstream_jobs_to_run: '../upgrade-tests/debian11-upgrade-test'
 )

--- a/jenkins-pipelines/manager/enterprise-ami-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/enterprise-ami-manager-sanity.jenkinsfile
@@ -16,5 +16,5 @@ managerPipeline(
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
 
-    downstream_jobs_to_run: 'enterprise-ami-upgrade-test'
+    downstream_jobs_to_run: '../upgrade-tests/enterprise-ami-upgrade-test'
 )

--- a/jenkins-pipelines/manager/ubuntu18-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu18-manager-sanity.jenkinsfile
@@ -13,5 +13,5 @@ managerPipeline(
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
 
-    downstream_jobs_to_run: 'ubuntu18-upgrade-test'
+    downstream_jobs_to_run: '../upgrade-tests/ubuntu18-upgrade-test'
 )

--- a/jenkins-pipelines/manager/ubuntu20-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu20-manager-sanity.jenkinsfile
@@ -13,5 +13,5 @@ managerPipeline(
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
 
-    downstream_jobs_to_run: 'ubuntu20-upgrade-test'
+    downstream_jobs_to_run: '../upgrade-tests/ubuntu20-upgrade-test'
 )

--- a/jenkins-pipelines/manager/ubuntu22-manager-sanity.jenkinsfile
+++ b/jenkins-pipelines/manager/ubuntu22-manager-sanity.jenkinsfile
@@ -13,5 +13,5 @@ managerPipeline(
     post_behavior_loader_nodes: 'destroy',
     post_behavior_monitor_nodes: 'destroy',
 
-    downstream_jobs_to_run: 'ubuntu22-upgrade-test'
+    downstream_jobs_to_run: '../upgrade-tests/ubuntu22-upgrade-test'
 )


### PR DESCRIPTION
Since the number of manager jobs has become quite large we decided to divide them into folders (sanity-tests, upgrade-tests, feature-tests). As such, we altered the names that are used by the sanity jobs to trigger the ugprade and feature jobs (downstream_jobs_to_run) to include the relevant folder names

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
