### PR TITLE
fix(performance_email_title): Add email title parameter to pipeline

### DIFF
--- a/jenkins-pipelines/perf-regression-latency-non-shard-aware-125gb.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-non-shard-aware-125gb.jenkinsfile
@@ -9,6 +9,7 @@ perfRegressionParallelPipeline(
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: '''["test-cases/performance/perf-regression-latency-125gb.yaml","configurations/perf-loaders-non-shard-aware-config.yaml", "configurations/run_db_node_benchmarks.yaml"]''',
     sub_tests: ["test_latency"],
+    test_email_title: "disk-and-cache - non-shard-aware",
 
     timeout: [time: 680, unit: "MINUTES"]
 )

--- a/jenkins-pipelines/perf-regression-latency-non-shard-aware-1TB.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-non-shard-aware-1TB.jenkinsfile
@@ -9,6 +9,7 @@ perfRegressionParallelPipeline(
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: '''["test-cases/performance/perf-regression-latency-1TB.yaml", "configurations/perf-loaders-non-shard-aware-config.yaml", "configurations/run_db_node_benchmarks.yaml"]''',
     sub_tests: ["test_latency"],
+    test_email_title: "non-shard-aware",
 
     timeout: [time: 500, unit: "MINUTES"]
 )

--- a/jenkins-pipelines/perf-regression-latency-non-shard-aware-250gb-with-nemesis.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-non-shard-aware-250gb-with-nemesis.jenkinsfile
@@ -7,5 +7,6 @@ perfRegressionParallelPipeline(
     backend: "aws",
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: '''["test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml", "configurations/perf-loaders-non-shard-aware-config.yaml", "configurations/run_db_node_benchmarks.yaml"]''',
-    sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"]
+    sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"],
+    test_email_title: "non-shard-aware"
 )

--- a/jenkins-pipelines/perf-regression-latency-shard-aware-125gb.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-shard-aware-125gb.jenkinsfile
@@ -9,6 +9,7 @@ perfRegressionParallelPipeline(
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: '''["test-cases/performance/perf-regression-latency-125gb.yaml","configurations/perf-loaders-shard-aware-config.yaml"]''',
     sub_tests: ["test_latency"],
+    test_email_title: "disk-and-cache - shard-aware",
 
     timeout: [time: 680, unit: "MINUTES"]
 )

--- a/jenkins-pipelines/perf-regression-latency-shard-aware-1TB.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-shard-aware-1TB.jenkinsfile
@@ -9,6 +9,7 @@ perfRegressionParallelPipeline(
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: '''["test-cases/performance/perf-regression-latency-1TB.yaml", "configurations/perf-loaders-non-shard-aware-config.yaml", "configurations/run_db_node_benchmarks.yaml"]''',
     sub_tests: ["test_latency"],
+    test_email_title: "shard-aware",
 
     timeout: [time: 500, unit: "MINUTES"]
 )

--- a/jenkins-pipelines/perf-regression-latency-shard-aware-250gb-with-nemesis.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-latency-shard-aware-250gb-with-nemesis.jenkinsfile
@@ -7,5 +7,6 @@ perfRegressionParallelPipeline(
     backend: "aws",
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: '''["test-cases/performance/perf-regression-latency-250gb-with-nemesis.yaml", "configurations/perf-loaders-shard-aware-config.yaml", "configurations/run_db_node_benchmarks.yaml"]''',
-    sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"]
+    sub_tests: ["test_latency_write_with_nemesis", "test_latency_read_with_nemesis", "test_latency_mixed_with_nemesis"],
+    test_email_title: "shard-aware"
 )

--- a/jenkins-pipelines/perf-regression-throughput-non-shard-aware-125gb.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-throughput-non-shard-aware-125gb.jenkinsfile
@@ -9,6 +9,7 @@ perfRegressionParallelPipeline(
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: '''["test-cases/performance/perf-regression-throughput-125gb.yaml", "configurations/perf-loaders-non-shard-aware-config.yaml", "configurations/run_db_node_benchmarks.yaml"]''',
     sub_tests: ["test_write", "test_read", "test_mixed"],
+    test_email_title: "throughput disk-and-cache - non-shard-aware",
 
     timeout: [time: 600, unit: "MINUTES"]
 )

