### PR TITLE
fix(es_index_mapping): change order of date formats

### DIFF
--- a/configurations/es_mapping/performance_index_mapping.json
+++ b/configurations/es_mapping/performance_index_mapping.json
@@ -4,7 +4,7 @@
 					"properties": {
 						"start_time": {
 							"type": "date",
-							"format": "yyyy-MM-dd HH:mm:ss||yyyy/MM/dd HH:mm:ss||epoch_millis||epoch_second||strict_date_optional_time"
+							"format": "yyyy-MM-dd HH:mm:ss||yyyy/MM/dd HH:mm:ss||epoch_second||epoch_millis||strict_date_optional_time"
 						}
 					}
 				},
@@ -14,7 +14,7 @@
 							"properties": {
 								"date": {
 									"type": "date",
-									"format": "yyyyMMdd||yyyy-MM-dd HH:mm:ss||yyyy/MM/dd HH:mm:ss||epoch_millis||epoch_second||strict_date_optional_time"
+									"format": "yyyyMMdd||yyyy-MM-dd HH:mm:ss||yyyy/MM/dd HH:mm:ss||epoch_second||epoch_millis||strict_date_optional_time"
 								}
 							}
 						}


### PR DESCRIPTION
Change order of date formats to proper detect date format. if epoch_milis is before epoch_seconds, date in seconds parsed as miliseconds and in correctly date used in ES

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
