### PR TITLE
fix(cluster.py): publish ScyllaYamlUpdateEvent

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -1550,7 +1550,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             diff = old_scylla_yaml.diff(new_scylla_yaml)
             if not diff:
                 ScyllaYamlUpdateEvent(node_name=self.name,
-                                      message=f"ScyllaYaml has not been changed on node: {self.name}")
+                                      message=f"ScyllaYaml has not been changed on node: {self.name}").publish()
                 return
             scylla_yaml.clear()
             scylla_yaml.update(
@@ -1562,7 +1562,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
                 )
             )
             ScyllaYamlUpdateEvent(node_name=self.name, message=f"ScyllaYaml has been changed on node: {self.name}. "
-                                                               f"Diff: {diff}")
+                                                               f"Diff: {diff}").publish()
 
     def remote_manager_yaml(self):
         return self._remote_yaml(path=SCYLLA_MANAGER_YAML_PATH)


### PR DESCRIPTION
Found internal SCT warnings that such events not published. This was from the introduction of them in https://github.com/scylladb/scylla-cluster-tests/pull/5670

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
