### PR TITLE
 improvement(manager backup feature): Added restoration with restore task

### DIFF
--- a/mgmt_cli_test.py
+++ b/mgmt_cli_test.py
@@ -869,7 +869,6 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
 
         target_node = self.db_cluster.nodes[1]
 
-        has_enospc_been_reached = False
         with ignore_no_space_errors(node=target_node):
             try:
                 backup_task = mgr_cluster.create_backup_task(location_list=self.locations)
@@ -877,7 +876,6 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
                 backup_task.stop()
 
                 reach_enospc_on_node(target_node=target_node)
-                has_enospc_been_reached = True
 
                 backup_task.start()
 
@@ -887,8 +885,7 @@ class MgmtCliTest(BackupFunctionsMixIn, ClusterTester):
                                                               "to the previous run"
 
             finally:
-                if has_enospc_been_reached:
-                    clean_enospc_on_node(target_node=target_node, sleep_time=30)
+                clean_enospc_on_node(target_node=target_node, sleep_time=30)
         self.log.info('finishing test_enospc_during_backup')
 
     def test_enospc_before_restore(self):

--- a/test-cases/manager/manager-regression-azure.yaml
+++ b/test-cases/manager/manager-regression-azure.yaml
@@ -1,6 +1,7 @@
 test_duration: 360
 
 stress_cmd: "cassandra-stress write cl=QUORUM n=4000000 -schema 'replication(factor=3)' -mode cql3 native -rate threads=200 -pop seq=400000000..600000000"
+stress_read_cmd: "cassandra-stress read cl=QUORUM n=4000000 -schema 'replication(factor=3)' -mode cql3 native -rate threads=200 -pop seq=400000000..600000000"
 
 n_db_nodes: 3
 n_loaders: 1

--- a/test-cases/manager/manager-regression-multiDC-gce.yaml
+++ b/test-cases/manager/manager-regression-multiDC-gce.yaml
@@ -1,6 +1,7 @@
 test_duration: 360
 
 stress_cmd: "cassandra-stress write cl=QUORUM n=4000000 -schema 'replication(strategy=NetworkTopologyStrategy,us-east1scylla_node_east=2,us-west1scylla_node_west=1)' -mode cql3 native -rate threads=200 -pop seq=400000000..600000000"
+stress_read_cmd: "cassandra-stress read cl=QUORUM n=4000000 -schema 'replication(strategy=NetworkTopologyStrategy,us-east1scylla_node_east=2,us-west1scylla_node_west=1)' -mode cql3 native -rate threads=200 -pop seq=400000000..600000000"
 
 n_db_nodes: "2 1"
 n_loaders: 1

--- a/test-cases/manager/manager-regression-multiDC-set-distro.yaml
+++ b/test-cases/manager/manager-regression-multiDC-set-distro.yaml
@@ -1,6 +1,7 @@
 test_duration: 240
 
 stress_cmd: "cassandra-stress write cl=QUORUM n=4000000 -schema 'replication(strategy=NetworkTopologyStrategy,us-eastscylla_node_east=2,us-west-2scylla_node_west=1)' -mode cql3 native -rate threads=200 -pop seq=400000000..600000000"
+stress_read_cmd: "cassandra-stress read cl=QUORUM n=4000000 -schema 'replication(strategy=NetworkTopologyStrategy,us-eastscylla_node_east=2,us-west-2scylla_node_west=1)' -mode cql3 native -rate threads=200 -pop seq=400000000..600000000"
 
 instance_type_db: 'i3.large'
 instance_type_loader: 'c5.large'


### PR DESCRIPTION
Since manager 3.1 now supports restoring backups using restore tasks,
I added a restore task for the backup that is created with test_basic_backup.

I also added a cassandra stress read thread after each of the restorations (both the
manual one and the restore task) to verify that they both of them were completed
successfully.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)

# TO BE MERGED ONLY AFTER #5779 IS MERGED