### PR TITLE
fix(Unit tests): fix EventsUtilsMixin teardown

### DIFF
--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -36,9 +36,11 @@ from unit_tests.lib.fake_region_definition_builder import FakeDefinitionBuilder
 from unit_tests.lib.fake_remoter import FakeRemoter
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope='module')
 def events():
-    mixing = EventsUtilsMixin()
+    class LocalMixing(EventsUtilsMixin):
+        pass
+    mixing = LocalMixing()
     mixing.setup_events_processes(events_device=True, events_main_device=False, registry_patcher=True)
     yield mixing
 

--- a/unit_tests/test_scan_operation_thread.py
+++ b/unit_tests/test_scan_operation_thread.py
@@ -13,7 +13,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 from cassandra import OperationTimedOut
 from unit_tests.test_cluster import DummyDbCluster, DummyNode
-from unit_tests.lib.events_utils import EventsUtilsMixin
 from sdcm.scan_operation_thread import ScanOperationThread, FullScanParams
 
 
@@ -44,23 +43,15 @@ class DBCluster(DummyDbCluster):  # pylint: disable=abstract-method
         return self.connection_mock
 
 
-def get_event_log_file(module_events):  # pylint: disable=redefined-outer-name
-    if (log_file := Path(module_events.temp_dir, "events_log", "events.log")).exists():
+def get_event_log_file(events):
+    if (log_file := Path(events.temp_dir, "events_log", "events.log")).exists():
         return log_file.read_text(encoding="utf-8").rstrip().split('\n')
     return ""
 
 
-@pytest.fixture(scope='module')
-def module_events():
-    mixing = EventsUtilsMixin()
-    mixing.setup_events_processes(events_device=True, events_main_device=False, registry_patcher=True)
-    yield mixing
-    mixing.teardown_events_processes()
-
-
 @pytest.fixture(scope='function', autouse=True)
-def cleanup_event_log_file(module_events):  # pylint: disable=redefined-outer-name
-    with open(os.path.join(module_events.temp_dir, "events_log", "events.log"), 'r+', encoding="utf-8") as file:
+def cleanup_event_log_file(events):
+    with open(os.path.join(events.temp_dir, "events_log", "events.log"), 'r+', encoding="utf-8") as file:
         file.truncate(0)
 
 
@@ -102,16 +93,16 @@ def cluster(node):  # pylint: disable=redefined-outer-name
 
 
 @pytest.mark.parametrize("mode", ['table', 'partition', 'aggregate'])
-def test_scan_positive(mode, module_events, cluster):  # pylint: disable=redefined-outer-name
+def test_scan_positive(mode, events, cluster):  # pylint: disable=redefined-outer-name
     default_params = FullScanParams(
         db_cluster=cluster,
         ks_cf='a.b',
         mode=mode,
         **DEFAULT_PARAMS
     )
-    with module_events.wait_for_n_events(module_events.get_events_logger(), count=2, timeout=10):
+    with events.wait_for_n_events(events.get_events_logger(), count=2, timeout=10):
         ScanOperationThread(default_params)._run_next_scan_operation()  # pylint: disable=protected-access
-    all_events = get_event_log_file(module_events)
+    all_events = get_event_log_file(events)
     assert "Severity.NORMAL" in all_events[0] and "period_type=begin" in all_events[0]
     assert "Severity.NORMAL" in all_events[1] and "period_type=end" in all_events[1]
     if mode == "aggregate":
@@ -138,7 +129,7 @@ class ExecuteAsyncOperationTimedOutMockCqlConnectionPatient(MockCqlConnectionPat
                           ['aggregate', 'WARNING', 60*30, 'execute'],
                           ['aggregate', 'ERROR', 0, 'execute'],
                           ['table', 'WARNING', 0, 'execute']])
-def test_scan_negative_operation_timed_out(mode, severity, timeout, execute_mock, module_events, node):
+def test_scan_negative_operation_timed_out(mode, severity, timeout, execute_mock, events, node):
     # pylint: disable=redefined-outer-name
     # pylint: disable=too-many-arguments
     if execute_mock == 'execute_async':
@@ -154,9 +145,9 @@ def test_scan_negative_operation_timed_out(mode, severity, timeout, execute_mock
         aggregate_operation_limit=timeout,
         **DEFAULT_PARAMS
     )
-    with module_events.wait_for_n_events(module_events.get_events_logger(), count=2, timeout=10):
+    with events.wait_for_n_events(events.get_events_logger(), count=2, timeout=10):
         ScanOperationThread(default_params)._run_next_scan_operation()  # pylint: disable=protected-access
-    all_events = get_event_log_file(module_events)
+    all_events = get_event_log_file(events)
     assert "Severity.NORMAL" in all_events[0] and "period_type=begin" in all_events[0]
     assert f"Severity.{severity}" in all_events[1] and "period_type=end" in all_events[1]
 
@@ -181,7 +172,7 @@ class ExecuteAsyncExceptionMockCqlConnectionPatient(MockCqlConnectionPatient):
     ['partition', 'execute_async'],
     ['aggregate', 'execute'],
     ['table', 'execute']])
-def test_scan_negative_exception(mode, severity, running_nemesis, execute_mock, module_events, node):
+def test_scan_negative_exception(mode, severity, running_nemesis, execute_mock, events, node):
     # pylint: disable=redefined-outer-name
     # pylint: disable=too-many-arguments
     if running_nemesis:
@@ -200,8 +191,8 @@ def test_scan_negative_exception(mode, severity, running_nemesis, execute_mock, 
         mode=mode,
         ** DEFAULT_PARAMS
     )
-    with module_events.wait_for_n_events(module_events.get_events_logger(), count=2, timeout=10):
+    with events.wait_for_n_events(events.get_events_logger(), count=2, timeout=10):
         ScanOperationThread(default_params)._run_next_scan_operation()  # pylint: disable=protected-access
-    all_events = get_event_log_file(module_events)
+    all_events = get_event_log_file(events)
     assert "Severity.NORMAL" in all_events[0] and "period_type=begin" in all_events[0]
     assert f"Severity.{severity}" in all_events[1] and "period_type=end" in all_events[1]


### PR DESCRIPTION
ignore errors like FileNotFoundError on EventsUtilsMixin teardown in shutil.rmtree 
not  best solution but fix the current error at the end of unit tests

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
