### PR TITLE
fix(search_best_perf): add client encryption

### DIFF
--- a/vars/perfSearchBestConfigParallelPipeline.groovy
+++ b/vars/perfSearchBestConfigParallelPipeline.groovy
@@ -83,6 +83,9 @@ def call(Map pipelineParams) {
             string(defaultValue: '', description: 'Write Cassandra Stress command to run', name: 'stress_cmd_w')
             string(defaultValue: '', description: 'Read Cassandra Stress command to run', name: 'stress_cmd_r')
             string(defaultValue: '', description: 'Mixed Cassandra Stress command to run', name: 'stress_cmd_m')
+            booleanParam(name: 'use_client_encryption',
+                         defaultValue: false,
+                         description: 'Enable client encryption')
 
             string(defaultValue: "${pipelineParams.get('k8s_scylla_operator_helm_repo', 'https://storage.googleapis.com/scylla-operator-charts/latest')}",
                    description: 'Scylla Operator helm repo',
@@ -254,6 +257,7 @@ def call(Map pipelineParams) {
                                                             export SCT_STRESS_CMD_M="${params.stress_cmd_m}"
                                                         fi
 
+                                                        export SCT_CLIENT_ENCRYPT=${params.use_client_encryption}
 
                                                         export SCT_AVAILABILITY_ZONE="${params.availability_zone}"
 


### PR DESCRIPTION
Add client encryption to search-best-performance test config file

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
