### PR TITLE
fix(decommission_streaming_err): remove timeout/retry from rebuild

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3348,9 +3348,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         ParallelObject(objects=[trigger, watcher], timeout=1200).call_objects()
         if new_node := decommission_post_action():
-            new_node.run_nodetool("rebuild", timeout=300, retry=3)
+            new_node.run_nodetool("rebuild")
         else:
-            self.target_node.run_nodetool(sub_cmd="rebuild", timeout=300, retry=3)
+            self.target_node.run_nodetool(sub_cmd="rebuild")
 
     def start_and_interrupt_repair_streaming(self):
         """


### PR DESCRIPTION
b26acc9530f5629002984b3a1566a2ac18c98164 introduced a 5min timeout of the rebuild command, that won't work on any dataset the same and isn't part of the intended fix, also doing it 3 times doesn't really works any faster.

so timeout and retry are removed.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
