### PR TITLE
feature(k8s): add support for dynamic local volume provisioner

### DIFF
--- a/defaults/k8s_eks_config.yaml
+++ b/defaults/k8s_eks_config.yaml
@@ -27,7 +27,11 @@ k8s_loader_cluster_name: 'sct-loaders'
 k8s_scylla_cluster_name: 'sct-cluster'
 k8s_scylla_datacenter: 'us-east1-b'
 k8s_scylla_disk_gi: 500
-k8s_scylla_disk_class: 'local-raid-disks'
+# NOTE: use any of the following pairs:
+#   'k8s_scylla_disk_class=local-raid-disks'   and 'k8s_local_volume_provisioner_type=static'
+#   'k8s_scylla_disk_class=scylladb-local-xfs' and 'k8s_local_volume_provisioner_type=dynamic'
+k8s_scylla_disk_class: 'scylladb-local-xfs'
+k8s_local_volume_provisioner_type: 'dynamic'
 
 # NOTE: If 'k8s_scylla_operator_docker_image' not set then the one from helm chart will be used.
 # To test nightly builds define it like this: 'scylladb/scylla-operator:nightly'

--- a/defaults/k8s_gke_config.yaml
+++ b/defaults/k8s_gke_config.yaml
@@ -30,6 +30,7 @@ k8s_scylla_operator_chart_version: 'latest'
 k8s_cert_manager_version: '1.8.0'
 k8s_deploy_monitoring: false
 k8s_enable_performance_tuning: false
+k8s_local_volume_provisioner_type: 'static'
 
 # NOTE: GKE requires 'k8s_scylla_utils_docker_image' be defined to enterprise Scylla version 2021+
 #       to have more performant configuration of disks.

--- a/defaults/k8s_local_kind_config.yaml
+++ b/defaults/k8s_local_kind_config.yaml
@@ -19,7 +19,12 @@ k8s_scylla_datacenter: 'dc-1'
 k8s_scylla_rack: 'kind'
 k8s_scylla_cluster_name: 'sct-cluster'
 k8s_scylla_disk_gi: 10
-k8s_scylla_disk_class: 'local-raid-disks'
+# NOTE: use any of the following pairs:
+#   'k8s_scylla_disk_class=local-raid-disks'   and 'k8s_local_volume_provisioner_type=static'
+#   'k8s_scylla_disk_class=scylladb-local-xfs' and 'k8s_local_volume_provisioner_type=dynamic'
+k8s_scylla_disk_class: 'scylladb-local-xfs'
+k8s_local_volume_provisioner_type: 'dynamic'
+
 k8s_minio_storage_size: '20Gi'
 k8s_enable_performance_tuning: false
 k8s_use_chaos_mesh: true

