### PR TITLE
fix(tester.py): fix copy_table method

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -2320,7 +2320,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         Copy data from <src_keyspace>.<src_view> to <dest_keyspace>.<dest_table> if copy_data is True
         """
         result = True
-        create_statement = "SELECT * FROM system_schema.table where ks_cf = '%s' " \
+        create_statement = "SELECT * FROM system_schema.table where table_name = '%s' " \
                            "and keyspace_name = '%s'" % (src_table, src_keyspace)
         if not self.create_table_as(node, src_keyspace, src_table, dest_keyspace,
                                     dest_table, create_statement, columns_list):
@@ -2396,7 +2396,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
                 for column in columns_list or result.column_names:
                     column_kind = session.execute("select kind from system_schema.columns where keyspace_name='{ks}' "
-                                                  "and ks_cf='{name}' and column_name='{column}'".format(
+                                                  "and table_name='{name}' and column_name='{column}'".format(
                                                       ks=src_keyspace,
                                                       name=src_table,
                                                       column=column))
@@ -2551,7 +2551,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         return table_id[0]
 
     def get_tables_name_of_keyspace(self, session, keyspace_name):
-        query = "SELECT ks_cf FROM system_schema.tables WHERE keyspace_name='{}' ".format(keyspace_name)
+        query = "SELECT table_name FROM system_schema.tables WHERE keyspace_name='{}' ".format(keyspace_name)
         table_id = self.rows_to_list(session.execute(query))
         return table_id[0]
 


### PR DESCRIPTION
fix bug intrduced in refactor(fullscan) introducing back the Fullscan refactoring, Fixing: #5495 initial change are https://github.com/scylladb/scylla-cluster-tests/pull/5355/files#

@juliayakovlev  found 1 more issue regarding https://github.com/scylladb/scylla-cluster-tests/pull/5355. in copy_table method
there are several non-related to full_scan changes connected with changing literal **table_name** to **ks_cf** 


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
