### PR TITLE
fix(cluster.py): install s-b commands still broken

### DIFF
--- a/sdcm/cluster.py
+++ b/sdcm/cluster.py
@@ -593,8 +593,8 @@ class BaseNode(AutoSshContainerMixin, WebDriverContainerMixin):  # pylint: disab
             echo 'export GOPATH=$HOME/go' >> $HOME/.bash_profile
             echo 'export PATH=$PATH:/usr/local/go/bin' >> $HOME/.bash_profile
             source $HOME/.bash_profile
-            curl -Lo sb.zip https://github.com/scylladb/scylla-bench/archive/refs/{sb_version}.zip
-            unzip sb.zip
+            curl -Lo sb.tar.gz https://github.com/scylladb/scylla-bench/archive/refs/{sb_version}.tar.gz
+            tar -C . -xvzf sb.tar.gz
             cd ./scylla-bench-*
             GO111MODULE=on go install .
         """))


### PR DESCRIPTION
thanks to @vponomaryov, this commit is to fix
what is still left broken after previous fix
on commit 5759f8e9a20fe61062a07341bd7697beaa51b9ee

giving it a try [here](https://jenkins.scylladb.com/job/enterprise-2021.1/job/longevity/job/longevity-10gb-3h-gce-test/89/)


## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
