### PR TITLE
fix(nemeses): support SLA nemeses for non-SLA tests

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1651,6 +1651,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                         clean_enospc_on_node(target_node=node, sleep_time=sleep_time)
 
     def disrupt_remove_service_level_while_load(self):
+        # Temporary solution. We do not want to run SLA nemeses during not-SLA test until the feature is stable
+        if not self.cluster.params.get('sla'):
+            raise UnsupportedNemesis("SLA nemesis can be run during SLA test only")
+
         if not self.cluster.nodes[0].is_enterprise:
             raise UnsupportedNemesis("SLA feature is only supported by Scylla Enterprise")
 
@@ -3924,6 +3928,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         return column_definition, data_set_size
 
     def disrupt_sla_increase_shares_during_load(self):
+        # Temporary solution. We do not want to run SLA nemeses during not-SLA test until the feature is stable
+        if not self.cluster.params.get('sla'):
+            raise UnsupportedNemesis("SLA nemesis can be run during SLA test only")
+
         if not self.cluster.nodes[0].is_enterprise:
             raise UnsupportedNemesis("SLA feature is only supported by Scylla Enterprise")
 
@@ -3945,6 +3953,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.format_error_for_sla_test_and_raise(error_events=error_events)
 
     def disrupt_sla_decrease_shares_during_load(self):
+        # Temporary solution. We do not want to run SLA nemeses during not-SLA test until the feature is stable
+        if not self.cluster.params.get('sla'):
+            raise UnsupportedNemesis("SLA nemesis can be run during SLA test only")
+
         if not self.cluster.nodes[0].is_enterprise:
             raise UnsupportedNemesis("SLA feature is only supported by Scylla Enterprise")
 
@@ -3966,6 +3978,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.format_error_for_sla_test_and_raise(error_events=error_events)
 
     def disrupt_replace_service_level_using_detach_during_load(self):
+        # Temporary solution. We do not want to run SLA nemeses during not-SLA test until the feature is stable
+        if not self.cluster.params.get('sla'):
+            raise UnsupportedNemesis("SLA nemesis can be run during SLA test only")
+
         if not self.cluster.nodes[0].is_enterprise:
             raise UnsupportedNemesis("SLA feature is only supported by Scylla Enterprise")
 
@@ -3988,6 +4004,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.format_error_for_sla_test_and_raise(error_events=error_events)
 
     def disrupt_replace_service_level_using_drop_during_load(self):
+        # Temporary solution. We do not want to run SLA nemeses during not-SLA test until the feature is stable
+        if not self.cluster.params.get('sla'):
+            raise UnsupportedNemesis("SLA nemesis can be run during SLA test only")
+
         if not self.cluster.nodes[0].is_enterprise:
             raise UnsupportedNemesis("SLA feature is only supported by Scylla Enterprise")
 
@@ -4011,6 +4031,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.format_error_for_sla_test_and_raise(error_events=error_events)
 
     def disrupt_increase_shares_by_attach_another_sl_during_load(self):
+        # Temporary solution. We do not want to run SLA nemeses during not-SLA test until the feature is stable
+        if not self.cluster.params.get('sla'):
+            raise UnsupportedNemesis("SLA nemesis can be run during SLA test only")
+
         if not self.cluster.nodes[0].is_enterprise:
             raise UnsupportedNemesis("SLA feature is only supported by Scylla Enterprise")
 
@@ -4034,6 +4058,10 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.format_error_for_sla_test_and_raise(error_events=error_events)
 
     def disrupt_maximum_allowed_sls_with_max_shares_during_load(self):
+        # Temporary solution. We do not want to run SLA nemeses during not-SLA test until the feature is stable
+        if not self.cluster.params.get('sla'):
+            raise UnsupportedNemesis("SLA nemesis can be run during SLA test only")
+
         if not self.cluster.nodes[0].is_enterprise:
             raise UnsupportedNemesis("SLA feature is only supported by Scylla Enterprise")
 
@@ -4446,6 +4474,7 @@ class RefreshBigMonkey(Nemesis):
 
 class RemoveServiceLevelMonkey(Nemesis):
     disruptive = True
+    sla = True
 
     def disrupt(self):
         self.disrupt_remove_service_level_while_load()

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -490,6 +490,10 @@ class SCTConfiguration(dict):
         dict(name="authorizer", env="SCT_AUTHORIZER", type=str,
              help="which authorizer scylla will use AllowAllAuthorizer/CassandraAuthorizer"),
 
