### PR TITLE
test(Ldap): Add/remove Ldap role permissions during stress

### DIFF
--- a/jenkins-pipelines/features-ldap-authorization-add-remove-role-permissions.jenkinsfile
+++ b/jenkins-pipelines/features-ldap-authorization-add-remove-role-permissions.jenkinsfile
@@ -1,0 +1,12 @@
+#!groovy
+
+// trick from https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/43
+def lib = library identifier: 'sct@snapshot', retriever: legacySCM(scm)
+
+longevityPipeline(
+    backend: 'aws',
+    region: 'eu-west-1',
+    test_name: 'test_add_remove_ldap_role_permission.AddRemoveLdapRolePermissionTest.test_add_remove_ldap_role_permission',
+    test_config: "test-cases/features/test_add_remove_ldap_role_permission.yaml"
+
+)

--- a/sdcm/utils/ldap.py
+++ b/sdcm/utils/ldap.py
@@ -14,8 +14,11 @@
 from time import sleep
 from enum import Enum
 
+from cassandra import Unauthorized
 from ldap3 import Server, Connection, ALL, ALL_ATTRIBUTES
 from ldap3.core.exceptions import LDAPSocketOpenError
+
+from sdcm.keystore import KeyStore
 from sdcm.utils.decorators import retrying
 
 
@@ -91,3 +94,182 @@ class LdapContainerMixin:  # pylint: disable=too-few-public-methods
     @staticmethod
     def modify_ldap_entry(*args, **kwargs):
         return LdapContainerMixin.ldap_conn.modify(*args, **kwargs)
