### PR TITLE
fix(Ldap nemesis): skip toggle-connection-disrupt if not using open-Ldap

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -98,7 +98,7 @@ from sdcm.utils.k8s import (
     convert_cpu_value_from_k8s_to_units, convert_memory_value_from_k8s_to_units,
 )
 from sdcm.utils.k8s.chaos_mesh import MemoryStressExperiment, IOFaultChaosExperiment, DiskError
-from sdcm.utils.ldap import SASLAUTHD_AUTHENTICATOR
+from sdcm.utils.ldap import SASLAUTHD_AUTHENTICATOR, LdapServerType
 from sdcm.utils.replication_strategy_utils import temporary_replication_strategy_setter, \
     NetworkTopologyReplicationStrategy, ReplicationStrategy, SimpleReplicationStrategy
 from sdcm.utils.sstable.load_utils import SstableLoadUtils
@@ -1109,6 +1109,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             raise UnsupportedNemesis('Cluster is not configured to run with LDAP authorization, hence skipping')
         if not self.target_node.is_enterprise:
             raise UnsupportedNemesis('Cluster is not enterprise. LDAP is supported only for enterprise. Skipping')
+        if not self.cluster.params.get('ldap_server_type') == LdapServerType.OPENLDAP:
+            raise UnsupportedNemesis('This nemesis is supported only for open-Ldap. Skipping')
 
         self.log.info('Will now pause the LDAP container')
         ContainerManager.pause_container(self.tester.localhost, 'ldap')


### PR DESCRIPTION
	toggle connection nemesis only applies to usage of open-Ldap
	and runs against a container, not against MS-AD server.

Fixes an error of:
```
2023-02-23 15:06:38.688: (DisruptionEvent Severity.ERROR) period_type=end event_id=ac7574aa-c4f9-44ab-b56b-969c897226d3 duration=1s: nemesis_name=LdapConnectionToggle target_node=Node longevity-100gb-4h-2023-1-db-node-64dc4bfc-3 [16.170.141.195 | 10.0.0.106] (seed: True) errors=There is no container `ldap' for <sdcm.localhost.LocalHost object at 0x7fc1e890c190>.
Traceback (most recent call last):
File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 4088, in wrapper
result = method(*args[1:], **kwargs)
File "/home/ubuntu/scylla-cluster-tests/sdcm/nemesis.py", line 1114, in disrupt_ldap_connection_toggle
ContainerManager.pause_container(self.tester.localhost, 'ldap')
File "/home/ubuntu/scylla-cluster-tests/sdcm/utils/docker_utils.py", line 418, in pause_container
cls.get_container(instance, name).pause()
File "/home/ubuntu/scylla-cluster-tests/sdcm/utils/docker_utils.py", line 185, in get_container
raise NotFound(f"There is no container `{name}' for {instance}.")
docker.errors.NotFound: There is no container `ldap' for <sdcm.localhost.LocalHost object at 0x7fc1e890c190>.
```
## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
