### PR TITLE
fix(artifacts): enable `aws_fallback_to_next_availability_zone`

### DIFF
--- a/test-cases/artifacts/amazon2.yaml
+++ b/test-cases/artifacts/amazon2.yaml
@@ -18,3 +18,4 @@ system_auth_rf: 1
 test_duration: 60
 use_preinstalled_scylla: false
 user_prefix: 'artifacts-amazon2'
+aws_fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/oel76.yaml
+++ b/test-cases/artifacts/oel76.yaml
@@ -18,3 +18,4 @@ test_duration: 60
 use_preinstalled_scylla: false
 user_prefix: 'artifacts-oel76'
 system_auth_rf: 1
+aws_fallback_to_next_availability_zone: true

--- a/test-cases/artifacts/oel81.yaml
+++ b/test-cases/artifacts/oel81.yaml
@@ -18,3 +18,4 @@ test_duration: 60
 use_preinstalled_scylla: false
 user_prefix: 'artifacts-oel81'
 system_auth_rf: 1
+aws_fallback_to_next_availability_zone: true


### PR DESCRIPTION
this feature was enabled only on AMI artifact test, and we habe more artifacts tests running on AWS that needs it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
