### PR TITLE
feature(adaptive-timeouts): calculate timeouts based on node load

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -72,6 +72,7 @@ from sdcm import wait, mgmt
 from sdcm.sct_config import SCTConfiguration
 from sdcm.sct_events.continuous_event import ContinuousEventsRegistry
 from sdcm.utils import properties
+from sdcm.utils.adaptive_timeouts import Operations, adaptive_timeout
 from sdcm.utils.benchmarks import ScyllaClusterBenchmarkManager
 from sdcm.utils.common import (
     S3Storage,
@@ -105,7 +106,7 @@ from sdcm.utils.version_utils import (
 from sdcm.sct_events import Severity
 from sdcm.sct_events.base import LogEvent
 from sdcm.sct_events.health import ClusterHealthValidatorEvent
-from sdcm.sct_events.system import TestFrameworkEvent, INSTANCE_STATUS_EVENTS_PATTERNS, InfoEvent, SoftTimeoutEvent
+from sdcm.sct_events.system import TestFrameworkEvent, INSTANCE_STATUS_EVENTS_PATTERNS, InfoEvent
 from sdcm.sct_events.grafana import set_grafana_url
 from sdcm.sct_events.database import SYSTEM_ERROR_EVENTS_PATTERNS, ScyllaHelpErrorEvent, ScyllaYamlUpdateEvent
 from sdcm.sct_events.nodetool import NodetoolEvent
@@ -4544,8 +4545,8 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         self.terminate_node(node)  # pylint: disable=no-member
         self.test_config.tester_obj().monitors.reconfigure_scylla_monitoring()
 
-    def decommission(self, node: BaseNode, timeout: int | float = None, soft_timeout: int | float = None):
-        with SoftTimeoutEvent(soft_timeout=soft_timeout, operation="decommission"):
+    def decommission(self, node: BaseNode, timeout: int | float = None):
+        with adaptive_timeout(operation=Operations.DECOMMISSION, node=node):
             node.run_nodetool("decommission", timeout=timeout)
         self.verify_decommission(node)
 

--- a/sdcm/sct_events/system.py
+++ b/sdcm/sct_events/system.py
@@ -14,7 +14,6 @@
 import re
 import sys
 import time
-import datetime
 from typing import Any, Optional, Sequence, Type, List, Tuple
 from traceback import format_stack
 
@@ -99,47 +98,10 @@ class TestFrameworkEvent(InformationalEvent):  # pylint: disable=too-many-instan
 
 
 class SoftTimeoutEvent(TestFrameworkEvent):
-    """
-    To be used as a context manager to raise an error event if `operation` took more the `soft_timeout`
 
-    Example:
-        >>> with SoftTimeoutEvent(soft_timeout=0.1, operation="long-one") as event:
-        ...    time.sleep(1) # do that long operation that takes more then `soft_timeout`
-
-        would raise event like, with a traceback where it happened:
-
-        SoftTimeoutEvent Severity.ERROR) period_type=one-time event_id=2cf14ba9-b2a0-402d-bc4f-ac102e9e51ff,
-        source=SoftTimeout message=operation 'long-one' took 0:00:01.000, soft_timeout=0:00:00.100
-        Traceback (most recent call last):
-        ...
-          File "/home/fruch/projects/scylla-cluster-tests/unit_tests/test_events.py", line 462, in test_soft_timeout
-            with SoftTimeoutEvent(soft_timeout=0.1, operation="long-one") as event:
-
-    """
-
-    def __init__(self, operation: str, soft_timeout: int | float):
-        super().__init__(source='SoftTimeout')
-        self.operation = operation
-        self.soft_timeout = soft_timeout
-        self.start_time = None
-
-    def __enter__(self):
-        if self.soft_timeout:
-            self.start_time = time.time()
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        if self.start_time and self.soft_timeout:
-            duration = (time.time() - self.start_time)
-            if self.soft_timeout < duration:
-                self.trace = "".join(format_stack(sys._getframe().f_back))
-                self.message = (f"operation '{self.operation}' took "
-                                f"{str(datetime.timedelta(seconds=duration))[:-3]}, "
-                                f"soft_timeout={str(datetime.timedelta(seconds=self.soft_timeout))[:-3]}")
-                self.severity = Severity.ERROR
-                self.publish_or_dump()
-        else:
-            self.dont_publish()
+    def __init__(self, operation: str, duration: int | float, soft_timeout: int | float):
+        message = f"operation '{operation}' took {duration}s and soft-timeout was set to {soft_timeout}s"
+        super().__init__(source='SoftTimeout', severity=Severity.ERROR, trace=sys._getframe().f_back, message=message)
 
 
 class ElasticsearchEvent(InformationalEvent):

--- a/sdcm/utils/adaptive_timeouts/__init__.py
+++ b/sdcm/utils/adaptive_timeouts/__init__.py
@@ -1,0 +1,84 @@
+import logging
+import time
+from contextlib import contextmanager
+from enum import Enum
+from typing import Any
+
+from sdcm.sct_events.system import SoftTimeoutEvent
+from sdcm.utils.adaptive_timeouts.load_info_store import NodeLoadInfoService, AdaptiveTimeoutStore, ESAdaptiveTimeoutStore, \
+    NodeLoadInfoServices
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _get_decommission_timeout(node_info_service: NodeLoadInfoService) -> tuple[int, dict[str, Any]]:
+    """Calculate timeout for decommission operation based on node load info. Still experimental, used to gather historical data."""
+    try:
+        # rough estimation from previous runs almost 9h for 1TB
+        timeout = int(node_info_service.node_data_size_mb * 0.03)
+        timeout = max(timeout, 7200)  # 2 hours minimum
+        return timeout, node_info_service.as_dict()
+    except Exception as exc:  # pylint: disable=broad-except
+        LOGGER.warning("Failed to calculate decommission timeout: \n%s \nDefaulting to 6 hours", exc)
+        return 6*60*60, {}
+
+
+def _get_soft_timeout(node_info_service: NodeLoadInfoService, timeout: int | float = None) -> tuple[int | float, dict[str, Any]]:
+    # no timeout calculation - just return the timeout passed as argument along with node load info
+    try:
+        return timeout, node_info_service.as_dict()
+    except Exception as exc:  # pylint: disable=broad-except
+        LOGGER.warning("Failed to get node info for timeout: \n%s", exc)
+        return timeout, {}
+
+
+class Operations(Enum):
+    """Available operations for adaptive timeouts. Each operation maps to a function to calculate timeout based on node load info.
+
+    maps to (function, (required arguments))"""
+    DECOMMISSION = ("decommission", _get_decommission_timeout, ())
+    NEW_NODE = ("new_node", _get_soft_timeout, ("timeout",))
+    CREATE_INDEX = ("create_index", _get_soft_timeout, ("timeout",))
+    MAJOR_COMPACT = ("major_compact", _get_soft_timeout, ("timeout",))
+    REPAIR = ("repair", _get_soft_timeout, ("timeout",))
+    REBUILD = ("rebuild", _get_soft_timeout, ("timeout",))
+    CLEANUP = ("cleanup", _get_soft_timeout, ("timeout",))
+    REMOVE_NODE = ("remove_node", _get_soft_timeout, ("timeout",))
+    SCRUB = ("scrub", _get_soft_timeout, ("timeout",))
+    SOFT_TIMEOUT = ("soft_timeout", _get_soft_timeout, ("timeout",))
+    FLUSH = ("flush", _get_soft_timeout, ("timeout",))
+
+
+@contextmanager
+def adaptive_timeout(operation: Operations, node: "BaseNode", stats_storage: AdaptiveTimeoutStore = ESAdaptiveTimeoutStore(), **kwargs):
+    """
+    Calculate timeout in seconds for given operation based on node load info and return its value.
+    Upon exit, verify if timeout occurred and publish SoftTimeoutEvent if happened.
+    Also store node load info and timeout value in AdaptiveTimeoutStore (ES by default) for future reference.
+    Use Operation.SOFT_TIMEOUT to set timeout explicitly without calculations.
+    """
+    args = {}
+    for arg in operation.value[2]:
+        assert arg in kwargs, f"Argument '{arg}' is required for operation {operation.name}"
+        args[arg] = kwargs[arg]
+    timeout, load_metrics = operation.value[1](node_info_service=NodeLoadInfoServices().get(node), **args)
+    start_time = time.time()
+    timeout_occurred = False
+    try:
+        yield timeout
+    except Exception as exc:  # pylint: disable=broad-except
+        exc_name = exc.__class__.__name__
+        if "timeout" in exc_name.lower() or "timed out" in str(exc):
+            timeout_occurred = True
+        raise
+    finally:
+        duration = time.time() - start_time
+        if duration > timeout:
+            timeout_occurred = True
+            SoftTimeoutEvent(operation=operation.name, soft_timeout=timeout, duration=duration).publish_or_dump()
+        try:
+            if load_metrics:
+                stats_storage.store(metrics=load_metrics, operation=operation.name, duration=duration,
+                                    timeout=timeout, timeout_occurred=timeout_occurred)
+        except Exception as exc:  # pylint: disable=broad-except
+            LOGGER.warning("Failed to store adaptive timeout stats: \n%s", exc)

--- a/sdcm/utils/adaptive_timeouts/load_info_store.py
+++ b/sdcm/utils/adaptive_timeouts/load_info_store.py
@@ -1,0 +1,236 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2023 ScyllaDB
+import logging
+import uuid
+from functools import cache, cached_property
+import re
+from typing import Any
+
+import yaml
+from cachetools import cached, TTLCache
+
+from sdcm.es import ES
+from sdcm.remote import RemoteCmdRunner
+from sdcm.test_config import TestConfig
+from sdcm.utils.decorators import retrying
+from sdcm.utils.metaclasses import Singleton
+
+LOGGER = logging.getLogger(__name__)
+
+
+def convert_to_mb(value) -> float:
+    pattern = re.compile(r'^(\d+(\.\d+)?) *([KMGT]?B)$')
+    match = pattern.match(value)
+    if match:
+        number = float(match.group(1))
+        suffix = match.group(3)
+        match suffix:
+            case 'KB':
+                number /= 1024
+            case 'GB':
+                number *= 1024
+            case 'TB':
+                number *= 1024 * 1024
+            case 'PB':
+                number *= 1024 * 1024 * 1024
+        return number
+    raise ValueError(f"Couldn't parse value {value} to MB")
+
+
+class NodeLoadInfoService:
+    """
+    Service to get information about node load through running commands on node like getting metrics from localhost:9180/9100,
+    nodetool status, uptime (load), vmstat (disk utilization). Command responses are cached for some time to avoid too much requests.
+    """
+
+    def __init__(self, remoter: RemoteCmdRunner, name: str, scylla_version: str):
+        self.remoter = remoter
+        self._name = name
+        self._scylla_version = scylla_version
+        self._io_properties = yaml.safe_load(self._get_io_properites_yaml())
+
+    @cache
+    def _get_io_properites_yaml(self):
+        return self.remoter.run('cat /etc/scylla.d/io_properties.yaml', retry=3).stdout
+
+    @cached(cache=TTLCache(maxsize=1024, ttl=300))
+    def _cf_stats(self, keyspace):
+        pass
+
+    @cached(cache=TTLCache(maxsize=1024, ttl=300))
+    def _get_nodetool_info(self):
+        return self.remoter.run('nodetool info', retry=3).stdout
+
+    @cached(cache=TTLCache(maxsize=1024, ttl=60))
+    def _get_node_load(self) -> tuple[float, float, float]:
+        try:
+            metrics = self._get_node_exporter_metrics()
+            load_1 = float(metrics['node_load1'])
+            load_5 = float(metrics['node_load5'])
+            load_15 = float(metrics['node_load15'])
+            return load_1, load_5, load_15
+        except Exception as exc:  # pylint: disable=broad-except
+            LOGGER.debug("Couldn't get node load from prometheus metrics. Error: %s", exc)
+            # fallback to uptime
+            load_1, load_5, load_15 = self.remoter.run('uptime', retry=3).stdout.split("load average: ")[1].split(",")
+            return float(load_1), float(load_5), float(load_15)
+
+    @retrying(n=5, sleep_time=1, allowed_exceptions=(ValueError,))
+    def _get_metrics(self, port):
+        metrics = self.remoter.run(f'curl -s localhost:{port}/metrics', verbose=False).stdout
+        metrics_dict = {}
+        for line in metrics.splitlines():
+            if line and not line.startswith('#'):
+                try:
+                    key, value = line.rsplit(' ', 1)
+                    metrics_dict[key] = value
+                except ValueError:
+                    LOGGER.debug("Couldn't parse line: %s", line)
+        return metrics_dict
+
+    @cached(cache=TTLCache(maxsize=1024, ttl=60))
+    def _get_scylla_metrics(self):
+        return self._get_metrics(port=9180)
+
+    @cached(cache=TTLCache(maxsize=1024, ttl=60))
+    def _get_node_exporter_metrics(self):
+        return self._get_metrics(port=9100)
+
+    @property
+    def node_data_size_mb(self) -> int:
+        for line in self._get_nodetool_info().splitlines():
+            if line.startswith('Load'):
+                return convert_to_mb(line.split(':')[1].strip())
+        raise ValueError("Couldn't find Load in nodetool info response")
+
+    @property
+    def cpu_load_5(self) -> float:
+        return self._get_node_load()[1]
+
+    @cached_property
+    def shards_count(self) -> int:
+        return len([key for key in self._get_scylla_metrics() if key.startswith('scylla_lsa_free_space')])
+
+    @cached_property
+    def read_bandwidth_mb(self) -> float:
+        """based on io_properties.yaml in MB/s """
+        return self._io_properties["disks"][0]["read_bandwidth"] / 1024 / 1024
+
+    @cached_property
+    def write_bandwidth_mb(self) -> float:
+        """based on io_properties.yaml in MB/s"""
+        return self._io_properties["disks"][0]["write_bandwidth"] / 1024 / 1024
+
+    @cached_property
+    def read_iops(self) -> float:
+        return self._io_properties["disks"][0]["read_iops"]
+
+    @cached_property
+    def write_iops(self) -> float:
+        return self._io_properties["disks"][0]["write_iops"]
+
+    def as_dict(self):
+        return {
+            "node_name": self._name,
+            "cpu_load_5": self.cpu_load_5,
+            "shards_count": self.shards_count,
+            "read_bandwidth_mb": self.read_bandwidth_mb,
+            "write_bandwidth_mb": self.write_bandwidth_mb,
+            "read_iops": self.read_iops,
+            "write_iops": self.write_iops,
+            "node_data_size_mb": self.node_data_size_mb,
+            "scylla_version": self._scylla_version,
+        }
+
+
+class AdaptiveTimeoutStore(metaclass=Singleton):
+    """Class for storing metrics and other info related to adaptive timeouts.
+
+    Used for future reference/node operations time tracking and calculations optimization."""
+
+    # pylint: disable=too-many-arguments
+    def store(self, metrics: dict[str, Any], operation: str, duration: int | float, timeout: int,
+              timeout_occurred: bool) -> None:
+        pass
+
+    def get(self, operation: str | None, timeout_occurred: bool = False):
+        pass
+
+
+class ESAdaptiveTimeoutStore(AdaptiveTimeoutStore):
+    """AdaptiveTimeoutStore implementation backed by Elasticsearch."""
+
+    def __init__(self):
+        try:
+            self._es = ES()
+            self._test_id = TestConfig.test_id()
+            self._index = "sct-adaptive-timeouts"
+        except Exception as exc:  # pylint: disable=broad-except
+            LOGGER.warning("Couldn't initialize ESAdaptiveTimeoutStore: %s", exc)
+            self._es = None
+
+    # pylint: disable=too-many-arguments
+    def store(self, metrics: dict[str, Any], operation: str, duration: float, timeout: float,
+              timeout_occurred: bool):
+        body = metrics
+        body["test_id"] = self._test_id
+        body["operation"] = operation
+        body["duration"] = duration
+        body["timeout"] = timeout
+        body["timeout_occurred"] = timeout_occurred
+        load_id = str(uuid.uuid4())
+        LOGGER.debug("Storing adaptive timeout info: %s=%s", load_id, body)
+        if not self._es:
+            LOGGER.debug("ESAdaptiveTimeoutStore is not initialized, skipping store")
+            return
+        # pylint: disable=unexpected-keyword-arg,no-value-for-parameter
+        self._es.create(index=self._index, id=load_id, document=body)
+
+    def get(self, operation: str | None, timeout_occurred: bool | None = None):
+        """Get adaptive timeout info from ES.
+
+        Example usage:
+            >>> from sdcm.utils.adaptive_timeouts.load_info_store import ESAdaptiveTimeoutStore
+            >>> from sdcm.utils.adaptive_timeouts import Operations
+            >>> ESAdaptiveTimeoutStore().get(operation=Operations.DECOMMISSION.name)
+        """
+        if not self._es:
+            return []
+        filters = []
+        if operation is not None:
+            filters.append({"match": {"operation": operation}})
+        if timeout_occurred is not None:
+            filters.append({"match": {"timeout_occurred": timeout_occurred}})
+        query = {
+            "query": {
+                "bool": {
+                    "must": filters
+                }
+            }
+        }
+        res = self._es.search(index=self._index, body=query)
+        return [hit["_source"] for hit in res["hits"]["hits"]]
+
+
+class NodeLoadInfoServices(metaclass=Singleton):  # pylint: disable=too-few-public-methods
+    """Cache for NodeLoadInfoService instances."""
+
+    def __init__(self):
+        self._services: dict[str, NodeLoadInfoService] = {}
+
+    def get(self, node: "BaseNode") -> NodeLoadInfoService:
+        if node not in self._services:
+            self._services[node.name] = NodeLoadInfoService(node.remoter, node.name, node.scylla_version_detailed)
+        if self._services[node.name].remoter != node.remoter:
+            self._services[node.name] = NodeLoadInfoService(node.remoter, node.name, node.scylla_version_detailed)
+        return self._services[node.name]

--- a/unit_tests/test_adaptive_timeouts.py
+++ b/unit_tests/test_adaptive_timeouts.py
@@ -1,0 +1,152 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2023 ScyllaDB
+# pylint: disable-all
+import logging
+import time
+import uuid
+from typing import Any
+from unittest import mock
+
+import pytest
+from invoke import Result
+
+from sdcm.remote import RemoteCmdRunnerBase
+from sdcm.utils.adaptive_timeouts.load_info_store import AdaptiveTimeoutStore
+from sdcm.utils.adaptive_timeouts import Operations, adaptive_timeout
+from unit_tests.lib.fake_remoter import FakeRemoter
+
+LOGGER = logging.getLogger(__name__)
+
+
+class FakeNode():
+
+    def __init__(self, name: str, remoter):
+        self.name = name
+        self.remoter = remoter
+        self.scylla_version_detailed = "2042.1.12-0.20220620.e23889f17"
+
+
+class MemoryAdaptiveTimeoutStore(AdaptiveTimeoutStore):
+
+    def __init__(self):
+        self._data = {}
+
+    def store(self, metrics: dict[str, Any], operation: str, duration: int, timeout: int,
+              timeout_occurred: bool) -> None:
+        metrics.update({
+            "operation": operation,
+            "duration": duration,
+            "timeout": timeout,
+            "timeout_occurred": timeout_occurred
+        })
+        key = str(uuid.uuid4())
+        self._data[key] = metrics
+
+    def get(self, operation: str | None, timeout_occurred: bool = False):
+        matching_items = []
+        for item in self._data.values():
+            if (operation is None or item["operation"] == operation) and item["timeout_occurred"] == timeout_occurred:
+                matching_items.append(item)
+        return matching_items
+
+    def clear(self):
+        self._data = {}
+
+
+@pytest.fixture
+def adaptive_timeout_remoter(fake_remoter):
+    io_properties = """
+       disks:
+         - mountpoint: /var/lib/scylla
+           read_iops: 540317
+           read_bandwidth: 1914761472
+           write_iops: 300319
+           write_bandwidth: 116202240
+    """
+    scylla_metrics = """
+scylla_lsa_free_space{shard="0"} 3749052416.000000
+scylla_lsa_free_space{shard="1"} 3750100992.000000
+scylla_lsa_free_space{shard="2"} 3750887424.000000
+    """
+    nodetool_info = """
+Using /etc/scylla/scylla.yaml as the config file
+ID                     : aa7409d6-4129-4e6a-96f8-e571abdabe7c
+Gossip active          : true
+Thrift active          : true
+Native Transport active: true
+Load                   : 100.00 GB
+Generation No          : 1678343052
+Uptime (seconds)       : 35061
+Heap Memory (MB)       : 40.31 / 247.50
+Off Heap Memory (MB)   : 4.76
+Data Center            : datacenter1
+Rack                   : rack1
+Exceptions             : 0
+Key Cache              : entries 0, size 0 bytes, capacity 0 bytes, 0 hits, 0 requests, 0.000 recent hit rate, 0 save period in seconds
+Row Cache              : entries 72, size 72 bytes, capacity 477.08 KiB, 4402 hits, 5043 requests, 0.873 recent hit rate, 0 save period in seconds
+Counter Cache          : entries 0, size 0 bytes, capacity 0 bytes, 0 hits, 0 requests, 0.000 recent hit rate, 0 save period in seconds
+Percent Repaired       : 0.0%
+Token                  : (invoke with -T/--tokens to see all 256 tokens)
+"""
+    fake_remoter.result_map = {
+        r"cat /etc/scylla.d/io_properties.yaml": Result(stdout=io_properties, stderr="", exited=0),
+        r"curl -s localhost:9180/metrics": Result(stdout=scylla_metrics, exited=0),
+        r"nodetool info": Result(stdout=nodetool_info, exited=0),
+        r"uptime": Result(stdout=" 10:00:00 up 1 day,  1:00,  1 user,  load average: 1.20, 2.30, 1.60", exited=0),
+    }
+    return RemoteCmdRunnerBase.create_remoter("test-node-host")
+
+
+@pytest.fixture
+def fake_node(adaptive_timeout_remoter):
+    return FakeNode("test-node", adaptive_timeout_remoter)
+
+
+@pytest.fixture
+def adaptive_timeout_store():
+    store = MemoryAdaptiveTimeoutStore()
+    store.clear()
+    return store
+
+
+@mock.patch('sdcm.sct_events.base.SctEvent.publish_or_dump')
+def test_soft_timeout_is_raised_when_timeout_reached(publish_or_dump, fake_node, adaptive_timeout_store):
+    with adaptive_timeout(operation=Operations.SOFT_TIMEOUT, node=fake_node, timeout=0.1, stats_storage=adaptive_timeout_store) as timeout:
+        assert timeout == 0.1
+        time.sleep(0.2)
+    publish_or_dump.assert_called_once()
+    metrics = MemoryAdaptiveTimeoutStore().get(operation=Operations.SOFT_TIMEOUT.name, timeout_occurred=True)
+    assert metrics[0]["duration"] > 0.2
+    assert metrics[0]["timeout"] == 0.1
+    assert metrics[0]["timeout_occurred"] is True
+    assert metrics[0]["operation"] == "SOFT_TIMEOUT"
+    assert metrics[0]["node_name"] == "test-node"
+    assert metrics[0]["shards_count"] == 3
+
+
+@mock.patch('sdcm.sct_events.base.SctEvent.publish_or_dump')
+def test_soft_timeout_is_not_raised_when_timeout_not_reached(publish_or_dump, fake_node, adaptive_timeout_store):
+    with adaptive_timeout(operation=Operations.SOFT_TIMEOUT, node=fake_node, timeout=1, stats_storage=adaptive_timeout_store) as timeout:
+        assert timeout == 1
+        time.sleep(0.2)
+    publish_or_dump.assert_not_called()
+    # still we store the metrics even when there's no timeout
+    assert MemoryAdaptiveTimeoutStore().get(operation="SOFT_TIMEOUT", timeout_occurred=False)
+
+
+@mock.patch('sdcm.sct_events.base.SctEvent.publish_or_dump')
+def test_decommission_timeout_is_calculated_and_stored(publish_or_dump, fake_node, adaptive_timeout_store):
+    with adaptive_timeout(operation=Operations.DECOMMISSION, node=fake_node, stats_storage=adaptive_timeout_store) as timeout:
+        assert timeout == 7200  # based on data size
+    publish_or_dump.assert_not_called()
+    assert MemoryAdaptiveTimeoutStore().get(operation=Operations.DECOMMISSION.name, timeout_occurred=False)

--- a/unit_tests/test_events.py
+++ b/unit_tests/test_events.py
@@ -458,27 +458,10 @@ class SctEventsTests(BaseEventsTest):  # pylint: disable=too-many-public-methods
         self.assertFalse(publish.called, "Publish function was called unexpectedly")
 
     @staticmethod
-    @mock.patch('sdcm.sct_events.base.SctEvent.publish')
-    def test_soft_timeout(publish):
-        with SoftTimeoutEvent(soft_timeout=0.1, operation="long-one") as event:
-            time.sleep(1)
+    def test_soft_timeout():
+        event = SoftTimeoutEvent(soft_timeout=0.1, operation="long-one", duration=0.2)
+        event.publish_or_dump()
+        event_data = str(event)
 
-        assert publish.called
         assert event.trace
-
-        event_data = str(event)
-        assert "operation 'long-one' took" in event_data
-        assert "soft_timeout=0:00:00.100" in event_data
-
-    @staticmethod
-    @mock.patch('sdcm.sct_events.base.SctEvent.publish')
-    def test_soft_timeout_no_timeout(publish):
-        with SoftTimeoutEvent(soft_timeout=None, operation="long-one") as event:
-            time.sleep(1)
-
-        assert not publish.called
-        assert not event.trace
-
-        event_data = str(event)
-        assert "operation 'long-one' took" not in event_data
-        assert "soft_timeout=0:00:00.100" not in event_data
+        assert "operation 'long-one' took 0.2s and soft-timeout was set to 0.1s" in event_data


### PR DESCRIPTION
During testing scenarios with different machine types and load it's
impossible to have one timeout value that fits all. Various operations
take more time when node performance is lower or data load is higher.

Implement `adaptive_timeout` context manager that will calculate right
timeout value for given operation based on node load (performance, data
size, and other factors). It is not raising any exceptions, just returns
timeout value that may be used within context. When context takes longer
duration than it, publish `SoftTimeoutEvent` with `Error` severity.

Because calculating timeout is not straightforward, collect various
'load metrics' to Elasticearch db for future reference and testing.

`SoftTimeoutEvent` has been refactored - dropped the context-manager
related code as it is no longer needed.

Supported `adaptive_timout` operations:
- `DECOMMISSION` - timeout for nodetool decommision operation.
Currently simple implementation, used for publishing `SoftTimeoutEvent`
- `SOFT_TIMEOUT` - passing timeout provided in args.

Other operations (like REPAIR, REBUILD, FLUSH etc. are created
only for collecting timeout data in ES for future reference when
designing timeout calcluators).

refs: https://github.com/scylladb/qa-tasks/issues/958

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
