### PR TITLE
improvement(logcollector): Implement log rotation

### DIFF
--- a/sdcm/log_archive.sh
+++ b/sdcm/log_archive.sh
@@ -1,0 +1,14 @@
+# $1 - file to archive
+# $2 - size splitter in Bytes
+# $3 - archive name
+wc -lc $1 | awk '{print $1,$2}' |  while read lines filesize
+do
+  parts=$(( ( filesize + $2 - 1 ) / $2 ))
+  lines_part=$(( ( lines + parts - 1 ) / parts ))
+  echo "file will be split into $parts parts, per $lines_part lines"
+  for (( i=1; i<=lines; i+=lines_part))
+  do
+    start_time=$(sed -n "${i}p" $1 | awk '{print $2,$3}' | sed -e 's/t://g;s/ /__/g;s/-/_/g;s/:/_/g;s/,/_/g;')
+    tail -n "+$i" "$1" | head -n "$lines_part"  | gzip > "${start_time}.$3.gz"
+  done
+done

--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -106,7 +106,8 @@ from sdcm.logcollector import (
     KubernetesLogCollector,
     LoaderLogCollector,
     MonitorLogCollector,
-    SCTLogCollector,
+    BaseSCTLogCollector,
+    PythonSCTLogCollector,
     ScyllaLogCollector,
     SirenManagerLogCollector,
 )
@@ -2866,9 +2867,11 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
 
     @silence()
     def collect_sct_logs(self):
-        s3_link = SCTLogCollector(
-            [], self.test_config.test_id(), os.path.join(self.logdir, "collected_logs"), params=self.params
-        ).collect_logs(self.logdir)
+        s3_link = []
+        for log_collector in [BaseSCTLogCollector, PythonSCTLogCollector]:
+            s3_link.extend(log_collector(
+                [], self.test_config.test_id(), os.path.join(self.logdir, "collected_logs"), params=self.params
+            ).collect_logs(self.logdir))
         if s3_link:
             self.log.info(s3_link)
             self.argus_collect_logs({"sct_job_log": s3_link})


### PR DESCRIPTION
Split big SCT files logs(more than 3GB) into multiple s3 objects

task: https://github.com/scylladb/qa-tasks/issues/928

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
