### PR TITLE
test(longevity): new longevity for MV running in synchronous mode

### DIFF
--- a/data_dir/mv_synchronous_updates.yaml
+++ b/data_dir/mv_synchronous_updates.yaml
@@ -1,0 +1,87 @@
+# LWT test: create and update data using LWT.
+### DML ###
+
+# Keyspace Name
+keyspace: mv_synchronous_ks
+
+# The CQL for creating a keyspace (optional if it already exists)
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS mv_synchronous_ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};
+
+# Table name
+table: blog_posts
+
+# The CQL for creating a table you wish to stress (optional if it already exists)
+table_definition: |
+  CREATE TABLE IF NOT EXISTS blog_posts (
+        domain int,
+        published_date date,
+        mv_pk int,
+        url ascii,
+        author varchar,
+        title varchar,
+        PRIMARY KEY(domain)
+  ) WITH comment='A table to hold blog posts'
+
+extra_definitions:
+  - create MATERIALIZED VIEW cf_update_2_columns_mv_pk as select mv_pk, author from blog_posts where domain is not null and mv_pk > 0 and mv_pk <= 100000000 PRIMARY KEY(mv_pk, domain) WITH synchronous_updates = true;
+  - create MATERIALIZED VIEW cf_update_mv_pk as select * from blog_posts where domain is not null and mv_pk > 100000001 and mv_pk < 200000000 PRIMARY KEY(mv_pk, domain) WITH synchronous_updates = true;
+  - create MATERIALIZED VIEW cf_update_asynch_test as select author from blog_posts where domain is not null and published_date < 2147289031 PRIMARY KEY(published_date, domain);
+  - create MATERIALIZED VIEW cf_update_synch_test as select title from blog_posts where domain is not null and published_date > 2147289031 PRIMARY KEY(published_date, domain) WITH synchronous_updates = true;
+  - create MATERIALIZED VIEW cf_update_asynch_view_1 as select author from blog_posts where domain is not null and published_date is not null PRIMARY KEY(published_date, domain);
+  - create MATERIALIZED VIEW cf_update_asynch_view_2 as select author from blog_posts where domain is not null and published_date is not null PRIMARY KEY(published_date, domain);
+  - create MATERIALIZED VIEW cf_update_asynch_view_3 as select author from blog_posts where domain is not null and published_date is not null PRIMARY KEY(published_date, domain);
+  - create MATERIALIZED VIEW cf_update_synch_view_1 as select title from blog_posts where domain is not null and published_date is not null PRIMARY KEY(published_date, domain) WITH synchronous_updates = true;
+  - create MATERIALIZED VIEW cf_update_synch_view_2 as select title from blog_posts where domain is not null and published_date is not null PRIMARY KEY(published_date, domain) WITH synchronous_updates = true;
+  - create MATERIALIZED VIEW cf_update_synch_view_3 as select title from blog_posts where domain is not null and published_date is not null PRIMARY KEY(published_date, domain) WITH synchronous_updates = true;
+
+### Column Distribution Specifications ###
+
+columnspec:
+  - name: domain
+    population: seq(1..200000000)  #20M possible domains to pick from
+
+  - name: published_date
+    cluster: uniform(-2147289031..1679349600000)
+
+  - name: mv_pk
+    population: seq(1..200000000)
+
+  - name: url
+    size: uniform(30..30)
+
+  - name: title                  #titles shouldn't go beyond 200 chars
+    size: gaussian(10..20)
+
+  - name: author
+    size: uniform(5..20)         #author names should be short
+
+### Batch Ratio Distribution Specifications ###
+
+insert:
+  partitions: fixed(1)            # Our partition key is the domain so only insert one per batch
+
+  select:    fixed(1)/1000        # We have 1000 posts per domain so 1/1000 will allow 1 post per batch
+
+  batchtype: UNLOGGED             # Unlogged batches
+
+
+#
+# A list of queries you wish to run against the schema
+#
+queries:
+   select_base:
+      cql: select * from blog_posts where domain = ? LIMIT 1
+      fields: samerow
+   select_mv:
+      cql: select * from cf_update_2_columns_mv_pk where domain = ? and mv_pk = ? LIMIT 1
+      fields: samerow
+   select_mv_2:
+      cql: select * from cf_update_mv_pk where domain = ? and mv_pk = ? LIMIT 1
+      fields: samerow
+   url_column_update:
+      cql: update blog_posts set url = ? where domain = ?
+      fields: samerow
+   row_delete:
+      cql: delete from blog_posts where domain = ?
+      fields: samerow