+        # Temporary solution. We do not want to run SLA nemeses during not-SLA test until the feature is stable
+        dict(name="sla", env="SCT_SLA", type=boolean,
+             help="run SLA nemeses if the test is SLA only"),
+
         dict(name="system_auth_rf", env="SCT_SYSTEM_AUTH_RF", type=int,
              help="Replication factor will be set to system_auth"),
 

--- a/sdcm/sla/libs/sla_utils.py
+++ b/sdcm/sla/libs/sla_utils.py
@@ -82,9 +82,12 @@ class SlaUtils:
 
         params = {'n': num_of_partitions, 'user': role.name, 'password': role.password, 'pop': pop,
                   'duration': '%dm' % stress_duration_min, 'threads': rate}
-        if kwargs:
-            params.update(kwargs['kwargs'])
         c_s_cmd = stress_command.format(**params)
+
+        if kwargs:
+            LOGGER.debug("Kwargs: %s", kwargs['kwargs'])
+            for param, value in kwargs['kwargs'].items():
+                c_s_cmd += f" {param} {value}"
         LOGGER.info("Created cassandra-stress command: %s", c_s_cmd)
 
         return c_s_cmd
@@ -128,7 +131,8 @@ class SlaUtils:
 
     # pylint: disable=too-many-arguments,too-many-locals
     def validate_scheduler_runtime(self, start_time, end_time, read_users, prometheus_stats, db_cluster,
-                                   expected_ratio=None, load_high_enough=None, publish_wp_error_event=False):
+                                   expected_ratio=None, load_high_enough=None, publish_wp_error_event=False,
+                                   possible_issue=None):
         # roles_full_info example:
         #   {'role250':
         #   {'service_level': ServiceLevel: name: 'sl250',
@@ -145,7 +149,13 @@ class SlaUtils:
 
         result = []
         sl_group_runtime_zero = False
-        for node_ip in db_cluster.get_node_private_ips():
+        # for node_ip in db_cluster.get_node_private_ips():
+        for node in db_cluster.nodes:
+            # If Scylla is not running on the node - do not perform validation
+            if not (node.jmx_up() and node.db_up()):
+                continue
+
+            node_ip = node.private_ip_address
             scheduler_runtime_per_sla = prometheus_stats.get_scylla_scheduler_runtime_ms(start_time, end_time, node_ip,
                                                                                          irate_sample_sec='60s')
             # Example of scheduler_runtime_per_sla:
@@ -192,7 +202,8 @@ class SlaUtils:
                                                                         node_ip=node_ip,
                                                                         node_cpu=node_cpu,
                                                                         load_high_enough=load_high_enough,
-                                                                        publish_wp_error_event=publish_wp_error_event))
+                                                                        publish_wp_error_event=publish_wp_error_event,
+                                                                        possible_issue=possible_issue))
                 continue
 
             # TODO: next 5 lines will be used by sla_per_user_system_test.py. Will need to be adapted
@@ -207,16 +218,25 @@ class SlaUtils:
                 result.insert(0, "\nProbably the issue https://github.com/scylladb/scylla-enterprise/issues/2572")
             raise SchedulerRuntimeUnexpectedValue("".join(result))
 
+    # pylint: disable=too-many-branches
     @staticmethod
     def validate_runtime_relatively_to_share(roles_full_info: dict, node_ip: str,
                                              load_high_enough: bool = None, node_cpu: float = None,
-                                             publish_wp_error_event=False):
+                                             publish_wp_error_event=False,
+                                             possible_issue=None):
         # roles_full_info example:
         #   {'role250': {'service_level': ServiceLevel: name: 'sl250',
         #   attributes: ServiceLevelAttributes(shares=250, timeout=None, workload_type=None),
         #   'service_level_shares': 250, 'service_level_name': "'sl250'", 'sl_group': 'sl:sl250',
         #   'sl_group_runtime': 181.23794405382156}}
         shares = [sl['service_level_shares'] for sl in roles_full_info.values()]
+
+        if not shares or len([s for s in shares if s]) < 2:
+            WorkloadPrioritisationEvent.RatioValidationEvent(
+                message='Not enough service level shares for validation. Expected two Service Levels, received '
+                        f'{len([s for s in shares if s])}: {shares}. Runtime can not be validated',
+                severity=Severity.NORMAL).publish()
+            return None
 
         # TODO: as Eliran about this case
         # If both roles are connected to the servie level with same shares we can not validate the ratio as we can not