+
+    @staticmethod
+    def delete_ldap_entry(*args, **kwargs):
+        return LdapContainerMixin.ldap_conn.delete(*args, **kwargs)
+
+
+class LdapUtilsMixin:
+    """This mixin can be added to any class that inherits the 'ClusterTester' one and configures Ldap container"""
+
+    @property
+    def ldap_server_ip(self) -> str:
+        if self.params.get('ldap_server_type') == LdapServerType.MS_AD:
+            ldap_ms_ad_credentials = KeyStore().get_ldap_ms_ad_credentials()
+            return ldap_ms_ad_credentials["server_address"]
+        ldap_server_ip = '127.0.0.1' if self.test_config.IP_SSH_CONNECTIONS == 'public' \
+            else self.test_config.LDAP_ADDRESS[0]
+        return ldap_server_ip
+
+    @property
+    def ldap_port(self) -> str:
+        if self.params.get('ldap_server_type') == LdapServerType.MS_AD:
+            return LDAP_PORT
+        ldap_port = LDAP_SSH_TUNNEL_LOCAL_PORT if self.test_config.IP_SSH_CONNECTIONS == 'public' \
+            else self.test_config.LDAP_ADDRESS[1]
+        return ldap_port
+
+    def _add_ldap_entry(self, ldap_entry: list):
+        self.log.debug("Adding an Ldap entry of: %s", ldap_entry)
+        username = f'cn=admin,{LDAP_BASE_OBJECT}'
+        self.localhost.add_ldap_entry(ip=self.ldap_server_ip, ldap_port=self.ldap_port,
+                                      user=username, password=LDAP_PASSWORD, ldap_entry=ldap_entry)
+
+    def create_role_in_ldap(self, ldap_role_name: str, unique_members: list):
+        unique_members_list = [f'uid={user},ou=Person,{LDAP_BASE_OBJECT}' for user in unique_members]
+        role_entry = [
+            f'cn={ldap_role_name},{LDAP_BASE_OBJECT}',
+            ['groupOfUniqueNames', 'simpleSecurityObject', 'top'],
+            {
+                'uniqueMember': unique_members_list,
+                'userPassword': LDAP_PASSWORD
+            }
+        ]
+        self._add_ldap_entry(ldap_entry=role_entry)
+
+    def search_ldap_role(self, ldap_role_name: str, raise_error: bool = True) -> str:
+        ldap_entry = f'(cn={ldap_role_name})'
+        self.log.debug("Searching for Ldap entry: %s, %s", LDAP_BASE_OBJECT, ldap_entry)
+        res = self.localhost.search_ldap_entry(LDAP_BASE_OBJECT, ldap_entry)
+        self.log.debug("Ldap entry Search result: %s", res)
+        if not res and raise_error:
+            raise Exception(f'Failed to find {ldap_role_name} in Ldap.')
+        distinguished_name = str(res).split()[1]
+        return distinguished_name
+
+    def search_ldap_user(self, ldap_user_name: str, raise_error: bool = True) -> str:
+        ldap_entry = f'(uid={ldap_user_name})'
+        self.log.debug("Searching for Ldap user: %s, %s", LDAP_BASE_OBJECT, ldap_entry)
+        res = self.localhost.search_ldap_entry(search_base=LDAP_BASE_OBJECT, search_filter=ldap_entry)
+        self.log.debug("Ldap user search result: %s", res)
+        if not res and raise_error:
+            raise Exception(f'Failed to find {ldap_user_name} in Ldap.')
+        distinguished_name = str(res).split()[1]
+        return distinguished_name
+
+    def modify_ldap_role_delete_member(self, ldap_role_name: str, member_name: str, raise_error: bool = True):
+        distinguished_name = self.search_ldap_role(ldap_role_name=ldap_role_name, raise_error=raise_error)
+        self.log.debug("Deleting member %s from Ldap entry: %s", member_name, distinguished_name)
+        unique_member_update = {'uniqueMember': [
+            ('MODIFY_DELETE', [f'uid={member_name},ou=Person,{LDAP_BASE_OBJECT}'])]}
+        res = self.localhost.modify_ldap_entry(distinguished_name, unique_member_update)
+        if not res and raise_error:
+            raise Exception(f'Failed to delete entry {distinguished_name} from Ldap role {ldap_role_name}')
+
+    def delete_ldap_role(self, ldap_role_name: str, raise_error: bool = True):
+        distinguished_name = self.search_ldap_role(ldap_role_name=ldap_role_name, raise_error=raise_error)
+        self.log.debug("Deleting Ldap entry: %s", distinguished_name)
+        res = self.localhost.delete_ldap_entry(distinguished_name)
+        if not res and raise_error:
+            raise Exception(f'Failed to delete entry {distinguished_name} from Ldap.')
+
+    def delete_ldap_user(self, ldap_user_name: str, raise_error: bool = True):
+        distinguished_name = self.search_ldap_user(ldap_user_name=ldap_user_name, raise_error=raise_error)
+        self.log.debug("Deleting Ldap user entry: %s", distinguished_name)
+        res = self.localhost.delete_ldap_entry(distinguished_name)
+        if not res and raise_error:
+            raise Exception(f'Failed to delete entry {distinguished_name} from Ldap.')
+
+    @retrying(n=10, sleep_time=30, message='Waiting for no user permissions verification', allowed_exceptions=(ValueError,))
+    def wait_verify_user_no_permissions(self, username: str):
+        """
+        Checks for unauthorized user permission following roles update.
+        Creating a keyspace by the user and verify it fails as expected.
+        """
+        self.log.debug("Verifying user %s roles permission change in Scylla DB (following an LDAP Role update) ", username)
+
+        try:
+            with self.db_cluster.cql_connection_patient(node=self.db_cluster.nodes[0], user=username,
+                                                        password=LDAP_PASSWORD) as session:
+                session.execute(
+                    """ CREATE KEYSPACE IF NOT EXISTS test_no_permission WITH replication = {'class': 'SimpleStrategy',
+                    'replication_factor': 1} """)
+                session.execute(""" DROP KEYSPACE IF EXISTS test_no_permission """)
+            raise ValueError('DID NOT RAISE')
+        except Unauthorized:
+            return
+
+    @retrying(n=10, sleep_time=30, message='Waiting for user permissions update', allowed_exceptions=Unauthorized)
+    def wait_verify_user_permissions(self, username: str, keyspace: str = 'customer_ldap'):
+        """
+        Checks for authorized user permission following roles update.
+        Creating a keyspace by the user and verify it doesn't fail.
+        """
+        self.log.debug("Verifying user %s roles permission change in Scylla DB (following an LDAP Role update) ", username)
+
+        with self.db_cluster.cql_connection_patient(node=self.db_cluster.nodes[0], user=username,
+                                                    password=LDAP_PASSWORD) as session:
+            session.execute(
+                """ CREATE KEYSPACE IF NOT EXISTS test_permission_ks WITH replication = {'class': 'SimpleStrategy',
+                'replication_factor': 1} """)
+            session.execute(""" DROP KEYSPACE IF EXISTS test_permission_ks """)
+
+            session.execute(
+                f""" CREATE KEYSPACE IF NOT EXISTS {keyspace} WITH replication = {{'class': 'SimpleStrategy',
+                'replication_factor': 3}} """)
+            session.execute(
+                f""" CREATE TABLE IF NOT EXISTS {keyspace}.info (key varchar, c varchar, v varchar, PRIMARY KEY(key, c)) """)
+            session.execute('INSERT INTO customer_ldap.info (key, c, v) VALUES (\'key1\', \'c1\', \'v1\')')
+            session.execute("SELECT * from customer_ldap.info LIMIT 1")
+
+    @retrying(n=10, sleep_time=30, message='Waiting for user permissions update', allowed_exceptions=(AssertionError,))
+    def wait_for_user_roles_update(self, username: str, are_roles_expected: bool):
+        """
+        Checks for updated output of user roles.
+        Example command: LIST ROLES OF new_user;
+        Example output:
+        LIST ROLES OF new_user;
+        ╭─────────┬─────────┬──────────────────────┬────────────╮
+        │role     │ super   │ login                │ options    │
+        ├─────────┼─────────┼──────────────────────┼────────────┤
+        │customer │ False   │ False                │ {}         │
+        ├─────────┼─────────┼──────────────────────┼────────────┤
+        │trainer  │ False   │ False                │ {}         │
+        ├─────────┼─────────┼──────────────────────┼────────────┤
+        │new_user │ False   │ True                 │ {}         │
+        ╰─────────┴─────────┴──────────────────────┴────────────╯
+        """
+        self.log.debug("Waiting user %s roles change in Scylla DB (following an LDAP Role update) ", username)
+        with self.db_cluster.cql_connection_patient(node=self.db_cluster.nodes[0]) as session:
+            query = f"LIST ROLES OF '{username}';"
+            result = session.execute(query)
+            output = result.all()
+            self.log.debug("LIST ROLES OF %s: %s", username, output)
+            if are_roles_expected:
+                assert len(output) > 1
+            else:
+                assert len(output) == 1
+
+    def add_user_in_ldap(self, username: str):
+        user_entry = [
+            f'uid={username},ou=Person,{LDAP_BASE_OBJECT}',
+            ['uidObject', 'organizationalPerson', 'top'],
+            {
+                'userPassword': LDAP_PASSWORD,
+                'sn': 'PersonSn',
+                'cn': 'PersonCn'
+            }
+        ]
+        self._add_ldap_entry(ldap_entry=user_entry)
+
+    def create_role_in_scylla(self, node, role_name: str, is_superuser: bool = True,
+                              is_login: bool = True):
+        self.log.debug("Configuring a Role %s in Scylla DB", role_name)
+        create_role_cmd = f'CREATE ROLE IF NOT EXISTS \'{role_name}\''
+        superuser_argument = ' WITH SUPERUSER=true' if is_superuser else ' WITH SUPERUSER=false'
+        login_argument = ' AND login=true' if is_login else ' AND login=false'
+        create_role_cmd += superuser_argument + login_argument
+        if not self.params.get('prepare_saslauthd'):
+            create_role_cmd += f' AND password=\'{LDAP_PASSWORD}\''
+        node.run_cqlsh(create_role_cmd)

