### PR TITLE
fix(instance_root_disk_size): lower duration requirement for extra space

### DIFF
--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -155,8 +155,8 @@ class SctRunner(ABC):
     @staticmethod
     def instance_root_disk_size(test_duration) -> int:
         disk_size = 80  # GB
-        if test_duration and test_duration > 3 * 24 * 60:  # 3 days
-            # add 40G more space for jobs which test_duration is longer than 3 days
+        if test_duration and test_duration > 1.5 * 24 * 60:  # 1.5 days
+            # add 40G more space for jobs which test_duration is longer than 1.5 days
             return disk_size + 40
         return disk_size
 


### PR DESCRIPTION
Previously, we increased the sct runner's disk by 40GB if a scenario was at lease 3 days long. However, it seems that even shorter runs require an additional disk space, so I altered instance_root_disk_size so that the additional disk space will be added on every scenario that is longer than 36 hours

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
