### PR TITLE
revert(tag_ami): remove a `tag_ami` feature that is not in use

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -144,7 +144,6 @@
 | **<a href="#user-content-backup_bucket_backend" name="backup_bucket_backend">backup_bucket_backend</a>**  | the backend to be used for backup (e.g., 's3', 'gcs' or 'azure') | N/A | SCT_BACKUP_BUCKET_BACKEND
 | **<a href="#user-content-backup_bucket_location" name="backup_bucket_location">backup_bucket_location</a>**  | the bucket name to be used for backup (e.g., 'manager-backup-tests') | N/A | SCT_BACKUP_BUCKET_LOCATION
 | **<a href="#user-content-backup_bucket_region" name="backup_bucket_region">backup_bucket_region</a>**  | the AWS region of a bucket to be used for backup (e.g., 'eu-west-1') | N/A | SCT_BACKUP_BUCKET_REGION
-| **<a href="#user-content-tag_ami_with_result" name="tag_ami_with_result">tag_ami_with_result</a>**  | If True, would tag the ami with the test final result | N/A | SCT_TAG_AMI_WITH_RESULT
 | **<a href="#user-content-use_prepared_loaders" name="use_prepared_loaders">use_prepared_loaders</a>**  | If True, we use prepared VMs for loader (instead of using docker images) | N/A | SCT_USE_PREPARED_LOADERS
 | **<a href="#user-content-gce_project" name="gce_project">gce_project</a>**  | gcp project name to use | N/A | SCT_GCE_PROJECT
 | **<a href="#user-content-gce_datacenter" name="gce_datacenter">gce_datacenter</a>**  | Supported: us-east1 - means that the zone will be selected automatically or you can mention the zone explicitly, for example: us-east1-b | N/A | SCT_GCE_DATACENTER

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -688,8 +688,6 @@ class SCTConfiguration(dict):
         dict(name="backup_bucket_region", env="SCT_BACKUP_BUCKET_REGION", type=str,
              help="the AWS region of a bucket to be used for backup (e.g., 'eu-west-1')"),
 
-        dict(name="tag_ami_with_result", env="SCT_TAG_AMI_WITH_RESULT", type=boolean,
-             help="If True, would tag the ami with the test final result"),
 
         dict(name="use_prepared_loaders", env="SCT_USE_PREPARED_LOADERS", type=boolean,
              help="If True, we use prepared VMs for loader (instead of using docker images)"),

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -67,7 +67,7 @@ from sdcm.utils.alternator.consts import NO_LWT_TABLE_NAME
 from sdcm.utils.aws_region import AwsRegion
 from sdcm.utils.aws_utils import init_monitoring_info_from_params, get_ec2_network_configuration, get_ec2_services, \
     get_common_params, init_db_info_from_params, ec2_ami_get_root_device_name
-from sdcm.utils.common import format_timestamp, wait_ami_available, tag_ami, update_certificates, \
+from sdcm.utils.common import format_timestamp, wait_ami_available, update_certificates, \
     download_dir_from_cloud, get_post_behavior_actions, get_testrun_status, download_encrypt_keys, PageFetcher, \
     rows_to_list, make_threads_be_daemonic_by_default, ParallelObject, clear_out_all_exit_hooks, \
     change_default_password
@@ -2755,7 +2755,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         self.clean_resources()
         if self.create_stats:
             self.update_test_with_errors()
-        self.tag_ami_with_result()
         time.sleep(1)  # Sleep is needed to let final event being saved into files
         self.save_email_data()
         self.destroy_localhost()
@@ -3503,17 +3502,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
                 "shard_awareness_driver": self.is_shard_awareness_driver,
                 "restore_monitor_job_base_link": restore_monitor_job_base_link,
                 "relocatable_pkg": get_relocatable_pkg_url(scylla_version)}