--- a/test-cases/features/test_add_remove_ldap_role_permission.yaml
+++ b/test-cases/features/test_add_remove_ldap_role_permission.yaml
@@ -1,0 +1,16 @@
+test_duration: 120
+
+use_ldap: true
+ldap_server_type: 'openldap'
+use_ldap_authorization: true
+authenticator: 'PasswordAuthenticator'
+authenticator_user: cassandra
+authenticator_password: cassandra
+authorizer: 'CassandraAuthorizer'
+
+n_db_nodes: 3
+n_loaders: 1
+n_monitor_nodes: 1
+instance_type_db: 'i3.large'
+user_prefix: 'test-add-remove-ldap-permissions'
+stress_cmd: "cassandra-stress write no-warmup cl=QUORUM duration=10m -schema 'replication(factor=3)' -mode cql3 native -rate threads=2 -pop seq=1..1002003 -log interval=5"

--- a/test_add_remove_ldap_role_permission.py
+++ b/test_add_remove_ldap_role_permission.py
@@ -1,0 +1,100 @@
+import time
+
+import pytest
+from cassandra import Unauthorized
+
+from longevity_test import LongevityTest
+from sdcm.cluster import BaseNode
+from sdcm.sct_events.system import InfoEvent
+from sdcm.utils.ldap import LdapServerType, LDAP_USERS, LDAP_PASSWORD, LdapUtilsMixin
+
+
+class AddRemoveLdapRolePermissionTest(LongevityTest, LdapUtilsMixin):
+
+    def test_add_remove_ldap_role_permission(self):  # pylint: disable=too-many-statements
+        """
+        Test adding a new user with Ldap permissions,
+        and run some load for it.
+        Then remove permissions and wait for its load to end.
+        Scenario :
+        1. Create new user in Scylla
+        2. Create new role in Ldap containing the new user as a member.
+        3. Verify this new user is unauthorised on resources (create a keyspace).
+        4. Create a new super-user role in Scylla.
+        5. Create a new super-user role in Ldap, with the new user as a member.
+        6. Verify this new user is authorised on resources.
+        7. Modify Ldap role to remove membership of new user.
+        8. Verify the new user is unauthorised on resources (create a table).
+        9. Do clean-up: delete Ldap Role, Scylla roles and keyspace/tables.
+
+        """
+        node: BaseNode = self.db_cluster.nodes[0]
+        stress_queue = []
+        background_write_cmd = self.params.get('stress_cmd')
+        InfoEvent(message=f"Starting C-S stress load: {background_write_cmd}").publish()
+        stress_queue.append(self.run_stress_thread(stress_cmd=background_write_cmd, round_robin=True))
+
+        if not node.is_enterprise:
+            raise ValueError('Cluster is not enterprise. LDAP is supported only for enterprise. aborting.')
+        if self.params.get('use_ldap_authentication'):
+            raise ValueError('Skipping this test with use_ldap_authentication because of scylla-enterprise#2641')
+        if not self.params.get('use_ldap_authorization'):
+            raise ValueError('Cluster is not configured to run with LDAP authorization, aborting.')
+        if self.params.get('ldap_server_type') == LdapServerType.MS_AD:
+            raise ValueError('Cluster is not configured to run with open LDAP authorization, aborting.')
+        superuser_role = 'superuser_role'
+        new_test_user = 'new_test_user'
+        ldap_keyspace = 'customer_ldap'
+        self.log.debug("Create new user in Scylla")
+        self.create_role_in_scylla(node=node, role_name=new_test_user, is_superuser=False,
+                                   is_login=True)
+        if self.params.get('prepare_saslauthd'):
+            self.add_user_in_ldap(username=new_test_user)
+        with pytest.raises(Unauthorized, match="has no CREATE permission"):
+            with self.db_cluster.cql_connection_patient(node=node, user=new_test_user, password=LDAP_PASSWORD) as session:
+                session.execute(
+                    f""" CREATE KEYSPACE IF NOT EXISTS {ldap_keyspace} WITH replication = {{'class': 'SimpleStrategy',
+                    'replication_factor': 1}} """)
+
+        self.log.debug("Create a new super-user role in Scylla")
+        self.create_role_in_scylla(node=node, role_name=superuser_role, is_superuser=True,
+                                   is_login=False)
+        self.db_cluster.wait_for_schema_agreement()
+        self.log.debug("Create a new super-user role in Ldap, associated with the new user")
+
+        self.create_role_in_ldap(ldap_role_name=superuser_role, unique_members=[new_test_user, LDAP_USERS[1]])
+
+        self.wait_for_user_roles_update(are_roles_expected=True, username=new_test_user)
+        self.log.debug("Create keyspace and table where authorized")
+        self.wait_verify_user_permissions(username=new_test_user, keyspace=ldap_keyspace)
+
+        # Run a stress while new user permissions are removed
+        new_test_user_stress = f"cassandra-stress write no-warmup cl=QUORUM duration=10m -schema 'keyspace={ldap_keyspace} " \
+                               f" replication(factor=3)' -mode cql3 native user={new_test_user} password={LDAP_PASSWORD}" \
+                               " -rate threads=2 -pop seq=1..1002003 -log interval=5"
+        stress_queue.append(self.run_stress_thread(stress_cmd=new_test_user_stress, round_robin=True))
+        self.log.debug("Let stress of new user run for few minutes before removing permissions")
+        time.sleep(120)
+        self.log.debug("Remove authorization and verify unauthorized user")
+        self.modify_ldap_role_delete_member(ldap_role_name=superuser_role, member_name=new_test_user)
+        self.wait_for_user_roles_update(are_roles_expected=False, username=new_test_user)
+        self.wait_verify_user_no_permissions(username=new_test_user)
+        for stress in stress_queue:
+            self.verify_stress_thread(cs_thread_pool=stress)
+
+        self.delete_ldap_role(ldap_role_name=superuser_role)
+        with pytest.raises(Unauthorized):
+            with self.db_cluster.cql_connection_patient(node=node, user=new_test_user, password=LDAP_PASSWORD) as session:
+                session.execute(""" DROP KEYSPACE IF EXISTS test_no_permission """)
+        with self.db_cluster.cql_connection_patient(node=node, user=LDAP_USERS[0], password=LDAP_PASSWORD) as session:
+
+            session.execute(f""" DROP TABLE IF EXISTS {ldap_keyspace}.info """)
+            session.execute(f""" DROP TABLE IF EXISTS {ldap_keyspace}.standard1 """)
+            session.execute(f""" DROP KEYSPACE IF EXISTS {ldap_keyspace} """)
+            session.execute(""" DROP KEYSPACE IF EXISTS test_no_permission """)
+            session.execute(""" DROP KEYSPACE IF EXISTS test_permission_ks """)
+            session.execute(f"DROP ROLE IF EXISTS {superuser_role}")
+            if self.params.get('prepare_saslauthd'):
+                self.delete_ldap_user(ldap_user_name=new_test_user)
+                session.execute(f"ALTER ROLE {new_test_user} WITH login=false")
+            session.execute(f"DROP ROLE IF EXISTS {new_test_user}")


### PR DESCRIPTION
	Test adding a new user with Ldap permissions,
	and run some load for it.
	Then remove permissions and wait for its load to end.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [x] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [x] I didn't leave commented-out/debugging code
- [x] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
