### PR TITLE
fix(k8s-functional): add refresh_ip in def test_operator_managed_tls

### DIFF
--- a/functional_tests/scylla_operator/test_functional.py
+++ b/functional_tests/scylla_operator/test_functional.py
@@ -720,6 +720,10 @@ def test_operator_managed_tls(db_cluster: ScyllaPodCluster, tmp_path: path.Path)
         log.debug(file)
         log.debug(file.read_text())
 
+    # since ip address of this node can change in previous tests,
+    # and we don't have the ip tracker thread in local-kind setup
+    db_cluster.nodes[0].refresh_ip_address()
+
     execution_profile = ExecutionProfile(load_balancing_policy=WhiteListRoundRobinPolicy([
                                          db_cluster.nodes[0].cql_ip_address]))
     cluster = Cluster(contact_points=[db_cluster.nodes[0].cql_ip_address], port=db_cluster.nodes[0].CQL_SSL_PORT,


### PR DESCRIPTION
Local K8S uses kind of `stable` `service IP` addresses for connections.
But it also may be silently recreated getting new IP address.
So, refresh IP address in the `test_operator_managed_tls` test for case target IP address gets changed.

```
E   cassandra.cluster.NoHostAvailable:
    ('Unable to connect to any servers',
    {'10.96.180.204:9142': OSError(None, "Tried connecting to
    [('10.96.180.204', 9142)]. Last error: timed out")})
cassandra/cluster.py:3617: NoHostAvailable
```

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