-
-    @silence()
-    def tag_ami_with_result(self):
-        if self.params.get('cluster_backend') != 'aws' or not self.params.get('tag_ami_with_result'):
-            return
-        test_result = 'PASSED' if self.get_test_status() == 'SUCCESS' else 'ERROR'
-        job_base_name = os.environ.get('JOB_BASE_NAME', 'UnknownJob')
-        ami_id = self.params.get('ami_id_db_scylla').split()[0]
-        region_name = self.params.region_names[0]
-
-        tag_ami(ami_id=ami_id, region_name=region_name, tags_dict={"JOB:{}".format(job_base_name): test_result})
 
     def get_test_results(self, source, severity=None):
         output = []

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -1953,17 +1953,6 @@ def get_ami_tags(ami_id, region_name):
         return {}
 
 
-def tag_ami(ami_id, tags_dict, region_name):
-    tags = [{'Key': key, 'Value': value} for key, value in tags_dict.items()]
-
-    ec2_resource: EC2ServiceResource = boto3.resource('ec2', region_name=region_name)
-    test_image = ec2_resource.Image(ami_id)
-    tags += test_image.tags
-    test_image.create_tags(Tags=tags)
-
-    LOGGER.info("tagged %s with %s", ami_id, tags)
-
-
 def get_db_tables(session, ks, with_compact_storage=True):
     """
     Return tables from keystore based on their compact storage feature

--- a/unit_tests/test_utils_common.py
+++ b/unit_tests/test_utils_common.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 from sdcm.cluster import BaseNode
 from sdcm.utils.distro import Distro
-from sdcm.utils.common import tag_ami, convert_metric_to_ms, download_dir_from_cloud
+from sdcm.utils.common import convert_metric_to_ms, download_dir_from_cloud
 from sdcm.utils.sstable import load_inventory
 from sdcm.utils.sstable.load_utils import SstableLoadUtils
 
@@ -29,10 +29,6 @@ logging.basicConfig(level=logging.DEBUG)
 
 
 class TestUtils(unittest.TestCase):
-    def test_tag_ami_01(self):  # pylint: disable=no-self-use
-        tag_ami(ami_id='ami-076a213c791dc19cd',
-                tags_dict={'JOB_longevity-multi-keyspaces-60h': 'PASSED'}, region_name='eu-west-1')
-
     def test_scylla_bench_metrics_conversion(self):  # pylint: disable=no-self-use
         metrics = {"4ms": 4.0, "950µs": 0.95, "30ms": 30.0, "8.592961906s": 8592.961905999999,
                    "18.120703ms": 18.120703, "5.963775µs": 0.005963775, "9h0m0.024080491s": 32400024.080491,

--- a/vars/byoLongevityPipeline.groovy
+++ b/vars/byoLongevityPipeline.groovy
@@ -103,9 +103,6 @@ def call() {
             string(defaultValue: '',
                    description: 'cloud path for RPMs, s3:// or gs://',
                    name: 'update_db_packages')
-            string(defaultValue: "false",
-                   description: 'true|false',
-                   name: 'tag_ami_with_result')
             string(defaultValue: "qa@scylladb.com",
                    description: 'email recipients of email report',
                    name: 'email_recipients')

--- a/vars/cdcReplicationPipeline.groovy
+++ b/vars/cdcReplicationPipeline.groovy
@@ -46,7 +46,6 @@ def runSctTest(Map params, String region){
     export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$GIT_BRANCH | sed -E 's+(origin/|origin/branch-)++')
     export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$SCT_AMI_ID_DB_SCYLLA_DESC | tr ._ - | cut -c1-8 )
 
-    export SCT_TAG_AMI_WITH_RESULT="${params.tag_ami_with_result}"
     export SCT_IP_SSH_CONNECTIONS="${params.ip_ssh_connections}"
 
     if [[ ! -z "${params.scylla_mgmt_address}" ]] ; then
@@ -117,10 +116,6 @@ def call(Map pipelineParams) {
             string(defaultValue: "${pipelineParams.get('post_behavior_monitor_nodes', 'keep-on-failure')}",
                    description: 'keep|keep-on-failure|destroy',
                    name: 'post_behavior_monitor_nodes')
-
-            string(defaultValue: "${pipelineParams.get('tag_ami_with_result', 'false')}",
-                   description: 'true|false',
-                   name: 'tag_ami_with_result')
 
             string(defaultValue: "${pipelineParams.get('ip_ssh_connections', 'private')}",
                    description: 'private|public|ipv6',

--- a/vars/longevityPipeline.groovy
+++ b/vars/longevityPipeline.groovy
@@ -71,10 +71,6 @@ def call(Map pipelineParams) {
                    description: 'keep|keep-on-failure|destroy',
                    name: 'post_behavior_k8s_cluster')
 
-            string(defaultValue: "${pipelineParams.get('tag_ami_with_result', 'false')}",
-                   description: 'true|false',
-                   name: 'tag_ami_with_result')
-
             string(defaultValue: "${pipelineParams.get('ip_ssh_connections', 'private')}",
                    description: 'private|public|ipv6',
                    name: 'ip_ssh_connections')

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -98,10 +98,6 @@ def call(Map pipelineParams) {
                    description: 'keep|keep-on-failure|destroy',
                    name: 'post_behavior_monitor_nodes')
 
-            string(defaultValue: "${pipelineParams.get('tag_ami_with_result', 'false')}",
-                   description: 'true|false',
-                   name: 'tag_ami_with_result')
-
             string(defaultValue: "${pipelineParams.get('ip_ssh_connections', 'private')}",
                    description: 'private|public|ipv6',
                    name: 'ip_ssh_connections')
@@ -263,7 +259,6 @@ def call(Map pipelineParams) {
                                         export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$GIT_BRANCH | sed -E 's+(origin/|origin/branch-)++')
                                         export SCT_AMI_ID_DB_SCYLLA_DESC=\$(echo \$SCT_AMI_ID_DB_SCYLLA_DESC | tr ._ - | cut -c1-8 )
 
-                                        export SCT_TAG_AMI_WITH_RESULT="${params.tag_ami_with_result}"
                                         export SCT_IP_SSH_CONNECTIONS="${params.ip_ssh_connections}"
 
                                         if [[ ! -z "${params.scylla_mgmt_address}" ]] ; then

--- a/vars/provisionResources.groovy
+++ b/vars/provisionResources.groovy
@@ -112,10 +112,6 @@ def call(Map params, String region){
         export SCT_UPDATE_DB_PACKAGES="${params.update_db_packages}"
     fi
 
-    if [[ -n "${params.tag_ami_with_result ? params.tag_ami_with_result : ''}" ]] ; then
-        export SCT_TAG_AMI_WITH_RESULT="${params.tag_ami_with_result}"
-    fi
-
     if [[ -n "${params.ip_ssh_connections ? params.ip_ssh_connections : ''}" ]] ; then
         export SCT_IP_SSH_CONNECTIONS="${params.ip_ssh_connections}"
     fi

--- a/vars/runSctTest.groovy
+++ b/vars/runSctTest.groovy
@@ -138,10 +138,6 @@ def call(Map params, String region, functional_test = false, Map pipelineParams 
         export SCT_UPDATE_DB_PACKAGES="${params.update_db_packages}"
     fi
 
-    if [[ -n "${params.tag_ami_with_result ? params.tag_ami_with_result : ''}" ]] ; then
-        export SCT_TAG_AMI_WITH_RESULT="${params.tag_ami_with_result}"
-    fi
-
     if [[ -n "${params.ip_ssh_connections ? params.ip_ssh_connections : ''}" ]] ; then
         export SCT_IP_SSH_CONNECTIONS="${params.ip_ssh_connections}"
     fi


### PR DESCRIPTION
`tag_ami` was created to tag AMIs with results of tests we never used that idea, and nowdays when we have Argus as a centeral place for release test results, there's no point for this feature stay in the code.

(also it testing was basing on specific AMI that is now deleted)

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