--- a/jenkins-pipelines/perf-regression-throughput-non-shard-aware-30min.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-throughput-non-shard-aware-30min.jenkinsfile
@@ -9,6 +9,7 @@ perfRegressionParallelPipeline(
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: '''["test-cases/performance/perf-regression.100threads.30M-keys.yaml","configurations/perf-loaders-non-shard-aware-config.yaml", "configurations/run_db_node_benchmarks.yaml"]''',
     sub_tests: ["test_write", "test_read", "test_mixed"],
+    test_email_title: "throughput - non-shard-aware",
 
     timeout: [time: 350, unit: "MINUTES"]
 )

--- a/jenkins-pipelines/perf-regression-throughput-shard-aware-125gb.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-throughput-shard-aware-125gb.jenkinsfile
@@ -9,6 +9,7 @@ perfRegressionParallelPipeline(
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: '''["test-cases/performance/perf-regression-throughput-125gb.yaml","configurations/perf-loaders-shard-aware-config.yaml"]''',
     sub_tests: ["test_write", "test_read", "test_mixed"],
+    test_email_title: "throughput disk-and-cache - shard-aware",
 
     timeout: [time: 600, unit: "MINUTES"]
 )

--- a/jenkins-pipelines/perf-regression-throughput-shard-aware-30min.jenkinsfile
+++ b/jenkins-pipelines/perf-regression-throughput-shard-aware-30min.jenkinsfile
@@ -9,6 +9,7 @@ perfRegressionParallelPipeline(
     test_name: "performance_regression_test.PerformanceRegressionTest",
     test_config: '''["test-cases/performance/perf-regression.100threads.30M-keys.yaml","configurations/perf-loaders-shard-aware-config.yaml", "configurations/run_db_node_benchmarks.yaml"]''',
     sub_tests: ["test_write", "test_read", "test_mixed"],
+    test_email_title: "throughput - shard-aware",
 
     timeout: [time: 350, unit: "MINUTES"]
 )

--- a/sdcm/results_analyze/__init__.py
+++ b/sdcm/results_analyze/__init__.py
@@ -727,7 +727,11 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
             test_name = full_test_name.split('.', 1)[1]  # Example: longevity_test.LongevityTest.test_custom_time
         except IndexError:
             test_name = full_test_name
-        subject = f'Performance Regression Compare Results - {test_name} - {test_version} - {str(test_start_time)}'
+        subject = f'Performance Regression Compare Results - {test_name} - {test_version}'
+        if email_subject_postfix:
+            subject += f' - {email_subject_postfix}'
+        subject += f' - {str(test_start_time)}'
+
         if ycsb:
             if ycsb_engine := ycsb.get('raw_cmd', "").split():
                 if len(ycsb_engine) > 3:
@@ -739,8 +743,6 @@ class PerformanceResultsAnalyzer(BaseResultsAnalyzer):
             subject = f'YCSB({ycsb_engine}) Performance Regression - {test_name} - {test_version} - {str(test_start_time)}'
         if ebs:
             subject = f'{subject} (ebs volume type {ebs_type})'
-        if email_subject_postfix:
-            subject = f'{subject} {email_subject_postfix}'
 
         email_data = {'email_body': results,
                       'attachments': (),

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -56,6 +56,10 @@ def call(Map pipelineParams) {
                    description: 'Stop test if perf hardware test values exceed the set limits',
                    name: 'stop_on_hw_perf_failure')
 
+            string(defaultValue: "${pipelineParams.get('test_email_title', '')}",
+                   description: 'String added to test email subject',
+                   name: 'test_email_title')
+
             string(defaultValue: "${pipelineParams.get('email_recipients', 'scylla-perf-results@scylladb.com')}",
                    description: 'email recipients of email report',
                    name: 'email_recipients')
@@ -243,6 +247,9 @@ def call(Map pipelineParams) {
                                                         fi
                                                         if [[ -n "${params.k8s_enable_tls ? params.k8s_enable_tls : ''}" ]] ; then
                                                             export SCT_K8S_ENABLE_TLS=${params.k8s_enable_tls}
+                                                        fi
+                                                        if [[ -n "${params.test_email_title ? params.test_email_title : ''}" ]] ; then
+                                                            export SCT_EMAIL_SUBJECT_POSTFIX=${params.test_email_title}
                                                         fi
 
                                                         echo "start test ......."


### PR DESCRIPTION
New performance jobs use several configuration files to run same test with different attributes: driver(shared/non-shard aware), hardware performance test enabling, etc). Such test when send email report results could be difficult to split.

Add new parameter to pipeline which allow to set email title for specific job.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