@@ -235,7 +255,7 @@ class SlaUtils:
             shares_ratio = False
 
         runtimes = [sl['sl_group_runtime'] for sl in roles_full_info.values()]
-        # If runtime of role1 less than shares of role2, dividing result will be less than 1 always
+        # If runtime of role1 less than runtime of role2, dividing result will be less than 1 always
         try:
             runtimes_ratio = (runtimes[0] / runtimes[1]) < 1
         except ZeroDivisionError:
@@ -243,37 +263,53 @@ class SlaUtils:
             runtimes_ratio = False
 
         # Validate that role with higher shares get more resources and vice versa
-        error_message = ""
-        if shares_ratio == runtimes_ratio:
+        if 0.0 not in runtimes and shares_ratio == runtimes_ratio:
             WorkloadPrioritisationEvent.RatioValidationEvent(
                 message=f'Role with higher shares got more resources on the node with IP {node_ip} as expected',
                 severity=Severity.NORMAL).publish()
+            return ""
+
+        error_message = ""
+        runtime_per_sl_group = []
+        zero_runtime_service_level = []
+        # If scheduler runtime per scheduler group is not as expected - return error.
+        for service_level in roles_full_info.values():
+            runtime_per_sl_group.append(f"{service_level['sl_group']} (shares "
+                                        f"{service_level['service_level_shares']}): "
+                                        f"{round(service_level['sl_group_runtime'], 2)}")
+            if service_level['sl_group_runtime'] == 0.0:
+                zero_runtime_service_level.append(service_level['sl_group'])
+
+        runtime_per_sl_group_str = "\n  ".join(runtime_per_sl_group)
+
+        issue = ""
+        if zero_runtime_service_level:
+            if possible_issue and possible_issue.get("zero resources"):
+                issue = f"\n  (Possible issue {possible_issue['zero resources']})"
+            message = (f'\n(Node {node_ip}) - Service level{"(s)" if len(zero_runtime_service_level) > 1 else ""} '
+                       f'{", ".join(zero_runtime_service_level)} did not get resources unexpectedly.%s '
+                       f'Runtime per service level group:\n  {runtime_per_sl_group_str}{issue}')
         else:
-            # If scheduler runtime per scheduler group is not as expected - return error.
-            runtime_per_sl_group = []
-            for service_level in roles_full_info.values():
-                runtime_per_sl_group.append(f"{service_level['sl_group']} (shares "
-                                            f"{service_level['service_level_shares']}): "
-                                            f"{round(service_level['sl_group_runtime'], 2)}")
-            runtime_per_sl_group_str = "\n  ".join(runtime_per_sl_group)
+            if possible_issue and possible_issue.get("less resources"):
+                issue = f"\n  (Possible issue {possible_issue['less resources']})"
+            message = (f'\n(Node {node_ip}) - Service level with higher shares got less resources unexpectedly.%s '
+                       f'Runtime per service level group:\n  {runtime_per_sl_group_str}{issue}')
 
-            message = (f'\n(Node {node_ip}) - Role with higher shares got less resources unexpectedly.%s '
-                       f'Runtime per service level group:\n  {runtime_per_sl_group_str}')
-            if load_high_enough is None and node_cpu is None:
-                WorkloadPrioritisationEvent.RatioValidationEvent(
-                    message=message % " Maybe due to not enough high load.",
-                    severity=Severity.WARNING).publish()
+        if load_high_enough is None and node_cpu is None:
+            WorkloadPrioritisationEvent.RatioValidationEvent(
+                message=message % " Maybe due to not enough high load.",
+                severity=Severity.WARNING).publish()
+        else:
+            if load_high_enough is not None:
+                error_message = message % ("" if not load_high_enough else "The load is not high enough.")
             else:
-                if load_high_enough is not None:
-                    error_message = message % ("" if not load_high_enough else "The load is not high enough.")
-                else:
-                    error_message = message % f" CPU%: {round(node_cpu, 2)}."
+                error_message = message % f" CPU%: {round(node_cpu, 2)}."
 
