### PR TITLE
fix(artifacts offline generator): re-introduce amazon2

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1373,15 +1373,9 @@ def create_test_release_jobs(branch, username, password, sct_branch, sct_repo):
 
     server.create_directory(
         name='artifacts-offline-install', display_name='SCT Artifacts Offline Install Tests')
-    artifacts_offline_exclude_jobs = r'-web|-ami-|-image'
-
-    def jenkinsfile_generator():
-        for i in ['ami', 'amazon2', 'docker', 'gce-image']:
-            yield f'-{i}.jenkinsfile' in jenkins_file
+    artifacts_offline_exclude_jobs = r'-web|-ami|-image|-docker'
 
     for jenkins_file in glob.glob(f'{base_path}/artifacts-*.jenkinsfile'):
-        if any(jenkinsfile_generator()):
-            continue
         if not re.search(artifacts_offline_exclude_jobs, jenkins_file):
             server.create_pipeline_job(jenkins_file, 'artifacts-offline-install')
     for jenkins_file in glob.glob(f'{base_path}/nonroot-offline-install/*.jenkinsfile'):


### PR DESCRIPTION
there was a function skipping few keywords when
creating the jobs for release in Jenkins.
happens that, it had some issues, and didn't really filter out some important ones that should not be
created, and removed some, that we could run without any problems (like `artifacts-amazon2`)

this PR enhances what #5770 already started,
and removed the bogus "filter".

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
