### PR TITLE
fix(nemesis): fix prepare_start_stop_compaction

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -606,9 +606,11 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         call split() on the output to get keyspace_name and
         cf_name separately.
         """
-        ks_cf = random.choice(self.cluster.get_non_system_ks_cf_list(
-            db_node=self.target_node, filter_empty_tables=filter_empty_tables))
-        return ks_cf.split(".") if ks_cf else None
+        if ks_cf_list := self.cluster.get_non_system_ks_cf_list(
+                db_node=self.target_node, filter_empty_tables=filter_empty_tables):
+            return random.choice(ks_cf_list).split(".")
+        else:
+            return None, None
 
     def _prepare_start_stop_compaction(self) -> StartStopCompactionArgs:
         self.set_target_node()


### PR DESCRIPTION
fix fail prepare_start_stop_compaction
in case of no non system ks_cf

initial error:

Traceback (most recent call last):
  File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 4081, in wrapper
    result = method(*args[1:], **kwargs)
  File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 775, in disrupt_start_stop_validation_compaction
    compaction_args = self._prepare_start_stop_compaction()
  File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 615, in _prepare_start_stop_compaction
    ks, cf = self._get_random_non_system_ks_cf()
  File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 609, in _get_random_non_system_ks_cf
    ks_cf = random.choice(self.cluster.get_non_system_ks_cf_list(
  File "/usr/local/lib/python3.10/random.py", line 378, in choice
    return seq[self._randbelow(len(seq))]
IndexError: list index out of range

tests locally on docker env. Now no errors in case no non_system_ks_cf
and the following messages will be in the log:

```
< t:2023-02-15 10:39:58,289 f:nemesis.py      l:4133 c:sdcm.nemesis         p:INFO  > sdcm.nemesis.StartStopScrubCompaction: log_info: {'start': 1676457596, 'end': 1676457598, 'duration': 1, 'node': 'Node PR-provision-docker-artsiom-db-node-2281b029-0 [172.17.0.2 | 172.17.0.2] (seed: True)', 'subtype': 'skipped', 'skip_reason': 'No non-system keyspaces to run the nemesis with. Skipping.'}
< t:2023-02-15 10:39:58,291 f:nemesis.py      l:382  c:sdcm.nemesis         p:WARNING > sdcm.nemesis.StartStopScrubCompaction: Skipping unsupported nemesis: No non-system keyspaces to run the nemesis with. Skipping.
< t:2023-02-15 10:39:58,293 f:file_logger.py  l:101  c:sdcm.sct_events.file_logger p:INFO  > 2023-02-15 10:39:58.291: (DisruptionEvent Severity.NORMAL) period_type=end event_id=33477c74-04c2-4c3d-b023-7ea25a328fad duration=1s: nemesis_name=StartStopScrubCompaction target_node=Node PR-provision-docker-artsiom-db-node-2281b029-0 [172.17.0.2 | 172.17.0.2] (seed: True) skipped skip_reason=No non-system keyspaces to run the nemesis with. Skipping.

```


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
