### PR TITLE
fix(manager): set monitor image in all manager tests to centos

### DIFF
--- a/test-cases/manager/manager-regression-azure.yaml
+++ b/test-cases/manager/manager-regression-azure.yaml
@@ -6,6 +6,8 @@ n_db_nodes: 3
 n_loaders: 1
 n_monitor_nodes: 1
 
+azure_image_monitor: 'OpenLogic:CentOS:7_9:latest'
+
 post_behavior_db_nodes: "destroy"
 post_behavior_loader_nodes: "destroy"
 post_behavior_monitor_nodes: "destroy"

--- a/test-cases/manager/manager-regression-ipv6.yaml
+++ b/test-cases/manager/manager-regression-ipv6.yaml
@@ -19,3 +19,6 @@ space_node_threshold: 6442
 ip_ssh_connections: 'ipv6'
 
 aws_instance_profile_name_db: 'qa-scylla-manager-backup-instance-profile'
+
+ami_monitor_user: 'centos'
+ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01

--- a/test-cases/upgrades/manager-upgrade.yaml
+++ b/test-cases/upgrades/manager-upgrade.yaml
@@ -22,3 +22,6 @@ ip_ssh_connections: 'private'
 manager_prometheus_port: 10091
 
 aws_instance_profile_name_db: 'qa-scylla-manager-backup-instance-profile'
+
+ami_monitor_user: 'centos'
+ami_id_monitor: 'ami-02eac2c0129f6376b' # Official CentOS Linux 7 x86_64 HVM EBS ENA 1901_01


### PR DESCRIPTION
In order to make all manager jobs consistent, I changed the default monitor image to be a centos image.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