-                # If error happens during test step, TestStepEvent will publish this error. To prevent duplication do
-                # not report WorkloadPrioritisationEvent
-                if publish_wp_error_event:
-                    WorkloadPrioritisationEvent.RatioValidationEvent(message=error_message,
-                                                                     severity=Severity.ERROR).publish()
+            # If error happens during test step, TestStepEvent will publish this error. To prevent duplication do
+            # not report WorkloadPrioritisationEvent
+            if publish_wp_error_event:
+                WorkloadPrioritisationEvent.RatioValidationEvent(message=error_message,
+                                                                 severity=Severity.ERROR).publish()
 
         return error_message
 
@@ -327,12 +363,9 @@ class SlaUtils:
     @staticmethod
     def clean_auth(entities_list_of_dict):
         for entity in entities_list_of_dict:
-            service_level = entity.get('service_level')
-            role = entity.get('role')
-            user = entity.get('user')
-            if user:
-                user.drop()
-            if role:
-                role.drop()
-            if service_level:
-                service_level.drop()
+            for auth in [entity.get('user'), entity.get('role'), entity.get('service_level')]:
+                if auth:
+                    try:
+                        auth.drop()
+                    except Exception as error:  # pylint: disable=broad-except
+                        LOGGER.error("Failed to drop '%s'. Error: %s", auth.name, error)

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -3011,6 +3011,19 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
             self.fail("Unable to get data set size from cassandra-stress command: %s" % cs_cmd)
             return None
 
+    def get_c_s_column_definition(self, cs_cmd):  # pylint: disable=inconsistent-return-statements
+        """:returns value of -col in stress comand, that is approximation and currently doesn't take in consideration
+            column definitions if they present in the command
+        """
+        try:
+            # Example:  -col 'size=FIXED(200) n=FIXED(5)'
+            if search_res := re.search(r".* -col ('.*') .*", cs_cmd):
+                return search_res.group(1)
+            return None
+        except Exception:  # pylint: disable=broad-except
+            self.fail("Unable to get column definition from cassandra-stress command: %s" % cs_cmd)
+            return None
+
     @retrying(n=60, sleep_time=60, allowed_exceptions=(AssertionError,))
     def wait_data_dir_reaching(self, size, node):
         query = '(sum(node_filesystem_size_bytes{{mountpoint="{0.scylla_dir}", ' \

--- a/test-cases/enterprise-features/workload-prioritization/longevity/longevity-sla-system-24h.yaml
+++ b/test-cases/enterprise-features/workload-prioritization/longevity/longevity-sla-system-24h.yaml
@@ -12,6 +12,8 @@ n_loaders: 2
 n_monitor_nodes: 1
 round_robin: true
 
+sla: true
+
 instance_type_db: 'i3.2xlarge'
 instance_type_loader: 'c5.2xlarge'
 

--- a/test-cases/enterprise-features/workload-prioritization/longevity/longevity-sla-system-24h.yaml
+++ b/test-cases/enterprise-features/workload-prioritization/longevity/longevity-sla-system-24h.yaml
@@ -29,4 +29,4 @@ space_node_threshold: 64424
 authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra
 authenticator_password: cassandra
-authorizer: 'ScyllaAuthorizer'
+authorizer: 'CassandraAuthorizer'

--- a/test-cases/longevity/longevity-sla-100gb-4h.yaml
+++ b/test-cases/longevity/longevity-sla-100gb-4h.yaml
@@ -1,11 +1,14 @@
 test_duration: 360
 
-prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=41943040 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=600 -pop seq=1..41943040 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
+prepare_write_cmd:  "cassandra-stress write cl=QUORUM n=83886080 -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native -rate threads=900 -pop seq=1..83886080 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
 
 # option <sla credentials 0> - where "0" is first element of "service_level_shares" test parameter. This option will be replaced with user and password of the role name that assigned to service level with shares=service_level_shares[0]
 # option <sla credentials 1> - where "1" is second element of "service_level_shares" test parameter. This option will be replaced with user and password of the role name that assigned to service level with shares=service_level_shares[1]
