### PR TITLE
fix(perf-nemesis-latency): Add operation duration to report

### DIFF
--- a/sdcm/report_templates/results_latency_during_ops_short.html
+++ b/sdcm/report_templates/results_latency_during_ops_short.html
@@ -78,27 +78,30 @@
                                 <th>Latency {{ lat_type }}</th>
                                 <th>Steady State {{lat_type}}</th>
                             {% endfor %}
+                            <th> Duration (sec) </th>
 
                             <th>Commit id, date</th>
                         </tr>
                         {% for cycle in results["cycles"] %}
                             {% set row_span = cycle["hdr_summary"]|length %}
+                            {% set cycle_index = loop.index %}
                             {% for workload in cycle["hdr_summary"] %}
                                 <tr>
                                     {% if loop.first %}
-                                            <td rowspan="{{ row_span }}"> Cycle #{{ loop.index }} </td>
+                                            <td rowspan="{{ row_span }}"> Cycle #{{ cycle_index }} </td>
                                             <td rowspan="{{ row_span }}"> current build </td>
-                                            <td> {{ workload }}</td>
+                                            <td style="text-align: center;"> {{ workload }}</td>
                                             {% for perc in lat_type_list %}
-                                                <td style="background-color: {{ cycle['hdr_summary'][workload]['color'][perc] }}"" }};"> {{ cycle['hdr_summary'][workload][perc]}} </td>
-                                                <td> {{ stats["Steady State"]["hdr_summary"][workload][perc] }} </td>
+                                                <td style="text-align: right; background-color: '{{ cycle['hdr_summary'][workload]['color'][perc] }}';"> {{ cycle['hdr_summary'][workload][perc]}} </td>
+                                                <td style="text-align: right;"> {{ stats["Steady State"]["hdr_summary"][workload][perc] }} </td>
                                             {% endfor %}
-                                            <td rowspan="{{ row_span }}"> {{ test_version }}</td>
+                                            <td rowspan="{{ row_span }}" style="text-align: right;"> {{ cycle.get('duration', "N/A") }} </td>
+                                            <td rowspan="{{ row_span }}" style="text-align: center;"> {{ test_version }} </td>
                                     {% else %}
-                                            <td> {{ workload }}</td>
+                                            <td style="text-align: right;"> {{ workload }}</td>
                                             {% for perc in lat_type_list %}
-                                                <td style="background-color: {{ cycle['hdr_summary'][workload]['color'][perc] }};"> {{ cycle['hdr_summary'][workload][perc]}} </td>
-                                                <td> {{ stats["Steady State"]["hdr_summary"][workload][perc] }} </td>
+                                                <td style="text-align: right; background-color: '{{ cycle['hdr_summary'][workload]['color'][perc] }}';"> {{ cycle['hdr_summary'][workload][perc]}} </td>
+                                                <td style="text-align: right;"> {{ stats["Steady State"]["hdr_summary"][workload][perc] }} </td>
                                             {% endfor %}
                                     {% endif %}
                                 </tr>

--- a/sdcm/utils/decorators.py
+++ b/sdcm/utils/decorators.py
@@ -202,6 +202,7 @@ def latency_calculator_decorator(original_function: Optional[Callable] = None, *
 
             result = latency.collect_latency(monitor, start, end, workload, args[0].cluster, all_nodes_list)
             result["screenshots"] = screenshots
+            result["duration"] = f"{datetime.timedelta(seconds=int(end - start))}"
             result["hdr"] = args[0].tester.get_cs_range_histogram_by_interval(stress_operation=workload,
                                                                               start_time=start,
                                                                               end_time=end)

--- a/sdcm/utils/latency.py
+++ b/sdcm/utils/latency.py
@@ -85,6 +85,9 @@ def collect_latency(monitor_node, start, end, load_type, cluster, nodes_list):
     return res
 
 
+NON_METRIC_FIELDS = ["screenshots", "hdr", "hdr_summary", "duration"]
+
+
 def calculate_latency(latency_results):
     result_dict = {}
     all_keys = list(latency_results.keys())
@@ -104,7 +107,7 @@ def calculate_latency(latency_results):
         temp_dict = {}
         for cycle in latency_results[key]['cycles']:
             for metric, value in cycle.items():
-                if metric in ["screenshots", "hdr", "hdr_summary"] or 'stdev' in metric or 'threshold' in metric:
+                if metric in NON_METRIC_FIELDS or 'stdev' in metric or 'threshold' in metric:
                     continue
                 if metric not in temp_dict:
                     temp_dict[metric] = []


### PR DESCRIPTION
Add new column, which contain operation duration in seconds

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