--- a/data_dir/mv_synchronous_updates_lwt.yaml
+++ b/data_dir/mv_synchronous_updates_lwt.yaml
@@ -1,0 +1,82 @@
+# LWT test: create and update data using LWT.
+### DML ###
+
+# Keyspace Name
+keyspace: mv_synchronous_lwt_ks
+
+# The CQL for creating a keyspace (optional if it already exists)
+keyspace_definition: |
+  CREATE KEYSPACE IF NOT EXISTS mv_synchronous_lwt_ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};
+
+# Table name
+table: blog_posts
+
+# The CQL for creating a table you wish to stress (optional if it already exists)
+table_definition: |
+  CREATE TABLE IF NOT EXISTS blog_posts (
+        domain int,
+        published_date int,
+        mv_pk int,
+        url text,
+        author text,
+        title text,
+        PRIMARY KEY(domain, mv_pk)
+  ) WITH comment='A table to hold data for MV synchronous updates test'
+
+extra_definitions:
+  - create MATERIALIZED VIEW mv_synchronous_lwt_publish_date as select published_date, author from blog_posts where domain is not null and mv_pk is not null and published_date > 0 and published_date > 150000 PRIMARY KEY(published_date, domain, mv_pk) WITH synchronous_updates = true;
+  - create MATERIALIZED VIEW mv_synchronous_lwt_publish_date_after_update as select published_date, author from blog_posts where domain is not null and mv_pk is not null and published_date = 300000000 PRIMARY KEY(published_date, domain, mv_pk) WITH synchronous_updates = true;
+  - create MATERIALIZED VIEW mv_synchronous_lwt_manual_test as select * from blog_posts where domain is not null and mv_pk is not null and published_date > 1000000 and published_date < 2000000 PRIMARY KEY(published_date, domain, mv_pk);
+  - create MATERIALIZED VIEW mv_synchronous_lwt_deletions as select * from blog_posts where domain is not null and mv_pk is not null and published_date > 150000 and published_date < 300000 PRIMARY KEY(published_date, domain, mv_pk);
+
+
+### Column Distribution Specifications ###
+
+columnspec:
+  - name: domain
+    population: seq(1..200000001)  #10M possible domains to pick from
+
+  - name: published_date
+    cluster: uniform(1..2000000)         #under each domain we will have max 1000 posts
+
+  - name: mv_pk
+    population: seq(1..2001000)
+
+  - name: url
+    size: uniform(30..30)
+
+  - name: title                  #titles shouldn't go beyond 200 chars
+    size: gaussian(10..20)
+
+  - name: author
+    size: uniform(5..20)         #author names should be short
+
+### Batch Ratio Distribution Specifications ###
+
+insert:
+  partitions: fixed(1)            # Our partition key is the domain so only insert one per batch
+
+  select:    fixed(1)/1000        # We have 1000 posts per domain so 1/1000 will allow 1 post per batch
+
+  batchtype: UNLOGGED             # Unlogged batches
+
+
+#
+# A list of queries you wish to run against the schema
+#
+queries:
+   select_base:
+      cql: select * from blog_posts where domain = ? and mv_pk = ? LIMIT 1
+      fields: samerow
+   select_mv:
+      cql: select * from mv_synchronous_lwt_publish_date where domain = ? and published_date = ? and mv_pk = ? LIMIT 1
+      fields: samerow
+   select_mv_2:
+      cql: select * from mv_synchronous_lwt_publish_date_after_update where domain = ? and published_date = ? and mv_pk = ? LIMIT 1
+      fields: samerow
+   lwt_update_one_column:
+      cql: update blog_posts set published_date = 30000000 where domain = ? and mv_pk = ? if published_date > 0 and published_date <= 150000
+      fields: samerow
+   lwt_deletes:
+     cql: delete from blog_posts where domain = ? and mv_pk = ? if published_date > 150000 and published_date < 240000
+     fields: samerow

