### PR TITLE
fix(autorizer): change authorizer for old SLA tests

### DIFF
--- a/sla_per_user_system_test.py
+++ b/sla_per_user_system_test.py
@@ -357,9 +357,10 @@ class SlaPerUserTest(LongevityTest):
 
         read_users = []
         for share in shares:
-            read_users.append({'user': User(session=session, name='user%d' % share, password='user%d' % share).create(),
+            read_users.append({'user': User(session=session, name='user%d' % share, password='user%d' % share,
+                                            superuser=True).create(),
                                'role': Role(session=session, name='role%d' % share, password='role%d' % share,
-                                            login=True).create(),
+                                            login=True, superuser=True).create(),
                                'service_level': ServiceLevel(session=session, name='sla%d' % share,
                                                              shares=share).create()})
 
@@ -432,9 +433,10 @@ class SlaPerUserTest(LongevityTest):
 
         # Define Service Levels/Roles/Users
         for share in shares:
-            read_users.append({'user': User(session=session, name='user%d' % share, password='user%d' % share).create(),
+            read_users.append({'user': User(session=session, name='user%d' % share, password='user%d' % share,
+                                            superuser=True).create(),
                                'role': Role(session=session, name='role%d' % share, password='role%d' % share,
-                                            login=True).create(),
+                                            login=True, superuser=True).create(),
                                'service_level': ServiceLevel(session=session, name='sla%d' % share,
                                                              shares=share).create()})
 
@@ -499,9 +501,10 @@ class SlaPerUserTest(LongevityTest):
 
         # Define Service Levels/Roles/Users
         for share in shares:
-            read_users.append({'user': User(session=session, name='user%d' % share, password='user%d' % share).create(),
+            read_users.append({'user': User(session=session, name='user%d' % share, password='user%d' % share,
+                                            superuser=True).create(),
                                'role': Role(session=session, name='role%d' % share,
-                                            password='role%d' % share, login=True).create(),
+                                            password='role%d' % share, login=True, superuser=True).create(),
                                'service_level': ServiceLevel(session=session, name='sla%d' % share,
                                                              shares=share).create()})
 
@@ -569,9 +572,10 @@ class SlaPerUserTest(LongevityTest):
         shares = [190, 950]
         read_users = []
         for share in shares:
-            read_users.append({'user': User(session=session, name='user%d' % share, password='user%d' % share).create(),
+            read_users.append({'user': User(session=session, name='user%d' % share, password='user%d' % share,
+                                            superuser=True).create(),
                                'role': Role(session=session, name='role%d' % share, password='role%d' % share,
-                                            login=True).create(),
+                                            login=True, superuser=True).create(),
                                'service_level': ServiceLevel(session=session, name='sla%d' % share,
                                                              shares=share).create()})
 
@@ -638,9 +642,10 @@ class SlaPerUserTest(LongevityTest):
         shares = [190, 950]
         read_users = []
         for share in shares:
-            read_users.append({'user': User(session=session, name='user%d' % share, password='user%d' % share).create(),
+            read_users.append({'user': User(session=session, name='user%d' % share, password='user%d' % share,
+                                            superuser=True).create(),
                                'role': Role(session=session, name='role%d' % share, password='role%d' % share,
-                                            login=True).create(),
+                                            login=True, superuser=True).create(),
                                'service_level': ServiceLevel(session=session, name='sla%d' % share,
                                                              shares=share).create()})
 
@@ -750,8 +755,9 @@ class SlaPerUserTest(LongevityTest):
 
         # Define Service Levels/Roles/Users
         interactive_role = Role(session=session, name="interactive",
-                                password="interactive", login=True, verbose=True).create()
-        batch_role = Role(session=session, name="batch", password="batch", login=True, verbose=True).create()
+                                password="interactive", login=True, verbose=True, superuser=True).create()
+        batch_role = Role(session=session, name="batch", password="batch", login=True, verbose=True,
+                          superuser=True).create()
         interactive_sla = ServiceLevel(session=session, name="interactive", shares=None,
                                        workload_type="interactive").create()
         batch_sla = ServiceLevel(session=session, name="batch", shares=None,


### PR DESCRIPTION
According to https://github.com/scylladb/scylla-docs/issues/1918 and documentation https://docs.scylladb.com/stable/operating-scylla/security/enable-authorization correct value for autorized is 'CassandraAuthorizer', not 'ScyllaAuthorizer'. Change it for SLA tests

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
