### PR TITLE
fix(chaos-mesh): whitelist chaos-daemon on scylla nodes

### DIFF
--- a/sdcm/cluster_k8s/eks.py
+++ b/sdcm/cluster_k8s/eks.py
@@ -271,6 +271,8 @@ class EksCluster(KubernetesCluster, EksClusterCleanupMixin):  # pylint: disable=
             # NOTE: add performance tuning related pods only if we expect it to be.
             #       When we have tuning disabled it must not exist.
             allowed_labels_on_scylla_node.extend(self.perf_pods_labels)
+        if self.params.get('k8s_use_chaos_mesh'):
+            allowed_labels_on_scylla_node.append(('app.kubernetes.io/component', 'chaos-daemon'))
         return allowed_labels_on_scylla_node
 
     def create_eks_cluster(self, wait_till_functional=True):

--- a/sdcm/cluster_k8s/gke.py
+++ b/sdcm/cluster_k8s/gke.py
@@ -230,6 +230,8 @@ class GkeCluster(KubernetesCluster):
             # NOTE: add performance tuning related pods only if we expect it to be.
             #       When we have tuning disabled it must not exist.
             allowed_labels_on_scylla_node.extend(self.perf_pods_labels)
+        if self.params.get('k8s_use_chaos_mesh'):
+            allowed_labels_on_scylla_node.append(('app.kubernetes.io/component', 'chaos-daemon'))
         return allowed_labels_on_scylla_node
 
     def __str__(self):

--- a/sdcm/cluster_k8s/mini_k8s.py
+++ b/sdcm/cluster_k8s/mini_k8s.py
@@ -433,13 +433,16 @@ class LocalKindCluster(LocalMinimalClusterBase):
 
     @cached_property
     def allowed_labels_on_scylla_node(self) -> list:
-        return [
+        allowed_labels_on_scylla_node = [
             ('k8s-app', 'kindnet'),
             ('k8s-app', 'kube-proxy'),
             ('k8s-app', 'calico-node'),
             ('app', 'static-local-volume-provisioner'),
             ('scylla/cluster', self.k8s_scylla_cluster_name),
         ]
+        if self.params.get('k8s_use_chaos_mesh'):
+            allowed_labels_on_scylla_node.append(('app.kubernetes.io/component', 'chaos-daemon'))
+        return allowed_labels_on_scylla_node
 
     @property
     def is_k8s_software_installed(self) -> bool:


### PR DESCRIPTION
chaos-daemon pods are not in the white list on scylla nodes and causing WRONG_SCHEDULED_PODS event to be raised.

This commit adds chaos-daemon pods to whitelist on scylla k8s nodes.

refs: #5811

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
