### PR TITLE
fix(pipeline): dont fallback to builder when no sct runner

### DIFF
--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -192,13 +192,11 @@ def call(Map pipelineParams) {
             }
             stage('Create SCT Runner') {
                 steps {
-                    catchError(stageResult: 'FAILURE') {
-                        script {
-                            wrap([$class: 'BuildUser']) {
-                                dir('scylla-cluster-tests') {
-                                    timeout(time: 5, unit: 'MINUTES') {
-                                        createSctRunner(params, runnerTimeout , builder.region)
-                                    }
+                    script {
+                        wrap([$class: 'BuildUser']) {
+                            dir('scylla-cluster-tests') {
+                                timeout(time: 5, unit: 'MINUTES') {
+                                    createSctRunner(params, runnerTimeout , builder.region)
                                 }
                             }
                         }


### PR DESCRIPTION
When sct-runner is not created due some error, longevity test continues using builder machine. This causes issues on Azure when builder is located in external network and uses private ips. Also with new builders which are weak are not capable of running longevity.

This commit removes exception catch from `Create SCT Runner` step, failing whole pipeline early.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
