### PR TITLE
fix(csrangehistogram): skip empty built histogram

### DIFF
--- a/performance_regression_test.py
+++ b/performance_regression_test.py
@@ -749,7 +749,7 @@ class PerformanceRegressionTest(ClusterTester):  # pylint: disable=too-many-publ
         if not self.params["use_hdr_cs_histogram"]:
             return
 
-        start_time = self.start_time
+        start_time = self.get_test_start_time() or self.start_time
         end_time = time.time()
 
         if test_type == PerformanceTestType.THROUGHPUT:

--- a/sdcm/utils/csrangehistogram.py
+++ b/sdcm/utils/csrangehistogram.py
@@ -119,8 +119,6 @@ class CSRangeHistogramBuilder:
                                                                range_end_time_sec=end_time,
                                                                absolute=absolute_time)
             if not next_hist:
-                if hdr_reader.start_time_sec > start_time:
-                    end_time = int(start_time)
                 break
             tag = next_hist.get_tag()
             if not tag:
@@ -139,7 +137,7 @@ class CSRangeHistogramBuilder:
 
     @staticmethod
     def build_histograms_range_with_interval(path: str,
-                                             start_time=0, end_time=sys.maxsize,
+                                             start_time: int | float, end_time: int | float,
                                              interval=TIME_INTERVAL, absolute_time=True) -> list[CSRangeHistogram]:
         """
             Build set of time range histogrmas (as list) from
@@ -150,7 +148,7 @@ class CSRangeHistogramBuilder:
         """
 
         start_ts = int(start_time)
-        end_ts = int(end_time or sys.maxsize)
+        end_ts = int(end_time)
         summary = []
 
         if end_ts - start_ts < TIME_INTERVAL:
@@ -172,10 +170,8 @@ class CSRangeHistogramBuilder:
         for start_interval in range(start_ts, end_ts, window_step):
             end_interval = end_ts if start_interval + window_step > end_ts else start_interval + window_step
             range_histograms = build_range_histogram(start_time=start_interval, end_time=end_interval)
-            if not range_histograms.histograms and int(range_histograms.start_time) == int(range_histograms.end_time):
-                continue
             if not range_histograms.histograms:
-                break
+                continue
             summary.append(range_histograms)
 
         return summary
@@ -298,5 +294,6 @@ class CSRangeHistogramSummary:
                 if tag.value in hst.histograms.keys():
                     parsed_summary = self.convert_raw_histogram(hst.histograms[tag.value], hst.start_time, hst.end_time)
                     summary.update({operation: asdict(parsed_summary)})
-            converted_histograms.append(summary)
+            if summary:
+                converted_histograms.append(summary)
         return converted_histograms


### PR DESCRIPTION
for performance latency test, start time for each sub_test was set incorrectly, and was equal to start_time of the test. This bring not need calculation of histogram for preload period and a lot of empty histograms in results.

Set the valid start time for each subtest based on test_details.start_time and set start_time and end_time parameters as required for build_histogram_by_range to avoid possible case, when histogram intervals could be build infinitely or till sys.maxsize()

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
