### PR TITLE
Fix discover vms in azure

### DIFF
--- a/sdcm/provision/azure/ip_provider.py
+++ b/sdcm/provision/azure/ip_provider.py
@@ -35,15 +35,12 @@ class IpAddressProvider:
     def __post_init__(self):
         """Discover existing ip addresses for resource group."""
         try:
-            ips = list(self._azure_service.network.public_ip_addresses.list(self._resource_group_name))
-        except ResourceNotFoundError:
-            return
-        for ip in ips:
-            try:
+            ips = self._azure_service.network.public_ip_addresses.list(self._resource_group_name)
+            for ip in ips:
                 ip = self._azure_service.network.public_ip_addresses.get(self._resource_group_name, ip.name)
                 self._cache[ip.name] = ip
-            except ResourceNotFoundError as exc:
-                LOGGER.warning("Could not get IP address '{}'. Exception: {}".format(ip.name, exc))
+        except ResourceNotFoundError:
+            pass
 
     def get_or_create(self, names: List[str] = "default", version: str = "IPV4") -> List[PublicIPAddress]:
         addresses = []

--- a/sdcm/provision/azure/provisioner.py
+++ b/sdcm/provision/azure/provisioner.py
@@ -142,10 +142,7 @@ class AzureProvisioner(Provisioner):  # pylint: disable=too-many-instance-attrib
         self._vm_provider.delete(name, wait=wait)
         del self._cache[name]
         self._nic_provider.delete(self._nic_provider.get(name))
-        try:
-            self._ip_provider.delete(self._ip_provider.get(name))
-        except KeyError:
-            LOGGER.warning("IP address for instance %s could not be found in cache.", name)
+        self._ip_provider.delete(self._ip_provider.get(name))
 
     def reboot_instance(self, name: str, wait=True) -> None:
         self._vm_provider.reboot(name, wait)

--- a/sdcm/provision/azure/virtual_machine_provider.py
+++ b/sdcm/provision/azure/virtual_machine_provider.py
@@ -43,7 +43,8 @@ class VirtualMachineProvider:
             v_ms = self._azure_service.compute.virtual_machines.list(self._resource_group_name)
             for v_m in v_ms:
                 v_m = self._azure_service.compute.virtual_machines.get(self._resource_group_name, v_m.name)
-                self._cache[v_m.name] = v_m
+                if v_m.provisioning_state != "Deleting":
+                    self._cache[v_m.name] = v_m
         except ResourceNotFoundError:
             pass
 


### PR DESCRIPTION
When running cleanup resources according to post behavior we run
`clean_cloud_resources` multiple times. Each time azure provisioner
discover VM's from scratch. Because IP's are deleted quicker than VM's
provisioner sometimes fails to obtain IP address for VM that is pending
delete and failing.

This PR makes instances discovery to skip ones that are pending
deletion. Also reverting previous fix that possibly doesn't work.


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
