### PR TITLE
fix(getJobTimeouts.groovy): convert region params to json before export

### DIFF
--- a/vars/getJobTimeouts.groovy
+++ b/vars/getJobTimeouts.groovy
@@ -8,15 +8,15 @@ List<Integer> call(Map params, String region){
     export SCT_CLUSTER_BACKEND="${params.backend}"
     export SCT_CONFIG_FILES=${test_config}
     if [[ -n "${params.region ? params.region : ''}" ]] ; then
-        export SCT_REGION_NAME=${params.region}
+        export SCT_REGION_NAME=${groovy.json.JsonOutput.toJson(params.region)}
     fi
 
     if [[ -n "${params.gce_datacenter ? params.gce_datacenter : ''}" ]] ; then
-        export SCT_GCE_DATACENTER=${params.gce_datacenter}
+        export SCT_GCE_DATACENTER=${groovy.json.JsonOutput.toJson(params.gce_datacenter)}
     fi
 
     if [[ -n "${params.azure_region_name ? params.azure_region_name : ''}" ]] ; then
-        export SCT_AZURE_REGION_NAME=${params.azure_region_name}
+        export SCT_AZURE_REGION_NAME=${groovy.json.JsonOutput.toJson(params.azure_region_name)}
     fi
     ./docker/env/hydra.sh output-conf -b "${params.backend}"
     """


### PR DESCRIPTION
Since in multi dc scenarios the region params (region, gce_datacenter or azure_region_name) value can be a list and not a string, it needs to be converted to json before being exported into an environment variable

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
