### PR TITLE
fix(build_range_histogram): return empty dict if histogrma empty

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -3544,7 +3544,8 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         range_histogram = CSRangeHistogramBuilder.build_histogram_from_dir(base_path=self.loaders.logdir,
                                                                            start_time=start_time,
                                                                            end_time=end_time)
-        return CSRangeHistogramSummary(range_histogram, tag_type).get_summary_for_operation(stress_operation)[0]
+        histogram_data = CSRangeHistogramSummary(range_histogram, tag_type).get_summary_for_operation(stress_operation)
+        return histogram_data[0] if histogram_data else {}
 
     def get_cs_range_histogram_by_interval(
             self, stress_operation: str,


### PR DESCRIPTION
if histogram is empty because provide interval
doesn't contain data in hdr log files, ClusterTester.build_range_histogram method could fail with error: list index out of range.
Check if histogram is empty and return empty dict

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
