### PR TITLE
fix(stress): fix c-s timeouts

### DIFF
--- a/sdcm/stress_thread.py
+++ b/sdcm/stress_thread.py
@@ -102,6 +102,10 @@ class CassandraStressThread(DockerBasedStressThread):  # pylint: disable=too-man
     def create_stress_cmd(self, cmd_runner, keyspace_idx):
         stress_cmd = self.stress_cmd
 
+        if "no-warmup" not in stress_cmd:
+            # add no-warmup to stress_cmd if it's not there. See issue #5767
+            stress_cmd = re.sub(r'(cassandra-stress [\w]+)', r'\1 no-warmup', stress_cmd)
+
         # When using cassandra-stress with "user profile" the profile yaml should be provided
         if 'profile' in stress_cmd and not self.profile:
             # support of using -profile in sct test-case yaml, assumes they exists data_dir


### PR DESCRIPTION
Recently c-s changed behavior and for duration workflows: it added warmup iterations. For heavy load, warmup doesn't fit to 10 minutes duration margin we assumed for c-s startup and causes SCT to timeout c-s thread.

This fix removes warmup by appending ` no-warmup` to all c-s cmd's. 
refs: #5767

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
