### PR TITLE
fix(argus.py): Handle cases where we can't use argus

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -35,6 +35,7 @@ import pytest
 import click
 import yaml
 from prettytable import PrettyTable
+from argus.client.sct.types import LogLink
 
 import sct_ssh
 from sdcm.localhost import LocalHost
@@ -1165,7 +1166,6 @@ def collect_logs(test_id=None, logdir=None, backend=None, config_file=None):
 def store_logs_in_argus(test_id: UUID, logs: dict[str, list[list[str] | str]]):
     # pylint: disable=import-outside-toplevel
     try:
-        from argus.client.sct.types import LogLink
         argus_client = get_argus_client(run_id=test_id)
         log_links = []
         for _, s3_links in logs.items():

--- a/sdcm/test_config.py
+++ b/sdcm/test_config.py
@@ -14,7 +14,7 @@ from sdcm.keystore import KeyStore
 from sdcm.provision.common.configuration_script import ConfigurationScriptBuilder
 from sdcm.sct_events import Severity
 from sdcm.sct_events.system import TestFrameworkEvent
-from sdcm.utils.argus import get_argus_client
+from sdcm.utils.argus import ArgusError, get_argus_client
 from sdcm.utils.net import get_my_ip
 from sdcm.utils.decorators import retrying
 from sdcm.utils.docker_utils import ContainerManager
@@ -294,8 +294,11 @@ class TestConfig(metaclass=Singleton):  # pylint: disable=too-many-public-method
     def init_argus_client(cls, params: dict):
         if params.get("enable_argus"):
             LOGGER.info("Initializing Argus connection...")
-            cls._argus_client = get_argus_client(run_id=cls.test_id())
-            return
+            try:
+                cls._argus_client = get_argus_client(run_id=cls.test_id())
+                return
+            except ArgusError as exc:
+                LOGGER.warning("Failed to initialize argus client: %s", exc.message)
         TestFrameworkEvent(
             source=cls.__name__,
             source_method='init_argus_client',

--- a/sdcm/utils/argus.py
+++ b/sdcm/utils/argus.py
@@ -8,7 +8,31 @@ from sdcm.keystore import KeyStore
 LOGGER = logging.getLogger(__name__)
 
 
+class ArgusError(Exception):
+
+    def __init__(self, message: str, *args: list) -> None:
+        self._message = message
+        super().__init__(*args)
+
+    @property
+    def message(self):
+        return self._message
+
+
+def is_uuid(uuid) -> bool:
+    if isinstance(uuid, UUID):
+        return True
+
+    try:
+        UUID(uuid)
+        return True
+    except (ValueError, AttributeError):
+        return False
+
+
 def get_argus_client(run_id: UUID | str) -> ArgusSCTClient:
+    if not is_uuid(run_id):
+        raise ArgusError("Malformed UUID provided")
     creds = KeyStore().get_argus_rest_credentials()
     argus_client = ArgusSCTClient(run_id=run_id, auth_token=creds["token"], base_url=creds["baseUrl"])
 

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -40,7 +40,7 @@ import tempfile
 import traceback
 from typing import Iterable, List, Callable, Optional, Dict, Union, Literal, Any
 from urllib.parse import urlparse
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 from textwrap import dedent
 from contextlib import closing
 from functools import wraps, cached_property, lru_cache
@@ -70,7 +70,7 @@ from prettytable import PrettyTable
 from sdcm.provision.azure.provisioner import AzureProvisioner
 from sdcm.sct_events import Severity
 from sdcm.sct_events.system import CpuNotHighEnoughEvent
-from sdcm.utils.argus import get_argus_client, terminate_resource_in_argus
+from sdcm.utils.argus import ArgusError, get_argus_client, terminate_resource_in_argus
 from sdcm.utils.aws_utils import EksClusterCleanupMixin, AwsArchType
 from sdcm.utils.ssh_agent import SSHAgent
 from sdcm.utils.decorators import retrying
@@ -759,12 +759,16 @@ def list_instances_aws(tags_dict=None, region_name=None, running=False, group_as
     return instances
 
 
-def clean_instances_aws(tags_dict, dry_run=False):
+def clean_instances_aws(tags_dict: dict, dry_run=False):
     """Remove all instances with specific tags in AWS."""
     # pylint: disable=too-many-locals,import-outside-toplevel
     assert tags_dict, "tags_dict not provided (can't clean all instances)"
     aws_instances = list_instances_aws(tags_dict=tags_dict, group_as_region=True)
-    argus_client = get_argus_client(run_id=tags_dict["TestId"])
+    try:
+        argus_client = get_argus_client(run_id=tags_dict.get("TestId"))
+    except ArgusError as exc:
+        LOGGER.warning("Unable to initialize Argus: %s", exc.message)
+        argus_client = MagicMock()
 
     for region, instance_list in aws_instances.items():
         if not instance_list:
@@ -1300,7 +1304,11 @@ def clean_instances_gce(tags_dict: dict, dry_run=False):
     def delete_instance(instance_with_tags: tuple[GCENode, dict]):
         instance, tags_dict = instance_with_tags
         LOGGER.info("Going to delete: %s", instance.name)
-        argus_client = get_argus_client(run_id=tags_dict["TestId"])
+        try:
+            argus_client = get_argus_client(run_id=tags_dict.get("TestId"))
+        except ArgusError as exc:
+            LOGGER.warning("Unable to initialize Argus: %s", exc.message)
+            argus_client = MagicMock()
 
         if not dry_run:
             # https://libcloud.readthedocs.io/en/latest/compute/api.html#libcloud.compute.base.Node.destroy
@@ -1312,7 +1320,7 @@ def clean_instances_gce(tags_dict: dict, dry_run=False):
                    timeout=60).run(delete_instance, ignore_exceptions=True)
 
 
-def clean_instances_azure(tags_dict, dry_run=False):
+def clean_instances_azure(tags_dict: dict, dry_run=False):
     """
     Cleans instances by tags.
 
@@ -1320,7 +1328,11 @@ def clean_instances_azure(tags_dict, dry_run=False):
     :return: None
     """
     assert tags_dict, "Running clean instances without tags would remove all SCT related resources in all regions"
-    argus_client = get_argus_client(run_id=tags_dict["TestId"])
+    try:
+        argus_client = get_argus_client(run_id=tags_dict.get("TestId"))
+    except ArgusError as exc:
+        LOGGER.warning("Unable to initialize Argus: %s", exc.message)
+        argus_client = MagicMock()
     provisioners = AzureProvisioner.discover_regions(tags_dict.get("TestId", ""))
     for provisioner in provisioners:
         all_instances = provisioner.list_instances()


### PR DESCRIPTION
This fix handles scenarios where get_argus_client is either provided
nothing or a non-uuid value to the client. Return MagicMock in such a
scenario to replicate previous behaviour

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [x] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
