### PR TITLE
fix(nemesis.py): use another log message pattern in RebuildStreamingErr

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3412,7 +3412,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         trigger = partial(
             self.target_node.run_nodetool, sub_cmd="rebuild", warning_event_on_exception=(Exception,), retry=0,
         )
-        log_follower = self.target_node.follow_system_log(patterns=["Rebuild starts"])
+        log_follower = self.target_node.follow_system_log(patterns=["rebuild from dc:"])
         timeout = 1800 if self._is_it_on_kubernetes() else 400
 
         watcher = partial(


### PR DESCRIPTION
After the rebuild operation has become a RNBO by default, the message `Rebuild starts` is not present in the node logs anymore. It causes failures of `RebuildStreamingErr` nemesis. Adjusted the nemesis to use another log message pattern - `rebuild from dc:` presents in logs in both types of rebuild (regular and repair-based) Fixes https://github.com/scylladb/scylla-cluster-tests/issues/5878

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [ ] All new and existing unit tests passed (CI)
- [ ] ~~I have updated the Readme/doc folder accordingly (if needed)~~