-stress_cmd: ["cassandra-stress read cl=QUORUM duration=240m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native <sla credentials 0> -rate threads=600 -pop seq=1..20971520 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
-             "cassandra-stress read  cl=QUORUM duration=240m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native <sla credentials 1> -rate threads=600 -pop seq=20971521..41943040 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
+stress_cmd: [
+             "cassandra-stress read cl=QUORUM duration=240m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native <sla credentials 0> -rate threads=400 -pop seq=1..41943040 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=240m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native <sla credentials 1> -rate threads=400 -pop seq=41943041..83886080 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+             "cassandra-stress read cl=QUORUM duration=240m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native <sla credentials 0> -rate threads=400 -pop seq=1..83886080 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5",
+             "cassandra-stress read  cl=QUORUM duration=240m -schema 'replication(factor=3) compaction(strategy=SizeTieredCompactionStrategy)' -mode cql3 native <sla credentials 1> -rate threads=400 -pop seq=1..83886080 -col 'n=FIXED(10) size=FIXED(512)' -log interval=5"
              ]
 
 n_db_nodes: 6
@@ -14,11 +17,13 @@ n_monitor_nodes: 1
 seeds_num: 3
 round_robin: true
 
-instance_type_db: 'i3.4xlarge'
+sla: true
+
+instance_type_db: 'i3.2xlarge'
+instance_type_loader: 'c5.2xlarge'
 
 run_fullscan: ['{"mode": "table_and_aggregate", "ks_cf": "keyspace1.standard1", "interval": 5}']
-nemesis_class_name: 'SisyphusMonkey'
-nemesis_seed: '032'
+nemesis_class_name: 'SlaNemeses'
 nemesis_interval: 5
 nemesis_filter_seeds: false
 nemesis_during_prepare: false
@@ -32,6 +37,6 @@ sstable_size: 100
 authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra
 authenticator_password: cassandra
-authorizer: 'ScyllaAuthorizer'
+authorizer: 'CassandraAuthorizer'
 
 service_level_shares: [200, 800]


### PR DESCRIPTION
1. SLA feature need that cluster will be configured with authenticator. Not all our longevities run with authenticator. So we need to filter out SLA nemeses.

2. Cassandra-stress default table 'keyspace1.standard1' can have different columns definition. SLA nemeses start cassandra-stress load on this table and need to use same columns definition. This commit get columns definition from cassandra-stress command (from test yaml) and run load with correct '-col' parameter.

3. To prevent parmission error 'User roleyyy has no SELECT permission on table ... or any of its parents', create the role as SUPERUSER.

4. Added temporary solution. We do not want to run SLA nemeses during not-SLA test until the feature is stable.
Example here: https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/longevity-1tb-7days-test/21/
```
Nemesis Information
Class: SlaNemeses
Name: disrupt_replace_service_level_using_detach_during_load
Status: Skipped
Duration: 1 second
Skip reason

SLA nemesis can be run during SLA test only
```

5. Added workaround for issue https://github.com/scylladb/scylla-enterprise/issues/2572
6. Due to different failures and known issues added issues numbers to the part of errors. Examples:
```
sdcm.nemesis.NemesisSubTestFailure: Step: Attach service level 'sl800_cd1b80a2' with 800 shares to role20_cd1b80a2. Validate scheduler runtime during load. Error:
 - (TestStepEvent Severity.ERROR) period_type=end event_id=2bb46fda-524a-4af5-b421-6503437afb8c during_nemesis=IncreaseSharesByAttachAnotherSlDuringLoad duration=11m38s: step=Attach service level 'sl800_cd1b80a2' with 800 shares to role20_cd1b80a2. Validate scheduler runtime during load  errors=
(Node 10.0.0.7) - Service level with higher shares got less resources unexpectedly. CPU%: 97.11. Runtime per service level group:
  sl:sl800_cd1b80a2 (shares 800): 44.06
  sl:sl500_cd1b80a2 (shares 500): 174.3
  (Possible issue scylla-enterprise#2572 or scylla-enterprise#2717)
```

```
sdcm.nemesis.NemesisSubTestFailure: Step: Run stress command and validate scheduler runtime during load. Error:
 - (TestStepEvent Severity.ERROR) period_type=end event_id=81b3a583-1e27-4ae4-bb6e-23be226710db during_nemesis=IncreaseSharesByAttachAnotherSlDuringLoad,NoCorruptRepair duration=10m24s: step=Run stress command and validate scheduler runtime during load  errors=
Probably the issue https://github.com/scylladb/scylla-enterprise/issues/2572
(Node 10.0.0.184) - Service level with higher shares got less resources unexpectedly. CPU%: 88.27. Runtime per service level group:
  sl:sl20_b025a062 (shares 20): 1.7
  sl:sl500_b025a062 (shares 500): 1.57
  (Possible issue scylla-enterprise#2717)
```

Tests:
https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/longevity-sla-system-24h/82/
https://jenkins.scylladb.com/job/scylla-staging/job/yulia/job/staging-sla-100gb-4h/76/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
