### PR TITLE
fix(csrangehistogram): Increase max value for hdr histogram

### DIFF
--- a/sdcm/utils/csrangehistogram.py
+++ b/sdcm/utils/csrangehistogram.py
@@ -51,7 +51,7 @@ HistorgramSummary = make_dataclass("HistorgramSummary",
 
 class CSHistogram(HdrHistogram):
     LOWEST = 1
-    HIGHEST = 12 * 3600 * 1000 * 1000
+    HIGHEST = 24 * 3600_000_000_000
     SIGNIFICANT = 3
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
CS could write to hdr.log value for some intervals higher value, than was configured. Python HDR histogram lib doesn't support autorescale feature (like in java lib), which allow to rescale histogram during merging.
Increase max value for HDR Histogram which allow
to store from 1 nanosecnds up to 24 hours

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
