### PR TITLE
fix(pipeline): dont fallback to builder when no sct runner. part2

### DIFF
--- a/vars/byoLongevityPipeline.groovy
+++ b/vars/byoLongevityPipeline.groovy
@@ -131,14 +131,12 @@ def call() {
             }
             stage('Create SCT Runner') {
                 steps {
-                    catchError(stageResult: 'FAILURE') {
-                        script {
-                            wrap([$class: 'BuildUser']) {
-                                dir('scylla-cluster-tests') {
-                                    println(params)
-                                    println(builder)
-                                    createSctRunner(params, params.timeout.toInteger(), builder.region)
-                                }
+                    script {
+                        wrap([$class: 'BuildUser']) {
+                            dir('scylla-cluster-tests') {
+                                println(params)
+                                println(builder)
+                                createSctRunner(params, params.timeout.toInteger(), builder.region)
                             }
                         }
                     }

--- a/vars/cdcReplicationPipeline.groovy
+++ b/vars/cdcReplicationPipeline.groovy
@@ -166,12 +166,10 @@ def call(Map pipelineParams) {
             }
             stage('Create SCT Runner') {
                 steps {
-                    catchError(stageResult: 'FAILURE') {
-                        script {
-                            wrap([$class: 'BuildUser']) {
-                                dir('scylla-cluster-tests') {
-                                    createSctRunner(params, pipelineParams.timeout.time , builder.region)
-                                }
+                    script {
+                        wrap([$class: 'BuildUser']) {
+                            dir('scylla-cluster-tests') {
+                                createSctRunner(params, pipelineParams.timeout.time , builder.region)
                             }
                         }
                     }

--- a/vars/jepsenPipeline.groovy
+++ b/vars/jepsenPipeline.groovy
@@ -107,13 +107,11 @@ def call(Map pipelineParams) {
             }
             stage('Create SCT Runner') {
                 steps {
-                    catchError(stageResult: 'FAILURE') {
-                        script {
-                            wrap([$class: 'BuildUser']) {
-                                dir('scylla-cluster-tests') {
-                                    timeout(time: 5, unit: 'MINUTES') {
-                                        createSctRunner(params, runnerTimeout , builder.region)
-                                    }
+                    script {
+                        wrap([$class: 'BuildUser']) {
+                            dir('scylla-cluster-tests') {
+                                timeout(time: 5, unit: 'MINUTES') {
+                                    createSctRunner(params, runnerTimeout , builder.region)
                                 }
                             }
                         }

--- a/vars/managerPipeline.groovy
+++ b/vars/managerPipeline.groovy
@@ -192,12 +192,10 @@ def call(Map pipelineParams) {
                     timeout(time: 5, unit: 'MINUTES')
                 }
                 steps {
-                    catchError(stageResult: 'FAILURE') {
-                        script {
-                            wrap([$class: 'BuildUser']) {
-                                dir('scylla-cluster-tests') {
-                                    createSctRunner(params, runnerTimeout , builder.region)
-                                }
+                    script {
+                        wrap([$class: 'BuildUser']) {
+                            dir('scylla-cluster-tests') {
+                                createSctRunner(params, runnerTimeout , builder.region)
                             }
                         }
                     }

--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -162,12 +162,10 @@ def call(Map pipelineParams) {
                                             }
                                         }
                                         stage("Create SCT Runner for ${sub_test}") {
-                                            catchError(stageResult: 'FAILURE') {
-                                                wrap([$class: 'BuildUser']) {
-                                                    dir('scylla-cluster-tests') {
-                                                        timeout(time: 10, unit: 'MINUTES') {
-                                                            createSctRunner(params, runnerTimeout, builder.region)
-                                                        }
+                                            wrap([$class: 'BuildUser']) {
+                                                dir('scylla-cluster-tests') {
+                                                    timeout(time: 10, unit: 'MINUTES') {
+                                                        createSctRunner(params, runnerTimeout, builder.region)
                                                     }
                                                 }
                                             }

--- a/vars/perfSearchBestConfigParallelPipeline.groovy
+++ b/vars/perfSearchBestConfigParallelPipeline.groovy
@@ -172,12 +172,10 @@ def call(Map pipelineParams) {
                                             }
                                         }
                                         stage("Create SCT Runner for ${sub_test}") {
-                                            catchError(stageResult: 'FAILURE') {
-                                                wrap([$class: 'BuildUser']) {
-                                                    dir('scylla-cluster-tests') {
-                                                        timeout(time: 5, unit: 'MINUTES') {
-                                                            createSctRunner(params, runnerTimeout, builder.region)
-                                                        }
+                                            wrap([$class: 'BuildUser']) {
+                                                dir('scylla-cluster-tests') {
+                                                    timeout(time: 5, unit: 'MINUTES') {
+                                                        createSctRunner(params, runnerTimeout, builder.region)
                                                     }
                                                 }
                                             }

--- a/vars/rollingOperatorUpgradePipeline.groovy
+++ b/vars/rollingOperatorUpgradePipeline.groovy
@@ -110,13 +110,11 @@ def call(Map pipelineParams) {
             }
             stage('Create SCT Runner') {
                 steps {
-                    catchError(stageResult: 'FAILURE') {
-                        script {
-                            wrap([$class: 'BuildUser']) {
-                                dir('scylla-cluster-tests') {
-                                    timeout(time: 5, unit: 'MINUTES') {
-                                        createSctRunner(params, runnerTimeout , builder.region)
-                                    }
+                    script {
+                        wrap([$class: 'BuildUser']) {
+                            dir('scylla-cluster-tests') {
+                                timeout(time: 5, unit: 'MINUTES') {
+                                    createSctRunner(params, runnerTimeout , builder.region)
                                 }
                             }
                         }

--- a/vars/rollingUpgradePipeline.groovy
+++ b/vars/rollingUpgradePipeline.groovy
@@ -151,12 +151,10 @@ def call(Map pipelineParams) {
                                             }
                                         }
                                         stage("Create SCT Runner for ${base_version}") {
-                                            catchError(stageResult: 'FAILURE') {
-                                                wrap([$class: 'BuildUser']) {
-                                                    dir('scylla-cluster-tests') {
-                                                        timeout(time: 5, unit: 'MINUTES') {
-                                                            createSctRunner(params, runnerTimeout, builder.region)
-                                                        }
+                                            wrap([$class: 'BuildUser']) {
+                                                dir('scylla-cluster-tests') {
+                                                    timeout(time: 5, unit: 'MINUTES') {
+                                                        createSctRunner(params, runnerTimeout, builder.region)
                                                     }
                                                 }
                                             }


### PR DESCRIPTION
Do the same thing which is done at (https://github.com/scylladb/scylla-cluster-tests/pull/5794) in all the pipelines which try to create SCT runners.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
