### PR TITLE
fix(benchmarks): prolong benchmark timeout

### DIFF
--- a/sdcm/utils/benchmarks.py
+++ b/sdcm/utils/benchmarks.py
@@ -113,15 +113,15 @@ class ScyllaClusterBenchmarkManager(metaclass=Singleton):
 
     def install_benchmark_tools(self):
         try:
-            parallel = ParallelObject(self._benchmark_runners, timeout=300)
-            parallel.run(lambda x: x.install_benchmark_tools(), ignore_exceptions=True)
+            parallel = ParallelObject(self._benchmark_runners, timeout=600)
+            parallel.run(lambda x: x.install_benchmark_tools(), ignore_exceptions=False)
         except TimeoutError as exc:
             LOGGER.warning("Ran into TimeoutError while installing benchmark tools: Exception:\n%s", exc)
 
     def run_benchmarks(self):
         try:
-            parallel = ParallelObject(self._benchmark_runners, timeout=300)
-            parallel.run(lambda x: x.run_benchmarks(), ignore_exceptions=True)
+            parallel = ParallelObject(self._benchmark_runners, timeout=1200)
+            parallel.run(lambda x: x.run_benchmarks(), ignore_exceptions=False)
         except TimeoutError as exc:
             LOGGER.warning("Run into TimeoutError during running benchmarks. Exception:\n%s", exc)
         self._collect_benchmark_output()


### PR DESCRIPTION
Because we ignore exceptions when running benchmarks we don't know what is the reason of failure. Later steps anyway fail the test.

This commit prolongs timeout for benchmarks as we presume they take longer than 300 seconds and stop ignoring exceptions so we have more details when debugging issues.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