--- a/data_dir/mv_synchronous_updates_on_standard.yaml
+++ b/data_dir/mv_synchronous_updates_on_standard.yaml
@@ -1,0 +1,26 @@
+# LWT test: create and update data using LWT.
+### DML ###
+
+# Keyspace Name
+keyspace: keyspace1
+
+# Table name
+table: standard1
+
+extra_definitions:
+  - create MATERIALIZED VIEW main_mv_standard1 as select * from standard1 where token(key) > -4570794944214759424 and token(key) < 4621334552741592064 PRIMARY KEY(key) WITH synchronous_updates = true;
+
+
+#
+# A list of queries you wish to run against the schema
+#
+queries:
+   select:
+      cql: select * from main_mv_standard1 where key = ? LIMIT 1
+      fields: samerow
+   mv_pk_update_pk:
+      cql: update standard1 set "C0" = ? where key = ?
+      fields: samerow
+   mv_pk_update_non_pk:
+      cql: update standard1 set "C1" = ? where key = ?
+      fields: samerow

--- a/jenkins-pipelines/longevity_mv_synchronous_updates-12h.jenkinsfile
+++ b/jenkins-pipelines/longevity_mv_synchronous_updates-12h.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/longevity/longevity-mv-synchronous-updates-12h.yaml'
+
+)

--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -26,7 +26,8 @@ from sdcm.loader import CassandraStressExporter, CassandraStressHDRExporter
 from sdcm.cluster import BaseLoaderSet  # , BaseNode
 from sdcm.prometheus import nemesis_metrics_obj
 from sdcm.sct_events import Severity
-from sdcm.utils.common import FileFollowerThread, get_profile_content, get_data_dir_path, time_period_str_to_seconds
+from sdcm.utils.common import FileFollowerThread, get_data_dir_path, time_period_str_to_seconds
+from sdcm.utils.user_profile import get_profile_content
 from sdcm.sct_events.loaders import CassandraStressEvent, CS_ERROR_EVENTS_PATTERNS, CS_NORMAL_EVENTS_PATTERNS
 from sdcm.stress.base import DockerBasedStressThread, format_stress_cmd_error
 from sdcm.utils.docker_remote import RemoteDocker

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -63,7 +63,6 @@ import libcloud.storage.types
 from libcloud.compute.base import Node as GCENode, NodeImage as GCEImage
 from libcloud.compute.providers import get_driver
 from libcloud.compute.types import Provider
-import yaml
 from packaging.version import Version
 from prettytable import PrettyTable
 
