### PR TITLE
fix(Jenkinsfile): create diffrent directory for each provision test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -205,18 +205,18 @@ pipeline {
                         if (pullRequestContainsLabels("test-provision,test-provision-${backend}")) {
                             sctParallelTests["provision test on ${backend}"] = {
                                 def curr_params = createRunConfiguration(backend)
+                                def working_dir = "${backend}/scylla-cluster-tests"
                                 def builder = getJenkinsLabels(curr_params.backend, curr_params.region, curr_params.gce_datacenter, curr_params.azure_region_name)
                                 withEnv(["SCT_TEST_ID=${UUID.randomUUID().toString()}",]) {
                                     script {
                                         def result = null
-
-                                        dir('scylla-cluster-tests') {
+                                        dir(working_dir) {
                                             checkout scm
                                         }
                                         if (sct_runner_backends.contains(backend)){
                                             try {
                                                 wrap([$class: 'BuildUser']) {
-                                                    dir('scylla-cluster-tests') {
+                                                    dir(working_dir) {
                                                         echo "calling createSctRunner"
                                                         createSctRunner(curr_params, 90 , builder.region)
                                                     }
@@ -230,7 +230,7 @@ pipeline {
                                         try {
                                             wrap([$class: 'BuildUser']) {
                                                 env.BUILD_USER_ID=env.CHANGE_AUTHOR
-                                                dir('scylla-cluster-tests') {
+                                                dir(working_dir) {
                                                     runSctTest(curr_params, builder.region, curr_params.get('functional_tests', false))
                                                     result = 'SUCCESS'
                                                     pullRequestSetResult('success', "jenkins/provision_${backend}", 'All test cases are passed')
@@ -243,7 +243,7 @@ pipeline {
                                         }
                                         try {
                                             wrap([$class: 'BuildUser']) {
-                                                dir('scylla-cluster-tests') {
+                                                dir(working_dir) {
                                                     runCollectLogs(curr_params, builder.region)
                                                 }
                                             }
@@ -252,7 +252,7 @@ pipeline {
                                         }
                                         try {
                                             wrap([$class: 'BuildUser']) {
-                                                dir('scylla-cluster-tests') {
+                                                dir(working_dir) {
                                                     runCleanupResource(curr_params, builder.region)
                                                 }
                                             }
@@ -262,7 +262,7 @@ pipeline {
                                         if (!(backend in ['k8s-local-kind-aws', 'k8s-eks'])) {
                                             try {
                                                 wrap([$class: 'BuildUser']) {
-                                                    dir('scylla-cluster-tests') {
+                                                    dir(working_dir) {
                                                         runRestoreMonitoringStack()
                                                     }
                                                 }


### PR DESCRIPTION
Since we are now runnig on sct-runner, and we are running in provision
tests in paralell on the same worker, we need to make sure we run each
parallel on it's own direcotry.

since we could fail on locking when checking out code, or by mistake using
the wrong sct-runner, since it's base on a file with the ip in the working
directory.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
