### PR TITLE
fix(sla): limit SLA nemesis only to sla test cases

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3863,6 +3863,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if not self.cluster.nodes[0].is_enterprise:
             raise UnsupportedNemesis("SLA feature is only supported by Scylla Enterprise")
 
+        if not getattr(self.tester, "roles", None):
+            raise UnsupportedNemesis('This nemesis is supported for SLA test only')
+
         # Set small amount rows 50000000 when can not recognize a real dataset size, suppose that this amount should be
         # inserted in any case
         dataset_size = self.get_test_data_set_size() or 50000000
@@ -3877,6 +3880,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def disrupt_sla_decrease_shares_during_load(self):
         if not self.cluster.nodes[0].is_enterprise:
             raise UnsupportedNemesis("SLA feature is only supported by Scylla Enterprise")
+
+        if not getattr(self.tester, "roles", None):
+            raise UnsupportedNemesis('This nemesis is supported for SLA test only')
 
         # Set small amount rows 50000000 when can not recognize a real dataset size, suppose that this amount should be
         # inserted in any case
@@ -3893,6 +3899,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if not self.cluster.nodes[0].is_enterprise:
             raise UnsupportedNemesis("SLA feature is only supported by Scylla Enterprise")
 
+        if not getattr(self.tester, "roles", None):
+            raise UnsupportedNemesis('This nemesis is supported for SLA test only')
+
         # Set small amount rows 50000000 when can not recognize a real dataset size, suppose that this amount should be
         # inserted in any case
         dataset_size = self.get_test_data_set_size() or 50000000
@@ -3908,6 +3917,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def disrupt_replace_service_level_using_drop_during_load(self):
         if not self.cluster.nodes[0].is_enterprise:
             raise UnsupportedNemesis("SLA feature is only supported by Scylla Enterprise")
+
+        if not getattr(self.tester, "roles", None):
+            raise UnsupportedNemesis('This nemesis is supported for SLA test only')
 
         # Set small amount rows 50000000 when can not recognize a real dataset size, suppose that this amount should be
         # inserted in any case
@@ -3926,6 +3938,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if not self.cluster.nodes[0].is_enterprise:
             raise UnsupportedNemesis("SLA feature is only supported by Scylla Enterprise")
 
+        if not getattr(self.tester, "roles", None):
+            raise UnsupportedNemesis('This nemesis is supported for SLA test only')
+
         # Set small amount rows 50000000 when can not recognize a real dataset size, suppose that this amount should be
         # inserted in any case
         dataset_size = self.get_test_data_set_size() or 50000000
@@ -3943,6 +3958,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def disrupt_seven_sl_with_max_shares_during_load(self):
         if not self.cluster.nodes[0].is_enterprise:
             raise UnsupportedNemesis("SLA feature is only supported by Scylla Enterprise")
+
+        if not getattr(self.tester, "roles", None):
+            raise UnsupportedNemesis('This nemesis is supported for SLA test only')
 
         # Set small amount rows 50000000 when can not recognize a real dataset size, suppose that this amount should be
         # inserted in any case


### PR DESCRIPTION
since we didn't yet test those nemesis in other regular test case we shouldn't yet let them run, only after we'll verify and test them.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
