### PR TITLE
fix(node_benchmark): correctly count average if metric is missing

### DIFF
--- a/sdcm/utils/benchmarks.py
+++ b/sdcm/utils/benchmarks.py
@@ -240,9 +240,9 @@ class ScyllaClusterBenchmarkManager(metaclass=Singleton):
                 LOGGER.warning(
                     "Failed to generate comparable result for the following item:\n%s"
                     "\nException:%s", item, exc)
-        eps = [item.sysbench_eps for item in results]
-        read_bw = [item.cassandra_fio_read_bw for item in results]
-        write_bw = [item.cassandra_fio_write_bw for item in results]
+        eps = [item.sysbench_eps for item in results] or [0.0]
+        read_bw = [item.cassandra_fio_read_bw for item in results] or [0.0]
+        write_bw = [item.cassandra_fio_write_bw for item in results] or [0.0]
 
         return Averages(sysbench_eps=sum(eps) / len(eps),
                         cassandra_fio_read_bw=sum(read_bw) / len(read_bw),


### PR DESCRIPTION
Fixes: #5751. If any node performance tool doesn't correclty store result in es document, next counting Average() value could lead to exception DivisionByZero, because final list is empty for failed metrics.

use list with single element [0.0] to avoid such collisions.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