@@ -122,24 +121,28 @@ def remote_get_file(remoter, src, dst, hash_expected=None, retries=1, user_agent
     assert _remote_get_hash(remoter, dst) == hash_expected
 
 
-def get_profile_content(stress_cmd):
-    """
-    Looking profile yaml in data_dir or the path as is to get the user profile
-    and loading it's yaml
+def get_first_view_with_name_like(view_name_substr: str, session) -> tuple:
+    query = f"select keyspace_name, view_name, base_table_name from system_schema.views " \
+            f"where view_name like '%_{view_name_substr}' ALLOW FILTERING"
+    LOGGER.debug("Run query: %s", query)
+    result = session.execute(query)
+    if not result:
+        return None, None, None
 
-    :return: (profile_filename, dict with yaml)
-    """
+    return result.one().keyspace_name, result.one().view_name, result.one().base_table_name
 
-    cs_profile = re.search(r'profile=(.*\.yaml)', stress_cmd).group(1)
-    sct_cs_profile = os.path.join(os.path.dirname(__file__), '../../', 'data_dir', os.path.basename(cs_profile))
-    if os.path.exists(sct_cs_profile):
-        cs_profile = sct_cs_profile
-    elif not os.path.exists(cs_profile):
-        raise FileNotFoundError('User profile file {} not found'.format(cs_profile))
 
-    with open(cs_profile, encoding="utf-8") as yaml_stream:
-        profile = yaml.safe_load(yaml_stream)
-    return cs_profile, profile
+def get_entity_columns(keyspace_name: str, entity_name: str, session) -> list:
+    query = f"select column_name, kind, type from system_schema.columns where keyspace_name = '{keyspace_name}' " \
+            f"and table_name='{entity_name}'"
+    LOGGER.debug("Run query: %s", query)
+    result = session.execute(query)
+    view_details = []
+
+    for row in result:
+        view_details.append({"column_name": row.column_name, "kind": row.kind, "type": row.type})
+
+    return view_details
 
 
 def generate_random_string(length):
@@ -2977,3 +2980,47 @@ def sleep_for_percent_of_duration(duration: int, percent: int, min_duration: int
     duration = max(min(duration, max_duration), min_duration)
     LOGGER.debug("Sleeping for %s seconds", duration)
     time.sleep(duration)
+
+
+def get_keyspace_partition_ranges(node, keyspace: str):
+    result = node.run_nodetool("describering", keyspace)
+    if not result.stdout:
+        return None
+
+    ranges_as_list = re.findall(r'^\s*TokenRange\((.*)\)\s*$', result.stdout, re.MULTILINE)
+    if not ranges_as_list:
+        raise ValueError(f"No TokenRange() found in describering: {result.stdout}")
+
+    return [describering_parsing(one_range) for one_range in ranges_as_list]
+
+
+def keyspace_min_max_tokens(node, keyspace: str):
+    ranges = get_keyspace_partition_ranges(node, keyspace)
+    if not ranges:
+        return None, None
+
+    min_token = min([token['start_token'] for token in ranges])
+    max_token = max([token['end_token'] for token in ranges])
+    return min_token, max_token
+
+
+def describering_parsing(describering_output):
+    def _list2dic(attr_list, heads_to_dict):
+        res = {}
+        for ind, attr in enumerate(heads_to_dict):
+            res[attr] = attr_list[ind].strip()
+        return res
+
+    found_attributes = re.findall(r'^\s*start_token:(-?\d+), end_token:(-?\d+), endpoints:\[([\d\., ]+)\], '
+                                  r'rpc_endpoints:\[([\d\., ]+)\], endpoint_details:\[(.*)\]\s*$',
+                                  describering_output, re.MULTILINE)
+    heads = ['start_token', 'end_token', 'endpoints', 'rpc_endpoints']
+    result = {}
+    assert found_attributes, "Wrong format of token range: " + describering_output
+    for index, attribute in enumerate(heads):
+        attr_value = found_attributes[0][index].strip()
+        result[attribute] = int(attr_value) if "token" in attribute else attr_value
+        result["details"] = [_list2dic(attr_list, ['host', 'datacenter', 'rack']) for attr_list in
+                             re.findall(r'EndpointDetails\(host:([\d\.,]+), datacenter:([^,]+), rack:([^\)]+)\),?',
+                                        found_attributes[0][4])]
+    return result

--- a/sdcm/utils/data_validator.py
+++ b/sdcm/utils/data_validator.py
@@ -141,7 +141,7 @@ from typing import NamedTuple, Optional
 from sdcm.sct_events import Severity
 from sdcm.test_config import TestConfig
 
-from sdcm.utils.common import get_profile_content
+from sdcm.utils.user_profile import get_profile_content
 from sdcm.sct_events.health import DataValidatorEvent
 
 

--- a/sdcm/utils/user_profile.py
+++ b/sdcm/utils/user_profile.py
@@ -1,0 +1,130 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2023 ScyllaDB
+
+""" This module keeps utilities that help to extract schema definition and stress commands from user profile """
+from __future__ import absolute_import, annotations
+
+import os
+import re
+
+import yaml
+
+
+def get_stress_command_for_profile(params, stress_cmds_part, search_for_user_profile, stress_cmd=None):
+    """
+    Extract stress command from test profiles if this command runs user profile and ignore not user profile command
+    Example:
+        "cassandra-stress user profile=/tmp/c-s_lwt_big_data_multidc.yaml n=10000000 ops'(insert_query=1)'
+        cl=QUORUM -mode native cql3 -rate threads=1000"
+    """
+    if not stress_cmd:
+        stress_cmd = params.get(stress_cmds_part) or []
+        stress_cmd = [cmd for cmd in stress_cmd if search_for_user_profile in cmd]
+
+    if not stress_cmd:
+        return []
+
+    if not isinstance(stress_cmd, list):
+        stress_cmd = [stress_cmd]
+
+    return stress_cmd
+
+
+def get_view_cmd_from_profile(profile_content, name_substr, all_entries=False):
+    """
+    Extract materialized view creation command from user profile, 'extra_definitions' part
+    """
+    all_mvs = profile_content['extra_definitions']
+    mv_cmd = [cmd for cmd in all_mvs if name_substr in cmd]
+
+    mv_cmd = [mv_cmd[0]] if not all_entries and mv_cmd else mv_cmd
+    return mv_cmd
+
+
+def get_view_name_from_stress_cmd(mv_create_cmd, name_substr):
+    """
+    Get materialized view name from creation command (how to get creation command see "get_view_cmd_from_profile" func)
+    Example:
+        extra_definitions:
+          - create MATERIALIZED VIEW cf_update_2_columns_mv_pk as select * from blog_posts where domain is not null;
+
+    """
+    find_mv_name = re.search(r'materialized view (.*%s.*) as' % name_substr, mv_create_cmd, re.I)
+    return find_mv_name.group(1) if find_mv_name else None
+
+
+def get_view_name_from_user_profile(params, stress_cmds_part: str, search_for_user_profile: str, view_name_substr: str):
+    """
+    Get materialized view name from user profile defined in the test yaml.
+    It may be used when we want query from materialized view that was created during running user profile
+    """
+    stress_cmd = get_stress_command_for_profile(params=params, stress_cmds_part=stress_cmds_part,
+                                                search_for_user_profile=search_for_user_profile)
+    if not stress_cmd:
+        return ""
+
+    _, profile = get_profile_content(stress_cmd[0])
+    mv_cmd = get_view_cmd_from_profile(profile, view_name_substr)
+    return get_view_name_from_stress_cmd(mv_cmd[0], view_name_substr)
+
+
+def get_keyspace_from_user_profile(params, stress_cmds_part: str, search_for_user_profile: str):
+    """
+     Get keyspace name from user profile defined in the test yaml.
+     Example:
+        # Keyspace Name
+        keyspace: mv_synchronous_ks
+    """
+    stress_cmd = get_stress_command_for_profile(params=params, stress_cmds_part=stress_cmds_part,
+                                                search_for_user_profile=search_for_user_profile)
+    if not stress_cmd:
+        return ""
+
+    _, profile = get_profile_content(stress_cmd[0])
+    return profile['keyspace']
+
+
+def get_table_from_user_profile(params, stress_cmds_part: str, search_for_user_profile: str):
+    """
+     Get table name from user profile defined in the test yaml.
+     Example:
+        # Table name
+        table: blog_posts
+    """
+    stress_cmd = get_stress_command_for_profile(params=params, stress_cmds_part=stress_cmds_part,
+                                                search_for_user_profile=search_for_user_profile)
+    if not stress_cmd:
+        return ""
+
+    _, profile = get_profile_content(stress_cmd[0])
+    return profile['table']
+
+
+def get_profile_content(stress_cmd):
+    """
+    Looking profile yaml in data_dir or the path as is to get the user profile
+    and loading it's yaml
+
+    :return: (profile_filename, dict with yaml)
+    """
+
+    cs_profile = re.search(r'profile=(.*\.yaml)', stress_cmd).group(1)
+    sct_cs_profile = os.path.join(os.path.dirname(__file__), '../../', 'data_dir', os.path.basename(cs_profile))
+    if os.path.exists(sct_cs_profile):
+        cs_profile = sct_cs_profile
+    elif not os.path.exists(cs_profile):
+        raise FileNotFoundError('User profile file {} not found'.format(cs_profile))
+
+    with open(cs_profile, encoding="utf-8") as yaml_stream:
+        profile = yaml.safe_load(yaml_stream)
+    return cs_profile, profile

--- a/test-cases/longevity/longevity-mv-synchronous-updates-12h.yaml
+++ b/test-cases/longevity/longevity-mv-synchronous-updates-12h.yaml
@@ -1,0 +1,27 @@
+test_duration: 780
+prepare_write_cmd: ["cassandra-stress write cl=ALL n=104857600  -schema 'replication(factor=3)' -mode cql3 native -rate threads=1000 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..104857600 -log interval=15",
+                    "cassandra-stress user profile=/tmp/mv_synchronous_updates.yaml ops'(insert=25)' cl=QUORUM n=20000000 -mode cql3 native -rate threads=100",
+                    "cassandra-stress user profile=/tmp/mv_synchronous_updates_lwt.yaml ops'(insert=25)' cl=QUORUM n=10000000 -mode cql3 native -rate threads=100"
+                   ]
+stress_read_cmd: ["cassandra-stress mixed cl=QUORUM duration=690m  -schema 'replication(factor=3)' -mode cql3 native -rate threads=100 -col 'size=FIXED(64) n=FIXED(16)' -pop seq=1..104857600 -log interval=15",
+                  "cassandra-stress user profile=/tmp/mv_synchronous_updates.yaml ops'(select_base=3,select_mv=3,select_mv_2=3,url_column_update=1,row_delete=1)' cl=QUORUM duration=690m -mode cql3 native -rate threads=50",
+                  "cassandra-stress user profile=/tmp/mv_synchronous_updates.yaml ops'(select_base=3,select_mv=3,select_mv_2=3,url_column_update=1,row_delete=1)' cl=QUORUM duration=690m -mode cql3 native -rate threads=50",
+                  "cassandra-stress user profile=/tmp/mv_synchronous_updates.yaml ops'(select_base=3,select_mv=3,select_mv_2=3,url_column_update=1,row_delete=1)' cl=QUORUM duration=690m -mode cql3 native -rate threads=50",
+                  "cassandra-stress user profile=/tmp/mv_synchronous_updates_lwt.yaml ops'(select_base=1,select_mv=1,select_mv_2=1,lwt_deletes=10)' cl=QUORUM duration=690m -mode cql3 native -rate threads=50",
+                  "cassandra-stress user profile=/tmp/mv_synchronous_updates_lwt.yaml ops'(select_base=1,select_mv=1,select_mv_2=1,lwt_update_one_column=10)' cl=QUORUM duration=690m -mode cql3 native -rate threads=50",
+                  "cassandra-stress user profile=/tmp/mv_synchronous_updates_on_standard.yaml ops'(select=6, mv_pk_update_pk=2, mv_pk_update_non_pk=2)' cl=QUORUM  duration=690m -pop seq=0..104857600 -mode cql3 native -rate threads=50",
+                  "cassandra-stress user profile=/tmp/mv_synchronous_updates_on_standard.yaml ops'(select=6, mv_pk_update_pk=2, mv_pk_update_non_pk=2)' cl=QUORUM  duration=690m -pop seq=0..104857600 -mode cql3 native -rate threads=50",
+                 ]
+
+n_db_nodes: 6
+n_loaders: 2
+n_monitor_nodes: 1
+round_robin: true
+
+instance_type_db: 'i4i.xlarge'
+
+nemesis_class_name: 'SisyphusMonkey'
+nemesis_interval: 5
+nemesis_during_prepare: false
+
+user_prefix: 'longevity-mv-synch-12h'


### PR DESCRIPTION
This commit add new basic longevity for MV feature is presented by https://github.com/scylladb/scylladb/commit/cb8a67dc98b60919ac9d5bbb6618e17f7d1602c7

It creates different materialized views. Part of MVs are running in sychronous mode, others in asynchronous mode. Updates/inserts/deletes into MVs perform in parallel with different nemeses, disruptive and non-disruptive

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
