### PR TITLE
fix(jenkins pipeline): Increase timeout of the 'Get test duration' stage

### DIFF
--- a/vars/jepsenPipeline.groovy
+++ b/vars/jepsenPipeline.groovy
@@ -93,7 +93,7 @@ def call(Map pipelineParams) {
             stage('Get test duration') {
                 steps {
                     catchError(stageResult: 'FAILURE') {
-                        timeout(time: 5, unit: 'MINUTES') {
+                        timeout(time: 10, unit: 'MINUTES') {
                             script {
                                 wrap([$class: 'BuildUser']) {
                                     dir('scylla-cluster-tests') {

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -178,7 +178,7 @@ def call(Map pipelineParams) {
             stage('Get test duration') {
                 steps {
                     catchError(stageResult: 'FAILURE') {
-                        timeout(time: 5, unit: 'MINUTES') {
+                        timeout(time: 10, unit: 'MINUTES') {
                             script {
                                 wrap([$class: 'BuildUser']) {
                                     dir('scylla-cluster-tests') {

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -177,7 +177,7 @@ def call(Map pipelineParams) {
             }
             stage('Get test duration') {
                 options {
-                    timeout(time: 5, unit: 'MINUTES')
+                    timeout(time: 10, unit: 'MINUTES')
                 }
                 steps {
                     catchError(stageResult: 'FAILURE') {

--- a/vars/perfSearchBestConfigParallelPipeline.groovy
+++ b/vars/perfSearchBestConfigParallelPipeline.groovy
@@ -121,7 +121,7 @@ def call(Map pipelineParams) {
                 }
                 steps {
                     catchError(stageResult: 'FAILURE') {
-                        timeout(time: 5, unit: 'MINUTES') {
+                        timeout(time: 10, unit: 'MINUTES') {
                             script {
                                 wrap([$class: 'BuildUser']) {
                                     dir('scylla-cluster-tests') {

--- a/vars/rollingOperatorUpgradePipeline.groovy
+++ b/vars/rollingOperatorUpgradePipeline.groovy
@@ -95,7 +95,7 @@ def call(Map pipelineParams) {
             stage('Get test duration') {
                 steps {
                     catchError(stageResult: 'FAILURE') {
-                        timeout(time: 5, unit: 'MINUTES') {
+                        timeout(time: 10, unit: 'MINUTES') {
                             script {
                                 wrap([$class: 'BuildUser']) {
                                     dir('scylla-cluster-tests') {


### PR DESCRIPTION
The stage times out often and its clear that 5 minutes is too short of a timeout. As such, I increased the timeout to 10 minutes across all of the pipelines.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
