### PR TITLE
fix(output-conf): fix missing region setup

### DIFF
--- a/vars/getJobTimeouts.groovy
+++ b/vars/getJobTimeouts.groovy
@@ -7,6 +7,17 @@ List<Integer> call(Map params, String region){
     #!/bin/bash
     export SCT_CLUSTER_BACKEND="${params.backend}"
     export SCT_CONFIG_FILES=${test_config}
+    if [[ -n "${params.region ? params.region : ''}" ]] ; then
+        export SCT_REGION_NAME=${current_region}
+    fi
+
+    if [[ -n "${params.gce_datacenter ? params.gce_datacenter : ''}" ]] ; then
+        export SCT_GCE_DATACENTER=${params.gce_datacenter}
+    fi
+
+    if [[ -n "${params.azure_region_name ? params.azure_region_name : ''}" ]] ; then
+        export SCT_AZURE_REGION_NAME=${params.azure_region_name}
+    fi
     ./docker/env/hydra.sh output-conf -b "${params.backend}"
     """
     def testData = sh(script: cmd, returnStdout: true).trim()


### PR DESCRIPTION
CI runs `sct.py output-conf` without specifying region name. This leads to error that some image may not be available for default region and causing error.

Set env variable with region so `output-conf` takes region name into consideration. Also this way is more proper as it is more similar to test execution.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
