### PR TITLE
test(multi-keyspace): Use installed stressed tools instead of dockers

### DIFF
--- a/test-cases/longevity/longevity-multi-keyspaces.yaml
+++ b/test-cases/longevity/longevity-multi-keyspaces.yaml
@@ -33,3 +33,4 @@ append_scylla_args: '--blocked-reactor-notify-ms 500'
 
 # TODO: remove when https://github.com/scylladb/scylla-tools-java/issues/175 resolved
 stop_test_on_stress_failure: false
+use_prepared_loaders: true


### PR DESCRIPTION
	In order to avoid previous stress errors.

c-s had errors of:
```
2023-02-17 08:20:06.056: (CassandraStressEvent Severity.ERROR) period_type=end event_id=75a04694-c45f-45f7-9e5b-e172cf7b906c during_nemesis=NodetoolDecommission duration=5h55m10s: node=Node longevity-1000-keyspaces-5-2-loader-node-1886ff81-3 [52.51.85.147 | 10.4.2.16] (seed: False)
stress_cmd=cassandra-stress mixed cl=QUORUM duration=48h -schema 'replication(factor=3)' -mode cql3 native -rate threads=10 -pop seq=1..4000000 -log interval=90 -node 10.4.0.216,10.4.0.95,10.4.1.62,10.4.2.137,10.4.2.19,10.4.3.133
errors:
Stress command completed with bad status 134: WARN  02:25:10,098 Not using advanced port-based shard awareness with /10.4.2.19:9042 because we're

2023-02-17 08:20:07.529: (CassandraStressEvent Severity.ERROR) period_type=end event_id=8d6c009f-3034-49a2-b7c0-495f5b232cad during_nemesis=NodetoolDecommission duration=6h8m9s: node=Node longevity-1000-keyspaces-5-2-loader-node-1886ff81-2 [52.51.61.25 | 10.4.2.246] (seed: False)
stress_cmd=cassandra-stress mixed cl=QUORUM duration=48h -schema 'replication(factor=3)' -mode cql3 native -rate threads=10 -pop seq=1..4000000 -log interval=90 -node 10.4.0.216,10.4.0.95,10.4.1.62,10.4.2.137,10.4.2.19,10.4.3.133
errors:
Stress command completed with bad status 255: WARN  02:12:01,369 Error creating netty channel to /10.4.1.62:9042
com.datastax.shaded.netty.channel

2023-02-17 08:20:07.530: (CassandraStressEvent Severity.ERROR) period_type=end event_id=408094f4-1542-4e4d-9e47-cfefb113d398 during_nemesis=NodetoolDecommission duration=5h55m22s: node=Node longevity-1000-keyspaces-5-2-loader-node-1886ff81-2 [52.51.61.25 | 10.4.2.246] (seed: False)
stress_cmd=cassandra-stress mixed cl=QUORUM duration=48h -schema 'replication(factor=3)' -mode cql3 native -rate threads=10 -pop seq=1..4000000 -log interval=90 -node 10.4.0.216,10.4.0.95,10.4.1.62,10.4.2.137,10.4.2.19,10.4.3.133
errors:
Stress command completed with bad status 255: WARN  02:25:10,345 Not using advanced port-based shard awareness with /10.4.2.19:9042 because we're
```
And loader got a core dump:
```

2023-02-17 08:20:58.810: (CoreDumpEvent Severity.ERROR) period_type=one-time event_id=c21edc8d-324a-4cff-887b-c302cd75c5dd during_nemesis=NodetoolDecommission node=Node longevity-1000-keyspaces-5-2-loader-node-1886ff81-3 [52.51.85.147 | 10.4.2.16] (seed: False)
```

(no logs collected since sct-runner became unreachable during test)

And some more c-s errors reported at end of test:
```
2023-02-19 02:38:17.232: (CassandraStressEvent Severity.ERROR) period_type=end event_id=5900812d-b026-47a1-9a80-52d212d44441 during_nemesis=MgmtRepairCli duration=2d0h25m46s: node=Node longevity-1000-keyspaces-5-2-loader-node-1886ff81-5 [63.32.59.203 | 10.4.1.61] (seed: False)
stress_cmd=cassandra-stress mixed cl=QUORUM duration=48h -schema 'replication(factor=3)' -mode cql3 native -rate threads=10 -pop seq=1..4000000 -log interval=90 -node 10.4.0.216,10.4.0.95,10.4.1.62,10.4.2.137,10.4.2.19,10.4.3.133
errors:
Stress command execution failed with: Command did not complete within 173400 seconds!
Command: 'sudo  docker exec b56c4cc9b9d8d508166c4f1d585e4396e021f9f9bc9653dde31479b01198fd61 /bin/sh -c \'echo TAG: loader_idx:0-cpu_idx:0-keyspace_idx:1; STRESS_TEST_MARKER=P4HGGNUTI4B7QISBR2Q4; cassandra-stress mixed cl=QUORUM duration=48h -schema keyspace=keyspace5 \'"\'"\'replication(factor=3)\'"\'"\' -mode cql3 native -rate threads=10 -pop seq=1..4000000 -log interval=90 -node 10.4.0.216,10.4.0.95,10.4.1.62,10.4.2.137,10.4.2.19,10.4.3.133 -errors skip-unsupported-columns\''
Stdout:
[Too many errors, abort]
[Too many errors, abort]
[Too many errors, abort]
[Too many errors, abort]
[Too many errors, abort]
[Too many errors, abort]
[Too many errors, abort]
[Too many errors, abort]
[Too many errors, abort]
[Too many errors, abort]
Stderr:
at com.datastax.shaded.netty.channel.socket.nio.NioSocketChannel.doFinishConnect(NioSocketChannel.java:330)
at com.datastax.shaded.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.finishConnect(AbstractNioChannel.java:334)
at com.datastax.shaded.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:710)
at com.datastax.shaded.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:658)
at com.datastax.shaded.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:584)
at com.datastax.shaded.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:496)
at com.datastax.shaded.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
at com.datastax.shaded.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
at com.datastax.shaded.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
at java.base/java.lang.Thread.run(Thread.java:829)
```
job url: https://jenkins.scylladb.com/job/scylla-5.2/job/longevity/job/longevity-multi-keyspaces-60h-test/2/
[argus](https://argus.scylladb.com/test/86571bb4-7ca9-45f5-9e8f-0315da77b786/runs?additionalRuns%5B%5D=1886ff81-68c5-4404-b077-a9f9d7997aa6)
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
