### PR TITLE
feature(consistent-cluster-management): Disable feature for several jobs

### DIFF
--- a/configurations/raft/consistent_cluster_management_off.yaml
+++ b/configurations/raft/consistent_cluster_management_off.yaml
@@ -1,0 +1,2 @@
+append_scylla_yaml: |
+  consistent_cluster_management: false

--- a/jenkins-pipelines/consistent_cluster_management_disabled/longevity-1tb-7days.jenkinsfile
+++ b/jenkins-pipelines/consistent_cluster_management_disabled/longevity-1tb-7days.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-1TB-5days-authorization-and-tls-ssl.yaml", "configurations/raft/consistent_cluster_management_off.yaml"]'''
+
+)

--- a/jenkins-pipelines/consistent_cluster_management_disabled/longevity-large-collections-12h.jenkinsfile
+++ b/jenkins-pipelines/consistent_cluster_management_disabled/longevity-large-collections-12h.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-large-collections-12h.yaml", "configurations/raft/consistent_cluster_management_off.yaml"]'''
+
+)

--- a/jenkins-pipelines/consistent_cluster_management_disabled/longevity-large-partition-8h.jenkinsfile
+++ b/jenkins-pipelines/consistent_cluster_management_disabled/longevity-large-partition-8h.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_large_partition_test.LargePartitionLongevityTest.test_large_partition_longevity',
+    test_config: '''["test-cases/longevity/longevity-large-partition-8h.yaml", "configurations/raft/consistent_cluster_management_off.yaml"]'''
+
+)

--- a/jenkins-pipelines/consistent_cluster_management_disabled/longevity-mv-si-4days.jenkinsfile
+++ b/jenkins-pipelines/consistent_cluster_management_disabled/longevity-mv-si-4days.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-mv-si-4days.yaml","configurations/raft/consistent_cluster_management_off.yaml"]''',
+
+)

--- a/jenkins-pipelines/consistent_cluster_management_disabled/longevity-schema-changes-3h-with-raft.jenkinsfile
+++ b/jenkins-pipelines/consistent_cluster_management_disabled/longevity-schema-changes-3h-with-raft.jenkinsfile
@@ -1,0 +1,13 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: '''["test-cases/longevity/longevity-schema-changes-3h.yaml", "configurations/raft/consistent_cluster_management_off.yaml"]''',
+
+    timeout: [time: 360, unit: 'MINUTES']
+)

--- a/sct.py
+++ b/sct.py
@@ -1364,6 +1364,7 @@ def create_test_release_jobs(branch, username, password, sct_branch, sct_repo):
         ('scale', 'SCT Scale Tests'),
         ('operator', 'SCT Operator Tests'),
         ('raft', 'SCT Raft Experimental'),
+        ('disabled_raft', 'SCT ConsistentClusterManagement disabled'),
     ]:
         server.create_directory(name=group_name, display_name=group_desc)
 
@@ -1380,6 +1381,9 @@ def create_test_release_jobs(branch, username, password, sct_branch, sct_repo):
                 server.create_pipeline_job(jenkins_file, group_name)
         if group_name == 'raft':
             for jenkins_file in glob.glob(f'{base_path}/raft/*'):
+                server.create_pipeline_job(jenkins_file, group_name)
+        if group_name == 'disabled_raft':
+            for jenkins_file in glob.glob(f'{base_path}/consistent_cluster_management_disabled/*'):
                 server.create_pipeline_job(jenkins_file, group_name)
 
     server.create_directory(


### PR DESCRIPTION
Disable feature consistent-cluster-management feature (raft group-0)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
