### PR TITLE
feature(adaptive-timeouts): base framework for adaptive timeouts

### DIFF
--- a/sdcm/utils/adaptive_timeouts.py
+++ b/sdcm/utils/adaptive_timeouts.py
@@ -1,0 +1,89 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2023 ScyllaDB
+
+from functools import cached_property
+
+from cachetools import cached
+
+from sdcm.remote import RemoteCmdRunner
+
+
+class NodeLoadInfoService:
+    """
+    Service to get information about node load through running commands on node like getting metrics from localhost:9180/9100,
+    nodetool status, uptime (load), vmstat (disk utilization). Command responses are cached for some time to avoid too much requests.
+    Available as @cached_property of BaseNode e.g. node.load_info_service
+    """
+
+    def __init__(self, remoter: RemoteCmdRunner):
+        self._remoter = remoter
+
+    @cached_property
+    def _io_properties_yaml(self):
+        pass
+
+    @cached_property  # with ttl
+    def _metrics(self):
+        """we can get metrics from localhost:9180/9100 and use them to calculate load/sizes"""
+
+    @cached  # with ttl
+    def _cf_stats(self, keyspace):
+        pass
+
+    @cached_property  # with ttl
+    def _nodetool_info(self):
+        pass
+
+    @property
+    def node_data_size(self) -> int:
+        pass
+
+    @property
+    def data_size(self) -> float:
+        """based on _nodetool_info"""
+
+    @property
+    def load_factor(self) -> float:
+        """In case we want to take into account current cpu/disk load"""
+
+    @property
+    def shards_count(self) -> int:
+        pass
+
+    def read_bandwidth(self, remoter: RemoteCmdRunner) -> float:
+        """based on io_properties.yaml"""
+
+    def write_bandwidth(self, remoter: RemoteCmdRunner) -> float:
+        """based on io_properties.yaml"""
+
+    def read_iops(self, remoter: RemoteCmdRunner) -> float:
+        """based on io_properties.yaml"""
+
+    def write_iops(self, remoter: RemoteCmdRunner) -> float:
+        """based on io_properties.yaml"""
+
+
+class AdaptiveTimeout:
+    """
+    Base class for adaptive timeout - timeout relative to data size, node performance (and maybe current load?)
+    using classmethod to have easy discoverable api like: AdaptiveTimeout.resharding(node.load_info_service)
+    """
+    @classmethod
+    def resharding(cls, nlis: NodeLoadInfoService) -> int:
+        """Gets resharding timeout for a given node and keyspace"""
+        base_timeout = nlis.data_size / nlis.shards_count / nlis.write_bandwidth
+        return base_timeout * 1.5  # TODO: define factor it based on historical resharding time to tune out timeout, make some margin
+
+    @classmethod
+    def flush(cls, nis: NodeLoadInfoService):
+        """should depend on memtable data size, pending flushes(?) and disk write speed"""


### PR DESCRIPTION
Commit showing example structure of how adaptive timeouts could be structured.
In words: each node will get new attribute `load_info_service` which will be queried when some timeout value is needed. Having `AdaptiveTimeout` class with class methods for specific timeouts. E.g. When requiring resharding timeout, can do:
`AdaptiveTimeout.resharding(node.load_info_service)` to get the value. or `AdaptiveTimeout.flush(node.load_info_service)`

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
