### PR TITLE
fix(ParallelObject): remove timeout exception

### DIFF
--- a/sdcm/nemesis.py
+++ b/sdcm/nemesis.py
@@ -3412,7 +3412,7 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         """
         self._destroy_data_and_restart_scylla()
         trigger = partial(
-            self.target_node.run_nodetool, sub_cmd="repair", warning_event_on_exception=(Exception,), retry=0,
+            self.target_node.run_nodetool, sub_cmd="repair", warning_event_on_exception=(Exception,), retry=0, timeout=600,
         )
         log_follower = self.target_node.follow_system_log(patterns=["Repair 1 out of"])
 
@@ -3435,11 +3435,11 @@ class Nemesis:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         """
         self._destroy_data_and_restart_scylla()
 
+        timeout = 1800 if self._is_it_on_kubernetes() else 400
         trigger = partial(
-            self.target_node.run_nodetool, sub_cmd="rebuild", warning_event_on_exception=(Exception,), retry=0,
+            self.target_node.run_nodetool, sub_cmd="rebuild", warning_event_on_exception=(Exception,), retry=0, timeout=timeout//2
         )
         log_follower = self.target_node.follow_system_log(patterns=["rebuild from dc:"])
-        timeout = 1800 if self._is_it_on_kubernetes() else 400
 
         watcher = partial(
             self._call_disrupt_func_after_expression_logged,

--- a/sdcm/utils/common.py
+++ b/sdcm/utils/common.py
@@ -430,9 +430,6 @@ class ParallelObject:
         if ignore_exceptions:
             return results
 
-        timed_out = [result for result in results if isinstance(result.exc, FuturesTimeoutError)]
-        if timed_out:
-            raise FuturesTimeoutError("when running on: %s" % [r.obj for r in results])
         runs_that_finished_with_exception = [res for res in results if res.exc]
         if runs_that_finished_with_exception:
             raise ParallelObjectException(results=results)

--- a/unit_tests/test_parallelobject.py
+++ b/unit_tests/test_parallelobject.py
@@ -78,9 +78,10 @@ class ParallelObjectTester(unittest.TestCase):
     def test_raised_exception_by_timeout(self):
         test_timeout = min(self.rand_timeouts)
         start_time = time.time()
-        with self.assertRaises(concurrent.futures.TimeoutError):
+        with self.assertRaises(ParallelObjectException) as exp:
             parallel_object = ParallelObject(self.rand_timeouts, timeout=test_timeout)
             parallel_object.run(dummy_func_return_tuple)
+        assert any(isinstance(e.exc, concurrent.futures.TimeoutError) for e in exp.exception.results)
         run_time = int(time.time() - start_time)
         self.assertAlmostEqual(first=test_timeout, second=run_time, delta=1)
 


### PR DESCRIPTION
this branch of the code, just add all of the parallel objects into the exception, and makes the outcome unclear, cause you can't know which part is failing

```
concurrent.futures._base.TimeoutError: when running on: [
   functools.partial(<bound method BaseNode.run_nodetool of <...>>, sub_cmd='repair',
                     warning_event_on_exception=(<class 'Exception'>,), retry=0),
   functools.partial(<bound method Nemesis._call_disrupt_func_after_expression_logged of <...>>,
                     log_follower=<...>, disrupt_func=<bound method Nemesis.reboot_node of <...>>,
                     disrupt_func_kwargs={'target_node': <...>, 'hard': True, 'verify_ssh': True},
                     delay=1)]
```

Removing this code path, would end up with the regualr exception in the case of failed parallal thread, and would should the backtrace of each it would be a bit more lengthly, but with clearer information on which part of the parallel had failed/timeoutd


## Testing
- [x] - OSS - https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-10gb-3h-gce-test/35/
- [x] - enterprise - https://jenkins.scylladb.com/job/scylla-staging/job/fruch/job/longevity-10gb-3h-gce-test/34/

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
