### PR TITLE
fix(pipeline): set empty test_name when not set

### DIFF
--- a/vars/createSctRunner.groovy
+++ b/vars/createSctRunner.groovy
@@ -3,7 +3,7 @@
 def call(Map params, Integer test_duration, String region) {
     def cloud_provider = getCloudProviderFromBackend(params.backend)
     def test_config = groovy.json.JsonOutput.toJson(params.test_config)
-    def test_name = groovy.json.JsonOutput.toJson(params.test_name)
+    def test_name = groovy.json.JsonOutput.toJson(params.get('test_name', ''))
 
     // NOTE: EKS jobs have 'availability_zone' be defined as 'a,b'
     //       So, just pick up the first one for the SCT runner in such a case.


### PR DESCRIPTION
When `test_name` param is empty, toJson coverter converts value to `null`. Better to use empty string instead (e.g. null value is forbidden in Azure tags)

refs: #5819

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
