### PR TITLE
fix(artifacts offline): remove unecessary jobs

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1373,6 +1373,7 @@ def create_test_release_jobs(branch, username, password, sct_branch, sct_repo):
 
     server.create_directory(
         name='artifacts-offline-install', display_name='SCT Artifacts Offline Install Tests')
+    artifacts_offline_exclude_jobs = r'-web|-ami-|-image'
 
     def jenkinsfile_generator():
         for i in ['ami', 'amazon2', 'docker', 'gce-image']:
@@ -1381,10 +1382,12 @@ def create_test_release_jobs(branch, username, password, sct_branch, sct_repo):
     for jenkins_file in glob.glob(f'{base_path}/artifacts-*.jenkinsfile'):
         if any(jenkinsfile_generator()):
             continue
-        server.create_pipeline_job(jenkins_file, 'artifacts-offline-install')
+        if not re.search(artifacts_offline_exclude_jobs, jenkins_file):
+            server.create_pipeline_job(jenkins_file, 'artifacts-offline-install')
     for jenkins_file in glob.glob(f'{base_path}/nonroot-offline-install/*.jenkinsfile'):
-        server.create_pipeline_job(jenkins_file, 'artifacts-offline-install',
-                                   job_name=str(Path(jenkins_file).stem) + '-nonroot')
+        if not re.search(artifacts_offline_exclude_jobs, jenkins_file):
+            server.create_pipeline_job(jenkins_file, 'artifacts-offline-install',
+                                       job_name=str(Path(jenkins_file).stem) + '-nonroot')
 
 
 @cli.command('create-test-release-jobs-enterprise', help="Create pipeline jobs for a new branch")


### PR DESCRIPTION
in the function used to create release Jenkins jobs, we didn't make any filter between artifacts and the offline artifacts, as many of them don't fit the
offline artifacts tests concept, as images and
web install.
this PR is addressing that, excluding few regex
of job names used for the regular artifacts,
to not create them as artifacts offline.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
