### PR TITLE
test(create release jobs): upgrade with raft enabled

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1369,6 +1369,7 @@ def create_test_release_jobs(branch, username, password, sct_branch, sct_repo):
         ('raft', 'SCT Raft Experimental'),
         ('disabled_raft', 'SCT ConsistentClusterManagement disabled'),
         ('nemesis', 'SCT Individual Nemesis'),
+        ('upgrade-with-raft', 'SCT Rolling Upgrades With Raft Enabled'),
     ]:
         server.create_directory(name=group_name, display_name=group_desc)
 
@@ -1389,6 +1390,9 @@ def create_test_release_jobs(branch, username, password, sct_branch, sct_repo):
                 server.create_pipeline_job(jenkins_file, group_name)
         if group_name == 'disabled_raft':
             for jenkins_file in glob.glob(f'{base_path}/consistent_cluster_management_disabled/*'):
+                server.create_pipeline_job(jenkins_file, group_name)
+        if group_name == 'upgrade-with-raft':
+            for jenkins_file in glob.glob(f'{base_path}/{group_name}/*.jenkinsfile'):
                 server.create_pipeline_job(jenkins_file, group_name)
         if group_name == 'nemesis':
             for jenkins_file in glob.glob(f'{base_path}/nemesis/*'):


### PR DESCRIPTION
as of now, RAFT is disabled for all upgrade jobs,
so, to test the RAFT feature on upgrade jobs,
there were few jobs introduced to test it, but their jobs are not yet being created automatically, and
will now have its own group, and jobs, and later,
should be added to the upgrade triggers as well.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
