### PR TITLE
fix(sdcm.tester): Fix incorrect keyword parameter passed to argus

### DIFF
--- a/sdcm/tester.py
+++ b/sdcm/tester.py
@@ -404,7 +404,7 @@ class ClusterTester(db_stats.TestStatsMixin, unittest.TestCase):  # pylint: disa
         thread_stop_signal = threading.Event()
         thread = threading.Thread(name="argus-heartbeat",
                                   target=send_argus_heartbeat,
-                                  kwargs={"connection": self.test_config.argus_client(), "stop_signal": thread_stop_signal})
+                                  kwargs={"client": self.test_config.argus_client(), "stop_signal": thread_stop_signal})
         thread.daemon = True
         thread.start()
 


### PR DESCRIPTION
#### PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
