### PR TITLE
test(nemesis): added create index nemesis

### DIFF
--- a/data_dir/nemesis.yml
+++ b/data_dir/nemesis.yml
@@ -8,6 +8,7 @@
   - networking = False
   - kubernetes = True
   - limited = True
+  - schema_changes = True
   - free_tier_set = True
 - disrupt_add_remove_dc:
   - disruptive = False
@@ -17,6 +18,10 @@
   - topology_changes = True
 - disrupt_corrupt_then_scrub:
   - disruptive = False
+- disrupt_create_index:
+  - disruptive = False
+  - schema_changes = True
+  - free_tier_set = True
 - disrupt_decommission_streaming_err:
   - disruptive = True
   - topology_changes = True
@@ -54,6 +59,7 @@
 - disrupt_grow_shrink_new_rack:
   - disruptive = True
   - kubernetes = True
+  - config_changes = True
 - disrupt_hard_reboot_node:
   - disruptive = True
   - kubernetes = True
@@ -61,6 +67,7 @@
   - free_tier_set = True
 - disrupt_hot_reloading_internode_certificate:
   - disruptive = False
+  - config_changes = True
 - disrupt_increase_shares_by_attach_another_sl_during_load:
   - disruptive = False
   - sla = True
@@ -97,6 +104,7 @@
   - disruptive = False
   - kubernetes = True
   - limited = True
+  - schema_changes = True
   - free_tier_set = True
 - disrupt_multiple_hard_reboot_node:
   - disruptive = True
@@ -183,14 +191,17 @@
   - sla = True
 - disrupt_resetlocalschema:
   - disruptive = False
+  - config_changes = True
   - free_tier_set = True
 - disrupt_restart_with_resharding:
   - disruptive = True
   - kubernetes = True
   - topology_changes = True
+  - config_changes = True
 - disrupt_rolling_config_change_internode_compression:
   - disruptive = True
   - full_cluster_restart = True
+  - config_changes = True
 - disrupt_rolling_restart_cluster:
   - disruptive = True
   - kubernetes = True
@@ -198,6 +209,7 @@
 - disrupt_rolling_restart_cluster:
   - disruptive = True
   - kubernetes = True
+  - config_changes = True
   - free_tier_set = True
 - disrupt_run_cdcstressor_tool:
   - disruptive = False
@@ -246,6 +258,7 @@
   - limited = True
 - disrupt_switch_between_password_authenticator_and_saslauthd_authenticator_and_back:
   - disruptive = True
+  - config_changes = True
 - disrupt_terminate_and_replace_node:
   - disruptive = True
   - kubernetes = False
@@ -258,13 +271,17 @@
   - kubernetes = True
 - disrupt_toggle_cdc_feature_properties_on_table:
   - disruptive = False
+  - schema_changes = True
+  - config_changes = True
   - free_tier_set = True
 - disrupt_toggle_table_gc_mode:
   - kubernetes = True
   - disruptive = False
+  - schema_changes = True
   - free_tier_set = True
 - disrupt_toggle_table_ics:
   - kubernetes = True
+  - schema_changes = True
   - free_tier_set = True
 - disrupt_truncate:
   - disruptive = False

--- a/data_dir/nemesis_classes.yml
+++ b/data_dir/nemesis_classes.yml
@@ -9,6 +9,7 @@
 - CorruptThenRebuildMonkey
 - CorruptThenRepairMonkey
 - CorruptThenScrubMonkey
+- CreateIndexNemesis
 - DecommissionMonkey
 - DecommissionSeedNode
 - DecommissionStreamingErrMonkey

--- a/jenkins-pipelines/nemesis/longevity-5gb-1h-CreateIndexNemesis-aws.jenkinsfile
+++ b/jenkins-pipelines/nemesis/longevity-5gb-1h-CreateIndexNemesis-aws.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'longevity_test.LongevityTest.test_custom_time',
+    test_config: 'test-cases/nemesis/longevity-5gb-1h-CreateIndexNemesis.yaml'
+
+)

--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -35,7 +35,7 @@ from concurrent.futures import ThreadPoolExecutor
 from threading import Lock
 from types import MethodType  # pylint: disable=no-name-in-module
 
-from cassandra import ConsistencyLevel
+from cassandra import ConsistencyLevel, InvalidRequest
 from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
 from invoke import UnexpectedExit
 from elasticsearch.exceptions import ConnectionTimeout as ElasticSearchConnectionTimeout
@@ -87,7 +87,7 @@ from sdcm.utils.common import (get_db_tables, generate_random_string,
                                update_certificates, reach_enospc_on_node, clean_enospc_on_node,
                                parse_nodetool_listsnapshots,
                                update_authenticator, ParallelObject,
-                               ParallelObjectResult)
+                               ParallelObjectResult, sleep_for_percent_of_duration)
 from sdcm.utils.compaction_ops import CompactionOps, StartStopCompactionArgs
 from sdcm.utils.decorators import retrying, latency_calculator_decorator
 from sdcm.utils.decorators import timeout as timeout_decor
