### PR TITLE
fix(nemesis): do not run SLA nemeses if authenticator is not defined

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3862,6 +3862,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def disrupt_sla_increase_shares_during_load(self):
         if not self.cluster.nodes[0].is_enterprise:
             raise UnsupportedNemesis("SLA feature is only supported by Scylla Enterprise")
+        if not self.cluster.params.get('authenticator'):
+            raise UnsupportedNemesis("SLA feature can't work without authenticator")
 
         if not getattr(self.tester, "roles", None):
             raise UnsupportedNemesis('This nemesis is supported for SLA test only')
@@ -3880,6 +3882,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def disrupt_sla_decrease_shares_during_load(self):
         if not self.cluster.nodes[0].is_enterprise:
             raise UnsupportedNemesis("SLA feature is only supported by Scylla Enterprise")
+        if not self.cluster.params.get('authenticator'):
+            raise UnsupportedNemesis("SLA feature can't work without authenticator")
 
         if not getattr(self.tester, "roles", None):
             raise UnsupportedNemesis('This nemesis is supported for SLA test only')
@@ -3898,6 +3902,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def disrupt_replace_service_level_using_detach_during_load(self):
         if not self.cluster.nodes[0].is_enterprise:
             raise UnsupportedNemesis("SLA feature is only supported by Scylla Enterprise")
+        if not self.cluster.params.get('authenticator'):
+            raise UnsupportedNemesis("SLA feature can't work without authenticator")
 
         if not getattr(self.tester, "roles", None):
             raise UnsupportedNemesis('This nemesis is supported for SLA test only')
@@ -3917,6 +3923,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def disrupt_replace_service_level_using_drop_during_load(self):
         if not self.cluster.nodes[0].is_enterprise:
             raise UnsupportedNemesis("SLA feature is only supported by Scylla Enterprise")
+        if not self.cluster.params.get('authenticator'):
+            raise UnsupportedNemesis("SLA feature can't work without authenticator")
 
         if not getattr(self.tester, "roles", None):
             raise UnsupportedNemesis('This nemesis is supported for SLA test only')
@@ -3937,6 +3945,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def disrupt_increase_shares_by_attach_another_sl_during_load(self):
         if not self.cluster.nodes[0].is_enterprise:
             raise UnsupportedNemesis("SLA feature is only supported by Scylla Enterprise")
+        if not self.cluster.params.get('authenticator'):
+            raise UnsupportedNemesis("SLA feature can't work without authenticator")
 
         if not getattr(self.tester, "roles", None):
             raise UnsupportedNemesis('This nemesis is supported for SLA test only')
@@ -3958,6 +3968,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def disrupt_seven_sl_with_max_shares_during_load(self):
         if not self.cluster.nodes[0].is_enterprise:
             raise UnsupportedNemesis("SLA feature is only supported by Scylla Enterprise")
+        if not self.cluster.params.get('authenticator'):
+            raise UnsupportedNemesis("SLA feature can't work without authenticator")
 
         if not getattr(self.tester, "roles", None):
             raise UnsupportedNemesis('This nemesis is supported for SLA test only')

--- a/test_lib/sla.py
+++ b/test_lib/sla.py
@@ -391,9 +391,9 @@ class User(UserRoleBase):
         return self
 
 
-def create_sla_auth(session, shares: int, index: str) -> Role:
+def create_sla_auth(session, shares: int, index: str, superuser: bool = True) -> Role:
     role = Role(session=session, name=STRESS_ROLE_NAME_TEMPLATE % (shares or '', index),
-                password=STRESS_ROLE_PASSWORD_TEMPLATE % shares or '', login=True).create()
+                password=STRESS_ROLE_PASSWORD_TEMPLATE % shares or '', login=True, superuser=superuser).create()
     role.attach_service_level(ServiceLevel(session=session, name=SERVICE_LEVEL_NAME_TEMPLATE % (shares or '', index),
                                            shares=shares).create())
 


### PR DESCRIPTION
SLA feature need that cluster will be configured with authenticator. Not all our longevities run with authenticator. So we need to filter out SLA nemeses

Test https://jenkins.scylladb.com/job/enterprise-2023.1/job/longevity/job/longevity-1tb-7days-test/4/ failed with error 'User role500_4d3df4a6 has no SELECT permission on table ... or any of its parents'. To prevent such kind of failures of the tests are running with 'authorizer: CassandraAuthorizer', create the role as SUPERUSER

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
