### PR TITLE
improvement(versions): Use ComparableScyllaVersion in more places

### DIFF
--- a/sdcm/fill_db_data.py
+++ b/sdcm/fill_db_data.py
@@ -33,7 +33,7 @@ from cassandra.protocol import ProtocolException  # pylint: disable=no-name-in-m
 from sdcm.tester import ClusterTester
 from sdcm.utils.decorators import retrying
 from sdcm.utils.cdc.options import CDC_LOGTABLE_SUFFIX
-from sdcm.utils.version_utils import parse_scylla_version
+from sdcm.utils.version_utils import ComparableScyllaVersion
 
 
 LOGGER = logging.getLogger(__name__)
@@ -3143,7 +3143,7 @@ class FillDatabaseData(ClusterTester):
 
     @property
     def parsed_scylla_version(self):
-        return parse_scylla_version(self.db_cluster.nodes[0].scylla_version)
+        return ComparableScyllaVersion(self.db_cluster.nodes[0].scylla_version)
 
     @property
     def is_enterprise(self) -> bool:
@@ -3154,14 +3154,14 @@ class FillDatabaseData(ClusterTester):
             version_with_support = self.NULL_VALUES_SUPPORT_ENTERPRISE_MIN_VERSION
         else:
             version_with_support = self.NULL_VALUES_SUPPORT_OS_MIN_VERSION
-        return self.parsed_scylla_version >= parse_scylla_version(version_with_support)
+        return self.parsed_scylla_version >= version_with_support
 
     def version_new_sorting_order_with_secondary_indexes(self):
         if self.is_enterprise:
             version_with_support = self.NEW_SORTING_ORDER_WITH_SECONDARY_INDEXES_ENTERPRISE_MIN_VERSION
         else:
             version_with_support = self.NEW_SORTING_ORDER_WITH_SECONDARY_INDEXES_OS_MIN_VERSION
