### PR TITLE
fix(host_id): get host id from `nodetool info`

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -368,11 +368,7 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
 
     @property
     def host_id(self):
-        full_nodetool_status = self.parent_cluster.get_nodetool_status(verification_node=self)
-        for data_center in full_nodetool_status:
-            if self.ip_address in full_nodetool_status[data_center]:
-                return full_nodetool_status[data_center][self.ip_address]['host_id']
-        raise AssertionError(f"Could not find the requested node {self.ip_address} in nodetool status")
+        return self.parent_cluster.get_nodetool_info(self, publish_event=False).get('ID')
 
     @property
     def db_node_instance_type(self) -> Optional[str]:
@@ -4046,7 +4042,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
         return status
 
     @staticmethod
-    def get_nodetool_info(node):
+    def get_nodetool_info(node, **kwargs):
         """
             Runs nodetool info and generates status structure.
             Info format:
@@ -4054,7 +4050,7 @@ class BaseScyllaCluster:  # pylint: disable=too-many-public-methods, too-many-in
             :param node: node to run the nodetool on
             :return: dict
         """
-        res = node.run_nodetool('info')
+        res = node.run_nodetool('info', **kwargs)
         # Removing unnecessary lines from the output
         proper_yaml_output = "\n".join([line for line in res.stdout.splitlines() if ":" in line])
         info_res = yaml.safe_load(proper_yaml_output)


### PR DESCRIPTION
get host id from `nodetool info` and not from our `nodetool status` implemetiontion which is much more complex since it's mapping the node based on IP, and we don't need that for getting the host_id

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
