### PR TITLE
fix(parallelperfpipeline): Use update_db_packages

### DIFF
--- a/vars/perfRegressionParallelPipeline.groovy
+++ b/vars/perfRegressionParallelPipeline.groovy
@@ -33,6 +33,9 @@ def call(Map pipelineParams) {
             string(defaultValue: '', description: '', name: 'scylla_ami_id')
             string(defaultValue: '', description: '', name: 'scylla_version')
             string(defaultValue: '', description: '', name: 'scylla_repo')
+            string(defaultValue: '',
+                   description: 'cloud path for RPMs, s3:// or gs://',
+                   name: 'update_db_packages')
             string(defaultValue: "${pipelineParams.get('provision_type', 'spot')}",
                    description: 'spot_low_price|on_demand|spot_fleet|spot_low_price|spot',
                    name: 'provision_type')
@@ -219,6 +222,11 @@ def call(Map pipelineParams) {
                                                             echo "need to choose one of SCT_AMI_ID_DB_SCYLLA | SCT_SCYLLA_VERSION | SCT_SCYLLA_REPO"
                                                             exit 1
                                                         fi
+
+                                                        if [[ "${params.update_db_packages || false}" == "true" ]] ; then
+                                                            export SCT_UPDATE_DB_PACKAGES="${params.update_db_packages}"
+                                                        fi
+
 
 
                                                         export SCT_POST_BEHAVIOR_DB_NODES="${params.post_behavior_db_nodes}"


### PR DESCRIPTION
Performance tests could not be run on specific
scylla db packages(patches, dev builds, etc). Adding pipeline parameters and export SCT variable to
run perf tests on special scylla builds

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
