### PR TITLE
test(eks-14-tenants): enable sni_proxy

### DIFF
--- a/sdcm/cluster_k8s/__init__.py
+++ b/sdcm/cluster_k8s/__init__.py
@@ -868,7 +868,6 @@ class KubernetesCluster(metaclass=abc.ABCMeta):  # pylint: disable=too-many-publ
             dns_domains = [f"{cluster_name}.sct.scylladb.com"]
             expose_options = {"cql": {"ingress": {
                 "annotations": {
-                    "haproxy.org/scale-server-slots": "1",
                     "haproxy.org/ssl-passthrough": "true",
                 },
                 "disabled": False,

--- a/sdcm/k8s_configs/ingress-controller/10_haproxy-kubernetes-ingress.configmap.yaml
+++ b/sdcm/k8s_configs/ingress-controller/10_haproxy-kubernetes-ingress.configmap.yaml
@@ -7,4 +7,4 @@ data:
   load-balance: "roundrobin"
   maxconn: "$HAPROXY_MAXCONN"
   src-ip-header: "True-Client-IP"
-  http-keep-alive: "true"
+  http-connection-mode: "http-keep-alive"

--- a/test-cases/scylla-operator/longevity-scylla-operator-12h-multitenant-14-clients.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-12h-multitenant-14-clients.yaml
@@ -50,3 +50,5 @@ nemesis_during_prepare: false
 user_prefix: 'long-scylla-operator-12h-multitenant-14-clients'
 
 k8s_enable_tls: true
+
+k8s_loader_run_type: 'static'

--- a/test-cases/scylla-operator/longevity-scylla-operator-12h-multitenant-14-clients.yaml
+++ b/test-cases/scylla-operator/longevity-scylla-operator-12h-multitenant-14-clients.yaml
@@ -1,6 +1,3 @@
-# TODO:
-# - enable tls and SNI proxy
-
 test_duration: 800
 
 prepare_write_cmd:  [
@@ -51,3 +48,5 @@ nemesis_seed: ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11',
 nemesis_during_prepare: false
 
 user_prefix: 'long-scylla-operator-12h-multitenant-14-clients'
+
+k8s_enable_tls: true


### PR DESCRIPTION
Enable the ingress controller for this case,
which is the target for server free-tier

Ref: https://github.com/scylladb/qa-tasks/issues/936


## Testing:
- [ ] - https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/fruch/job/longevity-scylla-operator-12h-multitenant-eks/11
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
