### PR TITLE
fix(parse_scylla_version): better check the version

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -45,7 +45,7 @@ class FillDatabaseData(ClusterTester):
 
     """
     NON_FROZEN_SUPPORT_OS_MIN_VERSION = '4.1'  # open source version with non-frozen user_types support
-    NON_FROZEN_SUPPORT_ENTERPRISE_MIN_VERSION = '2020'  # enterprise version with non-frozen user_types support
+    NON_FROZEN_SUPPORT_ENTERPRISE_MIN_VERSION = '2020.1'  # enterprise version with non-frozen user_types support
     NULL_VALUES_SUPPORT_OS_MIN_VERSION = "4.4.rc0"
     NULL_VALUES_SUPPORT_ENTERPRISE_MIN_VERSION = "2021.1.3"
     NEW_SORTING_ORDER_WITH_SECONDARY_INDEXES_OS_MIN_VERSION = "4.4.rc0"

--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -120,7 +120,9 @@ RepositoryDetails = namedtuple("RepositoryDetails", ["type", "urls"])
 
 def parse_scylla_version(version_to_parse: str) -> version.Version:
     version_format = re.compile(r'(\d+\.\d)|(\.\d+)')
-    return parse_version(version_format.search(version_to_parse)[0])
+    major_version = version_format.search(version_to_parse)
+    assert major_version, f"version_to_parse: '{version_to_parse}' isn't supported scylla version string"
+    return parse_version(major_version[0])
 
 
 @lru_cache(maxsize=1024)


### PR DESCRIPTION
it was failing like:
```
File ".../sdcm/fill_db_data.py", line 3173, in version_non_frozen_udt_support
return self.parsed_scylla_version >= parse_scylla_version(version_with_support)
File ".../sdcm/utils/version_utils.py", line 123, in parse_scylla_version
return parse_version(version_format.search(version_to_parse)[0])
TypeError: 'NoneType' object is not subscriptable
```

since the version passed to is was not matching the regex

```python
NON_FROZEN_SUPPORT_ENTERPRISE_MIN_VERSION = '2020'
```

now it checking it better and rasining clear exception why it was failing

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
