### PR TITLE
fix(sla system): fix run_fullscan parameter

### DIFF
--- a/test-cases/enterprise-features/workload-prioritization/longevity/longevity-sla-system-24h.yaml
+++ b/test-cases/enterprise-features/workload-prioritization/longevity/longevity-sla-system-24h.yaml
@@ -15,7 +15,7 @@ round_robin: true
 instance_type_db: 'i3.2xlarge'
 instance_type_loader: 'c5.2xlarge'
 
-run_fullscan: '{"ks_cf": "keyspace1.standard1", "interval": 5}' # 'ks.cf|random, interval(min)'
+run_fullscan: ['{"mode": "random", "ks_cf": "keyspace1.standard1", "interval": 5}'] # 'ks.cf|random, interval(min)'
 nemesis_class_name: 'SlaNemeses:1 SisyphusMonkey:1'
 nemesis_selector: ['!sla']
 nemesis_interval: 5


### PR DESCRIPTION
After https://github.com/scylladb/scylla-cluster-tests/pull/5710 'run_fullscan' parameter have to be list.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
