### PR TITLE
fix(restore_data_with_task): fixed assertion message

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -209,7 +209,7 @@ class BackupFunctionsMixIn(LoaderUtilsMixin):
         restore_task = mgr_cluster.create_restore_task(restore_data=True, location_list=self.locations,
                                                        snapshot_tag=snapshot_tag)
         restore_task.wait_and_get_final_status(step=30, timeout=timeout)
-        assert restore_task.status == TaskStatus.DONE, f"Schema restoration of {snapshot_tag} has failed!"
+        assert restore_task.status == TaskStatus.DONE, f"Data restoration of {snapshot_tag} has failed!"
         for node in self.db_cluster.nodes:
             node.run_nodetool("repair")  # After data restoration, you should repair every node
 


### PR DESCRIPTION
The assert message in restore_data_with_task falsely stated that the schema was restored by the restore task instead of the data. I amended the message.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
