### PR TITLE
fix(K8S): use latest stable scylla-operator v1.8.0

### DIFF
--- a/defaults/k8s_local_kind_config.yaml
+++ b/defaults/k8s_local_kind_config.yaml
@@ -12,7 +12,7 @@ mgmt_docker_image: 'scylladb/scylla-manager:3.0.0'
 # To test nightly builds define it like this: 'scylladb/scylla-operator:nightly'
 k8s_scylla_operator_docker_image: ''
 k8s_scylla_operator_helm_repo: 'https://storage.googleapis.com/scylla-operator-charts/stable'
-k8s_scylla_operator_chart_version: 'v1.7.2'
+k8s_scylla_operator_chart_version: 'v1.8.0'
 k8s_cert_manager_version: '1.8.0'
 
 k8s_scylla_datacenter: 'dc-1'

--- a/test-cases/scylla-operator/functional.yaml
+++ b/test-cases/scylla-operator/functional.yaml
@@ -19,7 +19,7 @@ k8s_cert_manager_version: '1.8.0'
 # - https://storage.googleapis.com/scylla-operator-charts/latest
 # - https://storage.googleapis.com/scylla-operator-charts/stable
 k8s_scylla_operator_helm_repo: 'https://storage.googleapis.com/scylla-operator-charts/stable'
-k8s_scylla_operator_chart_version: 'v1.7.2'
+k8s_scylla_operator_chart_version: 'v1.8.0'
 # NOTE: If 'k8s_scylla_operator_docker_image' option is not set
 # then the one from helm chart will be used.
 k8s_scylla_operator_docker_image: ''


### PR DESCRIPTION
If we do not specify scylla operator version for any local K8S (kind) test run then we get following incompatibility error:

    no matches for kind "PodDisruptionBudget" in version "policy/v1beta1"

The root cause for it is that we use K8S v1.25 where 'policy/v1beta1' API support was dropped.

So, use latest stable scylla-operator version which won't use this old API.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
