### PR TITLE
fix(test_generic_cluster_upgrade): Added truncate_ks

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -3073,6 +3073,8 @@ class FillDatabaseData(ClusterTester):
 
             # Insert data to the tables
             self.cql_insert_data_to_simple_tables(session, rows=insert_rows)
+        # Let to ks_truncate complete the schema changes
+        self.db_cluster.wait_for_schema_agreement()
 
     def _enable_cdc(self, item, create_table):
         cdc_properties = "cdc = {'enabled': true, 'preimage': true, 'postimage': true, 'ttl': 36000}"

--- a/upgrade_test.py
+++ b/upgrade_test.py
@@ -545,8 +545,6 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         if self.truncate_entries_flag:
             self.insert_rows = 10
             self.fill_db_data_for_truncate_test(insert_rows=self.insert_rows)
-            # Let to ks_truncate complete the schema changes
-            time.sleep(120)
 
         # generate random order to upgrade
         nodes_num = len(self.db_cluster.nodes)
@@ -858,8 +856,6 @@ class UpgradeTest(FillDatabaseData, loader_utils.LoaderUtilsMixin):
         if self.truncate_entries_flag:
             self.insert_rows = 10
             self.fill_db_data_for_truncate_test(insert_rows=self.insert_rows)
-            # Let to ks_truncate complete the schema changes
-            time.sleep(120)
 
         self._add_sla_credentials_to_stress_commands(workloads_with_sla=['stress_during_entire_upgrade',
                                                                          'stress_after_cluster_upgrade'])


### PR DESCRIPTION
When upgrading a node, the truncate_entries decorator is called. Inside it, we create a cql connection inwhich we expect 'truncate_ks' to have been created by this point. In test_generic_cluster_upgrade, however, we did not create the keyspace beforehand, which caused it to fail. I altered test_generic_cluster_upgrade so that truncate_ks and fill it with data before truncate_entries is called.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