--- a/docker/env/hydra.sh
+++ b/docker/env/hydra.sh
@@ -258,6 +258,7 @@ function run_in_docker () {
         -v /etc/sudoers:/etc/sudoers:ro \
         -v /etc/sudoers.d/:/etc/sudoers.d:ro \
         -v /etc/shadow:/etc/shadow:ro \
+        -v /dev:/dev:rw \
         ${DOCKER_GROUP_ARGS[@]} \
         ${DOCKER_ADD_HOST_ARGS[@]} \
         ${docker_common_args[@]} \

--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -276,6 +276,9 @@ class EksCluster(KubernetesCluster, EksClusterCleanupMixin):  # pylint: disable=
             allowed_labels_on_scylla_node.extend(self.perf_pods_labels)
         if self.params.get('k8s_use_chaos_mesh'):
             allowed_labels_on_scylla_node.append(('app.kubernetes.io/component', 'chaos-daemon'))
+        if self.params.get("k8s_local_volume_provisioner_type") != 'static':
+            allowed_labels_on_scylla_node.append(('app', 'node-pkg-installer'))
+            allowed_labels_on_scylla_node.append(('app.kubernetes.io/name', 'local-csi-driver'))
         return allowed_labels_on_scylla_node
 
     def create_eks_cluster(self, wait_till_functional=True):

--- a/sdcm/k8s_configs/eks/scylla-node-prepare.yaml
+++ b/sdcm/k8s_configs/eks/scylla-node-prepare.yaml
@@ -156,6 +156,49 @@ spec:
           hostPath:
             path: /lib/systemd
 ---
+# NOTE: 'node-pkg-installer' is taken from here:
+# https://github.com/scylladb/scylla-operator/commit/fa09b328c9c6aabded912a98f2a7aadad74d07e4
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-pkg-installer
+  labels:
+    app: node-pkg-installer
+spec:
+  selector:
+    matchLabels:
+      app: node-pkg-installer
+  template:
+    metadata:
+      labels:
+        app: node-pkg-installer
+    spec:
+      containers:
+      # NOTE: image is built on Feb 1, 2023 -> scylla-operator:1.9.0-alpha.1
+      - image: "scylladb/scylla-operator@sha256:10e3e7dddc2de1bbd473710223a4be5e8c5ef5dc9bb1a61d81fdc398d9dcd74c"
+        imagePullPolicy: "Always"
+        name: node-pkg-installer
+        command:
+        - "/usr/sbin/chroot"
+        - "/host"
+        - "/usr/bin/bash"
+        - "-euExo"
+        - "pipefail"
+        - "-c"
+        args:
+        - |
+          yum install -y util-linux xfsprogs mdadm && \
+          sleep infinity
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /host
+          name: hostfs
+      volumes:
+      - name: hostfs
+        hostPath:
+          path: /
+---
 # Daemonset that will configure disks and networking interfaces on node.
 apiVersion: apps/v1
 kind: DaemonSet

--- a/sdcm/k8s_configs/node-config-crd.yaml
+++ b/sdcm/k8s_configs/node-config-crd.yaml
@@ -5,6 +5,22 @@ metadata:
   labels:
     app: scylla-node-config
 spec:
+  localDiskSetup:
+    filesystems:
+      - type: xfs
+        device: /dev/md/nvmes
+    mounts:
+      - device: /dev/md/nvmes
+        mountPoint: /mnt/persistent-volumes
+        unsupportedOptions:
+        - prjquota
+    raids:
+      - type: RAID0
+        name: nvmes
+        RAID0:
+          devices:
+            modelRegex: "Amazon EC2 NVMe Instance Storage"
+            nameRegex: "/dev/nvme\\d+n\\d+$"
   placement:
     nodeSelector: {}
     # NOTE: 'affinity' will be updated in the code

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -823,6 +823,13 @@ class SCTConfiguration(dict):
         dict(name="k8s_deploy_monitoring", env="SCT_K8S_DEPLOY_MONITORING", type=boolean,
              help=""),
 
+        dict(name="k8s_local_volume_provisioner_type", env="SCT_K8S_LOCAL_VOLUME_PROVISIONER_TYPE",
+             type=str, choices=("static", "dynamic"),
+             help="Defines the type of the K8S local volume provisioner to be deployed. "
+                  "It may be either 'static' or 'dynamic'. Details about 'dynamic': "
+                  "'dynamic': https://github.com/scylladb/k8s-local-volume-provisioner; "
+                  "'static': sdcm/k8s_configs/static-local-volume-provisioner.yaml"),
+
         dict(name="k8s_scylla_operator_docker_image",
              env="SCT_K8S_SCYLLA_OPERATOR_DOCKER_IMAGE", type=str,
              help="Docker image to be used for installation of scylla operator."),

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -1370,8 +1370,10 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             image_type="fake-image-type",
             instance_type="fake-instance-type")
         self.k8s_cluster.deploy_node_pool(scylla_pool, wait_till_ready=False)
-        self.k8s_cluster.install_static_local_volume_provisioner(
-            node_pools=scylla_pool)
+        if self.params.get("k8s_local_volume_provisioner_type") == 'static':
+            self.k8s_cluster.install_static_local_volume_provisioner(node_pools=scylla_pool)
+        else:
+            self.k8s_cluster.install_dynamic_local_volume_provisioner(node_pools=scylla_pool)
 
         self.k8s_cluster.deploy_cert_manager(pool_name=self.k8s_cluster.AUXILIARY_POOL_NAME)
         if self.params.get('k8s_enable_tls'):


### PR DESCRIPTION
Following new configuration option is added:
    
    k8s_local_volume_provisioner_type: Literal["static", "dynamic"] = "static"
    
If it is set to `static` then will be used old approach for Scylla disk setup.
If it is set to `dynamic` then new approach will be used which is added in latest dev operator versions `1.9.0+`
    
Backend support:
- `EKS` backend is fully supported.
- Local K8S backend (`kind`) is partially supported - only volume provisioner part without disk setup (mocked using `dd`+`mkfs` commands).
- `GKE` backend is not supported.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