@@ -99,6 +99,8 @@ from sdcm.utils.k8s import (
 from sdcm.utils.k8s.chaos_mesh import MemoryStressExperiment, IOFaultChaosExperiment, DiskError
 from sdcm.utils.ldap import SASLAUTHD_AUTHENTICATOR, LdapServerType
 from sdcm.utils.loader_utils import DEFAULT_USER, DEFAULT_USER_PASSWORD, SERVICE_LEVEL_NAME_TEMPLATE
+from sdcm.utils.nemesis_utils.indexes import get_random_column_name, create_index, \
+    wait_for_index_to_be_built, verify_query_by_index_works, drop_index
 from sdcm.utils.replication_strategy_utils import temporary_replication_strategy_setter, \
     NetworkTopologyReplicationStrategy, ReplicationStrategy, SimpleReplicationStrategy
 from sdcm.utils.sstable.load_utils import SstableLoadUtils
@@ -4098,6 +4100,31 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                                                   for error in error_events if error)
                                         )
 
+    def disrupt_create_index(self):
+        """
+        Create index on a random column (regular or static) of a table with the most number of partitions and wait until it gets build.
+        Then verify it can be used in a query. Finally, drop the index.
+        """
+        with self.cluster.cql_connection_patient(self.target_node, connect_timeout=300) as session:
+            ks_cf_list = self.cluster.get_non_system_ks_cf_list(self.target_node, filter_out_mv=True)
+            if not ks_cf_list:
+                raise UnsupportedNemesis("No table found to create index on")
+            ks, cf = random.choice(ks_cf_list).split('.')
+            column = get_random_column_name(session, ks, cf)
+            try:
+                index_name = create_index(session, ks, cf, column)
+            except InvalidRequest as exc:
+                LOGGER.warning(exc)
+                raise UnsupportedNemesis(  # pylint: disable=raise-missing-from
+                    "Tried to create already existing index. See log for details")
+            try:
+                wait_for_index_to_be_built(self.target_node, ks, index_name, timeout=7200)
+                verify_query_by_index_works(session, ks, cf, column)
+                sleep_for_percent_of_duration(self.tester.test_duration * 60, percent=1,
+                                              min_duration=300, max_duration=2400)
+            finally:
+                drop_index(session, ks, index_name)
+
 
 def disrupt_method_wrapper(method, is_exclusive=False):  # pylint: disable=too-many-statements
     """
@@ -5466,3 +5493,13 @@ class SlaNemeses(Nemesis):
 
     def disrupt(self):
         self.call_random_disrupt_method(disrupt_methods=self.disrupt_methods_list)
+
+
+class CreateIndexNemesis(Nemesis):
+
+    disruptive = False
+    schema_changes = True
+    free_tier_set = True
+
+    def disrupt(self):
+        self.disrupt_create_index()

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -2960,3 +2960,11 @@ duration_pattern = re.compile(r'(?P<hours>[\d]*)h|(?P<minutes>[\d]*)m|(?P<second
 def time_period_str_to_seconds(time_str: str) -> int:
     """Transforms duration string into seconds int. e.g. 1h -> 3600, 1h22m->4920 or 10m->600"""
     return sum([int(g[0] or 0) * 3600 + int(g[1] or 0) * 60 + int(g[2] or 0) for g in duration_pattern.findall(time_str)])
+
+
+def sleep_for_percent_of_duration(duration: int, percent: int, min_duration: int, max_duration: int):
+    """Waits the percentage of a duration in seconds, with a minimum and maximum duration (min < duration * percentage < max)"""
+    duration = int(duration * percent / 100)
+    duration = max(min(duration, max_duration), min_duration)
+    LOGGER.debug("Sleeping for %s seconds", duration)
+    time.sleep(duration)

--- a/sdcm/utils/nemesis_utils/indexes.py
+++ b/sdcm/utils/nemesis_utils/indexes.py
@@ -1,0 +1,88 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2023 ScyllaDB
+
+import logging
+import random
+import time
+
+from cassandra.query import SimpleStatement  # pylint: disable=no-name-in-module
+
+from sdcm.cluster import BaseNode
+from sdcm.sct_events import Severity
+from sdcm.sct_events.database import DatabaseLogEvent
+from sdcm.sct_events.filters import DbEventsFilter
+from sdcm.sct_events.system import InfoEvent
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get_random_column_name(session, ks, cf) -> str:
+    res = session.execute(f"SELECT column_name FROM system_schema.columns"
+                          f" WHERE keyspace_name = '{ks}'"
+                          f" AND table_name = '{cf}'"
+                          f" AND kind in ('static', 'regular')"
+                          f" ALLOW FILTERING")
+    column = random.choice(list(res)).column_name
+    return column
+
+
+def create_index(session, ks, cf, column) -> str:
+    InfoEvent(message=f"Starting creating index: {ks}.{cf}({column})").publish()
+    index_name = f"{cf}_{column}_nemesis".lower()
+    session.execute(f'CREATE INDEX {index_name} ON {ks}.{cf}("{column}")')
+    return index_name
+
+
+def wait_for_index_to_be_built(node: BaseNode, ks, index_name, timeout=300) -> None:
+    LOGGER.info('waiting for index %s to be built', index_name)
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        result = node.run_nodetool(f"viewbuildstatus {ks}.{index_name}_index",
+                                   ignore_status=True, verbose=False, publish_event=False)
+        if f"{ks}.{index_name}_index has finished building" in result.stdout:
+            InfoEvent(message=f"Index {ks}.{index_name} was built").publish()
+            return
+        time.sleep(30)
+    raise TimeoutError(f"Timeout error while creating index {index_name}. "
+                       f"stdout\n: {result.stdout}\n"
+                       f"stderr\n: {result.stderr}")
+
+
+def verify_query_by_index_works(session, ks, cf, column) -> None:
+    # get some value from table to use it in query by index
+    result = session.execute(SimpleStatement(f'SELECT "{column}" FROM {ks}.{cf} limit 1', fetch_size=1))
+    value = list(result)[0][0]
+    match type(value).__name__:
+        case "str" | "datetime":
+            value = f"'{value}'"
+        case "bytes":
+            value = "0x" + value.hex()
+    try:
+        query = SimpleStatement(f'SELECT * FROM {ks}.{cf} WHERE "{column}" = {value} LIMIT 100', fetch_size=100)
+        LOGGER.debug("Verifying query by index works: %s", query)
+        result = session.execute(query)
+    except Exception as exc:  # pylint: disable=broad-except
+        InfoEvent(message=f"Index {ks}.{cf}({column}) does not work in query: {query}. Reason: {exc}",
+                  severity=Severity.ERROR).publish()
+    if len(list(result)) == 0:
+        InfoEvent(message=f"Index {ks}.{cf}({column}) does not work. No rows returned for query {query}",
+                  severity=Severity.ERROR).publish()
+
+
+def drop_index(session, ks, index_name) -> None:
+    InfoEvent(message=f"Starting dropping index: {ks}.{index_name}").publish()
+    with DbEventsFilter(
+            db_event=DatabaseLogEvent.DATABASE_ERROR,
+            line="Error applying view update"):
+        session.execute(f'DROP INDEX {ks}.{index_name}')
+        time.sleep(30)  # errors can happen only within several seconds after index drop #12977

--- a/test-cases/nemesis/longevity-5gb-1h-CreateIndexNemesis.yaml
+++ b/test-cases/nemesis/longevity-5gb-1h-CreateIndexNemesis.yaml
@@ -1,0 +1,31 @@
+test_duration: 90
+
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=5048570 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=80 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+
+stress_cmd: ["cassandra-stress write cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=60m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=40 -pop seq=1..5048570 -col 'n=FIXED(8) size=FIXED(128)' -log interval=5"
+             ]
+
+n_db_nodes: 3
+n_loaders: 1
+n_monitor_nodes: 1
+seeds_num: 3
+
+instance_type_db: 'i4i.large'
+gce_instance_type_db: 'n1-highmem-2'
+gce_instance_type_loader: 'e2-standard-2'
+azure_instance_type_db: 'Standard_L8s_v3'
+instance_type_loader: 'c5.large'
+azure_instance_type_loader: 'Standard_F2s_v2'
+
+nemesis_class_name: 'CreateIndexNemesis'
+nemesis_interval: 3
+nemesis_filter_seeds: false
+nemesis_during_prepare: true
+
+gce_n_local_ssd_disk_db: 1
+
+user_prefix: 'longevity-5gb-1h-CreateIndexNemesis'
+
+server_encrypt: true
+client_encrypt: true

--- a/unit_tests/test_nemesis.py
+++ b/unit_tests/test_nemesis.py
@@ -228,6 +228,7 @@ class TestSisyphusMonkeyNemesisFilter:
             "disrupt_toggle_cdc_feature_properties_on_table",
             "disrupt_modify_table",
             "disrupt_toggle_table_gc_mode",
+            "disrupt_create_index",
         ]
 
     @pytest.fixture(autouse=True)

--- a/unit_tests/test_nemesis_sisyphus.py
+++ b/unit_tests/test_nemesis_sisyphus.py
@@ -71,7 +71,7 @@ def test_list_all_available_nemesis(generate_file=True):
     disruption_list, disruptions_dict, disruption_classes = sisyphus.get_list_of_disrupt_methods(
         subclasses_list=subclasses, export_properties=True)
 
-    assert len(disruption_list) == 75
+    assert len(disruption_list) == 76
 
     if generate_file:
         with open('data_dir/nemesis.yml', 'w', encoding="utf-8") as outfile1:


### PR DESCRIPTION
Currently we test indexes by having some c-s profiles with MV's. Indexes are created along with tables and are populated incrementally. We miss the scenario, where an user decides to create index after some time, when table is full of data.

This commit introduces new nemesis covering this scenario. When executed, gets a table with the most partitions and creates index on some random regular or static column. Waits for creation and verify if index can be used in a query without ALLOW FILTERING option without any issue. Drops index after nemesis to not change schema permanently.

refs: https://github.com/scylladb/qa-tasks/issues/1011

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
