### PR TITLE
fix(event-handler): remove redundant event handler stop

### DIFF
--- a/sdcm/sct_events/event_handler.py
+++ b/sdcm/sct_events/event_handler.py
@@ -14,12 +14,12 @@
 import logging
 import threading
 from functools import partial
-from typing import Tuple, Any, Optional
+from typing import Tuple, Any
 
 from sdcm.cluster import TestConfig
 from sdcm.sct_events.events_processes import \
-    EVENTS_HANDLER_ID, EventsProcessesRegistry, BaseEventsProcess, \
-    start_events_process, get_events_process, verbose_suppress
+    EVENTS_HANDLER_ID, BaseEventsProcess, \
+    start_events_process, verbose_suppress
 from sdcm.sct_events.handlers.schema_disagreement import SchemaDisagreementHandler
 
 LOGGER = logging.getLogger(__name__)
@@ -58,11 +58,4 @@ class EventsHandler(BaseEventsProcess[Tuple[str, Any], None], threading.Thread):
 
 
 start_events_handler = partial(start_events_process, EVENTS_HANDLER_ID, EventsHandler)
-
-
-def stop_events_handler(_registry: Optional[EventsProcessesRegistry] = None) -> None:
-    if handler := get_events_process(EVENTS_HANDLER_ID, _registry=_registry):
-        handler.stop(timeout=60)
-
-
-__all__ = ("start_events_handler", "stop_events_handler", )
+__all__ = ("start_events_handler",)

--- a/sdcm/sct_events/events_processes.py
+++ b/sdcm/sct_events/events_processes.py
@@ -93,8 +93,16 @@ class BaseEventsProcess(Generic[T_inbound_event, T_outbound_event], abc.ABC):
         self.stop_event.set()
 
     def stop(self, timeout: float = None) -> None:
+        events_process_class_name = self.__class__.__name__
+        LOGGER.debug("Stopping events process %s", events_process_class_name)
         self.terminate()
+        LOGGER.debug("Waiting for events process %s to stop", events_process_class_name)
         self.join(timeout)  # pylint: disable=no-member; both threading.Thread and multiprocessing.Process have it
+        if self.is_alive():  # pylint: disable=no-member;
+            LOGGER.error("Events process %s is still alive after timeout", events_process_class_name)
+            assert False, f"Events process {events_process_class_name} is still alive after timeout"
+        else:
+            LOGGER.debug("Events process %s stopped", events_process_class_name)
 
 
 class EventsProcessPipe(BaseEventsProcess[T_inbound_event, T_outbound_event], threading.Thread):

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -58,7 +58,6 @@ from sdcm.provision.azure.provisioner import AzureProvisioner
 from sdcm.provision.provisioner import provisioner_factory
 from sdcm.scan_operation_thread import FullScanParams, ScanOperationThread
 from sdcm.nosql_thread import NoSQLBenchStressThread
-from sdcm.sct_events.event_handler import stop_events_handler
 from sdcm.scylla_bench_thread import ScyllaBenchThread
 from sdcm.cassandra_harry_thread import CassandraHarryThread
 from sdcm.tombstone_gc_verification_thread import TombstoneGcVerificationThread
@@ -2738,7 +2737,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             InfoEvent(message="TEST_END").publish()
         self.log.info('TearDown is starting...')
         self.stop_timeout_thread()
-        self.stop_event_handler()
         self.stop_event_analyzer()
         self.stop_resources()
         self.get_test_failures()
@@ -2829,10 +2827,6 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
     @silence()
     def stop_event_analyzer(self):  # pylint: disable=no-self-use
         stop_events_analyzer(_registry=self.events_processes_registry)
-
-    @silence()
-    def stop_event_handler(self):  # pylint: disable=no-self-use
-        stop_events_handler(_registry=self.events_processes_registry)
 
     @silence()
     def stop_timeout_thread(self):


### PR DESCRIPTION
We face issues with stopping event_handler - it hangs indefinitely. I realized stopping it early is actually redundant.

This commit removes explicit stop of event_handler as it is stopped by `stop_events_device` function at later teardown stage. At later stage sct is less loaded with tasks and maybe it will help solving the issue.
Additionally debug messages on events devices stop were added to have better understanding on which step is hanging exactly in case we still hit the issue.

refs: #5626

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
