### PR TITLE
fix(Azure): fix when tag value is null

### DIFF
--- a/unit_tests/provisioner/test_provisioner.py
+++ b/unit_tests/provisioner/test_provisioner.py
@@ -132,6 +132,17 @@ def test_can_add_tags(provisioner, definition, backend, provisioner_params):
     assert provisioner.get_or_create_instance(definition).tags.get("tag_key") == "tag_value"
 
 
+def test_null_tag_value_is_replaced_with_empty_string(provisioner, definition, backend, provisioner_params):
+    if backend != "azure":
+        pytest.skip("Only Azure does not support null tags")
+    provisioner.add_instance_tags(definition.name, {"tag_key": "null"})
+    assert provisioner.get_or_create_instance(definition).tags.get("tag_key") == ""
+
+    # validate real tags change
+    provisioner = provisioner_factory.create_provisioner(backend=backend, **provisioner_params)
+    assert provisioner.get_or_create_instance(definition).tags.get("tag_key") == ""
+
+
 def test_can_terminate_vm_instance(provisioner, definition, backend, provisioner_params):
     """should read from cache instead creating anything - so should be fast (after provisioner initialized)"""
     provisioner.terminate_instance(definition.name, wait=True)


### PR DESCRIPTION
Azure does not accept 'null' as tag value. This causes an issue when jenkins param without a value is assigned to some tag - can't create such VM in that case.

This commit makes 'null' values to be replaced with empty string in tags.

fixes: #5819

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
