### PR TITLE
feature(manager): Added the ability to create a restore task

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -217,21 +217,7 @@ class BackupFunctionsMixIn(LoaderUtilsMixin):
         stress_queue = []
         stress_cmd = self.params.get('stress_read_cmd')
         keyspace_num = self.params.get('keyspace_num')
-        if stress_cmd:
-            # Stress: Same as in prepare_write - allow the load to be spread across all loaders when using multi ks
-            if keyspace_num > 1 and self.params.get('round_robin'):
-                self.log.debug("Using round_robin for multiple Keyspaces...")
-                for i in range(1, keyspace_num + 1):
-                    keyspace_name = self._get_keyspace_name(i)
-                    params = {'keyspace_name': keyspace_name, 'round_robin': True, 'stress_cmd': stress_cmd}
-
-                    self._run_all_stress_cmds(stress_queue, params)
-
-            # The old method when we run all stress_cmds for all keyspace on the same loader, or in round-robin if defined in test yaml
-            else:
-                params = {'keyspace_num': keyspace_num, 'stress_cmd': stress_cmd,
-                          'round_robin': self.params.get('round_robin')}
-                self._run_all_stress_cmds(stress_queue, params)
+        self.assemble_and_run_all_stress_cmd(stress_queue, stress_cmd, keyspace_num)
         for stress in stress_queue:
             self.verify_stress_thread(cs_thread_pool=stress)
 

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -47,7 +47,7 @@ from sdcm.sct_events.group_common_events import ignore_no_space_errors
 from sdcm.keystore import KeyStore
 
 
-class BackupFunctionsMixIn:
+class BackupFunctionsMixIn(LoaderUtilsMixin):
     DESTINATION = Path('/tmp/backup')
 
     backup_azure_blob_service = None
@@ -301,7 +301,7 @@ class FilesNotCorrupted(Exception):
 
 
 # pylint: disable=too-many-public-methods
-class MgmtCliTest(BackupFunctionsMixIn, LoaderUtilsMixin, ClusterTester):
+class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
     """
     Test Scylla Manager operations on Scylla cluster.
     """

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -39,6 +39,7 @@ from sdcm.tester import ClusterTester
 from sdcm.cluster import TestConfig
 from sdcm.nemesis import MgmtRepair
 from sdcm.utils.common import reach_enospc_on_node, clean_enospc_on_node
+from sdcm.utils.loader_utils import LoaderUtilsMixin
 from sdcm.sct_events.system import InfoEvent
 from sdcm.sct_events.filters import DbEventsFilter
 from sdcm.sct_events.database import DatabaseLogEvent
@@ -227,53 +228,6 @@ class BackupFunctionsMixIn:
     def _get_keyspace_name(ks_number, keyspace_pref='keyspace'):
         return '{}{}'.format(keyspace_pref, ks_number)
 
-    def _run_all_stress_cmds(self, stress_queue, params):
-        stress_cmds = params['stress_cmd']
-        if not isinstance(stress_cmds, list):
-            stress_cmds = [stress_cmds]
-        # In some cases we want the same stress_cmd to run several times (can be used with round_robin or not).
-        stress_multiplier = self.params.get('stress_multiplier')
-        if stress_multiplier > 1:
-            stress_cmds *= stress_multiplier
-
-        for stress_cmd in stress_cmds:
-            params.update({'stress_cmd': stress_cmd})
-            self._parse_stress_cmd(stress_cmd, params)
-
-            # Run all stress commands
-            self.log.debug('stress cmd: {}'.format(stress_cmd))
-            if stress_cmd.startswith('scylla-bench'):
-                stress_queue.append(self.run_stress_thread_bench(stress_cmd=stress_cmd,
-                                                                 stats_aggregate_cmds=False,
-                                                                 round_robin=self.params.get('round_robin')))
-            else:
-                stress_queue.append(self.run_stress_thread(**params))
-
-    def run_prepare_write_cmd(self):
-        # In some cases (like many keyspaces), we want to create the schema (all keyspaces & tables) before the load
-        # starts - due to the heavy load, the schema propogation can take long time and c-s fails.
-        prepare_write_cmd = self.params.get('prepare_write_cmd')
-        keyspace_num = self.params.get('keyspace_num')
-        write_queue = []
-
-        # When the load is too heavy for one loader when using MULTI-KEYSPACES, the load is spreaded evenly across
-        # the loaders (round_robin).
-        if keyspace_num > 1 and self.params.get('round_robin'):
-            self.log.debug("Using round_robin for multiple Keyspaces...")
-            for i in range(1, keyspace_num + 1):
-                keyspace_name = self._get_keyspace_name(i)
-                self._run_all_stress_cmds(write_queue, params={'stress_cmd': prepare_write_cmd,
-                                                               'keyspace_name': keyspace_name,
-                                                               'round_robin': True})
-        # Not using round_robin and all keyspaces will run on all loaders
-        else:
-            self._run_all_stress_cmds(write_queue, params={'stress_cmd': prepare_write_cmd,
-                                                           'keyspace_num': keyspace_num,
-                                                           'round_robin': self.params.get('round_robin')})
-
-        for stress in write_queue:
-            self.verify_stress_thread(cs_thread_pool=stress)
-
     def generate_background_read_load(self):
         self.log.info('Starting c-s read')
         stress_cmd = self.params.get('stress_read_cmd')
