### PR TITLE
fix(create release jobs): fix upgrade with raft jobs

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -1358,7 +1358,6 @@ def create_test_release_jobs(branch, username, password, sct_branch, sct_repo):
     for group_name, group_desc in [
         ('longevity', 'SCT Longevity Tests'),
         ('rolling-upgrade', 'SCT Rolling Upgrades'),
-        ('rolling-upgrade-raft-disabled', 'SCT Rolling Upgrades Raft Disabled'),
         ('gemini-', 'SCT Gemini Tests'),
         ('features-', 'SCT Feature Tests'),
         ('artifacts', 'SCT Artifacts Tests'),
@@ -1396,9 +1395,6 @@ def create_test_release_jobs(branch, username, password, sct_branch, sct_repo):
                 server.create_pipeline_job(jenkins_file, group_name)
         if group_name == 'nemesis':
             for jenkins_file in glob.glob(f'{base_path}/nemesis/*'):
-                server.create_pipeline_job(jenkins_file, group_name)
-        if group_name == 'rolling-upgrade-raft-disabled':
-            for jenkins_file in glob.glob(f'{base_path}/upgrade-with-raft/*'):
                 server.create_pipeline_job(jenkins_file, group_name)
 
     server.create_directory(


### PR DESCRIPTION
introduced on #5759 the creation of upgrade with
raft disabled, but then, the PR was reverted, but
the jobs creation wasn't.
then on #5836 was added the correct behavior,
so we ended up with duplicated behavior.
this PR is removing the jobs creation of
rolling upgrade with raft disabled,
as this is the default for all rolling upgrade
jobs, and leaving the jobs with raft enabled.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
