### PR TITLE
fix(perfrefressionpipeline): Enlarge timeout for stages

### DIFF
--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -107,7 +107,7 @@ def call(Map pipelineParams) {
                 }
                 steps {
                     catchError(stageResult: 'FAILURE') {
-                        timeout(time: 5, unit: 'MINUTES') {
+                        timeout(time: 10, unit: 'MINUTES') {
                             script {
                                 wrap([$class: 'BuildUser']) {
                                     dir('scylla-cluster-tests') {
@@ -161,7 +161,7 @@ def call(Map pipelineParams) {
                                             catchError(stageResult: 'FAILURE') {
                                                 wrap([$class: 'BuildUser']) {
                                                     dir('scylla-cluster-tests') {
-                                                        timeout(time: 5, unit: 'MINUTES') {
+                                                        timeout(time: 10, unit: 'MINUTES') {
                                                             createSctRunner(params, runnerTimeout, builder.region)
                                                         }
                                                     }


### PR DESCRIPTION
New performance jobs marked as failed because stages GetDuration and Create SCT runner exceed default time.

ex: https://jenkins.scylladb.com/view/master/job/scylla-master/job/scylla-master-perf-regression-throughput-shard-aware-test/12
Increase duration for stages

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
