### PR TITLE
feature(node): support new 'replace_node_first_boot' Scylla option

### DIFF
--- a/sdcm/cluster_aws.py
+++ b/sdcm/cluster_aws.py
@@ -638,11 +638,18 @@ class AWSNode(cluster.BaseNode):
                                   DbEventsFilter(db_event=DatabaseLogEvent.RUNTIME_ERROR, node=self), ):
                     stack.enter_context(db_filter)
 
+                if self.is_replacement_by_host_id_supported:
+                    replace_option_name = "replace_node_first_boot"
+                    replace_option_value = self.host_id
+                else:
+                    replace_option_name = "replace_address_first_boot"
+                    replace_option_value = self.ip_address
                 self.remoter.sudo(shell_script_cmd(f"""\
                     sed -e '/.*scylla/s/^/#/g' -i /etc/fstab
                     sed -e '/auto_bootstrap:.*/s/false/true/g' -i /etc/scylla/scylla.yaml
-                    if ! grep ^replace_address_first_boot: /etc/scylla/scylla.yaml; then
-                        echo 'replace_address_first_boot: {self.ip_address}' | tee --append /etc/scylla/scylla.yaml
+                    if ! grep ^{replace_option_name}: /etc/scylla/scylla.yaml; then
+                        echo '{replace_option_name}: {replace_option_value}' | \
+                            tee --append /etc/scylla/scylla.yaml
                     fi
                 """))
 
@@ -680,6 +687,7 @@ class AWSNode(cluster.BaseNode):
                 self.remoter.sudo(shell_script_cmd("""\
                     sed -e '/auto_bootstrap:.*/s/true/false/g' -i /etc/scylla/scylla.yaml
                     sed -e 's/^replace_address_first_boot:/# replace_address_first_boot:/g' -i /etc/scylla/scylla.yaml
+                    sed -e 's/^replace_node_first_boot:/# replace_node_first_boot:/g' -i /etc/scylla/scylla.yaml
                 """))
 
     def hard_reboot(self):

--- a/sdcm/cluster_docker.py
+++ b/sdcm/cluster_docker.py
@@ -302,7 +302,7 @@ class ScyllaDockerCluster(cluster.BaseScyllaCluster, DockerCluster):  # pylint: 
                                         current_node=node,
                                         removed_nodes_list=self.dead_nodes_ip_address_list):
             event.publish()
-        self.clean_replacement_node_ip(node)
+        self.clean_replacement_node_options(node)
 
     @staticmethod
     def check_aio_max_nr(node: DockerNode, recommended_value: int = AIO_MAX_NR_RECOMMENDED_VALUE):

--- a/sdcm/provision/scylla_yaml/scylla_yaml.py
+++ b/sdcm/provision/scylla_yaml/scylla_yaml.py
@@ -243,6 +243,7 @@ class ScyllaYaml(BaseModel):  # pylint: disable=too-few-public-methods
     replace_token: str = ""
     replace_address: str = ""
     replace_address_first_boot: str = ""
+    replace_node_first_boot: str = ""
     override_decommission: bool = False
     enable_repair_based_node_ops: bool = True
     ring_delay_ms: int = 30 * 1000

--- a/unit_tests/test_scylla_yaml.py
+++ b/unit_tests/test_scylla_yaml.py
@@ -323,6 +323,7 @@ class ScyllaYamlTest(unittest.TestCase):
                 'replace_token': '',
                 'replace_address': '',
                 'replace_address_first_boot': '',
+                'replace_node_first_boot': '',
                 'override_decommission': False,
                 'enable_repair_based_node_ops': True,
                 'ring_delay_ms': 30000,


### PR DESCRIPTION
In Scylla 5.2 was added possibility to replace a node by it's host_id. 
It can be done by setting `replace-node-first-boot` Scylla option instead of old `replace-address-first-boot` one.

So, add support for it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
