### PR TITLE
fix(longevity): keyspace for data validator

### DIFF
--- a/sdcm/utils/data_validator.py
+++ b/sdcm/utils/data_validator.py
@@ -209,6 +209,7 @@ class LongevityDataValidator:
             cs_profile = profiles[0]
             _, profile = get_profile_content(cs_profile)
             self._keyspace_name = profile['keyspace']
+            LOGGER.debug("Keyspace name: %s, profile: %s", self._keyspace_name, profile)
 
         return self._keyspace_name
 


### PR DESCRIPTION
Test https://jenkins.scylladb.com/job/scylla-master/job/raft/job/longevity-lwt-parallel-schema- changes-with-disruptive-24h-raft-test/8/ failed with error:
```
File /home/ubuntu/scylla-cluster-tests/sdcm/cluster.py, line 3380, in cql_connection return self._create_session(node=node, keyspace=keyspace, user=user, password=password, 
File /home/ubuntu/scylla-cluster-tests/sdcm/cluster.py, line 3364, in _create_session session.set_keyspace(keyspace)
File cassandra/cluster.py, line 3362, in cassandra.cluster.Session.set_keyspace 
File cassandra/metadata.py, line 1599, in cassandra.metadata.protect_name 
File cassandra/metadata.py, line 1626, in cassandra.metadata.maybe_escape_name 
File cassandra/metadata.py, line 1622, in cassandra.metadata.is_valid_name 
TypeError: expected string or bytes-like object
```

Add keyspace validation before create a session and add debug print to find the problem.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
