### PR TITLE
test(upgrade_test): enable raft for some upgrade jobs

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -138,6 +138,7 @@ recover_system_tables: false
 scylla_version: ''
 test_upgrade_from_installed_3_1_0: false
 target_upgrade_version: ''
+disable_raft: true
 
 stress_cdclog_reader_cmd: "cdc-stressor -stream-query-round-duration 30s"
 

--- a/jenkins-pipelines/rolling-upgrade-ubuntu22.04.jenkinsfile
+++ b/jenkins-pipelines/rolling-upgrade-ubuntu22.04.jenkinsfile
@@ -7,7 +7,7 @@ rollingUpgradePipeline(
     backend: 'gce',
     base_versions: '',  // auto mode
     linux_distro: 'ubuntu-focal',
-    gce_image_db: 'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2004-lts',
+    use_preinstalled_scylla: true,
     test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
     test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
     workaround_kernel_bug_for_iotune: false,

--- a/jenkins-pipelines/upgrade-with-raft/rolling-upgrade-centos8-with-raft.jenkinsfile
+++ b/jenkins-pipelines/upgrade-with-raft/rolling-upgrade-centos8-with-raft.jenkinsfile
@@ -1,0 +1,17 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+rollingUpgradePipeline(
+    backend: 'gce',
+    base_versions: '',  // auto mode
+    linux_distro: 'centos-8',
+    disable_raft: false,
+    gce_image_db: 'https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/family/centos-stream-8',
+
+    test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
+    test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
+    workaround_kernel_bug_for_iotune: false,
+    internode_compression: 'all'
+)

--- a/jenkins-pipelines/upgrade-with-raft/rolling-upgrade-debian11-with-raft.jenkinsfile
+++ b/jenkins-pipelines/upgrade-with-raft/rolling-upgrade-debian11-with-raft.jenkinsfile
@@ -1,0 +1,16 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+rollingUpgradePipeline(
+    backend: 'gce',
+    base_versions: '',  // auto mode
+    linux_distro: 'debian-bullseye',
+    disable_raft: false,
+    gce_image_db: 'https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-11',
+
+    test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
+    test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
+    workaround_kernel_bug_for_iotune: false
+)

--- a/jenkins-pipelines/upgrade-with-raft/rolling-upgrade-ubuntu22.04-with-raft.jenkinsfile
+++ b/jenkins-pipelines/upgrade-with-raft/rolling-upgrade-ubuntu22.04-with-raft.jenkinsfile
@@ -1,0 +1,16 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+rollingUpgradePipeline(
+    backend: 'gce',
+    base_versions: '',  // auto mode
+    linux_distro: 'ubuntu-jammy',
+    disable_raft: false,
+    use_preinstalled_scylla: true,
+    test_name: 'upgrade_test.UpgradeTest.test_rolling_upgrade',
+    test_config: 'test-cases/upgrades/rolling-upgrade.yaml',
+    workaround_kernel_bug_for_iotune: false,
+    internode_compression: 'all',
+)

--- a/sct.py
+++ b/sct.py
@@ -1356,6 +1356,7 @@ def create_test_release_jobs(branch, username, password, sct_branch, sct_repo):
     for group_name, group_desc in [
         ('longevity', 'SCT Longevity Tests'),
         ('rolling-upgrade', 'SCT Rolling Upgrades'),
+        ('rolling-upgrade-raft-disabled', 'SCT Rolling Upgrades Raft Disabled'),
         ('gemini-', 'SCT Gemini Tests'),
         ('features-', 'SCT Feature Tests'),
         ('artifacts', 'SCT Artifacts Tests'),
@@ -1388,6 +1389,9 @@ def create_test_release_jobs(branch, username, password, sct_branch, sct_repo):
                 server.create_pipeline_job(jenkins_file, group_name)
         if group_name == 'nemesis':
             for jenkins_file in glob.glob(f'{base_path}/nemesis/*'):
+                server.create_pipeline_job(jenkins_file, group_name)
+        if group_name == 'rolling-upgrade-raft-disabled':
+            for jenkins_file in glob.glob(f'{base_path}/upgrade-with-raft/*'):
                 server.create_pipeline_job(jenkins_file, group_name)
 
     server.create_directory(

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1100,9 +1100,16 @@ class SCTConfiguration(dict):
 
         dict(name="new_version", env="SCT_NEW_VERSION", type=str,
              help="Assign new upgrade version, use it to upgrade to specific minor release. eg: 3.0.1"),
+
         dict(name="target_upgrade_version", env="SCT_TARGET_UPGRADE_VERSION", type=str,
              help="Assign target upgrade version, use for decide if the truncate entries test should be run. "
                   "This test should be performed in case the target upgrade version >= 3.1"),
+
+        dict(name="disable_raft", env="SCT_DISABLE_RAFT", type=boolean,
+             help="As for now, raft will be enable by default in all [upgrade] tests, so this flag will allow us"
+                  "to still run [upgrade] test without raft enabled (or disabling raft), so we will have better"
+                  "coverage"),
+
         dict(name="upgrade_node_packages", env="SCT_UPGRADE_NODE_PACKAGES", type=str,
              help=""),
 

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -219,6 +219,9 @@ def call(Map pipelineParams) {
                                                             if [[ ${pipelineParams.gce_image_db} != null ]] ; then
                                                                 export SCT_GCE_IMAGE_DB=${pipelineParams.gce_image_db}
                                                             fi
+                                                            if [[ ${pipelineParams.disable_raft} != null ]] ; then
+                                                                export SCT_DISABLE_RAFT=${pipelineParams.disable_raft}
+                                                            fi
                                                             export SCT_SCYLLA_LINUX_DISTRO=${pipelineParams.linux_distro}
                                                             export SCT_AMI_ID_DB_SCYLLA_DESC="\$SCT_AMI_ID_DB_SCYLLA_DESC-\$SCT_SCYLLA_LINUX_DISTRO"
 


### PR DESCRIPTION
as of now, and since fd6033769560d9b7d1ad693cffc40679b9043de5, all
upgrade jobs have raft enabled on target version.
As this is still not the default option, we want to run part of the
jobs with raft enabled, and all others will be disabled.
and as part of 5.2/2023.1 effort, this PR is introducing
3 new upgrade tests that will run exclusively with raft
enabled.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
