### PR TITLE
fix(gce_download): Skip first element by name upon download

### DIFF
--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -2119,8 +2119,9 @@ def gce_download_dir(bucket, path, target):
 
     container = driver.get_container(container_name=bucket)
     dir_listing = driver.list_container_objects(container, ex_prefix=path)
-    # first element is gce dir itself. Skip it.
-    for obj in dir_listing[1:]:
+    for obj in dir_listing:
+        if obj.name in [".", "..", path]:
+            continue
         rel_path = obj.name[len(path):]
         local_file_path = os.path.join(target, rel_path)
 


### PR DESCRIPTION
list_container_objects method in gce_download_dir returns list of objects in gce bucket. Previously first returned element
 was folder itself. Latest run shows that now method return only objects
in bucket. Current implementation could skip first object or if only one object in bucket don't download anything and later fail the job.

Add checks element by name and filter out objects with non-relevant names

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
