### PR TITLE
improvement(nemesis.py): adding `using <timeout>` to truncate

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -1825,7 +1825,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         # In order to workaround issue #4924 when truncate timeouts, we try to flush before truncate.
         self.target_node.run_nodetool("flush")
         # do the actual truncation
-        self.target_node.run_cqlsh(cmd='TRUNCATE {}.{}'.format(keyspace_truncate, table), timeout=120)
+        truncate_timeout = 600
+        self.target_node.run_cqlsh(cmd=f'TRUNCATE {keyspace_truncate}.{table} USING TIMEOUT {int(truncate_timeout)}s',
+                                   timeout=truncate_timeout)
 
     def disrupt_truncate_large_partition(self):
         """
@@ -1846,7 +1848,9 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         # In order to workaround issue #4924 when truncate timeouts, we try to flush before truncate.
         self.target_node.run_nodetool("flush")
         # do the actual truncation
-        self.target_node.run_cqlsh(cmd='TRUNCATE {}.{}'.format(ks_name, table), timeout=120)
+        truncate_timeout = 600
+        self.target_node.run_cqlsh(cmd=f'TRUNCATE {ks_name}.{table} USING TIMEOUT {int(truncate_timeout)}s',
+                                   timeout=truncate_timeout)
 
     def _modify_table_property(self, name, val, filter_out_table_with_counter=False, keyspace_table=None):
         disruption_name = "".join([p.strip().capitalize() for p in name.split("_")])


### PR DESCRIPTION
following work on #5854 and after it was reverted
on #5875, re-introducing this improvement to have
the `truncate` commands running with the
CQL ability to timeout it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
