### PR TITLE
fix(autorizer): change to CassandraAuthorizer

### DIFF
--- a/test-cases/features/sl-workloads-test.yaml
+++ b/test-cases/features/sl-workloads-test.yaml
@@ -15,4 +15,4 @@ round_robin: true
 authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra
 authenticator_password: cassandra
-authorizer: 'ScyllaAuthorizer'
+authorizer: 'CassandraAuthorizer'

--- a/test-cases/features/system-sla-test.yaml
+++ b/test-cases/features/system-sla-test.yaml
@@ -17,4 +17,4 @@ round_robin: true
 authenticator: 'PasswordAuthenticator'
 authenticator_user: cassandra
 authenticator_password: cassandra
-authorizer: 'ScyllaAuthorizer'
+authorizer: 'CassandraAuthorizer'


### PR DESCRIPTION
According to https://github.com/scylladb/scylla-docs/issues/1918 and documentation https://docs.scylladb.com/stable/operating-scylla/security/enable-authorization correct value for autorized is 'CassandraAuthorizer', not 'ScyllaAuthorizer'. Change it for SLA tests

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
