### PR TITLE
revert(sct)config): revert added default param for get method

### DIFF
--- a/defaults/test_default.yaml
+++ b/defaults/test_default.yaml
@@ -219,3 +219,5 @@ use_hdr_cs_histogram: false
 stop_on_hw_perf_failure: false
 
 custom_es_index: ''
+
+run_fullscan: []

--- a/longevity_test.py
+++ b/longevity_test.py
@@ -42,7 +42,7 @@ class LongevityTest(ClusterTester, loader_utils.LoaderUtilsMixin):
         return params
 
     def _get_scan_operation_params(self) -> list[FullScanParams]:
-        params = self.params.get("run_fullscan", {})
+        params = self.params.get("run_fullscan")
         self.log.info('Scan operation params are: %s', params)
 
         sla_role_name, sla_role_password = None, None

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1826,7 +1826,7 @@ class SCTConfiguration(dict):
 
         return environment_vars
 
-    def get(self, key: str | None, default=None):
+    def get(self, key: str | None):
         """
         get the value of test configuration parameter by the name
         """
@@ -1834,7 +1834,7 @@ class SCTConfiguration(dict):
         if key and '.' in key:
             if ret_val := self._dotted_get(key):
                 return ret_val
-        ret_val = super().get(key, default)
+        ret_val = super().get(key)
 
         if key in self.multi_region_params and isinstance(ret_val, list):
             ret_val = ' '.join(ret_val)


### PR DESCRIPTION
according to improvement
https://github.com/scylladb/scylla-cluster-tests/pull/2823

Remove 'default' parameter from params.get() method

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