-        return self.parsed_scylla_version >= parse_scylla_version(version_with_support)
+        return self.parsed_scylla_version >= version_with_support
 
     def version_non_frozen_udt_support(self):
         """
@@ -3172,14 +3172,14 @@ class FillDatabaseData(ClusterTester):
             version_with_support = self.NON_FROZEN_SUPPORT_ENTERPRISE_MIN_VERSION
         else:
             version_with_support = self.NON_FROZEN_SUPPORT_OS_MIN_VERSION
-        return self.parsed_scylla_version >= parse_scylla_version(version_with_support)
+        return self.parsed_scylla_version >= version_with_support
 
     def version_cdc_support(self):
         if self.is_enterprise:
             version_with_support = self.CDC_SUPPORT_MIN_ENTERPRISE_VERSION
         else:
             version_with_support = self.CDC_SUPPORT_MIN_VERSION
-        return self.parsed_scylla_version >= parse_scylla_version(version_with_support)
+        return self.parsed_scylla_version >= version_with_support
 
     @retrying(n=3, sleep_time=20, allowed_exceptions=ProtocolException)
     def truncate_table(self, session, truncate):  # pylint: disable=no-self-use

--- a/sdcm/utils/version_utils.py
+++ b/sdcm/utils/version_utils.py
@@ -21,7 +21,6 @@ from collections import namedtuple
 from urllib.parse import urlparse
 from functools import lru_cache, wraps
 from itertools import count
-from pkg_resources import parse_version
 
 import yaml
 import boto3
@@ -30,7 +29,6 @@ import dateutil.parser
 from mypy_boto3_s3 import S3Client
 from botocore import UNSIGNED
 from botocore.client import Config
-from packaging import version
 from repodataParser.RepoParser import Parser
 
 from sdcm.remote import LOCALRUNNER
@@ -116,13 +114,6 @@ FILE_REGEX_DICT = {
 # The variable "type" indices the type of URL (Debian or Yum)
 # The variable "urls" contains all urls using the Scylla pattern
 RepositoryDetails = namedtuple("RepositoryDetails", ["type", "urls"])
-
-
-def parse_scylla_version(version_to_parse: str) -> version.Version:
-    version_format = re.compile(r'(\d+\.\d)|(\.\d+)')
-    major_version = version_format.search(version_to_parse)
-    assert major_version, f"version_to_parse: '{version_to_parse}' isn't supported scylla version string"
-    return parse_version(major_version[0])
 
 
 class ComparableScyllaVersion:

--- a/unit_tests/test_version_utils.py
+++ b/unit_tests/test_version_utils.py
@@ -6,7 +6,6 @@ from unittest import mock
 
 import pytest
 import requests
-import pkg_resources
 
 import sdcm
 from sdcm.utils.version_utils import (
@@ -19,7 +18,6 @@ from sdcm.utils.version_utils import (
     get_scylla_urls_from_repository,
     get_specific_tag_of_docker_image,
     is_enterprise,
-    parse_scylla_version,
     scylla_versions,
     ComparableScyllaOperatorVersion,
     ComparableScyllaVersion,
@@ -444,34 +442,6 @@ def test_get_docker_image_by_version_fallback_on_errors():
 
         get_mock.side_effect = raise_request_error
         assert get_docker_image_by_version(scylla_version=non_existing_version) == expected_fallback
-
-
-@pytest.mark.parametrize("version_string, expected", (
-    ("5.1", "5.1"),
-    ("5.1.0~rc1", "5.1"),
-    ("5.1.rc1", "5.1"),
-    ("2023.1", "2023.1"),
-    ("2023.1~rc0", "2023.1"),
-    ("2021.1.dev", "2021.1"),
-))
-def test_parse_scylla_version(version_string, expected):
-    version_object = parse_scylla_version(version_string)
-    assert isinstance(version_object, pkg_resources.parse_version)
-    assert str(version_object) == expected
-
-
-@pytest.mark.parametrize("version_string, expected", (
-    pytest.param("2021",
-                 "version_to_parse: '2021' isn't supported scylla version string",
-                 id="2021"),
-    pytest.param("this_is_not_a_version",
-                 "version_to_parse: 'this_is_not_a_version' isn't supported scylla version string",
-                 id="this_is_not_a_version"),
-))
-def test_parse_scylla_version_unsupported(version_string, expected):
-    with pytest.raises(AssertionError) as exp:
-        parse_scylla_version(version_string)
-    assert str(exp.value) == expected
 
 
 @pytest.mark.parametrize("version_string, expected", (

--- a/utils/get_supported_scylla_base_versions.py
+++ b/utils/get_supported_scylla_base_versions.py
@@ -6,7 +6,7 @@ import os
 
 from sdcm.utils.version_utils import is_enterprise, get_all_versions
 from sdcm.utils.common import get_s3_scylla_repos_mapping
-from sdcm.utils.version_utils import parse_scylla_version
+from sdcm.utils.version_utils import ComparableScyllaVersion
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
@@ -97,10 +97,9 @@ class UpgradeBaseVersion:  # pylint: disable=too-many-instance-attributes
                 else:
                     # Choose the last two releases as upgrade base
                     ent_base_version += ent_release_list[idx-1:][:2]
-            elif version == 'enterprise' or parse_scylla_version(version) > parse_scylla_version(ent_release_list[0]):
+            elif version == 'enterprise' or ComparableScyllaVersion(version) > ent_release_list[0]:
                 ent_base_version.append(ent_release_list[-1])
-            elif re.match(r'\d+.\d+', version) and parse_scylla_version(version) \
-                    >= parse_scylla_version(ent_release_list[0]):
+            elif re.match(r'\d+.\d+', version) and ComparableScyllaVersion(version) >= ent_release_list[0]:
                 oss_base_version.append(oss_release_list[-1])
                 ent_base_version += ent_release_list[-2:]
         elif product == 'scylla':
@@ -113,10 +112,9 @@ class UpgradeBaseVersion:  # pylint: disable=too-many-instance-attributes
                 else:
                     # Choose the last two releases as upgrade base
                     oss_base_version += oss_release_list[idx-1:][:2]
-            elif version == 'master' or parse_scylla_version(version) > parse_scylla_version(oss_release_list[0]):
+            elif version == 'master' or ComparableScyllaVersion(version) > oss_release_list[0]:
                 oss_base_version.append(oss_release_list[-1])
-            elif re.match(r'\d+.\d+', version) and parse_scylla_version(version) \
-                    < parse_scylla_version(oss_release_list[0]):
+            elif re.match(r'\d+.\d+', version) and ComparableScyllaVersion(version) < oss_release_list[0]:
                 # If dest version is smaller than the first supported opensource release,
                 # it might be an invalid dest version
                 oss_base_version.append(oss_release_list[-1])
@@ -156,11 +154,11 @@ class UpgradeBaseVersion:  # pylint: disable=too-many-instance-attributes
                 continue
             # OSS: the major version is smaller than the start support version
             if self.oss_start_support_version and not is_enterprise(version_prefix) and \
-                    parse_scylla_version(version_prefix) < parse_scylla_version(self.oss_start_support_version):
+                    ComparableScyllaVersion(version_prefix) < self.oss_start_support_version:
                 continue
             # Enterprise: the major version is smaller than the start support version
             if self.ent_start_support_version and is_enterprise(version_prefix) and \
-                    parse_scylla_version(version_prefix) < parse_scylla_version(self.ent_start_support_version):
+                    ComparableScyllaVersion(version_prefix) < self.ent_start_support_version:
                 continue
             supported_versions.append(version_prefix)
         version_list = self.get_supported_scylla_base_versions(supported_versions)


### PR DESCRIPTION
Use `ComparableScyllaVersion` instead of the `parse_scylla_version`.
Delete `parse_scylla_version` as unneeded.

It is follow-up for the following PR: https://github.com/scylladb/scylla-cluster-tests/pull/5817

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
