### PR TITLE
fix(pipelines): enlarge timeout for get duration stage

### DIFF
--- a/vars/jepsenPipeline.groovy
+++ b/vars/jepsenPipeline.groovy
@@ -93,7 +93,7 @@ def call(Map pipelineParams) {
             stage('Get test duration') {
                 steps {
                     catchError(stageResult: 'FAILURE') {
-                        timeout(time: 2, unit: 'MINUTES') {
+                        timeout(time: 5, unit: 'MINUTES') {
                             script {
                                 wrap([$class: 'BuildUser']) {
                                     dir('scylla-cluster-tests') {

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -178,7 +178,7 @@ def call(Map pipelineParams) {
             stage('Get test duration') {
                 steps {
                     catchError(stageResult: 'FAILURE') {
-                        timeout(time: 20, unit: 'MINUTES') {
+                        timeout(time: 5, unit: 'MINUTES') {
                             script {
                                 wrap([$class: 'BuildUser']) {
                                     dir('scylla-cluster-tests') {

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -177,7 +177,7 @@ def call(Map pipelineParams) {
             }
             stage('Get test duration') {
                 options {
-                    timeout(time: 2, unit: 'MINUTES')
+                    timeout(time: 5, unit: 'MINUTES')
                 }
                 steps {
                     catchError(stageResult: 'FAILURE') {

--- a/vars/rollingOperatorUpgradePipeline.groovy
+++ b/vars/rollingOperatorUpgradePipeline.groovy
@@ -95,7 +95,7 @@ def call(Map pipelineParams) {
             stage('Get test duration') {
                 steps {
                     catchError(stageResult: 'FAILURE') {
-                        timeout(time: 2, unit: 'MINUTES') {
+                        timeout(time: 5, unit: 'MINUTES') {
                             script {
                                 wrap([$class: 'BuildUser']) {
                                     dir('scylla-cluster-tests') {


### PR DESCRIPTION
seems like 2min isn't enough cause of recent changes to use a weaker meachines for jenkins builders, and addition of more AWS api calls during configuration read (to translate name to ami ids)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
