### PR TITLE
Improvements for search_best_config_performance tests

### DIFF
--- a/performance_search_max_throughput_test.py
+++ b/performance_search_max_throughput_test.py
@@ -91,7 +91,7 @@ class MaximumPerformanceSearchTest(PerformanceRegressionTest):
         threads = start_threads
         self.log.info("Start search best performance")
         self.log.debug("Use c-s cmd template %s", stress_cmd_tmpl)
-        while len(self.loaders.nodes) > 1:
+        while len(self.loaders.nodes) > 0:
             stress_cmd = self._build_stress_command(cmd_tmpl=stress_cmd_tmpl,
                                                     threads=threads,
                                                     duration=stress_step_duration)

--- a/performance_search_max_throughput_test.py
+++ b/performance_search_max_throughput_test.py
@@ -224,6 +224,8 @@ class MaximumPerformanceSearchTest(PerformanceRegressionTest):
 
     @staticmethod
     def _build_stress_command(cmd_tmpl: str, threads: int, duration: str) -> str:
+        if isinstance(cmd_tmpl, list):
+            cmd_tmpl = cmd_tmpl[0]
         cmd_tmpl = re.sub(r'\sthreads=\d+\s', f' threads={threads} ', cmd_tmpl)
         cmd_tmpl = re.sub(r'\sduration=\d+[mhd]\s', f' duration={duration} ', cmd_tmpl)
         return cmd_tmpl

--- a/performance_search_max_throughput_test.py
+++ b/performance_search_max_throughput_test.py
@@ -106,7 +106,8 @@ class MaximumPerformanceSearchTest(PerformanceRegressionTest):
                 "threads": threads,
                 "n_loaders": len(self.loaders.nodes),
                 "n_process": stress_num,
-                "total_threads": threads * stress_num * len(self.loaders.nodes)})
+                "total_threads": threads * stress_num * len(self.loaders.nodes),
+                "stress_cmd": stress_cmd})
 
             self.log.debug("Summary results for current step: %s", current_result)
             all_results.append(current_result)
@@ -173,7 +174,8 @@ class MaximumPerformanceSearchTest(PerformanceRegressionTest):
             "scylla_version": self.db_cluster.nodes[0].scylla_version_detailed,
             "start_time": format_timestamp(self.start_time),
             "instance_type_db": self.params.get("instance_type_db"),
-            "instance_type_loader": self.params.get("instance_type_loader")
+            "instance_type_loader": self.params.get("instance_type_loader"),
+            "prepare_cs_cmd": self.params.get("prepare_write_cmd")
         }
 
         analyzer = SearchBestThroughputConfigPerformanceAnalyzer(es_index=self._test_index,

--- a/sdcm/report_templates/results_search_best_throughput_config.html
+++ b/sdcm/report_templates/results_search_best_throughput_config.html
@@ -23,6 +23,13 @@
     </div>
 
     <h2> Best throughput with configuration </h2>
+    {% if test_results['best_stat'].get('stress_cmd') %}
+        <h3>Command</h3>
+        <table id="results_table">
+        <tr><td>{{ test_results['best_stat'].get('stress_cmd') }}</td></tr>
+        </table>
+    {% endif %}
+
     <table id="results_table">
         <tr>
             <th> Number of Loaders </th>
@@ -70,5 +77,6 @@
                     <td> {{ stat['latency 99th percentile']}} </td>
                 </tr>
         {% endfor %}
+    </table>
 
 {% endblock %}

--- a/test-cases/performance/perf-search-best-throughput-config.yaml
+++ b/test-cases/performance/perf-search-best-throughput-config.yaml
@@ -32,3 +32,4 @@ email_recipients: ['scylla-perf-results@scylladb.com']
 store_perf_results: false
 # tests are running on aws. The loader uses the shard-aware driver
 ami_id_loader: 'scylla-qa-loader-ami-v19'
+enable_argus: false


### PR DESCRIPTION
Improvement report:
- added prepare_command and best_stress command to report

Fixes:
- run with one loader node
- disable argus for test
- choose 1st element if stress template was passed jenkins parameters



## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
