### PR TITLE
Revert "improvement(nemesis.py): truncate nemesis using timeout"

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1845,10 +1845,8 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         # In order to workaround issue #4924 when truncate timeouts, we try to flush before truncate.
         self.target_node.run_nodetool("flush")
-        truncate_timeout = 600
         # do the actual truncation
-        self.target_node.run_cqlsh(cmd=f'TRUNCATE {ks_name}.{table} USING TIMEOUT {truncate_timeout}',
-                                   timeout=truncate_timeout)
+        self.target_node.run_cqlsh(cmd='TRUNCATE {}.{}'.format(ks_name, table), timeout=120)
 
     def _modify_table_property(self, name, val, filter_out_table_with_counter=False, keyspace_table=None):
         disruption_name = "".join([p.strip().capitalize() for p in name.split("_")])


### PR DESCRIPTION
Reverts scylladb/scylla-cluster-tests#5854

Closes: https://github.com/scylladb/scylla-cluster-tests/issues/5874