### PR TITLE
fix(offline-installer): remove deprecated seastar parameters

### DIFF
--- a/configurations/io.conf
+++ b/configurations/io.conf
@@ -1,1 +1,1 @@
-SEASTAR_IO="--num-io-queues=8 --io-properties-file=/etc/scylla.d/io_properties.yaml"
+SEASTAR_IO="--io-properties-file=/etc/scylla.d/io_properties.yaml"

--- a/query_limits_test.py
+++ b/query_limits_test.py
@@ -66,7 +66,7 @@ class QueryLimitsTest(ClusterTester):
         self.db_cluster.run("sudo cp /tmp/l /etc/sysconfig/scylla-server")
         self.db_cluster.run("sudo chown root.root /etc/sysconfig/scylla-server")
         # Configure seastar IO to use the smallest acceptable values (slow disk)
-        self.db_cluster.run('echo \'SEASTAR_IO="--num-io-queues 1 --max-io-requests 4"\' > /tmp/m')
+        self.db_cluster.run('echo \'SEASTAR_IO="--max-io-requests 4"\' > /tmp/m')
         self.db_cluster.run("sudo mv /tmp/m /etc/scylla.d/io.conf")
         self.db_cluster.run("sudo chown root.root /etc/scylla.d/io.conf")
         # Start scylla-server


### PR DESCRIPTION
all non-root offline installer tests fail with the following error message:
```
error: unrecognised option '--num-io-queues=8'
```

Following the latest update of seastar
https://github.com/scylladb/scylladb/commit/4f5a460db91de59018815106abb54c1246bbb014. one of the changes was https://github.com/scylladb/seastar/commit/6ad997708f20636a2e8394c83165cf0009d7b77e

Since `num-io-queues` is no longer available it should be removed
