### PR TITLE
fix(data validator): rows were not deleted

### DIFF
--- a/sdcm/utils/data_validator.py
+++ b/sdcm/utils/data_validator.py
@@ -790,6 +790,11 @@ class LongevityDataValidator:
                 ).publish()
             else:
                 LOGGER.debug('Validation deleted rows finished successfully')
+        elif len(actual_result) == self.rows_before_deletion:
+            DataValidatorEvent.DeletedRowsValidator(
+                severity=Severity.WARNING,
+                message="Rows were not deleted. Maybe need to increase dataset for delete."
+            ).publish()
         else:
             LOGGER.warning('Deleted row were not found. May be issue #6181. '
                            'Actual dataset length: {}, Expected dataset length: {}'.format(len(actual_result),


### PR DESCRIPTION
Fix `sdcm.utils.data_validator.LongevityDataValidator.validate_deleted_rows`. Handle case in validation of deleted rows when rows were not deleted. Print relevant message

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