@@ -308,7 +262,7 @@ class FilesNotCorrupted(Exception):
 
 
 # pylint: disable=too-many-public-methods
-class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
+class MgmtCliTest(BackupFunctionsMixIn, LoaderUtilsMixin, ClusterTester):
     """
     Test Scylla Manager operations on Scylla cluster.
     """

--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -196,6 +196,28 @@ class BackupFunctionsMixIn:
         self.restore_backup_from_backup_task(mgr_cluster=mgr_cluster, backup_task=backup_task,
                                              keyspace_and_table_list=per_keyspace_tables_dict)
 
+    def run_verification_read_stress(self):
+        stress_queue = []
+        stress_cmd = self.params.get('stress_read_cmd')
+        keyspace_num = self.params.get('keyspace_num')
+        if stress_cmd:
+            # Stress: Same as in prepare_write - allow the load to be spread across all loaders when using multi ks
+            if keyspace_num > 1 and self.params.get('round_robin'):
+                self.log.debug("Using round_robin for multiple Keyspaces...")
+                for i in range(1, keyspace_num + 1):
+                    keyspace_name = self._get_keyspace_name(i)
+                    params = {'keyspace_name': keyspace_name, 'round_robin': True, 'stress_cmd': stress_cmd}
+
+                    self._run_all_stress_cmds(stress_queue, params)
+
+            # The old method when we run all stress_cmds for all keyspace on the same loader, or in round-robin if defined in test yaml
+            else:
+                params = {'keyspace_num': keyspace_num, 'stress_cmd': stress_cmd,
+                          'round_robin': self.params.get('round_robin')}
+                self._run_all_stress_cmds(stress_queue, params)
+        for stress in stress_queue:
+            self.verify_stress_thread(cs_thread_pool=stress)
+
     def _generate_load(self, keyspace_name_to_replace=None):
         self.log.info('Starting c-s write workload')
         stress_cmd = self.params.get('stress_cmd')

--- a/sdcm/mgmt/cli.py
+++ b/sdcm/mgmt/cli.py
@@ -491,6 +491,11 @@ class BackupTask(ManagerTask):
                            "manager can only delete snapshots of finished tasks".format(self.id, str(self.status)))
 
 
+class RestoreTask(ManagerTask):
+    def __init__(self, task_id, cluster_id, manager_node):
+        ManagerTask.__init__(self, task_id=task_id, cluster_id=cluster_id, manager_node=manager_node)
+
+
 class ManagerCluster(ScyllaManagerBase):
 
     def __init__(self, manager_node, cluster_id=None, client_encrypt=False):
@@ -515,6 +520,23 @@ class ManagerCluster(ScyllaManagerBase):
 
     def set_cluster_id(self, value: str):
         self.id = value
+
+    def create_restore_task(self, restore_schema=False, restore_data=False, location_list=None, snapshot_tag=None):
+        cmd = f"restore -c {self.id}"
+        if restore_schema:
+            cmd += " --restore-schema"
+        if restore_data:
+            cmd += " --restore-tables"
+        if location_list:
+            locations_names = ','.join(location_list)
+            cmd += " --location {} ".format(locations_names)
+        if snapshot_tag:
+            cmd += f" --snapshot-tag {snapshot_tag}"
+
+        res = self.sctool.run(cmd=cmd, parse_table_res=False)
+        task_id = res.stdout.strip()
+        LOGGER.debug("Created task id is: {}".format(task_id))
+        return RestoreTask(task_id=task_id, cluster_id=self.id, manager_node=self.manager_node)
 
     def create_backup_task(self, dc_list=None,  # pylint: disable=too-many-arguments,too-many-locals,too-many-branches
                            dry_run=None, interval=None, keyspace_list=None, cron=None,


### PR DESCRIPTION
```
feature(manager): Added the ability to create a restore task 

New in manager 3.1.
A new task type that will restore the data of a table or even an entire cluster
from a backup
```
``` 
refactor(manager_cli_test): remove duplicated loader functions 

Both '_run_all_stress_cmds' and 'run_prepare_write_cmd' were included in
BackupFunctionsMixIn, when they were copies of the same functions in LoaderUtilsMixin.
So I deleted the functions from BackupFunctionsMixIn and used LoaderUtilsMixin instead.
 ```
```
improvement(manager): Added stress read function to verify restores 

To confirm that the manager's restore task has indeed successfully restored the backed up data,
I added the run_read_stress to the BackupFunctionsMixIn, so we will be able to run it after a
restore task has ended, and confirm its results.
 ```
```
feature(manager restore): encapsulated the 2 restore types in methods 

New in manager 3.1
There are two types of restore tasks: one that restores the schema, and one that restores the data.
Restoring the schema requires us to restart each of the nodes one by one.
Restoring the data requires us to to run a repair on all of the nodes.
I encapsulated those two tasks in methods under BackupFunctionsMixIn: restore_schema_with_task and
restore_data_with_task
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
