### PR TITLE
fix(nemesis.py): use BaseNode.install_package for iptables installation

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3201,7 +3201,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def _install_iptables(self) -> None:
         if self.target_node.distro.is_ubuntu:  # iptables is missing in a minimized Ubuntu installation
-            self.target_node.remoter.sudo("apt install iptables")
+            self.target_node.install_package("iptables")
 
     @staticmethod
     def _iptables_randomly_get_random_matching_rule():


### PR DESCRIPTION
Several jobs stuck on installation using "apt install iptables" (due to a prompt, we guess).  It's better to switch to a more flexible installation routine.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [x] ~~New configuration option are added and documented (in `sdcm/sct_config.py`)~~
- [x] ~~I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)~~
- [x] All new and existing unit tests passed (CI)
- [x] I have updated the Readme/doc folder accordingly (if needed)
