### PR TITLE
feature(sct-builders): use aws ASGs as Azure builders

### DIFF
--- a/test-cases/artifacts/azure-image.yaml
+++ b/test-cases/artifacts/azure-image.yaml
@@ -17,3 +17,6 @@ nemesis_class_name: 'NoOpMonkey'
 test_duration: 60
 user_prefix: 'artifacts-azure-image'
 system_auth_rf: 1
+
+# since running from runner in AWS, we need the address to be publicly available
+intra_node_comm_public: true

--- a/vars/getJenkinsLabels.groovy
+++ b/vars/getJenkinsLabels.groovy
@@ -28,7 +28,7 @@ def call(String backend, String region=null, String datacenter=null, String loca
                           'gce-us-west1': "${gcp_project}-builders-us-west1-template",
                           'gce': "${gcp_project}-builders-us-east1-template",
                           'aws': 'aws-sct-builders-eu-west-1-v2-asg',
-                          'azure-eastus': 'azure-sct-builders']
+                          'azure-eastus': 'aws-sct-builders-us-east-1-v2-asg']
 
     def cloud_provider = getCloudProviderFromBackend(backend)
 


### PR DESCRIPTION
since we don't really need the jenkins builder todo much we can use AWS ones to spin up an Azure pipeline/job

## Testing

- [x] - artifact - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/artifacts-azure-image-test/4/
- [x] - longevity - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-10gb-3h-azure-test/2

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
