### PR TITLE
feature(versions): add classes for scylla versions comparisons

### DIFF
--- a/functional_tests/scylla_operator/conftest.py
+++ b/functional_tests/scylla_operator/conftest.py
@@ -23,7 +23,6 @@ from typing import Optional
 
 import pytest
 from deepdiff import DeepDiff
-from packaging import version
 
 from functional_tests.scylla_operator.libs.auxiliary import ScyllaOperatorFunctionalClusterTester, sct_abs_path
 from sdcm.cluster_k8s import ScyllaPodCluster
@@ -225,8 +224,9 @@ def skip_if_not_supported_scylla_version(request: pytest.FixtureRequest,
 def skip_based_on_operator_version(request: pytest.FixtureRequest, tester: ScyllaOperatorFunctionalClusterTester):
     # pylint: disable=protected-access
     if required_operator := request.node.get_closest_marker('required_operator'):
-        if (version.LegacyVersion(tester.k8s_cluster._scylla_operator_chart_version.split("-")[0])
-                < version.LegacyVersion(required_operator.args[0])):
+        current_version = tester.k8s_cluster._scylla_operator_chart_version.split("-")[0]
+        required_version = required_operator.args[0]
+        if version_utils.ComparableScyllaOperatorVersion(current_version) < required_version:
             pytest.skip(f"require operator version: {required_operator.args[0]} , "
                         f"current version: {tester.k8s_cluster._scylla_operator_chart_version}")
 


### PR DESCRIPTION
In various cases we need to know scylla or scylla-operator version to make some desicions.
The structure of versions differs for GA and dev/rc versions. Also, it differs based on the source of version - binary or docker image.
We used to use `packaging.version.LegacyVersion` class for comparisons. But it got removed from the latest `packaging` package versions.

So, stop using that library and replace it with our own even more improved classes for comparisons of Scylla and Scylla operator versions.

Examples of usage:

    ComparableScyllaVersion("5.1.0~rc1") < "5.1.0"
    ComparableScyllaVersion("5.1.rc1") > "5.1.0-0.20220922.539a55e35"
    ComparableScyllaVersion("5.2.rc1") > "5.2.0-dev-0.20230109.08b3a9c786d9"

The same is done for Scylla Operator
in the ComparableScyllaOperatorVersion class where it's own specific version workarounds are implemented.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
