### PR TITLE
improvement(MV): A new nemesis to add/remove MV dynamically

### DIFF
--- a/unit_tests/test_nemesis_sisyphus.py
+++ b/unit_tests/test_nemesis_sisyphus.py
@@ -71,7 +71,7 @@ def test_list_all_available_nemesis(generate_file=True):
     disruption_list, disruptions_dict, disruption_classes = sisyphus.get_list_of_disrupt_methods(
         subclasses_list=subclasses, export_properties=True)
 
-    assert len(disruption_list) == 75
+    assert len(disruption_list) == 76
 
     if generate_file:
         with open('data_dir/nemesis.yml', 'w', encoding="utf-8") as outfile1:


### PR DESCRIPTION
improvement(Materialized view): A nemesis to add/remove MV dynamically
    
            Test adding/removing MV + node down and data verification.

Task: https://github.com/scylladb/qa-tasks/issues/1012
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
