### PR TITLE
fix(cluster.py): install s-b commands went broken

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -585,8 +585,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             sb_version = f'heads/{sb_version}'
         self.remoter.sudo(shell_script_cmd(f"""\
             rm -rf /usr/local/go
-            rm -f /tmp/sb_install || true
-            mkdir /tmp/sb_install
+            rm -rf /tmp/sb_install || true
+            mkdir -p /tmp/sb_install
             cd /tmp/sb_install
             curl -Lo go.tar.gz https://storage.googleapis.com/golang/go1.17.4.linux-amd64.tar.gz
             tar -C /usr/local -xvzf go.tar.gz


### PR DESCRIPTION
not sure what changed, but on job longevity-10gb-3h-gce-test we are seeing failures since last October,
related to the function `install_scylla_bench` failing because `rm -f` on a directory doesn't work, and then `mkdir` fails with file already exists, making the whole installation process to fail.
adding the `-r` flag to the `rm` command will fix it.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
