### PR TITLE
improvement(run_fullscan): implement param validation functionality

### DIFF
--- a/internal_test_data/negative_fullscan_param.yaml
+++ b/internal_test_data/negative_fullscan_param.yaml
@@ -1,0 +1,2 @@
+run_fullscan: ['{"mode": "table", "ks_cf": "keyspace1.standard1", "interval": 1}',
+               '{"mode": "agggregate", "ks_cf": 1, "interval": 1, "full_scan_aggregates_operation_limit": "a", "validate_data": "no"}',]

--- a/internal_test_data/positive_fullscan_param.yaml
+++ b/internal_test_data/positive_fullscan_param.yaml
@@ -1,0 +1,2 @@
+run_fullscan: ['{"mode": "aggregate", "ks_cf": "keyspace1.standard1", "interval": 1, "full_scan_aggregates_operation_limit":10}',
+               '{"mode": "table", "validate_data": false}']

--- a/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-200k_pks-4days.yaml
@@ -71,4 +71,4 @@ space_node_threshold: 644245094
 stop_test_on_stress_failure: false
 
 
-run_fullscan: ['{"mode": "partition", "ks_cf": "scylla_bench.test", "interval": 300, "pk_name":"pk", "rows_count": 100000, "validate_data": "true"}']
+run_fullscan: ['{"mode": "partition", "ks_cf": "scylla_bench.test", "interval": 300, "pk_name":"pk", "rows_count": 100000, "validate_data": true}']

--- a/test-cases/longevity/longevity-large-partition-3h.yaml
+++ b/test-cases/longevity/longevity-large-partition-3h.yaml
@@ -44,4 +44,4 @@ space_node_threshold: 644245094
 
 run_fullscan:
   - '{"mode": "table", "ks_cf": "scylla_bench.test", "interval": 10}'
-  - '{"mode": "partition", "ks_cf": "scylla_bench.test", "interval": 300, "pk_name":"pk", "rows_count": 5000, "validate_data": "true", "include_data_column": "true"}'
+  - '{"mode": "partition", "ks_cf": "scylla_bench.test", "interval": 300, "pk_name":"pk", "rows_count": 5000, "validate_data": true, "include_data_column": true}'

--- a/test-cases/longevity/longevity-large-partition-4days.yaml
+++ b/test-cases/longevity/longevity-large-partition-4days.yaml
@@ -41,4 +41,4 @@ table_name: "scylla_bench.test"
 primary_key_column: "pk"
 
 
-run_fullscan: ['{"mode": "random", "ks_cf": "scylla_bench.test", "interval": 300, "pk_name":"pk", "rows_count": 10000000, "validate_data": "true"}']
+run_fullscan: ['{"mode": "random", "ks_cf": "scylla_bench.test", "interval": 300, "pk_name":"pk", "rows_count": 10000000, "validate_data": true}']

--- a/test-cases/longevity/longevity-large-partition-8h.yaml
+++ b/test-cases/longevity/longevity-large-partition-8h.yaml
@@ -50,4 +50,4 @@ user_prefix: 'longevity-large-partitions-8h'
 
 space_node_threshold: 644245094
 
-run_fullscan: ['{"mode": "partition", "ks_cf": "scylla_bench.test", "interval": 300, "pk_name":"pk", "rows_count": 5555, "validate_data": "true"}']
+run_fullscan: ['{"mode": "partition", "ks_cf": "scylla_bench.test", "interval": 300, "pk_name":"pk", "rows_count": 5555, "validate_data": true}']

--- a/unit_tests/test_config.py
+++ b/unit_tests/test_config.py
@@ -770,6 +770,26 @@ class ConfigurationTests(unittest.TestCase):  # pylint: disable=too-many-public-
             self.assertTrue(ami_id_loader.startswith("ami-"))
             self.assertTrue(ami_id_monitor.startswith("ami-"))
 
+    @staticmethod
+    def test_26_run_fullscan_params_validtion_positive():
+        os.environ['SCT_CONFIG_FILES'] = '''["internal_test_data/minimal_test_case.yaml", \
+                                                   "internal_test_data/positive_fullscan_param.yaml"]'''
+        sct_config.SCTConfiguration()
+
+    @staticmethod
+    def test_27_run_fullscan_params_validtion_negative():
+        os.environ['SCT_CONFIG_FILES'] = '''["internal_test_data/minimal_test_case.yaml", \
+                                                      "internal_test_data/negative_fullscan_param.yaml"]'''
+        try:
+            sct_config.SCTConfiguration()
+        except ValueError as exp:
+            assert str(exp) == "Config fullscan params validarion errors:\n\tfield 'mode' must be one of " \
+                "'('random', 'table', 'partition', 'aggregate', 'table_and_aggregate')' " \
+                "but got 'agggregate'\n\t" \
+                "field 'ks_cf' must be an instance of <class 'str'>, but got '1'\n\t" \
+                "field 'validate_data' must be an instance of <class 'bool'>, but got 'no'\n\t" \
+                "field 'full_scan_aggregates_operation_limit' must be an instance of <class 'int'>, but got 'a'"
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
split validation into 2 parts
1) validation logic in sct_cofig contains format validation 
2) validation logic in scan_operation_thead.py contains data validation
3) fix existing miss configurations

must be rebased and merge after https://github.com/scylladb/scylla-cluster-tests/pull/5797

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
